### PR TITLE
Fix extrude w/o pipe

### DIFF
--- a/src/lang/modifyAst.ts
+++ b/src/lang/modifyAst.ts
@@ -305,7 +305,11 @@ export function extrudeSketch(
   }
   const name = findUniqueName(node, 'part')
   const VariableDeclaration = createVariableDeclaration(name, extrudeCall)
-  const showCallIndex = getShowIndex(_node)
+  let showCallIndex = getShowIndex(_node)
+  if (showCallIndex == -1) {
+    // We didn't find a show, so let's just append everything
+    showCallIndex = _node.body.length
+  }
   _node.body.splice(showCallIndex, 0, VariableDeclaration)
   const pathToExtrudeArg: PathToNode = [
     ['body', ''],


### PR DESCRIPTION
Starting with code like this:
```
const part001 = startSketchAt([3.42, 2.69])
  |> line([3.51, -0.16], %)
  |> line([0.03, -4.36], %)
  |> line([-3.69, 0.13], %)
  |> close(%)
```

Then clicking ExtrudeSketch (w/o pipe), resulted in code like this:
```
const part002 = extrude(4, part001)
const part001 = startSketchAt([3.42, 2.69])
  |> line([3.51, -0.16], %)
  |> line([0.03, -4.36], %)
  |> line([-3.69, 0.13], %)
  |> close(%)
show(part002)
```

When we really want:
```
const part001 = startSketchAt([3.42, 2.69])
  |> line([3.51, -0.16], %)
  |> line([0.03, -4.36], %)
  |> line([-3.69, 0.13], %)
  |> close(%)
const part002 = extrude(4, part001)
show(part002)
```

On the language side, I don't think we'd allow defining constants that reference each other out of order, but that's a very programmer/imperative mindset. It's easy enough to put them in the right order for now, too.

