### PR TITLE
Creating new sketch calling sketch fns with dumby default values

### DIFF
--- a/src/lang/modifyAst.test.ts
+++ b/src/lang/modifyAst.test.ts
@@ -111,9 +111,9 @@ describe('Testing addSketchTo', () => {
       'yz'
     )
     const str = recast(result.modifiedAst)
-    expect(str).toBe(`const part001 = startSketchAt([0, 0])
+    expect(str).toBe(`const part001 = startSketchAt('default')
   |> ry(90, %)
-  |> lineTo([1, 1], %)
+  |> line('default', %)
 show(part001)`)
   })
 })

--- a/src/lang/modifyAst.ts
+++ b/src/lang/modifyAst.ts
@@ -32,14 +32,14 @@ export function addSketchTo(
   const _name = name || findUniqueName(node, 'part')
 
   const startSketchAt = createCallExpression('startSketchAt', [
-    createArrayExpression([createLiteral(0), createLiteral(0)]),
+    createLiteral('default'),
   ])
   const rotate = createCallExpression(axis === 'xz' ? 'rx' : 'ry', [
     createLiteral(90),
     createPipeSubstitution(),
   ])
-  const initialLineTo = createCallExpression('lineTo', [
-    createArrayExpression([createLiteral(1), createLiteral(1)]),
+  const initialLineTo = createCallExpression('line', [
+    createLiteral('default'),
     createPipeSubstitution(),
   ])
 


### PR DESCRIPTION
https://user-images.githubusercontent.com/29681384/225814798-f89ad95a-8a71-49f0-b579-110d6399deba.mp4

<details>
<summary>transcript

</summary>

0:02
So when, when starting a sketch, after selecting a plane, it put some dummy code in here.

0:10
And it's definitely not the best thing because if you select a tooltip, then you either have to like come and fix this back up to where you want it or delete these lines.

0:21
And so it is really a polished item but trying to make that process a bit better.

0:28
What I've done is when you started again, once you select the plane, it still puts in a default, like start sketch and line, but explicitly called it with this kind of like dummy value of like string, default or literal default.

0:41
And that allows like further modification, the kind of query the S T for like an argument of this, which it kind of expects to replace.

0:50
So if I select line as a tooltip again and I click a few places, the first click, it's gonna, it's going to move the starting place and replace it with these lines.

0:59
And then when I add another line, it's before I add the new line is going to check to see if there's a line with that same default value and then replace it as well.

1:08
And then any clicks after that, it goes back to normal behavior and is adding line.

1:13
So I think that's just a bit better in terms of still putting something there.

1:16
So it looks, you know what's happening where the how to keep continue on.

1:21
But it's also not something you have to then like annoyingly changed later because it just kind of automatically overrides.
</details>

Resolves #66