### PR TITLE
Add support for camera Pan

### DIFF
--- a/src/components/Stream.tsx
+++ b/src/components/Stream.tsx
@@ -31,17 +31,20 @@ export const Stream = () => {
   const handleMouseMove: MouseEventHandler<HTMLVideoElement> = ({
     clientX,
     clientY,
+    ctrlKey,
   }) => {
     if (!videoRef.current) return
     if (!cmdId.current) return
     const { left, top } = videoRef.current.getBoundingClientRect()
     const x = clientX - left
     const y = clientY - top
+    const interaction = ctrlKey ? 'pan' : 'rotate'
+
     debounceSocketSend({
       type: 'ModelingCmdReq',
       cmd: {
         CameraDragMove: {
-          interaction: 'rotate',
+          interaction,
           window: {
             x: x,
             y: y,
@@ -56,6 +59,7 @@ export const Stream = () => {
   const handleMouseDown: MouseEventHandler<HTMLVideoElement> = ({
     clientX,
     clientY,
+    ctrlKey,
   }) => {
     if (!videoRef.current) return
     const { left, top } = videoRef.current.getBoundingClientRect()
@@ -66,11 +70,13 @@ export const Stream = () => {
     const newId = uuidv4()
     cmdId.current = newId
 
+    const interaction = ctrlKey ? 'pan' : 'rotate'
+
     engineCommandManager?.sendSceneCommand({
       type: 'ModelingCmdReq',
       cmd: {
         CameraDragStart: {
-          interaction: 'rotate',
+          interaction,
           window: {
             x: x,
             y: y,
@@ -84,6 +90,7 @@ export const Stream = () => {
   const handleMouseUp: MouseEventHandler<HTMLVideoElement> = ({
     clientX,
     clientY,
+    ctrlKey,
   }) => {
     if (!videoRef.current) return
     const { left, top } = videoRef.current.getBoundingClientRect()
@@ -94,11 +101,13 @@ export const Stream = () => {
       return
     }
 
+    const interaction = ctrlKey ? 'pan' : 'rotate'
+
     engineCommandManager?.sendSceneCommand({
       type: 'ModelingCmdReq',
       cmd: {
         CameraDragEnd: {
-          interaction: 'rotate',
+          interaction,
           window: {
             x: x,
             y: y,
@@ -123,6 +132,8 @@ export const Stream = () => {
         onMouseDown={handleMouseDown}
         onMouseUp={handleMouseUp}
         onMouseLeave={handleMouseUp}
+        onContextMenu={(e) => e.preventDefault()}
+        onContextMenuCapture={(e) => e.preventDefault()}
       />
     </div>
   )

--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -30,7 +30,7 @@ interface CursorSelectionsArgs {
 
 // TODO these types should be in the openApi spec, and therefore in @kittycad/lib
 interface MouseStuff {
-  interaction: 'rotate'
+  interaction: 'rotate' | 'pan' | 'zoom'
   window: {
     x: number
     y: number


### PR DESCRIPTION
Very small PR, just adds the ability to hold the `Ctrl` key while clicking and dragging to pan instead of rotating. Thanks @Irev-Dev for showing me how to look in the [types.rs file](https://github.com/KittyCAD/common/blob/main/src/types.rs#L6102).

I didn't feel confident adding support for Zoom for two reasons:
1. There isn't an equivalent "start-move-end" set of events for scrolling in the browsers, so I think detecting "start" and "end" of scroll for Zoom will require more state management on our side. There is a new [`scrollend` event](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollend_event), but it doesn't have Safari support yet.
2. It's not clear to me how to determine the current zoom level or increment/decrement that value, because the CameraDragMove command only takes a 2D point.