### PR TITLE
Change event handlers from pointer{down,move,up} to mouse{down,move,up}

### DIFF
--- a/src/clientSideScene/CameraControls.ts
+++ b/src/clientSideScene/CameraControls.ts
@@ -229,9 +229,9 @@ export class CameraControls {
     this.mouseDownPosition = new Vector2()
     this.mouseNewPosition = new Vector2()
 
-    this.domElement.addEventListener('pointerdown', this.onMouseDown)
-    this.domElement.addEventListener('pointermove', this.onMouseMove)
-    this.domElement.addEventListener('pointerup', this.onMouseUp)
+    this.domElement.addEventListener('mousedown', this.onMouseDown)
+    this.domElement.addEventListener('mousemove', this.onMouseMove)
+    this.domElement.addEventListener('mouseup', this.onMouseUp)
     this.domElement.addEventListener('wheel', this.onMouseWheel)
 
     window.addEventListener('resize', this.onWindowResize)


### PR DESCRIPTION
For some reason (I have no idea why, I'm not clever enough to understand the distinction given the docs[1][2] yet), my browser won't pass along right-click or middle-click events, only left-click.

I have no earthly idea what's causing this but this change appears to fix it. It needs some review from someone who actually understands the moving parts and implications of this change beyond the specifc bug I'm solving for.

[1]: https://developer.mozilla.org/en-US/docs/Web/API/Element/pointerdown_event
[2]: https://developer.mozilla.org/en-US/docs/Web/API/Element/mousedown_event