### PR TITLE
Disable modeling commands when network is bad

### DIFF
--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -374,6 +374,7 @@ export const ModelingMachineProvider = ({
     send: modelingSend,
     actor: modelingActor,
     commandBarConfig: modelingMachineConfig,
+    allCommandsRequireNetwork: true,
     onCancel: () => modelingSend({ type: 'Cancel' }),
   })
 

--- a/src/hooks/useStateMachineCommands.ts
+++ b/src/hooks/useStateMachineCommands.ts
@@ -52,15 +52,12 @@ export default function useStateMachineCommands<
   const { isStreamReady } = useStore((s) => ({
     isStreamReady: s.isStreamReady,
   }))
-  
+
   useEffect(() => {
     const disableAllButtons =
       overallState !== NetworkHealthState.Ok || isExecuting || !isStreamReady
     const newCommands = state.nextEvents
-      .filter(
-        (_) =>
-          !allCommandsRequireNetwork || !disableAllButtons
-      )
+      .filter((_) => !allCommandsRequireNetwork || !disableAllButtons)
       .filter((e) => !['done.', 'error.'].some((n) => e.includes(n)))
       .map((type) =>
         createMachineCommand<T, S>({


### PR DESCRIPTION
Should finish off the last of @Irev-Dev's checklist. Allows new state machines to flag themselves as requiring the network to be good to be available, the n updates the modelingMachine to use that option.