### PR TITLE
Engine manager can be cloned

### DIFF
--- a/src/wasm-lib/kcl/src/engine/conn_mock.rs
+++ b/src/wasm-lib/kcl/src/engine/conn_mock.rs
@@ -6,7 +6,7 @@ use kittycad::types::OkWebSocketResponseData;
 
 use crate::errors::KclError;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EngineConnection {}
 
 impl EngineConnection {

--- a/src/wasm-lib/kcl/src/engine/mod.rs
+++ b/src/wasm-lib/kcl/src/engine/mod.rs
@@ -32,7 +32,7 @@ use anyhow::Result;
 pub use conn_mock::EngineConnection;
 
 #[async_trait::async_trait(?Send)]
-pub trait EngineManager {
+pub trait EngineManager: Clone {
     /// Send a modeling command.
     /// Do not wait for the response message.
     fn send_modeling_cmd(


### PR DESCRIPTION
This will make it easier to use with async, no need to maintain references or lifetimes, just clone it.