### PR TITLE
Grackle: Runtime computed array indices

### DIFF
--- a/src/wasm-lib/Cargo.lock
+++ b/src/wasm-lib/Cargo.lock
@@ -431,6 +431,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
+name = "bytecount"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
+
+[[package]]
 name = "bytemuck"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,6 +1432,7 @@ dependencies = [
  "kittycad-modeling-session",
  "pretty_assertions",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -1943,7 +1950,7 @@ dependencies = [
 [[package]]
 name = "kittycad-execution-plan"
 version = "0.1.0"
-source = "git+https://github.com/KittyCAD/modeling-api?branch=main#cd3e2c339b4794478e995247ca693d17c6b8ac4d"
+source = "git+https://github.com/KittyCAD/modeling-api?branch=main#0a891ad3d4a189410f457e00b644ff4e116e7175"
 dependencies = [
  "bytes",
  "insta",
@@ -1953,6 +1960,7 @@ dependencies = [
  "kittycad-modeling-session",
  "parse-display-derive",
  "serde",
+ "tabled",
  "thiserror",
  "tokio",
  "uuid",
@@ -1972,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "kittycad-execution-plan-macros"
 version = "0.1.2"
-source = "git+https://github.com/KittyCAD/modeling-api?branch=main#cd3e2c339b4794478e995247ca693d17c6b8ac4d"
+source = "git+https://github.com/KittyCAD/modeling-api?branch=main#0a891ad3d4a189410f457e00b644ff4e116e7175"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1981,9 +1989,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad-execution-plan-traits"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1486416eacecf481188a253199461fde5dbbc9bccaf176d60c48181cd0465273"
+checksum = "29dc558ca98b726d998fe9617f7cab0c427f54b49b42fb68d0a69d85e1b52dc7"
 dependencies = [
  "serde",
  "thiserror",
@@ -1993,7 +2001,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds"
 version = "0.1.12"
-source = "git+https://github.com/KittyCAD/modeling-api?branch=main#cd3e2c339b4794478e995247ca693d17c6b8ac4d"
+source = "git+https://github.com/KittyCAD/modeling-api?branch=main#0a891ad3d4a189410f457e00b644ff4e116e7175"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2020,7 +2028,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-session"
 version = "0.1.0"
-source = "git+https://github.com/KittyCAD/modeling-api?branch=main#cd3e2c339b4794478e995247ca693d17c6b8ac4d"
+source = "git+https://github.com/KittyCAD/modeling-api?branch=main#0a891ad3d4a189410f457e00b644ff4e116e7175"
 dependencies = [
  "futures",
  "kittycad",
@@ -2525,6 +2533,17 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2",
+]
+
+[[package]]
+name = "papergrid"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2ccbe15f2b6db62f9a9871642746427e297b0ceb85f9a7f1ee5ff47d184d0c8"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
 ]
 
 [[package]]
@@ -3918,6 +3937,30 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tabled"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfe9c3632da101aba5131ed63f9eed38665f8b3c68703a6bb18124835c1a5d22"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99f688a08b54f4f02f0a3c382aefdb7884d3d69609f785bd253dc033243e3fe4"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/src/wasm-lib/Cargo.toml
+++ b/src/wasm-lib/Cargo.toml
@@ -60,7 +60,7 @@ members = [
 [workspace.dependencies]
 kittycad = { version = "0.2.45", default-features = false, features = ["js"] }
 kittycad-execution-plan = { git = "https://github.com/KittyCAD/modeling-api", branch = "main" }
-kittycad-execution-plan-traits = "0.1.2"
+kittycad-execution-plan-traits = "0.1.5"
 kittycad-modeling-session = { git = "https://github.com/KittyCAD/modeling-api", branch = "main" }
 kittycad-execution-plan-macros = { git = "https://github.com/KittyCAD/modeling-api", branch = "main" }
 
@@ -71,3 +71,8 @@ path = "tests/executor/main.rs"
 [[test]]
 name = "modify"
 path = "tests/modify/main.rs"
+
+# Example: how to point modeling-api at a different repo (e.g. a branch or a local clone)
+# [patch."https://github.com/KittyCAD/modeling-api"]
+# kittycad-execution-plan = { path = "../../../modeling-api/execution-plan" }
+# kittycad-modeling-session = { path = "../../../modeling-api/modeling-session" }

--- a/src/wasm-lib/grackle/Cargo.toml
+++ b/src/wasm-lib/grackle/Cargo.toml
@@ -12,6 +12,7 @@ kittycad-execution-plan = { workspace = true }
 kittycad-execution-plan-traits = { workspace = true }
 kittycad-modeling-session = { workspace = true }
 thiserror = "1.0.56"
+tokio = { version = "1.35.1", features = ["macros", "rt"] }
 
 
 [dev-dependencies]

--- a/src/wasm-lib/grackle/src/kcl_value_group.rs
+++ b/src/wasm-lib/grackle/src/kcl_value_group.rs
@@ -5,7 +5,6 @@ use kcl_lib::ast::{self, types::BinaryPart};
 /// You can convert losslessly between KclValueGroup and `kcl_lib::ast::types::Value` with From/Into.
 pub enum KclValueGroup {
     Single(SingleValue),
-    ArrayExpression(Box<ast::types::ArrayExpression>),
     ObjectExpression(Box<ast::types::ObjectExpression>),
 }
 
@@ -21,6 +20,7 @@ pub enum SingleValue {
     MemberExpression(Box<ast::types::MemberExpression>),
     FunctionExpression(Box<ast::types::FunctionExpression>),
     PipeSubstitution(Box<ast::types::PipeSubstitution>),
+    ArrayExpression(Box<ast::types::ArrayExpression>),
 }
 
 impl From<ast::types::BinaryPart> for KclValueGroup {
@@ -59,7 +59,7 @@ impl From<ast::types::Value> for KclValueGroup {
             ast::types::Value::PipeExpression(e) => Self::Single(SingleValue::PipeExpression(e)),
             ast::types::Value::None(e) => Self::Single(SingleValue::KclNoneExpression(e)),
             ast::types::Value::UnaryExpression(e) => Self::Single(SingleValue::UnaryExpression(e)),
-            ast::types::Value::ArrayExpression(e) => Self::ArrayExpression(e),
+            ast::types::Value::ArrayExpression(e) => Self::Single(SingleValue::ArrayExpression(e)),
             ast::types::Value::ObjectExpression(e) => Self::ObjectExpression(e),
             ast::types::Value::MemberExpression(e) => Self::Single(SingleValue::MemberExpression(e)),
             ast::types::Value::FunctionExpression(e) => Self::Single(SingleValue::FunctionExpression(e)),
@@ -82,8 +82,8 @@ impl From<KclValueGroup> for ast::types::Value {
                 SingleValue::MemberExpression(e) => ast::types::Value::MemberExpression(e),
                 SingleValue::FunctionExpression(e) => ast::types::Value::FunctionExpression(e),
                 SingleValue::PipeSubstitution(e) => ast::types::Value::PipeSubstitution(e),
+                SingleValue::ArrayExpression(e) => ast::types::Value::ArrayExpression(e),
             },
-            KclValueGroup::ArrayExpression(e) => ast::types::Value::ArrayExpression(e),
             KclValueGroup::ObjectExpression(e) => ast::types::Value::ObjectExpression(e),
         }
     }


### PR DESCRIPTION
This PR:
* Adds support for computed array indices, like `let i = 1+1; let x = myArray[i]` -- previously Grackle could only resolve array indices at compiletime, but now it can emit instructions that calculate and loom up indices at runtime
* As a result, arrays can be moved into the SingleValue enum.

The next PR will do something similar for objects, at which point we can delete the KclValueGroup enum.
