### PR TITLE
Cut release v0.21.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "untitled-app",
-  "version": "0.21.6",
+  "version": "0.21.7",
   "private": true,
   "dependencies": {
     "@codemirror/autocomplete": "^6.16.0",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -74,5 +74,5 @@
     }
   },
   "productName": "Zoo Modeling App",
-  "version": "0.21.6"
+  "version": "0.21.7"
 }


### PR DESCRIPTION
* Add basic keyboard shortcuts for sketch and modeling tools (#2419)
* First `esc` now unequips sketch tools, second exits sketch (#2419)
* Fix xz-plane (#2376)
* Add more rust file tests (#2452)
* Fix rename project directory (#2451)

**Full Changelog**: https://github.com/KittyCAD/modeling-app/compare/v0.21.6...v0.21.7