### PR TITLE
make setupSketch more composable instead of a monster function

### DIFF
--- a/src/clientSideScene/sceneEntities.ts
+++ b/src/clientSideScene/sceneEntities.ts
@@ -442,35 +442,7 @@ export class SceneEntities {
       position: origin,
       maybeModdedAst: kclManager.ast,
     })
-    sceneInfra.setCallbacks({
-      onDrag: ({ selected, intersectionPoint, mouseEvent, intersects }) => {
-        if (mouseEvent.which !== 1) return
-        this.onDragSegment({
-          object: selected,
-          intersection2d: intersectionPoint.twoD,
-          intersects,
-          sketchPathToNode,
-        })
-      },
-      onMove: () => {},
-      onClick: (args) => {
-        if (args?.mouseEvent.which !== 1) return
-        if (!args || !args.selected) {
-          sceneInfra.modelingSend({
-            type: 'Set selection',
-            data: {
-              selectionType: 'singleCodeCursor',
-            },
-          })
-          return
-        }
-        const { selected } = args
-        const event = getEventForSegmentSelection(selected)
-        if (!event) return
-        sceneInfra.modelingSend(event)
-      },
-      ...mouseEnterLeaveCallbacks(),
-    })
+    this.setupSketchIdleCallbacks(sketchPathToNode)
   }
   setUpDraftSegment = async (
     sketchPathToNode: PathToNode,
@@ -527,6 +499,37 @@ export class SceneEntities {
       truncatedAst,
       programMemoryOverride,
       variableDeclarationName,
+    })
+  }
+  setupSketchIdleCallbacks = (pathToNode: PathToNode) => {
+    sceneInfra.setCallbacks({
+      onDrag: ({ selected, intersectionPoint, mouseEvent, intersects }) => {
+        if (mouseEvent.which !== 1) return
+        this.onDragSegment({
+          object: selected,
+          intersection2d: intersectionPoint.twoD,
+          intersects,
+          sketchPathToNode: pathToNode,
+        })
+      },
+      onMove: () => {},
+      onClick: (args) => {
+        if (args?.mouseEvent.which !== 1) return
+        if (!args || !args.selected) {
+          sceneInfra.modelingSend({
+            type: 'Set selection',
+            data: {
+              selectionType: 'singleCodeCursor',
+            },
+          })
+          return
+        }
+        const { selected } = args
+        const event = getEventForSegmentSelection(selected)
+        if (!event) return
+        sceneInfra.modelingSend(event)
+      },
+      ...mouseEnterLeaveCallbacks(),
     })
   }
   setupDraftSegmentCallbacks = ({
@@ -1292,7 +1295,7 @@ function massageFormats(a: any): Vector3 {
     : new Vector3(a.x, a.y, a.z)
 }
 
-export function mouseEnterLeaveCallbacks() {
+function mouseEnterLeaveCallbacks() {
   return {
     onMouseEnter: ({ selected }: OnMouseEnterLeaveArgs) => {
       if ([X_AXIS, Y_AXIS].includes(selected?.userData?.type)) {

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -1,10 +1,5 @@
 import { PathToNode, VariableDeclarator } from 'lang/wasm'
-import {
-  Axis,
-  Selection,
-  Selections,
-  getEventForSegmentSelection,
-} from 'lib/selections'
+import { Axis, Selection, Selections } from 'lib/selections'
 import { assign, createMachine } from 'xstate'
 import { getNodePathFromSourceRange } from 'lang/queryAst'
 import { kclManager, sceneInfra, sceneEntitiesManager } from 'lib/singletons'
@@ -39,10 +34,7 @@ import {
 } from 'components/Toolbar/SetAbsDistance'
 import { Models } from '@kittycad/lib/dist/types/src'
 import { ModelingCommandSchema } from 'lib/commandBarConfigs/modelingCommandConfig'
-import {
-  DefaultPlaneStr,
-  mouseEnterLeaveCallbacks,
-} from 'clientSideScene/sceneEntities'
+import { DefaultPlaneStr } from 'clientSideScene/sceneEntities'
 import { Vector3 } from 'three'
 import { quaternionFromUpNForward } from 'clientSideScene/helpers'
 
@@ -845,40 +837,9 @@ export const modelingMachine = createMachine(
             position: sketchDetails.origin,
             maybeModdedAst: kclManager.ast,
           })
-          sceneInfra.setCallbacks({
-            onDrag: ({
-              selected,
-              intersectionPoint,
-              mouseEvent,
-              intersects,
-            }) => {
-              if (mouseEvent.which !== 1) return
-              sceneEntitiesManager.onDragSegment({
-                object: selected,
-                intersection2d: intersectionPoint.twoD,
-                intersects,
-                sketchPathToNode: sketchDetails.sketchPathToNode,
-              })
-            },
-            onMove: () => {},
-            onClick: (args) => {
-              if (args?.mouseEvent.which !== 1) return
-              if (!args || !args.selected) {
-                sceneInfra.modelingSend({
-                  type: 'Set selection',
-                  data: {
-                    selectionType: 'singleCodeCursor',
-                  },
-                })
-                return
-              }
-              const { selected } = args
-              const event = getEventForSegmentSelection(selected)
-              if (!event) return
-              sceneInfra.modelingSend(event)
-            },
-            ...mouseEnterLeaveCallbacks(),
-          })
+          sceneEntitiesManager.setupSketchIdleCallbacks(
+            sketchDetails?.sketchPathToNode || []
+          )
         })()
       },
       'animate after sketch': () => {


### PR DESCRIPTION
The setupSketch method in `src/clientSideScene/sceneEntities.ts` baked in quite a few assumptions
- it assumed that a draft segment (segment drawn with dashes) would only ever be the last segment
- because of the above it would also make the AST mod for you to add that last segment
- It would also setup scene callbacks within the function

It been changed to take an already modified ast, and the indices of the draft lines are specified as an input, and then and callback setup is done after setup is called.

This should unblock Frank who's going add a rectangle tool, it needs to add 4 draft segments, and no doubt will need a custom onMove callback.

@franknoirot I have a feeling that this change will be 95% of what you needed, but there might be one or two things remaining, but obviously we can fix things as we need to.

Below is a quick demo video of changing a line to `const draftExpressionsIndices = { start: index -3, end: index }` to get multiple draft lines.

https://github.com/KittyCAD/modeling-app/assets/29681384/b4ff1619-94f7-4457-b105-e3ec3d2bb8c9

