### PR TITLE
don't overwrite current file on onboarding-replay

### DIFF
--- a/src/routes/Onboarding/Introduction.tsx
+++ b/src/routes/Onboarding/Introduction.tsx
@@ -121,7 +121,7 @@ function OnboardingWithNewFile() {
                 Element="button"
                 onClick={() => {
                   createAndOpenNewProject()
-                  kclManager.setCode(bracket)
+                  kclManager.setCode(bracket, false)
                   dismiss()
                 }}
                 icon={{ icon: faArrowRight }}


### PR DESCRIPTION
#862 was resolved by #897 

however I did find a bug when double checking that this PR fixes so I'll say

Resolves #862 


The bug was that when you clicked "make a new project" as part of the onboarding replay, it would overwrite the user's current file with the bracket code.