### PR TITLE
Set max-bundle for local engine

### DIFF
--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -654,7 +654,9 @@ failed cmd type was ${artifactThatFailed?.commandType}`
           // No ICE servers can be valid in a local dev. env.
           if (ice_servers?.length === 0) {
             console.warn('No ICE servers')
-            this.pc?.setConfiguration({})
+            this.pc?.setConfiguration({
+              bundlePolicy: 'max-bundle',
+            })
           } else {
             // When we set the Configuration, we want to always force
             // iceTransportPolicy to 'relay', since we know the topology


### PR DESCRIPTION
It's not permissible to transition the bundle policy during runtime, so we need to maintain max-bundle, even if we know there's no ICE and it won't matter any.