### PR TITLE
fix max std lib

### DIFF
--- a/src/wasm-lib/kcl/src/std/math.rs
+++ b/src/wasm-lib/kcl/src/std/math.rs
@@ -239,7 +239,7 @@ pub async fn max(args: Args) -> Result<MemoryItem, KclError> {
     tags = ["math"],
 }]
 fn inner_max(args: Vec<f64>) -> f64 {
-    let mut max = std::f64::MAX;
+    let mut max = std::f64::MIN;
     for arg in args.iter() {
         if *arg > max {
             max = *arg;


### PR DESCRIPTION
Related to #2384 But really we should probably add a bunch of unit tests for the math stdlib functions too.