### PR TITLE
stop double execute on project open

### DIFF
--- a/src/hooks/useSetupEngineManager.ts
+++ b/src/hooks/useSetupEngineManager.ts
@@ -26,10 +26,6 @@ export function useSetupEngineManager(
 
   const hasSetNonZeroDimensions = useRef<boolean>(false)
 
-  useEffect(() => {
-    kclManager.executeCode()
-  }, [])
-
   useLayoutEffect(() => {
     // Load the engine command manager once with the initial width and height,
     // then we do not want to reload it.


### PR DESCRIPTION
We should not use react listeners like this for executing because we are handling files opening and closing while keeping the stream open and so that open close logic should handle re-executes. Since the x-state migration and moving kcl state inte the kcl-singleton, react listeners should not be involved with triggering re-executions.

Continues some of the work from #897.

Related to #959 

