### PR TITLE
Exit edit mode when selection input is up, re-enter when it's not.

### DIFF
--- a/src/components/CommandBar/CommandBarSelectionInput.tsx
+++ b/src/components/CommandBar/CommandBarSelectionInput.tsx
@@ -7,6 +7,7 @@ import {
   getSelectionType,
   getSelectionTypeDisplayText,
 } from 'lib/selections'
+import { kclManager } from 'lib/singletons'
 import { modelingMachine } from 'machines/modelingMachine'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
@@ -49,6 +50,14 @@ function CommandBarSelectionInput({
   useEffect(() => {
     inputRef.current?.focus()
   }, [selection, inputRef])
+
+  // Exit engine's edit mode when this input step is active,
+  // and re-enter it when it's not.
+  // In future the engine's edit mode will go away and this will be handled differently.
+  useEffect(() => {
+    kclManager.exitEditMode()
+    return () => kclManager.enterEditMode()
+  }, [])
 
   // Fast-forward through this arg if it's marked as skippable
   // and we have a valid selection already


### PR DESCRIPTION
Fixes #2302

## Demo

https://github.com/KittyCAD/modeling-app/assets/23481541/22ca4d7e-26c3-47bd-b738-d178800b20c8

