### PR TITLE
settings/auth outermost

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -38,15 +38,15 @@ const router = createBrowserRouter([
     /* Make sure auth is the outermost provider or else we will have
      * inefficient re-renders, use the react profiler to see. */
     element: (
-      <SettingsAuthProvider>
-        <CommandBarProvider>
+      <CommandBarProvider>
+        <SettingsAuthProvider>
           <KclContextProvider>
             <LspProvider>
               <Outlet />
             </LspProvider>
           </KclContextProvider>
-        </CommandBarProvider>
-      </SettingsAuthProvider>
+        </SettingsAuthProvider>
+      </CommandBarProvider>
     ),
     errorElement: <ErrorPage />,
     children: [

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -40,11 +40,11 @@ const router = createBrowserRouter([
     element: (
       <CommandBarProvider>
         <SettingsAuthProvider>
-          <KclContextProvider>
-            <LspProvider>
+          <LspProvider>
+            <KclContextProvider>
               <Outlet />
-            </LspProvider>
-          </KclContextProvider>
+            </KclContextProvider>
+          </LspProvider>
         </SettingsAuthProvider>
       </CommandBarProvider>
     ),

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -35,16 +35,18 @@ const router = createBrowserRouter([
   {
     loader: settingsLoader,
     id: paths.INDEX,
+      /* Make sure auth is the outermost provider or else we will have
+     * inefficient re-renders, use the react profiler to see. */
     element: (
+          <SettingsAuthProvider>
       <CommandBarProvider>
         <KclContextProvider>
-          <SettingsAuthProvider>
             <LspProvider>
               <Outlet />
             </LspProvider>
-          </SettingsAuthProvider>
         </KclContextProvider>
       </CommandBarProvider>
+          </SettingsAuthProvider>
     ),
     errorElement: <ErrorPage />,
     children: [

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -35,18 +35,18 @@ const router = createBrowserRouter([
   {
     loader: settingsLoader,
     id: paths.INDEX,
-      /* Make sure auth is the outermost provider or else we will have
+    /* Make sure auth is the outermost provider or else we will have
      * inefficient re-renders, use the react profiler to see. */
     element: (
-          <SettingsAuthProvider>
-      <CommandBarProvider>
-        <KclContextProvider>
+      <SettingsAuthProvider>
+        <CommandBarProvider>
+          <KclContextProvider>
             <LspProvider>
               <Outlet />
             </LspProvider>
-        </KclContextProvider>
-      </CommandBarProvider>
-          </SettingsAuthProvider>
+          </KclContextProvider>
+        </CommandBarProvider>
+      </SettingsAuthProvider>
     ),
     errorElement: <ErrorPage />,
     children: [


### PR DESCRIPTION
as a part of my using the profiler, we were getting auth re-rendering for no reason when kclContext re-rendered, sticking it in outermost fixes that

https://github.com/KittyCAD/modeling-app/assets/1445228/fe8118dc-9a50-402a-9e8d-838ee1f68e0a


