### PR TITLE
cancel execution on file change

### DIFF
--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -36,6 +36,7 @@ import { sep } from '@tauri-apps/api/path'
 import { homeCommandBarConfig } from 'lib/commandBarConfigs/homeCommandConfig'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { isTauri } from 'lib/isTauri'
+import { kclManager } from 'lang/KclSingleton'
 
 // This route only opens in the Tauri desktop context for now,
 // as defined in Router.tsx, so we can use the Tauri APIs and types.
@@ -55,6 +56,7 @@ const Home = () => {
   // during the loading of the home page. This is wrapped
   // in a single-use effect to avoid a potential infinite loop.
   useEffect(() => {
+    kclManager.cancelAllExecutions()
     if (newDefaultDirectory) {
       sendToSettings({
         type: 'Set Default Directory',


### PR DESCRIPTION
https://github.com/KittyCAD/modeling-app/assets/29681384/ecc33977-d7bc-4acd-9b7f-4765c6eba1cf

<details>
<summary>
transcript
</summary>

0:00
So this one, I could at least replicate easily.

0:02
So if I open this project, it's yours.

0:05
But with some extra stuff, basically me trying to make sure that the execution takes a while because that helps with replicating.

0:11
So I go ahead and make a small change and immediately go home new file, open that file.

0:17
Then you know, when I try and do stuff, it's like that, that code is still there, right?

0:23
So it is, it is successfully adding sketches in this case, like it's down the bottom here, but obviously, the code appeared when we didn't want it to.

0:32
So basically what's happening is when we re execute at the end of the end of the execution, there's some side effects which is basically like putting the new code into new artifacts and whatnot interstate and loading up the code mirror code.

0:47
And the reason why it changes code, mirror code is sometimes we're executing from the A ST not the code because you have a, you might have a modified A ST So anyway, the solution was, or at least a quick fix.

0:57
I I'll talk about at the moment.

0:58
The quick fix was to like just make sure we cancel executions when we're changing files.

1:02
So let me just quickly comment out in line.

1:05
Let me just save this and this will probably does this reload.

1:11
I'm not sure I'll go home and just do a reload.

1:14
Sure.

1:17
So I opened this.

1:19
We should have the original files.

1:21
Let's do the exact same thing again.

1:23
Once this is done, I'll change this go new open and we still saw like a little flash in the engine.

1:32
Maybe that's something we can fix with a new goal button.

1:34
But if I start a sketch, we should be good now.

1:37
So, so, so the quick thing I wanted to mention is that, so we talked about having some sort of new gore state on file change as a way to safeguard against these issues.

1:48
And while that might be a good long term solution and I'm open to it, it, it does, it does seem like quite a big refactor and this is like a a quick fix and the ref factor it would, to me, it would be challenging, not challenging, it would be a bit of a decision about where the nuke core state ends because I assume part of the state we don't want to nuke is the engine connection.

2:14
And, and it's just kind of gray areas with other like classes that are in the app.

2:19
So yeah, some something maybe to talk about.

</details>