### PR TITLE
Cut release v0.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "untitled-app",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "private": true,
   "dependencies": {
     "@codemirror/autocomplete": "^6.10.2",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "kittycad-modeling",
-    "version": "0.11.2"
+    "version": "0.11.3"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
Cutting a release for a regression I introduced in #1013 

PRs in this release:
- selections fix follow up (#1019)
- Neaten up stdlib code (#1017)