### PR TITLE
Use shift instead of capslock for multiple line selection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -153,7 +153,10 @@ function App() {
             >
               format
             </button> */}
-            <div className="bg-red h-full w-full overflow-auto">
+            <div
+              className="bg-red h-full w-full overflow-auto"
+              id="code-mirror-override"
+            >
               <CodeMirror
                 className="h-full"
                 value={code}

--- a/src/hooks/useHotKeyListener.ts
+++ b/src/hooks/useHotKeyListener.ts
@@ -1,11 +1,15 @@
 import { useStore } from '../useStore'
 import { useEffect } from 'react'
 
+// Kurt's note: codeMirror styling overrides were needed to make this work
+// namely, the cursor needs to still be shown when the editor is not focused
+// search for code-mirror-override in the repo to find the relevant styles
+
 export function useHotKeyListener() {
   const { setIsShiftDown } = useStore((s) => ({
     setIsShiftDown: s.setIsShiftDown,
   }))
-  const keyName = 'CapsLock' // TODO #32 should be shift, but shift conflicts with the editor's use of the shift key atm.
+  const keyName = 'Shift'
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) =>
       event.key === keyName && setIsShiftDown(true)

--- a/src/hooks/useSetCursor.ts
+++ b/src/hooks/useSetCursor.ts
@@ -11,9 +11,5 @@ export function useSetCursor(sourceRange: Range) {
       ? [...selectionRanges, sourceRange]
       : [sourceRange]
     setCursor(ranges)
-    const element: HTMLDivElement | null = document.querySelector('.cm-content')
-    if (element) {
-      element.focus()
-    }
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -17,3 +17,12 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+
+#code-mirror-override .cm-focused .cm-cursor {
+  border-left: 1.2px solid black;
+}
+#code-mirror-override .cm-cursor {
+  display: block;
+  border-left: 5px solid #0084e2;
+}


### PR DESCRIPTION
Resolves #61 

Hard to describe in words, so the video might be best, since I can click around and explain, but here's an attempt at text.

Holding shift while selecting multiple lines is most intuitive for multiple-select, however because shift has existing functionality in the editor, capslock was used as a compromise.

Turns out the issue stems for a previous fix, when the user selects a line naturally they are not focused on the editor anymore, and by default code-mirror stops showing the cursor when the editor is not in focus. So when we update their cursor in the editor (because that's how selections work in the UI) from a click on a 3d line, we update the cursor position in the editor, but also focus the editor manually so that the cursor shows up, and now that the editor is focused, if the user is holding shift when we update the cursor position again, it selects a whole bunch of code.

So the fix was to stop focusing on the editor, and overriding some of the code-mirror styles so that the cursor is still visible. Note that it does stop blinking, but I think that's okay, maybe even desirable.

Looks like this.

https://user-images.githubusercontent.com/29681384/225240120-87068004-6b03-4a79-9cf6-8f73cc6df5bc.mp4

