### PR TITLE
fix selections

### DIFF
--- a/src/hooks/useEngineConnectionSubscriptions.ts
+++ b/src/hooks/useEngineConnectionSubscriptions.ts
@@ -32,6 +32,7 @@ export function useEngineConnectionSubscriptions() {
     const unSubClick = engineCommandManager.subscribeTo({
       event: 'select_with_point',
       callback: async (engineEvent) => {
+        if (!context.sketchEnginePathId) return
         const event = await getEventForSelectWithPoint(engineEvent, {
           sketchEnginePathId: context.sketchEnginePathId,
         })


### PR DESCRIPTION
I can't say I understand why, but when the frontend sent a bad `path_get_curve_uuids_for_vertices` request to the backend, it would break the selections stuff 🤷 