### PR TITLE
use deferredSetCode so the 3D view resets

### DIFF
--- a/src/routes/Onboarding/FutureWork.tsx
+++ b/src/routes/Onboarding/FutureWork.tsx
@@ -7,13 +7,13 @@ import { bracket } from 'lib/exampleKcl'
 
 export default function FutureWork() {
   const dismiss = useDismiss()
-  const { setCode } = useStore((s) => ({
-    setCode: s.setCode,
+  const { deferredSetCode } = useStore((s) => ({
+    deferredSetCode: s.deferredSetCode,
   }))
 
   useEffect(() => {
-    setCode(bracket)
-  }, [setCode])
+    deferredSetCode(bracket)
+  }, [deferredSetCode])
 
   return (
     <div className="fixed grid justify-center items-center inset-0 bg-chalkboard-100/50 z-50">

--- a/src/routes/Onboarding/Sketching.tsx
+++ b/src/routes/Onboarding/Sketching.tsx
@@ -5,16 +5,16 @@ import { useStore } from 'useStore'
 import { useEffect } from 'react'
 
 export default function Sketching() {
-  const { setCode, buttonDownInStream } = useStore((s) => ({
-    setCode: s.setCode,
+  const { deferredSetCode, buttonDownInStream } = useStore((s) => ({
+    deferredSetCode: s.deferredSetCode,
     buttonDownInStream: s.buttonDownInStream,
   }))
   const dismiss = useDismiss()
   const next = useNextClick(onboardingPaths.FUTURE_WORK)
 
   useEffect(() => {
-    setCode('')
-  }, [setCode])
+    deferredSetCode('')
+  }, [deferredSetCode])
 
   return (
     <div className="fixed grid justify-center items-end inset-0 z-50 pointer-events-none">


### PR DESCRIPTION
This very minor change just fixes the issue where during the tutorial we were resetting the code but not using `deferredSetCode`, which re-executes the engine.