### PR TITLE
Fix the debug panel overflow

### DIFF
--- a/src/components/DebugPanel.tsx
+++ b/src/components/DebugPanel.tsx
@@ -30,7 +30,9 @@ export const DebugPanel = ({ className, ...props }: CollapsiblePanelProps) => {
   return (
     <CollapsiblePanel
       {...props}
-      className={'!absolute overflow-hidden !h-auto bottom-5 right-5 ' + className}
+      className={
+        '!absolute overflow-hidden !h-auto bottom-5 right-5 ' + className
+      }
       // header height, top-5, and bottom-5
       style={{ maxHeight: 'calc(100% - 3rem - 1.25rem - 1.25rem)' }}
     >


### PR DESCRIPTION
Fixes #592 

The added max-height fixes the top going under the header (and beyond).

The overflow-hidden isn't not a fix though, with this on very not-tall windows it's not possible to scroll all the way to the bottom because of the height: 400px. A workaround could be to make that in vh or something else. I tried to use flex grow but failed

![image](https://github.com/KittyCAD/modeling-app/assets/10795683/cd3e6b2e-5739-4ad0-8920-a5e748e82313)
