### PR TITLE
Bump to 0.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "untitled-app",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.4.2",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "kittycad-modeling-app",
-    "version": "0.0.3"
+    "version": "0.0.4"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
Tentative changelog (generated from `git log --oneline` plus quick formatting)
```
- Signed Auto-Updates and CI Reorg
- Generate ts types from rust
- Fix serialization of errors to client errors 
- Fix lint warnings 
- Remove redundant error-to-string fn 
- Start a refactor of the connection to the Engine 
- Rust style + performance tweaks 
- Allow warning banner to be dismissed 
- Fix export types 
- Better UI theme colors, onboarding dismiss, Export button in sidebar 
- Port abstractSyntaxtTree (the Parser) to Rust/WASM 🦀  
- Update README
- Add in a note about Third-Party cookies in Chrome 
- Add 'Request a feature' links 
- Home page in desktop, separate file support 
```

Will help test the update release process from #231 

---

Reminder of what the process is:
https://github.com/KittyCAD/modeling-app/blob/main/README.md#L75-L88

> 
> 1. Bump the versions in the .json files by creating a `Bump to v{x}.{y}.{z}` PR, committing the changes from
> 
> ```bash
> VERSION=x.y.z yarn run bump-jsons
> ```
> The PR may serve as a place to discuss the human-readable changelog and extra QA.
> 
> 2. Merge the PR
> 
> 3. Create a new release and tag pointing to the bump version commit using semantic versioning `v{x}.{y}.{z}`
> 
> 4. A new Action kicks in at https://github.com/KittyCAD/modeling-app/actions, uploading artifacts to the release