### PR TITLE
Fix tauri e2e tests (tauri-driver = 0.1.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
       - name: Run e2e tests (linux only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          cargo install tauri-driver
+          cargo install tauri-driver@0.1.3
           source .env.${{ env.BUILD_RELEASE == 'true' && 'production' || 'development' }}
           export VITE_KC_API_BASE_URL
           xvfb-run yarn test:e2e:tauri

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,6 @@ jobs:
       - name: Run e2e tests (linux only)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          cargo install tauri-driver@0.1.3
           source .env.${{ env.BUILD_RELEASE == 'true' && 'production' || 'development' }}
           export VITE_KC_API_BASE_URL
           xvfb-run yarn test:e2e:tauri

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,11 +25,11 @@ tauri-plugin-fs-extra = { git = "https://github.com/tauri-apps/plugins-workspace
 tokio = { version = "1.34.0", features = ["time"] }
 toml = "0.8.2"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+tauri-driver = "0.1.3"
+
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.
 # If you use cargo directly instead of tauri's cli you can use this feature flag to switch between tauri's `dev` and `build` modes.
 # DO NOT REMOVE!!
 custom-protocol = ["tauri/custom-protocol"]
-
-[target.'cfg(target_os = "linux")'.dependencies]
-tauri-driver = "0.1.3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,3 +30,6 @@ toml = "0.8.2"
 # If you use cargo directly instead of tauri's cli you can use this feature flag to switch between tauri's `dev` and `build` modes.
 # DO NOT REMOVE!!
 custom-protocol = ["tauri/custom-protocol"]
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tauri-driver = "0.1.3"


### PR DESCRIPTION
Fixes #1343

Looks like it's due to 0.1.4 (not sure why yet).
Specifying the dependency in a cleaner way, this way we should get dependabots PRs and not have it randomly upgrade and break.