### PR TITLE
Always run cargo clippy in CI

### DIFF
--- a/.github/workflows/cargo-clippy.yml
+++ b/.github/workflows/cargo-clippy.yml
@@ -9,12 +9,6 @@ on:
       - '**.rs'
       - .github/workflows/cargo-clippy.yml
   pull_request:
-    paths:
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
-      - '**/rust-toolchain.toml'
-      - '**.rs'
-      - .github/workflows/cargo-build.yml
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
It's now a required job before merge is allowed. Unfortunately GitHub now blocks any non-Rust PR, because they require cargo clippy but don't trigger it to run.

Solution is simple, just always run cargo clippy, so it can pass, so that merge is allowed.