### PR TITLE
initial set horz-vert distance constraint

### DIFF
--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -3,6 +3,7 @@ import { extrudeSketch, sketchOnExtrudedFace } from './lang/modifyAst'
 import { getNodePathFromSourceRange } from './lang/queryAst'
 import { HorzVert } from './components/Toolbar/HorzVert'
 import { Equal } from './components/Toolbar/Equal'
+import { SetHorzDistance } from './components/Toolbar/SetHorzDistance'
 
 export const Toolbar = () => {
   const {
@@ -156,6 +157,8 @@ export const Toolbar = () => {
       <HorzVert horOrVert="horizontal" />
       <HorzVert horOrVert="vertical" />
       <Equal />
+      <SetHorzDistance horOrVert="setHorzDistance" />
+      <SetHorzDistance horOrVert="setVertDistance" />
     </div>
   )
 }

--- a/src/components/Toolbar/SetHorzDistance.tsx
+++ b/src/components/Toolbar/SetHorzDistance.tsx
@@ -1,0 +1,97 @@
+import { useState, useEffect } from 'react'
+import { toolTips, useStore } from '../../useStore'
+import { Value, VariableDeclarator } from '../../lang/abstractSyntaxTree'
+import {
+  getNodePathFromSourceRange,
+  getNodeFromPath,
+} from '../../lang/queryAst'
+import { isSketchVariablesLinked } from '../../lang/std/sketchConstraints'
+import {
+  TransformInfo,
+  transformAstForSketchLines,
+  getTransformInfos,
+} from '../../lang/std/sketchcombos'
+
+export const SetHorzDistance = ({
+  horOrVert,
+}: {
+  horOrVert: 'setHorzDistance' | 'setVertDistance'
+}) => {
+  const { guiMode, selectionRanges, ast, programMemory, updateAst } = useStore(
+    (s) => ({
+      guiMode: s.guiMode,
+      ast: s.ast,
+      updateAst: s.updateAst,
+      selectionRanges: s.selectionRanges,
+      programMemory: s.programMemory,
+    })
+  )
+  const [enable, setEnable] = useState(false)
+  const [transformInfos, setTransformInfos] = useState<TransformInfo[]>()
+  useEffect(() => {
+    if (!ast) return
+    const paths = selectionRanges.map((selectionRange) =>
+      getNodePathFromSourceRange(ast, selectionRange)
+    )
+    const nodes = paths.map(
+      (pathToNode) => getNodeFromPath<Value>(ast, pathToNode).node
+    )
+    const varDecs = paths.map(
+      (pathToNode) =>
+        getNodeFromPath<VariableDeclarator>(
+          ast,
+          pathToNode,
+          'VariableDeclarator'
+        )?.node
+    )
+    const primaryLine = varDecs[0]
+    const secondaryVarDecs = varDecs.slice(1)
+    const isOthersLinkedToPrimary = secondaryVarDecs.every((secondary) =>
+      isSketchVariablesLinked(secondary, primaryLine, ast)
+    )
+    const isAllTooltips = nodes.every(
+      (node) =>
+        node?.type === 'CallExpression' &&
+        toolTips.includes(node.callee.name as any)
+    )
+
+    const theTransforms = getTransformInfos(
+      selectionRanges.slice(1),
+      ast,
+      horOrVert
+    )
+    setTransformInfos(theTransforms)
+
+    const _enableEqual =
+      secondaryVarDecs.length === 1 &&
+      isAllTooltips &&
+      isOthersLinkedToPrimary &&
+      theTransforms.every(Boolean)
+    setEnable(_enableEqual)
+  }, [guiMode, selectionRanges])
+  if (guiMode.mode !== 'sketch') return null
+
+  return (
+    <button
+      onClick={() =>
+        transformInfos &&
+        ast &&
+        updateAst(
+          transformAstForSketchLines({
+            ast,
+            selectionRanges,
+            transformInfos,
+            programMemory,
+          })?.modifiedAst
+        )
+      }
+      className={`border m-1 px-1 rounded ${
+        enable ? 'bg-gray-50 text-gray-800' : 'bg-gray-200 text-gray-400'
+      }`}
+      disabled={!enable}
+      title="yo dawg"
+    >
+      {horOrVert}
+    </button>
+  )
+}

--- a/src/lang/std/sketchConstraints.ts
+++ b/src/lang/std/sketchConstraints.ts
@@ -33,6 +33,28 @@ export const segLen: InternalFn = (
   )
 }
 
