### PR TITLE
selections e2e test

### DIFF
--- a/e2e/playwright/flow-tests.spec.ts
+++ b/e2e/playwright/flow-tests.spec.ts
@@ -437,7 +437,7 @@ test('Onboarding redirects and code updating', async ({ page, context }) => {
   await expect(page.locator('.cm-content')).toHaveText(/.+/)
 })
 
-test.only('Selections work on fresh and edited sketch', async ({ page }) => {
+test('Selections work on fresh and edited sketch', async ({ page }) => {
   const u = getUtils(page)
   const PUR = 400 / 37.5 //pixeltoUnitRatio
   await page.setViewportSize({ width: 1200, height: 500 })

--- a/e2e/playwright/flow-tests.spec.ts
+++ b/e2e/playwright/flow-tests.spec.ts
@@ -147,12 +147,9 @@ test('if you write invalid kcl you get inlined errors', async ({ page }) => {
     const bottomAng = 25
    */
   await page.click('.cm-content')
-  await page.keyboard.type('# error')
-  await page.keyboard.press('Enter')
-  await page.keyboard.type('const topAng = 30')
-  await page.keyboard.press('Enter')
-  await page.keyboard.type('const bottomAng = 25')
-  await page.keyboard.press('Enter')
+  await page.keyboard.type(`# error
+const topAng = 30
+const bottomAng = 25`)
 
   // error in guter
   await expect(page.locator('.cm-lint-marker-error')).toBeVisible()

--- a/e2e/playwright/flow-tests.spec.ts
+++ b/e2e/playwright/flow-tests.spec.ts
@@ -443,6 +443,9 @@ test('Onboarding redirects and code updating', async ({ page, context }) => {
 })
 
 test('Selections work on fresh and edited sketch', async ({ page }) => {
+  // tests mapping works on fresh sketch and edited sketch
+  // tests using hovers which is the same as selections, because if
+  // source ranges are wrong, hovers won't work
   const u = getUtils(page)
   const PUR = 400 / 37.5 //pixeltoUnitRatio
   await page.setViewportSize({ width: 1200, height: 500 })

--- a/e2e/playwright/flow-tests.spec.ts
+++ b/e2e/playwright/flow-tests.spec.ts
@@ -437,7 +437,10 @@ test('Onboarding redirects and code updating', async ({ page, context }) => {
   await expect(page.locator('.cm-content')).toHaveText(/.+/)
 })
 
-test('Selections work on fresh and edited sketch', async ({ page }) => {
+test('Selections work on fresh and edited sketches', async ({ page }) => {
+  // tests mapping works on fresh sketch and edited sketch
+  // tests using hovers which is the same as selections, because if
+  // source ranges are wrong, hovers won't work
   const u = getUtils(page)
   const PUR = 400 / 37.5 //pixeltoUnitRatio
   await page.setViewportSize({ width: 1200, height: 500 })

--- a/e2e/playwright/flow-tests.spec.ts
+++ b/e2e/playwright/flow-tests.spec.ts
@@ -147,9 +147,17 @@ test('if you write invalid kcl you get inlined errors', async ({ page }) => {
     const bottomAng = 25
    */
   await page.click('.cm-content')
-  await page.keyboard.type(`# error
-const topAng = 30
-const bottomAng = 25`)
+  await page.keyboard.type('# error')
+
+  // press arrows to clear autocomplete
+  await page.keyboard.press('ArrowLeft')
+  await page.keyboard.press('ArrowRight')
+
+  await page.keyboard.press('Enter')
+  await page.keyboard.type('const topAng = 30')
+  await page.keyboard.press('Enter')
+  await page.keyboard.type('const bottomAng = 25')
+  await page.keyboard.press('Enter')
 
   // error in guter
   await expect(page.locator('.cm-lint-marker-error')).toBeVisible()
@@ -434,10 +442,7 @@ test('Onboarding redirects and code updating', async ({ page, context }) => {
   await expect(page.locator('.cm-content')).toHaveText(/.+/)
 })
 
-test('Selections work on fresh and edited sketches', async ({ page }) => {
-  // tests mapping works on fresh sketch and edited sketch
-  // tests using hovers which is the same as selections, because if
-  // source ranges are wrong, hovers won't work
+test('Selections work on fresh and edited sketch', async ({ page }) => {
   const u = getUtils(page)
   const PUR = 400 / 37.5 //pixeltoUnitRatio
   await page.setViewportSize({ width: 1200, height: 500 })

--- a/e2e/playwright/snapshot-tests.spec.ts
+++ b/e2e/playwright/snapshot-tests.spec.ts
@@ -32,7 +32,7 @@ test.setTimeout(60000)
 test('change camera, show planes', async ({ page, context }) => {
   const u = getUtils(page)
   await page.setViewportSize({ width: 1200, height: 500 })
-  await page.goto('localhost:3000')
+  await page.goto('/')
   await u.waitForAuthSkipAppStart()
   await u.openAndClearDebugPanel()
 

--- a/e2e/playwright/test-utils.ts
+++ b/e2e/playwright/test-utils.ts
@@ -2,8 +2,6 @@ import { expect, Page } from '@playwright/test'
 import { EngineCommand } from '../../src/lang/std/engineConnection'
 
 async function waitForPageLoad(page: Page) {
-  // wait for 'Loading KittyCAD Modeling App...' spinner
-  await page.getByTestId('initial-load').waitFor()
   // wait for 'Loading stream...' spinner
   await page.getByTestId('loading-stream').waitFor()
   // wait for all spinners to be gone

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://127.0.0.1:3000',
+    baseURL: 'http://localhost:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/src/components/EngineCommands.tsx
+++ b/src/components/EngineCommands.tsx
@@ -32,7 +32,7 @@ export const EngineCommands = () => {
           const stringer = JSON.stringify(command)
           if (containsFilter && !stringer.includes(containsFilter)) return null
           return (
-            <pre className="text-xs">
+            <pre className="text-xs" key={index}>
               <code
                 key={index}
                 data-message-type={command.type}

--- a/src/editor/highlightextension.ts
+++ b/src/editor/highlightextension.ts
@@ -27,4 +27,7 @@ export const lineHighlightField = StateField.define({
   provide: (f) => EditorView.decorations.from(f),
 })
 
-const matchDeco = Decoration.mark({ class: 'bg-yellow-200' })
+const matchDeco = Decoration.mark({
+  class: 'bg-yellow-200',
+  attributes: { 'data-testid': 'hover-highlight' },
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,8 +26,7 @@
     "jsx": "react-jsx"
   },
   "include": [
-    "src",
-    "e2e"
+    "src"
   ],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
related to https://github.com/KittyCAD/modeling-app/issues/833

The tests mapping works on fresh sketch and edited sketch, tests using hovers which is the same as selections, because if source ranges are wrong, hovers won't work.

Also fixed an issue caused by auto-complete for the test `if you write invalid kcl you get inlined errors` that only appeared in CI in the macos runner.