### PR TITLE
addNewSketchLn should close when latest point matches start

### DIFF
--- a/src/components/Stream.tsx
+++ b/src/components/Stream.tsx
@@ -14,7 +14,13 @@ import { useGlobalStateContext } from 'hooks/useGlobalStateContext'
 import { CameraDragInteractionType_type } from '@kittycad/lib/dist/types/src/models'
 import { Models } from '@kittycad/lib'
 import { addStartSketch } from 'lang/modifyAst'
-import { addNewSketchLn } from 'lang/std/sketch'
+import {
+  addCloseToPipe,
+  addNewSketchLn,
+  compareVec2Epsilon,
+} from 'lang/std/sketch'
+import { getNodeFromPath } from 'lang/queryAst'
+import { Program, VariableDeclarator } from 'lang/abstractSyntaxTreeTypes'
 
 export const Stream = ({ className = '' }) => {
   const [isLoading, setIsLoading] = useState(true)
@@ -204,8 +210,8 @@ export const Stream = ({ className = '' }) => {
         window: { x, y },
       }
     }
-    engineCommandManager?.sendSceneCommand(command).then(async ({ data }) => {
-      if (command.cmd.type !== 'mouse_click' || !ast) return
+    engineCommandManager?.sendSceneCommand(command).then(async (resp) => {
+      if (command?.cmd?.type !== 'mouse_click' || !ast) return
       if (
         !(
           guiMode.mode === 'sketch' &&
@@ -214,13 +220,16 @@ export const Stream = ({ className = '' }) => {
       )
         return
 
-      if (data?.data?.entities_modified?.length && guiMode.waitingFirstClick) {
+      if (
+        resp?.data?.data?.entities_modified?.length &&
+        guiMode.waitingFirstClick
+      ) {
         const curve = await engineCommandManager?.sendSceneCommand({
           type: 'modeling_cmd_req',
           cmd_id: uuidv4(),
           cmd: {
             type: 'curve_get_control_points',
-            curve_id: data?.data?.entities_modified[0],
+            curve_id: resp?.data?.data?.entities_modified[0],
           },
         })
         const coords: { x: number; y: number }[] =
@@ -243,7 +252,7 @@ export const Stream = ({ className = '' }) => {
         })
         updateAst(_modifiedAst)
       } else if (
-        data?.data?.entities_modified?.length &&
+        resp?.data?.data?.entities_modified?.length &&
         !guiMode.waitingFirstClick
       ) {
         const curve = await engineCommandManager?.sendSceneCommand({
@@ -251,26 +260,47 @@ export const Stream = ({ className = '' }) => {
           cmd_id: uuidv4(),
           cmd: {
             type: 'curve_get_control_points',
-            curve_id: data?.data?.entities_modified[0],
+            curve_id: resp?.data?.data?.entities_modified[0],
           },
         })
         const coords: { x: number; y: number }[] =
           curve.data.data.control_points
-        const { modifiedAst: _modifiedAst, sketchClosed } = addNewSketchLn({
-          node: ast,
-          programMemory,
-          to: [coords[1].x, coords[1].y],
-          fnName: 'line',
-          pathToNode: guiMode.pathToNode,
-        })
-        updateAst(_modifiedAst)
-        if (sketchClosed) {
+
+        const { node: varDec } = getNodeFromPath<VariableDeclarator>(
+          ast,
+          guiMode.pathToNode,
+          'VariableDeclarator'
+        )
+        const variableName = varDec.id.name
+        const sketchGroup = programMemory.root[variableName]
+        if (!sketchGroup || sketchGroup.type !== 'SketchGroup') return
+        const initialCoords = sketchGroup.value[0].from
+
+        const isClose = compareVec2Epsilon(initialCoords, [
+          coords[1].x,
+          coords[1].y,
+        ])
+
+        let _modifiedAst: Program
+        if (!isClose) {
+          _modifiedAst = addNewSketchLn({
+            node: ast,
+            programMemory,
+            to: [coords[1].x, coords[1].y],
+            fnName: 'line',
+            pathToNode: guiMode.pathToNode,
+          }).modifiedAst
+        } else {
+          _modifiedAst = addCloseToPipe({
+            node: ast,
+            programMemory,
+            pathToNode: guiMode.pathToNode,
+          })
           setGuiMode({
-            ...guiMode,
-            pathToNode: [],
-            waitingFirstClick: true,
+            mode: 'default',
           })
         }
+        updateAst(_modifiedAst)
       }
     })
     setDidDragInStream(false)

--- a/src/lang/std/sketch.test.ts
+++ b/src/lang/std/sketch.test.ts
@@ -4,6 +4,7 @@ import {
   addNewSketchLn,
   getYComponent,
   getXComponent,
+  addCloseToPipe,
 } from './sketch'
 import { parser_wasm } from '../abstractSyntaxTree'
 import { getNodePathFromSourceRange } from '../queryAst'
@@ -169,12 +170,9 @@ show(mySketch001)
 `
     expect(recast(modifiedAst)).toBe(expectedCode)
 
-    modifiedAst = addNewSketchLn({
+    modifiedAst = addCloseToPipe({
       node: ast,
       programMemory,
-      // End at some distance between epsilon and 0,0
-      to: [0.01, 0.01],
-      fnName: 'lineTo',
       pathToNode: [
         ['body', ''],
         [0, 'index'],
@@ -182,7 +180,7 @@ show(mySketch001)
         [0, 'index'],
         ['init', 'VariableDeclarator'],
       ],
-    }).modifiedAst
+    })
 
     expectedCode = `const mySketch001 = startSketchAt([0, 0])
   // |> rx(45, %)

--- a/src/lang/std/sketch.ts
+++ b/src/lang/std/sketch.ts
@@ -892,60 +892,7 @@ export const angledLineThatIntersects: SketchLineHelper = {
   addTag: addTagWithTo('angleTo'), // TODO might be wrong
 }
 
-export const close: SketchLineHelper = {
-  add: ({
-    node,
-    previousProgramMemory,
-    pathToNode,
-    to,
-    from,
-    replaceExisting,
-    referencedSegment,
-    createCallback,
-  }) => {
-    const _node = { ...node }
-    const { node: pipe } = getNodeFromPath<PipeExpression | CallExpression>(
-      _node,
-      pathToNode,
-      'PipeExpression'
-    )
-    const { node: varDec } = getNodeFromPath<VariableDeclarator>(
-      _node,
-      pathToNode,
-      'VariableDeclarator'
-    )
-    const variableName = varDec.id.name
-    const sketch = previousProgramMemory?.root?.[variableName]
-    if (sketch.type !== 'SketchGroup') throw new Error('not a SketchGroup')
-
-    const callExp = createCallExpression('close', [createPipeSubstitution()])
-    if (pipe.type === 'PipeExpression') {
-      pipe.body = [...pipe.body, callExp]
-    } else {
-      varDec.init = createPipeExpression([varDec.init, callExp])
-    }
-    return {
-      modifiedAst: _node,
-      pathToNode,
-    }
-  },
-  updateArgs: ({ node, pathToNode, to, from }) => {
-    const _node = { ...node }
-    const { node: callExpression } = getNodeFromPath<CallExpression>(
-      _node,
-      pathToNode
-    )
-
-    return {
-      modifiedAst: _node,
-      pathToNode,
-    }
-  },
-  addTag: addTagWithTo('default'),
-}
-
 export const sketchLineHelperMap: { [key: string]: SketchLineHelper } = {
-  close,
   line,
   lineTo,
   xLine,
@@ -1000,7 +947,10 @@ interface CreateLineFnCallArgs {
   pathToNode: PathToNode
 }
 
-function compareVec2Epsilon(vec1: [number, number], vec2: [number, number]) {
+export function compareVec2Epsilon(
+  vec1: [number, number],
+  vec2: [number, number]
+) {
   const compareEpsilon = 0.015625 // or 2^-6
   const xDifference = Math.abs(vec1[0] - vec2[0])
   const yDifference = Math.abs(vec1[0] - vec2[0])
@@ -1015,9 +965,10 @@ export function addNewSketchLn({
   pathToNode,
 }: Omit<CreateLineFnCallArgs, 'from'>): {
   modifiedAst: Program
-  sketchClosed: boolean
 } {
   const node = JSON.parse(JSON.stringify(_node))
+  const { add, updateArgs } = sketchLineHelperMap?.[fnName] || {}
+  if (!add || !updateArgs) throw new Error('not a sketch line helper')
   const { node: varDec } = getNodeFromPath<VariableDeclarator>(
     node,
     pathToNode,
@@ -1032,27 +983,37 @@ export function addNewSketchLn({
 
   const last = sketch.value[sketch.value.length - 1] || sketch.start
   const from = last.to
-  let newFnName = fnName
-  if (compareVec2Epsilon(to, sketch.start.from)) {
-    // I imagine in the future there may be more than just close
-    // as this now assumes it's always the same. Perhaps we could derive
-    // the close type from the fnName in the future.
-    newFnName = 'close'
-  }
-  let { add, updateArgs } = sketchLineHelperMap?.[newFnName]
-  if (!add || !updateArgs) throw new Error('not a sketch line helper')
+  return add({
+    node,
+    previousProgramMemory,
+    pathToNode,
+    to,
+    from,
+    replaceExisting: false,
+  })
+}
 
-  return {
-    ...add({
-      node,
-      previousProgramMemory,
-      pathToNode,
-      to,
-      from,
-      replaceExisting: false,
-    }),
-    sketchClosed: newFnName === 'close',
-  }
+export function addCloseToPipe({
+  node,
+  pathToNode,
+}: {
+  node: Program
+  programMemory: ProgramMemory
+  pathToNode: PathToNode
+}) {
+  const _node = { ...node }
+  const closeExpression = createCallExpression('close', [
+    createPipeSubstitution(),
+  ])
+  const pipeExpression = getNodeFromPath<PipeExpression>(
+    _node,
+    pathToNode,
+    'PipeExpression'
+  ).node
+  if (pipeExpression.type !== 'PipeExpression')
+    throw new Error('not a pipe expression')
+  pipeExpression.body = [...pipeExpression.body, closeExpression]
+  return _node
 }
 
 export function replaceSketchLine({

--- a/src/useStore.ts
+++ b/src/useStore.ts
@@ -42,7 +42,6 @@ export type TooTip =
   | 'xLineTo'
   | 'yLineTo'
   | 'angledLineThatIntersects'
-  | 'close'
 
 export const toolTips = [
   'sketch_line',


### PR DESCRIPTION
Closes #466.

This only works with `line`, but it'd prob work with other line types when they work. I added a new `SketchLineHelper` for close since that seemed to be a pattern, but I don't know if we really need it, as I'm not yet sure how the update portions work.

It's been a bit since I did any real js work, so feel free to tear this apart. I'm also not yet sure on testing it, but I'll keep digging in on that side. I also need to get the tests running locally for myself.