### PR TITLE
Reset data channel seq every connect (closes #336)

### DIFF
--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -551,6 +551,7 @@ class EngineConnection {
           // Everything is now connected.
           this.state = { type: EngineConnectionStateType.ConnectionEstablished }
 
+          this.engineCommandManager.inSequence = 1
           this.onEngineConnectionOpen(this)
         })
 


### PR DESCRIPTION
Reset inSequence back to 1 every time we connect to the Engine, otherwise we'll continue to think the current sequence is a high number (while the engine has no memory of the last session -- and may even be a new engine instance!) and ignore messages until we pass that counter again.