### PR TITLE
Prevent stale Cargo.lock

### DIFF
--- a/.github/workflows/cargo-clippy.yml
+++ b/.github/workflows/cargo-clippy.yml
@@ -54,3 +54,8 @@ jobs:
         run: |
           cd "${{ matrix.dir }}"
           cargo clippy --all --tests --benches -- -D warnings
+      # If this fails, run "cargo check" to update Cargo.lock,
+      # then add Cargo.lock to the PR.
+      - name: Check Cargo.lock doesn't need updating
+        run: |
+          cargo check --locked || echo "Pls run cargo check and commit the changed Cargo.lock"


### PR DESCRIPTION
Sometimes the `src-tauri/` project gets out of date Cargo.lock. This adds a CI check to prevent it.

This can happen because `src-tauri` is a separate Cargo project from `src/wasm-lib`, but the former includes the latter as a dependency. So, when wasm-lib updates a dep (e.g. bump databake from 1.7 to 1.8), the former will, upon recompilation, pull in the newer databake dep. But programmers in the wasm-lib repo don't usually work in the src-tauri repo and so the src-tauri repo doesn't get updated.

If the check fails, it prints a helpful message explaining how to resolve it.