### PR TITLE
Clean up vite build warnings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,7 +83,7 @@ export function App() {
   useEngineConnectionSubscriptions()
 
   const debounceSocketSend = throttle<EngineCommand>((message) => {
-    engineCommandManager.sendSceneCommand(message)
+    void engineCommandManager.sendSceneCommand(message)
   }, 16)
   const handleMouseMove: MouseEventHandler<HTMLDivElement> = (e) => {
     e.nativeEvent.preventDefault()

--- a/src/components/AvailableVarsHelpers.tsx
+++ b/src/components/AvailableVarsHelpers.tsx
@@ -138,7 +138,7 @@ export function useCalc({
   }, [kclManager.ast, kclManager.programMemory, selectionRange])
 
   useEffect(() => {
-    (async () => {
+    ;(async () => {
       try {
         const code = `const __result__ = ${value}`
         const ast = parse(code)

--- a/src/components/AvailableVarsHelpers.tsx
+++ b/src/components/AvailableVarsHelpers.tsx
@@ -138,39 +138,38 @@ export function useCalc({
   }, [kclManager.ast, kclManager.programMemory, selectionRange])
 
   useEffect(() => {
-    ;(async () => {
-      try {
-        const code = `const __result__ = ${value}`
-        const ast = parse(code)
-        const _programMem: any = { root: {}, return: null }
-        availableVarInfo.variables.forEach(({ key, value }) => {
-          _programMem.root[key] = { type: 'userVal', value, __meta: [] }
-        })
-        const { programMemory } = await executeAst({
-          ast,
-          engineCommandManager,
-          defaultPlanes: kclManager.defaultPlanes,
-          useFakeExecutor: true,
-          programMemoryOverride: JSON.parse(
-            JSON.stringify(kclManager.programMemory)
-          ),
-        })
-        const resultDeclaration = ast.body.find(
-          (a) =>
-            a.type === 'VariableDeclaration' &&
-            a.declarations?.[0]?.id?.name === '__result__'
-        )
-        const init =
-          resultDeclaration?.type === 'VariableDeclaration' &&
-          resultDeclaration?.declarations?.[0]?.init
-        const result = programMemory?.root?.__result__?.value
-        setCalcResult(typeof result === 'number' ? String(result) : 'NAN')
-        init && setValueNode(init)
-      } catch (e) {
-        setCalcResult('NAN')
-        setValueNode(null)
-      }
-    })()
+    const execAstAndSetResult = async () => {
+      const code = `const __result__ = ${value}`
+      const ast = parse(code)
+      const _programMem: any = { root: {}, return: null }
+      availableVarInfo.variables.forEach(({ key, value }) => {
+        _programMem.root[key] = { type: 'userVal', value, __meta: [] }
+      })
+      const programMemory = await executeAst({
+        ast,
+        engineCommandManager,
+        defaultPlanes: kclManager.defaultPlanes,
+        useFakeExecutor: true,
+        programMemoryOverride: JSON.parse(
+          JSON.stringify(kclManager.programMemory)
+        ),
+      })
+      const resultDeclaration = ast.body.find(
+        (a) =>
+          a.type === 'VariableDeclaration' &&
+          a.declarations?.[0]?.id?.name === '__result__'
+      )
+      const init =
+        resultDeclaration?.type === 'VariableDeclaration' &&
+        resultDeclaration?.declarations?.[0]?.init
+      const result = programMemory?.root?.__result__?.value
+      setCalcResult(typeof result === 'number' ? String(result) : 'NAN')
+      init && setValueNode(init)
+    }
+    execAstAndSetResult().catch((e) => {
+      setCalcResult('NAN')
+      setValueNode(null)
+    })
   }, [value, availableVarInfo])
 
   return {

--- a/src/components/AvailableVarsHelpers.tsx
+++ b/src/components/AvailableVarsHelpers.tsx
@@ -138,22 +138,23 @@ export function useCalc({
   }, [kclManager.ast, kclManager.programMemory, selectionRange])
 
   useEffect(() => {
-    try {
-      const code = `const __result__ = ${value}`
-      const ast = parse(code)
-      const _programMem: any = { root: {}, return: null }
-      availableVarInfo.variables.forEach(({ key, value }) => {
-        _programMem.root[key] = { type: 'userVal', value, __meta: [] }
-      })
-      executeAst({
-        ast,
-        engineCommandManager,
-        defaultPlanes: kclManager.defaultPlanes,
-        useFakeExecutor: true,
-        programMemoryOverride: JSON.parse(
-          JSON.stringify(kclManager.programMemory)
-        ),
-      }).then(({ programMemory }) => {
+    (async () => {
+      try {
+        const code = `const __result__ = ${value}`
+        const ast = parse(code)
+        const _programMem: any = { root: {}, return: null }
+        availableVarInfo.variables.forEach(({ key, value }) => {
+          _programMem.root[key] = { type: 'userVal', value, __meta: [] }
+        })
+        const { programMemory } = await executeAst({
+          ast,
+          engineCommandManager,
+          defaultPlanes: kclManager.defaultPlanes,
+          useFakeExecutor: true,
+          programMemoryOverride: JSON.parse(
+            JSON.stringify(kclManager.programMemory)
+          ),
+        })
         const resultDeclaration = ast.body.find(
           (a) =>
             a.type === 'VariableDeclaration' &&
@@ -165,11 +166,11 @@ export function useCalc({
         const result = programMemory?.root?.__result__?.value
         setCalcResult(typeof result === 'number' ? String(result) : 'NAN')
         init && setValueNode(init)
-      })
-    } catch (e) {
-      setCalcResult('NAN')
-      setValueNode(null)
-    }
+      } catch (e) {
+        setCalcResult('NAN')
+        setValueNode(null)
+      }
+    })()
   }, [value, availableVarInfo])
 
   return {

--- a/src/components/AvailableVarsHelpers.tsx
+++ b/src/components/AvailableVarsHelpers.tsx
@@ -166,7 +166,7 @@ export function useCalc({
       setCalcResult(typeof result === 'number' ? String(result) : 'NAN')
       init && setValueNode(init)
     }
-    execAstAndSetResult().catch((e) => {
+    execAstAndSetResult().catch(() => {
       setCalcResult('NAN')
       setValueNode(null)
     })

--- a/src/components/AvailableVarsHelpers.tsx
+++ b/src/components/AvailableVarsHelpers.tsx
@@ -145,7 +145,7 @@ export function useCalc({
       availableVarInfo.variables.forEach(({ key, value }) => {
         _programMem.root[key] = { type: 'userVal', value, __meta: [] }
       })
-      const programMemory = await executeAst({
+      const { programMemory } = await executeAst({
         ast,
         engineCommandManager,
         defaultPlanes: kclManager.defaultPlanes,

--- a/src/components/ExportButton.tsx
+++ b/src/components/ExportButton.tsx
@@ -52,7 +52,7 @@ export const ExportButton = ({ children, className }: ExportButtonProps) => {
   }
   const formik = useFormik({
     initialValues,
-    onSubmit: async (values: OutputFormat) => {
+    onSubmit: (values: OutputFormat) => {
       // Set the default coords.
       if (
         values.type === 'obj' ||
@@ -93,7 +93,7 @@ export const ExportButton = ({ children, className }: ExportButtonProps) => {
       if (values.type === 'ply' || values.type === 'stl') {
         values.selection = { type: 'default_scene' }
       }
-      await engineCommandManager.sendSceneCommand({
+      void engineCommandManager.sendSceneCommand({
         type: 'modeling_cmd_req',
         cmd: {
           type: 'export',

--- a/src/components/ExportButton.tsx
+++ b/src/components/ExportButton.tsx
@@ -52,7 +52,7 @@ export const ExportButton = ({ children, className }: ExportButtonProps) => {
   }
   const formik = useFormik({
     initialValues,
-    onSubmit: (values: OutputFormat) => {
+    onSubmit: async (values: OutputFormat) => {
       // Set the default coords.
       if (
         values.type === 'obj' ||
@@ -93,7 +93,7 @@ export const ExportButton = ({ children, className }: ExportButtonProps) => {
       if (values.type === 'ply' || values.type === 'stl') {
         values.selection = { type: 'default_scene' }
       }
-      engineCommandManager.sendSceneCommand({
+      await engineCommandManager.sendSceneCommand({
         type: 'modeling_cmd_req',
         cmd: {
           type: 'export',

--- a/src/components/GlobalStateProvider.tsx
+++ b/src/components/GlobalStateProvider.tsx
@@ -101,7 +101,7 @@ export const GlobalStateProvider = ({
       goToSignInPage: () => {
         navigate(paths.SIGN_IN)
 
-        logout()
+        void logout()
       },
       goToIndexPage: () => {
         if (window.location.pathname.includes(paths.SIGN_IN)) {

--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -97,19 +97,19 @@ export const ModelingMachineProvider = ({
         'Modify AST': () => {},
         'Update code selection cursors': () => {},
         'show default planes': () => {
-          kclManager.showPlanes()
+          void kclManager.showPlanes()
         },
         'create path': assign({
           sketchEnginePathId: () => {
             const sketchUuid = uuidv4()
-            engineCommandManager.sendSceneCommand({
+            void engineCommandManager.sendSceneCommand({
               type: 'modeling_cmd_req',
               cmd_id: sketchUuid,
               cmd: {
                 type: 'start_path',
               },
             })
-            engineCommandManager.sendSceneCommand({
+            void engineCommandManager.sendSceneCommand({
               type: 'modeling_cmd_req',
               cmd_id: uuidv4(),
               cmd: {
@@ -177,7 +177,7 @@ export const ModelingMachineProvider = ({
                 raw: {} as any,
               }
 
-            kclManager.executeAstMock(astWithUpdatedSource, true)
+            void kclManager.executeAstMock(astWithUpdatedSource, true)
 
             return {
               sketchPathToNode: _pathToNode,
@@ -228,7 +228,7 @@ export const ModelingMachineProvider = ({
               pathToNode: sketchPathToNode,
             })
             const _modifiedAst = newSketchLn.modifiedAst
-            kclManager.executeAstMock(_modifiedAst, true).then(() => {
+            void kclManager.executeAstMock(_modifiedAst, true).then(() => {
               const lineCallExp = getNodeFromPath<CallExpression>(
                 kclManager.ast,
                 newSketchLn.pathToNode
@@ -249,22 +249,22 @@ export const ModelingMachineProvider = ({
               programMemory: kclManager.programMemory,
               pathToNode: sketchPathToNode,
             })
-            engineCommandManager.sendSceneCommand({
+            void engineCommandManager.sendSceneCommand({
               type: 'modeling_cmd_req',
               cmd_id: uuidv4(),
               cmd: { type: 'edit_mode_exit' },
             })
-            engineCommandManager.sendSceneCommand({
+            void engineCommandManager.sendSceneCommand({
               type: 'modeling_cmd_req',
               cmd_id: uuidv4(),
               cmd: { type: 'default_camera_disable_sketch_mode' },
             })
-            kclManager.executeAstMock(_modifiedAst, true)
+            void kclManager.executeAstMock(_modifiedAst, true)
             // updateAst(_modifiedAst, true)
           }
         },
         'sketch exit execute': () => {
-          kclManager.executeAst()
+          void kclManager.executeAst()
         },
         'set tool': () => {}, // TODO
         'Set selection': assign(({ selectionRanges }, event) => {

--- a/src/components/Stream.tsx
+++ b/src/components/Stream.tsx
@@ -91,7 +91,7 @@ export const Stream = ({ className = '' }) => {
       ) {
         return
       }
-      engineCommandManager.sendSceneCommand({
+      void engineCommandManager.sendSceneCommand({
         type: 'modeling_cmd_req',
         cmd: {
           type: 'handle_mouse_drag_start',
@@ -100,7 +100,7 @@ export const Stream = ({ className = '' }) => {
         cmd_id: newId,
       })
     } else if (!state.matches('Sketch.Line Tool')) {
-      engineCommandManager.sendSceneCommand({
+      void engineCommandManager.sendSceneCommand({
         type: 'modeling_cmd_req',
         cmd: {
           type: 'camera_drag_start',
@@ -118,7 +118,7 @@ export const Stream = ({ className = '' }) => {
   const fps = 60
   const handleScroll: WheelEventHandler<HTMLVideoElement> = throttle((e) => {
     if (!cameraMouseDragGuards[cameraControls].zoom.scrollCallback(e)) return
-    engineCommandManager.sendSceneCommand({
+    void engineCommandManager.sendSceneCommand({
       type: 'modeling_cmd_req',
       cmd: {
         type: 'default_camera_zoom',
@@ -161,13 +161,13 @@ export const Stream = ({ className = '' }) => {
         selection_type: 'add',
         selected_at_window: { x, y },
       }
-      engineCommandManager.sendSceneCommand(command)
+      void engineCommandManager.sendSceneCommand(command)
     } else if (!didDragInStream && state.matches('Sketch.Line Tool')) {
       command.cmd = {
         type: 'mouse_click',
         window: { x, y },
       }
-      engineCommandManager.sendSceneCommand(command).then(async (resp) => {
+      void engineCommandManager.sendSceneCommand(command).then(async (resp) => {
         const entities_modified = resp?.data?.data?.entities_modified
         if (!entities_modified) return
         if (state.matches('Sketch.Line Tool.No Points')) {
@@ -251,20 +251,20 @@ export const Stream = ({ className = '' }) => {
         selection_type: 'add',
       }
 
-      engineCommandManager.sendSceneCommand(command)
+      void engineCommandManager.sendSceneCommand(command)
     } else if (!didDragInStream && state.matches('Sketch.Move Tool')) {
       command.cmd = {
         type: 'select_with_point',
         selected_at_window: { x, y },
         selection_type: 'add',
       }
-      engineCommandManager.sendSceneCommand(command)
+      void engineCommandManager.sendSceneCommand(command)
     } else if (didDragInStream && state.matches('Sketch.Move Tool')) {
       command.cmd = {
         type: 'handle_mouse_drag_end',
         window: { x, y },
       }
-      engineCommandManager.sendSceneCommand(command).then(async () => {
+      void engineCommandManager.sendSceneCommand(command).then(async () => {
         if (!context.sketchPathToNode) return
         getNodeFromPath<VariableDeclarator>(
           kclManager.ast,
@@ -353,10 +353,10 @@ export const Stream = ({ className = '' }) => {
           ]
         }
 
-        kclManager.executeAstMock(modifiedAst, true)
+        void kclManager.executeAstMock(modifiedAst, true)
       })
     } else {
-      engineCommandManager.sendSceneCommand(command)
+      void engineCommandManager.sendSceneCommand(command)
     }
 
     setDidDragInStream(false)

--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -76,10 +76,12 @@ export const TextEditor = ({
     const fromServer: FromServer = FromServer.create()
     const client = new Client(fromServer, intoServer)
     if (!TEST) {
-      Server.initialize(intoServer, fromServer).then((lspServer) => {
-        lspServer.start()
-        setIsLSPServerReady(true)
-      })
+      Server.initialize(intoServer, fromServer)
+        .then((lspServer) => {
+          void lspServer.start()
+          setIsLSPServerReady(true)
+        })
+        .catch((e) => console.log(e))
     }
 
     const lspClient = new LanguageServerClient({ client })
@@ -151,7 +153,7 @@ export const TextEditor = ({
           key: editorShortcutMeta.convertToVariable.codeMirror,
           run: () => {
             if (convertEnabled) {
-              convertCallback()
+              void convertCallback()
               return true
             }
             return false

--- a/src/editor/lsp/index.ts
+++ b/src/editor/lsp/index.ts
@@ -67,7 +67,7 @@ export class LanguageServerClient {
 
   async initialize() {
     // Start the client in the background.
-    this.client.start()
+    await this.client.start()
 
     this.ready = true
   }
@@ -81,12 +81,12 @@ export class LanguageServerClient {
   textDocumentDidOpen(params: LSP.DidOpenTextDocumentParams) {
     this.notify('textDocument/didOpen', params)
 
-    this.updateSemanticTokens(params.textDocument.uri)
+    void this.updateSemanticTokens(params.textDocument.uri)
   }
 
   textDocumentDidChange(params: LSP.DidChangeTextDocumentParams) {
     this.notify('textDocument/didChange', params)
-    this.updateSemanticTokens(params.textDocument.uri)
+    void this.updateSemanticTokens(params.textDocument.uri)
   }
 
   async updateSemanticTokens(uri: string) {

--- a/src/editor/lsp/plugin.ts
+++ b/src/editor/lsp/plugin.ts
@@ -60,9 +60,7 @@ export class LanguageServerPlugin implements PluginValue {
     this.languageId = this.view.state.facet(languageId)
     this.documentVersion = 0
 
-    this.client.attachPlugin(this)
-
-    (async () => {
+    this.client.attachPlugin(this)(async () => {
       await this.initialize({
         documentText: this.view.state.doc.toString(),
       })

--- a/src/editor/lsp/plugin.ts
+++ b/src/editor/lsp/plugin.ts
@@ -62,15 +62,17 @@ export class LanguageServerPlugin implements PluginValue {
 
     this.client.attachPlugin(this)
 
-    this.initialize({
-      documentText: this.view.state.doc.toString(),
+    (async () => {
+      await this.initialize({
+        documentText: this.view.state.doc.toString(),
+      })
     })
   }
 
-  update({ docChanged }: ViewUpdate) {
+  async update({ docChanged }: ViewUpdate) {
     if (!docChanged) return
 
-    this.sendChange({
+    await this.sendChange({
       documentText: this.view.state.doc.toString(),
     })
   }
@@ -126,8 +128,8 @@ export class LanguageServerPlugin implements PluginValue {
     }
   }
 
-  requestDiagnostics(view: EditorView) {
-    this.sendChange({ documentText: view.state.doc.toString() })
+  async requestDiagnostics(view: EditorView) {
+    await this.sendChange({ documentText: view.state.doc.toString() })
   }
 
   async requestHoverTooltip(
@@ -140,7 +142,7 @@ export class LanguageServerPlugin implements PluginValue {
     )
       return null
 
-    this.sendChange({ documentText: view.state.doc.toString() })
+    await this.sendChange({ documentText: view.state.doc.toString() })
     const result = await this.client.textDocumentHover({
       textDocument: { uri: this.documentUri },
       position: { line, character },
@@ -178,7 +180,7 @@ export class LanguageServerPlugin implements PluginValue {
     )
       return null
 
-    this.sendChange({
+    await this.sendChange({
       documentText: context.state.doc.toString(),
     })
 

--- a/src/editor/lsp/plugin.ts
+++ b/src/editor/lsp/plugin.ts
@@ -60,17 +60,17 @@ export class LanguageServerPlugin implements PluginValue {
     this.languageId = this.view.state.facet(languageId)
     this.documentVersion = 0
 
-    this.client.attachPlugin(this)(async () => {
-      await this.initialize({
-        documentText: this.view.state.doc.toString(),
-      })
+    this.client.attachPlugin(this)
+
+    void this.initialize({
+      documentText: this.view.state.doc.toString(),
     })
   }
 
-  async update({ docChanged }: ViewUpdate) {
+  update({ docChanged }: ViewUpdate) {
     if (!docChanged) return
 
-    await this.sendChange({
+    void this.sendChange({
       documentText: this.view.state.doc.toString(),
     })
   }
@@ -126,8 +126,8 @@ export class LanguageServerPlugin implements PluginValue {
     }
   }
 
-  async requestDiagnostics(view: EditorView) {
-    await this.sendChange({ documentText: view.state.doc.toString() })
+  requestDiagnostics(view: EditorView) {
+    void this.sendChange({ documentText: view.state.doc.toString() })
   }
 
   async requestHoverTooltip(

--- a/src/hooks/useToolbarGuards.ts
+++ b/src/hooks/useToolbarGuards.ts
@@ -39,7 +39,7 @@ export function useConvertToVariable() {
         variableName
       )
 
-      kclManager.updateAst(_modifiedAst, true)
+      void kclManager.updateAst(_modifiedAst, true)
     } catch (e) {
       console.log('error', e)
     }

--- a/src/lang/KclSinglton.tsx
+++ b/src/lang/KclSinglton.tsx
@@ -59,7 +59,7 @@ class KclManager {
     } catch (e) {
       console.error(e)
     }
-    this.executeAst(ast)
+    void this.executeAst(ast)
   }, 600)
 
   private _isExecutingCallback: (arg: boolean) => void = () => {}
@@ -376,15 +376,15 @@ class KclManager {
   }
 
   showPlanes() {
-    this.engineCommandManager.setPlaneHidden(this.defaultPlanes.xy, false)
-    this.engineCommandManager.setPlaneHidden(this.defaultPlanes.yz, false)
-    this.engineCommandManager.setPlaneHidden(this.defaultPlanes.xz, false)
+    void this.engineCommandManager.setPlaneHidden(this.defaultPlanes.xy, false)
+    void this.engineCommandManager.setPlaneHidden(this.defaultPlanes.yz, false)
+    void this.engineCommandManager.setPlaneHidden(this.defaultPlanes.xz, false)
   }
 
   hidePlanes() {
-    this.engineCommandManager.setPlaneHidden(this.defaultPlanes.xy, true)
-    this.engineCommandManager.setPlaneHidden(this.defaultPlanes.yz, true)
-    this.engineCommandManager.setPlaneHidden(this.defaultPlanes.xz, true)
+    void this.engineCommandManager.setPlaneHidden(this.defaultPlanes.xy, true)
+    void this.engineCommandManager.setPlaneHidden(this.defaultPlanes.yz, true)
+    void this.engineCommandManager.setPlaneHidden(this.defaultPlanes.xz, true)
   }
 }
 

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -10,11 +10,7 @@ import {
 import { assign, createMachine } from 'xstate'
 import { v4 as uuidv4 } from 'uuid'
 import { isCursorInSketchCommandRange } from 'lang/util'
-import {
-  doesPipeHaveCallExp,
-  getNodePathFromSourceRange,
-  hasExtrudeSketchGroup,
-} from 'lang/queryAst'
+import { getNodePathFromSourceRange } from 'lang/queryAst'
 import { kclManager } from 'lang/KclSinglton'
 import {
   horzVertInfo,
@@ -817,7 +813,7 @@ export const modelingMachine = createMachine(
         }),
       }),
       'sketch mode enabled': ({ sketchPlaneId }) => {
-        engineCommandManager.sendSceneCommand({
+        void engineCommandManager.sendSceneCommand({
           type: 'modeling_cmd_req',
           cmd_id: uuidv4(),
           cmd: {
@@ -838,7 +834,7 @@ export const modelingMachine = createMachine(
           selectionRanges
         )
         pathId &&
-          engineCommandManager.sendSceneCommand({
+          void engineCommandManager.sendSceneCommand({
             type: 'modeling_cmd_req',
             cmd_id: uuidv4(),
             cmd: {
@@ -848,7 +844,7 @@ export const modelingMachine = createMachine(
           })
       },
       'hide default planes': () => {
-        kclManager.hidePlanes()
+        void kclManager.hidePlanes()
       },
       edit_mode_exit: () =>
         engineCommandManager.sendSceneCommand({
@@ -914,7 +910,7 @@ export const modelingMachine = createMachine(
           kclManager.ast,
           kclManager.programMemory
         )
-        kclManager.updateAst(modifiedAst, true)
+        void kclManager.updateAst(modifiedAst, true)
       },
       'Make selection vertical': ({ selectionRanges }) => {
         const { modifiedAst } = applyConstraintHorzVert(
@@ -923,53 +919,53 @@ export const modelingMachine = createMachine(
           kclManager.ast,
           kclManager.programMemory
         )
-        kclManager.updateAst(modifiedAst, true)
+        void kclManager.updateAst(modifiedAst, true)
       },
       'Constrain horizontally align': ({ selectionRanges }) => {
         const { modifiedAst } = applyConstraintHorzVertAlign({
           selectionRanges,
           constraint: 'setVertDistance',
         })
-        kclManager.updateAst(modifiedAst, true)
+        void kclManager.updateAst(modifiedAst, true)
       },
       'Constrain vertically align': ({ selectionRanges }) => {
         const { modifiedAst } = applyConstraintHorzVertAlign({
           selectionRanges,
           constraint: 'setHorzDistance',
         })
-        kclManager.updateAst(modifiedAst, true)
+        void kclManager.updateAst(modifiedAst, true)
       },
       'Constrain snap to X': ({ selectionRanges }) => {
         const { modifiedAst } = applyConstraintAxisAlign({
           selectionRanges,
           constraint: 'snapToXAxis',
         })
-        kclManager.updateAst(modifiedAst, true)
+        void kclManager.updateAst(modifiedAst, true)
       },
       'Constrain snap to Y': ({ selectionRanges }) => {
         const { modifiedAst } = applyConstraintAxisAlign({
           selectionRanges,
           constraint: 'snapToYAxis',
         })
-        kclManager.updateAst(modifiedAst, true)
+        void kclManager.updateAst(modifiedAst, true)
       },
       'Constrain equal length': ({ selectionRanges }) => {
         const { modifiedAst } = applyConstraintEqualLength({
           selectionRanges,
         })
-        kclManager.updateAst(modifiedAst, true)
+        void kclManager.updateAst(modifiedAst, true)
       },
       'Constrain parallel': ({ selectionRanges }) => {
         const { modifiedAst } = applyConstraintEqualAngle({
           selectionRanges,
         })
-        kclManager.updateAst(modifiedAst, true)
+        void kclManager.updateAst(modifiedAst, true)
       },
       'Constrain remove constraints': ({ selectionRanges }) => {
         const { modifiedAst } = applyRemoveConstrainingValues({
           selectionRanges,
         })
-        kclManager.updateAst(modifiedAst, true)
+        void kclManager.updateAst(modifiedAst, true)
       },
       'AST extrude': (_, event) => {
         if (!event.data) return
@@ -985,7 +981,7 @@ export const modelingMachine = createMachine(
           distance
         )
         // TODO not handling focusPath correctly I think
-        kclManager.updateAst(modifiedAst, true, {
+        void kclManager.updateAst(modifiedAst, true, {
           focusPath: pathToExtrudeArg,
         })
       },

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -2,13 +2,15 @@ import { ReportHandler } from 'web-vitals'
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
-    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-      getCLS(onPerfEntry)
-      getFID(onPerfEntry)
-      getFCP(onPerfEntry)
-      getLCP(onPerfEntry)
-      getTTFB(onPerfEntry)
-    })
+    import('web-vitals')
+      .then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+        getCLS(onPerfEntry)
+        getFID(onPerfEntry)
+        getFCP(onPerfEntry)
+        getLCP(onPerfEntry)
+        getTTFB(onPerfEntry)
+      })
+      .catch((e) => console.log(e))
   }
 }
 

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -70,7 +70,7 @@ export const Settings = () => {
     }
   }
 
-  function restartOnboarding() {
+  async function restartOnboarding() {
     send({
       type: 'Set Onboarding Status',
       data: { onboardingStatus: '' },
@@ -79,7 +79,7 @@ export const Settings = () => {
     if (isFileSettings) {
       navigate(dotDotSlash(1) + paths.ONBOARDING.INDEX)
     } else {
-      createAndOpenNewProject()
+      await createAndOpenNewProject()
     }
   }
 

--- a/src/routes/SignIn.tsx
+++ b/src/routes/SignIn.tsx
@@ -22,7 +22,6 @@ const SignIn = () => {
     },
   } = useGlobalStateContext()
 
-  const appliedTheme = theme === Themes.System ? getSystemTheme() : theme
   const signInTauri = async () => {
     // We want to invoke our command to login via device auth.
     try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3292,15 +3292,10 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-caniuse-lite@^1.0.30001464, caniuse-lite@^1.0.30001517:
-  version "1.0.30001518"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001518.tgz#b3ca93904cb4699c01218246c4d77a71dbe97150"
-  integrity sha512-rup09/e3I0BKjncL+FesTayKtPrdwKhUufQFd3riFw1hHg8JmIFoInYfB102cFcY/pPgGmdyl/iy+jgiDi2vdA==
-
-caniuse-lite@^1.0.30001541:
-  version "1.0.30001561"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001561.tgz#752f21f56f96f1b1a52e97aae98c57c562d5d9da"
-  integrity sha512-NTt0DNoKe958Q0BE0j0c1V9jbUzhBxHIEJy7asmGrpE0yG63KTV7PLHPnK2E1O9RsQrQ081I3NLuXGS6zht3cw==
+caniuse-lite@^1.0.30001464, caniuse-lite@^1.0.30001517, caniuse-lite@^1.0.30001541:
+  version "1.0.30001581"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001581.tgz"
+  integrity sha512-whlTkwhqV2tUmP3oYhtNfaWGYHDdS3JYFQBKXxcUR9qqPWsRhFHhoISO2Xnl/g0xyKzht9mI1LZpiNWfMzHixQ==
 
 chai@^4.3.10:
   version "4.3.10"


### PR DESCRIPTION
Fixes #1014 (og issue was about React hooks but this is the same intent, cleaning up the Github Actions threads on PRs)

Mostly just adding the `void` keyword to all the non-awaited promises we have with KclSingleton and other parts as I didn't want to change the current behavior. When it made sense to just add `await` I did so.

`vite build` also had a log about an update needed to caniuse, hence the yarn.lock change.

I'll try to fix the playwright tests in another PR