### PR TITLE
Parser ensures that pipe expressions have a % arg

### DIFF
--- a/src/wasm-lib/kcl/src/ast/types.rs
+++ b/src/wasm-lib/kcl/src/ast/types.rs
@@ -986,6 +986,17 @@ impl CallExpression {
         })
     }
 
+    /// Is at least one argument the '%' i.e. the substitution operator?
+    pub fn has_substitution_arg(&self) -> bool {
+        self.arguments
+            .iter()
+            .any(|arg| matches!(arg, Value::PipeSubstitution(_)))
+    }
+
+    pub fn as_source_ranges(&self) -> Vec<SourceRange> {
+        vec![SourceRange([self.start, self.end])]
+    }
+
     pub fn replace_value(&mut self, source_range: SourceRange, new_value: Value) {
         for arg in &mut self.arguments {
             arg.replace_value(source_range, new_value.clone());

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ai.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ai.snap
@@ -4,18 +4,18 @@ expression: actual
 ---
 {
   "start": 0,
-  "end": 26,
+  "end": 29,
   "body": [
     {
       "type": "VariableDeclaration",
       "type": "VariableDeclaration",
       "start": 0,
-      "end": 26,
+      "end": 29,
       "declarations": [
         {
           "type": "VariableDeclarator",
           "start": 6,
-          "end": 26,
+          "end": 29,
           "id": {
             "type": "Identifier",
             "start": 6,
@@ -26,7 +26,7 @@ expression: actual
             "type": "PipeExpression",
             "type": "PipeExpression",
             "start": 14,
-            "end": 26,
+            "end": 29,
             "body": [
               {
                 "type": "CallExpression",
@@ -55,7 +55,7 @@ expression: actual
                 "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 22,
-                "end": 26,
+                "end": 29,
                 "callee": {
                   "type": "Identifier",
                   "start": 22,
@@ -70,6 +70,12 @@ expression: actual
                     "end": 25,
                     "value": 2,
                     "raw": "2"
+                  },
+                  {
+                    "type": "PipeSubstitution",
+                    "type": "PipeSubstitution",
+                    "start": 27,
+                    "end": 28
                   }
                 ],
                 "optional": false


### PR DESCRIPTION
Closes https://github.com/KittyCAD/modeling-app/issues/1411.

Several of the unit tests broke this rule (i.e. were using a pipe expression where one child expression didn't have a `%` as an arg). So those tests have been updated and now use `%` properly.