### PR TITLE
remove excessive serialisation

### DIFF
--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -490,10 +490,12 @@ export class EngineConnection {
 
     this.onConnectionStarted(this)
   }
-  send(message: object) {
+  send(message: object | string) {
     // TODO(paultag): Add in logic to determine the connection state and
     // take actions if needed?
-    this.websocket?.send(JSON.stringify(message))
+    this.websocket?.send(
+      typeof message === 'string' ? message : JSON.stringify(message)
+    )
   }
   close() {
     this.websocket?.close()
@@ -779,7 +781,7 @@ export class EngineCommandManager {
   }: {
     id: string
     range: SourceRange
-    command: EngineCommand
+    command: EngineCommand | string
   }): Promise<any> {
     this.sourceRangeMap[id] = range
 
@@ -816,10 +818,9 @@ export class EngineCommandManager {
     if (commandStr === undefined) {
       throw new Error('commandStr is undefined')
     }
-    const command: EngineCommand = JSON.parse(commandStr)
     const range: SourceRange = JSON.parse(rangeStr)
 
-    return this.sendModelingCommand({ id, range, command })
+    return this.sendModelingCommand({ id, range, command: commandStr })
   }
   commandResult(id: string): Promise<any> {
     const command = this.artifactMap[id]


### PR DESCRIPTION
The rust executor serialises it's engine commands to get them across the wasm-js barrier, it then gets deserialised, before finally being serialised again to get sent over the websocket.
the `sendModelingCommand` method takes `id`, `range` and the `command`, and while the range does need to be deserialized as it's used for the id-range map, the command can be passed straight through to the websocket-send.

This should be considered a temporary optimization because `engineConnection.ts` is likely to be ported to rust anyway.