### PR TITLE
use zoom rust function

### DIFF
--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -10,6 +10,7 @@ import init, {
   ServerConfig,
   copilot_lsp_run,
   kcl_lsp_run,
+  get_camera_zoom_magnitude_per_unit_length,
 } from '../wasm-lib/pkg/wasm_lib'
 import { KCLError } from './errors'
 import { KclError as RustKclError } from '../wasm-lib/kcl/bindings/KclError'
@@ -21,6 +22,8 @@ import type { Token } from '../wasm-lib/kcl/bindings/Token'
 import { Coords2d } from './std/sketch'
 import { fileSystemManager } from 'lang/std/fileSystemManager'
 import { DEV } from 'env'
+import { Point2d } from 'wasm-lib/kcl/bindings/Point2d'
+import { BaseUnit } from 'lib/settings/settingsTypes'
 
 export type { Program } from '../wasm-lib/kcl/bindings/Program'
 export type { Value } from '../wasm-lib/kcl/bindings/Value'
@@ -307,4 +310,17 @@ export async function kclLspRun(config: ServerConfig, token: string) {
     console.log('kcl lsp failed', e)
     // We can't restart here because a moved value, we should do this another way.
   }
+}
+
+export function getCameraZoomMagnitudePerUnitLength(
+  unit: BaseUnit
+): Promise<Point2d> {
+  return initPromise
+    .then(() => {
+      return get_camera_zoom_magnitude_per_unit_length(JSON.stringify(unit))
+    })
+    .catch((e: any) => {
+      console.log(e)
+      throw e
+    })
 }

--- a/src/wasm-lib/src/wasm.rs
+++ b/src/wasm-lib/src/wasm.rs
@@ -376,3 +376,18 @@ pub fn program_memory_init() -> Result<JsValue, String> {
     // gloo-serialize crate instead.
     JsValue::from_serde(&memory).map_err(|e| e.to_string())
 }
+
+/// Get the camera zoom magnitude per unit length for a given unit length.
+/// We share this logic with the front end so its the same for the cargo tests and the modeling
+/// app.
+#[wasm_bindgen]
+pub fn get_camera_zoom_magnitude_per_unit_length(unit_str: &str) -> Result<JsValue, String> {
+    let unit: kittycad::types::UnitLength = serde_json::from_str(unit_str).map_err(|e| e.to_string())?;
+    let result = kcl_lib::std::utils::get_camera_zoom_magnitude_per_unit_length(unit);
+
+    JsValue::from_serde(&kcl_lib::executor::Point2d {
+        x: result.0,
+        y: result.1,
+    })
+    .map_err(|e| e.to_string())
+}


### PR DESCRIPTION
closes https://github.com/KittyCAD/modeling-app/issues/1874

so this exact code works for the tests on the rust side so like I KNOW it works but its not working here maybe its the async bullshit i likely fucked up in js since we have to await InitPromise ?


or something else but yeah easy to test with 
```
const part001 = startSketchOn('XY')
  |> startProfileAt([-10, -10], %)
  |> line([20, 0], %)
  |> line([0, 20], %)
  |> line([-20, 0], %)
  |> close(%)
  ```

on mm should zoom to mm