### PR TITLE
fix reset settings in browser

### DIFF
--- a/e2e/playwright/flow-tests.spec.ts
+++ b/e2e/playwright/flow-tests.spec.ts
@@ -900,6 +900,79 @@ test('Project settings can be opened with keybinding from the editor', async ({
   await expect(page.locator('select[name="app-theme"]')).toHaveValue('light')
 })
 
+test('Project and user settings can be reset', async ({ page }) => {
+  await page.setViewportSize({ width: 1200, height: 500 })
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page
+    .getByRole('button', { name: 'Start Sketch' })
+    .waitFor({ state: 'visible' })
+
+  // Put the cursor in the editor
+  await page.click('.cm-content')
+
+  // Open the settings modal with the browser keyboard shortcut
+  await page.keyboard.press('Meta+Shift+,')
+
+  await expect(
+    page.getByRole('heading', { name: 'Settings', exact: true })
+  ).toBeVisible()
+
+  // Click the reset settings button.
+  await page.getByRole('button', { name: 'Restore default settings' }).click()
+
+  await page
+    .locator('select[name="app-theme"]')
+    .selectOption({ value: 'light' })
+
+  // Verify the toast appeared
+  await expect(
+    page.getByText(`Set theme to "light" for this project`)
+  ).toBeVisible()
+  // Check that the theme changed
+  await expect(page.locator('body')).not.toHaveClass(`body-bg dark`)
+  await expect(page.locator('select[name="app-theme"]')).toHaveValue('light')
+
+  // Check that the user setting was not changed
+  await page.getByRole('radio', { name: 'User' }).click()
+  await expect(page.locator('select[name="app-theme"]')).toHaveValue('system')
+
+  // Click the reset settings button.
+  await page.getByRole('button', { name: 'Restore default settings' }).click()
+
+  // Verify it is now set to the default value
+  await expect(page.locator('select[name="app-theme"]')).toHaveValue('system')
+
+  // Set the user theme to light.
+  await page
+    .locator('select[name="app-theme"]')
+    .selectOption({ value: 'light' })
+
+  // Verify the toast appeared
+  await expect(
+    page.getByText(`Set theme to "light" as a user default`)
+  ).toBeVisible()
+  // Check that the theme changed
+  await expect(page.locator('body')).not.toHaveClass(`body-bg dark`)
+  await expect(page.locator('select[name="app-theme"]')).toHaveValue('light')
+
+  await page.getByRole('radio', { name: 'Project' }).click()
+  await expect(page.locator('select[name="app-theme"]')).toHaveValue('light')
+
+  // Click the reset settings button.
+  await page.getByRole('button', { name: 'Restore default settings' }).click()
+  // Verify it is now set to the default value
+  await expect(page.locator('select[name="app-theme"]')).toHaveValue('system')
+
+  await page.getByRole('radio', { name: 'User' }).click()
+  await expect(page.locator('select[name="app-theme"]')).toHaveValue('system')
+
+  // Click the reset settings button.
+  await page.getByRole('button', { name: 'Restore default settings' }).click()
+
+  // Verify it is now set to the default value
+  await expect(page.locator('select[name="app-theme"]')).toHaveValue('system')
+})
+
 test('Click through each onboarding step', async ({ page }) => {
   const u = getUtils(page)
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -8,23 +8,36 @@ import { Project } from 'wasm-lib/kcl/bindings/Project'
 import { FileEntry } from 'wasm-lib/kcl/bindings/FileEntry'
 import { ProjectState } from 'wasm-lib/kcl/bindings/ProjectState'
 import { ProjectRoute } from 'wasm-lib/kcl/bindings/ProjectRoute'
+import { isTauri } from './isTauri'
 
 // Get the app state from tauri.
 export async function getState(): Promise<ProjectState | undefined> {
+  if (!isTauri()) {
+    return undefined
+  }
   return await invoke<ProjectState | undefined>('get_state')
 }
 
 // Set the app state in tauri.
 export async function setState(state: ProjectState | undefined): Promise<void> {
+  if (!isTauri()) {
+    return
+  }
   return await invoke('set_state', { state })
 }
 
 // Get the initial default dir for holding all projects.
 export async function getInitialDefaultDir(): Promise<string> {
+  if (!isTauri()) {
+    return ''
+  }
   return invoke<string>('get_initial_default_dir')
 }
 
 export async function showInFolder(path: string | undefined): Promise<void> {
+  if (!isTauri()) {
+    return
+  }
   if (!path) {
     console.error('path is undefined cannot call tauri showInFolder')
     return
@@ -34,7 +47,10 @@ export async function showInFolder(path: string | undefined): Promise<void> {
 
 export async function initializeProjectDirectory(
   settings: Configuration
-): Promise<string> {
+): Promise<string | undefined> {
+  if (!isTauri()) {
+    return undefined
+  }
   return await invoke<string>('initialize_project_directory', {
     configuration: settings,
   })


### PR DESCRIPTION
closes https://github.com/KittyCAD/modeling-app/issues/2433

one thing that is curious that I dont know how to fix is reset settings I kinda expected to reset just the user settings or just the project settings without effecting the other, cc @franknoirot if thats the intent we need a new issue for that bug, as I don't know how to fix that, but when it gets fixed it should be easy to update my test since i kinda had assumed thats how it worked so most of the checks are there just with the wrong values haha