### PR TITLE
Make "Replay Onboarding" button available on home settings page

### DIFF
--- a/src/components/UserSidebarMenu.tsx
+++ b/src/components/UserSidebarMenu.tsx
@@ -7,7 +7,7 @@ import {
   faSignOutAlt,
 } from '@fortawesome/free-solid-svg-icons'
 import { faGithub } from '@fortawesome/free-brands-svg-icons'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { Fragment, useState } from 'react'
 import { paths } from '../Router'
 import { Models } from '@kittycad/lib'
@@ -17,6 +17,7 @@ import { useAbsoluteFilePath } from 'hooks/useAbsoluteFilePath'
 type User = Models['User_type']
 
 const UserSidebarMenu = ({ user }: { user?: User }) => {
+  const location = useLocation()
   const filePath = useAbsoluteFilePath()
   const displayedName = getDisplayName(user)
   const [imageLoadFailed, setImageLoadFailed] = useState(false)
@@ -132,7 +133,10 @@ const UserSidebarMenu = ({ user }: { user?: User }) => {
                     // since /settings is a nested route the sidebar doesn't close
                     // automatically when navigating to it
                     close()
-                    navigate(filePath + paths.SETTINGS)
+                    const targetPath = location.pathname.includes(paths.FILE)
+                      ? filePath + paths.SETTINGS
+                      : paths.HOME + paths.SETTINGS
+                    navigate(targetPath)
                   }}
                 >
                   Settings

--- a/src/routes/Onboarding/Introduction.tsx
+++ b/src/routes/Onboarding/Introduction.tsx
@@ -1,6 +1,6 @@
 import { faArrowRight, faXmark } from '@fortawesome/free-solid-svg-icons'
 import { ActionButton } from '../../components/ActionButton'
-import { onboardingPaths, useDismiss, useNextClick } from '.'
+import { ONBOARDING_PROJECT_NAME, onboardingPaths, useDismiss, useNextClick } from '.'
 import { useGlobalStateContext } from 'hooks/useGlobalStateContext'
 import { Themes, getSystemTheme } from 'lib/theme'
 import { bracket } from 'lib/exampleKcl'
@@ -25,14 +25,14 @@ function OnboardingWithNewFile() {
   }))
   const {
     settings: {
-      context: { defaultDirectory, defaultProjectName },
+      context: { defaultDirectory },
     },
   } = useGlobalStateContext()
 
   async function createAndOpenNewProject() {
     const projects = await getProjectsInDir(defaultDirectory)
-    const nextIndex = await getNextProjectIndex(defaultProjectName, projects)
-    const name = interpolateProjectNameWithIndex(defaultProjectName, nextIndex)
+    const nextIndex = await getNextProjectIndex(ONBOARDING_PROJECT_NAME, projects)
+    const name = interpolateProjectNameWithIndex(ONBOARDING_PROJECT_NAME, nextIndex)
     const newFile = await createNewProject(defaultDirectory + '/' + name)
     navigate(`${paths.FILE}/${encodeURIComponent(newFile.path)}`)
   }

--- a/src/routes/Onboarding/Introduction.tsx
+++ b/src/routes/Onboarding/Introduction.tsx
@@ -1,6 +1,11 @@
 import { faArrowRight, faXmark } from '@fortawesome/free-solid-svg-icons'
 import { ActionButton } from '../../components/ActionButton'
-import { ONBOARDING_PROJECT_NAME, onboardingPaths, useDismiss, useNextClick } from '.'
+import {
+  ONBOARDING_PROJECT_NAME,
+  onboardingPaths,
+  useDismiss,
+  useNextClick,
+} from '.'
 import { useGlobalStateContext } from 'hooks/useGlobalStateContext'
 import { Themes, getSystemTheme } from 'lib/theme'
 import { bracket } from 'lib/exampleKcl'
@@ -31,8 +36,14 @@ function OnboardingWithNewFile() {
 
   async function createAndOpenNewProject() {
     const projects = await getProjectsInDir(defaultDirectory)
-    const nextIndex = await getNextProjectIndex(ONBOARDING_PROJECT_NAME, projects)
-    const name = interpolateProjectNameWithIndex(ONBOARDING_PROJECT_NAME, nextIndex)
+    const nextIndex = await getNextProjectIndex(
+      ONBOARDING_PROJECT_NAME,
+      projects
+    )
+    const name = interpolateProjectNameWithIndex(
+      ONBOARDING_PROJECT_NAME,
+      nextIndex
+    )
     const newFile = await createNewProject(defaultDirectory + '/' + name)
     navigate(`${paths.FILE}/${encodeURIComponent(newFile.path)}`)
   }

--- a/src/routes/Onboarding/index.tsx
+++ b/src/routes/Onboarding/index.tsx
@@ -18,6 +18,8 @@ import FutureWork from './FutureWork'
 import { paths } from 'Router'
 import { useAbsoluteFilePath } from 'hooks/useAbsoluteFilePath'
 
+export const ONBOARDING_PROJECT_NAME = 'Tutorial Project $nn'
+
 export const onboardingPaths = {
   INDEX: '/',
   CAMERA: '/camera',


### PR DESCRIPTION
Resolves #728.

- If the user clicks the button from `/home/settings`, a new file with the title "Tutorial Project 00" (number auto-increments) is created and opened to the onboarding.
- If the user clicks from within a file's settings, they are taken through the usual flow depending on if their file has changed content or not.

## Demo

https://github.com/KittyCAD/modeling-app/assets/23481541/03dc6f16-f896-48ed-9bea-317731637496
