### PR TITLE
Fix pipe expression start

### DIFF
--- a/src/lang/abstractSyntaxTree.test.ts
+++ b/src/lang/abstractSyntaxTree.test.ts
@@ -403,7 +403,7 @@ describe('testing pipe operator special', () => {
             id: { type: 'Identifier', start: 6, end: 14, name: 'mySketch' },
             init: {
               type: 'PipeExpression',
-              start: 15,
+              start: 17,
               end: 145,
               body: [
                 {
@@ -644,7 +644,7 @@ describe('testing pipe operator special', () => {
             },
             init: {
               type: 'PipeExpression',
-              start: 12,
+              start: 14,
               end: 36,
               body: [
                 {

--- a/src/wasm-lib/kcl/src/parser.rs
+++ b/src/wasm-lib/kcl/src/parser.rs
@@ -1283,7 +1283,11 @@ impl Parser {
         let end_token = self.get_token(pipe_body_result.last_index)?;
         Ok(PipeExpressionResult {
             expression: PipeExpression {
-                start: current_token.start,
+                start: pipe_body_result
+                    .body
+                    .first()
+                    .map(|v| v.start())
+                    .unwrap_or(current_token.start),
                 end: end_token.end,
                 body: pipe_body_result.body,
                 non_code_meta: pipe_body_result.non_code_meta,


### PR DESCRIPTION
Currently the parser thinks the pipe expression starts here:

```
    let code = `const myVar = 5 + 6 |> myFunc(45, %)`
                            ^
```

But I don't think pipe expressions should start there. The pipe is the RHS of the =, it should not _include_ the =. 

IMO it makes more sense for the pipe expression to start at


```
    let code = `const myVar = 5 + 6 |> myFunc(45, %)`
                              ^
```