### PR TITLE
remove printlns from stdlib

### DIFF
--- a/src/wasm-lib/Cargo.lock
+++ b/src/wasm-lib/Cargo.lock
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-lib"
-version = "0.1.56"
+version = "0.1.57"
 dependencies = [
  "anyhow",
  "approx 0.5.1",

--- a/src/wasm-lib/kcl/Cargo.toml
+++ b/src/wasm-lib/kcl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-lib"
 description = "KittyCAD Language implementation and tools"
-version = "0.1.56"
+version = "0.1.57"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/src/wasm-lib/kcl/src/std/import.rs
+++ b/src/wasm-lib/kcl/src/std/import.rs
@@ -163,9 +163,6 @@ async fn inner_import(
         }));
     }
 
-    //print the current working directory
-    println!("Current working directory: {:?}", std::env::current_dir().unwrap());
-
     // Make sure the file exists.
     if !args.ctx.fs.exists(&file_path, args.source_range).await? {
         return Err(KclError::Semantic(KclErrorDetails {

--- a/src/wasm-lib/kcl/src/std/patterns.rs
+++ b/src/wasm-lib/kcl/src/std/patterns.rs
@@ -204,19 +204,6 @@ async fn inner_pattern_linear_3d(
 
 async fn pattern_linear(data: LinearPattern, geometry: Geometry, args: Args) -> Result<Geometries, KclError> {
     let id = uuid::Uuid::new_v4();
-    println!(
-        "id: {:#?}",
-        ModelingCmd::EntityLinearPattern {
-            axis: kittycad::types::Point3D {
-                x: data.axis()[0],
-                y: data.axis()[1],
-                z: data.axis()[2],
-            },
-            entity_id: geometry.id(),
-            num_repetitions: data.repetitions(),
-            spacing: data.distance(),
-        }
-    );
 
     let resp = args
         .send_modeling_cmd(


### PR DESCRIPTION
something to be cognizant of but leaving around printlns in the executor/parser/tokenizer will break the vscode version of the lsp sincce it communicates over stdin and stdout

we likely want some sort of longer term test here for these