### PR TITLE
Grackle: compile and execute user-defined KCL functions

### DIFF
--- a/src/wasm-lib/grackle/src/binding_scope.rs
+++ b/src/wasm-lib/grackle/src/binding_scope.rs
@@ -133,8 +133,11 @@ impl BindingScope {
     pub fn get_fn(&self, identifier: &str) -> GetFnResult {
         if let Some(f) = self.function_bindings.get(identifier) {
             GetFnResult::Found(f.as_ref())
-        } else if self.get(identifier).is_some() {
-            GetFnResult::NonCallable
+        } else if let Some(x) = self.get(identifier) {
+            match x {
+                EpBinding::Function(f) => GetFnResult::Found(f),
+                _ => GetFnResult::NonCallable,
+            }
         } else if let Some(ref parent) = self.parent {
             parent.get_fn(identifier)
         } else {

--- a/src/wasm-lib/grackle/src/kcl_value_group.rs
+++ b/src/wasm-lib/grackle/src/kcl_value_group.rs
@@ -18,6 +18,7 @@ pub enum SingleValue {
     UnaryExpression(Box<ast::types::UnaryExpression>),
     KclNoneExpression(ast::types::KclNone),
     MemberExpression(Box<ast::types::MemberExpression>),
+    FunctionExpression(Box<ast::types::FunctionExpression>),
 }
 
 impl From<ast::types::BinaryPart> for KclValueGroup {
@@ -59,7 +60,8 @@ impl From<ast::types::Value> for KclValueGroup {
             ast::types::Value::ArrayExpression(e) => Self::ArrayExpression(e),
             ast::types::Value::ObjectExpression(e) => Self::ObjectExpression(e),
             ast::types::Value::MemberExpression(e) => Self::Single(SingleValue::MemberExpression(e)),
-            ast::types::Value::PipeSubstitution(_) | ast::types::Value::FunctionExpression(_) => todo!(),
+            ast::types::Value::FunctionExpression(e) => Self::Single(SingleValue::FunctionExpression(e)),
+            ast::types::Value::PipeSubstitution(_) => todo!(),
         }
     }
 }
@@ -76,6 +78,7 @@ impl From<KclValueGroup> for ast::types::Value {
                 SingleValue::UnaryExpression(e) => ast::types::Value::UnaryExpression(e),
                 SingleValue::KclNoneExpression(e) => ast::types::Value::None(e),
                 SingleValue::MemberExpression(e) => ast::types::Value::MemberExpression(e),
+                SingleValue::FunctionExpression(e) => ast::types::Value::FunctionExpression(e),
             },
             KclValueGroup::ArrayExpression(e) => ast::types::Value::ArrayExpression(e),
             KclValueGroup::ObjectExpression(e) => ast::types::Value::ObjectExpression(e),

--- a/src/wasm-lib/grackle/src/lib.rs
+++ b/src/wasm-lib/grackle/src/lib.rs
@@ -80,13 +80,14 @@ impl Planner {
                     end: _,
                     params_required,
                     params_optional,
-                    body: _,
+                    body,
                 } = expr.into_parts().map_err(CompileError::BadParamOrder)?;
                 Ok(EvalPlan {
                     instructions: Vec::new(),
                     binding: EpBinding::Function(UserDefinedFunction {
                         params_optional,
                         params_required,
+                        body,
                     }),
                 })
             }
@@ -443,14 +444,22 @@ trait KclFunction: std::fmt::Debug {
 pub type String2 = std::borrow::Cow<'static, str>;
 
 #[derive(Debug, Clone)]
-#[cfg_attr(test, derive(Eq, PartialEq))]
 struct UserDefinedFunction {
     params_optional: Vec<ast::types::Parameter>,
     params_required: Vec<ast::types::Parameter>,
+    body: ast::types::Program,
 }
+
+impl PartialEq for UserDefinedFunction {
+    fn eq(&self, other: &Self) -> bool {
+        self.params_optional == other.params_optional && self.params_required == other.params_required
+    }
+}
+
+impl Eq for UserDefinedFunction {}
 
 impl KclFunction for UserDefinedFunction {
     fn call(&self, next_addr: &mut Address, args: Vec<EpBinding>) -> Result<EvalPlan, CompileError> {
-        todo!()
+        todo!("Emit a plan to execute user-defined KCL functions")
     }
 }

--- a/src/wasm-lib/grackle/src/lib.rs
+++ b/src/wasm-lib/grackle/src/lib.rs
@@ -228,6 +228,14 @@ impl Planner {
                         // Bind the call's arguments to the names of the function's parameters.
                         let num_actual_params = args.len();
                         let mut arg_iter = args.into_iter();
+                        let max_params = params_required.len() + params_optional.len();
+                        if num_actual_params > max_params {
+                            return Err(CompileError::TooManyArgs {
+                                fn_name: "".into(),
+                                maximum: max_params,
+                                actual: num_actual_params,
+                            });
+                        }
 
                         // Bind required parameters
                         for param in params_required {
@@ -239,7 +247,13 @@ impl Planner {
                             self.binding_scope.bind(param.identifier.name, arg);
                         }
 
-                        // TODO: Bind optional parameters
+                        // Bind optional parameters
+                        for param in params_optional {
+                            let Some(arg) = arg_iter.next() else {
+                                break;
+                            };
+                            self.binding_scope.bind(param.identifier.name, arg);
+                        }
 
                         let (instructions, retval) = self.build_plan(function_body)?;
                         let Some(retval) = retval else {

--- a/src/wasm-lib/grackle/src/native_functions.rs
+++ b/src/wasm-lib/grackle/src/native_functions.rs
@@ -6,13 +6,18 @@ use kcl_lib::std::sketch::PlaneData;
 use kittycad_execution_plan::{Address, Arithmetic, Instruction};
 use kittycad_execution_plan_traits::Value;
 
-use crate::{CompileError, EpBinding, EvalPlan, KclFunction};
+use crate::{CompileError, EpBinding, EvalPlan};
 
 /// The identity function. Always returns its first input.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct Id;
 
-impl KclFunction for Id {
+pub trait Callable {
+    fn call(&self, next_addr: &mut Address, args: Vec<EpBinding>) -> Result<EvalPlan, CompileError>;
+}
+
+impl Callable for Id {
     fn call(&self, _: &mut Address, args: Vec<EpBinding>) -> Result<EvalPlan, CompileError> {
         if args.len() > 1 {
             return Err(CompileError::TooManyArgs {
@@ -36,10 +41,11 @@ impl KclFunction for Id {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct StartSketchAt;
 
-impl KclFunction for StartSketchAt {
+impl Callable for StartSketchAt {
     fn call(&self, next_addr: &mut Address, _args: Vec<EpBinding>) -> Result<EvalPlan, CompileError> {
         let mut instructions = Vec::new();
         // Store the plane.
@@ -64,10 +70,11 @@ impl KclFunction for StartSketchAt {
 }
 
 /// A test function that adds two numbers.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct Add;
 
-impl KclFunction for Add {
+impl Callable for Add {
     fn call(&self, next_address: &mut Address, mut args: Vec<EpBinding>) -> Result<EvalPlan, CompileError> {
         let len = args.len();
         if len > 2 {

--- a/src/wasm-lib/grackle/src/tests.rs
+++ b/src/wasm-lib/grackle/src/tests.rs
@@ -362,6 +362,21 @@ fn composite_binary_exprs() {
 }
 
 #[test]
+#[ignore = "reason"]
+fn use_kcl_functions() {
+    let (plan, scope) = must_plan(
+        "fn triple = (x) => { return x * 3 }
+    let x = triple(1)",
+    );
+    assert!(plan.is_empty());
+    match scope.get("x").unwrap() {
+        EpBinding::Single(_addr) => {}
+        other => {
+            panic!("expected 'x' bound to an address but it was bound to {other:?}");
+        }
+    }
+}
+#[test]
 fn define_kcl_functions() {
     let (plan, scope) = must_plan("fn triple = (x) => { return x * 3 }");
     assert!(plan.is_empty());

--- a/src/wasm-lib/grackle/src/tests.rs
+++ b/src/wasm-lib/grackle/src/tests.rs
@@ -383,6 +383,30 @@ fn use_kcl_functions_zero_params() {
         }
     }
 }
+
+#[test]
+fn use_kcl_functions_with_params() {
+    let (plan, scope) = must_plan(
+        "fn triple = (x) => { return x*3 }
+    let x = triple(1)",
+    );
+    assert_eq!(
+        plan,
+        vec![Instruction::SetPrimitive {
+            address: Address::ZERO,
+            value: 123i64.into()
+        }]
+    );
+    match scope.get("x").unwrap() {
+        EpBinding::Single(addr) => {
+            assert_eq!(addr, &Address::ZERO);
+        }
+        other => {
+            panic!("expected 'x' bound to an address but it was bound to {other:?}");
+        }
+    }
+}
+
 #[test]
 fn define_kcl_functions() {
     let (plan, scope) = must_plan("fn triple = (x) => { return x * 3 }");

--- a/src/wasm-lib/grackle/src/tests.rs
+++ b/src/wasm-lib/grackle/src/tests.rs
@@ -381,7 +381,7 @@ fn define_kcl_functions() {
     let (plan, scope) = must_plan("fn triple = (x) => { return x * 3 }");
     assert!(plan.is_empty());
     match scope.get("triple").unwrap() {
-        EpBinding::Function(expr) => {
+        EpBinding::Function(KclFunction::UserDefined(expr)) => {
             assert!(expr.params_optional.is_empty());
             assert_eq!(expr.params_required.len(), 1);
         }

--- a/src/wasm-lib/grackle/src/tests.rs
+++ b/src/wasm-lib/grackle/src/tests.rs
@@ -362,6 +362,21 @@ fn composite_binary_exprs() {
 }
 
 #[test]
+fn define_kcl_functions() {
+    let (plan, scope) = must_plan("fn triple = (x) => { return x * 3 }");
+    assert!(plan.is_empty());
+    match scope.get("triple").unwrap() {
+        EpBinding::Function(expr) => {
+            assert!(expr.params_optional.is_empty());
+            assert_eq!(expr.params_required.len(), 1);
+        }
+        other => {
+            panic!("expected 'triple' bound to a user-defined KCL function but it was bound to {other:?}");
+        }
+    }
+}
+
+#[test]
 fn aliases_dont_affect_plans() {
     let (plan1, _) = must_plan(
         "let one = 1

--- a/src/wasm-lib/grackle/src/tests.rs
+++ b/src/wasm-lib/grackle/src/tests.rs
@@ -390,16 +390,31 @@ fn use_kcl_functions_with_params() {
         "fn triple = (x) => { return x*3 }
     let x = triple(1)",
     );
+    let destination = Address::ZERO + 2;
     assert_eq!(
         plan,
-        vec![Instruction::SetPrimitive {
-            address: Address::ZERO,
-            value: 123i64.into()
-        }]
+        vec![
+            Instruction::SetPrimitive {
+                address: Address::ZERO,
+                value: 1i64.into(),
+            },
+            Instruction::SetPrimitive {
+                address: Address::ZERO + 1,
+                value: 3i64.into(),
+            },
+            Instruction::Arithmetic {
+                arithmetic: ep::Arithmetic {
+                    operation: ep::Operation::Mul,
+                    operand0: ep::Operand::Reference(Address::ZERO),
+                    operand1: ep::Operand::Reference(Address::ZERO.offset(1))
+                },
+                destination,
+            }
+        ]
     );
     match scope.get("x").unwrap() {
         EpBinding::Single(addr) => {
-            assert_eq!(addr, &Address::ZERO);
+            assert_eq!(addr, &destination);
         }
         other => {
             panic!("expected 'x' bound to an address but it was bound to {other:?}");


### PR DESCRIPTION
Now Grackle can compile programs that define and use KCL functions, like

```
fn triple = (x) => { return x*3 }
let x = triple(1)
```

This also works for higher-order functions (functions which accept other functions as parameters, or return other functions).

This PR is broken into several small commits, it might be easier to review one-by-one. Each commit has a meaningful commit message and does one thing.