### PR TITLE
Fix id source range mapping with path_get_info

### DIFF
--- a/src/hooks/useCodeEval.ts
+++ b/src/hooks/useCodeEval.ts
@@ -102,7 +102,7 @@ export function useCodeEval() {
         )
 
         const { artifactMap, sourceRangeMap } =
-          await engineCommandManager.waitForAllCommands()
+          await engineCommandManager.waitForAllCommands(_ast, programMemory)
         setIsExecuting(false)
         if (programMemory !== undefined) {
           setProgramMemory(programMemory)

--- a/src/lang/executor.ts
+++ b/src/lang/executor.ts
@@ -48,7 +48,7 @@ export const executor = async (
     engineCommandManager
   )
   const { artifactMap, sourceRangeMap } =
-    await engineCommandManager.waitForAllCommands()
+    await engineCommandManager.waitForAllCommands(node, _programMemory)
   tempMapCallback({ artifactMap, sourceRangeMap })
 
   engineCommandManager.endSession()

--- a/src/lib/testHelpers.ts
+++ b/src/lib/testHelpers.ts
@@ -75,6 +75,6 @@ export async function executor(
   await engineCommandManager.waitForReady
   engineCommandManager.startNewSession()
   const programMemory = await _executor(ast, pm, engineCommandManager)
-  await engineCommandManager.waitForAllCommands()
+  await engineCommandManager.waitForAllCommands(ast, programMemory)
   return programMemory
 }


### PR DESCRIPTION

https://github.com/KittyCAD/modeling-app/assets/29681384/ff888c10-1bf0-47ab-b150-6cf89adaf92d

Pasting in the same comment I left in this PR, TLDR I think this should be a temp fix
```
/* This is a temporary solution since the cmd_ids that are sent through when
    sending 'extend_path' ids are not used as the segment ids. 

    We have a way to back fill them with 'path_get_info', however this relies on one
    the sketchGroup array and the segements array returned from the server to be in
    the same length and order. plus it's super hacky, we first use the path_id to get
    the source range of the pipe expression then use the name of the variable to get
    the sketchGroup from programMemory.
    
    I feel queezy about relying on all these steps to always line up.
    We have also had to pollute this EngineCommandManager class with knowledge of both the ast and programMemory
    We should get the cmd_ids to match with the segment ids and delete this method.
*/
```
