### PR TITLE
Timeout ahead of flaky sign out

### DIFF
--- a/e2e/tauri/specs/auth.e2e.ts
+++ b/e2e/tauri/specs/auth.e2e.ts
@@ -152,6 +152,7 @@ describe('ZMA (Tauri)', () => {
   })
 
   it('signs out', async () => {
+    await new Promise((resolve) => setTimeout(resolve, 1000))
     const menuButton = await $('[data-testid="user-sidebar-toggle"]')
     await click(menuButton)
     const signoutButton = await $('[data-testid="user-sidebar-sign-out"]')


### PR DESCRIPTION
Timer before sign out, ubuntu test passed three times in a row. Would be better to understand why but I believe this should help people now.