### PR TITLE
Add Playwright tests for onboarding

### DIFF
--- a/src/routes/Onboarding/Export.tsx
+++ b/src/routes/Onboarding/Export.tsx
@@ -62,6 +62,7 @@ export default function Export() {
             Element="button"
             onClick={next}
             icon={{ icon: faArrowRight }}
+            data-testid="onboarding-next"
           >
             Next: Sketching
           </ActionButton>

--- a/src/routes/Onboarding/Sketching.tsx
+++ b/src/routes/Onboarding/Sketching.tsx
@@ -57,6 +57,7 @@ export default function Sketching() {
             Element="button"
             onClick={next}
             icon={{ icon: faArrowRight }}
+            data-testid="onboarding-next"
           >
             Next: Future Work
           </ActionButton>

--- a/src/routes/Onboarding/index.tsx
+++ b/src/routes/Onboarding/index.tsx
@@ -125,9 +125,9 @@ const Onboarding = () => {
   useHotkeys('esc', dismiss)
 
   return (
-    <>
+    <div className="content" data-testid="onboarding-content">
       <Outlet />
-    </>
+    </div>
   )
 }
 


### PR DESCRIPTION
Resolves #1110, adds a test for onboarding that tests the following:
- The app redirects users with valid onboarding state in localStorage get redirected to that page in onboarding
- Reloading the page keeps them at the same URL
- The onboarding content loads properly
- Advancing to the "Sketching" step clears that code
- Advancing to the "Next Steps" step resets the code to be non-empty.