### PR TITLE
Bump to v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "untitled-app",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.4.2",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "kittycad-modeling-app",
-    "version": "0.1.0"
+    "version": "0.2.0"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
Tentative changelog

```
- Wrap await in try/catch to fix sign-in in tauri builds
- Bump kittycad.rs
- Fmt and move error stuff locally
- Change name for initial publish to cargo
- Bugfix: don't show a toast when onboarding changes
- Refactor to just CommandBar and GlobalState
- Add Ctrl/Cmd+K bar
- Fix export and prepare for cli lib
```