### PR TITLE
Allow Vertical Scroll Wheel to affect Horizontal Scroll for Toolbar

### DIFF
--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -10,7 +10,7 @@ import { SetHorzVertDistance } from './components/Toolbar/SetHorzVertDistance'
 import { SetAngleLength } from './components/Toolbar/setAngleLength'
 import { SetAbsDistance } from './components/Toolbar/SetAbsDistance'
 import { SetAngleBetween } from './components/Toolbar/SetAngleBetween'
-import { Fragment, useEffect } from 'react'
+import { Fragment, WheelEvent, useRef } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSearch, faX } from '@fortawesome/free-solid-svg-icons'
 import { Popover, Transition } from '@headlessui/react'
@@ -62,10 +62,24 @@ export const Toolbar = () => {
     executeAst: s.executeAst,
   }))
   useAppMode()
+  const toolbarButtonsRef = useRef<HTMLSpanElement>(null)
+
+  function handleToolbarButtonsWheelEvent(ev: WheelEvent<HTMLSpanElement>) {
+    const span = toolbarButtonsRef.current
+    if (!span) {
+      return
+    }
+
+    span.scrollLeft = span.scrollLeft += ev.deltaY
+  }
 
   function ToolbarButtons({ className }: React.HTMLAttributes<HTMLElement>) {
     return (
-      <span className={styles.toolbarButtons + ' ' + className}>
+      <span
+        ref={toolbarButtonsRef}
+        onWheel={handleToolbarButtonsWheelEvent}
+        className={styles.toolbarButtons + ' ' + className}
+      >
         {guiMode.mode === 'default' && (
           <button
             onClick={() => {


### PR DESCRIPTION
Previously the toolbar would not scroll when a vertical mouse wheel event occurred - which forced the user to drag the scroll bar horizontally to scroll, or use a horizontal scroll wheel (if their mouse has one).

This PR allows vertical scrolling to affect the horizontal scroll of the toolbar. Since there is no vertical scrolling space available here, the default vertical scrolling behaviour can be used as horizontal scrolling for a better UX.

Demo vid:

https://github.com/KittyCAD/modeling-app/assets/9722062/3981dcbb-8fa4-4ec2-af52-515d549ddf65


