### PR TITLE
Retry when the Server flakes out on us.

### DIFF
--- a/src/wasm-lib/tests/executor/main.rs
+++ b/src/wasm-lib/tests/executor/main.rs
@@ -21,9 +21,9 @@ async fn execute_and_snapshot(code: &str, units: kittycad::types::UnitLength) ->
     let token = std::env::var("KITTYCAD_API_TOKEN").expect("KITTYCAD_API_TOKEN not set");
 
     // Create the client.
-    let client = kittycad::Client::new_from_reqwest(token, http_client, ws_client);
+    let mut client = kittycad::Client::new_from_reqwest(token, http_client, ws_client);
     // uncomment to use a local server
-    //client.set_base_url("http://system76-pc:8080/");
+    client.set_base_url("http://localhost:8100/");
 
     let ws = client
         .modeling()


### PR DESCRIPTION
This isn't ideal, and I'd love to remove this eventually; but this is helpful when we exhaust the Engine pool, or when running locally. This will retry a few times, and only fail if there's a few repeated failures.

Since the WebSocket fully handshakes, and then fails after handshake (when api-deux realizes we're out of Engines, specifically), I can't check the HTTP code directly where I wanted to.

This is kludgey for now, and it may mask flaky endpoints; but it may be worth it in the short-term. I'd love to find a way for the modeling endpoint to not upgrade via api-deux unless there's an engine for it long-er term.