### PR TITLE
Bump to v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "untitled-app",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "private": true,
   "dependencies": {
     "@codemirror/autocomplete": "^6.9.0",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "kittycad-modeling",
-    "version": "0.3.2"
+    "version": "0.4.0"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
Changelog
```
- Add macOS universal release builds
- More tests (fuzz)
- Remove noisy log
- Implement rename
- Remove rust tests in ci, already covered in build
- Fix LSP tooltip cutoff, style hover/autocomplete tooltips, add text wrapping setting
- Tweak prettierignore
- Break up ci
- Bump kitty lib
- Allow people to set format options
```