### PR TITLE
make edge helpers + more mock safe

### DIFF
--- a/src/wasm-lib/kcl/src/std/fillet.rs
+++ b/src/wasm-lib/kcl/src/std/fillet.rs
@@ -172,6 +172,9 @@ pub async fn get_opposite_edge(args: Args) -> Result<MemoryItem, KclError> {
     name = "getOppositeEdge",
 }]
 async fn inner_get_opposite_edge(tag: String, extrude_group: Box<ExtrudeGroup>, args: Args) -> Result<Uuid, KclError> {
+    if args.ctx.is_mock {
+        return Ok(Uuid::new_v4());
+    }
     let tagged_path = extrude_group
         .sketch_group_values
         .iter()
@@ -260,6 +263,9 @@ async fn inner_get_next_adjacent_edge(
     extrude_group: Box<ExtrudeGroup>,
     args: Args,
 ) -> Result<Uuid, KclError> {
+    if args.ctx.is_mock {
+        return Ok(Uuid::new_v4());
+    }
     let tagged_path = extrude_group
         .sketch_group_values
         .iter()

--- a/src/wasm-lib/kcl/src/std/fillet.rs
+++ b/src/wasm-lib/kcl/src/std/fillet.rs
@@ -353,6 +353,9 @@ async fn inner_get_previous_adjacent_edge(
     extrude_group: Box<ExtrudeGroup>,
     args: Args,
 ) -> Result<Uuid, KclError> {
+    if args.ctx.is_mock {
+        return Ok(Uuid::new_v4());
+    }
     let tagged_path = extrude_group
         .sketch_group_values
         .iter()

--- a/src/wasm-lib/kcl/src/std/patterns.rs
+++ b/src/wasm-lib/kcl/src/std/patterns.rs
@@ -177,6 +177,10 @@ async fn inner_pattern_linear_3d(
     extrude_group: Box<ExtrudeGroup>,
     args: Args,
 ) -> Result<Vec<Box<ExtrudeGroup>>, KclError> {
+    if args.ctx.is_mock {
+        return Ok(vec![extrude_group.clone()]);
+    }
+
     let geometries = pattern_linear(
         LinearPattern::ThreeD(data),
         Geometry::ExtrudeGroup(extrude_group),

--- a/src/wasm-lib/kcl/src/std/revolve.rs
+++ b/src/wasm-lib/kcl/src/std/revolve.rs
@@ -314,6 +314,9 @@ pub async fn get_edge(args: Args) -> Result<MemoryItem, KclError> {
     name = "getEdge",
 }]
 async fn inner_get_edge(tag: String, extrude_group: Box<ExtrudeGroup>, args: Args) -> Result<Uuid, KclError> {
+    if args.ctx.is_mock {
+        return Ok(Uuid::new_v4());
+    }
     let tagged_path = extrude_group
         .sketch_group_values
         .iter()


### PR DESCRIPTION
Resolves https://github.com/KittyCAD/modeling-app/issues/2301 and technically resolves https://github.com/KittyCAD/modeling-app/issues/2208 too, but there's going to be more stdlib functions to make mock safe.

But there's impetus to merge this soon since it currently is broken for when users are trying to sketch with the broker code open.