+function segEndFactory(which: 'x' | 'y'): InternalFn {
+  return (_, segName: string, sketchGroup: SketchGroup): number => {
+    const line = sketchGroup?.value.find((seg) => seg.name === segName)
+    // maybe this should throw, but the language doesn't have a way to handle errors yet
+    if (!line) return 0
+    return which === 'x' ? line.to[0] : line.to[1]
+  }
+}
+
+export const segEndX: InternalFn = segEndFactory('x')
+export const segEndY: InternalFn = segEndFactory('y')
+
+function lastSegFactory(which: 'x' | 'y'): InternalFn {
+  return (_, sketchGroup: SketchGroup): number => {
+    const lastLine = sketchGroup?.value[sketchGroup.value.length - 1]
+    return which === 'x' ? lastLine.to[0] : lastLine.to[1]
+  }
+}
+
+export const lastSegX: InternalFn = lastSegFactory('x')
+export const lastSegY: InternalFn = lastSegFactory('y')
+
 function angleToMatchLengthFactory(which: 'x' | 'y'): InternalFn {
   return (_, segName: string, to: number, sketchGroup: SketchGroup): number => {
     const isX = which === 'x'

--- a/src/lang/std/std.ts
+++ b/src/lang/std/std.ts
@@ -17,6 +17,10 @@ import {
   segLen,
   angleToMatchLengthX,
   angleToMatchLengthY,
+  segEndX,
+  segEndY,
+  lastSegX,
+  lastSegY,
 } from './sketchConstraints'
 import { extrude, getExtrudeWallTransform } from './extrude'
 import { Quaternion, Vector3 } from 'three'
@@ -100,6 +104,10 @@ export const internalFns: { [key in InternalFnNames]: InternalFn } = {
   legLen,
   legAngX,
   legAngY,
+  segEndX,
+  segEndY,
+  lastSegX,
+  lastSegY,
   segLen,
   angleToMatchLengthX,
   angleToMatchLengthY,

--- a/src/lang/std/stdTypes.ts
+++ b/src/lang/std/stdTypes.ts
@@ -24,6 +24,10 @@ export type InternalFnNames =
   | 'legLen'
   | 'legAngX'
   | 'legAngY'
+  | 'segEndX'
+  | 'segEndY'
+  | 'lastSegX'
+  | 'lastSegY'
   | 'segLen'
   | 'angleToMatchLengthX'
   | 'angleToMatchLengthY'
@@ -52,7 +56,8 @@ export interface ModifyAstBase {
 
 interface addCall extends ModifyAstBase {
   to: [number, number]
-  from?: [number, number]
+  from: [number, number]
+  referencedSegment?: Path
   replaceExisting?: boolean
   createCallback?: TransformCallback // TODO: #29 probably should not be optional
 }
@@ -62,7 +67,10 @@ interface updateArgs extends ModifyAstBase {
   to: [number, number]
 }
 
-export type TransformCallback = (args: [Value, Value]) => Value
+export type TransformCallback = (
+  args: [Value, Value],
+  referencedSegment?: Path
+) => Value
 
 export type SketchCallTransfromMap = {
   [key in TooTip]: TransformCallback


### PR DESCRIPTION
The constraint has really only been implemented for `free`, `xRelative` and `yRelative` constrained `line`s, previous constraints were implemented much more thoroughly (horz, vertical, equalLength).

I think it's best to focus on a usecase atm so I'm going to aim for the minimum to get a realistic sketch done. Plus getting this constraint didn't require me to come up with whole new patterns, which was needed for the last two constraints, this strongly implies the patterns so far are holding up and I can move forward with some confidence from this point.

[Uploading Screen Recording 2023-03-05 at 7.42.04 am.mp4…](https://user-images.githubusercontent.com/29681384/222927849-be59815f-7c48-4144-8d71-381023fe73ba.mp4)

Related to #41 

Coverage is at 67.14%