### PR TITLE
Rename TooTip to ToolTip

### DIFF
--- a/src/lang/modifyAst.ts
+++ b/src/lang/modifyAst.ts
@@ -1,4 +1,4 @@
-import { Selection, TooTip } from '../useStore'
+import { Selection, ToolTip } from '../useStore'
 import {
   Program,
   CallExpression,
@@ -635,7 +635,7 @@ export function giveSketchFnCallTag(
     createLiteral(tag || findUniqueName(ast, 'seg', 2))) as Literal
   const tagStr = String(tagValue.value)
   const newFirstArg = createFirstArg(
-    primaryCallExp.callee.name as TooTip,
+    primaryCallExp.callee.name as ToolTip,
     firstArg.val,
     tagValue
   )

--- a/src/lang/queryAst.ts
+++ b/src/lang/queryAst.ts
@@ -1,5 +1,5 @@
 import { PathToNode, ProgramMemory, SketchGroup, SourceRange } from './executor'
-import { Selection, TooTip } from '../useStore'
+import { Selection, ToolTip } from '../useStore'
 import {
   BinaryExpression,
   Program,
@@ -457,7 +457,7 @@ export function isLinesParallelAndConstrained(
     const secondaryFirstArg = getFirstArg(secondaryNode)
     const constraintType = getConstraintType(
       secondaryFirstArg.val,
-      secondaryNode.callee.name as TooTip
+      secondaryNode.callee.name as ToolTip
     )
     const constraintLevel = getConstraintLevelFromSourceRange(
       secondaryLine.range,

--- a/src/lang/std/sketch.ts
+++ b/src/lang/std/sketch.ts
@@ -21,7 +21,7 @@ import {
   getNodePathFromSourceRange,
 } from '../queryAst'
 import { isLiteralArrayOrStatic } from './sketchcombos'
-import { GuiModes, toolTips, TooTip } from '../../useStore'
+import { GuiModes, toolTips, ToolTip } from '../../useStore'
 import { createPipeExpression, splitPathAtPipeExpression } from '../modifyAst'
 import { generateUuidFromHashSeed } from '../../lib/uuid'
 
@@ -57,7 +57,7 @@ export function getCoordsFromPaths(skGroup: SketchGroup, index = 0): Coords2d {
 }
 
 export function createFirstArg(
-  sketchFn: TooTip,
+  sketchFn: ToolTip,
   val: Value | [Value, Value] | [Value, Value, Value],
   tag?: Value
 ): Value {
@@ -943,7 +943,7 @@ interface CreateLineFnCallArgs {
   programMemory: ProgramMemory
   to: [number, number]
   from: [number, number]
-  fnName: TooTip
+  fnName: ToolTip
   pathToNode: PathToNode
 }
 
@@ -1029,7 +1029,7 @@ export function replaceSketchLine({
   node: Program
   programMemory: ProgramMemory
   sourceRange: SourceRange
-  fnName: TooTip
+  fnName: ToolTip
   to: [number, number]
   from: [number, number]
   createCallback: TransformCallback
@@ -1208,7 +1208,7 @@ function getFirstArgValuesForAngleFns(callExpression: CallExpression): {
     const tag = firstArg.properties.find((p) => p.key.name === 'tag')?.value
     const angle = firstArg.properties.find((p) => p.key.name === 'angle')?.value
     const secondArgName = ['angledLineToX', 'angledLineToY'].includes(
-      callExpression?.callee?.name as TooTip
+      callExpression?.callee?.name as ToolTip
     )
       ? 'to'
       : 'length'

--- a/src/lang/std/sketchConstraints.ts
+++ b/src/lang/std/sketchConstraints.ts
@@ -1,4 +1,4 @@
-import { TooTip, toolTips } from '../../useStore'
+import { ToolTip, toolTips } from '../../useStore'
 import {
   Program,
   VariableDeclarator,
@@ -67,7 +67,10 @@ export function isSketchVariablesLinked(
     return false
   const firstCallExp = // first in pipe expression or just the call expression
     init?.type === 'CallExpression' ? init : (init?.body[0] as CallExpression)
-  if (!firstCallExp || !toolTips.includes(firstCallExp?.callee?.name as TooTip))
+  if (
+    !firstCallExp ||
+    !toolTips.includes(firstCallExp?.callee?.name as ToolTip)
+  )
     return false
   // convention for sketch fns is that the second argument is the sketch group
   const secondArg = firstCallExp?.arguments[1]

--- a/src/lang/std/sketchcombos.test.ts
+++ b/src/lang/std/sketchcombos.test.ts
@@ -9,7 +9,7 @@ import {
   getConstraintLevelFromSourceRange,
 } from './sketchcombos'
 import { initPromise } from '../rust'
-import { Selections, TooTip } from '../../useStore'
+import { Selections, ToolTip } from '../../useStore'
 import { enginelessExecutor } from '../../lib/testHelpers'
 import { recast } from '../../lang/recast'
 
@@ -68,7 +68,7 @@ function getConstraintTypeFromSourceHelper(
     Value,
     Value
   ]
-  const fnName = (ast.body[0] as any).expression.callee.name as TooTip
+  const fnName = (ast.body[0] as any).expression.callee.name as ToolTip
   return getConstraintType(args, fnName)
 }
 function getConstraintTypeFromSourceHelper2(
@@ -76,7 +76,7 @@ function getConstraintTypeFromSourceHelper2(
 ): ReturnType<typeof getConstraintType> {
   const ast = parser_wasm(code)
   const arg = (ast.body[0] as any).expression.arguments[0] as Value
-  const fnName = (ast.body[0] as any).expression.callee.name as TooTip
+  const fnName = (ast.body[0] as any).expression.callee.name as ToolTip
   return getConstraintType(arg, fnName)
 }
 

--- a/src/lang/std/sketchcombos.ts
+++ b/src/lang/std/sketchcombos.ts
@@ -1,5 +1,5 @@
 import { TransformCallback } from './stdTypes'
-import { Selections, toolTips, TooTip, Selection } from '../../useStore'
+import { Selections, toolTips, ToolTip, Selection } from '../../useStore'
 import {
   CallExpression,
   Program,
@@ -54,7 +54,7 @@ export type ConstraintType =
   | 'setAngleBetween'
 
 function createCallWrapper(
-  a: TooTip,
+  a: ToolTip,
   val: [Value, Value] | Value,
   tag?: Value,
   valueUsedInTransform?: number
@@ -101,7 +101,7 @@ function intersectCallWrapper({
 }
 
 export type TransformInfo = {
-  tooltip: TooTip
+  tooltip: ToolTip
   createNode: (a: {
     varValA: Value // x / angle
     varValB: Value // y / length or x y for angledLineOfXlength etc
@@ -112,7 +112,7 @@ export type TransformInfo = {
 }
 
 type TransformMap = {
-  [key in TooTip]?: {
+  [key in ToolTip]?: {
     [key in LineInputsType | 'free']?: {
       [key in ConstraintType]?: TransformInfo
     }
@@ -1095,12 +1095,12 @@ export function getRemoveConstraintsTransform(
   sketchFnExp: CallExpression,
   constraintType: ConstraintType
 ): TransformInfo | false {
-  let name = sketchFnExp.callee.name as TooTip
+  let name = sketchFnExp.callee.name as ToolTip
   if (!toolTips.includes(name)) {
     return false
   }
   const xyLineMap: {
-    [key in TooTip]?: TooTip
+    [key in ToolTip]?: ToolTip
   } = {
     xLine: 'line',
     yLine: 'line',
@@ -1167,12 +1167,12 @@ function getTransformMapPath(
   constraintType: ConstraintType
 ):
   | {
-      toolTip: TooTip
+      toolTip: ToolTip
       lineInputType: LineInputsType | 'free'
       constraintType: ConstraintType
     }
   | false {
-  const name = sketchFnExp.callee.name as TooTip
+  const name = sketchFnExp.callee.name as ToolTip
   if (!toolTips.includes(name)) {
     return false
   }
@@ -1225,7 +1225,7 @@ export function getTransformInfo(
 
 export function getConstraintType(
   val: Value | [Value, Value] | [Value, Value, Value],
-  fnName: TooTip
+  fnName: ToolTip
 ): LineInputsType | null {
   // this function assumes that for two val sketch functions that one arg is locked down not both
   // and for one val sketch functions that the arg is NOT locked down
@@ -1445,7 +1445,7 @@ export function transformAstSketchLines({
         programMemory,
         sourceRange: range,
         referencedSegment,
-        fnName: transformTo || (callExp.callee.name as TooTip),
+        fnName: transformTo || (callExp.callee.name as ToolTip),
         to,
         from,
         createCallback: callBack({
@@ -1511,7 +1511,7 @@ export function getConstraintLevelFromSourceRange(
     getNodePathFromSourceRange(ast, cursorRange),
     'CallExpression'
   )
-  const name = sketchFnExp?.callee?.name as TooTip
+  const name = sketchFnExp?.callee?.name as ToolTip
   if (!toolTips.includes(name)) return 'free'
 
   const firstArg = getFirstArg(sketchFnExp)

--- a/src/lang/std/stdTypes.ts
+++ b/src/lang/std/stdTypes.ts
@@ -1,6 +1,6 @@
 import { ProgramMemory, Path, SourceRange } from '../executor'
 import { Program, Value } from '../abstractSyntaxTreeTypes'
-import { TooTip } from '../../useStore'
+import { ToolTip } from '../../useStore'
 import { PathToNode } from '../executor'
 import { EngineCommandManager } from './engineConnection'
 
@@ -45,7 +45,7 @@ export type TransformCallback = (
 }
 
 export type SketchCallTransfromMap = {
-  [key in TooTip]: TransformCallback
+  [key in ToolTip]: TransformCallback
 }
 
 export interface SketchLineHelper {

--- a/src/useStore.ts
+++ b/src/useStore.ts
@@ -27,7 +27,7 @@ export type Selections = {
   otherSelections: ('y-axis' | 'x-axis' | 'z-axis')[]
   codeBasedSelections: Selection[]
 }
-export type TooTip =
+export type ToolTip =
   | 'lineTo'
   | 'line'
   | 'angledLine'
@@ -57,7 +57,7 @@ export const toolTips = [
   'xLineTo',
   'yLineTo',
   'angledLineThatIntersects',
-] as any as TooTip[]
+] as any as ToolTip[]
 
 export type GuiModes =
   | {
@@ -65,7 +65,7 @@ export type GuiModes =
     }
   | {
       mode: 'sketch'
-      sketchMode: TooTip
+      sketchMode: ToolTip
       isTooltip: true
       waitingFirstClick: boolean
       rotation: Rotation


### PR DESCRIPTION
Hopefully, `ToolTip` isn't some weird reserved word in js land. I was triggered by the misspelling, but I also looked right past it a bunch of times lol.