### PR TITLE
Cut release v0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "untitled-app",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "private": true,
   "dependencies": {
     "@codemirror/autocomplete": "^6.10.2",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "kittycad-modeling",
-    "version": "0.11.3"
+    "version": "0.12.0"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
```
- Add first KCL stdlib and circle function (#1029)
- Fit resolutions to less than 2k x 2k (#1065)
- Add a console.error when ICE fails (#1067)
- Disable eslint rule `react-hooks/exhaustive-deps` (#1055)
- Macro for parsing KCL at Rust compile-time (#1049)
- Implement databake for all AST node types (#1047)
- Add top level expressions fix (#1046)
- Describe Rust version for devs (#1044)
- AST function nodes no longer have stdlib function members (#1031)
- Test with a circle function (#1030)
- Refactor the call_fn fn to be more readable (#1028)
- Fix auto-version in nightly builds (#1026)
- Fix epsilon bug (#1025)
```