### PR TITLE
Use absolute URLs to settings to avoid relative URL edge cases

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,7 +1,12 @@
 import { render, screen } from '@testing-library/react'
 import { App } from './App'
 import { describe, test, vi } from 'vitest'
-import { BrowserRouter } from 'react-router-dom'
+import {
+  Route,
+  RouterProvider,
+  createMemoryRouter,
+  createRoutesFromElements,
+} from 'react-router-dom'
 import { GlobalStateProvider } from './components/GlobalStateProvider'
 import CommandBarProvider from 'components/CommandBar'
 import { BROWSER_FILE_NAME } from 'Router'
@@ -42,12 +47,24 @@ describe('App tests', () => {
 })
 
 function TestWrap({ children }: { children: React.ReactNode }) {
-  // wrap in router and xState context
-  return (
-    <BrowserRouter>
-      <CommandBarProvider>
-        <GlobalStateProvider>{children}</GlobalStateProvider>
-      </CommandBarProvider>
-    </BrowserRouter>
+  // We have to use a memory router in the testing environment,
+  // and we have to use the createMemoryRouter function instead of <MemoryRouter /> as of react-router v6.4:
+  // https://reactrouter.com/en/6.16.0/routers/picking-a-router#using-v64-data-apis
+  const router = createMemoryRouter(
+    createRoutesFromElements(
+      <Route
+        path="/file/:id"
+        element={
+          <CommandBarProvider>
+            <GlobalStateProvider>{children}</GlobalStateProvider>
+          </CommandBarProvider>
+        }
+      />
+    ),
+    {
+      initialEntries: ['/file/new'],
+      initialIndex: 0,
+    }
   )
+  return <RouterProvider router={router} />
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -4,6 +4,7 @@ import { describe, test, vi } from 'vitest'
 import { BrowserRouter } from 'react-router-dom'
 import { GlobalStateProvider } from './components/GlobalStateProvider'
 import CommandBarProvider from 'components/CommandBar'
+import { BROWSER_FILE_NAME } from 'Router'
 
 let listener: ((rect: any) => void) | undefined = undefined
 ;(global as any).ResizeObserver = class ResizeObserver {
@@ -24,7 +25,7 @@ describe('App tests', () => {
       >
       return {
         ...actual,
-        useParams: () => ({ id: 'new' }),
+        useParams: () => ({ id: BROWSER_FILE_NAME }),
         useLoaderData: () => ({ code: null }),
       }
     })

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -94,6 +94,8 @@ export const paths = {
   ) as typeof onboardingPaths,
 }
 
+export const BROWSER_FILE_NAME = 'new'
+
 export type IndexLoaderData = {
   code: string | null
   project?: ProjectWithEntryPointMetadata
@@ -129,7 +131,9 @@ const router = createBrowserRouter(
     {
       path: paths.INDEX,
       loader: () =>
-        isTauri() ? redirect(paths.HOME) : redirect(paths.FILE + '/new'),
+        isTauri()
+          ? redirect(paths.HOME)
+          : redirect(paths.FILE + '/' + BROWSER_FILE_NAME),
       errorElement: <ErrorPage />,
     },
     {
@@ -167,7 +171,7 @@ const router = createBrowserRouter(
           )
         }
 
-        if (params.id && params.id !== 'new') {
+        if (params.id && params.id !== BROWSER_FILE_NAME) {
           // Note that PROJECT_ENTRYPOINT is hardcoded until we support multiple files
           const code = await readTextFile(params.id + '/' + PROJECT_ENTRYPOINT)
           const entrypoint_metadata = await metadata(
@@ -212,7 +216,7 @@ const router = createBrowserRouter(
       ),
       loader: async () => {
         if (!isTauri()) {
-          return redirect(paths.FILE + '/new')
+          return redirect(paths.FILE + '/' + BROWSER_FILE_NAME)
         }
         const fetchedStorage = localStorage?.getItem(SETTINGS_PERSIST_KEY)
         const persistedSettings = JSON.parse(fetchedStorage || '{}') as Partial<

--- a/src/components/ErrorPage.tsx
+++ b/src/components/ErrorPage.tsx
@@ -47,11 +47,9 @@ export const ErrorPage = () => {
             Clear storage
           </ActionButton>
           <ActionButton
-            Element="link"
+            Element="externalLink"
             icon={{ icon: faBug }}
-            target="_blank"
-            rel="noopener noreferrer"
-            to="https://discord.com/channels/915388055236509727/1138967922614743060"
+            to="https://github.com/KittyCAD/modeling-app/issues/new"
           >
             Report Bug
           </ActionButton>

--- a/src/components/UserSidebarMenu.test.tsx
+++ b/src/components/UserSidebarMenu.test.tsx
@@ -1,6 +1,11 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import UserSidebarMenu from './UserSidebarMenu'
-import { BrowserRouter } from 'react-router-dom'
+import {
+  Route,
+  RouterProvider,
+  createMemoryRouter,
+  createRoutesFromElements,
+} from 'react-router-dom'
 import { Models } from '@kittycad/lib'
 import { GlobalStateProvider } from './GlobalStateProvider'
 import CommandBarProvider from './CommandBar'
@@ -93,11 +98,24 @@ describe('UserSidebarMenu tests', () => {
 
 function TestWrap({ children }: { children: React.ReactNode }) {
   // wrap in router and xState context
-  return (
-    <BrowserRouter>
-      <CommandBarProvider>
-        <GlobalStateProvider>{children}</GlobalStateProvider>
-      </CommandBarProvider>
-    </BrowserRouter>
+  // We have to use a memory router in the testing environment,
+  // and we have to use the createMemoryRouter function instead of <MemoryRouter /> as of react-router v6.4:
+  // https://reactrouter.com/en/6.16.0/routers/picking-a-router#using-v64-data-apis
+  const router = createMemoryRouter(
+    createRoutesFromElements(
+      <Route
+        path="/file/:id"
+        element={
+          <CommandBarProvider>
+            <GlobalStateProvider>{children}</GlobalStateProvider>
+          </CommandBarProvider>
+        }
+      />
+    ),
+    {
+      initialEntries: ['/file/new'],
+      initialIndex: 0,
+    }
   )
+  return <RouterProvider router={router} />
 }

--- a/src/components/UserSidebarMenu.tsx
+++ b/src/components/UserSidebarMenu.tsx
@@ -7,17 +7,17 @@ import {
   faSignOutAlt,
 } from '@fortawesome/free-solid-svg-icons'
 import { faGithub } from '@fortawesome/free-brands-svg-icons'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import { Fragment, useState } from 'react'
 import { paths } from '../Router'
-import makeUrlPathRelative from '../lib/makeUrlPathRelative'
 import { Models } from '@kittycad/lib'
 import { useGlobalStateContext } from 'hooks/useGlobalStateContext'
+import { useAbsoluteFilePath } from 'hooks/useAbsoluteFilePath'
 
 type User = Models['User_type']
 
 const UserSidebarMenu = ({ user }: { user?: User }) => {
-  const location = useLocation()
+  const filePath = useAbsoluteFilePath()
   const displayedName = getDisplayName(user)
   const [imageLoadFailed, setImageLoadFailed] = useState(false)
   const navigate = useNavigate()
@@ -132,11 +132,7 @@ const UserSidebarMenu = ({ user }: { user?: User }) => {
                     // since /settings is a nested route the sidebar doesn't close
                     // automatically when navigating to it
                     close()
-                    navigate(
-                      (location.pathname.endsWith('/')
-                        ? location.pathname.slice(0, -1)
-                        : location.pathname) + paths.SETTINGS
-                    )
+                    navigate(filePath + paths.SETTINGS)
                   }}
                 >
                   Settings

--- a/src/hooks/useAbsoluteFilePath.ts
+++ b/src/hooks/useAbsoluteFilePath.ts
@@ -1,0 +1,10 @@
+import { IndexLoaderData, paths } from 'Router'
+import { useRouteLoaderData } from 'react-router-dom'
+
+export function useAbsoluteFilePath() {
+  const routeData = useRouteLoaderData(paths.FILE) as IndexLoaderData
+
+  return (
+    paths.FILE + '/' + encodeURIComponent(routeData?.project?.path || 'new')
+  )
+}

--- a/src/hooks/useAbsoluteFilePath.ts
+++ b/src/hooks/useAbsoluteFilePath.ts
@@ -1,10 +1,12 @@
-import { IndexLoaderData, paths } from 'Router'
+import { BROWSER_FILE_NAME, IndexLoaderData, paths } from 'Router'
 import { useRouteLoaderData } from 'react-router-dom'
 
 export function useAbsoluteFilePath() {
   const routeData = useRouteLoaderData(paths.FILE) as IndexLoaderData
 
   return (
-    paths.FILE + '/' + encodeURIComponent(routeData?.project?.path || 'new')
+    paths.FILE +
+    '/' +
+    encodeURIComponent(routeData?.project?.path || BROWSER_FILE_NAME)
   )
 }

--- a/src/routes/Onboarding/index.tsx
+++ b/src/routes/Onboarding/index.tsx
@@ -1,5 +1,5 @@
 import { useHotkeys } from 'react-hotkeys-hook'
-import { Outlet, useRouteLoaderData, useNavigate } from 'react-router-dom'
+import { Outlet, useNavigate } from 'react-router-dom'
 import Introduction from './Introduction'
 import Camera from './Camera'
 import Sketching from './Sketching'
@@ -15,7 +15,8 @@ import UserMenu from './UserMenu'
 import ProjectMenu from './ProjectMenu'
 import Export from './Export'
 import FutureWork from './FutureWork'
-import { IndexLoaderData, paths } from 'Router'
+import { paths } from 'Router'
+import { useAbsoluteFilePath } from 'hooks/useAbsoluteFilePath'
 
 export const onboardingPaths = {
   INDEX: '/',
@@ -86,29 +87,23 @@ export const onboardingRoutes = [
 ]
 
 export function useNextClick(newStatus: string) {
+  const filePath = useAbsoluteFilePath()
   const {
     settings: { send },
   } = useGlobalStateContext()
   const navigate = useNavigate()
-  const { project } = useRouteLoaderData(paths.FILE) as IndexLoaderData
 
   return useCallback(() => {
     send({
       type: 'Set Onboarding Status',
       data: { onboardingStatus: newStatus },
     })
-    navigate(
-      paths.FILE +
-        '/' +
-        encodeURIComponent(project?.path || 'new') +
-        paths.ONBOARDING.INDEX.slice(0, -1) +
-        newStatus
-    )
-  }, [project, newStatus, send, navigate])
+    navigate(filePath + paths.ONBOARDING.INDEX.slice(0, -1) + newStatus)
+  }, [filePath, newStatus, send, navigate])
 }
 
 export function useDismiss() {
-  const routeData = useRouteLoaderData(paths.FILE) as IndexLoaderData
+  const filePath = useAbsoluteFilePath()
   const {
     settings: { send },
   } = useGlobalStateContext()
@@ -119,10 +114,8 @@ export function useDismiss() {
       type: 'Set Onboarding Status',
       data: { onboardingStatus: 'dismissed' },
     })
-    navigate(
-      paths.FILE + '/' + encodeURIComponent(routeData?.project?.path || 'new')
-    )
-  }, [send, navigate, routeData])
+    navigate(filePath)
+  }, [send, navigate, filePath])
 }
 
 const Onboarding = () => {


### PR DESCRIPTION
Fixes #774 by using absolute paths to get to the `/file/:id/settings` page, making it possible to click the Settings button in the sidebar from anywhere—whether in a normal file view (`/file/:id`), or deep in the onboarding (`/file/:id/onboarding/cmd-bar`).

Had to start reworking how we wrap UI tests now that we use what react-router calls its "[v6.4 Data APIs](https://reactrouter.com/en/6.16.0/routers/picking-a-router#using-v64-data-apis)" within components that we have tests for.

## How to test
1. Open a project in the Tauri or browser app versions
2. Restart onboarding from the `/settings` page
3. Go through the onboarding until you can access the menus (I believe the Cmd + K bar step is the earliest)
4. Open the right side user menu, then click on the Settings button
5. The app should no longer error on this branch, but error on main


https://github.com/KittyCAD/modeling-app/assets/23481541/3fcc2f8f-c4dc-4871-8e05-1bfaabce3d9b
