### PR TITLE
Allow developers to override token behavior only for LSP plugin

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -3,3 +3,4 @@ VITE_KC_API_BASE_URL=https://api.dev.zoo.dev
 VITE_KC_SITE_BASE_URL=https://dev.zoo.dev
 VITE_KC_SKIP_AUTH=false
 VITE_KC_CONNECTION_TIMEOUT_MS=5000
+VITE_KC_DEV_TOKEN="your token from dev.zoo.dev should go in .env.development.local"

--- a/README.md
+++ b/README.md
@@ -68,7 +68,11 @@ finally, to run the web app only, run:
 yarn start
 ```
 
-## Developing in Chrome
+### Development environment variables
+
+The Copilot LSP plugin in the editor requires a Zoo API token to run. In production, we authenticate this with a token via cookie in the browser and device auth token in the desktop environment, but this token is inaccessible in the dev browser version because the cookie is considered "cross-site" (from `localhost` to `dev.zoo.dev`). There is an optional environment variable called `VITE_KC_DEV_TOKEN` that you can populate with a dev token in a `.env.development.local` file to not check it into Git, which will use that token instead of other methods for the LSP service.
+
+### Developing in Chrome
 
 Chrome is in the process of rolling out a new default which
 [blocks Third-Party Cookies](https://developer.chrome.com/en/docs/privacy-sandbox/third-party-cookie-phase-out/).

--- a/src/components/LspProvider.tsx
+++ b/src/components/LspProvider.tsx
@@ -3,7 +3,7 @@ import type * as LSP from 'vscode-languageserver-protocol'
 import React, { createContext, useMemo, useEffect, useContext } from 'react'
 import { FromServer, IntoServer } from 'editor/plugins/lsp/codec'
 import Client from '../editor/plugins/lsp/client'
-import { DEV, TEST } from 'env'
+import { DEV, TEST, VITE_KC_DEV_TOKEN } from 'env'
 import kclLanguage from 'editor/plugins/lsp/kcl/language'
 import { copilotPlugin } from 'editor/plugins/lsp/copilot'
 import { useStore } from 'useStore'
@@ -85,7 +85,7 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
       },
     },
   } = useSettingsAuthContext()
-  const token = auth?.context?.token
+  const token = !DEV ? auth.context.token : VITE_KC_DEV_TOKEN || 'dev'
   const navigate = useNavigate()
   const { overallState } = useNetworkStatus()
   const isNetworkOkay = overallState === NetworkHealthState.Ok

--- a/src/env.ts
+++ b/src/env.ts
@@ -7,5 +7,6 @@ export const VITE_KC_API_BASE_URL = import.meta.env.VITE_KC_API_BASE_URL
 export const VITE_KC_SITE_BASE_URL = import.meta.env.VITE_KC_SITE_BASE_URL
 export const VITE_KC_CONNECTION_TIMEOUT_MS = import.meta.env
   .VITE_KC_CONNECTION_TIMEOUT_MS
+export const VITE_KC_DEV_TOKEN = import.meta.env.VITE_KC_DEV_TOKEN
 export const TEST = import.meta.env.TEST
 export const DEV = import.meta.env.DEV


### PR DESCRIPTION
See changes to README for longer explanation. Make only the Copilot LSP not work in browser dev mode without a token, not have the whole execution stop. And let devs set an env var to provide a token, since the cookie method we use doesn't work in browser dev mode.