### PR TITLE
KCL: Refactor pipe bodies

### DIFF
--- a/src/wasm-lib/grackle/src/lib.rs
+++ b/src/wasm-lib/grackle/src/lib.rs
@@ -465,7 +465,7 @@ impl Planner {
                 }
             }
             SingleValue::PipeExpression(expr) => {
-                let mut bodies = expr.body.into_iter();
+                let mut bodies = (*expr).all_children();
 
                 // Get the first expression (i.e. body) of the pipeline.
                 let first = bodies.next().expect("Pipe expression must have > 1 item");

--- a/src/wasm-lib/kcl/src/parser/parser_impl.rs
+++ b/src/wasm-lib/kcl/src/parser/parser_impl.rs
@@ -136,7 +136,7 @@ fn pipe_expression(i: TokenSlice) -> PResult<PipeExpression> {
     if let Some(nc) = noncode {
         non_code_meta.insert(0, nc);
     }
-    let mut values = vec![head];
+    let mut values = Vec::new();
     let value_surrounded_by_comments = (
         repeat(0.., preceded(opt(whitespace), non_code_node)), // Before the value
         preceded(opt(whitespace), fn_call),                    // The value
@@ -185,7 +185,8 @@ fn pipe_expression(i: TokenSlice) -> PResult<PipeExpression> {
     Ok(PipeExpression {
         start: values.first().unwrap().start(),
         end: values.last().unwrap().end().max(max_noncode_end),
-        body: values,
+        head,
+        tail: values,
         non_code_meta,
     })
 }
@@ -1584,7 +1585,7 @@ const mySk1 = startSketchAt([0, 0])"#;
         let tokens = crate::token::lexer(test_input);
         let mut slice = tokens.as_slice();
         let PipeExpression {
-            body, non_code_meta, ..
+            tail, non_code_meta, ..
         } = pipe_expression.parse_next(&mut slice).unwrap();
         assert_eq!(non_code_meta.non_code_nodes.len(), 1);
         assert_eq!(
@@ -1594,7 +1595,7 @@ const mySk1 = startSketchAt([0, 0])"#;
                 style: CommentStyle::Line,
             }
         );
-        assert_eq!(body.len(), 4);
+        assert_eq!(tail.len(), 3);
     }
 
     #[test]

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__a.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__a.snap
@@ -25,48 +25,48 @@ expression: actual
           "init": {
             "type": "PipeExpression",
             "type": "PipeExpression",
-            "start": 18,
+            "start": 47,
             "end": 143,
-            "body": [
-              {
-                "type": "CallExpression",
-                "type": "CallExpression",
+            "head": {
+              "type": "CallExpression",
+              "type": "CallExpression",
+              "start": 18,
+              "end": 39,
+              "callee": {
+                "type": "Identifier",
                 "start": 18,
-                "end": 39,
-                "callee": {
-                  "type": "Identifier",
-                  "start": 18,
-                  "end": 31,
-                  "name": "startSketchAt"
-                },
-                "arguments": [
-                  {
-                    "type": "ArrayExpression",
-                    "type": "ArrayExpression",
-                    "start": 32,
-                    "end": 38,
-                    "elements": [
-                      {
-                        "type": "Literal",
-                        "type": "Literal",
-                        "start": 33,
-                        "end": 34,
-                        "value": 0,
-                        "raw": "0"
-                      },
-                      {
-                        "type": "Literal",
-                        "type": "Literal",
-                        "start": 36,
-                        "end": 37,
-                        "value": 0,
-                        "raw": "0"
-                      }
-                    ]
-                  }
-                ],
-                "optional": false
+                "end": 31,
+                "name": "startSketchAt"
               },
+              "arguments": [
+                {
+                  "type": "ArrayExpression",
+                  "type": "ArrayExpression",
+                  "start": 32,
+                  "end": 38,
+                  "elements": [
+                    {
+                      "type": "Literal",
+                      "type": "Literal",
+                      "start": 33,
+                      "end": 34,
+                      "value": 0,
+                      "raw": "0"
+                    },
+                    {
+                      "type": "Literal",
+                      "type": "Literal",
+                      "start": 36,
+                      "end": 37,
+                      "value": 0,
+                      "raw": "0"
+                    }
+                  ]
+                }
+              ],
+              "optional": false
+            },
+            "tail": [
               {
                 "type": "CallExpression",
                 "type": "CallExpression",

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__af.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__af.snap
@@ -25,48 +25,48 @@ expression: actual
           "init": {
             "type": "PipeExpression",
             "type": "PipeExpression",
-            "start": 17,
+            "start": 49,
             "end": 167,
-            "body": [
-              {
-                "type": "CallExpression",
-                "type": "CallExpression",
+            "head": {
+              "type": "CallExpression",
+              "type": "CallExpression",
+              "start": 17,
+              "end": 37,
+              "callee": {
+                "type": "Identifier",
                 "start": 17,
-                "end": 37,
-                "callee": {
-                  "type": "Identifier",
-                  "start": 17,
-                  "end": 30,
-                  "name": "startSketchAt"
-                },
-                "arguments": [
-                  {
-                    "type": "ArrayExpression",
-                    "type": "ArrayExpression",
-                    "start": 31,
-                    "end": 36,
-                    "elements": [
-                      {
-                        "type": "Literal",
-                        "type": "Literal",
-                        "start": 32,
-                        "end": 33,
-                        "value": 0,
-                        "raw": "0"
-                      },
-                      {
-                        "type": "Literal",
-                        "type": "Literal",
-                        "start": 34,
-                        "end": 35,
-                        "value": 0,
-                        "raw": "0"
-                      }
-                    ]
-                  }
-                ],
-                "optional": false
+                "end": 30,
+                "name": "startSketchAt"
               },
+              "arguments": [
+                {
+                  "type": "ArrayExpression",
+                  "type": "ArrayExpression",
+                  "start": 31,
+                  "end": 36,
+                  "elements": [
+                    {
+                      "type": "Literal",
+                      "type": "Literal",
+                      "start": 32,
+                      "end": 33,
+                      "value": 0,
+                      "raw": "0"
+                    },
+                    {
+                      "type": "Literal",
+                      "type": "Literal",
+                      "start": 34,
+                      "end": 35,
+                      "value": 0,
+                      "raw": "0"
+                    }
+                  ]
+                }
+              ],
+              "optional": false
+            },
+            "tail": [
               {
                 "type": "CallExpression",
                 "type": "CallExpression",

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ag.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ag.snap
@@ -25,48 +25,48 @@ expression: actual
           "init": {
             "type": "PipeExpression",
             "type": "PipeExpression",
-            "start": 17,
+            "start": 41,
             "end": 70,
-            "body": [
-              {
-                "type": "CallExpression",
-                "type": "CallExpression",
+            "head": {
+              "type": "CallExpression",
+              "type": "CallExpression",
+              "start": 17,
+              "end": 37,
+              "callee": {
+                "type": "Identifier",
                 "start": 17,
-                "end": 37,
-                "callee": {
-                  "type": "Identifier",
-                  "start": 17,
-                  "end": 30,
-                  "name": "startSketchAt"
-                },
-                "arguments": [
-                  {
-                    "type": "ArrayExpression",
-                    "type": "ArrayExpression",
-                    "start": 31,
-                    "end": 36,
-                    "elements": [
-                      {
-                        "type": "Literal",
-                        "type": "Literal",
-                        "start": 32,
-                        "end": 33,
-                        "value": 0,
-                        "raw": "0"
-                      },
-                      {
-                        "type": "Literal",
-                        "type": "Literal",
-                        "start": 34,
-                        "end": 35,
-                        "value": 0,
-                        "raw": "0"
-                      }
-                    ]
-                  }
-                ],
-                "optional": false
+                "end": 30,
+                "name": "startSketchAt"
               },
+              "arguments": [
+                {
+                  "type": "ArrayExpression",
+                  "type": "ArrayExpression",
+                  "start": 31,
+                  "end": 36,
+                  "elements": [
+                    {
+                      "type": "Literal",
+                      "type": "Literal",
+                      "start": 32,
+                      "end": 33,
+                      "value": 0,
+                      "raw": "0"
+                    },
+                    {
+                      "type": "Literal",
+                      "type": "Literal",
+                      "start": 34,
+                      "end": 35,
+                      "value": 0,
+                      "raw": "0"
+                    }
+                  ]
+                }
+              ],
+              "optional": false
+            },
+            "tail": [
               {
                 "type": "CallExpression",
                 "type": "CallExpression",

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ai.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ai.snap
@@ -25,32 +25,32 @@ expression: actual
           "init": {
             "type": "PipeExpression",
             "type": "PipeExpression",
-            "start": 14,
+            "start": 22,
             "end": 29,
-            "body": [
-              {
-                "type": "CallExpression",
-                "type": "CallExpression",
+            "head": {
+              "type": "CallExpression",
+              "type": "CallExpression",
+              "start": 14,
+              "end": 18,
+              "callee": {
+                "type": "Identifier",
                 "start": 14,
-                "end": 18,
-                "callee": {
-                  "type": "Identifier",
-                  "start": 14,
-                  "end": 15,
-                  "name": "f"
-                },
-                "arguments": [
-                  {
-                    "type": "Literal",
-                    "type": "Literal",
-                    "start": 16,
-                    "end": 17,
-                    "value": 1,
-                    "raw": "1"
-                  }
-                ],
-                "optional": false
+                "end": 15,
+                "name": "f"
               },
+              "arguments": [
+                {
+                  "type": "Literal",
+                  "type": "Literal",
+                  "start": 16,
+                  "end": 17,
+                  "value": 1,
+                  "raw": "1"
+                }
+              ],
+              "optional": false
+            },
+            "tail": [
               {
                 "type": "CallExpression",
                 "type": "CallExpression",

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__aj.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__aj.snap
@@ -25,31 +25,31 @@ expression: actual
           "init": {
             "type": "PipeExpression",
             "type": "PipeExpression",
-            "start": 14,
+            "start": 34,
             "end": 49,
-            "body": [
-              {
-                "type": "CallExpression",
-                "type": "CallExpression",
+            "head": {
+              "type": "CallExpression",
+              "type": "CallExpression",
+              "start": 14,
+              "end": 30,
+              "callee": {
+                "type": "Identifier",
                 "start": 14,
-                "end": 30,
-                "callee": {
-                  "type": "Identifier",
-                  "start": 14,
-                  "end": 27,
-                  "name": "startSketchAt"
-                },
-                "arguments": [
-                  {
-                    "type": "Identifier",
-                    "type": "Identifier",
-                    "start": 28,
-                    "end": 29,
-                    "name": "p"
-                  }
-                ],
-                "optional": false
+                "end": 27,
+                "name": "startSketchAt"
               },
+              "arguments": [
+                {
+                  "type": "Identifier",
+                  "type": "Identifier",
+                  "start": 28,
+                  "end": 29,
+                  "name": "p"
+                }
+              ],
+              "optional": false
+            },
+            "tail": [
               {
                 "type": "CallExpression",
                 "type": "CallExpression",

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__au.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__au.snap
@@ -25,32 +25,32 @@ expression: actual
           "init": {
             "type": "PipeExpression",
             "type": "PipeExpression",
-            "start": 17,
+            "start": 44,
             "end": 86,
-            "body": [
-              {
-                "type": "CallExpression",
-                "type": "CallExpression",
+            "head": {
+              "type": "CallExpression",
+              "type": "CallExpression",
+              "start": 17,
+              "end": 36,
+              "callee": {
+                "type": "Identifier",
                 "start": 17,
-                "end": 36,
-                "callee": {
-                  "type": "Identifier",
-                  "start": 17,
-                  "end": 30,
-                  "name": "startSketchOn"
-                },
-                "arguments": [
-                  {
-                    "type": "Literal",
-                    "type": "Literal",
-                    "start": 31,
-                    "end": 35,
-                    "value": "XY",
-                    "raw": "'XY'"
-                  }
-                ],
-                "optional": false
+                "end": 30,
+                "name": "startSketchOn"
               },
+              "arguments": [
+                {
+                  "type": "Literal",
+                  "type": "Literal",
+                  "start": 31,
+                  "end": 35,
+                  "value": "XY",
+                  "raw": "'XY'"
+                }
+              ],
+              "optional": false
+            },
+            "tail": [
               {
                 "type": "CallExpression",
                 "type": "CallExpression",

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__d.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__d.snap
@@ -25,32 +25,32 @@ expression: actual
           "init": {
             "type": "PipeExpression",
             "type": "PipeExpression",
-            "start": 14,
+            "start": 23,
             "end": 36,
-            "body": [
-              {
-                "type": "BinaryExpression",
-                "type": "BinaryExpression",
+            "head": {
+              "type": "BinaryExpression",
+              "type": "BinaryExpression",
+              "start": 14,
+              "end": 19,
+              "operator": "+",
+              "left": {
+                "type": "Literal",
+                "type": "Literal",
                 "start": 14,
-                "end": 19,
-                "operator": "+",
-                "left": {
-                  "type": "Literal",
-                  "type": "Literal",
-                  "start": 14,
-                  "end": 15,
-                  "value": 5,
-                  "raw": "5"
-                },
-                "right": {
-                  "type": "Literal",
-                  "type": "Literal",
-                  "start": 18,
-                  "end": 19,
-                  "value": 6,
-                  "raw": "6"
-                }
+                "end": 15,
+                "value": 5,
+                "raw": "5"
               },
+              "right": {
+                "type": "Literal",
+                "type": "Literal",
+                "start": 18,
+                "end": 19,
+                "value": 6,
+                "raw": "6"
+              }
+            },
+            "tail": [
               {
                 "type": "CallExpression",
                 "type": "CallExpression",

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__z.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__z.snap
@@ -25,31 +25,31 @@ expression: actual
           "init": {
             "type": "PipeExpression",
             "type": "PipeExpression",
-            "start": 11,
+            "start": 33,
             "end": 53,
-            "body": [
-              {
-                "type": "CallExpression",
-                "type": "CallExpression",
+            "head": {
+              "type": "CallExpression",
+              "type": "CallExpression",
+              "start": 11,
+              "end": 29,
+              "callee": {
+                "type": "Identifier",
                 "start": 11,
-                "end": 29,
-                "callee": {
-                  "type": "Identifier",
-                  "start": 11,
-                  "end": 24,
-                  "name": "startSketchAt"
-                },
-                "arguments": [
-                  {
-                    "type": "Identifier",
-                    "type": "Identifier",
-                    "start": 25,
-                    "end": 28,
-                    "name": "pos"
-                  }
-                ],
-                "optional": false
+                "end": 24,
+                "name": "startSketchAt"
               },
+              "arguments": [
+                {
+                  "type": "Identifier",
+                  "type": "Identifier",
+                  "start": 25,
+                  "end": 28,
+                  "name": "pos"
+                }
+              ],
+              "optional": false
+            },
+            "tail": [
               {
                 "type": "CallExpression",
                 "type": "CallExpression",


### PR DESCRIPTION
PipeExpressions should always have at least two child expressions. The first expression (the head) is a little different from the following subexpressions, because the head can be any value. But the remaining expressions (tail) must be function calls.

This refactors the AST node for PipeExpression so that information is encoded in the type system, not just checked at runtime. Instead of a Vec<Value>, it should have a separate head Value and tail Vec<Value>.