### PR TITLE
Make it impossible to crash app while extruding

### DIFF
--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -267,10 +267,12 @@ export const ModelingMachineProvider = ({
         'has valid extrude selection': ({ selectionRanges }) => {
           // A user can begin extruding if they either have 1+ faces selected or nothing selected
           // TODO: I believe this guard only allows for extruding a single face at a time
-          if (selectionRanges.codeBasedSelections.length < 1) return false
           const isPipe = isSketchPipe(selectionRanges)
 
-          if (isSelectionLastLine(selectionRanges, codeManager.code))
+          if (
+            selectionRanges.codeBasedSelections.length === 0 ||
+            isSelectionLastLine(selectionRanges, codeManager.code)
+          )
             return true
           if (!isPipe) return false
 

--- a/src/lib/selections.ts
+++ b/src/lib/selections.ts
@@ -420,7 +420,13 @@ export function getSelectionTypeDisplayText(
   const selectionsByType = getSelectionType(selection)
 
   return (selectionsByType as Exclude<typeof selectionsByType, 'none'>)
-    .map(([type, count]) => `${count} ${type}${count > 1 ? 's' : ''}`)
+    .map(
+      // Hack for showing "face" instead of "extrude-wall" in command bar text
+      ([type, count]) =>
+        `${count} ${type.replace('extrude-wall', 'face')}${
+          count > 1 ? 's' : ''
+        }`
+    )
     .join(', ')
 }
 

--- a/src/lib/useCalculateKclExpression.ts
+++ b/src/lib/useCalculateKclExpression.ts
@@ -31,9 +31,11 @@ export function useCalculateKclExpression({
   newVariableInsertIndex: number
   setNewVariableName: (a: string) => void
 } {
-  const { programMemory } = useKclContext()
+  const { programMemory, code } = useKclContext()
   const { context } = useModelingContext()
-  const selectionRange = context.selectionRanges.codeBasedSelections[0].range
+  const selectionRange:
+    | (typeof context.selectionRanges.codeBasedSelections)[number]['range']
+    | undefined = context.selectionRanges.codeBasedSelections[0]?.range
   const inputRef = useRef<HTMLInputElement>(null)
   const [availableVarInfo, setAvailableVarInfo] = useState<
     ReturnType<typeof findAllPreviousVariables>
@@ -67,7 +69,7 @@ export function useCalculateKclExpression({
     } else {
       setIsNewVariableNameUnique(true)
     }
-  }, [newVariableName])
+  }, [programMemory, newVariableName])
 
   useEffect(() => {
     if (!programMemory || !selectionRange) return
@@ -81,8 +83,8 @@ export function useCalculateKclExpression({
 
   useEffect(() => {
     const execAstAndSetResult = async () => {
-      const code = `const __result__ = ${value}`
-      const ast = parse(code)
+      const _code = `const __result__ = ${value}`
+      const ast = parse(_code)
       const _programMem: any = { root: {}, return: null }
       availableVarInfo.variables.forEach(({ key, value }) => {
         _programMem.root[key] = { type: 'userVal', value, __meta: [] }
@@ -111,7 +113,7 @@ export function useCalculateKclExpression({
       setCalcResult('NAN')
       setValueNode(null)
     })
-  }, [value, availableVarInfo])
+  }, [value, availableVarInfo, code, kclManager.programMemory])
 
   return {
     valueNode,


### PR DESCRIPTION
Fixes #2190 by making it impossible to get in the state where you have an invalid selection but are still able to step through the command bar.

The problem was that an empty selection I believe used to be represented by a `codeBasedSelection` set to the end of the file, but is no longer the case. Because of this, `selection.codeBasedSelections[0]?.range[1]` can be `undefined`, and our selection resolution logic returns a `[]` instead of `none` which is how we know not to allow the user to advance through the selection step. Now we also check that `selection.codeBasedSelections[0]?.range[1]` is not `undefined`, along with a couple other related logic changes.

**NOTE:** This will still result in expected user experience while using the Extrude command, such that face selection has to be made only by selecting in the code editor, until https://github.com/KittyCAD/engine/issues/2003 is resolved and the selecting solid2Ds is traceable by the frontend again.