### PR TITLE
Grackle: Compile member expressions

### DIFF
--- a/src/wasm-lib/Cargo.lock
+++ b/src/wasm-lib/Cargo.lock
@@ -1943,7 +1943,7 @@ dependencies = [
 [[package]]
 name = "kittycad-execution-plan"
 version = "0.1.0"
-source = "git+https://github.com/KittyCAD/modeling-api?branch=main#627d6b1c861ac1d534b4fecc280aa8c9b7d5df03"
+source = "git+https://github.com/KittyCAD/modeling-api?branch=main#9200b9540fa5ae99b692db276c625223116f467f"
 dependencies = [
  "bytes",
  "insta",
@@ -1972,7 +1972,7 @@ dependencies = [
 [[package]]
 name = "kittycad-execution-plan-macros"
 version = "0.1.2"
-source = "git+https://github.com/KittyCAD/modeling-api?branch=main#627d6b1c861ac1d534b4fecc280aa8c9b7d5df03"
+source = "git+https://github.com/KittyCAD/modeling-api?branch=main#9200b9540fa5ae99b692db276c625223116f467f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1993,7 +1993,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds"
 version = "0.1.11"
-source = "git+https://github.com/KittyCAD/modeling-api?branch=main#627d6b1c861ac1d534b4fecc280aa8c9b7d5df03"
+source = "git+https://github.com/KittyCAD/modeling-api?branch=main#9200b9540fa5ae99b692db276c625223116f467f"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2020,7 +2020,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-session"
 version = "0.1.0"
-source = "git+https://github.com/KittyCAD/modeling-api?branch=main#627d6b1c861ac1d534b4fecc280aa8c9b7d5df03"
+source = "git+https://github.com/KittyCAD/modeling-api?branch=main#9200b9540fa5ae99b692db276c625223116f467f"
 dependencies = [
  "futures",
  "kittycad",

--- a/src/wasm-lib/grackle/src/kcl_value_group.rs
+++ b/src/wasm-lib/grackle/src/kcl_value_group.rs
@@ -58,9 +58,8 @@ impl From<ast::types::Value> for KclValueGroup {
             ast::types::Value::UnaryExpression(e) => Self::Single(SingleValue::UnaryExpression(e)),
             ast::types::Value::ArrayExpression(e) => Self::ArrayExpression(e),
             ast::types::Value::ObjectExpression(e) => Self::ObjectExpression(e),
-            ast::types::Value::PipeSubstitution(_)
-            | ast::types::Value::FunctionExpression(_)
-            | ast::types::Value::MemberExpression(_) => todo!(),
+            ast::types::Value::MemberExpression(e) => Self::Single(SingleValue::MemberExpression(e)),
+            ast::types::Value::PipeSubstitution(_) | ast::types::Value::FunctionExpression(_) => todo!(),
         }
     }
 }

--- a/src/wasm-lib/grackle/src/tests.rs
+++ b/src/wasm-lib/grackle/src/tests.rs
@@ -172,6 +172,49 @@ fn use_native_function_id() {
 }
 
 #[test]
+fn member_expressions_object() {
+    let program = r#"
+    let obj = {x: 1, y: 2}
+    let prop = obj["y"]
+    "#;
+    let (_plan, scope) = must_plan(program);
+    match scope.get("prop").unwrap() {
+        EpBinding::Single(addr) => {
+            assert_eq!(*addr, Address::ZERO + 1);
+        }
+        other => {
+            panic!("expected 'number' bound to 0x0 but it was bound to {other:?}");
+        }
+    }
+}
+
+#[test]
+fn member_expressions_array() {
+    let program = "
+    let array = [[1,2],[3,4]]
+    let first = array[0][0]
+    let last = array[1][1]
+    ";
+    let (_plan, scope) = must_plan(program);
+    match scope.get("first").unwrap() {
+        EpBinding::Single(addr) => {
+            assert_eq!(*addr, Address::ZERO);
+        }
+        other => {
+            panic!("expected 'number' bound to 0x0 but it was bound to {other:?}");
+        }
+    }
+    match scope.get("last").unwrap() {
+        EpBinding::Single(addr) => {
+            assert_eq!(*addr, Address::ZERO + 3);
+        }
+        other => {
+            panic!("expected 'number' bound to 0x3 but it was bound to {other:?}");
+        }
+    }
+}
+
+#[test]
 fn add_literals() {
     let program = "let x = 1 + 2";
     let (plan, _scope) = must_plan(program);

--- a/src/wasm-lib/kcl/src/parser/parser_impl.rs
+++ b/src/wasm-lib/kcl/src/parser/parser_impl.rs
@@ -2721,7 +2721,7 @@ show(b1)
 show(b2)"#;
         let tokens = crate::token::lexer(some_program_string);
         let parser = crate::parser::Parser::new(tokens);
-        parser.ast().unwrap();
+        dbg!(parser.ast().unwrap());
     }
 
     #[test]


### PR DESCRIPTION
Member expressions like "obj.property" just look up "property" under the binding for "obj".