### PR TITLE
Grid axis should be able to be selected for angles

### DIFF
--- a/src/components/Toolbar/ConvertVariable.tsx
+++ b/src/components/Toolbar/ConvertVariable.tsx
@@ -23,7 +23,7 @@ export const ConvertToVariable = () => {
 
     const { isSafe, value } = isNodeSafeToReplace(
       ast,
-      selectionRanges.codeBasedSelections[0].range
+      selectionRanges.codeBasedSelections?.[0]?.range || []
     )
     const canReplace = isSafe && value.type !== 'Identifier'
     const isOnlyOneSelection = selectionRanges.codeBasedSelections.length === 1

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,6 +20,10 @@ export function getLength(a: [number, number], b: [number, number]): number {
 export function getAngle(a: [number, number], b: [number, number]): number {
   const x = b[0] - a[0]
   const y = b[1] - a[1]
-  const result = ((Math.atan2(y, x) * 180) / Math.PI + 360) % 360
+  return normaliseAngle((Math.atan2(y, x) * 180) / Math.PI)
+}
+
+export function normaliseAngle(angle: number): number {
+  const result = ((angle % 360) + 360) % 360
   return result > 180 ? result - 360 : result
 }


### PR DESCRIPTION
related to #98

https://user-images.githubusercontent.com/29681384/229485045-5ad09db6-1c4a-4384-a6af-c13423f0f402.mp4

<details>
<summary>Transcript</summary>

0:00
So I've recently added the ability to select axis in sketches.

0:04
So that's like these guys here.

0:07
Now, these are going to be very useful for things like the distance and select vertical distance.

0:13
But for now, it's just for angles.

0:15
And the basic use case that I've got going is it allows you to select an axis and therefore define an angle in terms of the smallest angle.

0:24
So this very basic example here, if I, by default, if I hit set angle, it's always based off the X axis and it's always like always from this like the line going out to the right going counterclockwise or up to 100 and 80 and then you get start getting negative numbers.

0:47
So if I drag this out here, you're gonna get quite a large number of sonic approaching 100 and 80 degrees.

0:52
But that's kind of unintuitive.

0:53
People do don't usually think of angles in that way.

0:56
So selecting the line and an AIS allows us to find it in the small term, the small.

1:02
So that's 12°. It's actually negative 12.

1:05
But that's simply because if you go from the axis to the line, it's in a negative direction.

1:10
But I can do the same thing, but you can see it's, it's it's not hiding any magic behind it.

1:15
It's not like referencing some access, it's just adding a quick and dirty 180 degrees plus 12.

1:23
So if I do a similar thing for the Y axis, this here by default, using the old method is going to be something around 100 100 and 15, maybe degrees.

1:34
But if I want it just, in terms of the small angle coming off the Y axis, I can hit this, this time, it will be positive because it's going in the 10 wise direction I can hit that and it's just giving me sort of 19 degrees between these two.

1:48
Yes.

</details>