### PR TITLE
Bump to v0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "untitled-app",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.4.2",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "kittycad-modeling-app",
-    "version": "0.0.4"
+    "version": "0.1.0"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
Would like to move to the next minor if alright with y'all? Keeping the third decimal for patches

Also hoping to test the updater on official builds.

Changelog generated from git log
```
- Add isReducedMotion util
- Docs macros
- Bump rust types
- Fix up message structure to match the new Engine messages
- Cleanup code we are no longer using 
- Port executor
- Fix typo in function name, cleanup unused args
- Remove EventTarget from EngineConnection
- Refactor engine connection to use callbacks
- Update for types only kittycad.rs
- Make the timeout for a WebRTC/WebSocket connection pair configurable
- Track the connection time in the console
- Detect when a video stream fails from the server
- Clean up after a closed EngineConnection
- Test parse errors are thrown
- Build out EngineConnection's retry and timeout logic
```