### PR TITLE
failing auto complete test

### DIFF
--- a/e2e/playwright/flow-tests.spec.ts
+++ b/e2e/playwright/flow-tests.spec.ts
@@ -387,7 +387,7 @@ test('Auto complete works', async ({ page }) => {
   await page.keyboard.press('ArrowDown')
   await page.keyboard.press('Enter')
   // finish line with comment
-  await page.keyboard.type('(5, %) // lin', { delay: 100 }) // We add a delay here so its slow like a user and the lsp can catch up
+  await page.keyboard.type('(5, %) // lin', {delay: 1000}) // We add a delay here so its slow like a user and the lsp can catch up
   await page.waitForTimeout(100)
   // there shouldn't be any auto complete options for 'lin' in the comment
   await expect(page.locator('.cm-completionLabel')).not.toBeVisible()

--- a/e2e/playwright/flow-tests.spec.ts
+++ b/e2e/playwright/flow-tests.spec.ts
@@ -703,6 +703,8 @@ test('Can extrude from the command bar', async ({ page, context }) => {
   ).toBeDisabled()
   await page.keyboard.press('Enter')
 
+  await expect(page.getByText('Confirm Extrude')).toBeVisible()
+
   // Check that the code was updated
   await page.keyboard.press('Enter')
   // Unfortunately this indentation seems to matter for the test

--- a/e2e/playwright/flow-tests.spec.ts
+++ b/e2e/playwright/flow-tests.spec.ts
@@ -387,7 +387,7 @@ test('Auto complete works', async ({ page }) => {
   await page.keyboard.press('ArrowDown')
   await page.keyboard.press('Enter')
   // finish line with comment
-  await page.keyboard.type('(5, %) // lin', { delay: 1000 }) // We add a delay here so its slow like a user and the lsp can catch up
+  await page.keyboard.type('(5, %) // lin')
   await page.waitForTimeout(100)
   // there shouldn't be any auto complete options for 'lin' in the comment
   await expect(page.locator('.cm-completionLabel')).not.toBeVisible()

--- a/e2e/playwright/flow-tests.spec.ts
+++ b/e2e/playwright/flow-tests.spec.ts
@@ -387,7 +387,7 @@ test('Auto complete works', async ({ page }) => {
   await page.keyboard.press('ArrowDown')
   await page.keyboard.press('Enter')
   // finish line with comment
-  await page.keyboard.type('(5, %) // lin', {delay: 1000}) // We add a delay here so its slow like a user and the lsp can catch up
+  await page.keyboard.type('(5, %) // lin', { delay: 1000 }) // We add a delay here so its slow like a user and the lsp can catch up
   await page.waitForTimeout(100)
   // there shouldn't be any auto complete options for 'lin' in the comment
   await expect(page.locator('.cm-completionLabel')).not.toBeVisible()

--- a/e2e/playwright/flow-tests.spec.ts
+++ b/e2e/playwright/flow-tests.spec.ts
@@ -387,7 +387,7 @@ test('Auto complete works', async ({ page }) => {
   await page.keyboard.press('ArrowDown')
   await page.keyboard.press('Enter')
   // finish line with comment
-  await page.keyboard.type('(5, %) // lin')
+  await page.keyboard.type('(5, %) // lin', {delay: 100}) // We add a delay here so its slow like a user and the lsp can catch up
   await page.waitForTimeout(100)
   // there shouldn't be any auto complete options for 'lin' in the comment
   await expect(page.locator('.cm-completionLabel')).not.toBeVisible()
@@ -934,7 +934,7 @@ fn yohey = (pos) => {
   |> line([-15.79, 17.08], %)
   return ''
 }
-    
+
     yohey([15.79, -34.6])
 `
       )

--- a/e2e/playwright/flow-tests.spec.ts
+++ b/e2e/playwright/flow-tests.spec.ts
@@ -386,12 +386,16 @@ test('Auto complete works', async ({ page }) => {
   await page.keyboard.press('ArrowDown')
   await page.keyboard.press('ArrowDown')
   await page.keyboard.press('Enter')
-  await page.keyboard.type('(5, %)')
+  // finish line with comment
+  await page.keyboard.type('(5, %) // lin')
+  await page.waitForTimeout(100)
+  // there shouldn't be any auto complete options for 'lin' in the comment
+  await expect(page.locator('.cm-completionLabel')).not.toBeVisible()
 
   await expect(page.locator('.cm-content'))
     .toHaveText(`const part001 = startSketchOn('XY')
   |> startProfileAt([0,0], %)
-  |> xLine(5, %)`)
+  |> xLine(5, %) // lin`)
 })
 
 // Onboarding tests

--- a/e2e/playwright/flow-tests.spec.ts
+++ b/e2e/playwright/flow-tests.spec.ts
@@ -387,7 +387,7 @@ test('Auto complete works', async ({ page }) => {
   await page.keyboard.press('ArrowDown')
   await page.keyboard.press('Enter')
   // finish line with comment
-  await page.keyboard.type('(5, %) // lin', {delay: 100}) // We add a delay here so its slow like a user and the lsp can catch up
+  await page.keyboard.type('(5, %) // lin', { delay: 100 }) // We add a delay here so its slow like a user and the lsp can catch up
   await page.waitForTimeout(100)
   // there shouldn't be any auto complete options for 'lin' in the comment
   await expect(page.locator('.cm-completionLabel')).not.toBeVisible()

--- a/src/editor/plugins/lsp/kcl/index.ts
+++ b/src/editor/plugins/lsp/kcl/index.ts
@@ -4,6 +4,7 @@ import { ViewPlugin, hoverTooltip, tooltips } from '@codemirror/view'
 import { CompletionTriggerKind } from 'vscode-languageserver-protocol'
 import { offsetToPos } from 'editor/plugins/lsp/util'
 import { LanguageServerOptions } from 'editor/plugins/lsp'
+import { syntaxTree } from '@codemirror/language'
 import {
   LanguageServerPlugin,
   documentUri,
@@ -40,6 +41,14 @@ export function kclPlugin(options: LanguageServerOptions): Extension {
           if (plugin == null) return null
 
           const { state, pos, explicit } = context
+
+          let nodeBefore = syntaxTree(state).resolveInner(pos, -1)
+          if (
+            nodeBefore.name === 'BlockComment' ||
+            nodeBefore.name === 'LineComment'
+          )
+            return null
+
           const line = state.doc.lineAt(pos)
           let trigKind: CompletionTriggerKind = CompletionTriggerKind.Invoked
           let trigChar: string | undefined
@@ -61,12 +70,6 @@ export function kclPlugin(options: LanguageServerOptions): Extension {
             return null
           }
 
-          // Get if we are in a comment token.
-          const tokens = state.languageDataAt('commentTokens', pos)
-          if (tokens && tokens.length > 0) {
-            // We are in a comment token, we should not trigger completion.
-            return null
-          }
           return await plugin.requestCompletion(
             context,
             offsetToPos(state.doc, pos),

--- a/src/editor/plugins/lsp/kcl/index.ts
+++ b/src/editor/plugins/lsp/kcl/index.ts
@@ -60,6 +60,13 @@ export function kclPlugin(options: LanguageServerOptions): Extension {
           ) {
             return null
           }
+
+          // Get if we are in a comment token.
+          const tokens = state.languageDataAt('commentTokens', pos)
+          if (tokens && tokens.length > 0) {
+            // We are in a comment token, we should not trigger completion.
+            return null
+          }
           return await plugin.requestCompletion(
             context,
             offsetToPos(state.doc, pos),

--- a/src/wasm-lib/kcl/src/ast/types.rs
+++ b/src/wasm-lib/kcl/src/ast/types.rs
@@ -3649,6 +3649,21 @@ const cylinder = startSketchOn('-XZ')
     }
 
     #[test]
+    fn test_ast_get_non_code_node_inline_comment() {
+        let some_program_string = r#"const part001 = startSketchOn('XY')
+  |> startProfileAt([0,0], %)
+  |> xLine(5, %) // lin
+"#;
+        let tokens = crate::token::lexer(some_program_string);
+        let parser = crate::parser::Parser::new(tokens);
+        let program = parser.ast().unwrap();
+
+        let value = program.get_non_code_meta_for_position(86);
+
+        assert!(value.is_some());
+    }
+
+    #[test]
     fn test_recast_negative_var() {
         let some_program_string = r#"const w = 20
 const l = 8

--- a/src/wasm-lib/kcl/src/lsp/kcl/mod.rs
+++ b/src/wasm-lib/kcl/src/lsp/kcl/mod.rs
@@ -434,9 +434,13 @@ impl LanguageServer for Backend {
         // Because if we are in a comment, we don't want to show completions.
         let filename = params.text_document_position.text_document.uri.to_string();
         if let Some(current_code) = self.current_code_map.get(&filename) {
-            let pos = position_to_char_index(params.text_document_position.position, &current_code);
+            let mut pos = position_to_char_index(params.text_document_position.position, &current_code);
             // Let's iterate over the AST and find the node that contains the cursor.
             if let Some(ast) = self.ast_map.get(&filename) {
+                if pos > 0 {
+                    pos -= 1;
+                }
+
                 if ast.get_non_code_meta_for_position(pos).is_some() {
                     // We are in a comment, don't show completions.
                     return Ok(None);

--- a/src/wasm-lib/kcl/src/lsp/kcl/mod.rs
+++ b/src/wasm-lib/kcl/src/lsp/kcl/mod.rs
@@ -430,24 +430,6 @@ impl LanguageServer for Backend {
     }
 
     async fn completion(&self, params: CompletionParams) -> RpcResult<Option<CompletionResponse>> {
-        // We want to get the position we are in.
-        // Because if we are in a comment, we don't want to show completions.
-        let filename = params.text_document_position.text_document.uri.to_string();
-        if let Some(current_code) = self.current_code_map.get(&filename) {
-            let mut pos = position_to_char_index(params.text_document_position.position, &current_code);
-            // Let's iterate over the AST and find the node that contains the cursor.
-            if let Some(ast) = self.ast_map.get(&filename) {
-                if pos > 0 {
-                    pos -= 1;
-                }
-
-                if ast.get_non_code_meta_for_position(pos).is_some() {
-                    // We are in a comment, don't show completions.
-                    return Ok(None);
-                }
-            }
-        }
-
         let mut completions = vec![CompletionItem {
             label: PIPE_OPERATOR.to_string(),
             label_details: None,


### PR DESCRIPTION
CC @jessfraz this fails locally even after pulling latest main and rebuilding the wasm, So I'll see if it's different in CI,

Here's what it looks like when the test runs

https://github.com/KittyCAD/modeling-app/assets/29681384/fb7b6714-2985-4516-aab8-09cff74b2b23

And here's the still frame from the test where it's auto completing the comment
![image](https://github.com/KittyCAD/modeling-app/assets/29681384/fea27e00-178b-40d8-bdff-a857a285ca00)


