### PR TITLE
Automatically create variable for setAngle and setLength

### DIFF
--- a/src/components/SetAngleLengthModal.tsx
+++ b/src/components/SetAngleLengthModal.tsx
@@ -15,6 +15,7 @@ export const SetAngleLengthModal = ({
   onReject,
   value: initialValue,
   valueName,
+  shouldCreateVariable: initialShouldCreateVariable = false,
 }: {
   isOpen: boolean
   onResolve: (a: {
@@ -27,10 +28,13 @@ export const SetAngleLengthModal = ({
   onReject: (a: any) => void
   value: number
   valueName: string
+  shouldCreateVariable: boolean
 }) => {
   const [sign, setSign] = useState(Math.sign(Number(initialValue)))
   const [value, setValue] = useState(String(initialValue * sign))
-  const [shouldCreateVariable, setShouldCreateVariable] = useState(false)
+  const [shouldCreateVariable, setShouldCreateVariable] = useState(
+    initialShouldCreateVariable
+  )
 
   const {
     prevVariables,

--- a/src/components/Toolbar/SetAngleLength.tsx
+++ b/src/components/Toolbar/SetAngleLength.tsx
@@ -103,6 +103,7 @@ export const SetAngleLength = ({
             await getModalInfo({
               value: forceVal,
               valueName: angleOrLength === 'setAngle' ? 'angle' : 'length',
+              shouldCreateVariable: true,
             } as any)
           let finalValue = removeDoubleNegatives(valueNode, sign, variableName)
           if (


### PR DESCRIPTION
Resolves #107

When setting length or angle without adding a variable, the segment will not be "constrained" since it will be left with a literal.
Maybe there's a better long term UX for this situation but this is a easy fix for now.