### PR TITLE
Only run cargo-test GH Action when wasm-lib is updated

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -3,7 +3,7 @@ on:
     branches:
       - main
     paths:
-      - '**.rs'
+      - 'src/wasm-lib/**.rs'
       - '**/Cargo.toml'
       - '**/Cargo.lock'
       - '**/rust-toolchain.toml'
@@ -20,7 +20,7 @@ permissions: read-all
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
-name: cargo test
+name: cargo test of wasm-lib
 jobs:
   cargotest:
     name: cargo test


### PR DESCRIPTION
Because we don't care about src-tauri's Rust code in this action