### PR TITLE
Mute stream by default for autoplay

### DIFF
--- a/src/components/Stream.tsx
+++ b/src/components/Stream.tsx
@@ -49,6 +49,7 @@ export const Stream = () => {
             if (videoRef.current) {
               videoRef.current.srcObject = event.streams[0]
               videoRef.current.autoplay = true
+              videoRef.current.muted = true
               videoRef.current.controls = false
             }
           }


### PR DESCRIPTION
Apparently some browsers don't play by default unless it's muted, we don't have any audio so this is totally acceptable to us.