### PR TITLE
Build tauri app in debug mode on PRs, release mode on releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,8 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
+          includeDebug: ${{ github.event_name == 'release' || github.event_name == 'schedule' }}
+          includeRelease: ${{ github.event_name != 'release' && github.event_name != 'schedule' }}
           args: ${{ matrix.os == 'macos-latest' && '--target universal-apple-darwin' || '' }}
 
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
Release builds are very slow and should only be used for actual releases. Fast debug builds should be used for CI on PRs.