### PR TITLE
getSketchSegmentIndexFromSourceRange bug fix

### DIFF
--- a/src/lang/std/sketch.ts
+++ b/src/lang/std/sketch.ts
@@ -41,7 +41,7 @@ import {
   findUniqueName,
 } from '../modifyAst'
 import { roundOff, getLength, getAngle } from '../../lib/utils'
-import { getSketchSegmentIndexFromSourceRange } from './sketchConstraints'
+import { getSketchSegmentFromSourceRange } from './sketchConstraints'
 import {
   intersectionWithParallelLine,
   perpendicularDistance,
@@ -1317,7 +1317,7 @@ export function addNewSketchLn({
       node,
       defaultLinePath
     ).node
-    const { from } = getSketchSegmentIndexFromSourceRange(sketch, [
+    const { from } = getSketchSegmentFromSourceRange(sketch, [
       defaultLine.start,
       defaultLine.end,
     ])

--- a/src/lang/std/sketchConstraints.test.ts
+++ b/src/lang/std/sketchConstraints.test.ts
@@ -8,7 +8,7 @@ import {
 } from './sketchcombos'
 import { recast } from '../recast'
 import { initPromise } from '../rust'
-import { getSketchSegmentIndexFromSourceRange } from './sketchConstraints'
+import { getSketchSegmentFromSourceRange } from './sketchConstraints'
 
 beforeAll(() => initPromise)
 
@@ -375,7 +375,7 @@ show(part001)`
   it('normal case works', () => {
     const programMemory = executor(abstractSyntaxTree(lexer(code)))
     const index = code.indexOf('// normal-segment') - 7
-    const { __geoMeta, ...segment } = getSketchSegmentIndexFromSourceRange(
+    const { __geoMeta, ...segment } = getSketchSegmentFromSourceRange(
       programMemory.root['part001'] as SketchGroup,
       [index, index]
     )
@@ -388,7 +388,7 @@ show(part001)`
   it('verify it works when the segment is in the `start` property', () => {
     const programMemory = executor(abstractSyntaxTree(lexer(code)))
     const index = code.indexOf('// segment-in-start') - 7
-    const { __geoMeta, ...segment } = getSketchSegmentIndexFromSourceRange(
+    const { __geoMeta, ...segment } = getSketchSegmentFromSourceRange(
       programMemory.root['part001'] as SketchGroup,
       [index, index]
     )

--- a/src/lang/std/sketchConstraints.ts
+++ b/src/lang/std/sketchConstraints.ts
@@ -8,7 +8,7 @@ import {
 import { SketchGroup } from '../executor'
 import { InternalFn } from './stdTypes'
 
-export function getSketchSegmentIndexFromSourceRange(
+export function getSketchSegmentFromSourceRange(
   sketchGroup: SketchGroup,
   [rangeStart, rangeEnd]: Range
 ): SketchGroup['value'][number] {

--- a/src/lang/std/sketchcombos.ts
+++ b/src/lang/std/sketchcombos.ts
@@ -24,7 +24,7 @@ import {
 } from '../modifyAst'
 import { createFirstArg, getFirstArg, replaceSketchLine } from './sketch'
 import { ProgramMemory } from '../executor'
-import { getSketchSegmentIndexFromSourceRange } from './sketchConstraints'
+import { getSketchSegmentFromSourceRange } from './sketchConstraints'
 import { getAngle, roundOff } from '../../lib/utils'
 
 type LineInputsType =
@@ -1157,12 +1157,9 @@ export function transformAstSketchLines({
     const sketchGroup = programMemory.root?.[varName]
     if (!sketchGroup || sketchGroup.type !== 'sketchGroup')
       throw new Error('not a sketch group')
-    const seg = getSketchSegmentIndexFromSourceRange(sketchGroup, range)
+    const seg = getSketchSegmentFromSourceRange(sketchGroup, range)
     const referencedSegment = referencedSegmentRange
-      ? getSketchSegmentIndexFromSourceRange(
-          sketchGroup,
-          referencedSegmentRange
-        )
+      ? getSketchSegmentFromSourceRange(sketchGroup, referencedSegmentRange)
       : sketchGroup.value.find((path) => path.name === referenceSegName)
     const { to, from } = seg
     const { modifiedAst, valueUsedInTransform } = replaceSketchLine({


### PR DESCRIPTION
It doesn't handle cases where the segment is in the `start` property.

The function wasn't tested directly prior-to as well.

Resolves #74 