### PR TITLE
Revert swapping `setCode` for `deferredSetCode` in App

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,7 @@ export function App() {
   const streamRef = useRef<HTMLDivElement>(null)
   useHotKeyListener()
   const {
-    deferredSetCode,
+    setCode,
     engineCommandManager,
     buttonDownInStream,
     openPanes,
@@ -51,7 +51,7 @@ export function App() {
   } = useStore((s) => ({
     guiMode: s.guiMode,
     setGuiMode: s.setGuiMode,
-    deferredSetCode: s.deferredSetCode,
+    setCode: s.setCode,
     engineCommandManager: s.engineCommandManager,
     buttonDownInStream: s.buttonDownInStream,
     openPanes: s.openPanes,
@@ -142,15 +142,15 @@ export function App() {
   // on mount, and overwrite any locally-stored code
   useEffect(() => {
     if (isTauri() && loadedCode !== null) {
-      deferredSetCode(loadedCode)
+      setCode(loadedCode)
     }
     return () => {
       // Clear code on unmount if in desktop app
       if (isTauri()) {
-        deferredSetCode('')
+        setCode('')
       }
     }
-  }, [loadedCode, deferredSetCode])
+  }, [loadedCode, setCode])
 
   useSetupEngineManager(streamRef, token)
   useEngineConnectionSubscriptions()


### PR DESCRIPTION
This fix was implemented in https://github.com/KittyCAD/modeling-app/pull/649 to try and address https://github.com/KittyCAD/modeling-app/issues/545. However, we need to run `setCode` to execute immediately here or else files will not render in the 3D view when opened, as reported by @pierremtb.

Reverting for now to allow for a timely release https://github.com/KittyCAD/modeling-app/pull/656