### PR TITLE
Ensure settings are persisted before we navigate for onboarding dismissal

### DIFF
--- a/src/components/SettingsAuthProvider.tsx
+++ b/src/components/SettingsAuthProvider.tsx
@@ -171,7 +171,9 @@ export const SettingsAuthProviderBase = ({
           })
         },
         'Execute AST': () => kclManager.executeCode(true, true),
-        persistSettings: (context) =>
+      },
+      services: {
+        'Persist settings': (context) =>
           saveSettings(context, loadedProject?.project?.path),
       },
     }

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -17,6 +17,10 @@ const prependRoutes =
     )
   }
 
+type OnboardingPaths = {
+  [K in keyof typeof onboardingPaths]: `/onboarding${typeof onboardingPaths[K]}`
+}
+
 export const paths = {
   INDEX: '/',
   HOME: '/home',
@@ -25,7 +29,7 @@ export const paths = {
   SIGN_IN: '/signin',
   ONBOARDING: prependRoutes(onboardingPaths)(
     '/onboarding'
-  ) as typeof onboardingPaths,
+  ) as OnboardingPaths,
 } as const
 export const BROWSER_PATH = `%2F${BROWSER_PROJECT_NAME}%2F${BROWSER_FILE_NAME}${FILE_EXT}`
 

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -18,7 +18,7 @@ const prependRoutes =
   }
 
 type OnboardingPaths = {
-  [K in keyof typeof onboardingPaths]: `/onboarding${typeof onboardingPaths[K]}`
+  [K in keyof typeof onboardingPaths]: `/onboarding${(typeof onboardingPaths)[K]}`
 }
 
 export const paths = {
@@ -27,9 +27,7 @@ export const paths = {
   FILE: '/file',
   SETTINGS: '/settings',
   SIGN_IN: '/signin',
-  ONBOARDING: prependRoutes(onboardingPaths)(
-    '/onboarding'
-  ) as OnboardingPaths,
+  ONBOARDING: prependRoutes(onboardingPaths)('/onboarding') as OnboardingPaths,
 } as const
 export const BROWSER_PATH = `%2F${BROWSER_PROJECT_NAME}%2F${BROWSER_FILE_NAME}${FILE_EXT}`
 

--- a/src/machines/settingsMachine.ts
+++ b/src/machines/settingsMachine.ts
@@ -11,96 +11,96 @@ import {
 
 export const settingsMachine = createMachine(
   {
-    /** @xstate-layout N4IgpgJg5mDOIC5QGUwBc0EsB2VYDpMIAbMAYlnXwEMAHW-Ae2wCNHqAnCHKZNatAFdYAbQAMAXUShajWJizNpIAB6IAbAFZN+AOwAWAIwAOYwE4AzGYBM+-ZosAaEAE9Eh62LP51ls+v0LMWt1awMAX3DnVAweAiJSCio6BjQACzAAWzAAYUZiRg5xKSQQWXlFbGU1BA9vQ0N1CwCxdVbdY1DnNwQzPp8zTTFje1D1QwtjSOj0LFx4knJKNHxMxggwYh58DYAzakFiNABVbAVi5XKFTCVSmotNY3w7YysHRuNDTXV1bvdG7w-IKTcbaazWCzTEAxOZ4QiLJIrFL4dJZMAXUpXSrVDTGazPMQPR4GXRBAx-XoGfDWIadMx4n6EqEwuLwxLLVbrTbbNKYKBpLb8tAAUWgcAxMjk11uoHumn0+DEw2sJkMulCgWsFL6YnwfX0ELsYg61jMumZs1ZCXIACU4OgAATLWGiSSXKXYu4aLz4UwWBr6DqBYYUzSePXqUlBLxmyZmC2xeZs8gxB3UYjEJ2W+YSsoem5VL0IKy6z6EsJifQ2Czq0MTHzq8Yjfz6MQmBMu5NkABUuaxBZxCDD+DD5lJgUjxssFP0xl0I+0pm06uMmg8kSiIGwXPgpRZ83dFQHRYAtA0LCO2tZjGIHJNdB5fq5EK3dc1OsNGkrA+oO1bFoe0qFrKiAnlol7BDed5zo+FK+Doc7qhCNaVv4UwbkAA */
+    /** @xstate-layout N4IgpgJg5mDOIC5QGUwBc0EsB2VYDpMIAbMAYlnXwEMAHW-Ae2wCNHqAnCHKZNatAFdYAbQAMAXUShajWJizNpIAB6IALAFYAnPgBMARgDsBsQDY969QGYjmzQBoQAT0SnrADnwePY61r0PAwNtMyMAX3CnVAweAiJSCio6BjQACzAAWzAAYUZiRg5xKSQQWXlFbGU1BD1PfFtfE3UzTUNNaydXBCD1b209PTEPTTMtdQNNSOj0LFx4knJKNHxMxggwYh58DYAzakFiNABVbAVi5XKFTCVSmsGxfCMPM08PQaDNU0cXRG1tLwedTaKxif7+UJTKIgGJzPCERZJFYpfDpLJgC6lK6VaqIEx6fBmCw2Do2IJ6MxdRDvTT4MRDdRGEzWbQ6ELTGGzOIIxLLVbrTbbNKYKBpLaitAAUWgcExMjk11uoBqVgM3jMYhsAIMrVs6ipPWChOeYhC9KMFhGHNh3IS5AASnB0AACZZw0SSS4KnF3PFafADTV1YZ2IxiH7dNpGfCaIzAgE+IzWMzBa1c+Y88gxZ3UYjEV3pvBysrem5VX0IFq0y3aTXWOp6JmU34IKMxuz0joGEYWsxp2IZu1kABUxexZdxtRG+EmQMZmne3dNBs0jKewLBsbCwI81n77vwtDAHHksDhBYHeDIEGYYEI2AAbowANZ3o8nzBnm3zMelpWqRAAFp62sJ4jEsZ4AT0UJGwjPFzH6cwNW0AwWXpbRImhbABXgUpvzwL0KgnCtgJMMCII8KCYLsA11EGOkXneDxmXMCk92hfCFlIQjFXLZUgLjddWhaFkgRCaxOhbEYzBnXwXkmOjAjjfduXfU9zzdOIeJ9fiEEA6ckwMClQ2BFpmJXMF9DjYI6hZfxmMw8IgA */
     id: 'Settings',
     predictableActionArguments: true,
     context: {} as ReturnType<typeof createSettings>,
     initial: 'idle',
     states: {
       idle: {
-        entry: ['setThemeClass', 'setClientSideSceneUnits', 'persistSettings'],
+        entry: ['setThemeClass', 'setClientSideSceneUnits'],
 
         on: {
           '*': {
-            target: 'idle',
-            internal: true,
-            actions: ['setSettingAtLevel', 'toastSuccess', 'persistSettings'],
+            target: 'persisting settings',
+            actions: ['setSettingAtLevel', 'toastSuccess'],
           },
 
           'set.app.onboardingStatus': {
-            target: 'idle',
-            internal: true,
-            actions: ['setSettingAtLevel', 'persistSettings'], // No toast
+            target: 'persisting settings',
+
+            // No toast
+            actions: ['setSettingAtLevel'],
           },
           'set.app.themeColor': {
-            target: 'idle',
-            internal: true,
-            actions: ['setSettingAtLevel', 'persistSettings'], // No toast
+            target: 'persisting settings',
+
+            // No toast
+            actions: ['setSettingAtLevel'],
           },
 
           'set.modeling.defaultUnit': {
-            target: 'idle',
-            internal: true,
+            target: 'persisting settings',
+
             actions: [
               'setSettingAtLevel',
               'toastSuccess',
               'setClientSideSceneUnits',
               'Execute AST',
-              'persistSettings',
             ],
           },
 
           'set.app.theme': {
-            target: 'idle',
-            internal: true,
+            target: 'persisting settings',
+
             actions: [
               'setSettingAtLevel',
               'toastSuccess',
               'setThemeClass',
               'setEngineTheme',
-              'persistSettings',
               'setClientTheme',
             ],
           },
 
           'set.modeling.highlightEdges': {
-            target: 'idle',
-            internal: true,
-            actions: [
-              'setSettingAtLevel',
-              'toastSuccess',
-              'setEngineEdges',
-              'persistSettings',
-            ],
+            target: 'persisting settings',
+
+            actions: ['setSettingAtLevel', 'toastSuccess', 'setEngineEdges'],
           },
 
           'Reset settings': {
-            target: 'idle',
-            internal: true,
+            target: 'persisting settings',
+
             actions: [
               'resetSettings',
               'setThemeClass',
               'setEngineTheme',
               'setClientSideSceneUnits',
               'Execute AST',
-              'persistSettings',
               'setClientTheme',
             ],
           },
 
           'Set all settings': {
-            target: 'idle',
-            internal: true,
+            target: 'persisting settings',
+
             actions: [
               'setAllSettings',
               'setThemeClass',
               'setEngineTheme',
               'setClientSideSceneUnits',
               'Execute AST',
-              'persistSettings',
               'setClientTheme',
             ],
           },
+        },
+      },
+
+      'persisting settings': {
+        invoke: {
+          src: 'Persist settings',
+          id: 'persistSettings',
+          onDone: 'idle',
         },
       },
     },


### PR DESCRIPTION
Resolves #2500 by converting "persistSettings" from an XState action to a service that is invoked in a new "Persisting settings" state. Now our dismiss hook only sends the event but doesn't immediately navigate. Instead, we handle navigation in a useEffect which navigates when it sees the onboarding state get set to "dismiss" _and_ the XState state is "idle", meaning we've already persisted the settings and can safely navigate.

Gonna try to write a Tauri test for this after #2659 gets merged and we have a framework for adding them.

## Demo

https://github.com/KittyCAD/modeling-app/assets/23481541/0ef2dbaf-aac3-4ed6-9c17-b53d4b94de56


