### PR TITLE
bugfix: don't show a toast when onboarding changes

### DIFF
--- a/src/machines/settingsMachine.ts
+++ b/src/machines/settingsMachine.ts
@@ -154,7 +154,6 @@ export const settingsMachine = createMachine(
                 onboardingStatus: (_, event) => event.data.onboardingStatus,
               }),
               'persistSettings',
-              'toastSuccess',
             ],
             target: 'idle',
             internal: true,

--- a/src/machines/settingsMachine.typegen.ts
+++ b/src/machines/settingsMachine.typegen.ts
@@ -25,7 +25,6 @@ export interface Typegen0 {
       | 'Set Base Unit'
       | 'Set Default Directory'
       | 'Set Default Project Name'
-      | 'Set Onboarding Status'
       | 'Set Theme'
       | 'Set Unit System'
       | 'Toggle Debug Panel'


### PR DESCRIPTION
Very minor little UX bug: when dismissing or replaying the onboarding, a toast appears announcing `Set Onboarding Status to "dismissed"` appeared, because in my state machine definition I had that setting also use the `toastSuccess` action..

Incidentally @Irev-Dev this is a testament to how useful XState will be. Turning on and off actions at any point in any of the machines is soo much easier with this mental model than hunting down why a toast popped up somewhere random. I'm really happy with that.