### PR TITLE
Filter files and folders that start with a `.`

### DIFF
--- a/src/wasm-lib/kcl/src/settings/utils.rs
+++ b/src/wasm-lib/kcl/src/settings/utils.rs
@@ -38,6 +38,11 @@ pub async fn walk_dir<P: AsRef<Path> + Send>(dir: P) -> Result<FileEntry> {
 
     let mut entries = tokio::fs::read_dir(&dir.as_ref()).await?;
     while let Some(e) = entries.next_entry().await? {
+        // ignore hidden files and directories (starting with a dot)
+        if e.file_name().to_string_lossy().starts_with('.') {
+            continue;
+        }
+
         if e.file_type().await?.is_dir() {
             children.push(walk_dir(&e.path()).await?);
         } else {


### PR DESCRIPTION
[We used to filter hidden files and folders](https://github.com/KittyCAD/modeling-app/commit/1afed68dd7d67b21f5bef3283bbc5d6c4ded24c3#diff-905caf827e322b95d483c917e7de299c55c7da3b39d4c2bb8a7b783418c2f42aL153-L154), usually understood as starting with a `.` character. If we don't want to do that anymore that's cool, but if we want to continue doing that this handles it. It's helpful for not showing the `.git` folder for example, even though we filter all the files within that folder anyway.