### PR TITLE
Cut release v0.19.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "untitled-app",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "private": true,
   "dependencies": {
     "@codemirror/autocomplete": "^6.16.0",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -71,5 +71,5 @@
     }
   },
   "productName": "Zoo Modeling App",
-  "version": "0.19.2"
+  "version": "0.19.3"
 }


### PR DESCRIPTION
## What's Changed
* Pass the ?pool query param through to the backend. (#2246)
* Fix the updater (#2250)
* Download-wasm if there's no rust changes (#2234)
* Filter files and folders that start with a `.` (#2249)
* Better rust parsing of route uris for files (#2248)

**Full Changelog**: https://github.com/KittyCAD/modeling-app/compare/v0.19.2...v0.19.3