### PR TITLE
Add macOS universal release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,54 +147,6 @@ jobs:
           path: ${{ matrix.os == 'macos-latest' && 'src-tauri/target/universal-apple-darwin/release/bundle/*/*' || 'src-tauri/target/release/bundle/*/*' }}
 
 
-  to-remove-publish-apps-release:
-    runs-on: ubuntu-20.04
-    needs: [build-test-web, build-apps]
-    env:
-      VERSION_NO_V: ${{ needs.build-test-web.outputs.version }}
-    steps:
-
-      - uses: actions/download-artifact@v3
-
-      - name: Generate the update static endpoint
-        run: |
-          ls -l artifact/*/*itty*
-          DARWIN_SIG=`cat artifact/macos/*.app.tar.gz.sig`
-          LINUX_SIG=`cat artifact/appimage/*.AppImage.tar.gz.sig`
-          WINDOWS_SIG=`cat artifact/nsis/*.nsis.zip.sig`
-          RELEASE_DIR=https://dl.kittycad.io/releases/modeling-app/v${VERSION_NO_V}
-          jq --null-input \
-            --arg version "v${VERSION_NO_V}" \
-            --arg darwin_sig "$DARWIN_SIG" \
-            --arg darwin_url "$RELEASE_DIR/macos/KittyCAD%20Modeling.app.tar.gz" \
-            --arg linux_sig "$LINUX_SIG" \
-            --arg linux_url "$RELEASE_DIR/appimage/kittycad-modeling_${VERSION_NO_V}_amd64.AppImage.tar.gz" \
-            --arg windows_sig "$WINDOWS_SIG" \
-            --arg windows_url "$RELEASE_DIR/nsis/KittyCAD%20Modeling_${VERSION_NO_V}_x64-setup.nsis.zip" \
-            '{
-              "version": $version,
-              "platforms": {
-                "darwin-x86_64": {
-                  "signature": $darwin_sig,
-                  "url": $darwin_url
-                },
-                "darwin-aarch64": {
-                  "signature": $darwin_sig,
-                  "url": $darwin_url
-                },
-                "linux-x86_64": {
-                  "signature": $linux_sig,
-                  "url": $linux_url
-                },
-                "windows-x86_64": {
-                  "signature": $windows_sig,
-                  "url": $windows_url
-                }
-              }
-            }' > last_update.json
-            cat last_update.json
-
-
   publish-apps-release:
     runs-on: ubuntu-20.04
     if: github.event_name == 'release'


### PR DESCRIPTION
Fixes #397

Based on @jessfraz' work! Great find this is awesome.

Since the target you picked was already macOS Universal, which contains both x86_64 and aarch64, I changed the workflow to only build and release that, since it will run natively on both Intel and Apple Silicon macs.

I think for large apps it makes sense to distribute both targets instead of going universal, but for us the bundle size went from 15MB uncompressed to 30MB, and I don't think this is an issue at all. Better yet, the user can't pick wrong!

![image](https://github.com/KittyCAD/modeling-app/assets/10795683/d1c33a3e-2cc9-4bc1-b6cb-29f0e15a408c)
