### PR TITLE
Fix onboarding example code loading

### DIFF
--- a/src/lang/codeManager.ts
+++ b/src/lang/codeManager.ts
@@ -22,7 +22,7 @@ export default class CodeManager {
       return
     }
 
-    const storedCode = safeLSGetItem(PERSIST_CODE_TOKEN) || ''
+    const storedCode = safeLSGetItem(PERSIST_CODE_TOKEN)
     // TODO #819 remove zustand persistence logic in a few months
     // short term migration, shouldn't make a difference for tauri app users
     // anyway since that's filesystem based.


### PR DESCRIPTION
In the new user, new sign-in case we were not setting the code in the KCL code editor, because we checked if a value was `null` before doing that, but just above had made the value coerce to `""` if it was found to be null. Annoying little JS behavior. This fixes that issue and adds a Playwright test to verify the "fresh user" case always sees the onboarding code in their editor.