### PR TITLE
Read/write composite values to KCEP memory

### DIFF
--- a/src/wasm-lib/execution-plan/src/in_memory.rs
+++ b/src/wasm-lib/execution-plan/src/in_memory.rs
@@ -1,0 +1,39 @@
+use crate::{ExecutionError, Value};
+
+/// Types that can be written to or read from KCEP program memory,
+/// but require multiple values to store.
+/// They get laid out into multiple consecutive memory addresses.
+pub trait Composite: Sized {
+    /// Store the value in memory.
+    fn into_parts(self) -> Vec<Value>;
+    /// Read the value from memory.
+    fn from_parts(values: Vec<Value>) -> Result<Self, ExecutionError>;
+    /// How many memory addresses are required to store this value?
+    const SIZE: usize;
+}
+
+impl Composite for kittycad::types::Point3D {
+    fn into_parts(self) -> Vec<Value> {
+        let points = [self.x, self.y, self.z];
+        points
+            .into_iter()
+            .map(|x| Value::NumericValue(crate::NumericValue::Float(x)))
+            .collect()
+    }
+
+    const SIZE: usize = 3;
+
+    fn from_parts(values: Vec<Value>) -> Result<Self, ExecutionError> {
+        let n = values.len();
+        let Ok([x, y, z]): Result<[Value; 3], _> = values.try_into() else {
+            return Err(ExecutionError::MemoryWrongSize {
+                actual: n,
+                expected: Self::SIZE,
+            });
+        };
+        let x = x.try_into()?;
+        let y = y.try_into()?;
+        let z = z.try_into()?;
+        Ok(Self { x, y, z })
+    }
+}


### PR DESCRIPTION
KCEP's memory model stores 'values', which can be either numbers or strings. But we'll need to support storing complex objects like points, lines, sketchgroups, etc in memory too.

This PR adds a trait for KCEP composite types, which are laid out in KCEP memory as a consecutive series of values, one for each field.

Part of https://github.com/KittyCAD/modeling-app/issues/993