### PR TITLE
Sign macOS builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,8 +168,8 @@ jobs:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          # APPLE_ID: ${{ secrets.APPLE_ID }}
-          # APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
         with:
           args: ${{ matrix.os == 'macos-latest' && '--target universal-apple-darwin' || '' }}
 


### PR DESCRIPTION
Fixes #295

Followed https://tauri.app/v1/guides/distribution/sign-macos, thank you @jessfraz and @Irev-Dev for the help

The only changes are env variables from secrets for the tauri-action to look for and sign with!

I went with `APPLE_ID` and app-specific `APPLE_PASSWORD`, which isn't as great as keys (the other option) but I wanted to get this out of the door asap. Everything is under the `pierre@kittycad.io` entry in 1Password.

@jgomez720 this is what to expect now, even from Spotlight on first run

![image](https://github.com/KittyCAD/modeling-app/assets/10795683/f8759793-c6e9-45f2-9c48-17258a61fcff)

```
$ codesign -dv --verbose=4 /Applications/KittyCAD\ Modeling.app
Executable=/Applications/KittyCAD Modeling.app/Contents/MacOS/KittyCAD Modeling
Identifier=io.kittycad.modeling-app
Format=app bundle with Mach-O universal (x86_64 arm64)
CodeDirectory v=20500 size=137348 flags=0x10000(runtime) hashes=4285+3 location=embedded
VersionPlatform=1
VersionMin=720896
VersionSDK=852224
Hash type=sha256 size=32
CandidateCDHash sha256=9934be7aaf0a52db40a5e5f7cfd1cf5430966830
CandidateCDHashFull sha256=9934be7aaf0a52db40a5e5f7cfd1cf5430966830da7765476be5661b05b82008
Hash choices=sha256
CMSDigest=9934be7aaf0a52db40a5e5f7cfd1cf5430966830da7765476be5661b05b82008
CMSDigestType=2
Executable Segment base=0
Executable Segment limit=12976128
Executable Segment flags=0x1
Page size=4096
Launch Constraints:
	None
CDHash=9934be7aaf0a52db40a5e5f7cfd1cf5430966830
Signature size=9044
Authority=Developer ID Application: KittyCAD Inc (92H8YB3B95)
Authority=Developer ID Certification Authority
Authority=Apple Root CA
Timestamp=Sep 16, 2023 at 8:27:34 AM
Info.plist entries=17
TeamIdentifier=92H8YB3B95
Runtime Version=13.1.0
Sealed Resources version=2 rules=13 files=1
Internal requirements count=1 size=184
```


