### PR TITLE
Disable SSAO temporarily

### DIFF
--- a/src/lib/settings/initialSettings.tsx
+++ b/src/lib/settings/initialSettings.tsx
@@ -157,7 +157,7 @@ export function createSettings() {
         ),
       }),
       enableSSAO: new Setting<boolean>({
-        defaultValue: true,
+        defaultValue: false,
         description:
           'Whether or not Screen Space Ambient Occlusion (SSAO) is enabled',
         validate: (v) => typeof v === 'boolean',


### PR DESCRIPTION
We're getting buggy behavior from SSAO while trying to manually set near and far values for FOV when entering and exiting sketches, so this is a quick temporary fix that makes the default value for the hidden setting `enableSSAO` to be `false`, turning it off for the vast majority of users, while we get things sorted.