### PR TITLE
Clean up after a closed EngineConnection

### DIFF
--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -314,6 +314,9 @@ export class EngineConnection extends EventTarget {
     this.websocket?.close()
     this.pc?.close()
     this.lossyDataChannel?.close()
+    this.websocket = undefined
+    this.pc = undefined
+    this.lossyDataChannel = undefined
 
     this.dispatchEvent(
       new CustomEvent(EngineConnectionEvents.Close, {
@@ -375,7 +378,7 @@ export class EngineCommandManager {
     this.engineConnection.addEventListener(
       EngineConnectionEvents.ConnectionStarted,
       (event: Event) => {
-        let customEvent = <CustomEvent<EngineConnection>>event
+        let customEvent = event as CustomEvent<EngineConnection>
         let conn = customEvent.detail
 
         this.engineConnection?.pc?.addEventListener('datachannel', (event) => {
@@ -421,7 +424,7 @@ export class EngineCommandManager {
     this.engineConnection.addEventListener(
       EngineConnectionEvents.NewTrack,
       (event: Event) => {
-        let customEvent = <CustomEvent<NewTrackArgs>>event
+        let customEvent = event as CustomEvent<NewTrackArgs>
 
         let mediaStream = customEvent.detail.mediaStream
         console.log('received track', mediaStream)


### PR DESCRIPTION
Because we gate a lot of things off this.foo?, leaving the closed websocket/pc/etc in-place was causing a noisy log, and mucking with reestablishing a broken connection.

While I was in here, I fixed a style nit from yarn.