### PR TITLE
Clean up new artifact types

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@headlessui/react": "^1.7.17",
     "@headlessui/tailwindcss": "^0.2.0",
-    "@kittycad/lib": "^0.0.50",
+    "@kittycad/lib": "^0.0.53",
     "@lezer/javascript": "^1.4.9",
     "@open-rpc/client-js": "^1.8.1",
     "@react-hook/resize-observer": "^1.2.6",

--- a/src/clientSideScene/sceneInfra.ts
+++ b/src/clientSideScene/sceneInfra.ts
@@ -24,7 +24,7 @@ import {
   Object3DEventMap,
 } from 'three'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
-import { engineCommandManager } from 'lang/std/engineConnection'
+import { EngineCommand, engineCommandManager } from 'lang/std/engineConnection'
 import { v4 as uuidv4 } from 'uuid'
 import { isReducedMotion, roundOff, throttle } from 'lib/utils'
 import { compareVec2Epsilon2 } from 'lang/std/sketch'
@@ -70,7 +70,7 @@ interface ThreeCamValues {
 
 const lastCmdDelay = 50
 
-let lastCmd: any = null
+let lastCmd: EngineCommand | null = null
 let lastCmdTime: number = Date.now()
 let lastCmdTimeoutId: number | null = null
 
@@ -82,14 +82,14 @@ const sendLastReliableChannel = () => {
 }
 
 const throttledUpdateEngineCamera = throttle((threeValues: ThreeCamValues) => {
-  const cmd = {
+  const cmd: EngineCommand = {
     type: 'modeling_cmd_req',
     cmd_id: uuidv4(),
     cmd: {
       type: 'default_camera_look_at',
       ...convertThreeCamValuesToEngineCam(threeValues),
     },
-  } as any
+  }
   engineCommandManager.sendSceneCommand(cmd)
   lastCmd = cmd
   lastCmdTime = Date.now()
@@ -103,7 +103,7 @@ const throttledUpdateEngineCamera = throttle((threeValues: ThreeCamValues) => {
   ) as any as number
 }, 1000 / 30)
 
-let lastPerspectiveCmd: any = null
+let lastPerspectiveCmd: EngineCommand | null = null
 let lastPerspectiveCmdTime: number = Date.now()
 let lastPerspectiveCmdTimeoutId: number | null = null
 
@@ -124,7 +124,7 @@ const throttledUpdateEngineFov = throttle(
     zoom: number
     fov: number
   }) => {
-    const cmd = {
+    const cmd: EngineCommand = {
       type: 'modeling_cmd_req',
       cmd_id: uuidv4(),
       cmd: {
@@ -136,7 +136,7 @@ const throttledUpdateEngineFov = throttle(
         fov_y: vals.fov,
         ...calculateNearFarFromFOV(vals.fov),
       },
-    } as any
+    }
     engineCommandManager.sendSceneCommand(cmd)
     lastPerspectiveCmd = cmd
     lastPerspectiveCmdTime = Date.now()

--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -1297,6 +1297,11 @@ export class EngineCommandManager {
       if (artifactTypesToDelete.includes(artifact.commandType)) {
         artifactsToDelete[id] = artifact
       }
+      if (artifact.commandType === 'import_files') {
+        // TODO why is this handled differently from other artifacts, i.e. why does it not use the id from the
+        // modeling command? We're having to do special clean up for this one special object.
+        artifactsToDelete[(artifact as any)?.data?.data?.object_id] = artifact
+      }
     })
     Object.keys(artifactsToDelete).forEach((id) => {
       const deleteCmd: EngineCommand = {

--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -1142,7 +1142,10 @@ export class EngineCommandManager {
         raw: message,
       } as const
       this.artifactMap[id] = artifact
-      if (command.commandType === 'entity_linear_pattern') {
+      if (
+        command.commandType === 'entity_linear_pattern' ||
+        command.commandType === 'entity_circular_pattern'
+      ) {
         const entities = (modelingResponse as any)?.data?.entity_ids
         entities?.forEach((entity: string) => {
           this.artifactMap[entity] = artifact
@@ -1289,6 +1292,7 @@ export class EngineCommandManager {
         // Using an array is the list is likely to grow.
         'start_path',
         'entity_linear_pattern',
+        'entity_circular_pattern',
       ]
       if (artifactTypesToDelete.includes(artifact.commandType)) {
         artifactsToDelete[id] = artifact

--- a/yarn.lock
+++ b/yarn.lock
@@ -1801,10 +1801,10 @@
   resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.4.0.tgz#08d6c5e20cf7e4cc02fd181c4b0c225cd31dbb60"
   integrity sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==
 
-"@kittycad/lib@^0.0.50":
-  version "0.0.50"
-  resolved "https://registry.yarnpkg.com/@kittycad/lib/-/lib-0.0.50.tgz#d80890af317d413bddc3f2c212d941b196d8f027"
-  integrity sha512-kiwfN8ybR8v8XuskZ64CF20Y9B+1gdDL7vj6xy56Uw0hxcqUmTqu9t1U5BIzWCTsMimL6e9+moZmN6leNOXIEA==
+"@kittycad/lib@^0.0.53":
+  version "0.0.53"
+  resolved "https://registry.yarnpkg.com/@kittycad/lib/-/lib-0.0.53.tgz#32f10f63428c5f3bb6a435507dbfa72c1e7ba10d"
+  integrity sha512-a0WTVVGKE+J7I1bERn8pcr8cC5/X14dFi78Y7wAsu8ok/SuHVTPoPHVCZ8bUmcWzY1iWpLC/HCIIHigXjkF3ZA==
   dependencies:
     node-fetch "3.3.2"
     openapi-types "^12.0.0"


### PR DESCRIPTION
Got circular patterns and imports cleaned up on re-execute.
Also upgraded the client lib to remove a few `any`s

The import object doesn't use the same id that it's given when we hit the end point, which means we have to do special clean up logic for this one object. Maybe there's a good reason for this, but annoying that we don't seem to be able to stick to the convention.