### PR TITLE
don't query program memory for add sketch line

### DIFF
--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -172,24 +172,33 @@ export const ModelingMachineProvider = ({
           }
         }
       ),
-      'AST add line segment': (
+      'AST add line segment': async (
         { sketchPathToNode, sketchEnginePathId },
         { data: { coords, segmentId } }
       ) => {
         if (!sketchPathToNode) return
         const lastCoord = coords[coords.length - 1]
 
-        const { node: varDec } = getNodeFromPath<VariableDeclarator>(
-          kclManager.ast,
-          sketchPathToNode,
-          'VariableDeclarator'
-        )
-        const variableName = varDec.id.name
-        const sketchGroup = kclManager.programMemory.root[variableName]
-        if (!sketchGroup || sketchGroup.type !== 'SketchGroup') return
-        const initialCoords = sketchGroup.value[0].from
-
-        const isClose = compareVec2Epsilon(initialCoords, [
+        const pathInfo = await engineCommandManager.sendSceneCommand({
+          type: 'modeling_cmd_req',
+          cmd_id: uuidv4(),
+          cmd: {
+            type: 'path_get_info',
+            path_id: sketchEnginePathId,
+          }
+        })
+        const firstSegment = pathInfo?.data?.data?.segments.find((seg: any) => seg.command === "line_to")
+        const firstSegCoords = await engineCommandManager.sendSceneCommand({
+          type: 'modeling_cmd_req',
+          cmd_id: uuidv4(),
+          cmd: {
+            type: 'curve_get_control_points',
+            curve_id: firstSegment.command_id,
+          }
+        })
+        const startPathCoord = firstSegCoords?.data?.data?.control_points[0]
+        
+        const isClose = compareVec2Epsilon([startPathCoord.x, startPathCoord.y], [
           lastCoord.x,
           lastCoord.y,
         ])
@@ -200,6 +209,7 @@ export const ModelingMachineProvider = ({
             node: kclManager.ast,
             programMemory: kclManager.programMemory,
             to: [lastCoord.x, lastCoord.y],
+            from: [coords[0].x, coords[0].y],
             fnName: 'line',
             pathToNode: sketchPathToNode,
           })

--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -185,23 +185,25 @@ export const ModelingMachineProvider = ({
           cmd: {
             type: 'path_get_info',
             path_id: sketchEnginePathId,
-          }
+          },
         })
-        const firstSegment = pathInfo?.data?.data?.segments.find((seg: any) => seg.command === "line_to")
+        const firstSegment = pathInfo?.data?.data?.segments.find(
+          (seg: any) => seg.command === 'line_to'
+        )
         const firstSegCoords = await engineCommandManager.sendSceneCommand({
           type: 'modeling_cmd_req',
           cmd_id: uuidv4(),
           cmd: {
             type: 'curve_get_control_points',
             curve_id: firstSegment.command_id,
-          }
+          },
         })
         const startPathCoord = firstSegCoords?.data?.data?.control_points[0]
-        
-        const isClose = compareVec2Epsilon([startPathCoord.x, startPathCoord.y], [
-          lastCoord.x,
-          lastCoord.y,
-        ])
+
+        const isClose = compareVec2Epsilon(
+          [startPathCoord.x, startPathCoord.y],
+          [lastCoord.x, lastCoord.y]
+        )
 
         let _modifiedAst: Program
         if (!isClose) {

--- a/src/lang/std/sketch.test.ts
+++ b/src/lang/std/sketch.test.ts
@@ -138,6 +138,7 @@ show(mySketch001)`
       node: ast,
       programMemory,
       to: [2, 3],
+      from: [0, 0],
       fnName: 'lineTo',
       pathToNode: [
         ['body', ''],

--- a/src/lang/std/sketch.ts
+++ b/src/lang/std/sketch.ts
@@ -193,9 +193,6 @@ export const line: SketchLineHelper = {
       pathToNode,
       'VariableDeclarator'
     )
-    const variableName = varDec.id.name
-    const sketch = previousProgramMemory?.root?.[variableName]
-    if (sketch.type !== 'SketchGroup') throw new Error('not a SketchGroup')
 
     const newXVal = createLiteral(roundOff(to[0] - from[0], 2))
     const newYVal = createLiteral(roundOff(to[1] - from[1], 2))
@@ -969,7 +966,8 @@ export function addNewSketchLn({
   to,
   fnName,
   pathToNode,
-}: Omit<CreateLineFnCallArgs, 'from'>): {
+  from,
+}: CreateLineFnCallArgs): {
   modifiedAst: Program
   pathToNode: PathToNode
 } {
@@ -984,12 +982,6 @@ export function addNewSketchLn({
   const { node: pipeExp, shallowPath: pipePath } = getNodeFromPath<
     PipeExpression | CallExpression
   >(node, pathToNode, 'PipeExpression')
-  const variableName = varDec.id.name
-  const sketch = previousProgramMemory?.root?.[variableName]
-  if (sketch.type !== 'SketchGroup') throw new Error('not a SketchGroup')
-
-  const last = sketch.value[sketch.value.length - 1] || sketch.start
-  const from = last.to
   return add({
     node,
     previousProgramMemory,

--- a/src/lang/std/stdTypes.ts
+++ b/src/lang/std/stdTypes.ts
@@ -24,6 +24,7 @@ export interface PathReturn {
 
 export interface ModifyAstBase {
   node: Program
+  // TODO #896: Remove ProgramMemory from this interface
   previousProgramMemory: ProgramMemory
   pathToNode: PathToNode
 }


### PR DESCRIPTION
Ostensibly this was to fix a bug where if create a second sketch, only the first segment would trigger code gen, the rest would fail.

But with this, we're actually hitting into an issue of us moving away from execute-everytime, to not. And basically, we need to stop querying programMemory, and get that information from elsewhere, namely the engine.

I've added a TODO for removing programMemory from `SketchLineHelper`/`ModifyAstBase`. Full write up here https://github.com/KittyCAD/modeling-app/issues/896