### PR TITLE
Fix home redirect in browser

### DIFF
--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -138,7 +138,7 @@ export const homeLoader: LoaderFunction = async (): Promise<
   HomeLoaderData | Response
 > => {
   if (!isTauri()) {
-    return redirect(paths.FILE + '/' + BROWSER_PROJECT_NAME)
+    return redirect(paths.FILE + '/%2F' + BROWSER_PROJECT_NAME)
   }
   const settings = await loadAndValidateSettings()
 


### PR DESCRIPTION
Fixes #2002. The logo link leads to `/home` which redirects in the browser version, but the redirect was just missing a leading `%2F` in the project path. Now when you click it you land back on the same page via the redirects, so apparently nothing happens, which is the point.