### PR TITLE
Track the connection time in the console

### DIFF
--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -268,6 +268,10 @@ export class EngineConnection extends EventTarget {
       )
     })
 
+    // During startup, we'll track the time from `connect` being called
+    // until the 'done' event fires.
+    let connectionStarted = new Date()
+
     this.pc.addEventListener('datachannel', (event) => {
       this.lossyDataChannel = event.channel
 
@@ -281,6 +285,8 @@ export class EngineConnection extends EventTarget {
           })
         )
 
+        let timeToConnectMs = new Date().getTime() - connectionStarted.getTime()
+        console.log(`engine connection time to connect: ${timeToConnectMs}ms`)
         this.dispatchEvent(
           new CustomEvent(EngineConnectionEvents.Open, {
             detail: this,


### PR DESCRIPTION
In the future, this should be sent as telemetry, but at least this would give us a bit of info about the latency sitatuion locally if we start seeing the refresh happen a lot.