### PR TITLE
Add transparent buffer around open panels

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -140,7 +140,7 @@ export function App() {
       <Resizable
         className={
           'pointer-events-none h-full flex flex-col flex-1 z-10 my-5 ml-5 pr-1 transition-opacity transition-duration-75 ' +
-          +paneOpacity
+          paneOpacity
         }
         defaultSize={{
           width: '550px',

--- a/src/components/CollapsiblePanel.module.css
+++ b/src/components/CollapsiblePanel.module.css
@@ -49,12 +49,12 @@
   TODO: make this logic flexible for if the panel is on the right side of the screen.
 */
 .panel[open]::before {
-  @apply absolute -inset-4 -top-2 -right-1 z-0;
+  @apply absolute -inset-5 -top-2 -right-1 z-0;
   @apply content-[''];
 }
 
 .panel[open]:first-of-type::before {
-  @apply -top-4;
+  @apply -top-5;
 }
 
 .panel[open] + .panel[open],

--- a/src/components/CollapsiblePanel.module.css
+++ b/src/components/CollapsiblePanel.module.css
@@ -39,7 +39,18 @@
 }
 
 .panel[open] {
-  @apply flex-grow max-h-full h-48 my-1 rounded;
+  @apply relative flex-grow max-h-full h-48 my-1 rounded;
+}
+
+/*
+  Open panels have a little bit of a buffer around them
+  to make it harder to accidentally click or interact with the stream behind them.
+  The right side buffer is a little smaller so people don't get frustrated by it.
+  TODO: make this logic flexible for if the panel is on the right side of the screen.
+*/
+.panel[open]::before {
+  @apply absolute -inset-4 -right-1 z-0;
+  @apply content-[''];
 }
 
 .panel[open] + .panel[open],

--- a/src/components/CollapsiblePanel.module.css
+++ b/src/components/CollapsiblePanel.module.css
@@ -49,8 +49,12 @@
   TODO: make this logic flexible for if the panel is on the right side of the screen.
 */
 .panel[open]::before {
-  @apply absolute -inset-4 -right-1 z-0;
+  @apply absolute -inset-4 -top-2 -right-1 z-0;
   @apply content-[''];
+}
+
+.panel[open]:first-of-type::before {
+  @apply -top-4;
 }
 
 .panel[open] + .panel[open],


### PR DESCRIPTION
Adds a small transparent buffer to all open code panels using CSS and the `::before` pseudo-element so that users don't inadvertently interact with the stream when they intend to manipulate or select something in the pane.

@JBEmbedded discovered it was very easy to land right in the gutter to the left of the code pane when selecting text, and if you were in the middle of an action like drawing a line, the mouse-up from that selection would drop a segment point there.

You can't see the buffers normally but here they are highlighted:
![Screenshot 2024-02-22 at 12 33 08 PM](https://github.com/KittyCAD/modeling-app/assets/23481541/a04be135-1d7f-4185-a9c9-5ecd937105cf)
