### PR TITLE
Fix path for starting second sketch

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = "1"
 oauth2 = "4.4.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tauri = { version = "1.3.0", features = [ "updater", "path-all", "dialog-all", "fs-all", "http-request", "shell-open", "shell-open-api"] }
+tauri = { version = "1.3.0", features = ["dialog-all", "fs-all", "http-request", "path-all", "shell-open", "shell-open-api", "updater"] }
 tokio = { version = "1.29.1", features = ["time"] }
 toml = "0.6.0"
 tauri-plugin-fs-extra = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }

--- a/src/lang/modifyAst.ts
+++ b/src/lang/modifyAst.ts
@@ -52,11 +52,12 @@ export function addStartSketch(
     createPipeExpression(pipeBody)
   )
 
+  const newIndex = node.body.length
   _node.body = [...node.body, variableDeclaration]
 
   let pathToNode: PathToNode = [
     ['body', ''],
-    ['0', 'index'],
+    [newIndex.toString(10), 'index'],
     ['declarations', 'VariableDeclaration'],
     ['0', 'index'],
     ['init', 'VariableDeclarator'],


### PR DESCRIPTION
I wanted to tackle one of the issues @Irev-Dev posted, but I found this one on the way. I'll see if I can figure out a test for this. But, I noticed anytime I started a second sketch it was always pointing at the first and this caused some weird behavior. The fix was really easy at least!

Basically, we hardcoded the path to the node, so it was always pointing at the first variable.