### PR TITLE
focus on extrude literal when extruding sketch

### DIFF
--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -62,8 +62,11 @@ export const Toolbar = () => {
             onClick={() => {
               if (!ast) return
               const pathToNode = getNodePathFromSourceRange(ast, selectionRange)
-              const { modifiedAst } = extrudeSketch(ast, pathToNode)
-              updateAst(modifiedAst)
+              const { modifiedAst, pathToExtrudeArg } = extrudeSketch(
+                ast,
+                pathToNode
+              )
+              updateAst(modifiedAst, pathToExtrudeArg)
             }}
             className="border m-1 px-1 rounded"
           >
@@ -73,8 +76,12 @@ export const Toolbar = () => {
             onClick={() => {
               if (!ast) return
               const pathToNode = getNodePathFromSourceRange(ast, selectionRange)
-              const { modifiedAst } = extrudeSketch(ast, pathToNode, false)
-              updateAst(modifiedAst)
+              const { modifiedAst, pathToExtrudeArg } = extrudeSketch(
+                ast,
+                pathToNode,
+                false
+              )
+              updateAst(modifiedAst, pathToExtrudeArg)
             }}
             className="border m-1 px-1 rounded"
           >

--- a/src/components/RenderViewerArtifacts.tsx
+++ b/src/components/RenderViewerArtifacts.tsx
@@ -55,7 +55,10 @@ function MovingSphere({
   const { originalXY } = useMemo(() => {
     if (ast) {
       const thePath = getNodePathFromSourceRange(ast, sourceRange)
-      const callExpression = getNodeFromPath(ast, thePath) as CallExpression
+      const { node: callExpression } = getNodeFromPath<CallExpression>(
+        ast,
+        thePath
+      )
       const [xArg, yArg] = callExpression?.arguments || []
       const x = xArg?.type === 'Literal' ? xArg.value : -1
       const y = yArg?.type === 'Literal' ? yArg.value : -1

--- a/src/lang/abstractSyntaxTree.ts
+++ b/src/lang/abstractSyntaxTree.ts
@@ -1,82 +1,82 @@
+import { PathToNode } from './executor'
 import { Token } from './tokeniser'
 
 type syntaxType =
   | 'Program'
   | 'ExpressionStatement'
   | 'BinaryExpression'
-  | 'NumberLiteral'
-  | 'StringLiteral'
   | 'CallExpression'
   | 'Identifier'
   | 'BlockStatement'
-  | 'IfStatement'
-  | 'WhileStatement'
-  | 'FunctionDeclaration'
   | 'ReturnStatement'
   | 'VariableDeclaration'
   | 'VariableDeclarator'
-  | 'AssignmentExpression'
-  | 'UnaryExpression'
   | 'MemberExpression'
   | 'ArrayExpression'
   | 'ObjectExpression'
   | 'ObjectProperty'
-  | 'Property'
-  | 'LogicalExpression'
-  | 'ConditionalExpression'
-  | 'ForStatement'
-  | 'ForInStatement'
-  | 'ForOfStatement'
-  | 'BreakStatement'
-  | 'ContinueStatement'
-  | 'SwitchStatement'
-  | 'SwitchCase'
-  | 'ThrowStatement'
-  | 'TryStatement'
-  | 'CatchClause'
-  | 'ClassDeclaration'
-  | 'ClassBody'
-  | 'MethodDefinition'
-  | 'NewExpression'
-  | 'ThisExpression'
-  | 'UpdateExpression'
-  // | "ArrowFunctionExpression"
   | 'FunctionExpression'
   | 'SketchExpression'
   | 'PipeExpression'
   | 'PipeSubstitution'
-  | 'YieldExpression'
-  | 'AwaitExpression'
-  | 'ImportDeclaration'
-  | 'ImportSpecifier'
-  | 'ImportDefaultSpecifier'
-  | 'ImportNamespaceSpecifier'
-  | 'ExportNamedDeclaration'
-  | 'ExportDefaultDeclaration'
-  | 'ExportAllDeclaration'
-  | 'ExportSpecifier'
-  | 'TaggedTemplateExpression'
-  | 'TemplateLiteral'
-  | 'TemplateElement'
-  | 'SpreadElement'
-  | 'RestElement'
-  | 'SequenceExpression'
-  | 'DebuggerStatement'
-  | 'LabeledStatement'
-  | 'DoWhileStatement'
-  | 'WithStatement'
-  | 'EmptyStatement'
   | 'Literal'
-  | 'ArrayPattern'
-  | 'ObjectPattern'
-  | 'AssignmentPattern'
-  | 'MetaProperty'
-  | 'Super'
-  | 'Import'
-  | 'RegExpLiteral'
-  | 'BooleanLiteral'
-  | 'NullLiteral'
-  | 'TypeAnnotation'
+// | 'NumberLiteral'
+// | 'StringLiteral'
+// | 'IfStatement'
+// | 'WhileStatement'
+// | 'FunctionDeclaration'
+// | 'AssignmentExpression'
+// | 'UnaryExpression'
+// | 'Property'
+// | 'LogicalExpression'
+// | 'ConditionalExpression'
+// | 'ForStatement'
+// | 'ForInStatement'
+// | 'ForOfStatement'
+// | 'BreakStatement'
+// | 'ContinueStatement'
+// | 'SwitchStatement'
+// | 'SwitchCase'
+// | 'ThrowStatement'
+// | 'TryStatement'
+// | 'CatchClause'
+// | 'ClassDeclaration'
+// | 'ClassBody'
+// | 'MethodDefinition'
+// | 'NewExpression'
+// | 'ThisExpression'
+// | 'UpdateExpression'
+// | 'YieldExpression'
+// | 'AwaitExpression'
+// | 'ImportDeclaration'
+// | 'ImportSpecifier'
+// | 'ImportDefaultSpecifier'
+// | 'ImportNamespaceSpecifier'
+// | 'ExportNamedDeclaration'
+// | 'ExportDefaultDeclaration'
+// | 'ExportAllDeclaration'
+// | 'ExportSpecifier'
+// | 'TaggedTemplateExpression'
+// | 'TemplateLiteral'
+// | 'TemplateElement'
+// | 'SpreadElement'
+// | 'RestElement'
+// | 'SequenceExpression'
+// | 'DebuggerStatement'
+// | 'LabeledStatement'
+// | 'DoWhileStatement'
+// | 'WithStatement'
+// | 'EmptyStatement'
+// | 'ArrayPattern'
+// | 'ObjectPattern'
+// | 'AssignmentPattern'
+// | 'MetaProperty'
+// | 'Super'
+// | 'Import'
+// | 'RegExpLiteral'
+// | 'BooleanLiteral'
+// | 'NullLiteral'
+// | 'TypeAnnotation'
 
 export interface Program {
   type: syntaxType
@@ -1345,27 +1345,37 @@ function debuggerr(tokens: Token[], indexes: number[], msg = ''): string {
   return debugResult
 }
 
-export function getNodeFromPath(
+export function getNodeFromPath<T>(
   node: Program,
   path: (string | number)[],
   stopAt: string = '',
   returnEarly = false
-) {
+): {
+  node: T
+  path: PathToNode
+} {
   let currentNode = node as any
   let stopAtNode = null
-  let successfulPaths: (string | number)[] = []
+  let successfulPaths: PathToNode = []
+  let pathsExplored: PathToNode = []
   for (const pathItem of path) {
     try {
       if (typeof currentNode[pathItem] !== 'object')
         throw new Error('not an object')
       currentNode = currentNode[pathItem]
       successfulPaths.push(pathItem)
+      if (!stopAtNode) {
+        pathsExplored.push(pathItem)
+      }
       if (currentNode.type === stopAt) {
         // it will match the deepest node of the type
         // instead of returning at the first match
         stopAtNode = currentNode
         if (returnEarly) {
-          return stopAtNode
+          return {
+            node: stopAtNode,
+            path: pathsExplored,
+          }
         }
       }
     } catch (e) {
@@ -1378,7 +1388,10 @@ export function getNodeFromPath(
       )
     }
   }
-  return stopAtNode || currentNode
+  return {
+    node: stopAtNode || currentNode,
+    path: pathsExplored,
+  }
 }
 
 type Path = (string | number)[]

--- a/src/lang/getNodePathFromSourceRange.test.ts
+++ b/src/lang/getNodePathFromSourceRange.test.ts
@@ -21,7 +21,7 @@ describe('testing getNodePathFromSourceRange', () => {
 
     const ast = abstractSyntaxTree(lexer(code))
     const nodePath = getNodePathFromSourceRange(ast, sourceRange)
-    const node = getNodeFromPath(ast, nodePath)
+    const { node } = getNodeFromPath<any>(ast, nodePath)
 
     expect([node.start, node.end]).toEqual(sourceRange)
     expect(node.type).toBe('CallExpression')


### PR DESCRIPTION
When extruding a sketch the ast modification gives the extrusion a default value of 4. This change puts the cursor at the `4` with it highlighted after the extrude so that the user can start typing to replace it with their desired value immediately, see demo 👇 

https://user-images.githubusercontent.com/29681384/212257503-130b6bf9-41f2-457c-b562-e5482c89316a.mov

