### PR TITLE
Allow Prettier to format JS generated in wasm projects

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,4 +3,5 @@ build
 coverage
 
 # Ignore Rust projects:
-src/wasm-lib
+*.rs
+target


### PR DESCRIPTION
Right now I'm getting ESLint errors because wasm-lib generates a JS project with semicolons. This didn't use to matter, because `yarn prettier` applied to the Rust projects too. But in my recent PR https://github.com/KittyCAD/untitled-lang/pull/192 I broke that.

This should fix it by ensuring the generated JS code gets formatted in a way that matches our ESLint requirements.