### PR TITLE
Move calls to the unreliable channel into a helper method

### DIFF
--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -475,6 +475,13 @@ export class EngineConnection {
 
     this.onConnectionStarted(this)
   }
+  unreliableSend(message: object | string) {
+    // TODO(paultag): Add in logic to determine the connection state and
+    // take actions if needed?
+    this.unreliableDataChannel?.send(
+      typeof message === 'string' ? message : JSON.stringify(message)
+    )
+  }
   send(message: object | string) {
     // TODO(paultag): Add in logic to determine the connection state and
     // take actions if needed?
@@ -778,9 +785,7 @@ export class EngineCommandManager {
     ) {
       cmd.sequence = this.outSequence
       this.outSequence++
-      this.engineConnection?.unreliableDataChannel?.send(
-        JSON.stringify(command)
-      )
+      this.engineConnection?.unreliableSend(command)
       return Promise.resolve()
     } else if (
       cmd.type === 'highlight_set_entity' &&
@@ -788,9 +793,7 @@ export class EngineCommandManager {
     ) {
       cmd.sequence = this.outSequence
       this.outSequence++
-      this.engineConnection?.unreliableDataChannel?.send(
-        JSON.stringify(command)
-      )
+      this.engineConnection?.unreliableSend(command)
       return Promise.resolve()
     } else if (
       cmd.type === 'mouse_move' &&
@@ -798,9 +801,7 @@ export class EngineCommandManager {
     ) {
       cmd.sequence = this.outSequence
       this.outSequence++
-      this.engineConnection?.unreliableDataChannel?.send(
-        JSON.stringify(command)
-      )
+      this.engineConnection?.unreliableSend(command)
       return Promise.resolve()
     }
     // since it's not mouse drag or highlighting send over TCP and keep track of the command


### PR DESCRIPTION
This'll let us handle JSON encoding in one place, as well as adding any logging or anything. Not a huge deal, but it's a minor cleanup I made while looking into an unrelated bug.