### PR TITLE
Grackle (KCL to EP compiler)

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 ignore-words-list: crate,everytime
-skip: **/target,node_modules,build
+skip: **/target,node_modules,build,**/Cargo.lock

--- a/src/wasm-lib/Cargo.lock
+++ b/src/wasm-lib/Cargo.lock
@@ -1943,7 +1943,7 @@ dependencies = [
 [[package]]
 name = "kittycad-execution-plan"
 version = "0.1.0"
-source = "git+https://github.com/KittyCAD/modeling-api?branch=main#20751ca8844a143d9690d13043fc6aa9107d19bd"
+source = "git+https://github.com/KittyCAD/modeling-api?branch=main#627d6b1c861ac1d534b4fecc280aa8c9b7d5df03"
 dependencies = [
  "bytes",
  "insta",
@@ -1972,7 +1972,7 @@ dependencies = [
 [[package]]
 name = "kittycad-execution-plan-macros"
 version = "0.1.2"
-source = "git+https://github.com/KittyCAD/modeling-api?branch=main#20751ca8844a143d9690d13043fc6aa9107d19bd"
+source = "git+https://github.com/KittyCAD/modeling-api?branch=main#627d6b1c861ac1d534b4fecc280aa8c9b7d5df03"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1981,9 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad-execution-plan-traits"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49e5ad9fd3c4277e1e770029fc63d530c023268379dac59684fbba797729c0e"
+checksum = "1486416eacecf481188a253199461fde5dbbc9bccaf176d60c48181cd0465273"
 dependencies = [
  "serde",
  "thiserror",
@@ -1993,7 +1993,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds"
 version = "0.1.11"
-source = "git+https://github.com/KittyCAD/modeling-api?branch=main#20751ca8844a143d9690d13043fc6aa9107d19bd"
+source = "git+https://github.com/KittyCAD/modeling-api?branch=main#627d6b1c861ac1d534b4fecc280aa8c9b7d5df03"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2020,7 +2020,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-session"
 version = "0.1.0"
-source = "git+https://github.com/KittyCAD/modeling-api?branch=main#20751ca8844a143d9690d13043fc6aa9107d19bd"
+source = "git+https://github.com/KittyCAD/modeling-api?branch=main#627d6b1c861ac1d534b4fecc280aa8c9b7d5df03"
 dependencies = [
  "futures",
  "kittycad",

--- a/src/wasm-lib/Cargo.lock
+++ b/src/wasm-lib/Cargo.lock
@@ -28,6 +28,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,10 +163,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
+
+[[package]]
 name = "arc-swap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
+name = "asn1-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits 0.2.17",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "synstructure 0.12.6",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "async-codec-lite"
@@ -157,7 +237,7 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -168,7 +248,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -176,6 +256,12 @@ name = "atomic"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atty"
@@ -222,6 +308,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +326,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,7 +341,7 @@ dependencies = [
  "libm",
  "num-bigint",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.17",
  "serde",
 ]
 
@@ -296,6 +394,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bson"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,7 +416,7 @@ dependencies = [
  "indexmap 1.9.3",
  "js-sys",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -351,6 +458,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,10 +476,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "ccm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae3c82e4355234767756212c570e29833699ab63e6ffd161887314cc5b43847"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cgmath"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a4b57c8f4e3a2e9ac07e0f6abc9c24b6fc9e1b54c3478cfb598f3d0023e51c"
+dependencies = [
+ "approx",
+ "mint",
+ "num-traits 0.1.43",
+ "rand 0.4.6",
+]
 
 [[package]]
 name = "chrono"
@@ -373,8 +513,10 @@ checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "num-traits",
+ "js-sys",
+ "num-traits 0.2.17",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.48.5",
 ]
 
@@ -403,6 +545,16 @@ checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
  "half 1.8.2",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -439,7 +591,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -485,6 +637,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +677,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,7 +713,7 @@ dependencies = [
  "criterion-plot",
  "is-terminal",
  "itertools 0.10.5",
- "num-traits",
+ "num-traits 0.2.17",
  "once_cell",
  "oorandom",
  "plotters",
@@ -593,7 +766,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.9.0",
  "scopeguard",
 ]
 
@@ -613,13 +786,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "platforms",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -660,8 +882,33 @@ checksum = "377af281d8f23663862a7c84623bc5dcf7f8c44b13c7496a590bdc157f941a43"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
- "synstructure",
+ "syn 2.0.48",
+ "synstructure 0.13.0",
+]
+
+[[package]]
+name = "der"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits 0.2.17",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -687,7 +934,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_tokenstream",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -703,7 +950,28 @@ dependencies = [
  "regex",
  "serde",
  "serde_tokenstream",
- "syn 2.0.39",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "diesel_derives"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8337737574f55a468005a83499da720f20c65586241ffea339db9ecdfd2b44"
+dependencies = [
+ "diesel_table_macro_syntax",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "diesel_table_macro_syntax"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
+dependencies = [
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -719,7 +987,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -744,16 +1014,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d2f3407d9a573d666de4b5bdf10569d73ca9478087346697dcbae6244bfbcd"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -771,6 +1087,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7add3873b5dd076766ee79c8e406ad1a472c385476b9e38849f8eec24f1be689"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +1120,16 @@ checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "euler"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f19d11568a4a46aee488bdab3a2963e5e2c3cfd6091aa0abceaddcea82c0bc1"
+dependencies = [
+ "approx",
+ "cgmath",
 ]
 
 [[package]]
@@ -829,6 +1175,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
+
+[[package]]
 name = "flate2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,7 +1206,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -852,6 +1214,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -874,6 +1251,12 @@ dependencies = [
  "serde_yaml 0.8.26",
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -937,7 +1320,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -978,6 +1361,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -991,6 +1375,16 @@ dependencies = [
  "libc",
  "wasi",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1023,6 +1417,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "grackle"
+version = "0.1.0"
+dependencies = [
+ "kcl-lib",
+ "kittycad-execution-plan",
+ "kittycad-execution-plan-traits",
+ "kittycad-modeling-session",
+ "pretty_assertions",
+ "thiserror",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,7 +1450,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.9",
  "indexmap 1.9.3",
  "slab",
  "tokio",
@@ -1096,6 +1513,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "home"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,13 +1551,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.9",
  "pin-project-lite",
 ]
 
@@ -1149,7 +1595,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.9",
  "http-body",
  "httparse",
  "httpdate",
@@ -1169,11 +1615,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
  "futures-util",
- "http",
+ "http 0.2.9",
  "hyper",
  "rustls",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1222,7 +1681,7 @@ dependencies = [
  "gif",
  "jpeg-decoder",
  "num-rational",
- "num-traits",
+ "num-traits 0.2.17",
  "png",
  "qoi",
  "tiff",
@@ -1262,6 +1721,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "inflections"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "insta"
 version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,6 +1760,25 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "interceptor"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5927883184e6a819b22d5e4f5f7bc7ca134fde9b2026fbddd8d95249746ba21e"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "log",
+ "rand 0.8.5",
+ "rtcp",
+ "rtp",
+ "thiserror",
+ "tokio",
+ "waitgroup",
+ "webrtc-srtp",
+ "webrtc-util",
 ]
 
 [[package]]
@@ -1376,6 +1870,8 @@ dependencies = [
  "itertools 0.12.0",
  "js-sys",
  "kittycad",
+ "kittycad-execution-plan-macros 0.1.2 (git+https://github.com/KittyCAD/modeling-api?branch=main)",
+ "kittycad-execution-plan-traits",
  "lazy_static",
  "parse-display",
  "pretty_assertions",
@@ -1385,7 +1881,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.20.1",
  "tower-lsp",
  "ts-rs-json-value",
  "uuid",
@@ -1404,7 +1900,7 @@ dependencies = [
  "pretty_assertions",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1422,12 +1918,12 @@ dependencies = [
  "data-encoding",
  "format_serde_error",
  "futures",
- "http",
+ "http 0.2.9",
  "itertools 0.10.5",
  "log",
  "parse-display",
  "phonenumber",
- "rand",
+ "rand 0.8.5",
  "reqwest",
  "reqwest-conditional-middleware",
  "reqwest-middleware",
@@ -1442,6 +1938,111 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "kittycad-execution-plan"
+version = "0.1.0"
+source = "git+https://github.com/KittyCAD/modeling-api?branch=main#20751ca8844a143d9690d13043fc6aa9107d19bd"
+dependencies = [
+ "bytes",
+ "insta",
+ "kittycad",
+ "kittycad-execution-plan-traits",
+ "kittycad-modeling-cmds",
+ "kittycad-modeling-session",
+ "parse-display-derive",
+ "serde",
+ "thiserror",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "kittycad-execution-plan-macros"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e86c3ddefd89be816db24186c3e2fbd427675198f4d64b6d244dd2c1a3bae3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "kittycad-execution-plan-macros"
+version = "0.1.2"
+source = "git+https://github.com/KittyCAD/modeling-api?branch=main#20751ca8844a143d9690d13043fc6aa9107d19bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "kittycad-execution-plan-traits"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a49e5ad9fd3c4277e1e770029fc63d530c023268379dac59684fbba797729c0e"
+dependencies = [
+ "serde",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
+name = "kittycad-modeling-cmds"
+version = "0.1.11"
+source = "git+https://github.com/KittyCAD/modeling-api?branch=main#20751ca8844a143d9690d13043fc6aa9107d19bd"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "data-encoding",
+ "diesel_derives",
+ "enum-iterator",
+ "enum-iterator-derive",
+ "euler",
+ "http 0.2.9",
+ "kittycad-execution-plan-macros 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kittycad-execution-plan-traits",
+ "kittycad-unit-conversion-derive",
+ "measurements",
+ "parse-display",
+ "parse-display-derive",
+ "schemars",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "uuid",
+ "webrtc",
+]
+
+[[package]]
+name = "kittycad-modeling-session"
+version = "0.1.0"
+source = "git+https://github.com/KittyCAD/modeling-api?branch=main#20751ca8844a143d9690d13043fc6aa9107d19bd"
+dependencies = [
+ "futures",
+ "kittycad",
+ "kittycad-modeling-cmds",
+ "reqwest",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-tungstenite 0.21.0",
+ "uuid",
+]
+
+[[package]]
+name = "kittycad-unit-conversion-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7001c46a92c1edce6722a3900539b198230980799035f02d92b4e7df3fc08738"
+dependencies = [
+ "inflections",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1528,10 +2129,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
+name = "measurements"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5b734b4e8187ea5777bc29c086f0970a27d8de42061b48f5af32cafc0ca904b"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "memoffset"
@@ -1575,6 +2204,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mint"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
+
+[[package]]
 name = "mio"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,12 +2221,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "newline-converter"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
 ]
 
 [[package]]
@@ -1612,7 +2278,7 @@ checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -1622,7 +2288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
- "num-traits",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -1633,7 +2299,16 @@ checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.17",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+dependencies = [
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -1680,6 +2355,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1698,6 +2382,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "openapitor"
 version = "0.0.9"
 source = "git+https://github.com/KittyCAD/kittycad.rs?branch=main#920ba7c69fa167d74e4cc1be4f2ed96635893e89"
@@ -1709,7 +2399,7 @@ dependencies = [
  "data-encoding",
  "format_serde_error",
  "futures-util",
- "http",
+ "http 0.2.9",
  "indexmap 2.0.2",
  "json-patch",
  "log",
@@ -1719,7 +2409,7 @@ dependencies = [
  "phonenumber",
  "proc-macro2",
  "quote",
- "rand",
+ "rand 0.8.5",
  "regex",
  "reqwest",
  "reqwest-middleware",
@@ -1751,10 +2441,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -1771,8 +2499,32 @@ dependencies = [
  "lazy_static",
  "percent-encoding",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "thiserror",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
 ]
 
 [[package]]
@@ -1846,7 +2598,26 @@ dependencies = [
  "regex",
  "regex-syntax 0.7.5",
  "structmeta",
- "syn 2.0.39",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
+dependencies = [
+ "base64 0.21.5",
+ "serde",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -1893,7 +2664,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1909,12 +2680,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
+
+[[package]]
+name = "platforms"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
+
+[[package]]
 name = "plotters"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.17",
  "plotters-backend",
  "plotters-svg",
  "wasm-bindgen",
@@ -1950,6 +2743,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "polyval"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52cff9d1d4dee5fe6d03729099f4a310a41179e0a10dbf542039873f2e826fb"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1969,6 +2774,15 @@ checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
 dependencies = [
  "diff",
  "yansi",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1997,9 +2811,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
@@ -2024,9 +2838,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -2039,13 +2853,26 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2055,8 +2882,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2085,6 +2927,28 @@ checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
+dependencies = [
+ "pem",
+ "ring 0.16.20",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2190,15 +3054,17 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.9",
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -2209,6 +3075,7 @@ dependencies = [
  "serde_urlencoded",
  "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower-service",
  "url",
@@ -2239,7 +3106,7 @@ checksum = "88a3e86aa6053e59030e7ce2d2a3b258dd08fc2d337d52f73f6cb480f5858690"
 dependencies = [
  "anyhow",
  "async-trait",
- "http",
+ "http 0.2.9",
  "reqwest",
  "serde",
  "task-local-extensions",
@@ -2257,7 +3124,7 @@ dependencies = [
  "chrono",
  "futures",
  "getrandom",
- "http",
+ "http 0.2.9",
  "hyper",
  "parking_lot 0.11.2",
  "reqwest",
@@ -2295,7 +3162,32 @@ checksum = "e09bbcb5003282bcb688f0bae741b278e9c7e8f378f561522c9806c58e075d9b"
 dependencies = [
  "anyhow",
  "chrono",
- "rand",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -2307,9 +3199,33 @@ dependencies = [
  "cc",
  "getrandom",
  "libc",
- "spin",
- "untrusted",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rtcp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3677908cadfbecb4cc1da9a56a32524fae4ebdfa7c2ea93886e1b1e846488cb9"
+dependencies = [
+ "bytes",
+ "thiserror",
+ "webrtc-util",
+]
+
+[[package]]
+name = "rtp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e60482acbe8afb31edf6b1413103b7bca7a65004c423b3c3993749a083994fbe"
+dependencies = [
+ "bytes",
+ "rand 0.8.5",
+ "serde",
+ "thiserror",
+ "webrtc-util",
 ]
 
 [[package]]
@@ -2317,6 +3233,15 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustfmt-wrapper"
@@ -2329,6 +3254,15 @@ dependencies = [
  "thiserror",
  "toml",
  "toolchain_find",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -2351,7 +3285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c"
 dependencies = [
  "log",
- "ring",
+ "ring 0.17.5",
  "rustls-webpki",
  "sct",
 ]
@@ -2383,8 +3317,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.5",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2458,8 +3392,34 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.5",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "sdp"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4653054c30ebce63658762eb0d64e27673868a95564474811ae6c220cf767640"
+dependencies = [
+ "rand 0.8.5",
+ "substring",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2517,7 +3477,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2551,7 +3511,7 @@ checksum = "8725e1dfadb3a50f7e5ce0b1a540466f6ed3fe7a0fca2ac2b8b831d31316bd00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2572,7 +3532,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2624,6 +3584,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2639,6 +3610,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2734,6 +3715,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
+name = "smol_str"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2755,11 +3745,27 @@ dependencies = [
 
 [[package]]
 name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -2777,7 +3783,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2788,7 +3794,7 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2814,6 +3820,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "stun"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7beb1624a3ea34778d58d30e2b8606b4d29fe65e87c4d50b87ed30afd5c3830c"
+dependencies = [
+ "base64 0.21.5",
+ "crc",
+ "lazy_static",
+ "md-5",
+ "rand 0.8.5",
+ "ring 0.16.20",
+ "subtle",
+ "thiserror",
+ "tokio",
+ "url",
+ "webrtc-util",
+]
+
+[[package]]
+name = "substring"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ee6433ecef213b2e72f587ef64a2f5943e7cd16fbd82dbe8bc07486c534c86"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2826,13 +3866,25 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2843,7 +3895,7 @@ checksum = "285ba80e733fac80aa4270fbcdf83772a79b80aa35c97075320abfee4a915b06"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
  "unicode-xid",
 ]
 
@@ -2934,22 +3986,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3031,9 +4083,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.34.0"
+version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
+checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3056,7 +4108,17 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -3081,7 +4143,19 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.20.1",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.21.0",
 ]
 
 [[package]]
@@ -3197,7 +4271,7 @@ checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3225,7 +4299,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3311,7 +4385,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
  "termcolor",
 ]
 
@@ -3324,15 +4398,53 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 0.2.9",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "rustls",
  "sha1",
  "thiserror",
  "url",
  "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.0.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "turn"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f4fcb97da0426e8146fe0e9b78cc13120161087256198701d12d9df77f7701"
+dependencies = [
+ "async-trait",
+ "base64 0.21.5",
+ "futures",
+ "log",
+ "md-5",
+ "rand 0.8.5",
+ "ring 0.16.20",
+ "stun",
+ "thiserror",
+ "tokio",
+ "webrtc-util",
 ]
 
 [[package]]
@@ -3402,10 +4514,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -3456,10 +4584,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "waitgroup"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1f50000a783467e6c0200f9d10642f4bc424e39efc1b770203e88b488f79292"
+dependencies = [
+ "atomic-waker",
+]
 
 [[package]]
 name = "walkdir"
@@ -3507,7 +4650,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -3542,7 +4685,7 @@ checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3621,6 +4764,210 @@ name = "webpki-roots"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+
+[[package]]
+name = "webrtc"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91e7cf018f7185552bf6a5dd839f4ed9827aea33b746763c9a215f84a0d0b34"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "hex",
+ "interceptor",
+ "lazy_static",
+ "log",
+ "rand 0.8.5",
+ "rcgen",
+ "regex",
+ "ring 0.16.20",
+ "rtcp",
+ "rtp",
+ "rustls",
+ "sdp",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smol_str",
+ "stun",
+ "thiserror",
+ "time",
+ "tokio",
+ "turn",
+ "url",
+ "waitgroup",
+ "webrtc-data",
+ "webrtc-dtls",
+ "webrtc-ice",
+ "webrtc-mdns",
+ "webrtc-media",
+ "webrtc-sctp",
+ "webrtc-srtp",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-data"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45d2461d0e0bf93f181e30eb0b40df32b8bf3efb89c53cebb1990e603e2067d"
+dependencies = [
+ "bytes",
+ "log",
+ "thiserror",
+ "tokio",
+ "webrtc-sctp",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-dtls"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b140b953f986e97828aa33ec6318186b05d862bee689efbc57af04a243e832"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "async-trait",
+ "bincode",
+ "byteorder",
+ "cbc",
+ "ccm",
+ "der-parser",
+ "hkdf",
+ "hmac",
+ "log",
+ "p256",
+ "p384",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rcgen",
+ "ring 0.16.20",
+ "rustls",
+ "sec1",
+ "serde",
+ "sha1",
+ "sha2",
+ "subtle",
+ "thiserror",
+ "tokio",
+ "webrtc-util",
+ "x25519-dalek",
+ "x509-parser",
+]
+
+[[package]]
+name = "webrtc-ice"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66eb4b85646f1c52225779db3e1e7e873dede6db68cc9be080b648f1713083a3"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "crc",
+ "log",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "stun",
+ "thiserror",
+ "tokio",
+ "turn",
+ "url",
+ "uuid",
+ "waitgroup",
+ "webrtc-mdns",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-mdns"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bebbd40e7f8b630a0f1a74783dbfff1edfc0ccaae891c4689891156a8c4d8c"
+dependencies = [
+ "log",
+ "socket2 0.5.5",
+ "thiserror",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-media"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfde3c7b9450b67d466bb2f02c6d9ff9514d33535eb9994942afd1f828839d1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "rand 0.8.5",
+ "rtp",
+ "thiserror",
+]
+
+[[package]]
+name = "webrtc-sctp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1af6116b7f9703560c3ad0b32f67220b171bb1b59633b03563db8404d0e482ea"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "crc",
+ "log",
+ "rand 0.8.5",
+ "thiserror",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-srtp"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1db1f36c1c81e4b1e531c0b9678ba0c93809e196ce62122d87259bb71c03b9f"
+dependencies = [
+ "aead",
+ "aes",
+ "aes-gcm",
+ "byteorder",
+ "bytes",
+ "ctr",
+ "hmac",
+ "log",
+ "rtcp",
+ "rtp",
+ "sha1",
+ "subtle",
+ "thiserror",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-util"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1adc96bee68417e1f4d19dd7698124a7f859db55ae2fd3eedbbb7e732f614735"
+dependencies = [
+ "async-trait",
+ "bitflags 1.3.2",
+ "bytes",
+ "cc",
+ "ipnet",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "rand 0.8.5",
+ "thiserror",
+ "tokio",
+ "winapi",
+]
 
 [[package]]
 name = "weezl"
@@ -3886,6 +5233,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7069fba5b66b9193bd2c5d3d4ff12b839118f6bcbef5328efafafb5395cf63da"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring 0.16.20",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3899,6 +5276,15 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "zerocopy"
@@ -3917,7 +5303,27 @@ checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/src/wasm-lib/Cargo.toml
+++ b/src/wasm-lib/Cargo.toml
@@ -25,7 +25,7 @@ image = "0.24.7"
 kittycad = { workspace = true, default-features = true }
 pretty_assertions = "1.4.0"
 reqwest = { version = "0.11.22", default-features = false }
-tokio = { version = "1.34.0", features = ["rt-multi-thread", "macros", "time"] }
+tokio = { version = "1.35.1", features = ["rt-multi-thread", "macros", "time"] }
 twenty-twenty = "0.7"
 uuid = { version = "1.6.1", features = ["v4", "js", "serde"] }
 
@@ -52,12 +52,17 @@ debug = true
 [workspace]
 members = [
 	"derive-docs",
+  "grackle",
 	"kcl",
   "kcl-macros",
 ]
 
 [workspace.dependencies]
 kittycad = { version = "0.2.45", default-features = false, features = ["js"] }
+kittycad-execution-plan = { git = "https://github.com/KittyCAD/modeling-api", branch = "main" }
+kittycad-execution-plan-traits = "0.1.2"
+kittycad-modeling-session = { git = "https://github.com/KittyCAD/modeling-api", branch = "main" }
+kittycad-execution-plan-macros = { git = "https://github.com/KittyCAD/modeling-api", branch = "main" }
 
 [[test]]
 name = "executor"

--- a/src/wasm-lib/grackle/Cargo.toml
+++ b/src/wasm-lib/grackle/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "grackle"
+version = "0.1.0"
+edition = "2021"
+description = "A new executor for KCL which compiles to Execution Plans"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+kcl-lib = { path = "../kcl" }
+kittycad-execution-plan = { workspace = true }
+kittycad-execution-plan-traits = { workspace = true }
+kittycad-modeling-session = { workspace = true }
+thiserror = "1.0.56"
+
+
+[dev-dependencies]
+pretty_assertions = "1"

--- a/src/wasm-lib/grackle/src/kcl_value_group.rs
+++ b/src/wasm-lib/grackle/src/kcl_value_group.rs
@@ -1,0 +1,85 @@
+use kcl_lib::ast::{self, types::BinaryPart};
+
+/// Basically the same enum as `kcl_lib::ast::types::Value`, but grouped according to whether the
+/// value is singular or composite.
+/// You can convert losslessly between KclValueGroup and `kcl_lib::ast::types::Value` with From/Into.
+pub enum KclValueGroup {
+    Single(SingleValue),
+    ArrayExpression(Box<ast::types::ArrayExpression>),
+    ObjectExpression(Box<ast::types::ObjectExpression>),
+}
+
+pub enum SingleValue {
+    Literal(Box<ast::types::Literal>),
+    Identifier(Box<ast::types::Identifier>),
+    BinaryExpression(Box<ast::types::BinaryExpression>),
+    CallExpression(Box<ast::types::CallExpression>),
+    PipeExpression(Box<ast::types::PipeExpression>),
+    UnaryExpression(Box<ast::types::UnaryExpression>),
+    KclNoneExpression(ast::types::KclNone),
+    MemberExpression(Box<ast::types::MemberExpression>),
+}
+
+impl From<ast::types::BinaryPart> for KclValueGroup {
+    fn from(value: ast::types::BinaryPart) -> Self {
+        match value {
+            BinaryPart::Literal(e) => Self::Single(SingleValue::Literal(e)),
+            BinaryPart::Identifier(e) => Self::Single(SingleValue::Identifier(e)),
+            BinaryPart::BinaryExpression(e) => Self::Single(SingleValue::BinaryExpression(e)),
+            BinaryPart::CallExpression(e) => Self::Single(SingleValue::CallExpression(e)),
+            BinaryPart::UnaryExpression(e) => Self::Single(SingleValue::UnaryExpression(e)),
+            BinaryPart::MemberExpression(e) => Self::Single(SingleValue::MemberExpression(e)),
+        }
+    }
+}
+
+impl From<ast::types::BinaryPart> for SingleValue {
+    fn from(value: ast::types::BinaryPart) -> Self {
+        match value {
+            BinaryPart::Literal(e) => Self::Literal(e),
+            BinaryPart::Identifier(e) => Self::Identifier(e),
+            BinaryPart::BinaryExpression(e) => Self::BinaryExpression(e),
+            BinaryPart::CallExpression(e) => Self::CallExpression(e),
+            BinaryPart::UnaryExpression(e) => Self::UnaryExpression(e),
+            BinaryPart::MemberExpression(e) => Self::MemberExpression(e),
+        }
+    }
+}
+
+impl From<ast::types::Value> for KclValueGroup {
+    fn from(value: ast::types::Value) -> Self {
+        match value {
+            ast::types::Value::Literal(e) => Self::Single(SingleValue::Literal(e)),
+            ast::types::Value::Identifier(e) => Self::Single(SingleValue::Identifier(e)),
+            ast::types::Value::BinaryExpression(e) => Self::Single(SingleValue::BinaryExpression(e)),
+            ast::types::Value::CallExpression(e) => Self::Single(SingleValue::CallExpression(e)),
+            ast::types::Value::PipeExpression(e) => Self::Single(SingleValue::PipeExpression(e)),
+            ast::types::Value::None(e) => Self::Single(SingleValue::KclNoneExpression(e)),
+            ast::types::Value::UnaryExpression(e) => Self::Single(SingleValue::UnaryExpression(e)),
+            ast::types::Value::ArrayExpression(e) => Self::ArrayExpression(e),
+            ast::types::Value::ObjectExpression(e) => Self::ObjectExpression(e),
+            ast::types::Value::PipeSubstitution(_)
+            | ast::types::Value::FunctionExpression(_)
+            | ast::types::Value::MemberExpression(_) => todo!(),
+        }
+    }
+}
+
+impl From<KclValueGroup> for ast::types::Value {
+    fn from(value: KclValueGroup) -> Self {
+        match value {
+            KclValueGroup::Single(e) => match e {
+                SingleValue::Literal(e) => ast::types::Value::Literal(e),
+                SingleValue::Identifier(e) => ast::types::Value::Identifier(e),
+                SingleValue::BinaryExpression(e) => ast::types::Value::BinaryExpression(e),
+                SingleValue::CallExpression(e) => ast::types::Value::CallExpression(e),
+                SingleValue::PipeExpression(e) => ast::types::Value::PipeExpression(e),
+                SingleValue::UnaryExpression(e) => ast::types::Value::UnaryExpression(e),
+                SingleValue::KclNoneExpression(e) => ast::types::Value::None(e),
+                SingleValue::MemberExpression(e) => ast::types::Value::MemberExpression(e),
+            },
+            KclValueGroup::ArrayExpression(e) => ast::types::Value::ArrayExpression(e),
+            KclValueGroup::ObjectExpression(e) => ast::types::Value::ObjectExpression(e),
+        }
+    }
+}

--- a/src/wasm-lib/grackle/src/lib.rs
+++ b/src/wasm-lib/grackle/src/lib.rs
@@ -279,8 +279,19 @@ impl Planner {
                             acc_bindings.push(binding);
                             Ok((acc_instrs, acc_bindings))
                         }
-                        KclValueBySize::Multiple(MultipleValue::ArrayExpression(_expr)) => {
-                            todo!("handle arrays where their elements aren't scalars")
+                        KclValueBySize::Multiple(MultipleValue::ArrayExpression(expr)) => {
+                            let binding = expr
+                                .elements
+                                .into_iter()
+                                .try_fold(Vec::new(), |mut seq, child_element| {
+                                    let (instructions, binding) = self.plan_to_bind_one(child_element)?;
+                                    acc_instrs.extend(instructions);
+                                    seq.push(binding);
+                                    Ok(seq)
+                                })
+                                .map(EpBinding::Sequence)?;
+                            acc_bindings.push(binding);
+                            Ok((acc_instrs, acc_bindings))
                         }
                         KclValueBySize::Multiple(MultipleValue::ObjectExpression(_expr)) => {
                             todo!("handle arrays where their elements aren't scalars")

--- a/src/wasm-lib/grackle/src/lib.rs
+++ b/src/wasm-lib/grackle/src/lib.rs
@@ -1,0 +1,460 @@
+mod native_functions;
+#[cfg(test)]
+mod tests;
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+use kcl_lib::ast::types::KclNone;
+use kittycad_execution_plan as ep;
+use kittycad_execution_plan::{Address, ExecutionError, Instruction};
+use kittycad_execution_plan_traits as ept;
+use kittycad_execution_plan_traits::NumericPrimitive;
+use kittycad_modeling_session::Session;
+
+use kcl_lib::{
+    ast,
+    ast::types::{BinaryPart, BodyItem, LiteralValue, Program, VariableDeclaration},
+};
+
+/// Execute a KCL program by compiling into an execution plan, then running that.
+pub async fn execute(ast: Program, session: Session) -> Result<(), Error> {
+    let mut planner = Planner::new();
+    let plan = planner.build_plan(ast)?;
+    let mut mem = kittycad_execution_plan::Memory::default();
+    kittycad_execution_plan::execute(&mut mem, plan, session).await?;
+    Ok(())
+}
+
+/// Compiles KCL programs into Execution Plans.
+struct Planner {
+    binding_scope: BindingScope,
+    next_addr: Address,
+}
+
+enum SingleValue {
+    Literal(Box<ast::types::Literal>),
+    Identifier(Box<ast::types::Identifier>),
+    BinaryExpression(Box<ast::types::BinaryExpression>),
+    CallExpression(Box<ast::types::CallExpression>),
+    PipeExpression(Box<ast::types::PipeExpression>),
+    UnaryExpression(Box<ast::types::UnaryExpression>),
+    KclNoneExpression(ast::types::KclNone),
+    MemberExpression(Box<ast::types::MemberExpression>),
+}
+
+enum MultipleValue {
+    ArrayExpression(Box<ast::types::ArrayExpression>),
+}
+
+enum KclValueBySize {
+    Single(SingleValue),
+    Multiple(MultipleValue),
+}
+
+impl From<ast::types::BinaryPart> for KclValueBySize {
+    fn from(value: ast::types::BinaryPart) -> Self {
+        match value {
+            BinaryPart::Literal(e) => Self::Single(SingleValue::Literal(e)),
+            BinaryPart::Identifier(e) => Self::Single(SingleValue::Identifier(e)),
+            BinaryPart::BinaryExpression(e) => Self::Single(SingleValue::BinaryExpression(e)),
+            BinaryPart::CallExpression(e) => Self::Single(SingleValue::CallExpression(e)),
+            BinaryPart::UnaryExpression(e) => Self::Single(SingleValue::UnaryExpression(e)),
+            BinaryPart::MemberExpression(e) => Self::Single(SingleValue::MemberExpression(e)),
+        }
+    }
+}
+
+impl From<ast::types::BinaryPart> for SingleValue {
+    fn from(value: ast::types::BinaryPart) -> Self {
+        match value {
+            BinaryPart::Literal(e) => Self::Literal(e),
+            BinaryPart::Identifier(e) => Self::Identifier(e),
+            BinaryPart::BinaryExpression(e) => Self::BinaryExpression(e),
+            BinaryPart::CallExpression(e) => Self::CallExpression(e),
+            BinaryPart::UnaryExpression(e) => Self::UnaryExpression(e),
+            BinaryPart::MemberExpression(_) => todo!("support member expressions"),
+        }
+    }
+}
+
+impl From<ast::types::Value> for KclValueBySize {
+    fn from(value: ast::types::Value) -> Self {
+        match value {
+            ast::types::Value::Literal(e) => Self::Single(SingleValue::Literal(e)),
+            ast::types::Value::Identifier(e) => Self::Single(SingleValue::Identifier(e)),
+            ast::types::Value::BinaryExpression(e) => Self::Single(SingleValue::BinaryExpression(e)),
+            ast::types::Value::CallExpression(e) => Self::Single(SingleValue::CallExpression(e)),
+            ast::types::Value::PipeExpression(e) => Self::Single(SingleValue::PipeExpression(e)),
+            ast::types::Value::None(e) => Self::Single(SingleValue::KclNoneExpression(e)),
+            ast::types::Value::UnaryExpression(e) => Self::Single(SingleValue::UnaryExpression(e)),
+            ast::types::Value::ArrayExpression(e) => Self::Multiple(MultipleValue::ArrayExpression(e)),
+            ast::types::Value::ObjectExpression(_)
+            | ast::types::Value::PipeSubstitution(_)
+            | ast::types::Value::FunctionExpression(_)
+            | ast::types::Value::MemberExpression(_) => todo!(),
+        }
+    }
+}
+
+impl Planner {
+    pub fn new() -> Self {
+        Self {
+            binding_scope: BindingScope::prelude(),
+            next_addr: Address::ZERO,
+        }
+    }
+
+    fn build_plan(&mut self, program: Program) -> PlanRes {
+        let mut instructions = Vec::new();
+        for item in program.body {
+            instructions.extend(self.visit_body_item(item)?);
+        }
+        Ok(instructions)
+    }
+
+    /// Emits instructions which, when run, compute a given KCL value and store it in memory.
+    /// Returns the instructions, and the destination address of the value.
+    fn plan_to_compute_single(&mut self, value: SingleValue) -> Result<(Vec<Instruction>, EpBinding), CompileError> {
+        match value {
+            SingleValue::KclNoneExpression(KclNone { start: _, end: _ }) => {
+                let address = self.next_addr.offset_by(1);
+                Ok((
+                    vec![Instruction::SetPrimitive {
+                        address,
+                        value: ept::Primitive::Nil,
+                    }],
+                    EpBinding::Single(address),
+                ))
+            }
+            SingleValue::Literal(expr) => {
+                let kcep_val = kcl_literal_to_kcep_literal(expr.value);
+                // KCEP primitives always have size of 1, because each address holds 1 primitive.
+                let size = 1;
+                let address = self.next_addr.offset_by(size);
+                Ok((
+                    vec![Instruction::SetPrimitive {
+                        address,
+                        value: kcep_val,
+                    }],
+                    EpBinding::Single(address),
+                ))
+            }
+            SingleValue::Identifier(expr) => {
+                // This is just duplicating a binding.
+                // So, don't emit any instructions, because the value has already been computed.
+                // Just return the address that it was stored at after being computed.
+                let previously_bound_to = self
+                    .binding_scope
+                    .get(&expr.name)
+                    .ok_or(CompileError::Undefined { name: expr.name })?;
+                Ok((Vec::new(), previously_bound_to.clone()))
+            }
+            SingleValue::BinaryExpression(expr) => {
+                let l = SingleValue::from(expr.left);
+                let r = SingleValue::from(expr.right);
+                let (l_plan, l_binding) = self.plan_to_compute_single(l)?;
+                let (r_plan, r_binding) = self.plan_to_compute_single(r)?;
+                let EpBinding::Single(l_binding) = l_binding else {
+                    return Err(CompileError::InvalidOperand(
+                        "you tried to use a composite value (e.g. array or object) as the operand to some math",
+                    ));
+                };
+                let EpBinding::Single(r_binding) = r_binding else {
+                    return Err(CompileError::InvalidOperand(
+                        "you tried to use a composite value (e.g. array or object) as the operand to some math",
+                    ));
+                };
+                let destination = self.next_addr.offset_by(1);
+                let mut plan = Vec::with_capacity(l_plan.len() + r_plan.len() + 1);
+                plan.extend(l_plan);
+                plan.extend(r_plan);
+                plan.push(Instruction::Arithmetic {
+                    arithmetic: ep::Arithmetic {
+                        operation: match expr.operator {
+                            ast::types::BinaryOperator::Add => ep::Operation::Add,
+                            ast::types::BinaryOperator::Sub => ep::Operation::Sub,
+                            ast::types::BinaryOperator::Mul => ep::Operation::Mul,
+                            ast::types::BinaryOperator::Div => ep::Operation::Div,
+                            ast::types::BinaryOperator::Mod => {
+                                todo!("execution plan instruction set doesn't support Mod yet")
+                            }
+                            ast::types::BinaryOperator::Pow => {
+                                todo!("execution plan instruction set doesn't support Pow yet")
+                            }
+                        },
+                        operand0: ep::Operand::Reference(l_binding),
+                        operand1: ep::Operand::Reference(r_binding),
+                    },
+                    destination,
+                });
+                Ok((plan, EpBinding::Single(destination)))
+            }
+            SingleValue::CallExpression(expr) => {
+                let (mut instructions, args) = expr.arguments.into_iter().try_fold(
+                    (Vec::new(), Vec::new()),
+                    |(mut acc_instrs, mut acc_args), argument| {
+                        let (new_instructions, arg_address) = match KclValueBySize::from(argument) {
+                            KclValueBySize::Single(value) => self.plan_to_compute_single(value)?,
+                            KclValueBySize::Multiple(_) => todo!(),
+                        };
+                        acc_instrs.extend(new_instructions);
+                        acc_args.push(arg_address);
+                        Ok((acc_instrs, acc_args))
+                    },
+                )?;
+                let callee = match self.binding_scope.get_fn(&expr.callee.name) {
+                    GetFnResult::Found(f) => f,
+                    GetFnResult::NonCallable => {
+                        return Err(CompileError::NotCallable {
+                            name: expr.callee.name.clone(),
+                        });
+                    }
+                    GetFnResult::NotFound => {
+                        return Err(CompileError::Undefined {
+                            name: expr.callee.name.clone(),
+                        })
+                    }
+                };
+
+                let EvalPlan {
+                    instructions: eval_instrs,
+                    binding,
+                } = callee.call(&mut self.next_addr, args)?;
+                instructions.extend(eval_instrs);
+                Ok((instructions, binding))
+            }
+            SingleValue::PipeExpression(_) => todo!(),
+            SingleValue::UnaryExpression(_) => todo!(),
+            SingleValue::MemberExpression(_) => todo!(),
+        }
+    }
+
+    /// Emits instructions which, when run, compute a given KCL value and store it in memory.
+    /// Returns the instructions.
+    /// Also binds the value to a name.
+    fn plan_to_bind(
+        &mut self,
+        declarations: ast::types::VariableDeclaration,
+    ) -> Result<Vec<Instruction>, CompileError> {
+        declarations
+            .declarations
+            .into_iter()
+            .try_fold(Vec::new(), |mut acc, declaration| {
+                match KclValueBySize::from(declaration.init) {
+                    KclValueBySize::Single(init_value) => {
+                        let (instructions, binding) = self.plan_to_compute_single(init_value)?;
+                        self.binding_scope.bind(declaration.id.name, binding);
+                        acc.extend(instructions);
+                        Ok(acc)
+                    }
+                    KclValueBySize::Multiple(MultipleValue::ArrayExpression(expr)) => {
+                        let (instructions, addresses) = expr.elements.into_iter().try_fold(
+                            (Vec::new(), Vec::new()),
+                            |(mut acc_instrs, mut acc_addrs), element| {
+                                let value = match KclValueBySize::from(element) {
+                                    KclValueBySize::Single(v) => v,
+                                    KclValueBySize::Multiple(_) => todo!("handle arrays of composite values"),
+                                };
+                                let (instructions, dst) = self.plan_to_compute_single(value)?;
+                                acc_instrs.extend(instructions);
+                                acc_addrs.extend(Vec::from(dst));
+                                Ok((acc_instrs, acc_addrs))
+                            },
+                        )?;
+                        self.binding_scope
+                            .bind(declaration.id.name.clone(), EpBinding::Composite(addresses));
+                        Ok(instructions)
+                    }
+                }
+            })
+    }
+}
+
+#[derive(Debug, thiserror::Error, Eq, PartialEq, Clone)]
+pub enum CompileError {
+    #[error("the name {name} was not defined")]
+    Undefined { name: String },
+    #[error("the function {fn_name} requires at least {required} arguments but you only supplied {actual}")]
+    NotEnoughArgs {
+        fn_name: String2,
+        required: usize,
+        actual: usize,
+    },
+    #[error("the function {fn_name} accepts at most {maximum} arguments but you supplied {actual}")]
+    TooManyArgs {
+        fn_name: String2,
+        maximum: usize,
+        actual: usize,
+    },
+    #[error("you tried to call {name} but it's not a function")]
+    NotCallable { name: String },
+    #[error("you're trying to use an operand that isn't compatible with the given arithmetic operator: {0}")]
+    InvalidOperand(&'static str),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("{0}")]
+    Compile(#[from] CompileError),
+    #[error("{0}")]
+    Execution(#[from] ExecutionError),
+}
+
+/// Something that can traverse expression trees, visiting nodes.
+/// When a node gets visited, it returns some type R.
+trait ExprVisitor<R> {
+    fn visit_body_item(&mut self, item: BodyItem) -> R;
+    fn visit_variable_declaration(&mut self, vd: VariableDeclaration) -> R;
+}
+
+type PlanRes = Result<Vec<Instruction>, CompileError>;
+
+impl ExprVisitor<PlanRes> for Planner {
+    fn visit_body_item(&mut self, item: BodyItem) -> PlanRes {
+        match item {
+            BodyItem::VariableDeclaration(vd) => self.visit_variable_declaration(vd),
+            BodyItem::ExpressionStatement(_) => todo!(),
+            BodyItem::ReturnStatement(_) => todo!(),
+        }
+    }
+
+    fn visit_variable_declaration(&mut self, variable_declaration: VariableDeclaration) -> PlanRes {
+        self.plan_to_bind(variable_declaration)
+    }
+}
+
+/// Every KCL literal value is equivalent to an Execution Plan value, and therefore can be
+/// bound to some KCL name and Execution Plan address.
+fn kcl_literal_to_kcep_literal(expr: LiteralValue) -> ept::Primitive {
+    match expr {
+        LiteralValue::IInteger(x) => ept::Primitive::NumericValue(NumericPrimitive::Integer(x)),
+        LiteralValue::Fractional(x) => ept::Primitive::NumericValue(NumericPrimitive::Float(x)),
+        LiteralValue::String(x) => ept::Primitive::String(x),
+    }
+}
+
+/// Instructions that can compute some value.
+struct EvalPlan {
+    /// The instructions which will compute the value.
+    instructions: Vec<Instruction>,
+    /// Where the value will be stored.
+    binding: EpBinding,
+}
+
+trait KclFunction {
+    fn call(&self, next_addr: &mut Address, args: Vec<EpBinding>) -> Result<EvalPlan, CompileError>;
+}
+
+/// KCL values which can be written to KCEP memory.
+#[derive(Clone)]
+enum EpBinding {
+    /// A KCL value which gets stored in a particular address in KCEP memory.
+    Single(Address),
+    /// A sequence of KCL values which get stored in a consecutive set of addresses in KCEP memory.
+    Composite(Vec<Address>),
+}
+
+impl From<EpBinding> for Vec<Address> {
+    fn from(value: EpBinding) -> Self {
+        match value {
+            EpBinding::Single(addr) => vec![addr],
+            EpBinding::Composite(addrs) => addrs,
+        }
+    }
+}
+
+/// A set of bindings in a particular scope.
+/// Bindings are KCL values that get "compiled" into KCEP values, which are stored in KCEP memory
+/// at a particular KCEP address.
+/// Bindings are referenced by the name of their KCL identifier.
+///
+/// KCL has multiple scopes -- each function has a scope for its own local variables and parameters.
+/// So when referencing a variable, it might be in this scope, or the parent scope. So, each environment
+/// has to keep track of parent environments. The root environment has no parent, and is used for KCL globals
+/// (e.g. the prelude of stdlib functions).
+///
+/// These are called "Environments" in the "Crafting Interpreters" book.
+struct BindingScope {
+    // KCL value which are stored in EP memory.
+    ep_bindings: HashMap<String, EpBinding>,
+    /// KCL functions. They do NOT get stored in EP memory.
+    function_bindings: HashMap<String2, Box<dyn KclFunction>>,
+    parent: Option<Box<BindingScope>>,
+}
+
+/// Either an owned string, or a static string. Either way it can be read and moved around.
+type String2 = Cow<'static, str>;
+
+impl BindingScope {
+    /// The parent scope for every program, before the user has defined anything.
+    /// Only includes some stdlib functions.
+    /// This is usually known as the "prelude" in other languages. It's the stdlib functions that
+    /// are already imported for you when you start coding.
+    pub fn prelude() -> Self {
+        Self {
+            // TODO: Actually put the stdlib prelude in here,
+            // things like `startSketchAt` and `line`.
+            function_bindings: HashMap::from([
+                ("id".into(), Box::new(native_functions::Id) as _),
+                ("add".into(), Box::new(native_functions::Add) as _),
+            ]),
+            ep_bindings: Default::default(),
+            parent: None,
+        }
+    }
+
+    /// Add a new scope, e.g. for new function calls.
+    #[allow(dead_code)] // TODO: when we implement function expressions.
+    pub fn add_scope(self) -> Self {
+        Self {
+            function_bindings: Default::default(),
+            ep_bindings: Default::default(),
+            parent: Some(Box::new(self)),
+        }
+    }
+
+    //// Remove a scope, e.g. when exiting a function call.
+    #[allow(dead_code)] // TODO: when we implement function expressions.
+    pub fn remove_scope(self) -> Self {
+        *self.parent.unwrap()
+    }
+
+    /// Add a binding (e.g. defining a new variable)
+    pub fn bind(&mut self, identifier: String, binding: EpBinding) {
+        self.ep_bindings.insert(identifier, binding);
+    }
+
+    /// Look up a binding.
+    pub fn get(&self, identifier: &str) -> Option<&EpBinding> {
+        if let Some(b) = self.ep_bindings.get(identifier) {
+            // The name was found in this scope.
+            Some(b)
+        } else if let Some(ref parent) = self.parent {
+            // Check the next scope outwards.
+            parent.get(identifier)
+        } else {
+            // There's no outer scope, and it wasn't found, so there's nowhere else to look.
+            None
+        }
+    }
+
+    /// Look up a function bound to the given identifier.
+    fn get_fn(&self, identifier: &str) -> GetFnResult {
+        if let Some(f) = self.function_bindings.get(identifier) {
+            GetFnResult::Found(f.as_ref())
+        } else if self.get(identifier).is_some() {
+            GetFnResult::NonCallable
+        } else if let Some(ref parent) = self.parent {
+            parent.get_fn(identifier)
+        } else {
+            GetFnResult::NotFound
+        }
+    }
+}
+
+enum GetFnResult<'a> {
+    Found(&'a dyn KclFunction),
+    NonCallable,
+    NotFound,
+}

--- a/src/wasm-lib/grackle/src/lib.rs
+++ b/src/wasm-lib/grackle/src/lib.rs
@@ -272,15 +272,19 @@ impl Planner {
                 // Track which EP address each array element will be computed into.
                 let (instructions, bindings) = expr.elements.into_iter().try_fold(
                     (Vec::new(), Vec::new()),
-                    |(mut acc_instrs, mut acc_bindings), element| {
-                        let value = match KclValueBySize::from(element) {
-                            KclValueBySize::Single(v) => v,
-                            KclValueBySize::Multiple(_) => todo!("handle arrays of composite values"),
-                        };
-                        let EvalPlan { instructions, binding } = self.plan_to_compute_single(value)?;
-                        acc_instrs.extend(instructions);
-                        acc_bindings.push(binding);
-                        Ok((acc_instrs, acc_bindings))
+                    |(mut acc_instrs, mut acc_bindings), element| match KclValueBySize::from(element) {
+                        KclValueBySize::Single(value) => {
+                            let EvalPlan { instructions, binding } = self.plan_to_compute_single(value)?;
+                            acc_instrs.extend(instructions);
+                            acc_bindings.push(binding);
+                            Ok((acc_instrs, acc_bindings))
+                        }
+                        KclValueBySize::Multiple(MultipleValue::ArrayExpression(_expr)) => {
+                            todo!("handle arrays where their elements aren't scalars")
+                        }
+                        KclValueBySize::Multiple(MultipleValue::ObjectExpression(_expr)) => {
+                            todo!("handle arrays where their elements aren't scalars")
+                        }
                     },
                 )?;
                 Ok((instructions, (declaration.id.name, EpBinding::Sequence(bindings))))

--- a/src/wasm-lib/grackle/src/lib.rs
+++ b/src/wasm-lib/grackle/src/lib.rs
@@ -1,21 +1,21 @@
+mod kcl_value_group;
 mod native_functions;
 #[cfg(test)]
 mod tests;
 
-use std::borrow::Cow;
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 
-use kcl_lib::ast::types::KclNone;
+use kcl_lib::{
+    ast,
+    ast::types::{BodyItem, KclNone, LiteralValue, Program, VariableDeclaration},
+};
 use kittycad_execution_plan as ep;
 use kittycad_execution_plan::{Address, ExecutionError, Instruction};
 use kittycad_execution_plan_traits as ept;
 use kittycad_execution_plan_traits::NumericPrimitive;
 use kittycad_modeling_session::Session;
 
-use kcl_lib::{
-    ast,
-    ast::types::{BinaryPart, BodyItem, LiteralValue, Program, VariableDeclaration},
-};
+use self::kcl_value_group::{KclValueGroup, SingleValue};
 
 /// Execute a KCL program by compiling into an execution plan, then running that.
 pub async fn execute(ast: Program, session: Session) -> Result<(), Error> {
@@ -32,68 +32,6 @@ struct Planner {
     binding_scope: BindingScope,
     /// Next available KCEP virtual machine memory address.
     next_addr: Address,
-}
-
-enum SingleValue {
-    Literal(Box<ast::types::Literal>),
-    Identifier(Box<ast::types::Identifier>),
-    BinaryExpression(Box<ast::types::BinaryExpression>),
-    CallExpression(Box<ast::types::CallExpression>),
-    PipeExpression(Box<ast::types::PipeExpression>),
-    UnaryExpression(Box<ast::types::UnaryExpression>),
-    KclNoneExpression(ast::types::KclNone),
-    MemberExpression(Box<ast::types::MemberExpression>),
-}
-
-enum KclValueGroup {
-    Single(SingleValue),
-    ArrayExpression(Box<ast::types::ArrayExpression>),
-    ObjectExpression(Box<ast::types::ObjectExpression>),
-}
-
-impl From<ast::types::BinaryPart> for KclValueGroup {
-    fn from(value: ast::types::BinaryPart) -> Self {
-        match value {
-            BinaryPart::Literal(e) => Self::Single(SingleValue::Literal(e)),
-            BinaryPart::Identifier(e) => Self::Single(SingleValue::Identifier(e)),
-            BinaryPart::BinaryExpression(e) => Self::Single(SingleValue::BinaryExpression(e)),
-            BinaryPart::CallExpression(e) => Self::Single(SingleValue::CallExpression(e)),
-            BinaryPart::UnaryExpression(e) => Self::Single(SingleValue::UnaryExpression(e)),
-            BinaryPart::MemberExpression(e) => Self::Single(SingleValue::MemberExpression(e)),
-        }
-    }
-}
-
-impl From<ast::types::BinaryPart> for SingleValue {
-    fn from(value: ast::types::BinaryPart) -> Self {
-        match value {
-            BinaryPart::Literal(e) => Self::Literal(e),
-            BinaryPart::Identifier(e) => Self::Identifier(e),
-            BinaryPart::BinaryExpression(e) => Self::BinaryExpression(e),
-            BinaryPart::CallExpression(e) => Self::CallExpression(e),
-            BinaryPart::UnaryExpression(e) => Self::UnaryExpression(e),
-            BinaryPart::MemberExpression(_) => todo!("support member expressions"),
-        }
-    }
-}
-
-impl From<ast::types::Value> for KclValueGroup {
-    fn from(value: ast::types::Value) -> Self {
-        match value {
-            ast::types::Value::Literal(e) => Self::Single(SingleValue::Literal(e)),
-            ast::types::Value::Identifier(e) => Self::Single(SingleValue::Identifier(e)),
-            ast::types::Value::BinaryExpression(e) => Self::Single(SingleValue::BinaryExpression(e)),
-            ast::types::Value::CallExpression(e) => Self::Single(SingleValue::CallExpression(e)),
-            ast::types::Value::PipeExpression(e) => Self::Single(SingleValue::PipeExpression(e)),
-            ast::types::Value::None(e) => Self::Single(SingleValue::KclNoneExpression(e)),
-            ast::types::Value::UnaryExpression(e) => Self::Single(SingleValue::UnaryExpression(e)),
-            ast::types::Value::ArrayExpression(e) => Self::ArrayExpression(e),
-            ast::types::Value::ObjectExpression(e) => Self::ObjectExpression(e),
-            ast::types::Value::PipeSubstitution(_)
-            | ast::types::Value::FunctionExpression(_)
-            | ast::types::Value::MemberExpression(_) => todo!(),
-        }
-    }
 }
 
 impl Planner {
@@ -334,7 +272,7 @@ impl Planner {
                                 acc_bindings.insert(key.name, binding);
                             }
                             KclValueGroup::ArrayExpression(expr) => {
-                                // If this value of the object is an array, then emit a plan to caclulate
+                                // If this value of the object is an array, then emit a plan to calculate
                                 // each element of that array. Collect their bindings, and bind them all
                                 // under one property of the parent object.
                                 let n = expr.elements.len();

--- a/src/wasm-lib/grackle/src/lib.rs
+++ b/src/wasm-lib/grackle/src/lib.rs
@@ -284,17 +284,19 @@ impl Planner {
                         let mut kvs = expr.properties.into_iter().map(|prop| (prop.key, prop.value));
                         let (instructions, addresses) = kvs.try_fold(
                             (Vec::new(), HashMap::new()),
-                            |(mut acc_instrs, mut acc_addrs), (key, value)| {
-                                let value = match KclValueBySize::from(value) {
-                                    KclValueBySize::Single(v) => v,
-                                    KclValueBySize::Multiple(_) => {
-                                        todo!("handle objects where their values aren't scalars")
-                                    }
-                                };
-                                let EvalPlan { instructions, binding } = self.plan_to_compute_single(value)?;
-                                acc_instrs.extend(instructions);
-                                acc_addrs.insert(key.name, binding);
-                                Ok((acc_instrs, acc_addrs))
+                            |(mut acc_instrs, mut acc_addrs), (key, value)| match KclValueBySize::from(value) {
+                                KclValueBySize::Single(value) => {
+                                    let EvalPlan { instructions, binding } = self.plan_to_compute_single(value)?;
+                                    acc_instrs.extend(instructions);
+                                    acc_addrs.insert(key.name, binding);
+                                    Ok((acc_instrs, acc_addrs))
+                                }
+                                KclValueBySize::Multiple(MultipleValue::ArrayExpression(_expr)) => {
+                                    todo!("handle objects where their values aren't scalars")
+                                }
+                                KclValueBySize::Multiple(MultipleValue::ObjectExpression(_expr)) => {
+                                    todo!("handle objects where their values aren't scalars")
+                                }
                             },
                         )?;
                         // Then, bind all those addresses under this single KCL variable.

--- a/src/wasm-lib/grackle/src/lib.rs
+++ b/src/wasm-lib/grackle/src/lib.rs
@@ -28,7 +28,9 @@ pub async fn execute(ast: Program, session: Session) -> Result<(), Error> {
 
 /// Compiles KCL programs into Execution Plans.
 struct Planner {
+    /// Maps KCL identifiers to what they hold, and where in KCEP virtual memory they'll be written to.
     binding_scope: BindingScope,
+    /// Next available KCEP virtual machine memory address.
     next_addr: Address,
 }
 

--- a/src/wasm-lib/grackle/src/lib.rs
+++ b/src/wasm-lib/grackle/src/lib.rs
@@ -272,42 +272,42 @@ impl Planner {
                 // Track which EP address each array element will be computed into.
                 let (instructions, bindings) = expr.elements.into_iter().try_fold(
                     (Vec::new(), Vec::new()),
-                    |(mut acc_instrs, mut acc_bindings), element| match KclValueBySize::from(element) {
-                        KclValueBySize::Single(value) => {
-                            let EvalPlan { instructions, binding } = self.plan_to_compute_single(value)?;
-                            acc_instrs.extend(instructions);
-                            acc_bindings.push(binding);
-                            Ok((acc_instrs, acc_bindings))
-                        }
-                        KclValueBySize::Multiple(MultipleValue::ArrayExpression(expr)) => {
-                            let binding = expr
-                                .elements
-                                .into_iter()
-                                .try_fold(Vec::new(), |mut seq, child_element| {
-                                    let (instructions, binding) = self.plan_to_bind_one(child_element)?;
-                                    acc_instrs.extend(instructions);
-                                    seq.push(binding);
-                                    Ok(seq)
-                                })
-                                .map(EpBinding::Sequence)?;
-                            acc_bindings.push(binding);
-                            Ok((acc_instrs, acc_bindings))
-                        }
-                        KclValueBySize::Multiple(MultipleValue::ObjectExpression(expr)) => {
-                            let map = HashMap::with_capacity(expr.properties.len());
-                            let binding = expr
-                                .properties
-                                .into_iter()
-                                .try_fold(map, |mut map, property| {
-                                    let (instructions, binding) = self.plan_to_bind_one(property.value)?;
-                                    map.insert(property.key.name, binding);
-                                    acc_instrs.extend(instructions);
-                                    Ok(map)
-                                })
-                                .map(EpBinding::Map)?;
-                            acc_bindings.push(binding);
-                            Ok((acc_instrs, acc_bindings))
-                        }
+                    |(mut acc_instrs, mut acc_bindings), element| {
+                        match KclValueBySize::from(element) {
+                            KclValueBySize::Single(value) => {
+                                let EvalPlan { instructions, binding } = self.plan_to_compute_single(value)?;
+                                acc_instrs.extend(instructions);
+                                acc_bindings.push(binding);
+                            }
+                            KclValueBySize::Multiple(MultipleValue::ArrayExpression(expr)) => {
+                                let binding = expr
+                                    .elements
+                                    .into_iter()
+                                    .try_fold(Vec::new(), |mut seq, child_element| {
+                                        let (instructions, binding) = self.plan_to_bind_one(child_element)?;
+                                        acc_instrs.extend(instructions);
+                                        seq.push(binding);
+                                        Ok(seq)
+                                    })
+                                    .map(EpBinding::Sequence)?;
+                                acc_bindings.push(binding);
+                            }
+                            KclValueBySize::Multiple(MultipleValue::ObjectExpression(expr)) => {
+                                let map = HashMap::with_capacity(expr.properties.len());
+                                let binding = expr
+                                    .properties
+                                    .into_iter()
+                                    .try_fold(map, |mut map, property| {
+                                        let (instructions, binding) = self.plan_to_bind_one(property.value)?;
+                                        map.insert(property.key.name, binding);
+                                        acc_instrs.extend(instructions);
+                                        Ok(map)
+                                    })
+                                    .map(EpBinding::Map)?;
+                                acc_bindings.push(binding);
+                            }
+                        };
+                        Ok((acc_instrs, acc_bindings))
                     },
                 )?;
                 Ok((instructions, EpBinding::Sequence(bindings)))
@@ -317,43 +317,43 @@ impl Planner {
                 let mut kvs = expr.properties.into_iter().map(|prop| (prop.key, prop.value));
                 let (instructions, each_property_binding) = kvs.try_fold(
                     (Vec::new(), HashMap::new()),
-                    |(mut acc_instrs, mut acc_bindings), (key, value)| match KclValueBySize::from(value) {
-                        KclValueBySize::Single(value) => {
-                            let EvalPlan { instructions, binding } = self.plan_to_compute_single(value)?;
-                            acc_instrs.extend(instructions);
-                            acc_bindings.insert(key.name, binding);
-                            Ok((acc_instrs, acc_bindings))
-                        }
-                        KclValueBySize::Multiple(MultipleValue::ArrayExpression(expr)) => {
-                            let n = expr.elements.len();
-                            let binding = expr
-                                .elements
-                                .into_iter()
-                                .try_fold(Vec::with_capacity(n), |mut seq, child_element| {
-                                    let (instructions, binding) = self.plan_to_bind_one(child_element)?;
-                                    seq.push(binding);
-                                    acc_instrs.extend(instructions);
-                                    Ok(seq)
-                                })
-                                .map(EpBinding::Sequence)?;
-                            acc_bindings.insert(key.name, binding);
-                            Ok((acc_instrs, acc_bindings))
-                        }
-                        KclValueBySize::Multiple(MultipleValue::ObjectExpression(expr)) => {
-                            let n = expr.properties.len();
-                            let binding = expr
-                                .properties
-                                .into_iter()
-                                .try_fold(HashMap::with_capacity(n), |mut map, property| {
-                                    let (instructions, binding) = self.plan_to_bind_one(property.value)?;
-                                    map.insert(property.key.name, binding);
-                                    acc_instrs.extend(instructions);
-                                    Ok(map)
-                                })
-                                .map(EpBinding::Map)?;
-                            acc_bindings.insert(key.name, binding);
-                            Ok((acc_instrs, acc_bindings))
-                        }
+                    |(mut acc_instrs, mut acc_bindings), (key, value)| {
+                        match KclValueBySize::from(value) {
+                            KclValueBySize::Single(value) => {
+                                let EvalPlan { instructions, binding } = self.plan_to_compute_single(value)?;
+                                acc_instrs.extend(instructions);
+                                acc_bindings.insert(key.name, binding);
+                            }
+                            KclValueBySize::Multiple(MultipleValue::ArrayExpression(expr)) => {
+                                let n = expr.elements.len();
+                                let binding = expr
+                                    .elements
+                                    .into_iter()
+                                    .try_fold(Vec::with_capacity(n), |mut seq, child_element| {
+                                        let (instructions, binding) = self.plan_to_bind_one(child_element)?;
+                                        seq.push(binding);
+                                        acc_instrs.extend(instructions);
+                                        Ok(seq)
+                                    })
+                                    .map(EpBinding::Sequence)?;
+                                acc_bindings.insert(key.name, binding);
+                            }
+                            KclValueBySize::Multiple(MultipleValue::ObjectExpression(expr)) => {
+                                let n = expr.properties.len();
+                                let binding = expr
+                                    .properties
+                                    .into_iter()
+                                    .try_fold(HashMap::with_capacity(n), |mut map, property| {
+                                        let (instructions, binding) = self.plan_to_bind_one(property.value)?;
+                                        map.insert(property.key.name, binding);
+                                        acc_instrs.extend(instructions);
+                                        Ok(map)
+                                    })
+                                    .map(EpBinding::Map)?;
+                                acc_bindings.insert(key.name, binding);
+                            }
+                        };
+                        Ok((acc_instrs, acc_bindings))
                     },
                 )?;
                 Ok((instructions, EpBinding::Map(each_property_binding)))

--- a/src/wasm-lib/grackle/src/native_functions.rs
+++ b/src/wasm-lib/grackle/src/native_functions.rs
@@ -1,0 +1,74 @@
+//! Defines functions which are written in Rust, but called from KCL.
+//! This includes some of the stdlib, e.g. `startSketchAt`.
+//! But some other stdlib functions will be written in KCL.
+
+use kittycad_execution_plan::{Address, Arithmetic, Instruction};
+
+use crate::{CompileError, EpBinding, EvalPlan, KclFunction};
+
+/// The identity function. Always returns its first input.
+pub struct Id;
+
+impl KclFunction for Id {
+    fn call(&self, _: &mut Address, args: Vec<EpBinding>) -> Result<EvalPlan, CompileError> {
+        if args.len() > 1 {
+            return Err(CompileError::TooManyArgs {
+                fn_name: "id".into(),
+                maximum: 1,
+                actual: args.len(),
+            });
+        }
+        let arg = args
+            .first()
+            .ok_or(CompileError::NotEnoughArgs {
+                fn_name: "id".into(),
+                required: 1,
+                actual: 0,
+            })?
+            .clone();
+        Ok(EvalPlan {
+            instructions: Vec::new(),
+            binding: arg,
+        })
+    }
+}
+
+/// A test function that adds two numbers.
+pub struct Add;
+
+impl KclFunction for Add {
+    fn call(&self, next_address: &mut Address, mut args: Vec<EpBinding>) -> Result<EvalPlan, CompileError> {
+        let len = args.len();
+        if len > 2 {
+            return Err(CompileError::TooManyArgs {
+                fn_name: "add".into(),
+                maximum: 2,
+                actual: len,
+            });
+        }
+        let not_enough_args = CompileError::NotEnoughArgs {
+            fn_name: "add".into(),
+            required: 2,
+            actual: len,
+        };
+        const ERR: &str = "cannot use composite values (e.g. array) as arguments to Add";
+        let EpBinding::Single(arg1) = args.pop().ok_or(not_enough_args.clone())? else {
+            return Err(CompileError::InvalidOperand(ERR));
+        };
+        let EpBinding::Single(arg0) = args.pop().ok_or(not_enough_args)? else {
+            return Err(CompileError::InvalidOperand(ERR));
+        };
+        let destination = next_address.offset_by(1);
+        Ok(EvalPlan {
+            instructions: vec![Instruction::Arithmetic {
+                arithmetic: Arithmetic {
+                    operation: kittycad_execution_plan::Operation::Add,
+                    operand0: kittycad_execution_plan::Operand::Reference(arg0),
+                    operand1: kittycad_execution_plan::Operand::Reference(arg1),
+                },
+                destination,
+            }],
+            binding: EpBinding::Single(destination),
+        })
+    }
+}

--- a/src/wasm-lib/grackle/src/native_functions.rs
+++ b/src/wasm-lib/grackle/src/native_functions.rs
@@ -77,11 +77,12 @@ impl KclFunction for Add {
                 actual: len,
             });
         }
-        let not_enough_args = CompileError::NotEnoughArgs {
-            fn_name: "add".into(),
-            required: 2,
-            actual: len,
-        };
+        let not_enough_args =
+            CompileError::NotEnoughArgs {
+                fn_name: "add".into(),
+                required: 2,
+                actual: len,
+            };
         const ERR: &str = "cannot use composite values (e.g. array) as arguments to Add";
         let EpBinding::Single(arg1) = args.pop().ok_or(not_enough_args.clone())? else {
             return Err(CompileError::InvalidOperand(ERR));

--- a/src/wasm-lib/grackle/src/native_functions.rs
+++ b/src/wasm-lib/grackle/src/native_functions.rs
@@ -2,7 +2,9 @@
 //! This includes some of the stdlib, e.g. `startSketchAt`.
 //! But some other stdlib functions will be written in KCL.
 
+use kcl_lib::std::sketch::PlaneData;
 use kittycad_execution_plan::{Address, Arithmetic, Instruction};
+use kittycad_execution_plan_traits::Value;
 
 use crate::{CompileError, EpBinding, EvalPlan, KclFunction};
 
@@ -31,6 +33,33 @@ impl KclFunction for Id {
             instructions: Vec::new(),
             binding: arg,
         })
+    }
+}
+
+#[derive(Debug)]
+pub struct StartSketchAt;
+
+impl KclFunction for StartSketchAt {
+    fn call(&self, next_addr: &mut Address, _args: Vec<EpBinding>) -> Result<EvalPlan, CompileError> {
+        let mut instructions = Vec::new();
+        // Store the plane.
+        let plane = PlaneData::XY.into_parts();
+        instructions.push(Instruction::SetValue {
+            address: next_addr.offset_by(plane.len()),
+            value_parts: plane,
+        });
+        // TODO: Get the plane ID from global context.
+        // TODO: Send this command:
+        // ModelingCmd::SketchModeEnable {
+        //     animated: false,
+        //     ortho: false,
+        //     plane_id: plane.id,
+        //     // We pass in the normal for the plane here.
+        //     disable_camera_with_plane: Some(plane.z_axis.clone().into()),
+        // },
+        // TODO: Send ModelingCmd::StartPath at the given point.
+        // TODO (maybe): Store the SketchGroup in KCEP memory.
+        todo!()
     }
 }
 

--- a/src/wasm-lib/grackle/src/native_functions.rs
+++ b/src/wasm-lib/grackle/src/native_functions.rs
@@ -7,6 +7,7 @@ use kittycad_execution_plan::{Address, Arithmetic, Instruction};
 use crate::{CompileError, EpBinding, EvalPlan, KclFunction};
 
 /// The identity function. Always returns its first input.
+#[derive(Debug)]
 pub struct Id;
 
 impl KclFunction for Id {
@@ -34,6 +35,7 @@ impl KclFunction for Id {
 }
 
 /// A test function that adds two numbers.
+#[derive(Debug)]
 pub struct Add;
 
 impl KclFunction for Add {

--- a/src/wasm-lib/grackle/src/native_functions.rs
+++ b/src/wasm-lib/grackle/src/native_functions.rs
@@ -77,12 +77,11 @@ impl KclFunction for Add {
                 actual: len,
             });
         }
-        let not_enough_args =
-            CompileError::NotEnoughArgs {
-                fn_name: "add".into(),
-                required: 2,
-                actual: len,
-            };
+        let not_enough_args = CompileError::NotEnoughArgs {
+            fn_name: "add".into(),
+            required: 2,
+            actual: len,
+        };
         const ERR: &str = "cannot use composite values (e.g. array) as arguments to Add";
         let EpBinding::Single(arg1) = args.pop().ok_or(not_enough_args.clone())? else {
             return Err(CompileError::InvalidOperand(ERR));

--- a/src/wasm-lib/grackle/src/tests.rs
+++ b/src/wasm-lib/grackle/src/tests.rs
@@ -1,0 +1,264 @@
+
+use super::*;
+use pretty_assertions::assert_eq;
+
+fn must_plan(program: &str) -> Vec<Instruction> {
+    let tokens = kcl_lib::token::lexer(program);
+    let parser = kcl_lib::parser::Parser::new(tokens);
+    let ast = parser.ast().unwrap();
+    let mut p = Planner::new();
+    p.build_plan(ast).unwrap()
+}
+
+fn should_not_compile(program: &str) -> CompileError {
+    let tokens = kcl_lib::token::lexer(program);
+    let parser = kcl_lib::parser::Parser::new(tokens);
+    let ast = parser.ast().unwrap();
+    let mut p = Planner::new();
+    p.build_plan(ast).unwrap_err()
+}
+
+#[test]
+fn assignments() {
+    let program = "
+        let x = 1
+        let y = 2";
+    let plan = must_plan(program);
+    assert_eq!(
+        plan,
+        vec![
+            Instruction::SetPrimitive {
+                address: Address::ZERO,
+                value: 1i64.into(),
+            },
+            Instruction::SetPrimitive {
+                address: Address::ZERO.offset(1),
+                value: 2i64.into(),
+            }
+        ]
+    );
+}
+
+#[test]
+fn bind_array() {
+    let program = r#"let x = [44, 55, "sixty-six"]"#;
+    let plan = must_plan(program);
+    assert_eq!(
+        plan,
+        vec![
+            Instruction::SetPrimitive {
+                address: Address::ZERO,
+                value: 44i64.into(),
+            },
+            Instruction::SetPrimitive {
+                address: Address::ZERO.offset(1),
+                value: 55i64.into(),
+            },
+            Instruction::SetPrimitive {
+                address: Address::ZERO.offset(2),
+                value: "sixty-six".to_owned().into(),
+            }
+        ]
+    );
+}
+
+#[test]
+fn name_not_found() {
+    // Users can't assign `y` to anything because `y` is undefined.
+    let err = should_not_compile("let x = y");
+    assert_eq!(err, CompileError::Undefined { name: "y".to_owned() });
+}
+
+#[test]
+fn aliases() {
+    let program = "
+        let x = 1
+        let y = x";
+    let plan = must_plan(program);
+    assert_eq!(
+        plan,
+        vec![Instruction::SetPrimitive {
+            address: Address::ZERO,
+            value: 1i64.into(),
+        }]
+    );
+}
+
+#[test]
+fn use_native_function_add() {
+    let program = "let x = add(1,2)";
+    let plan = must_plan(program);
+    assert_eq!(
+        plan,
+        vec![
+            Instruction::SetPrimitive {
+                address: Address::ZERO,
+                value: 1i64.into()
+            },
+            Instruction::SetPrimitive {
+                address: Address::ZERO.offset(1),
+                value: 2i64.into()
+            },
+            Instruction::Arithmetic {
+                arithmetic: ep::Arithmetic {
+                    operation: ep::Operation::Add,
+                    operand0: ep::Operand::Reference(Address::ZERO),
+                    operand1: ep::Operand::Reference(Address::ZERO.offset(1))
+                },
+                destination: Address::ZERO.offset(2),
+            }
+        ]
+    );
+}
+
+#[test]
+fn use_native_function_id() {
+    let program = "let x = id(2)";
+    let plan = must_plan(program);
+    assert_eq!(
+        plan,
+        vec![Instruction::SetPrimitive {
+            address: Address::ZERO,
+            value: 2i64.into()
+        }]
+    );
+}
+
+#[test]
+fn add_literals() {
+    let program = "let x = 1 + 2";
+    let plan = must_plan(program);
+    assert_eq!(
+        plan,
+        vec![
+            Instruction::SetPrimitive {
+                address: Address::ZERO,
+                value: 1i64.into()
+            },
+            Instruction::SetPrimitive {
+                address: Address::ZERO.offset(1),
+                value: 2i64.into()
+            },
+            Instruction::Arithmetic {
+                arithmetic: ep::Arithmetic {
+                    operation: ep::Operation::Add,
+                    operand0: ep::Operand::Reference(Address::ZERO),
+                    operand1: ep::Operand::Reference(Address::ZERO.offset(1)),
+                },
+                destination: Address::ZERO.offset(2),
+            }
+        ]
+    );
+}
+
+#[test]
+fn add_vars() {
+    let program = "
+        let one = 1
+        let two = 2
+        let x = one + two";
+    let plan = must_plan(program);
+    let addr0 = Address::ZERO;
+    let addr1 = Address::ZERO.offset(1);
+    assert_eq!(
+        plan,
+        vec![
+            Instruction::SetPrimitive {
+                address: addr0,
+                value: 1i64.into(),
+            },
+            Instruction::SetPrimitive {
+                address: addr1,
+                value: 2i64.into(),
+            },
+            Instruction::Arithmetic {
+                arithmetic: ep::Arithmetic {
+                    operation: ep::Operation::Add,
+                    operand0: ep::Operand::Reference(addr0),
+                    operand1: ep::Operand::Reference(addr1),
+                },
+                destination: Address::ZERO.offset(2),
+            }
+        ]
+    );
+}
+
+#[test]
+fn composite_binary_exprs() {
+    let program = "
+        let x = 1
+        let y = 2
+        let z = 3
+        let six = x + y + z
+        ";
+    let plan = must_plan(program);
+    let addr0 = Address::ZERO;
+    let addr1 = Address::ZERO.offset(1);
+    let addr2 = Address::ZERO.offset(2);
+    let addr3 = Address::ZERO.offset(3);
+    assert_eq!(
+        plan,
+        vec![
+            Instruction::SetPrimitive {
+                address: addr0,
+                value: 1i64.into(),
+            },
+            Instruction::SetPrimitive {
+                address: addr1,
+                value: 2i64.into(),
+            },
+            Instruction::SetPrimitive {
+                address: addr2,
+                value: 3i64.into(),
+            },
+            // Adds 1 + 2
+            Instruction::Arithmetic {
+                arithmetic: ep::Arithmetic {
+                    operation: ep::Operation::Add,
+                    operand0: ep::Operand::Reference(addr0),
+                    operand1: ep::Operand::Reference(addr1),
+                },
+                destination: addr3,
+            },
+            // Adds `x` + 3, where `x` is (1 + 2)
+            Instruction::Arithmetic {
+                arithmetic: ep::Arithmetic {
+                    operation: ep::Operation::Add,
+                    operand0: ep::Operand::Reference(addr3),
+                    operand1: ep::Operand::Reference(addr2),
+                },
+                destination: Address::ZERO.offset(4),
+            }
+        ]
+    );
+}
+
+#[test]
+fn aliases_dont_affect_plans() {
+    let plan1 = must_plan(
+        "let one = 1
+            let two = 2
+            let x = one + two",
+    );
+    let plan2 = must_plan(
+        "let one = 1
+            let two = 2
+            let y = two
+            let x = one + y",
+    );
+    assert_eq!(plan1, plan2);
+}
+
+#[ignore = "haven't done API calls or stdlib yet"]
+#[test]
+fn stdlib_api_calls() {
+    let program = "const x0 = startSketchAt([0, 0])
+        const x1 = line([0, 10], x0)
+        const x2 = line([10, 0], x1)
+        const x3 = line([0, -10], x2)
+        const x4 = line([0, 0], x3)
+        const x5 = close(x4)
+        const x6 = extrude(20, x5)
+      show(x6)";
+    must_plan(program);
+}

--- a/src/wasm-lib/grackle/src/tests.rs
+++ b/src/wasm-lib/grackle/src/tests.rs
@@ -331,6 +331,41 @@ fn store_object() {
     )
 }
 
+#[test]
+fn store_object_with_array_property() {
+    let program = "const x0 = {a: 1, b: [2, 3]}";
+    let (actual, bindings) = must_plan(program);
+    let expected = vec![
+        Instruction::SetPrimitive {
+            address: Address::ZERO,
+            value: 1i64.into(),
+        },
+        Instruction::SetPrimitive {
+            address: Address::ZERO.offset(1),
+            value: 2i64.into(),
+        },
+        Instruction::SetPrimitive {
+            address: Address::ZERO.offset(2),
+            value: 3i64.into(),
+        },
+    ];
+    assert_eq!(actual, expected);
+    eprintln!("{bindings:#?}");
+    assert_eq!(
+        bindings.get("x0").unwrap(),
+        &EpBinding::Map(HashMap::from([
+            ("a".to_owned(), EpBinding::Single(Address::ZERO),),
+            (
+                "b".to_owned(),
+                EpBinding::Sequence(vec![
+                    EpBinding::Single(Address::ZERO.offset(1)),
+                    EpBinding::Single(Address::ZERO.offset(2)),
+                ])
+            ),
+        ]))
+    )
+}
+
 #[ignore = "haven't done API calls or stdlib yet"]
 #[test]
 fn stdlib_api_calls() {

--- a/src/wasm-lib/grackle/src/tests.rs
+++ b/src/wasm-lib/grackle/src/tests.rs
@@ -323,7 +323,10 @@ fn store_object() {
             ("b".to_owned(), EpBinding::Single(Address::ZERO.offset(1))),
             (
                 "c".to_owned(),
-                EpBinding::Map(HashMap::from([("d".to_owned(), EpBinding::Single(Address::ZERO.offset(2)))]))
+                EpBinding::Map(HashMap::from([(
+                    "d".to_owned(),
+                    EpBinding::Single(Address::ZERO.offset(2))
+                )]))
             ),
         ]))
     )

--- a/src/wasm-lib/grackle/src/tests.rs
+++ b/src/wasm-lib/grackle/src/tests.rs
@@ -1,5 +1,6 @@
-use super::*;
 use pretty_assertions::assert_eq;
+
+use super::*;
 
 fn must_plan(program: &str) -> (Vec<Instruction>, BindingScope) {
     let tokens = kcl_lib::token::lexer(program);
@@ -322,10 +323,7 @@ fn store_object() {
             ("b".to_owned(), EpBinding::Single(Address::ZERO.offset(1))),
             (
                 "c".to_owned(),
-                EpBinding::Map(HashMap::from([(
-                    "d".to_owned(),
-                    EpBinding::Single(Address::ZERO.offset(2))
-                )]))
+                EpBinding::Map(HashMap::from([("d".to_owned(), EpBinding::Single(Address::ZERO.offset(2)))]))
             ),
         ]))
     )

--- a/src/wasm-lib/grackle/src/tests.rs
+++ b/src/wasm-lib/grackle/src/tests.rs
@@ -1,4 +1,3 @@
-
 use super::*;
 use pretty_assertions::assert_eq;
 
@@ -7,7 +6,9 @@ fn must_plan(program: &str) -> Vec<Instruction> {
     let parser = kcl_lib::parser::Parser::new(tokens);
     let ast = parser.ast().unwrap();
     let mut p = Planner::new();
-    p.build_plan(ast).unwrap()
+    let instrs = p.build_plan(ast).unwrap();
+    dbg!(p.binding_scope);
+    instrs
 }
 
 fn should_not_compile(program: &str) -> CompileError {
@@ -247,6 +248,23 @@ fn aliases_dont_affect_plans() {
             let x = one + y",
     );
     assert_eq!(plan1, plan2);
+}
+
+#[test]
+fn store_object() {
+    let program = "const x0 = {a: 1, b: 2}";
+    let actual = must_plan(program);
+    let expected = vec![
+        Instruction::SetPrimitive {
+            address: Address::ZERO,
+            value: 1i64.into(),
+        },
+        Instruction::SetPrimitive {
+            address: Address::ZERO.offset(1),
+            value: 2i64.into(),
+        },
+    ];
+    assert_eq!(actual, expected);
 }
 
 #[ignore = "haven't done API calls or stdlib yet"]

--- a/src/wasm-lib/grackle/src/tests.rs
+++ b/src/wasm-lib/grackle/src/tests.rs
@@ -64,6 +64,29 @@ fn bind_array() {
 }
 
 #[test]
+fn bind_nested_array() {
+    let program = r#"let x = [44, [55, "sixty-six"]]"#;
+    let plan = must_plan(program);
+    assert_eq!(
+        plan,
+        vec![
+            Instruction::SetPrimitive {
+                address: Address::ZERO,
+                value: 44i64.into(),
+            },
+            Instruction::SetPrimitive {
+                address: Address::ZERO.offset(1),
+                value: 55i64.into(),
+            },
+            Instruction::SetPrimitive {
+                address: Address::ZERO.offset(2),
+                value: "sixty-six".to_owned().into(),
+            }
+        ]
+    );
+}
+
+#[test]
 fn name_not_found() {
     // Users can't assign `y` to anything because `y` is undefined.
     let err = should_not_compile("let x = y");

--- a/src/wasm-lib/grackle/src/tests.rs
+++ b/src/wasm-lib/grackle/src/tests.rs
@@ -87,6 +87,29 @@ fn bind_nested_array() {
 }
 
 #[test]
+fn bind_arrays_with_objects_elements() {
+    let program = r#"let x = [44, {a: 55, b: "sixty-six"}]"#;
+    let plan = must_plan(program);
+    assert_eq!(
+        plan,
+        vec![
+            Instruction::SetPrimitive {
+                address: Address::ZERO,
+                value: 44i64.into(),
+            },
+            Instruction::SetPrimitive {
+                address: Address::ZERO.offset(1),
+                value: 55i64.into(),
+            },
+            Instruction::SetPrimitive {
+                address: Address::ZERO.offset(2),
+                value: "sixty-six".to_owned().into(),
+            }
+        ]
+    );
+}
+
+#[test]
 fn name_not_found() {
     // Users can't assign `y` to anything because `y` is undefined.
     let err = should_not_compile("let x = y");

--- a/src/wasm-lib/kcl/Cargo.toml
+++ b/src/wasm-lib/kcl/Cargo.toml
@@ -21,6 +21,8 @@ databake = { version = "0.1.7", features = ["derive"] }
 derive-docs = { version = "0.1.5" }
 # derive-docs = { path = "../derive-docs" }
 kittycad = { workspace = true }
+kittycad-execution-plan-macros = { workspace = true }
+kittycad-execution-plan-traits = { workspace = true }
 lazy_static = "1.4.0"
 parse-display = "0.8.2"
 schemars = { version = "0.8.16", features = ["impl_json_schema", "url", "uuid1"] }

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -5,6 +5,7 @@ use std::{collections::HashMap, sync::Arc};
 use anyhow::Result;
 use async_recursion::async_recursion;
 use kittycad::types::{Color, ModelingCmd, Point3D};
+use kittycad_execution_plan_macros::ExecutionPlanValue;
 use parse_display::{Display, FromStr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -610,7 +611,7 @@ impl Point2d {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Clone, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Clone, ts_rs::TS, JsonSchema, ExecutionPlanValue)]
 #[ts(export)]
 pub struct Point3d {
     pub x: f64,

--- a/src/wasm-lib/kcl/src/std/sketch.rs
+++ b/src/wasm-lib/kcl/src/std/sketch.rs
@@ -3,6 +3,7 @@
 use anyhow::Result;
 use derive_docs::stdlib;
 use kittycad::types::{Angle, ModelingCmd, Point3D};
+use kittycad_execution_plan_macros::ExecutionPlanValue;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -648,7 +649,7 @@ async fn inner_start_sketch_at(data: LineData, args: Args) -> Result<Box<SketchG
 }
 
 /// Data for a plane.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, ExecutionPlanValue)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub enum PlaneData {


### PR DESCRIPTION
This begins work on a second, different executor. The old executor is a tree-walk interpreter, this executor compiles the KCL programs into the Execution Plan virtual machine defined in its [own crate](https://github.com/KittyCAD/modeling-api/tree/main/execution-plan). This executor is called "Grackle", after an Austin bird, and it's got its own module in wasm-lib so that I can keep merging small PRs and developing incrementally, rather than building a complete executor which replaces the old executor in one PR.

Grackle's "Planner" walks the AST, like the tree-walk executor. But it doesn't actually execute code. Instead, as it walks each AST node, it outputs a sequence of Execution Plan instructions which, when run, can compute that node's value. It also notes which Execution Plan virtual machine address will eventually contain each KCL variable.

# Implemented in this PR
 - Storing KCL variables
 - Computing primitives, literals, binary expressions
 - Calling native (i.e. Rust) functions from KCL
 - Storing arrays

# To do in future PRs

- KCL functions (i.e. user-defined functions)
- Objects
- Member expressions
- Port over existing executor's native funtions (e.g. `lineTo`, `extrude` and `startSketchAt`)