### PR TITLE
Fit resolutions to less than 2k x 2k

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1914,12 +1914,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "minisign-verify"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "933dca44d65cdd53b355d0b73d380a2ff5da71f87f036053188bf1eab6a19881"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3745,7 +3739,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bfe673cf125ef364d6f56b15e8ce7537d9ca7e4dae1cf6fbbdeed2e024db3d9"
 dependencies = [
  "anyhow",
- "base64 0.21.2",
  "bytes",
  "cocoa",
  "dirs-next",
@@ -3759,7 +3752,6 @@ dependencies = [
  "heck 0.4.1",
  "http",
  "ignore",
- "minisign-verify",
  "objc",
  "once_cell",
  "open",
@@ -3784,14 +3776,12 @@ dependencies = [
  "tauri-utils",
  "tempfile",
  "thiserror",
- "time",
  "tokio",
  "url",
  "uuid",
  "webkit2gtk",
  "webview2-com",
  "windows 0.39.0",
- "zip",
 ]
 
 [[package]]
@@ -5011,15 +5001,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
-]
-
-[[package]]
-name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "byteorder",
- "crc32fast",
- "crossbeam-utils",
 ]

--- a/src/hooks/useSetupEngineManager.ts
+++ b/src/hooks/useSetupEngineManager.ts
@@ -82,9 +82,14 @@ export function useSetupEngineManager(
 }
 
 function getDimensions(streamWidth?: number, streamHeight?: number) {
+  const maxResolution = 2000
   const width = streamWidth ? streamWidth : 0
-  const quadWidth = Math.round(width / 4) * 4
   const height = streamHeight ? streamHeight : 0
-  const quadHeight = Math.round(height / 4) * 4
+  const ratio = Math.min(
+    Math.min(maxResolution / width, maxResolution / height),
+    1.0
+  )
+  const quadWidth = Math.round((width * ratio) / 4) * 4
+  const quadHeight = Math.round((height * ratio) / 4) * 4
   return { width: quadWidth, height: quadHeight }
 }

