### PR TITLE
Guard Promise resolution with a shouldTrace()

### DIFF
--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -193,15 +193,17 @@ export class EngineConnection {
         )
       }
 
-      Promise.all([
-        handshakeSpan.promise,
-        iceSpan.promise,
-        dataChannelSpan.promise,
-        mediaTrackSpan.promise,
-      ]).then(() => {
-        console.log('All spans finished, reporting')
-        webrtcMediaTransaction?.finish()
-      })
+      if (this.shouldTrace()) {
+        Promise.all([
+          handshakeSpan.promise,
+          iceSpan.promise,
+          dataChannelSpan.promise,
+          mediaTrackSpan.promise,
+        ]).then(() => {
+          console.log('All spans finished, reporting')
+          webrtcMediaTransaction?.finish()
+        })
+      }
 
       this.onWebsocketOpen(this)
     })
@@ -302,7 +304,9 @@ export class EngineConnection {
 
         this.pc.addEventListener('connectionstatechange', (event) => {
           if (this.pc?.iceConnectionState === 'connected') {
-            iceSpan.resolve?.()
+            if (this.shouldTrace()) {
+              iceSpan.resolve?.()
+            }
           }
         })
 


### PR DESCRIPTION
The Promises are created behind a shouldTrace, so they'll be undefined if you shouldn't be tracing. As a result, we need to guard the resoluton of the promises.

Thanks @mlfarrell for spotting this in local dev!