### PR TITLE
Revert "Bump dashmap from 5.5.3 to 6.0.0 in /src/wasm-lib"

### DIFF
--- a/src/wasm-lib/Cargo.lock
+++ b/src/wasm-lib/Cargo.lock
@@ -663,20 +663,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fadfd577acfd4485fb258011b0fd080882ea83359b6fd41304900b94ccf487"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.3",
- "lock_api",
- "once_cell",
- "parking_lot_core 0.9.9",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,7 +1381,7 @@ dependencies = [
  "clap",
  "convert_case",
  "criterion",
- "dashmap 6.0.0",
+ "dashmap",
  "databake",
  "derive-docs",
  "expectorate",
@@ -3083,7 +3069,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "bytes",
- "dashmap 5.5.3",
+ "dashmap",
  "futures",
  "httparse",
  "lsp-types",

--- a/src/wasm-lib/kcl/Cargo.toml
+++ b/src/wasm-lib/kcl/Cargo.toml
@@ -17,7 +17,7 @@ async-trait = "0.1.80"
 base64 = "0.22.1"
 chrono = "0.4.38"
 clap = { version = "4.5.7", default-features = false, optional = true }
-dashmap = "6.0.0"
+dashmap = "5.5.3"
 databake = { version = "0.1.8", features = ["derive"] }
 derive-docs = { version = "0.1.18",  path = "../derive-docs" }
 form_urlencoded = "1.2.1"


### PR DESCRIPTION
Reverts KittyCAD/modeling-app#2704 because it looks like the dashmap team has yanked their 6.0.0 release for the time being https://crates.io/crates/dashmap/versions

![Screenshot 2024-06-19 at 2 16 11 PM](https://github.com/KittyCAD/modeling-app/assets/23481541/8e6a39aa-7c05-47bb-970c-3b019c41636f)
