### PR TITLE
Adjust config to open localhost

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,15 @@
 import react from '@vitejs/plugin-react'
 import viteTsconfigPaths from 'vite-tsconfig-paths'
 import eslint from 'vite-plugin-eslint'
+import dns from 'dns'
+import { defineConfig } from 'vite'
 
-const config = {
+// Only needed because we run Node < 17 
+// and we want to open `localhost` not `127.0.0.1` on server start
+// reference: https://vitejs.dev/config/server-options.html#server-host
+dns.setDefaultResultOrder('verbatim')
+
+const config = defineConfig({
   server: {
     open: true,
     port: 3000,
@@ -15,6 +22,6 @@ const config = {
     viteTsconfigPaths(),
     eslint(),
   ],
-}
+})
 
 export default config


### PR DESCRIPTION
Small PR to configure Vite to open with `localhost:3000` instead of `127.0.0.1:3000`, following [this guidance from the Vite docs](https://vitejs.dev/config/server-options.html#server-host).