### PR TITLE
add Parallel helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-json-view": "^1.21.3",
     "react-modal-promise": "^1.0.2",
     "react-scripts": "5.0.1",
+    "sketch-helpers": "^0.0.1",
     "swr": "^2.0.4",
     "three": "^0.146.0",
     "typescript": "^4.4.2",

--- a/src/lang/std/std.test.ts
+++ b/src/lang/std/std.test.ts
@@ -1,0 +1,26 @@
+import { abstractSyntaxTree } from '../abstractSyntaxTree'
+import { executor } from '../executor'
+import { lexer } from '../tokeniser'
+import { initPromise } from '../rust'
+
+beforeAll(() => initPromise)
+
+describe('testing angledLineThatIntersects', () => {
+  it('angledLineThatIntersects should intersect with another line', () => {
+    const code = (offset: string) => `const part001 = startSketchAt([0, 0])
+  |> lineTo({to:[2, 2], tag: "yo"}, %)
+  |> lineTo([3, 1], %)
+  |> angledLineThatIntersects({
+  angle: 180,
+  intersectTag: 'yo',
+  offset: ${offset},
+  tag: "yo2"
+}, %)
+const intersect = segEndX('yo2', part001)
+show(part001)`
+    const { root } = executor(abstractSyntaxTree(lexer(code('-1'))))
+    expect(root.intersect.value).toBe(1 + Math.sqrt(2))
+    const { root: noOffset } = executor(abstractSyntaxTree(lexer(code('0'))))
+    expect(noOffset.intersect.value).toBeCloseTo(1)
+  })
+})

--- a/src/lang/std/stdTypes.ts
+++ b/src/lang/std/stdTypes.ts
@@ -47,6 +47,7 @@ export type InternalFnNames =
   | 'angledLineToY'
   | 'startSketchAt'
   | 'closee'
+  | 'angledLineThatIntersects'
 
 export interface ModifyAstBase {
   node: Program

--- a/yarn.lock
+++ b/yarn.lock
@@ -9360,6 +9360,11 @@ sisteransi@^1.0.4, sisteransi@^1.0.5:
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
 
+sketch-helpers@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/sketch-helpers/-/sketch-helpers-0.0.1.tgz#637ead1f6e39276408d2c2e2a48dfefe13dc0cb0"
+  integrity sha512-ePn4nTA5sVNR6+8JalyCPQ+K7tpuYtCrccw2QGL6H2N3JRq6bO8x9RmZpyjTe/+T0uSrd2+F41d+ibsrjHHSFg==
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"


### PR DESCRIPTION
Resolves #59 

Add helper lib and add `angledLineThatIntersects` fn to lang std, next constraining UX will be needed for this helper.

`angledLineThatIntersects` is an important helper for doing parallel lines in a sketch. It's easy to make two lines parallel, as you just make sure they have the same angle, but it's more difficult to be able to specify the distance between two parallel lines with current helpers. The `angledLineThatIntersects` helper determines when one line intersects with an existing line, but it also has an `offset` property that is the perpendicular distance from the line being intersected. Here's an example

![image](https://user-images.githubusercontent.com/29681384/225133009-8316716c-1713-47e5-98d3-6b949d94894f.png)

 
in the above the `thickness` var is used three times, twice as the `offset` of `angledLineThatIntersects`, in order to ensure the arm has the same width after a few direction changes.


code for good measure: paste into https://untitled-app.kittycad.io/ and use the hover over features to see how this plays together
```
const thickness = 1
const firstAng = 200
const secondAng = 45
const part001 = startSketchAt([0, 0])
  |> angledLine({ angle: firstAng, length: 8, tag: 'first' }, %)
  |> angledLineToY({ angle: secondAng, to: 5, tag: "second" }, %)
  |> xLine(5, %)
  |> yLine(thickness, %)
  |> angledLineThatIntersects({
  angle: 0,
  intersectTag: 'second',
  offset: thickness
}, %)
  |> angledLineThatIntersects({
  angle: secondAng,
  intersectTag: 'first',
  offset: thickness
}, %)
  |> angledLineToY([firstAng, 0], %)
  
show(part001)
```