### PR TITLE
Cut release v0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "untitled-app",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "dependencies": {
     "@codemirror/autocomplete": "^6.10.2",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "kittycad-modeling",
-    "version": "0.12.0"
+    "version": "0.13.0"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
```
- update e2e tests after grid update (#1171)
- expand lsp test (#1167)
- Rename mod in_memory to composite (#1169)
- Read/write composite values to KCEP memory (#1164)
- EP instructions must be serializable (#1163)
- Start execution plans (#1155)
- Sort constraint buttons (#1161)
- side quest for screenshot diffs (#1160)
- Select axis and relevant constraints (#1154)
- more e2e export fixes (#1150)
- Add tauri e2e test for auth on Linux (#1040)
- fix ply and stl exports (#1141)
- test exports (#1139)
- ensure import files always sent as bson (#1138)
- selections e2e test (#1136)
- Add Playwright tests for onboarding (#1125)
- make error not so long (#1129)
- readme (#1119)
- initial playwright setup and test (#1039)
- Cargo.lock updates (#1108)
- remove the buffer we were using for debugging, its too small for import (#1100)
- Derive Databake now that it has HashMap support (#1095)
- KCL optional parameters (#1087)
- Release KCL 0.1.36 (#1078)
```

Smoke tested on Windows 10 and macOS:
- sign in
- open existing mode
- create new extruded triangle model
- export to STL
- sign out