### PR TITLE
Disable tauri e2e tests on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,7 +354,7 @@ jobs:
           path: "${{ env.PREFIX }}/${{ env.MODE }}/bundle/*/*"
 
       - name: Run e2e tests (linux only)
-        if: matrix.os == 'ubuntu-latest'
+        if: ${{ matrix.os == 'ubuntu-latest' && github.event_name != 'release' && github.event_name != 'schedule' }}
         run: |
           cargo install tauri-driver --force
           source .env.${{ env.BUILD_RELEASE == 'true' && 'production' || 'development' }}


### PR DESCRIPTION
Just like Playwright tests, shouldn't be enabled on release or nightly release pipelines.

The tests on nightly builds were failing because in this stage, the driver was looking for `zoo-modeling-app` instead of `zoo-modeling-app-(nightly)`, would have been an easy fix but this seems better. We don't want a flaky test to stop a release pipeline, as those aren't started without proper testing in the `Cut release v` PR.