### PR TITLE
make `.4` parse as number

### DIFF
--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -1162,4 +1162,14 @@ show(thisBox)
             memory.root.get("myVar").unwrap().get_json_value().unwrap()
         );
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_math_define_decimal_without_leading_zero() {
+        let ast = r#"let thing = .4 + 7"#;
+        let memory = parse_execute(ast).await.unwrap();
+        assert_eq!(
+            serde_json::json!(7.4),
+            memory.root.get("thing").unwrap().get_json_value().unwrap()
+        );
+    }
 }

--- a/src/wasm-lib/kcl/src/tokeniser.rs
+++ b/src/wasm-lib/kcl/src/tokeniser.rs
@@ -137,7 +137,7 @@ impl From<&Token> for crate::executor::SourceRange {
 }
 
 lazy_static! {
-    static ref NUMBER: Regex = Regex::new(r"^-?\d+(\.\d+)?").unwrap();
+    static ref NUMBER: Regex = Regex::new(r"^(\d+(\.\d*)?|\.\d+)\b").unwrap();
     static ref WHITESPACE: Regex = Regex::new(r"\s+").unwrap();
     static ref WORD: Regex = Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_]*").unwrap();
     // TODO: these should be generated using our struct types for these.
@@ -394,19 +394,18 @@ mod tests {
     fn is_number_test() {
         assert!(is_number("1"));
         assert!(is_number("1 abc"));
-        assert!(is_number("1abc"));
         assert!(is_number("1.1"));
         assert!(is_number("1.1 abc"));
         assert!(!is_number("a"));
 
         assert!(is_number("1"));
+        assert!(is_number(".1"));
         assert!(is_number("5?"));
         assert!(is_number("5 + 6"));
         assert!(is_number("5 + a"));
-        assert!(is_number("-5"));
         assert!(is_number("5.5"));
-        assert!(is_number("-5.5"));
 
+        assert!(!is_number("1abc"));
         assert!(!is_number("a"));
         assert!(!is_number("?"));
         assert!(!is_number("?5"));


### PR DESCRIPTION
fixes #487


actually my fix for `1 -2` helped this since we no longer need the tokenizer to take into account `-` since they are always an operator, so this was super easy regex change