### PR TITLE
Revert "Improve Prop Typings for Modals. Remove instances of `any`. (…

### DIFF
--- a/src/components/SetAngleLengthModal.tsx
+++ b/src/components/SetAngleLengthModal.tsx
@@ -1,6 +1,5 @@
 import { Dialog, Transition } from '@headlessui/react'
 import { Fragment, useState } from 'react'
-import { type InstanceProps, create } from 'react-modal-promise'
 import { Value } from '../lang/wasm'
 import {
   AvailableVars,
@@ -10,28 +9,6 @@ import {
   CreateNewVariable,
 } from './AvailableVarsHelpers'
 
-type ModalResolve = {
-  value: string
-  sign: number
-  valueNode: Value
-  variableName?: string
-  newVariableInsertIndex: number
-}
-
-type ModalReject = boolean
-
-type SetAngleLengthModalProps = InstanceProps<ModalResolve, ModalReject> & {
-  value: number
-  valueName: string
-  shouldCreateVariable?: boolean
-}
-
-export const createSetAngleLengthModal = create<
-  SetAngleLengthModalProps,
-  ModalResolve,
-  ModalReject
->
-
 export const SetAngleLengthModal = ({
   isOpen,
   onResolve,
@@ -39,7 +16,20 @@ export const SetAngleLengthModal = ({
   value: initialValue,
   valueName,
   shouldCreateVariable: initialShouldCreateVariable = false,
-}: SetAngleLengthModalProps) => {
+}: {
+  isOpen: boolean
+  onResolve: (a: {
+    value: string
+    sign: number
+    valueNode: Value
+    variableName?: string
+    newVariableInsertIndex: number
+  }) => void
+  onReject: (a: any) => void
+  value: number
+  valueName: string
+  shouldCreateVariable: boolean
+}) => {
   const [sign, setSign] = useState(Math.sign(Number(initialValue)))
   const [value, setValue] = useState(String(initialValue * sign))
   const [shouldCreateVariable, setShouldCreateVariable] = useState(

--- a/src/components/SetHorVertDistanceModal.tsx
+++ b/src/components/SetHorVertDistanceModal.tsx
@@ -1,6 +1,5 @@
 import { Dialog, Transition } from '@headlessui/react'
 import { Fragment, useState } from 'react'
-import { type InstanceProps, create } from 'react-modal-promise'
 import { Value } from '../lang/wasm'
 import {
   AvailableVars,
@@ -10,30 +9,6 @@ import {
   CreateNewVariable,
 } from './AvailableVarsHelpers'
 
-type ModalResolve = {
-  value: string
-  segName: string
-  valueNode: Value
-  variableName?: string
-  newVariableInsertIndex: number
-  sign: number
-}
-
-type ModalReject = boolean
-
-type GetInfoModalProps = InstanceProps<ModalResolve, ModalReject> & {
-  segName: string
-  isSegNameEditable: boolean
-  value?: number
-  initialVariableName: string
-}
-
-export const createInfoModal = create<
-  GetInfoModalProps,
-  ModalResolve,
-  ModalReject
->
-
 export const GetInfoModal = ({
   isOpen,
   onResolve,
@@ -42,12 +17,25 @@ export const GetInfoModal = ({
   isSegNameEditable,
   value: initialValue,
   initialVariableName,
-}: GetInfoModalProps) => {
+}: {
+  isOpen: boolean
+  onResolve: (a: {
+    value: string
+    segName: string
+    valueNode: Value
+    variableName?: string
+    newVariableInsertIndex: number
+    sign: number
+  }) => void
+  onReject: (a: any) => void
+  segName: string
+  isSegNameEditable: boolean
+  value: number
+  initialVariableName: string
+}) => {
   const [sign, setSign] = useState(Math.sign(Number(initialValue)))
   const [segName, setSegName] = useState(initialSegName)
-  const [value, setValue] = useState(
-    initialValue === undefined ? '' : String(Math.abs(initialValue))
-  )
+  const [value, setValue] = useState(String(Math.abs(initialValue)))
   const [shouldCreateVariable, setShouldCreateVariable] = useState(false)
 
   const {

--- a/src/components/SetVarNameModal.tsx
+++ b/src/components/SetVarNameModal.tsx
@@ -4,26 +4,19 @@ import { useCalc, CreateNewVariable } from './AvailableVarsHelpers'
 import { ActionButton } from './ActionButton'
 import { faPlus } from '@fortawesome/free-solid-svg-icons'
 import { toast } from 'react-hot-toast'
-import { type InstanceProps, create } from 'react-modal-promise'
-
-type ModalResolve = { variableName: string }
-type ModalReject = boolean
-type SetVarNameModalProps = InstanceProps<ModalResolve, ModalReject> & {
-  valueName: string
-}
-
-export const createSetVarNameModal = create<
-  SetVarNameModalProps,
-  ModalResolve,
-  ModalReject
->
 
 export const SetVarNameModal = ({
   isOpen,
   onResolve,
   onReject,
   valueName,
-}: SetVarNameModalProps) => {
+}: {
+  isOpen: boolean
+  onResolve: (a: { variableName?: string }) => void
+  onReject: (a: any) => void
+  value: number
+  valueName: string
+}) => {
   const { isNewVariableNameUnique, newVariableName, setNewVariableName } =
     useCalc({ value: '', initialVariableName: valueName })
 

--- a/src/components/Toolbar/Intersect.tsx
+++ b/src/components/Toolbar/Intersect.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { create } from 'react-modal-promise'
 import { toolTips, useStore } from '../../useStore'
 import { BinaryPart, Value, VariableDeclarator } from '../../lang/wasm'
 import {
@@ -12,12 +13,12 @@ import {
   transformSecondarySketchLinesTagFirst,
   getTransformInfos,
 } from '../../lang/std/sketchcombos'
-import { GetInfoModal, createInfoModal } from '../SetHorVertDistanceModal'
+import { GetInfoModal } from '../SetHorVertDistanceModal'
 import { createVariableDeclaration } from '../../lang/modifyAst'
 import { removeDoubleNegatives } from '../AvailableVarsHelpers'
 import { updateCursors } from '../../lang/util'
 
-const getModalInfo = createInfoModal(GetInfoModal)
+const getModalInfo = create(GetInfoModal as any)
 
 export const Intersect = () => {
   const { guiMode, selectionRanges, ast, programMemory, updateAst, setCursor } =
@@ -135,19 +136,20 @@ export const Intersect = () => {
           variableName,
           newVariableInsertIndex,
           sign,
+        }: {
+          segName: string
+          value: number
+          valueNode: Value
+          variableName?: string
+          newVariableInsertIndex: number
+          sign: number
         } = await getModalInfo({
           segName: tagInfo?.tag,
           isSegNameEditable: !tagInfo?.isTagExisting,
           value: valueUsedInTransform,
           initialVariableName: 'offset',
-        })
-        if (
-          segName === tagInfo?.tag &&
-          value ===
-            (valueUsedInTransform === undefined
-              ? ''
-              : String(Math.abs(valueUsedInTransform)))
-        ) {
+        } as any)
+        if (segName === tagInfo?.tag && value === valueUsedInTransform) {
           updateAst(modifiedAst, true, {
             callBack: updateCursors(setCursor, selectionRanges, pathToNodeMap),
           })

--- a/src/components/Toolbar/SetAbsDistance.tsx
+++ b/src/components/Toolbar/SetAbsDistance.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
+import { create } from 'react-modal-promise'
 import { toolTips, useStore } from '../../useStore'
-import { BinaryPart, Identifier, Value } from '../../lang/wasm'
+import { Value } from '../../lang/wasm'
 import {
   getNodePathFromSourceRange,
   getNodeFromPath,
@@ -11,10 +12,7 @@ import {
   transformAstSketchLines,
   ConstraintType,
 } from '../../lang/std/sketchcombos'
-import {
-  SetAngleLengthModal,
-  createSetAngleLengthModal,
-} from '../SetAngleLengthModal'
+import { SetAngleLengthModal } from '../SetAngleLengthModal'
 import {
   createIdentifier,
   createVariableDeclaration,
@@ -22,7 +20,7 @@ import {
 import { removeDoubleNegatives } from '../AvailableVarsHelpers'
 import { updateCursors } from '../../lang/util'
 
-const getModalInfo = createSetAngleLengthModal(SetAngleLengthModal)
+const getModalInfo = create(SetAngleLengthModal as any)
 
 type ButtonType = 'xAbs' | 'yAbs' | 'snapToYAxis' | 'snapToXAxis'
 
@@ -100,67 +98,40 @@ export const SetAbsDistance = ({ buttonType }: { buttonType: ButtonType }) => {
           programMemory,
           referenceSegName: '',
         })
-
-        function transformValue(
-          fv: Identifier | BinaryPart,
-          transformInfos: TransformInfo[]
-        ) {
-          return transformAstSketchLines({
-            ast: JSON.parse(JSON.stringify(ast)),
-            selectionRanges: selectionRanges,
-            transformInfos,
-            programMemory,
-            referenceSegName: '',
-            forceValueUsedInTransform: fv,
-          })
-        }
-
         try {
-          if (!isAlign) {
-            const forceVal = valueUsedInTransform || 0
-
-            const { valueNode, variableName, newVariableInsertIndex, sign } =
-              await getModalInfo({
+          let forceVal = valueUsedInTransform || 0
+          const { valueNode, variableName, newVariableInsertIndex, sign } =
+            await (!isAlign &&
+              getModalInfo({
                 value: forceVal,
                 valueName: disType === 'yAbs' ? 'yDis' : 'xDis',
-              })
+              } as any))
+          let finalValue = isAlign
+            ? createIdentifier('_0')
+            : removeDoubleNegatives(valueNode, sign, variableName)
 
-            const finalValue = removeDoubleNegatives(
-              valueNode as BinaryPart,
-              sign,
-              variableName
+          const { modifiedAst: _modifiedAst, pathToNodeMap } =
+            transformAstSketchLines({
+              ast: JSON.parse(JSON.stringify(ast)),
+              selectionRanges: selectionRanges,
+              transformInfos,
+              programMemory,
+              referenceSegName: '',
+              forceValueUsedInTransform: finalValue,
+            })
+          if (variableName) {
+            const newBody = [..._modifiedAst.body]
+            newBody.splice(
+              newVariableInsertIndex,
+              0,
+              createVariableDeclaration(variableName, valueNode)
             )
-            const { modifiedAst: _modifiedAst, pathToNodeMap: _pathToNodeMap } =
-              transformValue(finalValue, transformInfos)
-
-            if (variableName) {
-              const newBody = [..._modifiedAst.body]
-              newBody.splice(
-                newVariableInsertIndex,
-                0,
-                createVariableDeclaration(variableName, valueNode)
-              )
-              _modifiedAst.body = newBody
-            }
-
-            updateAst(_modifiedAst, true, {
-              callBack: updateCursors(
-                setCursor,
-                selectionRanges,
-                _pathToNodeMap
-              ),
-            })
-          } else {
-            const { modifiedAst: _modifiedAst, pathToNodeMap: _pathToNodeMap } =
-              transformValue(createIdentifier('_0'), transformInfos)
-            updateAst(_modifiedAst, true, {
-              callBack: updateCursors(
-                setCursor,
-                selectionRanges,
-                _pathToNodeMap
-              ),
-            })
+            _modifiedAst.body = newBody
           }
+
+          updateAst(_modifiedAst, true, {
+            callBack: updateCursors(setCursor, selectionRanges, pathToNodeMap),
+          })
         } catch (e) {
           console.log('error', e)
         }

--- a/src/components/Toolbar/SetAngleBetween.tsx
+++ b/src/components/Toolbar/SetAngleBetween.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { create } from 'react-modal-promise'
 import { toolTips, useStore } from '../../useStore'
 import { BinaryPart, Value, VariableDeclarator } from '../../lang/wasm'
 import {
@@ -11,12 +12,12 @@ import {
   transformSecondarySketchLinesTagFirst,
   getTransformInfos,
 } from '../../lang/std/sketchcombos'
-import { GetInfoModal, createInfoModal } from '../SetHorVertDistanceModal'
+import { GetInfoModal } from '../SetHorVertDistanceModal'
 import { createVariableDeclaration } from '../../lang/modifyAst'
 import { removeDoubleNegatives } from '../AvailableVarsHelpers'
 import { updateCursors } from '../../lang/util'
 
-const getModalInfo = createInfoModal(GetInfoModal)
+const getModalInfo = create(GetInfoModal as any)
 
 export const SetAngleBetween = () => {
   const { guiMode, selectionRanges, ast, programMemory, updateAst, setCursor } =
@@ -94,19 +95,20 @@ export const SetAngleBetween = () => {
           variableName,
           newVariableInsertIndex,
           sign,
+        }: {
+          segName: string
+          value: number
+          valueNode: Value
+          variableName?: string
+          newVariableInsertIndex: number
+          sign: number
         } = await getModalInfo({
           segName: tagInfo?.tag,
           isSegNameEditable: !tagInfo?.isTagExisting,
           value: valueUsedInTransform,
           initialVariableName: 'angle',
-        })
-        if (
-          segName === tagInfo?.tag &&
-          value ===
-            (valueUsedInTransform === undefined
-              ? ''
-              : String(Math.abs(valueUsedInTransform)))
-        ) {
+        } as any)
+        if (segName === tagInfo?.tag && value === valueUsedInTransform) {
           updateAst(modifiedAst, true, {
             callBack: updateCursors(setCursor, selectionRanges, pathToNodeMap),
           })

--- a/src/components/Toolbar/SetHorzVertDistance.tsx
+++ b/src/components/Toolbar/SetHorzVertDistance.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { create } from 'react-modal-promise'
 import { toolTips, useStore } from '../../useStore'
 import { BinaryPart, Value, VariableDeclarator } from '../../lang/wasm'
 import {
@@ -12,12 +13,12 @@ import {
   getTransformInfos,
   ConstraintType,
 } from '../../lang/std/sketchcombos'
-import { GetInfoModal, createInfoModal } from '../SetHorVertDistanceModal'
+import { GetInfoModal } from '../SetHorVertDistanceModal'
 import { createLiteral, createVariableDeclaration } from '../../lang/modifyAst'
 import { removeDoubleNegatives } from '../AvailableVarsHelpers'
 import { updateCursors } from '../../lang/util'
 
-const getModalInfo = createInfoModal(GetInfoModal)
+const getModalInfo = create(GetInfoModal as any)
 
 type ButtonType =
   | 'setHorzDistance'
@@ -118,46 +119,38 @@ export const SetHorzVertDistance = ({
             transformInfos,
             programMemory,
           })
-
-        if (!isAlign) {
-          const {
-            segName,
-            value,
-            valueNode,
-            variableName,
-            newVariableInsertIndex,
-            sign,
-          } = await getModalInfo({
+        const {
+          segName,
+          value,
+          valueNode,
+          variableName,
+          newVariableInsertIndex,
+          sign,
+        }: {
+          segName: string
+          value: number
+          valueNode: Value
+          variableName?: string
+          newVariableInsertIndex: number
+          sign: number
+        } = await (!isAlign &&
+          getModalInfo({
             segName: tagInfo?.tag,
             isSegNameEditable: !tagInfo?.isTagExisting,
             value: valueUsedInTransform,
             initialVariableName:
               constraint === 'setHorzDistance' ? 'xDis' : 'yDis',
+          } as any))
+        if (segName === tagInfo?.tag && value === valueUsedInTransform) {
+          updateAst(modifiedAst, true, {
+            callBack: updateCursors(setCursor, selectionRanges, pathToNodeMap),
           })
-
-          if (
-            segName === tagInfo?.tag &&
-            value ===
-              (valueUsedInTransform === undefined
-                ? ''
-                : String(Math.abs(valueUsedInTransform)))
-          ) {
-            updateAst(modifiedAst, true, {
-              callBack: updateCursors(
-                setCursor,
-                selectionRanges,
-                pathToNodeMap
-              ),
-            })
-          }
-
-          const finalValue = removeDoubleNegatives(
-            valueNode as BinaryPart,
-            sign,
-            variableName
-          )
-
-          const { modifiedAst: _modifiedAst, pathToNodeMap: _pathToNodeMap } =
+        } else {
+          let finalValue = isAlign
+            ? createLiteral(0)
+            : removeDoubleNegatives(valueNode as BinaryPart, sign, variableName)
+          // transform again but forcing certain values
+          const { modifiedAst: _modifiedAst, pathToNodeMap } =
             transformSecondarySketchLinesTagFirst({
               ast,
               selectionRanges,
@@ -166,7 +159,6 @@ export const SetHorzVertDistance = ({
               forceSegName: segName,
               forceValueUsedInTransform: finalValue,
             })
-
           if (variableName) {
             const newBody = [..._modifiedAst.body]
             newBody.splice(
@@ -176,24 +168,8 @@ export const SetHorzVertDistance = ({
             )
             _modifiedAst.body = newBody
           }
-
           updateAst(_modifiedAst, true, {
-            callBack: updateCursors(setCursor, selectionRanges, _pathToNodeMap),
-          })
-        } else {
-          const finalValue = createLiteral(0)
-
-          const { modifiedAst: _modifiedAst, pathToNodeMap: _pathToNodeMap } =
-            transformSecondarySketchLinesTagFirst({
-              ast,
-              selectionRanges,
-              transformInfos,
-              programMemory,
-              forceValueUsedInTransform: finalValue,
-            })
-
-          updateAst(_modifiedAst, true, {
-            callBack: updateCursors(setCursor, selectionRanges, _pathToNodeMap),
+            callBack: updateCursors(setCursor, selectionRanges, pathToNodeMap),
           })
         }
       }}

--- a/src/components/Toolbar/setAngleLength.tsx
+++ b/src/components/Toolbar/setAngleLength.tsx
@@ -21,7 +21,7 @@ import { removeDoubleNegatives } from '../AvailableVarsHelpers'
 import { normaliseAngle } from '../../lib/utils'
 import { updateCursors } from '../../lang/util'
 
-const getModalInfo = create(SetAngleLengthModal)
+const getModalInfo = create(SetAngleLengthModal as any)
 
 type ButtonType = 'setAngle' | 'setLength'
 
@@ -112,7 +112,7 @@ export const SetAngleLength = ({
               value: forceVal,
               valueName: angleOrLength === 'setAngle' ? 'angle' : 'length',
               shouldCreateVariable: true,
-            })
+            } as any)
           let finalValue = removeDoubleNegatives(valueNode, sign, variableName)
           if (
             isReferencingYAxisAngle ||

--- a/src/hooks/useToolbarGuards.ts
+++ b/src/hooks/useToolbarGuards.ts
@@ -1,13 +1,11 @@
-import {
-  SetVarNameModal,
-  createSetVarNameModal,
-} from 'components/SetVarNameModal'
+import { SetVarNameModal } from 'components/SetVarNameModal'
 import { moveValueIntoNewVariable } from 'lang/modifyAst'
 import { isNodeSafeToReplace } from 'lang/queryAst'
 import { useEffect, useState } from 'react'
+import { create } from 'react-modal-promise'
 import { useStore } from 'useStore'
 
-const getModalInfo = createSetVarNameModal(SetVarNameModal)
+const getModalInfo = create(SetVarNameModal as any)
 
 export function useConvertToVariable() {
   const { guiMode, selectionRanges, ast, programMemory, updateAst } = useStore(
@@ -39,7 +37,7 @@ export function useConvertToVariable() {
     try {
       const { variableName } = await getModalInfo({
         valueName: 'var',
-      })
+      } as any)
 
       const { modifiedAst: _modifiedAst } = moveValueIntoNewVariable(
         ast,


### PR DESCRIPTION
…#792)"

This reverts commit 629f326f4cdf13d83a62f471b4b9a40d3c3a2a88.

add this back in later, just a short cut to get the xState stuff in sooner