### PR TITLE
Add batch support to current KCL implementation

### DIFF
--- a/src/wasm-lib/kcl/src/engine/conn.rs
+++ b/src/wasm-lib/kcl/src/engine/conn.rs
@@ -150,7 +150,7 @@ impl EngineConnection {
                     cmd_id: *cmd_id,
                 });
 
-                if is_cmd_with_return_values(&cmd) || *cmd_id == uuid::Uuid::nil() {
+                if is_cmd_with_return_values(cmd) || *cmd_id == uuid::Uuid::nil() {
                     // If the batch has zero commands, and we're about to load
                     // a command that has return values, don't wrap it in a
                     // ModelingCmdBatchReq.

--- a/src/wasm-lib/kcl/src/engine/mod.rs
+++ b/src/wasm-lib/kcl/src/engine/mod.rs
@@ -10,6 +10,24 @@ pub mod conn_wasm;
 
 #[async_trait::async_trait]
 pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
+    /// Tell the EngineManager there will be no more commands.
+    /// We send a "dummy command" to signal EngineConnection that we're
+    /// at the end of the program and there'll be no more requests.
+    /// This means in tests, where it's impossible to look ahead, we'll need to
+    /// add this to mark the end of commands.
+    /// In compiled KCL tests, it will be auto-inserted.
+    async fn signal_end(&self) -> Result<kittycad::types::OkWebSocketResponseData, crate::errors::KclError> {
+        self.send_modeling_cmd(
+            // THE NIL UUID IS THE SIGNAL OF THE END OF TIMES FOR THIS POOR PROGRAM.
+            uuid::Uuid::nil(),
+            // This will be ignored.
+            crate::executor::SourceRange([0, 0]),
+            // This will be ignored. It was one I found with no fields.
+            kittycad::types::ModelingCmd::EditModeExit {},
+        )
+        .await
+    }
+
     /// Send a modeling command and wait for the response message.
     async fn send_modeling_cmd(
         &self,

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -1219,6 +1219,9 @@ pub async fn execute(
         }
     }
 
+    // Signal to engine we're done. Flush the batch.
+    ctx.engine.signal_end().await?;
+
     Ok(memory.clone())
 }
 

--- a/src/wasm-lib/kcl/src/std/fillet.rs
+++ b/src/wasm-lib/kcl/src/std/fillet.rs
@@ -165,6 +165,7 @@ async fn inner_get_opposite_edge(tag: String, extrude_group: Box<ExtrudeGroup>, 
             },
         )
         .await?;
+
     let kittycad::types::OkWebSocketResponseData::Modeling {
         modeling_response: kittycad::types::OkModelingCmdResponse::Solid3DGetOppositeEdge { data: opposite_edge },
     } = &resp

--- a/src/wasm-lib/kcl/src/std/sketch.rs
+++ b/src/wasm-lib/kcl/src/std/sketch.rs
@@ -915,7 +915,7 @@ async fn start_sketch_on_face(
             })
             .ok_or_else(|| {
                 KclError::Type(KclErrorDetails {
-                    message: format!("Expected a face with the tag `{}`", tag),
+                    message: format!("Expected a face with the tag `{}` for sketch", tag),
                     source_ranges: vec![args.source_range],
                 })
             })??,


### PR DESCRIPTION
A single test fails because of how we handle errors.

Batch returns responses for all commands that were sent **asynchronously**, even errors.

In order for us to pass this last test easily, we need to make an engine modification. https://github.com/KittyCAD/engine/pull/1887

Batch must return the first error in **its own response**, **rather than a separate asynchronous response**, otherwise, "OK" if there were no errors.

The rest of its behavior can remain exactly the same, which is returning the responses for all its submitted commands.