### PR TITLE
Allow any value to start a pipe expression

### DIFF
--- a/src/wasm-lib/tests/executor/inputs/pipe_as_arg.kcl
+++ b/src/wasm-lib/tests/executor/inputs/pipe_as_arg.kcl
@@ -19,4 +19,4 @@ fn cube = (length, center) => {
 fn double = (x) => { return x * 2}
 fn width = () => { return 200 }
 
-const myCube = cube(width() |> double(%), [0,0])
+const myCube = cube(200 |> double(%), [0,0])


### PR DESCRIPTION
Relaxes an arbitrary restriction. Previously KCL pipelines couldn't start with a number, e.g. `2 |> double(%)`. Now they can.