### PR TITLE
Franknoirot/onboarding avatar text

### DIFF
--- a/e2e/playwright/flow-tests.spec.ts
+++ b/e2e/playwright/flow-tests.spec.ts
@@ -1399,8 +1399,6 @@ test.describe('Onboarding tests', () => {
   test('Avatar text updates depending on image load success', async ({
     page,
   }) => {
-    const u = await getUtils(page)
-
     // Override beforeEach test setup
     await page.addInitScript(
       async ({ settingsKey, settings }) => {

--- a/e2e/playwright/storageStates.ts
+++ b/e2e/playwright/storageStates.ts
@@ -1,5 +1,6 @@
 import { SaveSettingsPayload } from 'lib/settings/settingsTypes'
 import { Themes } from 'lib/theme'
+import { onboardingPaths } from 'routes/Onboarding/paths'
 
 export const TEST_SETTINGS_KEY = '/settings.toml'
 export const TEST_SETTINGS = {
@@ -22,9 +23,14 @@ export const TEST_SETTINGS = {
   },
 } satisfies Partial<SaveSettingsPayload>
 
+export const TEST_SETTINGS_ONBOARDING_USER_MENU = {
+  ...TEST_SETTINGS,
+  app: { ...TEST_SETTINGS.app, onboardingStatus: onboardingPaths.USER_MENU },
+} satisfies Partial<SaveSettingsPayload>
+
 export const TEST_SETTINGS_ONBOARDING_EXPORT = {
   ...TEST_SETTINGS,
-  app: { ...TEST_SETTINGS.app, onboardingStatus: '/export' },
+  app: { ...TEST_SETTINGS.app, onboardingStatus: onboardingPaths.EXPORT },
 } satisfies Partial<SaveSettingsPayload>
 
 export const TEST_SETTINGS_ONBOARDING_START = {

--- a/src/components/UserSidebarMenu.tsx
+++ b/src/components/UserSidebarMenu.tsx
@@ -39,7 +39,7 @@ const UserSidebarMenu = ({ user }: { user?: User }) => {
     <Popover className="relative">
       {user?.image && !imageLoadFailed ? (
         <Popover.Button
-          className="border-0 rounded-full w-fit min-w-max p-0 group"
+          className="relative border-0 rounded-full w-fit min-w-max p-0 group"
           data-testid="user-sidebar-toggle"
         >
           <div className="rounded-full border overflow-hidden">
@@ -51,6 +51,9 @@ const UserSidebarMenu = ({ user }: { user?: User }) => {
               onError={() => setImageLoadFailed(true)}
             />
           </div>
+          <Tooltip position="bottom-right" delay={1000}>
+            User menu
+          </Tooltip>
         </Popover.Button>
       ) : (
         <ActionButton
@@ -59,7 +62,7 @@ const UserSidebarMenu = ({ user }: { user?: User }) => {
           className="border-transparent !px-0"
           data-testid="user-sidebar-toggle"
         >
-          <Tooltip position="left" delay={1000}>
+          <Tooltip position="bottom-right" delay={1000}>
             User menu
           </Tooltip>
         </ActionButton>

--- a/src/routes/Onboarding/UserMenu.tsx
+++ b/src/routes/Onboarding/UserMenu.tsx
@@ -1,6 +1,7 @@
 import { OnboardingButtons, useDismiss, useNextClick } from '.'
 import { onboardingPaths } from 'routes/Onboarding/paths'
 import { useStore } from '../../useStore'
+import { useEffect, useState } from 'react'
 
 export default function UserMenu() {
   const { buttonDownInStream } = useStore((s) => ({
@@ -8,6 +9,20 @@ export default function UserMenu() {
   }))
   const dismiss = useDismiss()
   const next = useNextClick(onboardingPaths.PROJECT_MENU)
+  const [avatarErrored, setAvatarErrored] = useState(false)
+  const buttonDescription = !avatarErrored ? 'your avatar' : 'the menu button'
+
+  // Set up error handling for the user's avatar image,
+  // so the onboarding text can be updated if it fails to load.
+  useEffect(() => {
+    const element = globalThis.document.querySelector(
+      '[data-testid="user-sidebar-toggle"] img'
+    )
+
+    if (element?.tagName === 'IMG') {
+      element.addEventListener('error', () => setAvatarErrored(true))
+    }
+  }, [])
 
   return (
     <div className="fixed grid justify-center items-start inset-0 z-50 pointer-events-none">
@@ -20,8 +35,8 @@ export default function UserMenu() {
         <section className="flex-1">
           <h2 className="text-2xl font-bold">User Menu</h2>
           <p className="my-4">
-            Click your avatar on the upper right to open the user menu. You can
-            change your settings, sign out, or request a feature.
+            Click {buttonDescription} in the upper right to open the user menu.
+            You can change your settings, sign out, or request a feature.
           </p>
           <p className="my-4">
             We only support global settings at the moment, but we are working to


### PR DESCRIPTION
Fixes #2720 by making the text we use to describe where to click depend on whether the avatar image has an error while loading. Also adds a Playwright test I'm pretty proud of for both cases, that passes 99/100 times at time of writing 🙂 . The flake was that the test expects to see the avatar initially (which it should given our test setup), but very rarely the avatar will simply not load. This new dynamic text will respond correctly either way.