### PR TITLE
Grackle: Extrude/ClosePath stdlib functions

### DIFF
--- a/src/wasm-lib/Cargo.lock
+++ b/src/wasm-lib/Cargo.lock
@@ -2007,7 +2007,7 @@ dependencies = [
 [[package]]
 name = "kittycad-execution-plan"
 version = "0.1.0"
-source = "git+https://github.com/KittyCAD/modeling-api?branch=main#adfae6ef5f658d447133016f284ac100c88893ed"
+source = "git+https://github.com/KittyCAD/modeling-api?branch=main#4dfeb5c9ce2cc3fb853dd14cf948a922f3724ef4"
 dependencies = [
  "bytes",
  "insta",
@@ -2027,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "kittycad-execution-plan-macros"
 version = "0.1.9"
-source = "git+https://github.com/KittyCAD/modeling-api?branch=main#adfae6ef5f658d447133016f284ac100c88893ed"
+source = "git+https://github.com/KittyCAD/modeling-api?branch=main#4dfeb5c9ce2cc3fb853dd14cf948a922f3724ef4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2037,7 +2037,7 @@ dependencies = [
 [[package]]
 name = "kittycad-execution-plan-traits"
 version = "0.1.13"
-source = "git+https://github.com/KittyCAD/modeling-api?branch=main#adfae6ef5f658d447133016f284ac100c88893ed"
+source = "git+https://github.com/KittyCAD/modeling-api?branch=main#4dfeb5c9ce2cc3fb853dd14cf948a922f3724ef4"
 dependencies = [
  "serde",
  "thiserror",
@@ -2047,7 +2047,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds"
 version = "0.1.30"
-source = "git+https://github.com/KittyCAD/modeling-api?branch=main#adfae6ef5f658d447133016f284ac100c88893ed"
+source = "git+https://github.com/KittyCAD/modeling-api?branch=main#4dfeb5c9ce2cc3fb853dd14cf948a922f3724ef4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2075,7 +2075,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-cmds-macros"
 version = "0.1.2"
-source = "git+https://github.com/KittyCAD/modeling-api?branch=main#adfae6ef5f658d447133016f284ac100c88893ed"
+source = "git+https://github.com/KittyCAD/modeling-api?branch=main#4dfeb5c9ce2cc3fb853dd14cf948a922f3724ef4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2085,7 +2085,7 @@ dependencies = [
 [[package]]
 name = "kittycad-modeling-session"
 version = "0.1.1"
-source = "git+https://github.com/KittyCAD/modeling-api?branch=main#adfae6ef5f658d447133016f284ac100c88893ed"
+source = "git+https://github.com/KittyCAD/modeling-api?branch=main#4dfeb5c9ce2cc3fb853dd14cf948a922f3724ef4"
 dependencies = [
  "futures",
  "kittycad",

--- a/src/wasm-lib/grackle/src/binding_scope.rs
+++ b/src/wasm-lib/grackle/src/binding_scope.rs
@@ -117,6 +117,10 @@ impl BindingScope {
                     "extrude".into(),
                     EpBinding::from(KclFunction::Extrude(native_functions::sketch::Extrude)),
                 ),
+                (
+                    "close".into(),
+                    EpBinding::from(KclFunction::Close(native_functions::sketch::Close)),
+                ),
             ]),
             parent: None,
         }

--- a/src/wasm-lib/grackle/src/binding_scope.rs
+++ b/src/wasm-lib/grackle/src/binding_scope.rs
@@ -113,6 +113,10 @@ impl BindingScope {
                     "lineTo".into(),
                     EpBinding::from(KclFunction::LineTo(native_functions::sketch::LineTo)),
                 ),
+                (
+                    "extrude".into(),
+                    EpBinding::from(KclFunction::Extrude(native_functions::sketch::Extrude)),
+                ),
             ]),
             parent: None,
         }

--- a/src/wasm-lib/grackle/src/lib.rs
+++ b/src/wasm-lib/grackle/src/lib.rs
@@ -24,7 +24,7 @@ use self::{
 };
 
 /// Execute a KCL program by compiling into an execution plan, then running that.
