### PR TITLE
Fix equal length sign bug for yLines

### DIFF
--- a/src/lang/std/sketchcombos.ts
+++ b/src/lang/std/sketchcombos.ts
@@ -126,6 +126,7 @@ const xyLineSetLength =
       : referenceSeg
       ? segRef
       : args[0]
+    // console.log({ lineVal, segRef, forceValueUsedInTransform, args })
     return createCallWrapper(xOrY, lineVal, tag, getArgLiteralVal(args[0]))
   }
 
@@ -894,8 +895,12 @@ const transformMap: TransformMap = {
         tooltip: 'yLine',
         createNode:
           ({ referenceSegName, tag }) =>
-          () =>
-            createCallWrapper('yLine', createSegLen(referenceSegName), tag),
+          (arg) => {
+            const argVal = getArgLiteralVal(arg[0])
+            let segLen = createSegLen(referenceSegName) as BinaryPart
+            if (argVal < 0) segLen = createUnaryExpression(segLen)
+            return createCallWrapper('yLine', segLen, tag, argVal)
+          },
       },
       setLength: {
         tooltip: 'yLine',


### PR DESCRIPTION
If you have a `yLine(-5,  %)` i.e. it's values is negative `-5` than when constraining it to the length of another line, it should take the sign into account and transform it to `yLine(-segLen('someSeg', %), %)`, currently it always does it positively i.e. `yLine(segLen('someSeg', %), %)` which is jaring for users to see the line they are constraining to flip direction.

Resolves #90