### PR TITLE
Cut release v0.15.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "untitled-app",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "private": true,
   "dependencies": {
     "@codemirror/autocomplete": "^6.10.2",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   },
   "package": {
     "productName": "zoo-modeling-app",
-    "version": "0.15.2"
+    "version": "0.15.3"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
- [bump kittcad/lib version](https://github.com/KittyCAD/modeling-app/pull/1565)
- [Grackle: implement StartSketchAt stdlib function](https://github.com/KittyCAD/modeling-app/pull/1535)
- [add issue template](https://github.com/KittyCAD/modeling-app/pull/1547)
- [short term cam fix](https://github.com/KittyCAD/modeling-app/pull/1543)
- [improve export test logs](https://github.com/KittyCAD/modeling-app/pull/1536)
- [Sketch on face of face](https://github.com/KittyCAD/modeling-app/pull/1524)
- [update cli to reestablish export test](https://github.com/KittyCAD/modeling-app/pull/1523)
- [Disable actions when stream disconnected](https://github.com/KittyCAD/modeling-app/pull/1483)
- [solve a couple of scene scale bugs](https://github.com/KittyCAD/modeling-app/pull/1496)
- [Some cam fixes](https://github.com/KittyCAD/modeling-app/pull/1520)
- [fixing discord automation to ignore nightly runs](https://github.com/KittyCAD/modeling-app/pull/1516)
- [Honor mod+z and mod+shift+z even with editor not in focus](https://github.com/KittyCAD/modeling-app/pull/1513)
- [Remove Sentry from production](https://github.com/KittyCAD/modeling-app/pull/1515)
- [Replace number command bar arg input type with kcl expression input](https://github.com/KittyCAD/modeling-app/pull/1474)
- [Sketch on arc error](https://github.com/KittyCAD/modeling-app/pull/1495)
- [Disable modeling commands when network is bad](https://github.com/KittyCAD/modeling-app/pull/1486)
- [Release derive-docs 0.1.7](https://github.com/KittyCAD/modeling-app/pull/1491)
- [Trim space off the return type before continuing](https://github.com/KittyCAD/modeling-app/pull/1487)
- [bump ahash to fix the nightly builds](https://github.com/KittyCAD/modeling-app/pull/1488)
- [Cube example didn't actually work](https://github.com/KittyCAD/modeling-app/pull/1478)
- [Bump ip from 1.1.8 to 1.1.9](https://github.com/KittyCAD/modeling-app/pull/1471)
- [Move discord automation into ci.yml](https://github.com/KittyCAD/modeling-app/pull/1479)