-pub async fn execute(ast: Program, session: Option<Session>) -> Result<ep::Memory, Error> {
+pub async fn execute(ast: Program, session: &mut Option<Session>) -> Result<ep::Memory, Error> {
     let mut planner = Planner::new();
     let (plan, _retval) = planner.build_plan(ast)?;
     let mut mem = ep::Memory::default();
@@ -263,6 +263,7 @@ impl Planner {
                     KclFunction::Extrude(f) => f.call(&mut ctx, args)?,
                     KclFunction::LineTo(f) => f.call(&mut ctx, args)?,
                     KclFunction::Add(f) => f.call(&mut ctx, args)?,
+                    KclFunction::Close(f) => f.call(&mut ctx, args)?,
                     KclFunction::UserDefined(f) => {
                         let UserDefinedFunction {
                             params_optional,
@@ -633,6 +634,7 @@ enum KclFunction {
     Add(native_functions::Add),
     UserDefined(UserDefinedFunction),
     Extrude(native_functions::sketch::Extrude),
+    Close(native_functions::sketch::Close),
 }
 
 /// Context used when compiling KCL.

--- a/src/wasm-lib/grackle/src/lib.rs
+++ b/src/wasm-lib/grackle/src/lib.rs
@@ -260,6 +260,7 @@ impl Planner {
                 } = match callee {
                     KclFunction::Id(f) => f.call(&mut ctx, args)?,
                     KclFunction::StartSketchAt(f) => f.call(&mut ctx, args)?,
+                    KclFunction::Extrude(f) => f.call(&mut ctx, args)?,
                     KclFunction::LineTo(f) => f.call(&mut ctx, args)?,
                     KclFunction::Add(f) => f.call(&mut ctx, args)?,
                     KclFunction::UserDefined(f) => {
@@ -631,6 +632,7 @@ enum KclFunction {
     LineTo(native_functions::sketch::LineTo),
     Add(native_functions::Add),
     UserDefined(UserDefinedFunction),
+    Extrude(native_functions::sketch::Extrude),
 }
 
 /// Context used when compiling KCL.

--- a/src/wasm-lib/grackle/src/native_functions/sketch.rs
+++ b/src/wasm-lib/grackle/src/native_functions/sketch.rs
@@ -3,4 +3,4 @@
 pub mod helpers;
 pub mod stdlib_functions;
 
-pub use stdlib_functions::{Extrude, LineTo, StartSketchAt};
+pub use stdlib_functions::{Close, Extrude, LineTo, StartSketchAt};

--- a/src/wasm-lib/grackle/src/native_functions/sketch.rs
+++ b/src/wasm-lib/grackle/src/native_functions/sketch.rs
@@ -3,4 +3,4 @@
 pub mod helpers;
 pub mod stdlib_functions;
 
-pub use stdlib_functions::{LineTo, StartSketchAt};
+pub use stdlib_functions::{Extrude, LineTo, StartSketchAt};

--- a/src/wasm-lib/grackle/src/tests.rs
+++ b/src/wasm-lib/grackle/src/tests.rs
@@ -1066,9 +1066,10 @@ async fn stdlib_cube_partial() {
         |> lineTo([21.0 , 21.0], %, "side1")
         |> lineTo([ 1.0 , 21.0], %, "side2")
         |> lineTo([ 1.0 ,  1.0], %, "side3")
+        |> extrude(10.0, %)
     "#;
     let (_plan, _scope, last_address) = must_plan(program);
-    assert_eq!(last_address, Address::ZERO + 65);
+    assert_eq!(last_address, Address::ZERO + 66);
     let ast = kcl_lib::parser::Parser::new(kcl_lib::token::lexer(program))
         .ast()
         .unwrap();

--- a/src/wasm-lib/grackle/src/tests.rs
+++ b/src/wasm-lib/grackle/src/tests.rs
@@ -305,7 +305,7 @@ async fn computed_object_property() {
     let ast = kcl_lib::parser::Parser::new(kcl_lib::token::lexer(program))
         .ast()
         .unwrap();
-    let mem = crate::execute(ast, None).await.unwrap();
+    let mem = crate::execute(ast, &mut None).await.unwrap();
     use ept::ReadMemory;
     // Should be 'true', based on the above KCL program.
     assert_eq!(mem.get(address_of_val).unwrap(), &ept::Primitive::Bool(true));
@@ -327,7 +327,7 @@ async fn computed_array_in_object() {
     let ast = kcl_lib::parser::Parser::new(kcl_lib::token::lexer(program))
         .ast()
         .unwrap();
-    let mem = crate::execute(ast, None).await.unwrap();
+    let mem = crate::execute(ast, &mut None).await.unwrap();
     use ept::ReadMemory;
     // Should be 'true', based on the above KCL program.
     assert_eq!(mem.get(address_of_val).unwrap(), &ept::Primitive::Bool(true));
@@ -349,7 +349,7 @@ async fn computed_object_in_array() {
     let ast = kcl_lib::parser::Parser::new(kcl_lib::token::lexer(program))
         .ast()
         .unwrap();
-    let mem = crate::execute(ast, None).await.unwrap();
+    let mem = crate::execute(ast, &mut None).await.unwrap();
     use ept::ReadMemory;
     // Should be 'true', based on the above KCL program.
     assert_eq!(mem.get(address_of_val).unwrap(), &ept::Primitive::Bool(true));
@@ -370,7 +370,7 @@ async fn computed_nested_object_property() {
     let ast = kcl_lib::parser::Parser::new(kcl_lib::token::lexer(program))
         .ast()
         .unwrap();
-    let mem = crate::execute(ast, None).await.unwrap();
+    let mem = crate::execute(ast, &mut None).await.unwrap();
     use ept::ReadMemory;
     // Should be 'true', based on the above KCL program.
     assert_eq!(mem.get(address_of_val).unwrap(), &ept::Primitive::Bool(true));
@@ -465,7 +465,7 @@ async fn computed_array_index() {
     let tokens = kcl_lib::token::lexer(program);
     let parser = kcl_lib::parser::Parser::new(tokens);
     let ast = parser.ast().unwrap();
-    let mem = crate::execute(ast, None).await.unwrap();
+    let mem = crate::execute(ast, &mut None).await.unwrap();
     use ept::ReadMemory;
     // Should be "b", as pointed out in the KCL program's comment.
     assert_eq!(
@@ -1061,20 +1061,21 @@ fn kcvm_dbg(kcl_program: &str) {
 #[tokio::test]
 async fn stdlib_cube_partial() {
     let program = r#"
-    let cube = startSketchAt([1.0, 1.0], "adam")
-        |> lineTo([21.0 ,  1.0], %, "side0")
-        |> lineTo([21.0 , 21.0], %, "side1")
-        |> lineTo([ 1.0 , 21.0], %, "side2")
-        |> lineTo([ 1.0 ,  1.0], %, "side3")
-        |> extrude(10.0, %)
+    let cube = startSketchAt([10.0, 10.0], "adam")
+        |> lineTo([210.0 ,  10.0], %, "side0")
+        |> lineTo([210.0 , 210.0], %, "side1")
+        |> lineTo([ 10.0 , 210.0], %, "side2")
+        |> lineTo([ 10.0 ,  10.0], %, "side3")
+        |> close(%)
+        |> extrude(100.0, %)
     "#;
     let (_plan, _scope, last_address) = must_plan(program);
     assert_eq!(last_address, Address::ZERO + 66);
     let ast = kcl_lib::parser::Parser::new(kcl_lib::token::lexer(program))
         .ast()
         .unwrap();
-    let client = test_client().await;
-    let mem = match crate::execute(ast, Some(client)).await {
+    let mut client = Some(test_client().await);
+    let mem = match crate::execute(ast, &mut client).await {
         Ok(mem) => mem,
         Err(e) => panic!("{e}"),
     };
@@ -1084,36 +1085,37 @@ async fn stdlib_cube_partial() {
         vec![
             sketch_types::PathSegment::ToPoint {
                 base: sketch_types::BasePath {
-                    from: Point2d { x: 1.0, y: 1.0 },
-                    to: Point2d { x: 21.0, y: 1.0 },
+                    from: Point2d { x: 10.0, y: 10.0 },
+                    to: Point2d { x: 210.0, y: 10.0 },
                     name: "side0".into(),
                 }
             },
             sketch_types::PathSegment::ToPoint {
                 base: sketch_types::BasePath {
-                    from: Point2d { x: 21.0, y: 1.0 },
-                    to: Point2d { x: 21.0, y: 21.0 },
+                    from: Point2d { x: 210.0, y: 10.0 },
+                    to: Point2d { x: 210.0, y: 210.0 },
                     name: "side1".into(),
                 }
             },
             sketch_types::PathSegment::ToPoint {
                 base: sketch_types::BasePath {
-                    from: Point2d { x: 21.0, y: 21.0 },
-                    to: Point2d { x: 1.0, y: 21.0 },
+                    from: Point2d { x: 210.0, y: 210.0 },
+                    to: Point2d { x: 10.0, y: 210.0 },
                     name: "side2".into(),
                 }
             },
             sketch_types::PathSegment::ToPoint {
                 base: sketch_types::BasePath {
-                    from: Point2d { x: 1.0, y: 21.0 },
-                    to: Point2d { x: 1.0, y: 1.0 },
+                    from: Point2d { x: 10.0, y: 210.0 },
+                    to: Point2d { x: 10.0, y: 10.0 },
                     name: "side3".into(),
                 }
             },
         ]
     );
-    // use kittycad_modeling_cmds::{each_cmd, ok_response::OkModelingCmdResponse, ImageFormat, ModelingCmd};
+    // use kittycad_modeling_cmds::{each_cmd, ok_response::OkModelingCmdResponse, ImageFormat};
     // let out = client
+    //     .unwrap()
     //     .run_command(
     //         uuid::Uuid::new_v4().into(),
     //         each_cmd::TakeSnapshot {
@@ -1127,6 +1129,7 @@ async fn stdlib_cube_partial() {
     //     other => panic!("wrong output: {other:?}"),
     // };
     // let out: Vec<u8> = out.contents.into();
+    // std::fs::write("image.png", out).unwrap();
 }
 
 async fn test_client() -> Session {


### PR DESCRIPTION
With these implemented, Grackle can now finally render a cube.

![image](https://github.com/KittyCAD/modeling-app/assets/5407457/bced4711-1682-43c7-a491-df96977c9975)
