### PR TITLE
Add trickle_ice back

### DIFF
--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -114,7 +114,7 @@ export class EngineCommandManager {
           if (message.ice_servers.length > 0) {
             this.pc?.setConfiguration({
               iceServers: message.ice_servers,
-              iceTransportPolicy: "relay",
+              iceTransportPolicy: 'relay',
             })
           } else {
             this.pc?.setConfiguration({})
@@ -139,14 +139,14 @@ export class EngineCommandManager {
                 })
               )
             } else {
-              console.log("sending trickle ice candidate")
-              const {
-                candidate
-              } = event
-              this.socket?.send(JSON.stringify({
-                type: "trickle_ice",
-                candidate: candidate.toJSON(),
-              }))
+              console.log('sending trickle ice candidate')
+              const { candidate } = event
+              this.socket?.send(
+                JSON.stringify({
+                  type: 'trickle_ice',
+                  candidate: candidate.toJSON(),
+                })
+              )
             }
           })
 


### PR DESCRIPTION
This disappeared at some point, but we definitely want to use trickle ice as it's _much_ faster and every browser supports it. We could make it work without trickle ice, but the flow is a bit different, i.e. we don't send an sdp offer right away, we wait until candidates are gathered to do that instead.