### PR TITLE
Bump to v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "untitled-app",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.4.2",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "kittycad-modeling-app",
-    "version": "0.2.0"
+    "version": "0.3.0"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
Changelog from git commits
```
- Disable high dpi video streaming
- Upload release artifacts to the release (on top of dl.kittycad.io)
- Messing around with arc and bezier
- Revert mute-reset behavior
- Don't fetch for user if in dev with a local engine
- Bump kitty lib
- Redo how Spans are used from the Engine
- Fix onboarding units
- Expandable toolbar
- Live system theme
- Only show the Replay Onboarding button in file settings
- Add subtle transitions to sidebars
- Tweak text constrast, blinking cursor
- Remove excessive serialisation
- Rename lossy to unreliable
- Refactor callbacks
- Start to clean up Sentry now that the app is back up again.
- Update production Sentry values
- Add in Sentry, WebRTC Statistics
```