### PR TITLE
Fix use of useDismiss in onboarding

### DIFF
--- a/src/routes/Onboarding/index.tsx
+++ b/src/routes/Onboarding/index.tsx
@@ -53,7 +53,8 @@ export function useDismiss() {
 }
 
 const Onboarding = () => {
-  useHotkeys('esc', useDismiss)
+  const dismiss = useDismiss()
+  useHotkeys('esc', dismiss)
 
   return (
     <>


### PR DESCRIPTION
I broke out the dismissal functionality to a custom hook, but failed to change how I was calling it in the original case, breaking the `Esc` keyboard functionality.