### PR TITLE
Bump to v0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "untitled-app",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "private": true,
   "dependencies": {
     "@codemirror/autocomplete": "^6.9.0",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "kittycad-modeling",
-    "version": "0.6.1"
+    "version": "0.7.0"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
Changes Windows preferred bundle to .msi with EV Code Sign,  
updates dependencies, and fixes language and execution bugs.