### PR TITLE
Select axis for horz/vert distances

### DIFF
--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -6,9 +6,10 @@ import { RemoveConstrainingValues } from './components/Toolbar/RemoveConstrainin
 import { EqualLength } from './components/Toolbar/EqualLength'
 import { EqualAngle } from './components/Toolbar/EqualAngle'
 import { Intersect } from './components/Toolbar/Intersect'
-import { SetHorzDistance } from './components/Toolbar/SetHorzDistance'
+import { SetHorzVertDistance } from './components/Toolbar/SetHorzVertDistance'
 import { SetAngleLength } from './components/Toolbar/SetAngleLength'
 import { ConvertToVariable } from './components/Toolbar/ConvertVariable'
+import { SetAbsDistance } from './components/Toolbar/SetAbsDistance'
 
 export const Toolbar = () => {
   const {
@@ -169,8 +170,10 @@ export const Toolbar = () => {
       <HorzVert horOrVert="vertical" />
       <EqualLength />
       <EqualAngle />
-      <SetHorzDistance horOrVert="setHorzDistance" />
-      <SetHorzDistance horOrVert="setVertDistance" />
+      <SetHorzVertDistance horOrVert="setHorzDistance" />
+      <SetAbsDistance disType="xAbs" />
+      <SetHorzVertDistance horOrVert="setVertDistance" />
+      <SetAbsDistance disType="yAbs" />
       <SetAngleLength angleOrLength="setAngle" />
       <SetAngleLength angleOrLength="setLength" />
       <Intersect />

--- a/src/components/Toolbar/SetAbsDistance.tsx
+++ b/src/components/Toolbar/SetAbsDistance.tsx
@@ -1,0 +1,123 @@
+import { useState, useEffect } from 'react'
+import { create } from 'react-modal-promise'
+import { toolTips, useStore } from '../../useStore'
+import { Value } from '../../lang/abstractSyntaxTree'
+import {
+  getNodePathFromSourceRange,
+  getNodeFromPath,
+} from '../../lang/queryAst'
+import {
+  TransformInfo,
+  getTransformInfos,
+  transformAstSketchLines,
+} from '../../lang/std/sketchcombos'
+import { SetAngleLengthModal } from '../SetAngleLengthModal'
+import { createVariableDeclaration } from '../../lang/modifyAst'
+import { removeDoubleNegatives } from '../AvailableVarsHelpers'
+
+const getModalInfo = create(SetAngleLengthModal as any)
+
+export const SetAbsDistance = ({ disType }: { disType: 'xAbs' | 'yAbs' }) => {
+  const {
+    guiMode,
+    selectionRanges: selections,
+    ast,
+    programMemory,
+    updateAst,
+  } = useStore((s) => ({
+    guiMode: s.guiMode,
+    ast: s.ast,
+    updateAst: s.updateAst,
+    selectionRanges: s.selectionRanges,
+    programMemory: s.programMemory,
+  }))
+  const [enableAngLen, setEnableAngLen] = useState(false)
+  const [transformInfos, setTransformInfos] = useState<TransformInfo[]>()
+  useEffect(() => {
+    if (!ast) return
+    const paths = selections.codeBasedSelections.map(({ range }) =>
+      getNodePathFromSourceRange(ast, range)
+    )
+    const nodes = paths.map(
+      (pathToNode) =>
+        getNodeFromPath<Value>(ast, pathToNode, 'CallExpression').node
+    )
+    const isAllTooltips = nodes.every(
+      (node) =>
+        node?.type === 'CallExpression' &&
+        toolTips.includes(node.callee.name as any)
+    )
+
+    const theTransforms = getTransformInfos(selections, ast, disType)
+    setTransformInfos(theTransforms)
+
+    const enableY =
+      disType === 'yAbs' &&
+      selections.otherSelections.length === 1 &&
+      selections.otherSelections[0] === 'x-axis' // select the x axis to set the distance from it i.e. y
+    const enableX =
+      disType === 'xAbs' &&
+      selections.otherSelections.length === 1 &&
+      selections.otherSelections[0] === 'y-axis' // select the y axis to set the distance from it i.e. x
+
+    const _enableHorz =
+      isAllTooltips &&
+      theTransforms.every(Boolean) &&
+      selections.codeBasedSelections.length === 1 &&
+      (enableX || enableY)
+    setEnableAngLen(_enableHorz)
+  }, [guiMode, selections])
+  if (guiMode.mode !== 'sketch') return null
+
+  return (
+    <button
+      onClick={async () => {
+        if (!(transformInfos && ast)) return
+        const { valueUsedInTransform } = transformAstSketchLines({
+          ast: JSON.parse(JSON.stringify(ast)),
+          selectionRanges: selections,
+          transformInfos,
+          programMemory,
+          referenceSegName: '',
+        })
+        try {
+          let forceVal = valueUsedInTransform || 0
+          const { valueNode, variableName, newVariableInsertIndex, sign } =
+            await getModalInfo({
+              value: forceVal,
+              valueName: disType === 'yAbs' ? 'yDis' : 'xDis',
+            } as any)
+          let finalValue = removeDoubleNegatives(valueNode, sign, variableName)
+
+          const { modifiedAst: _modifiedAst } = transformAstSketchLines({
+            ast: JSON.parse(JSON.stringify(ast)),
+            selectionRanges: selections,
+            transformInfos,
+            programMemory,
+            referenceSegName: '',
+            forceValueUsedInTransform: finalValue,
+          })
+          if (variableName) {
+            const newBody = [..._modifiedAst.body]
+            newBody.splice(
+              newVariableInsertIndex,
+              0,
+              createVariableDeclaration(variableName, valueNode)
+            )
+            _modifiedAst.body = newBody
+          }
+
+          updateAst(_modifiedAst)
+        } catch (e) {
+          console.log('e', e)
+        }
+      }}
+      className={`border m-1 px-1 rounded text-xs ${
+        enableAngLen ? 'bg-gray-50 text-gray-800' : 'bg-gray-200 text-gray-400'
+      }`}
+      disabled={!enableAngLen}
+    >
+      {disType}
+    </button>
+  )
+}

--- a/src/components/Toolbar/SetHorzVertDistance.tsx
+++ b/src/components/Toolbar/SetHorzVertDistance.tsx
@@ -25,7 +25,7 @@ import { removeDoubleNegatives } from '../AvailableVarsHelpers'
 
 const getModalInfo = create(GetInfoModal as any)
 
-export const SetHorzDistance = ({
+export const SetHorzVertDistance = ({
   horOrVert,
 }: {
   horOrVert: 'setHorzDistance' | 'setVertDistance'


### PR DESCRIPTION
Resolves #101


https://user-images.githubusercontent.com/29681384/229985022-04c6eb8d-8b53-4473-b81f-7aca24b6fd0b.mp4


<details>
<summary>Transcript</summary>

0:00
A should be a quick one.

0:02
So previously, when you wanted to set the horizontal vertical distance, you'd have to select two parts of the sketch.

0:07
So for example, if I select this starting point and this line here, I can now set the vertical distance.

0:13
So let's say I want that to be two of this total half height, I can do so to get set.

0:19
But if you just want to set something in like an absolute value or in relation to one of the axis, you couldn't do that.

0:25
So now you can, so by selecting the line and the axis there is like for example, y absolute and I can set that to maybe this minus this and happy days it works.

0:37
Now it's a little bit Janky, let me just undo that.

0:40
I don't intend it to long term, be a different button like this really should be the same as like set vertical distance, but it's just kind of easier to throw it in a new button and get the functionality there and we can combine them quite easily soon.

</details