### PR TITLE
fix move cmd order

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,6 @@
-VITE_KC_API_WS_MODELING_URL=wss://api.dev.kittycad.io/ws/modeling/commands
-VITE_KC_API_BASE_URL=https://api.dev.kittycad.io
-VITE_KC_SITE_BASE_URL=https://dev.kittycad.io
+VITE_KC_API_WS_MODELING_URL=wss://api.kittycad.io/ws/modeling/commands
+VITE_KC_API_BASE_URL=https://api.kittycad.io
+VITE_KC_SITE_BASE_URL=https://kittycad.io
 VITE_KC_SKIP_AUTH=false
-VITE_KC_CONNECTION_TIMEOUT_MS=5000
+VITE_KC_CONNECTION_TIMEOUT_MS=15000
 VITE_KC_SENTRY_DSN=

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -314,18 +314,6 @@ export function App() {
             window: { x, y },
           },
         })
-      } else if (
-        guiMode.mode === 'sketch' &&
-        guiMode.sketchMode === ('move' as any)
-      ) {
-        debounceSocketSend({
-          type: 'modeling_cmd_req',
-          cmd_id: newCmdId,
-          cmd: {
-            type: 'handle_mouse_drag_move',
-            window: { x, y },
-          },
-        })
       } else {
         debounceSocketSend({
           type: 'modeling_cmd_req',
@@ -337,6 +325,17 @@ export function App() {
         })
       }
     } else {
+      if (guiMode.mode === 'sketch' && guiMode.sketchMode === ('move' as any)) {
+        debounceSocketSend({
+          type: 'modeling_cmd_req',
+          cmd_id: newCmdId,
+          cmd: {
+            type: 'handle_mouse_drag_move',
+            window: { x, y },
+          },
+        })
+        return
+      }
       const interactionGuards = cameraMouseDragGuards[cameraControls]
       let interaction: CameraDragInteractionType_type
 

--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -770,7 +770,8 @@ export class EngineCommandManager {
     if (command.type !== 'modeling_cmd_req') return Promise.resolve()
     const cmd = command.cmd
     if (
-      cmd.type === 'camera_drag_move' &&
+      (cmd.type === 'camera_drag_move' ||
+        cmd.type === 'handle_mouse_drag_move') &&
       this.engineConnection?.unreliableDataChannel
     ) {
       cmd.sequence = this.outSequence


### PR DESCRIPTION
Quick fix

Order of the commands looks right to me
<img width="319" alt="image" src="https://github.com/KittyCAD/modeling-app/assets/29681384/772c6a3b-6448-43f7-8bad-0706de5b85da">

and I changed the `handle_mouse_drag_move` cmd to be sent over the unreliable channel as well.

https://github.com/KittyCAD/modeling-app/assets/29681384/1fc06b7a-4de6-4d5a-89ad-1bcf680a1dcf

