### PR TITLE
Execution plans should allow dynamic sized types

### DIFF
--- a/src/wasm-lib/execution-plan/src/composite.rs
+++ b/src/wasm-lib/execution-plan/src/composite.rs
@@ -1,5 +1,7 @@
 use crate::{ExecutionError, Value};
 
+mod impls;
+
 /// Types that can be written to or read from KCEP program memory,
 /// but require multiple values to store.
 /// They get laid out into multiple consecutive memory addresses.
@@ -8,23 +10,4 @@ pub trait Composite: Sized {
     fn into_parts(self) -> Vec<Value>;
     /// Read the value from memory.
     fn from_parts(values: &[Option<Value>]) -> Result<Self, ExecutionError>;
-}
-
-impl Composite for kittycad::types::Point3D {
-    fn into_parts(self) -> Vec<Value> {
-        let points = [self.x, self.y, self.z];
-        points
-            .into_iter()
-            .map(|x| Value::NumericValue(crate::NumericValue::Float(x)))
-            .collect()
-    }
-
-    fn from_parts(values: &[Option<Value>]) -> Result<Self, ExecutionError> {
-        let err = ExecutionError::MemoryWrongSize { expected: 3 };
-        let [x, y, z] = [0, 1, 2].map(|n| values.get(n).ok_or(err.clone()));
-        let x = x?.to_owned().ok_or(err.clone())?.try_into()?;
-        let y = y?.to_owned().ok_or(err.clone())?.try_into()?;
-        let z = z?.to_owned().ok_or(err.clone())?.try_into()?;
-        Ok(Self { x, y, z })
-    }
 }

--- a/src/wasm-lib/execution-plan/src/composite/impls.rs
+++ b/src/wasm-lib/execution-plan/src/composite/impls.rs
@@ -1,0 +1,22 @@
+use crate::{ExecutionError, Value};
+
+use super::Composite;
+
+impl Composite for kittycad::types::Point3D {
+    fn into_parts(self) -> Vec<Value> {
+        let points = [self.x, self.y, self.z];
+        points
+            .into_iter()
+            .map(|x| Value::NumericValue(crate::NumericValue::Float(x)))
+            .collect()
+    }
+
+    fn from_parts(values: &[Option<Value>]) -> Result<Self, ExecutionError> {
+        let err = ExecutionError::MemoryWrongSize { expected: 3 };
+        let [x, y, z] = [0, 1, 2].map(|n| values.get(n).ok_or(err.clone()));
+        let x = x?.to_owned().ok_or(err.clone())?.try_into()?;
+        let y = y?.to_owned().ok_or(err.clone())?.try_into()?;
+        let z = z?.to_owned().ok_or(err.clone())?.try_into()?;
+        Ok(Self { x, y, z })
+    }
+}

--- a/src/wasm-lib/execution-plan/src/tests.rs
+++ b/src/wasm-lib/execution-plan/src/tests.rs
@@ -58,14 +58,11 @@ fn add_to_composite_value() {
 
     // Write a point to memory.
     let point_before = Point3D { x: 2.0, y: 3.0, z: 4.0 };
-    let start_addr = Address(100);
+    let start_addr = Address(0);
     mem.set_composite(point_before, start_addr);
-    assert_eq!(
-        mem,
-        Memory(HashMap::from(
-            [(100, 2.0.into()), (101, 3.0.into()), (102, 4.0.into()),]
-        ))
-    );
+    assert_eq!(mem.0[0], Some(2.0.into()));
+    assert_eq!(mem.0[1], Some(3.0.into()));
+    assert_eq!(mem.0[2], Some(4.0.into()));
 
     // Update the point's x-value in memory.
     execute(


### PR DESCRIPTION
- Change memory from HashMap<address, value> to Vec<Value>
- Reading a composite value from its parts out of memory now takes a slice of memory, not a vec of memory values. 
- This way, types like Vec<Point3d> can be laid out in memory as [size, elem0, elem1, ..., elemSize]