--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -76,12 +76,12 @@ export class EngineConnection {
   constructor({
     url,
     token,
-    onWebsocketOpen = () => { },
-    onNewTrack = () => { },
-    onEngineConnectionOpen = () => { },
-    onConnectionStarted = () => { },
-    onClose = () => { },
-    onDataChannelOpen = () => { },
+    onWebsocketOpen = () => {},
+    onNewTrack = () => {},
+    onEngineConnectionOpen = () => {},
+    onConnectionStarted = () => {},
+    onClose = () => {},
+    onDataChannelOpen = () => {},
   }: {
     url: string
     token?: string
@@ -592,7 +592,7 @@ export class EngineCommandManager {
   // Folks should realize that wait for ready does not get called _everytime_
   // the connection resets and restarts, it only gets called the first time.
   // Be careful what you put here.
-  private resolveReady = () => { }
+  private resolveReady = () => {}
   waitForReady: Promise<void> = new Promise((resolve) => {
     this.resolveReady = resolve
   })
@@ -1001,7 +1001,7 @@ export class EngineCommandManager {
     command: Models['ModelingCmd_type'],
     range?: SourceRange
   ) {
-    let resolve: (val: any) => void = () => { }
+    let resolve: (val: any) => void = () => {}
     const promise = new Promise((_resolve, reject) => {
       resolve = _resolve
     })
@@ -1114,7 +1114,7 @@ export class EngineCommandManager {
     )
   }
 
-  onPlaneSelectCallback = (id: string) => { }
+  onPlaneSelectCallback = (id: string) => {}
   onPlaneSelected(callback: (id: string) => void) {
     this.onPlaneSelectCallback = callback
   }
@@ -1169,7 +1169,7 @@ export class EngineCommandManager {
 }
 
 function fitResolution(width: number, height: number) {
-  var ratio = Math.min(2000 / width, 2000 / height)
+  const ratio = Math.min(2000 / width, 2000 / height)
 
   return {
     width: Math.floor(width * ratio),

--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -76,12 +76,12 @@ export class EngineConnection {
   constructor({
     url,
     token,
-    onWebsocketOpen = () => {},
-    onNewTrack = () => {},
-    onEngineConnectionOpen = () => {},
-    onConnectionStarted = () => {},
-    onClose = () => {},
-    onDataChannelOpen = () => {},
+    onWebsocketOpen = () => { },
+    onNewTrack = () => { },
+    onEngineConnectionOpen = () => { },
+    onConnectionStarted = () => { },
+    onClose = () => { },
+    onDataChannelOpen = () => { },
   }: {
     url: string
     token?: string
@@ -592,7 +592,7 @@ export class EngineCommandManager {
   // Folks should realize that wait for ready does not get called _everytime_
   // the connection resets and restarts, it only gets called the first time.
   // Be careful what you put here.
-  private resolveReady = () => {}
+  private resolveReady = () => { }
   waitForReady: Promise<void> = new Promise((resolve) => {
     this.resolveReady = resolve
   })
@@ -1001,7 +1001,7 @@ export class EngineCommandManager {
     command: Models['ModelingCmd_type'],
     range?: SourceRange
   ) {
-    let resolve: (val: any) => void = () => {}
+    let resolve: (val: any) => void = () => { }
     const promise = new Promise((_resolve, reject) => {
       resolve = _resolve
     })
@@ -1114,7 +1114,7 @@ export class EngineCommandManager {
     )
   }
 
-  onPlaneSelectCallback = (id: string) => {}
+  onPlaneSelectCallback = (id: string) => { }
   onPlaneSelected(callback: (id: string) => void) {
     this.onPlaneSelectCallback = callback
   }
@@ -1171,7 +1171,10 @@ export class EngineCommandManager {
 function fitResolution(width: number, height: number) {
   var ratio = Math.min(2000 / width, 2000 / height)
 
-  return { width: width * ratio, height: height * ratio }
+  return {
+    width: Math.floor(width * ratio),
+    height: Math.floor(height * ratio),
+  }
 }
 
 export const engineCommandManager = new EngineCommandManager()

--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -631,22 +631,16 @@ export class EngineCommandManager {
       return
     }
 
-    // Engine is currently constrained to 2000 by 2000, so normalize width and height first
-    const { width: scaledWidth, height: scaledHeight } = fitResolution(
-      width,
-      height
-    )
-
     // If we already have an engine connection, just need to resize the stream.
     if (this.engineConnection) {
       this.handleResize({
-        streamWidth: scaledWidth,
-        streamHeight: scaledHeight,
+        streamWidth: width,
+        streamHeight: height,
       })
       return
     }
 
-    const url = `${VITE_KC_API_WS_MODELING_URL}?video_res_width=${scaledWidth}&video_res_height=${scaledHeight}`
+    const url = `${VITE_KC_API_WS_MODELING_URL}?video_res_width=${width}&video_res_height=${height}`
     this.engineConnection = new EngineConnection({
       url,
       token,
@@ -1165,15 +1159,6 @@ export class EngineCommandManager {
     })
     await this.setPlaneHidden(planeId, true)
     return planeId
-  }
-}
-
-function fitResolution(width: number, height: number) {
-  const ratio = Math.min(2000 / width, 2000 / height)
-
-  return {
-    width: Math.floor(width * ratio),
-    height: Math.floor(height * ratio),
   }
 }
 

--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -631,13 +631,22 @@ export class EngineCommandManager {
       return
     }
 
+    // Engine is currently constrained to 2000 by 2000, so normalize width and height first
+    const { width: scaledWidth, height: scaledHeight } = fitResolution(
+      width,
+      height
+    )
+
     // If we already have an engine connection, just need to resize the stream.
     if (this.engineConnection) {
-      this.handleResize({ streamWidth: width, streamHeight: height })
+      this.handleResize({
+        streamWidth: scaledWidth,
+        streamHeight: scaledHeight,
+      })
       return
     }
 
-    const url = `${VITE_KC_API_WS_MODELING_URL}?video_res_width=${width}&video_res_height=${height}`
+    const url = `${VITE_KC_API_WS_MODELING_URL}?video_res_width=${scaledWidth}&video_res_height=${scaledHeight}`
     this.engineConnection = new EngineConnection({
       url,
       token,
@@ -1157,6 +1166,12 @@ export class EngineCommandManager {
     await this.setPlaneHidden(planeId, true)
     return planeId
   }
+}
+
+function fitResolution(width: number, height: number) {
+  var ratio = Math.min(2000 / width, 2000 / height)
+
+  return { width: width * ratio, height: height * ratio }
 }
 
 export const engineCommandManager = new EngineCommandManager()

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -93,16 +93,8 @@ export function getNormalisedCoordinates({
   const { left, top, width, height } = el?.getBoundingClientRect()
   const browserX = clientX - left
   const browserY = clientY - top
-
-  const maxResolution = 2000
-  const ratio = Math.min(
-    maxResolution / streamWidth,
-    maxResolution / streamHeight
-  )
-  const scaledWidth = Math.floor(streamWidth * ratio)
-  const scaledHeight = Math.floor(streamHeight * ratio)
   return {
-    x: Math.round((browserX / width) * scaledWidth),
-    y: Math.round((browserY / height) * scaledHeight),
+    x: Math.round((browserX / width) * streamWidth),
+    y: Math.round((browserY / height) * streamHeight),
   }
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -93,8 +93,16 @@ export function getNormalisedCoordinates({
   const { left, top, width, height } = el?.getBoundingClientRect()
   const browserX = clientX - left
   const browserY = clientY - top
+
+  const maxResolution = 2000
+  const ratio = Math.min(
+    maxResolution / streamWidth,
+    maxResolution / streamHeight
+  )
+  const scaledWidth = Math.floor(streamWidth * ratio)
+  const scaledHeight = Math.floor(streamHeight * ratio)
   return {
-    x: Math.round((browserX / width) * streamWidth),
-    y: Math.round((browserY / height) * streamHeight),
+    x: Math.round((browserX / width) * scaledWidth),
+    y: Math.round((browserY / height) * scaledHeight),
   }
 }


### PR DESCRIPTION
I put in limits on the API side to prevent huge resolutions. But, we still have a few cases where modeling app will request a bigger resolution, like full screen on my biggest monitor.

An unfortunate side-effect of this is that we'll also need to scale the resolution of all mouse events, but I'll do some testing to be sure.