### PR TITLE
fix zoom cam change

### DIFF
--- a/src/clientSideScene/sceneInfra.ts
+++ b/src/clientSideScene/sceneInfra.ts
@@ -626,10 +626,21 @@ class SceneInfra {
     const { x: px, y: py, z: pz } = this.camera.position
     const { x: qx, y: qy, z: qz, w: qw } = this.camera.quaternion
     const { x: tx, y: ty, z: tz } = this.controls.target
+    const zoom = this.camera.zoom
     this.camera = this.createPerspectiveCamera()
 
     this.camera.position.set(px, py, pz)
     this.camera.quaternion.set(qx, qy, qz, qw)
+    const zoomFudgeFactor = 2280
+    const distance = zoomFudgeFactor / (zoom * this.fov)
+    const direction = new Vector3().subVectors(
+      this.camera.position,
+      this.controls.target
+    )
+    direction.normalize()
+    this.camera.position
+      .copy(this.controls.target)
+      .addScaledVector(direction, distance)
 
     this.setupOrbitControls([tx, ty, tz])
 


### PR DESCRIPTION
When going between sketch mode and not sketch mode we switch between an orthographic and perspective camera.
When doing so we were getting position, target etc all synced up, but zoom was a problem to make look right when switching, particularly from ortho to persp, because zoom in ortho is the size of the window, where as it's the position of the camera for perspective.

This has been resolved in this PR by factoring in the orthographic-camera's zoom before the switch, the FOV of the camera we're switching to and a little fudge constant.