### PR TITLE
Tweak default value for onboardingStatus

### DIFF
--- a/src/useStore.ts
+++ b/src/useStore.ts
@@ -331,7 +331,7 @@ export const useStore = create<StoreState>()(
       setDefaultUnitSystem: (defaultUnitSystem) => set({ defaultUnitSystem }),
       defaultBaseUnit: 'in',
       setDefaultBaseUnit: (defaultBaseUnit) => set({ defaultBaseUnit }),
-      onboardingStatus: 'new',
+      onboardingStatus: '',
       setOnboardingStatus: (onboardingStatus) => set({ onboardingStatus }),
       showHomeMenu: true,
       setHomeShowMenu: (showHomeMenu) => set({ showHomeMenu }),


### PR DESCRIPTION
I had the initial value of `onboardingStatus` defaulting to `"new"`, and thanks to our onboarding routing system this is leading to a `404` as users are sent to the `/onboarding/new` route that doesn't exist.