### PR TITLE
Add a console.error when ICE fails

### DIFF
--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -216,6 +216,26 @@ export class EngineConnection {
       }
     })
 
+    this.pc.addEventListener('icecandidateerror', (_event) => {
+      const event = _event as RTCPeerConnectionIceErrorEvent
+      console.error(
+        `ICE candidate returned an error: ${event.errorCode}: ${event.errorText} for ${event.url}`
+      )
+    })
+
+    this.pc.addEventListener('connectionstatechange', (event) => {
+      if (this.pc?.iceConnectionState === 'connected') {
+        if (this.shouldTrace()) {
+          iceSpan.resolve?.()
+        }
+      } else if (this.pc?.iceConnectionState === 'failed') {
+        // failed is a terminal state; let's explicitly kill the
+        // connection to the server at this point.
+        console.log('failed to negotiate ice connection; restarting')
+        this.close()
+      }
+    })
+
     this.websocket.addEventListener('open', (event) => {
       if (this.shouldTrace()) {
         websocketSpan.resolve?.()
@@ -350,19 +370,6 @@ export class EngineConnection {
         // ICE negotiation happen in the background. Everything from here
         // until the end of this function is setup of our end of the
         // PeerConnection and waiting for events to fire our callbacks.
-
-        this.pc.addEventListener('connectionstatechange', (event) => {
-          if (this.pc?.iceConnectionState === 'connected') {
-            if (this.shouldTrace()) {
-              iceSpan.resolve?.()
-            }
-          } else if (this.pc?.iceConnectionState === 'failed') {
-            // failed is a terminal state; let's explicitly kill the
-            // connection to the server at this point.
-            console.log('failed to negotiate ice connection; restarting')
-            this.close()
-          }
-        })
 
         this.pc.addEventListener('icecandidate', (event) => {
           if (!this.pc || !this.websocket) return


### PR DESCRIPTION
This is purely cosmetic right now, but I want to try and make it easier to tell when the browser is unable to communicate with the ICE server by writing it to the console.

I want to add some Sentry logging in the future, but for now, when we see a stream failing to start, we can at least see what I suspect is the most common trigger in the console.