### PR TITLE
Add 'remove constraining values' UI

### DIFF
--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -2,6 +2,7 @@ import { useStore, toolTips } from './useStore'
 import { extrudeSketch, sketchOnExtrudedFace } from './lang/modifyAst'
 import { getNodePathFromSourceRange } from './lang/queryAst'
 import { HorzVert } from './components/Toolbar/HorzVert'
+import { RemoveConstrainingValues } from './components/Toolbar/RemoveConstrainingValues'
 import { EqualLength } from './components/Toolbar/EqualLength'
 import { EqualAngle } from './components/Toolbar/EqualAngle'
 import { Intersect } from './components/Toolbar/Intersect'
@@ -170,6 +171,7 @@ export const Toolbar = () => {
       <SetAngleLength angleOrLength="setAngle" />
       <SetAngleLength angleOrLength="setLength" />
       <Intersect />
+      <RemoveConstrainingValues />
     </div>
   )
 }

--- a/src/components/Toolbar/RemoveConstrainingValues.tsx
+++ b/src/components/Toolbar/RemoveConstrainingValues.tsx
@@ -1,0 +1,76 @@
+import { useState, useEffect } from 'react'
+import { toolTips, useStore } from '../../useStore'
+import { Value } from '../../lang/abstractSyntaxTree'
+import {
+  getNodePathFromSourceRange,
+  getNodeFromPath,
+} from '../../lang/queryAst'
+import {
+  TransformInfo,
+  getRemoveConstraintsTransforms,
+  transformAstSketchLines,
+} from '../../lang/std/sketchcombos'
+
+export const RemoveConstrainingValues = () => {
+  const { guiMode, selectionRanges, ast, programMemory, updateAst } = useStore(
+    (s) => ({
+      guiMode: s.guiMode,
+      ast: s.ast,
+      updateAst: s.updateAst,
+      selectionRanges: s.selectionRanges,
+      programMemory: s.programMemory,
+    })
+  )
+  const [enableHorz, setEnableHorz] = useState(false)
+  const [transformInfos, setTransformInfos] = useState<TransformInfo[]>()
+  useEffect(() => {
+    if (!ast) return
+    const paths = selectionRanges.map((selectionRange) =>
+      getNodePathFromSourceRange(ast, selectionRange)
+    )
+    const nodes = paths.map(
+      (pathToNode) => getNodeFromPath<Value>(ast, pathToNode).node
+    )
+    const isAllTooltips = nodes.every(
+      (node) =>
+        node?.type === 'CallExpression' &&
+        toolTips.includes(node.callee.name as any)
+    )
+
+    const theTransforms = getRemoveConstraintsTransforms(
+      selectionRanges,
+      ast,
+      'removeConstrainingValues'
+    )
+    setTransformInfos(theTransforms)
+
+    const _enableHorz = isAllTooltips && theTransforms.every(Boolean)
+    setEnableHorz(_enableHorz)
+  }, [guiMode, selectionRanges])
+  if (guiMode.mode !== 'sketch') return null
+
+  return (
+    <button
+      onClick={() =>
+        transformInfos &&
+        ast &&
+        updateAst(
+          transformAstSketchLines({
+            ast,
+            selectionRanges,
+            transformInfos,
+            programMemory,
+            referenceSegName: '',
+          })?.modifiedAst
+        )
+      }
+      className={`border m-1 px-1 rounded text-xs ${
+        enableHorz ? 'bg-gray-50 text-gray-800' : 'bg-gray-200 text-gray-400'
+      }`}
+      disabled={!enableHorz}
+      title="yo dawg"
+    >
+      RemoveConstrainingValues
+    </button>
+  )
+}

--- a/src/lang/std/sketch.ts
+++ b/src/lang/std/sketch.ts
@@ -1666,7 +1666,10 @@ function getFirstArgValuesForXYLineFns(callExpression: CallExpression): {
   if (length) {
     return { val: length, tag }
   }
-  throw new Error('expected ArrayExpression or ObjectExpression')
+  console.warn('expected ArrayExpression or ObjectExpression')
+  return {
+    val: createLiteral(1),
+  }
 }
 
 const getAngledLineThatIntersects = (


### PR DESCRIPTION
Resolves #79

https://user-images.githubusercontent.com/29681384/226665689-74ac47d5-fc58-4afc-876d-4ef25ad48dc1.mp4

<details>
<summary>Transcipt</summary>

0:00
It should be a pretty quick demo.

0:02
So with the ability to add constraints at some point, it's going to be convenient to be able to remove them or annoying, not to be able to remove them easily.

0:11
So Reuben constraints just basically comes down to removing any variable uses or any kind of like anything that's not a literal in a in one of these line function calls.

0:22
So as an example, like let's say we have this line and we can train it to be horizontal, I should show what actually happened there just to be clear.

0:34
So this is just like a line call with two literal values and if I go horizontal and it becomes an X line, so it's now constrained to only be horizontal because there is no Y component whatsoever.

0:46
Now, if I change my mind, I want to drag this somewhere else, it's not constrained.

0:50
I can just hit this removed, constraining value and change it back to a line with hard coded values.

0:55
And so I can drag it now and maybe I in fact wanted it to be vertical and that can be done.

1:02
So that's it in a nutshell.

1:05
And I guess like the extreme example is this, so this is a fully constrained sketch by the green.

1:11
There's like variables used in like every part of these lines or variables or equations, which is how it interprets it.

1:18
This is a constraint.

1:22
So the extreme example is if I go through and just select every single one of these lines, yeah.

1:38
And then when we hit remove constraining values, you should see them all collapse into just simple, like calls.

1:44
But the actual actual sketch doesn't change.

1:47
It's just that now I can come and edit these when, before you know, these, I could not like it wouldn't let me drag any of these anyway.

1:58
Cool.
</details>
