### PR TITLE
Fix one missing use of sep without parens after Tauri V2 migration

### DIFF
--- a/src/lib/tauriFS.ts
+++ b/src/lib/tauriFS.ts
@@ -414,7 +414,7 @@ export async function getSettingsFilePaths(
     user: user + 'user' + SETTINGS_FILE_EXT,
     project:
       project !== undefined
-        ? project + (isTauri() ? sep : '/') + 'project' + SETTINGS_FILE_EXT
+        ? project + (isTauri() ? sep() : '/') + 'project' + SETTINGS_FILE_EXT
         : undefined,
   }
 }


### PR DESCRIPTION
[`sep` is now a function in Tauri V2 ](https://beta.tauri.app/references/v2/js/core/namespacepath/#sep)and we missed one use (or reverted it after @pierremtb did a good job cleaning them all up.