### PR TITLE
safe parse

### DIFF
--- a/src/components/Stream.tsx
+++ b/src/components/Stream.tsx
@@ -342,7 +342,8 @@ export const Stream = ({ className = '' }) => {
 
           // update artifact map ranges now that we have updated the ast.
           code = recast(modded.modifiedAst)
-          const astWithCurrentRanges = parse(code)
+          const astWithCurrentRanges = kclManager.safeParse(code)
+          if (!astWithCurrentRanges) return
           const updateNode = getNodeFromPath<CallExpression>(
             astWithCurrentRanges,
             modded.pathToNode


### PR DESCRIPTION
added a safeParse method to the `kclSingleton` that adds errors correctly.

There are still uses of `parse` as there are situations where we're parsing code out side of the user's ux loop

resolves https://github.com/KittyCAD/modeling-app/issues/994