### PR TITLE
Disable extrude button if there is no extrudable geometry

### DIFF
--- a/e2e/playwright/flow-tests.spec.ts
+++ b/e2e/playwright/flow-tests.spec.ts
@@ -1742,6 +1742,74 @@ test.describe('Testing selections', () => {
     await page.waitForTimeout(100)
     await expect(page.getByTestId('hover-highlight')).not.toBeVisible()
   })
+  test("Extrude button should be disabled if there's no extrudable geometry when nothing is selected", async ({
+    page,
+  }) => {
+    const u = await getUtils(page)
+    await page.addInitScript(async () => {
+      localStorage.setItem(
+        'persistCode',
+        `const sketch001 = startSketchOn('XZ')
+  |> startProfileAt([3.29, 7.86], %)
+  |> line([2.48, 2.44], %)
+  |> line([2.66, 1.17], %)
+  |> line([3.75, 0.46], %)
+  |> line([4.99, -0.46], %, 'seg01')
+  |> line([3.3, -2.12], %)
+  |> line([2.16, -3.33], %)
+  |> line([0.85, -3.08], %)
+  |> line([-0.18, -3.36], %)
+  |> line([-3.86, -2.73], %)
+  |> line([-17.67, 0.85], %)
+  |> close(%)
+const extrude001 = extrude(10, sketch001)
+  `
+      )
+    })
+    await page.setViewportSize({ width: 1000, height: 500 })
+    await page.goto('/')
+    await u.waitForAuthSkipAppStart()
+
+    // wait for execution done
+    await u.openDebugPanel()
+    await u.expectCmdLog('[data-message-type="execution-done"]')
+    await u.closeDebugPanel()
+
+    const selectUnExtrudable = () =>
+      page.getByText(`line([4.99, -0.46], %, 'seg01')`).click()
+    const clickEmpty = () => page.mouse.click(700, 460)
+    await selectUnExtrudable()
+    // expect extrude button to be disabled
+    await expect(page.getByRole('button', { name: 'Extrude' })).toBeDisabled()
+
+    await clickEmpty()
+
+    // expect active line to contain nothing
+    await expect(page.locator('.cm-activeLine')).toHaveText('')
+    // and extrude to still be disabled
+    await expect(page.getByRole('button', { name: 'Extrude' })).toBeDisabled()
+
+    const codeToAdd = `${await u.codeLocator.allInnerTexts()}
+const sketch002 = startSketchOn(extrude001, 'seg01')
+  |> startProfileAt([-12.94, 6.6], %)
+  |> line([2.45, -0.2], %)
+  |> line([-2, -1.25], %)
+  |> lineTo([profileStartX(%), profileStartY(%)], %)
+  |> close(%)
+`
+    await u.codeLocator.fill(codeToAdd)
+
+    await selectUnExtrudable()
+    // expect extrude button to be disabled
+    await expect(page.getByRole('button', { name: 'Extrude' })).toBeDisabled()
+
+    await clickEmpty()
+    await expect(page.locator('.cm-activeLine')).toHaveText('')
+    // there's not extrudable geometry, so button should be enabled
+    await expect(
+      page.getByRole('button', { name: 'Extrude' })
+    ).not.toBeDisabled()
+  })
 
   test('Testing selections (and hovers) work on sketches when NOT in sketch mode', async ({
     page,

--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -63,6 +63,7 @@ import {
 import {
   getNodeFromPath,
   getNodePathFromSourceRange,
+  hasExtrudableGeometry,
   isSingleCursorInPipe,
 } from 'lang/queryAst'
 import { TEST } from 'env'
@@ -447,8 +448,13 @@ export const ModelingMachineProvider = ({
           if (
             selectionRanges.codeBasedSelections.length === 0 ||
             isSelectionLastLine(selectionRanges, codeManager.code)
-          )
-            return true
+          ) {
+            // they have no selection, we should enable the button
+            // so they can select the face through the cmdbar
+            // BUT only if there's extrudable geometry
+            if (hasExtrudableGeometry(kclManager.ast)) return true
+            return false
+          }
           if (!isPipe) return false
 
           return canExtrudeSelection(selectionRanges)

--- a/src/lib/selections.ts
+++ b/src/lib/selections.ts
@@ -16,6 +16,7 @@ import { Program } from 'lang/wasm'
 import {
   doesPipeHaveCallExp,
   getNodeFromPath,
+  hasSketchPipeBeenExtruded,
   isSingleCursorInPipe,
 } from 'lang/queryAst'
 import { CommandArgument } from './commandTypes'
@@ -387,6 +388,7 @@ export function canExtrudeSelection(selection: Selections) {
   )
   return (
     !!isSketchPipe(selection) &&
+    commonNodes.every((n) => !hasSketchPipeBeenExtruded(n.selection, n.ast)) &&
     commonNodes.every((n) => nodeHasClose(n)) &&
     commonNodes.every((n) => !nodeHasExtrude(n))
   )


### PR DESCRIPTION
Resolves #2722

When the user has no selection we enable the extrude button to allow the user to select their sketch through the cmdbar interface, however we'd allow this even when there's was nothing extrudable to select.

Now fixed, also fixed an issue where you could select to extrude a sketch that had already been extruded, this would generate code with an error.