### PR TITLE
Don't assume a command is found in "Find and select command" command bar action

### DIFF
--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -67,8 +67,15 @@ function ProjectMenuPopover({
   project?: IndexLoaderData['project']
   file?: IndexLoaderData['file']
 }) {
-  const { commandBarSend } = useCommandsContext()
+  const { commandBarState, commandBarSend } = useCommandsContext()
   const { onProjectClose } = useLspContext()
+  const exportCommandInfo = { name: 'Export', ownerMachine: 'modeling' }
+  const findCommand = (obj: { name: string; ownerMachine: string }) =>
+    Boolean(
+      commandBarState.context.commands.find(
+        (c) => c.name === obj.name && c.ownerMachine === obj.ownerMachine
+      )
+    )
 
   return (
     <Popover className="relative">
@@ -150,10 +157,11 @@ function ProjectMenuPopover({
                   Element="button"
                   icon={{ icon: 'exportFile', className: 'p-1' }}
                   className="border-transparent dark:border-transparent"
+                  disabled={!findCommand(exportCommandInfo)}
                   onClick={() =>
                     commandBarSend({
                       type: 'Find and select command',
-                      data: { name: 'Export', ownerMachine: 'modeling' },
+                      data: exportCommandInfo,
                     })
                   }
                 >

--- a/src/machines/commandBarMachine.ts
+++ b/src/machines/commandBarMachine.ts
@@ -402,8 +402,8 @@ export const commandBarMachine = createMachine(
       'Initialize arguments to submit': assign({
         argumentsToSubmit: (c, e) => {
           const command =
-            'command' in e.data ? e.data.command : c.selectedCommand!
-          if (!command.args) return {}
+            'command' in e.data ? e.data.command : c.selectedCommand
+          if (!command?.args) return {}
           const args: { [x: string]: unknown } = {}
           for (const [argName, arg] of Object.entries(command.args)) {
             args[argName] =


### PR DESCRIPTION
Fixes #1991 by not assuming we have a command to initialize the args for when we fire the "Find and select command" XState event, and failing more gracefully if we don't find one.

Furthermore, adds logic so that the Export button is disabled if the corresponding command isn't found in the available commands, since in circumstances such as a network outage all modeling commands are filtered out of the command bar anyway.