### PR TITLE
Cut release v0.9.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "untitled-app",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "private": true,
   "dependencies": {
     "@codemirror/autocomplete": "^6.9.0",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "kittycad-modeling",
-    "version": "0.9.4"
+    "version": "0.9.5"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
Bug fixes (file export, reexecution, firefox PiP) and MIT license.