### PR TITLE
save path id on path create

### DIFF
--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -83,16 +83,16 @@ export const ModelingMachineProvider = ({
       'show default planes': () => {
         kclManager.showPlanes()
       },
-      'create path': async () => {
-        const sketchUuid = uuidv4()
-        const proms = [
+      'create path': assign({
+        sketchEnginePathId: () => {
+          const sketchUuid = uuidv4()
           engineCommandManager.sendSceneCommand({
             type: 'modeling_cmd_req',
             cmd_id: sketchUuid,
             cmd: {
               type: 'start_path',
             },
-          }),
+          })
           engineCommandManager.sendSceneCommand({
             type: 'modeling_cmd_req',
             cmd_id: uuidv4(),
@@ -100,10 +100,10 @@ export const ModelingMachineProvider = ({
               type: 'edit_mode_enter',
               target: sketchUuid,
             },
-          }),
-        ]
-        await Promise.all(proms)
-      },
+          })
+          return sketchUuid
+        },
+      }),
       'AST start new sketch': assign((_, { data: { coords, axis } }) => {
         // Something really weird must have happened for this to happen.
         if (!axis) {

--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -765,7 +765,6 @@ export class EngineCommandManager {
     streamWidth: number
     streamHeight: number
   }) {
-    console.log('handleResize', streamWidth, streamHeight)
     if (!this.engineConnection?.isReady()) {
       return
     }


### PR DESCRIPTION
Fixes part of #843 

<img width="579" alt="image" src="https://github.com/KittyCAD/modeling-app/assets/29681384/67e03da5-861e-4127-8e01-4e20026645f3">

The creating new sketch goes via the `Sketch no face state`, and triggers `Select default plane` event which has a few actions. The last of which creates the path, we just needed to hold onto that path id, and that's what this diff is.