### PR TITLE
Redo how Spans are used from the Engine

### DIFF
--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -27,16 +27,6 @@ export interface SourceRangeMap {
   [key: string]: SourceRange
 }
 
-// interface SelectionsArgs {
-//   id: string
-//   type: Selections['codeBasedSelections'][number]['type']
-// }
-
-// interface CursorSelectionsArgs {
-//   otherSelections: Selections['otherSelections']
-//   idBasedSelections: { type: string; id: string }[]
-// }
-
 interface NewTrackArgs {
   conn: EngineConnection
   mediaStream: MediaStream


### PR DESCRIPTION
I don't like all the Sentry-specific stuff we've got to work around, and I want to add a bunch more spans and more cleanly end the transaction.

This isn't generic enough to pull out of this code (yet?), but we clearly need some class of abstraction due to the highly async pattern in the WebRTC code.

I want to add in more tags, but there are a lot of events we need to wait on. I'd like to hook into the <video> 'play' eventListener, but it's hard to do from all the way down in the Engine.