### PR TITLE
Cut release v0.15.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "untitled-app",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "private": true,
   "dependencies": {
     "@codemirror/autocomplete": "^6.10.2",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   },
   "package": {
     "productName": "zoo-modeling-app",
-    "version": "0.15.3"
+    "version": "0.15.4"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
- [client side sketch scene not respecting base-unit-scale](https://github.com/KittyCAD/modeling-app/pull/1576)
- [Bump serde_json from 1.0.113 to 1.0.114 in /src-tauri](https://github.com/KittyCAD/modeling-app/pull/1463)
- [Bump serde from 1.0.196 to 1.0.197 in /src-tauri](https://github.com/KittyCAD/modeling-app/pull/1462)
- [Bump anyhow from 1.0.79 to 1.0.80 in /src-tauri](https://github.com/KittyCAD/modeling-app/pull/1465)
- [Vector for tracking cargo tests](https://github.com/KittyCAD/modeling-app/pull/1580)
- [Fix autocomplete in comment](https://github.com/KittyCAD/modeling-app/pull/1575)
- [Bump clap from 4.5.0 to 4.5.1 in /src/wasm-lib](https://github.com/KittyCAD/modeling-app/pull/1448)
- [Bump google-github-actions/auth from 2.1.1 to 2.1.2](https://github.com/KittyCAD/modeling-app/pull/1521)
- [Bump kittycad-execution-plan from 9cb86ba to 29086e1 in /src/wasm-lib](https://github.com/KittyCAD/modeling-app/pull/1570)
- [Bump kittycad-modeling-session from 9cb86ba to 29086e1 in /src/wasm-lib](https://github.com/KittyCAD/modeling-app/pull/1568)
- [Bump tauri-plugin-fs-extra from 01211ff to ed682dd in /src-tauri](https://github.com/KittyCAD/modeling-app/pull/1567)
- [Bump syn from 2.0.49 to 2.0.52 in /src/wasm-lib](https://github.com/KittyCAD/modeling-app/pull/1563)
- [Hide cam when moving](https://github.com/KittyCAD/modeling-app/pull/1577)
- [fix trailing comma](https://github.com/KittyCAD/modeling-app/pull/1574)
- [fix recast](https://github.com/KittyCAD/modeling-app/pull/1571)
- [Update test artifacts for patterns with holes](https://github.com/KittyCAD/modeling-app/pull/1566)