### PR TITLE
bump ahash to fix the nightly builds

### DIFF
--- a/src/wasm-lib/Cargo.lock
+++ b/src/wasm-lib/Cargo.lock
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.5"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7d5a2cecb58716e47d67d5703a249964b14c7be1ec3cad3affc295b2d1c35d"
+checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
 dependencies = [
  "cfg-if",
  "getrandom",


### PR DESCRIPTION
Specifically, i'm hitting https://github.com/tkaitchuck/aHash/issues/200 ahash FTBFS because of https://github.com/rust-lang/rust/pull/117372 which is fixed in 0.8.7.

This rolls us forward which should fix future builds.