### PR TITLE
Do not aggressively disconnect when video stream goes down

### DIFF
--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -147,7 +147,6 @@ export enum ConnectionError {
   Unset = 0,
   LongLoadingTime,
 
-  LostVideoStream,
   ICENegotiate,
   DataChannelError,
   WebSocketError,
@@ -168,8 +167,6 @@ export const CONNECTION_ERROR_TEXT: Record<ConnectionError, string> = {
   [ConnectionError.Unset]: '',
   [ConnectionError.LongLoadingTime]:
     'Loading is taking longer than expected...',
-  [ConnectionError.LostVideoStream]:
-    'Lost connection to video stream... Reconnecting...',
   [ConnectionError.ICENegotiate]: 'ICE negotiation failed.',
   [ConnectionError.DataChannelError]: 'The data channel signaled an error.',
   [ConnectionError.WebSocketError]: 'The websocket signaled an error.',
@@ -1350,17 +1347,9 @@ export class EngineCommandManager extends EventTarget {
             console.log('received track', mediaStream)
 
             mediaStream.getVideoTracks()[0].addEventListener('mute', () => {
-              if (this.engineConnection) {
-                this.engineConnection.state = {
-                  type: EngineConnectionStateType.Disconnecting,
-                  value: {
-                    type: DisconnectingType.Error,
-                    value: {
-                      error: ConnectionError.LostVideoStream,
-                    },
-                  },
-                }
-              }
+              console.error(
+                'video track mute: check webrtc internals -> inbound rtp'
+              )
             })
 
             setMediaStream(mediaStream)


### PR DESCRIPTION
Should resolve @Irev-Dev and @dshaw 's reported issue of the app restarting more frequently lately.

The issue is, `mute` event on a video track doubles as a signal about the network https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack#events

Before my last PR which overhauled the connection logic, we never did anything when receiving this signal, except report it. I decided in my PR that we should handle such a signal, and restart the connection, since it's erroneous. 

On further investigation (@paultag helped me out), we discovered **any PLI will cause this event to fire**. This effectively means Kurt and Dshaw *actually do have flaky streams*. The difference is, the flakiness is so incredibly minor, that we should basically ignore it.

This PR simply reverts this "aggressive" reconnect logic for this scenario and goes back to reporting a message and asking the reader to go check the webrtc internals.