### PR TITLE
Use route loader data to instantiate the kcl code

### DIFF
--- a/src/lang/KclSinglton.tsx
+++ b/src/lang/KclSinglton.tsx
@@ -16,6 +16,8 @@ import {
 import { bracket } from 'lib/exampleKcl'
 import { createContext, useContext, useEffect, useState } from 'react'
 import { getNodeFromPath } from './queryAst'
+import { IndexLoaderData } from 'Router'
+import { useLoaderData } from 'react-router-dom'
 
 const PERSIST_CODE_TOKEN = 'persistCode'
 
@@ -314,7 +316,10 @@ export function KclContextProvider({
 }: {
   children: React.ReactNode
 }) {
-  const [code, setCode] = useState(kclManager.code)
+  // If we try to use this component anywhere but under the paths.FILE route it will fail
+  // Because useLoaderData assumes we are on within it's context.
+  const { code: loadedCode } = useLoaderData() as IndexLoaderData
+  const [code, setCode] = useState(loadedCode || kclManager.code)
   const [programMemory, setProgramMemory] = useState(kclManager.programMemory)
   const [ast, setAst] = useState(kclManager.ast)
   const [isExecuting, setIsExecuting] = useState(false)


### PR DESCRIPTION
We added a [KclSinglton](https://github.com/kittycad/modeling-app/blob/fix-code-loader-race/src/lang/KclSinglton.tsx) singleton to prepare for migration of all source code management to Rust. When we instantiate this, we weren't respecting the new code provided to the modeling app via [the loader on the `/file/:id` route](https://github.com/kittycad/modeling-app/blob/fix-code-loader-race/src/Router.tsx#L155-L202), which reads from the file system.

This resulted in multiple updates to the value of `code`, leading to a mismatch that left the CodeMirror component with an empty value, but only when navigating between projects via client-side navigation.

This small change remedies that by instantiating the KclSinglton's `code` value with the route loader data, ensuring everything loads on the same foot, as it were.

### Demo

https://github.com/KittyCAD/modeling-app/assets/23481541/52687897-73c7-44b0-ab79-997dbd8b2de4

