### PR TITLE
allow for sketching on the face of a chamfer in kcl

### DIFF
--- a/docs/kcl/KNOWN-ISSUES.md
+++ b/docs/kcl/KNOWN-ISSUES.md
@@ -23,5 +23,7 @@ once fixed in engine will just start working here with no language changes.
 - **Chamfers**: Chamfers cannot intersect, you will get an error. Only simple
     chamfer cases work currently.
 
+    Sketching on the chamfered face does not currently work.
+
 - **Shell**: Shell is only working for `end` faces, not for `side` or `start` 
     faces. We are tracking the engine side bug on this.

--- a/docs/kcl/angleToMatchLengthX.md
+++ b/docs/kcl/angleToMatchLengthX.md
@@ -90,6 +90,7 @@ const extrusion = extrude(5, sketch001)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/angleToMatchLengthY.md
+++ b/docs/kcl/angleToMatchLengthY.md
@@ -91,6 +91,7 @@ const extrusion = extrude(5, sketch001)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/angledLine.md
+++ b/docs/kcl/angledLine.md
@@ -97,6 +97,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -371,6 +372,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/angledLineOfXLength.md
+++ b/docs/kcl/angledLineOfXLength.md
@@ -96,6 +96,7 @@ const extrusion = extrude(10, sketch001)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -370,6 +371,7 @@ const extrusion = extrude(10, sketch001)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/angledLineOfYLength.md
+++ b/docs/kcl/angledLineOfYLength.md
@@ -98,6 +98,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -372,6 +373,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/angledLineThatIntersects.md
+++ b/docs/kcl/angledLineThatIntersects.md
@@ -102,6 +102,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -376,6 +377,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/angledLineToX.md
+++ b/docs/kcl/angledLineToX.md
@@ -95,6 +95,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -369,6 +370,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/angledLineToY.md
+++ b/docs/kcl/angledLineToY.md
@@ -95,6 +95,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -369,6 +370,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/arc.md
+++ b/docs/kcl/arc.md
@@ -106,6 +106,7 @@ const exampleSketch = startSketchOn('XZ')
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -380,6 +381,7 @@ const exampleSketch = startSketchOn('XZ')
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/bezierCurve.md
+++ b/docs/kcl/bezierCurve.md
@@ -101,6 +101,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -375,6 +376,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/chamfer.md
+++ b/docs/kcl/chamfer.md
@@ -9,7 +9,7 @@ Create chamfers on tagged paths.
 
 
 ```js
-chamfer(data: ChamferData, extrude_group: ExtrudeGroup) -> ExtrudeGroup
+chamfer(data: ChamferData, extrude_group: ExtrudeGroup, tag?: String) -> ExtrudeGroup
 ```
 
 ### Examples
@@ -73,6 +73,7 @@ string],
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -135,6 +136,7 @@ string],
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -295,6 +297,7 @@ string],
 }],
 }
 ```
+* `tag`: `String` (OPTIONAL)
 
 ### Returns
 
@@ -318,6 +321,7 @@ string],
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -380,6 +384,7 @@ string],
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/circle.md
+++ b/docs/kcl/circle.md
@@ -95,6 +95,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -287,6 +288,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -481,6 +483,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/close.md
+++ b/docs/kcl/close.md
@@ -96,6 +96,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -370,6 +371,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/extrude.md
+++ b/docs/kcl/extrude.md
@@ -121,6 +121,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -361,6 +362,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -423,6 +425,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/fillet.md
+++ b/docs/kcl/fillet.md
@@ -73,6 +73,7 @@ string],
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -135,6 +136,7 @@ string],
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -318,6 +320,7 @@ string],
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -380,6 +383,7 @@ string],
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/getEdge.md
+++ b/docs/kcl/getEdge.md
@@ -60,6 +60,7 @@ const revolution = startSketchOn(box, "revolveAxis")
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -122,6 +123,7 @@ const revolution = startSketchOn(box, "revolveAxis")
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/getNextAdjacentEdge.md
+++ b/docs/kcl/getNextAdjacentEdge.md
@@ -58,6 +58,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -120,6 +121,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/getOppositeEdge.md
+++ b/docs/kcl/getOppositeEdge.md
@@ -56,6 +56,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -118,6 +119,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/getPreviousAdjacentEdge.md
+++ b/docs/kcl/getPreviousAdjacentEdge.md
@@ -58,6 +58,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -120,6 +121,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/helix.md
+++ b/docs/kcl/helix.md
@@ -63,6 +63,7 @@ const part001 = startSketchOn('XY')
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -125,6 +126,7 @@ const part001 = startSketchOn('XY')
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -308,6 +310,7 @@ const part001 = startSketchOn('XY')
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -370,6 +373,7 @@ const part001 = startSketchOn('XY')
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/hole.md
+++ b/docs/kcl/hole.md
@@ -107,6 +107,7 @@ const example = extrude(1, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -381,6 +382,7 @@ const example = extrude(1, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -654,6 +656,7 @@ const example = extrude(1, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/lastSegX.md
+++ b/docs/kcl/lastSegX.md
@@ -87,6 +87,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/lastSegY.md
+++ b/docs/kcl/lastSegY.md
@@ -87,6 +87,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/line.md
+++ b/docs/kcl/line.md
@@ -100,6 +100,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -374,6 +375,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/lineTo.md
+++ b/docs/kcl/lineTo.md
@@ -87,6 +87,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -361,6 +362,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/patternCircular2d.md
+++ b/docs/kcl/patternCircular2d.md
@@ -105,6 +105,7 @@ const example = extrude(1, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/patternCircular3d.md
+++ b/docs/kcl/patternCircular3d.md
@@ -67,6 +67,7 @@ const example = extrude(-5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -129,6 +130,7 @@ const example = extrude(-5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/patternLinear2d.md
+++ b/docs/kcl/patternLinear2d.md
@@ -98,6 +98,7 @@ const example = extrude(1, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/patternLinear3d.md
+++ b/docs/kcl/patternLinear3d.md
@@ -65,6 +65,7 @@ const example = extrude(1, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -127,6 +128,7 @@ const example = extrude(1, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/profileStart.md
+++ b/docs/kcl/profileStart.md
@@ -88,6 +88,7 @@ const sketch001 = startSketchOn('XY')
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/profileStartX.md
+++ b/docs/kcl/profileStartX.md
@@ -83,6 +83,7 @@ const sketch001 = startSketchOn('XY')
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/profileStartY.md
+++ b/docs/kcl/profileStartY.md
@@ -82,6 +82,7 @@ const sketch001 = startSketchOn('XY')
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/revolve.md
+++ b/docs/kcl/revolve.md
@@ -216,6 +216,7 @@ string,
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -452,6 +453,7 @@ string,
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -514,6 +516,7 @@ string,
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/segAng.md
+++ b/docs/kcl/segAng.md
@@ -90,6 +90,7 @@ const example = extrude(4, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/segEndX.md
+++ b/docs/kcl/segEndX.md
@@ -88,6 +88,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/segEndY.md
+++ b/docs/kcl/segEndY.md
@@ -89,6 +89,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/segLen.md
+++ b/docs/kcl/segLen.md
@@ -90,6 +90,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/shell.md
+++ b/docs/kcl/shell.md
@@ -61,6 +61,7 @@ string],
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -123,6 +124,7 @@ string],
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -306,6 +308,7 @@ string],
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -368,6 +371,7 @@ string],
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/startProfileAt.md
+++ b/docs/kcl/startProfileAt.md
@@ -109,6 +109,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -365,6 +366,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/startSketchAt.md
+++ b/docs/kcl/startSketchAt.md
@@ -113,6 +113,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/startSketchOn.md
+++ b/docs/kcl/startSketchOn.md
@@ -9,7 +9,7 @@ Start a sketch on a specific plane or face.
 
 
 ```js
-startSketchOn(data: SketchData, tag?: SketchOnFaceTag) -> SketchSurface
+startSketchOn(data: SketchData, tag?: FaceTag) -> SketchSurface
 ```
 
 ### Examples
@@ -178,6 +178,7 @@ const a1 = startSketchOn({
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -349,7 +350,7 @@ const a1 = startSketchOn({
 }],
 }
 ```
-* `tag`: `SketchOnFaceTag` - A tag for sketch on face. (OPTIONAL)
+* `tag`: `FaceTag` - A tag for a face. (OPTIONAL)
 ```js
 "start" | "end" |
 string
@@ -410,6 +411,7 @@ string
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/tangentialArc.md
+++ b/docs/kcl/tangentialArc.md
@@ -96,6 +96,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -370,6 +371,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/tangentialArcTo.md
+++ b/docs/kcl/tangentialArcTo.md
@@ -87,6 +87,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -361,6 +362,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/xLine.md
+++ b/docs/kcl/xLine.md
@@ -90,6 +90,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -364,6 +365,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/xLineTo.md
+++ b/docs/kcl/xLineTo.md
@@ -90,6 +90,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -364,6 +365,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/yLine.md
+++ b/docs/kcl/yLine.md
@@ -88,6 +88,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -362,6 +363,7 @@ const example = extrude(10, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/docs/kcl/yLineTo.md
+++ b/docs/kcl/yLineTo.md
@@ -86,6 +86,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.
@@ -360,6 +361,7 @@ const example = extrude(5, exampleSketch)
 	// The id of the engine command that called this chamfer.
 	id: uuid,
 	length: number,
+	tag: string,
 	type: "chamfer",
 }],
 	// The height of the extrude group.

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -201,11 +201,31 @@ impl From<SketchGroupSet> for MemoryItem {
     }
 }
 
+impl From<Vec<Box<SketchGroup>>> for MemoryItem {
+    fn from(sg: Vec<Box<SketchGroup>>) -> Self {
+        if sg.len() == 1 {
+            MemoryItem::SketchGroup(sg[0].clone())
+        } else {
+            MemoryItem::SketchGroups { value: sg }
+        }
+    }
+}
+
 impl From<ExtrudeGroupSet> for MemoryItem {
     fn from(eg: ExtrudeGroupSet) -> Self {
         match eg {
             ExtrudeGroupSet::ExtrudeGroup(eg) => MemoryItem::ExtrudeGroup(eg),
             ExtrudeGroupSet::ExtrudeGroups(egs) => MemoryItem::ExtrudeGroups { value: egs },
+        }
+    }
+}
+
+impl From<Vec<Box<ExtrudeGroup>>> for MemoryItem {
+    fn from(eg: Vec<Box<ExtrudeGroup>>) -> Self {
+        if eg.len() == 1 {
+            MemoryItem::ExtrudeGroup(eg[0].clone())
+        } else {
+            MemoryItem::ExtrudeGroups { value: eg }
         }
     }
 }

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -228,6 +228,45 @@ pub enum SketchGroupSet {
     SketchGroups(Vec<Box<SketchGroup>>),
 }
 
+impl From<SketchGroup> for SketchGroupSet {
+    fn from(sg: SketchGroup) -> Self {
+        SketchGroupSet::SketchGroup(Box::new(sg))
+    }
+}
+
+impl From<Box<SketchGroup>> for SketchGroupSet {
+    fn from(sg: Box<SketchGroup>) -> Self {
+        SketchGroupSet::SketchGroup(sg)
+    }
+}
+
+impl From<Vec<SketchGroup>> for SketchGroupSet {
+    fn from(sg: Vec<SketchGroup>) -> Self {
+        SketchGroupSet::SketchGroups(sg.into_iter().map(Box::new).collect())
+    }
+}
+
+impl From<SketchGroupSet> for Vec<Box<SketchGroup>> {
+    fn from(sg: SketchGroupSet) -> Self {
+        match sg {
+            SketchGroupSet::SketchGroup(sg) => vec![sg],
+            SketchGroupSet::SketchGroups(sgs) => sgs,
+        }
+    }
+}
+
+impl From<&SketchGroup> for Vec<Box<SketchGroup>> {
+    fn from(sg: &SketchGroup) -> Self {
+        vec![Box::new(sg.clone())]
+    }
+}
+
+impl From<Box<SketchGroup>> for Vec<Box<SketchGroup>> {
+    fn from(sg: Box<SketchGroup>) -> Self {
+        vec![sg]
+    }
+}
+
 /// A extrude group or a group of extrude groups.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
@@ -235,6 +274,45 @@ pub enum SketchGroupSet {
 pub enum ExtrudeGroupSet {
     ExtrudeGroup(Box<ExtrudeGroup>),
     ExtrudeGroups(Vec<Box<ExtrudeGroup>>),
+}
+
+impl From<ExtrudeGroup> for ExtrudeGroupSet {
+    fn from(eg: ExtrudeGroup) -> Self {
+        ExtrudeGroupSet::ExtrudeGroup(Box::new(eg))
+    }
+}
+
+impl From<Box<ExtrudeGroup>> for ExtrudeGroupSet {
+    fn from(eg: Box<ExtrudeGroup>) -> Self {
+        ExtrudeGroupSet::ExtrudeGroup(eg)
+    }
+}
+
+impl From<Vec<ExtrudeGroup>> for ExtrudeGroupSet {
+    fn from(eg: Vec<ExtrudeGroup>) -> Self {
+        ExtrudeGroupSet::ExtrudeGroups(eg.into_iter().map(Box::new).collect())
+    }
+}
+
+impl From<ExtrudeGroupSet> for Vec<Box<ExtrudeGroup>> {
+    fn from(eg: ExtrudeGroupSet) -> Self {
+        match eg {
+            ExtrudeGroupSet::ExtrudeGroup(eg) => vec![eg],
+            ExtrudeGroupSet::ExtrudeGroups(egs) => egs,
+        }
+    }
+}
+
+impl From<&ExtrudeGroup> for Vec<Box<ExtrudeGroup>> {
+    fn from(eg: &ExtrudeGroup) -> Self {
+        vec![Box::new(eg.clone())]
+    }
+}
+
+impl From<Box<ExtrudeGroup>> for Vec<Box<ExtrudeGroup>> {
+    fn from(eg: Box<ExtrudeGroup>) -> Self {
+        vec![eg]
+    }
 }
 
 /// Data for an imported geometry.

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -242,7 +242,21 @@ impl From<Box<SketchGroup>> for SketchGroupSet {
 
 impl From<Vec<SketchGroup>> for SketchGroupSet {
     fn from(sg: Vec<SketchGroup>) -> Self {
-        SketchGroupSet::SketchGroups(sg.into_iter().map(Box::new).collect())
+        if sg.len() == 1 {
+            SketchGroupSet::SketchGroup(Box::new(sg[0].clone()))
+        } else {
+            SketchGroupSet::SketchGroups(sg.into_iter().map(Box::new).collect())
+        }
+    }
+}
+
+impl From<Vec<Box<SketchGroup>>> for SketchGroupSet {
+    fn from(sg: Vec<Box<SketchGroup>>) -> Self {
+        if sg.len() == 1 {
+            SketchGroupSet::SketchGroup(sg[0].clone())
+        } else {
+            SketchGroupSet::SketchGroups(sg)
+        }
     }
 }
 
@@ -290,7 +304,21 @@ impl From<Box<ExtrudeGroup>> for ExtrudeGroupSet {
 
 impl From<Vec<ExtrudeGroup>> for ExtrudeGroupSet {
     fn from(eg: Vec<ExtrudeGroup>) -> Self {
-        ExtrudeGroupSet::ExtrudeGroups(eg.into_iter().map(Box::new).collect())
+        if eg.len() == 1 {
+            ExtrudeGroupSet::ExtrudeGroup(Box::new(eg[0].clone()))
+        } else {
+            ExtrudeGroupSet::ExtrudeGroups(eg.into_iter().map(Box::new).collect())
+        }
+    }
+}
+
+impl From<Vec<Box<ExtrudeGroup>>> for ExtrudeGroupSet {
+    fn from(eg: Vec<Box<ExtrudeGroup>>) -> Self {
+        if eg.len() == 1 {
+            ExtrudeGroupSet::ExtrudeGroup(eg[0].clone())
+        } else {
+            ExtrudeGroupSet::ExtrudeGroups(eg)
+        }
     }
 }
 

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -172,7 +172,7 @@ impl MemoryItem {
             MemoryItem::UserVal(value) => {
                 let sg: Vec<Box<SketchGroup>> = serde_json::from_value(value.value.clone())
                     .map_err(|e| anyhow::anyhow!("Failed to deserialize array of sketch groups from JSON: {}", e))?;
-                Ok(SketchGroupSet::SketchGroups(sg.clone()))
+                Ok(sg.into())
             }
             _ => anyhow::bail!("Not a sketch group or sketch groups: {:?}", self),
         }
@@ -185,9 +185,27 @@ impl MemoryItem {
             MemoryItem::UserVal(value) => {
                 let eg: Vec<Box<ExtrudeGroup>> = serde_json::from_value(value.value.clone())
                     .map_err(|e| anyhow::anyhow!("Failed to deserialize array of extrude groups from JSON: {}", e))?;
-                Ok(ExtrudeGroupSet::ExtrudeGroups(eg.clone()))
+                Ok(eg.into())
             }
             _ => anyhow::bail!("Not a extrude group or extrude groups: {:?}", self),
+        }
+    }
+}
+
+impl From<SketchGroupSet> for MemoryItem {
+    fn from(sg: SketchGroupSet) -> Self {
+        match sg {
+            SketchGroupSet::SketchGroup(sg) => MemoryItem::SketchGroup(sg),
+            SketchGroupSet::SketchGroups(sgs) => MemoryItem::SketchGroups { value: sgs },
+        }
+    }
+}
+
+impl From<ExtrudeGroupSet> for MemoryItem {
+    fn from(eg: ExtrudeGroupSet) -> Self {
+        match eg {
+            ExtrudeGroupSet::ExtrudeGroup(eg) => MemoryItem::ExtrudeGroup(eg),
+            ExtrudeGroupSet::ExtrudeGroups(egs) => MemoryItem::ExtrudeGroups { value: egs },
         }
     }
 }

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -631,6 +631,7 @@ pub enum FilletOrChamfer {
         length: f64,
         /// The engine id of the edge to chamfer.
         edge_id: uuid::Uuid,
+        tag: Option<String>,
     },
 }
 
@@ -646,6 +647,13 @@ impl FilletOrChamfer {
         match self {
             FilletOrChamfer::Fillet { edge_id, .. } => *edge_id,
             FilletOrChamfer::Chamfer { edge_id, .. } => *edge_id,
+        }
+    }
+
+    pub fn tag(&self) -> Option<&str> {
+        match self {
+            FilletOrChamfer::Fillet { .. } => None,
+            FilletOrChamfer::Chamfer { tag, .. } => tag.as_deref(),
         }
     }
 }

--- a/src/wasm-lib/kcl/src/lsp/tests.rs
+++ b/src/wasm-lib/kcl/src/lsp/tests.rs
@@ -876,7 +876,7 @@ async fn test_kcl_lsp_on_hover() {
             hover.contents,
             tower_lsp::lsp_types::HoverContents::Markup(tower_lsp::lsp_types::MarkupContent {
                 kind: tower_lsp::lsp_types::MarkupKind::Markdown,
-                value: "```startSketchOn(data: SketchData, tag?: SketchOnFaceTag) -> SketchSurface```\nStart a sketch on a specific plane or face.".to_string()
+                value: "```startSketchOn(data: SketchData, tag?: FaceTag) -> SketchSurface```\nStart a sketch on a specific plane or face.".to_string()
             })
         );
     } else {

--- a/src/wasm-lib/kcl/src/std/chamfer.rs
+++ b/src/wasm-lib/kcl/src/std/chamfer.rs
@@ -95,7 +95,7 @@ async fn inner_chamfer(
     // error to the user that they can only tag one edge at a time.
     if tag.is_some() && data.tags.len() > 1 {
         return Err(KclError::Type(KclErrorDetails {
-                message: "You can only tag one edge at a time with a tagged chamfer. Either delete the tag for the chamfer fn if you don't need it OR seperate into individial chamfer functions for each tag.".to_string(),
+                message: "You can only tag one edge at a time with a tagged chamfer. Either delete the tag for the chamfer fn if you don't need it OR separate into individual chamfer functions for each tag.".to_string(),
                 source_ranges: vec![args.source_range],
             }));
     }

--- a/src/wasm-lib/kcl/src/std/chamfer.rs
+++ b/src/wasm-lib/kcl/src/std/chamfer.rs
@@ -38,9 +38,10 @@ pub enum EdgeReference {
 
 /// Create chamfers on tagged paths.
 pub async fn chamfer(args: Args) -> Result<MemoryItem, KclError> {
-    let (data, extrude_group): (ChamferData, Box<ExtrudeGroup>) = args.get_data_and_extrude_group()?;
+    let (data, extrude_group, tag): (ChamferData, Box<ExtrudeGroup>, Option<String>) =
+        args.get_data_and_extrude_group_and_tag()?;
 
-    let extrude_group = inner_chamfer(data, extrude_group, args).await?;
+    let extrude_group = inner_chamfer(data, extrude_group, tag, args).await?;
     Ok(MemoryItem::ExtrudeGroup(extrude_group))
 }
 
@@ -76,6 +77,7 @@ pub async fn chamfer(args: Args) -> Result<MemoryItem, KclError> {
 async fn inner_chamfer(
     data: ChamferData,
     extrude_group: Box<ExtrudeGroup>,
+    tag: Option<String>,
     args: Args,
 ) -> Result<Box<ExtrudeGroup>, KclError> {
     // Check if tags contains any duplicate values.
@@ -89,19 +91,28 @@ async fn inner_chamfer(
         }));
     }
 
+    // If you try and tag multiple edges with a tagged chamfer, we want to return an
+    // error to the user that they can only tag one edge at a time.
+    if tag.is_some() && data.tags.len() > 1 {
+        return Err(KclError::Type(KclErrorDetails {
+                message: "You can only tag one edge at a time with a tagged chamfer. Either delete the tag for the chamfer fn if you don't need it OR seperate into individial chamfer functions for each tag.".to_string(),
+                source_ranges: vec![args.source_range],
+            }));
+    }
+
     let mut fillet_or_chamfers = Vec::new();
-    for tag in data.tags {
-        let edge_id = match tag {
+    for edge_tag in data.tags {
+        let edge_id = match edge_tag {
             EdgeReference::Uuid(uuid) => uuid,
-            EdgeReference::Tag(tag) => {
+            EdgeReference::Tag(edge_tag) => {
                 extrude_group
                     .sketch_group
                     .value
                     .iter()
-                    .find(|p| p.get_name() == tag)
+                    .find(|p| p.get_name() == edge_tag)
                     .ok_or_else(|| {
                         KclError::Type(KclErrorDetails {
-                            message: format!("No edge found with tag: `{}`", tag),
+                            message: format!("No edge found with tag: `{}`", edge_tag),
                             source_ranges: vec![args.source_range],
                         })
                     })?
@@ -128,6 +139,7 @@ async fn inner_chamfer(
             id,
             edge_id,
             length: data.length,
+            tag: tag.clone(),
         });
     }
 

--- a/src/wasm-lib/kcl/src/std/extrude.rs
+++ b/src/wasm-lib/kcl/src/std/extrude.rs
@@ -77,12 +77,9 @@ async fn inner_extrude(length: f64, sketch_group_set: SketchGroupSet, args: Args
     let id = uuid::Uuid::new_v4();
 
     // Extrude the element(s).
-    let sketch_groups = match sketch_group_set {
-        SketchGroupSet::SketchGroup(sketch_group) => vec![sketch_group],
-        SketchGroupSet::SketchGroups(sketch_groups) => sketch_groups,
-    };
+    let sketch_groups: Vec<Box<SketchGroup>> = sketch_group_set.into();
     let mut extrude_groups = Vec::new();
-    for sketch_group in sketch_groups.iter() {
+    for sketch_group in &sketch_groups {
         args.send_modeling_cmd(
             id,
             kittycad::types::ModelingCmd::Extrude {
@@ -95,11 +92,7 @@ async fn inner_extrude(length: f64, sketch_group_set: SketchGroupSet, args: Args
         extrude_groups.push(do_post_extrude(sketch_group.clone(), length, id, args.clone()).await?);
     }
 
-    if extrude_groups.len() == 1 {
-        Ok(ExtrudeGroupSet::ExtrudeGroup(extrude_groups.pop().unwrap()))
-    } else {
-        Ok(ExtrudeGroupSet::ExtrudeGroups(extrude_groups))
-    }
+    Ok(extrude_groups.into())
 }
 
 pub(crate) async fn do_post_extrude(

--- a/src/wasm-lib/kcl/src/std/extrude.rs
+++ b/src/wasm-lib/kcl/src/std/extrude.rs
@@ -20,10 +20,7 @@ pub async fn extrude(args: Args) -> Result<MemoryItem, KclError> {
 
     let result = inner_extrude(length, sketch_group_set, args).await?;
 
-    match result {
-        ExtrudeGroupSet::ExtrudeGroup(extrude_group) => Ok(MemoryItem::ExtrudeGroup(extrude_group)),
-        ExtrudeGroupSet::ExtrudeGroups(extrude_groups) => Ok(MemoryItem::ExtrudeGroups { value: extrude_groups }),
-    }
+    Ok(result.into())
 }
 
 /// Extrudes by a given amount.

--- a/src/wasm-lib/kcl/src/std/fillet.rs
+++ b/src/wasm-lib/kcl/src/std/fillet.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 use crate::{
     errors::{KclError, KclErrorDetails},
-    executor::{ExtrudeGroup, ExtrudeSurface, FilletOrChamfer, MemoryItem, UserVal},
+    executor::{ExtrudeGroup, FilletOrChamfer, MemoryItem, UserVal},
     std::Args,
 };
 
@@ -201,7 +201,7 @@ async fn inner_get_opposite_edge(tag: String, extrude_group: Box<ExtrudeGroup>, 
         })?
         .get_base();
 
-    let face_id = get_adjacent_face_to_tag(&extrude_group, &tag, &args)?;
+    let face_id = args.get_adjacent_face_to_tag(&extrude_group, &tag, false)?;
 
     let resp = args
         .send_modeling_cmd(
@@ -293,7 +293,7 @@ async fn inner_get_next_adjacent_edge(
         })?
         .get_base();
 
-    let face_id = get_adjacent_face_to_tag(&extrude_group, &tag, &args)?;
+    let face_id = args.get_adjacent_face_to_tag(&extrude_group, &tag, false)?;
 
     let resp = args
         .send_modeling_cmd(
@@ -390,7 +390,7 @@ async fn inner_get_previous_adjacent_edge(
         })?
         .get_base();
 
-    let face_id = get_adjacent_face_to_tag(&extrude_group, &tag, &args)?;
+    let face_id = args.get_adjacent_face_to_tag(&extrude_group, &tag, false)?;
 
     let resp = args
         .send_modeling_cmd(
@@ -418,21 +418,4 @@ async fn inner_get_previous_adjacent_edge(
             source_ranges: vec![args.source_range],
         })
     })
-}
-
-fn get_adjacent_face_to_tag(extrude_group: &ExtrudeGroup, tag: &str, args: &Args) -> Result<uuid::Uuid, KclError> {
-    extrude_group
-        .value
-        .iter()
-        .find_map(|extrude_surface| match extrude_surface {
-            ExtrudeSurface::ExtrudePlane(extrude_plane) if extrude_plane.name == tag => Some(Ok(extrude_plane.face_id)),
-            ExtrudeSurface::ExtrudeArc(extrude_arc) if extrude_arc.name == tag => Some(Ok(extrude_arc.face_id)),
-            ExtrudeSurface::ExtrudePlane(_) | ExtrudeSurface::ExtrudeArc(_) => None,
-        })
-        .ok_or_else(|| {
-            KclError::Type(KclErrorDetails {
-                message: format!("Expected a face with the tag `{}`", tag),
-                source_ranges: vec![args.source_range],
-            })
-        })?
 }

--- a/src/wasm-lib/kcl/src/std/fillet.rs
+++ b/src/wasm-lib/kcl/src/std/fillet.rs
@@ -201,7 +201,7 @@ async fn inner_get_opposite_edge(tag: String, extrude_group: Box<ExtrudeGroup>, 
         })?
         .get_base();
 
-    let face_id = args.get_adjacent_face_to_tag(&extrude_group, &tag, false)?;
+    let face_id = args.get_adjacent_face_to_tag(&extrude_group, &tag, false).await?;
 
     let resp = args
         .send_modeling_cmd(
@@ -293,7 +293,7 @@ async fn inner_get_next_adjacent_edge(
         })?
         .get_base();
 
-    let face_id = args.get_adjacent_face_to_tag(&extrude_group, &tag, false)?;
+    let face_id = args.get_adjacent_face_to_tag(&extrude_group, &tag, false).await?;
 
     let resp = args
         .send_modeling_cmd(
@@ -390,7 +390,7 @@ async fn inner_get_previous_adjacent_edge(
         })?
         .get_base();
 
-    let face_id = args.get_adjacent_face_to_tag(&extrude_group, &tag, false)?;
+    let face_id = args.get_adjacent_face_to_tag(&extrude_group, &tag, false).await?;
 
     let resp = args
         .send_modeling_cmd(

--- a/src/wasm-lib/kcl/src/std/mod.rs
+++ b/src/wasm-lib/kcl/src/std/mod.rs
@@ -252,12 +252,10 @@ impl Args {
     }
 
     /// Flush just the fillets and chamfers for this specific ExtrudeGroupSet.
-    pub async fn flush_batch_for_extrude_group_set(&self, extrude_group_set: &ExtrudeGroupSet) -> Result<(), KclError> {
-        let extrude_groups = match extrude_group_set {
-            ExtrudeGroupSet::ExtrudeGroup(eg) => vec![eg.clone()],
-            ExtrudeGroupSet::ExtrudeGroups(egs) => egs.clone(),
-        };
-
+    pub async fn flush_batch_for_extrude_group_set(
+        &self,
+        extrude_groups: Vec<Box<ExtrudeGroup>>,
+    ) -> Result<(), KclError> {
         // Make sure we don't traverse sketch_groups more than once.
         let mut traversed_sketch_groups = Vec::new();
 
@@ -1074,7 +1072,7 @@ impl Args {
         Ok((number, sketch_set))
     }
 
-    pub fn get_adjacent_face_to_tag(
+    pub async fn get_adjacent_face_to_tag(
         &self,
         extrude_group: &ExtrudeGroup,
         tag: &str,
@@ -1114,6 +1112,9 @@ impl Args {
                 None
             }
         }) {
+            // We want to make sure we execute the fillet before this operation.
+            self.flush_batch_for_extrude_group_set(extrude_group.into()).await?;
+
             return face_from_chamfer_fillet;
         }
 

--- a/src/wasm-lib/kcl/src/std/patterns.rs
+++ b/src/wasm-lib/kcl/src/std/patterns.rs
@@ -184,12 +184,10 @@ async fn inner_pattern_linear_3d(
     // Flush the batch for our fillets/chamfers if there are any.
     // If we do not flush these, then you won't be able to pattern something with fillets.
     // Flush just the fillets/chamfers that apply to these extrude groups.
-    args.flush_batch_for_extrude_group_set(&extrude_group_set).await?;
+    args.flush_batch_for_extrude_group_set(extrude_group_set.clone().into())
+        .await?;
 
-    let starting_extrude_groups = match extrude_group_set {
-        ExtrudeGroupSet::ExtrudeGroup(extrude_group) => vec![extrude_group],
-        ExtrudeGroupSet::ExtrudeGroups(extrude_groups) => extrude_groups,
-    };
+    let starting_extrude_groups: Vec<Box<ExtrudeGroup>> = extrude_group_set.into();
 
     if args.ctx.is_mock {
         return Ok(starting_extrude_groups);
@@ -447,12 +445,10 @@ async fn inner_pattern_circular_3d(
     // Flush the batch for our fillets/chamfers if there are any.
     // If we do not flush these, then you won't be able to pattern something with fillets.
     // Flush just the fillets/chamfers that apply to these extrude groups.
-    args.flush_batch_for_extrude_group_set(&extrude_group_set).await?;
+    args.flush_batch_for_extrude_group_set(extrude_group_set.clone().into())
+        .await?;
 
-    let starting_extrude_groups = match extrude_group_set {
-        ExtrudeGroupSet::ExtrudeGroup(extrude_group) => vec![extrude_group],
-        ExtrudeGroupSet::ExtrudeGroups(extrude_groups) => extrude_groups,
-    };
+    let starting_extrude_groups: Vec<Box<ExtrudeGroup>> = extrude_group_set.into();
 
     if args.ctx.is_mock {
         return Ok(starting_extrude_groups);

--- a/src/wasm-lib/kcl/src/std/patterns.rs
+++ b/src/wasm-lib/kcl/src/std/patterns.rs
@@ -84,7 +84,7 @@ pub async fn pattern_linear_2d(args: Args) -> Result<MemoryItem, KclError> {
     }
 
     let sketch_groups = inner_pattern_linear_2d(data, sketch_group_set, args).await?;
-    Ok(MemoryItem::SketchGroups { value: sketch_groups })
+    Ok(sketch_groups.into())
 }
 
 /// A linear pattern on a 2D sketch.
@@ -150,7 +150,7 @@ pub async fn pattern_linear_3d(args: Args) -> Result<MemoryItem, KclError> {
     }
 
     let extrude_groups = inner_pattern_linear_3d(data, extrude_group_set, args).await?;
-    Ok(MemoryItem::ExtrudeGroups { value: extrude_groups })
+    Ok(extrude_groups.into())
 }
 
 /// A linear pattern on a 3D model.
@@ -348,7 +348,7 @@ pub async fn pattern_circular_2d(args: Args) -> Result<MemoryItem, KclError> {
     let (data, sketch_group_set): (CircularPattern2dData, SketchGroupSet) = args.get_data_and_sketch_group_set()?;
 
     let sketch_groups = inner_pattern_circular_2d(data, sketch_group_set, args).await?;
-    Ok(MemoryItem::SketchGroups { value: sketch_groups })
+    Ok(sketch_groups.into())
 }
 
 /// A circular pattern on a 2D sketch.
@@ -410,7 +410,7 @@ pub async fn pattern_circular_3d(args: Args) -> Result<MemoryItem, KclError> {
     let (data, extrude_group_set): (CircularPattern3dData, ExtrudeGroupSet) = args.get_data_and_extrude_group_set()?;
 
     let extrude_groups = inner_pattern_circular_3d(data, extrude_group_set, args).await?;
-    Ok(MemoryItem::ExtrudeGroups { value: extrude_groups })
+    Ok(extrude_groups.into())
 }
 
 /// A circular pattern on a 3D model.

--- a/src/wasm-lib/kcl/src/std/patterns.rs
+++ b/src/wasm-lib/kcl/src/std/patterns.rs
@@ -108,10 +108,7 @@ async fn inner_pattern_linear_2d(
     sketch_group_set: SketchGroupSet,
     args: Args,
 ) -> Result<Vec<Box<SketchGroup>>, KclError> {
-    let starting_sketch_groups = match sketch_group_set {
-        SketchGroupSet::SketchGroup(sketch_group) => vec![sketch_group],
-        SketchGroupSet::SketchGroups(sketch_groups) => sketch_groups,
-    };
+    let starting_sketch_groups: Vec<Box<SketchGroup>> = sketch_group_set.into();
 
     if args.ctx.is_mock {
         return Ok(starting_sketch_groups);
@@ -380,10 +377,7 @@ async fn inner_pattern_circular_2d(
     sketch_group_set: SketchGroupSet,
     args: Args,
 ) -> Result<Vec<Box<SketchGroup>>, KclError> {
-    let starting_sketch_groups = match sketch_group_set {
-        SketchGroupSet::SketchGroup(sketch_group) => vec![sketch_group],
-        SketchGroupSet::SketchGroups(sketch_groups) => sketch_groups,
-    };
+    let starting_sketch_groups: Vec<Box<SketchGroup>> = sketch_group_set.into();
 
     if args.ctx.is_mock {
         return Ok(starting_sketch_groups);

--- a/src/wasm-lib/kcl/src/std/shell.rs
+++ b/src/wasm-lib/kcl/src/std/shell.rs
@@ -3,26 +3,14 @@
 use anyhow::Result;
 use derive_docs::stdlib;
 use kittycad::types::ModelingCmd;
-use parse_display::{Display, FromStr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     errors::{KclError, KclErrorDetails},
-    executor::{ExtrudeGroup, ExtrudeSurface, MemoryItem},
-    std::{sketch::StartOrEnd, Args},
+    executor::{ExtrudeGroup, MemoryItem},
+    std::{sketch::FaceTag, Args},
 };
-
-/// A tag for a face.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, FromStr, Display)]
-#[ts(export)]
-#[serde(rename_all = "snake_case", untagged)]
-#[display("{0}")]
-pub enum FaceTag {
-    StartOrEnd(StartOrEnd),
-    /// A string tag for the face you want to sketch on.
-    String(String),
-}
 
 /// Data for shells.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
@@ -77,44 +65,7 @@ async fn inner_shell(
 
     let mut face_ids = Vec::new();
     for tag in data.faces {
-        let extrude_plane_id = match tag {
-            FaceTag::String(ref s) => {
-                if s.is_empty() {
-                    return Err(KclError::Type(KclErrorDetails {
-                        message: "Expected a non-empty tag for the face".to_string(),
-                        source_ranges: vec![args.source_range],
-                    }));
-                }
-                extrude_group
-                    .value
-                    .iter()
-                    .find_map(|extrude_surface| match extrude_surface {
-                        ExtrudeSurface::ExtrudePlane(extrude_plane) if extrude_plane.name == *s => {
-                            Some(extrude_plane.face_id)
-                        }
-                        ExtrudeSurface::ExtrudeArc(extrude_arc) if extrude_arc.name == *s => Some(extrude_arc.face_id),
-                        ExtrudeSurface::ExtrudePlane(_) | ExtrudeSurface::ExtrudeArc(_) => None,
-                    })
-                    .ok_or_else(|| {
-                        KclError::Type(KclErrorDetails {
-                            message: format!("Expected a face with the tag `{}`", tag),
-                            source_ranges: vec![args.source_range],
-                        })
-                    })?
-            }
-            FaceTag::StartOrEnd(StartOrEnd::Start) => extrude_group.start_cap_id.ok_or_else(|| {
-                KclError::Type(KclErrorDetails {
-                    message: "Expected a start face".to_string(),
-                    source_ranges: vec![args.source_range],
-                })
-            })?,
-            FaceTag::StartOrEnd(StartOrEnd::End) => extrude_group.end_cap_id.ok_or_else(|| {
-                KclError::Type(KclErrorDetails {
-                    message: "Expected an end face".to_string(),
-                    source_ranges: vec![args.source_range],
-                })
-            })?,
-        };
+        let extrude_plane_id = tag.get_face_id(&extrude_group, &args, false)?;
 
         face_ids.push(extrude_plane_id);
     }

--- a/src/wasm-lib/kcl/src/std/shell.rs
+++ b/src/wasm-lib/kcl/src/std/shell.rs
@@ -65,7 +65,7 @@ async fn inner_shell(
 
     let mut face_ids = Vec::new();
     for tag in data.faces {
-        let extrude_plane_id = tag.get_face_id(&extrude_group, &args, false)?;
+        let extrude_plane_id = tag.get_face_id(&extrude_group, &args, false).await?;
 
         face_ids.push(extrude_plane_id);
     }

--- a/src/wasm-lib/kcl/src/std/sketch.rs
+++ b/src/wasm-lib/kcl/src/std/sketch.rs
@@ -10,8 +10,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     errors::{KclError, KclErrorDetails},
     executor::{
-        BasePath, ExtrudeGroup, ExtrudeSurface, Face, GeoMeta, MemoryItem, Path, Plane, PlaneType, Point2d, Point3d,
-        SketchGroup, SketchGroupSet, SketchSurface, SourceRange, UserVal,
+        BasePath, ExtrudeGroup, Face, GeoMeta, MemoryItem, Path, Plane, PlaneType, Point2d, Point3d, SketchGroup,
+        SketchGroupSet, SketchSurface, SourceRange, UserVal,
     },
     std::{
         utils::{
@@ -21,6 +21,60 @@ use crate::{
         Args, ExtrudeGroupSet,
     },
 };
+
+/// A tag for a face.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, FromStr, Display)]
+#[ts(export)]
+#[serde(rename_all = "snake_case", untagged)]
+#[display("{0}")]
+pub enum FaceTag {
+    StartOrEnd(StartOrEnd),
+    /// A string tag for the face you want to sketch on.
+    String(String),
+}
+
+impl FaceTag {
+    /// Get the face id from the tag.
+    pub fn get_face_id(
+        &self,
+        extrude_group: &ExtrudeGroup,
+        args: &Args,
+        must_be_planar: bool,
+    ) -> Result<uuid::Uuid, KclError> {
+        match self {
+            FaceTag::String(ref s) => args.get_adjacent_face_to_tag(extrude_group, s, must_be_planar),
+            FaceTag::StartOrEnd(StartOrEnd::Start) => extrude_group.start_cap_id.ok_or_else(|| {
+                KclError::Type(KclErrorDetails {
+                    message: "Expected a start face".to_string(),
+                    source_ranges: vec![args.source_range],
+                })
+            }),
+            FaceTag::StartOrEnd(StartOrEnd::End) => extrude_group.end_cap_id.ok_or_else(|| {
+                KclError::Type(KclErrorDetails {
+                    message: "Expected an end face".to_string(),
+                    source_ranges: vec![args.source_range],
+                })
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, FromStr, Display)]
+#[ts(export)]
+#[serde(rename_all = "snake_case")]
+#[display(style = "snake_case")]
+pub enum StartOrEnd {
+    /// The start face as in before you extruded. This could also be known as the bottom
+    /// face. But we do not call it bottom because it would be the top face if you
+    /// extruded it in the opposite direction or flipped the camera.
+    #[serde(rename = "start", alias = "START")]
+    Start,
+    /// The end face after you extruded. This could also be known as the top
+    /// face. But we do not call it top because it would be the bottom face if you
+    /// extruded it in the opposite direction or flipped the camera.
+    #[serde(rename = "end", alias = "END")]
+    End,
+}
 
 /// Draw a line to a point.
 pub async fn line_to(args: Args) -> Result<MemoryItem, KclError> {
@@ -857,7 +911,7 @@ impl From<PlaneData> for Plane {
 
 /// Start a sketch on a specific plane or face.
 pub async fn start_sketch_on(args: Args) -> Result<MemoryItem, KclError> {
-    let (data, tag): (SketchData, Option<SketchOnFaceTag>) = args.get_data_and_optional_tag()?;
+    let (data, tag): (SketchData, Option<FaceTag>) = args.get_data_and_optional_tag()?;
 
     match inner_start_sketch_on(data, tag, args).await? {
         SketchSurface::Plane(plane) => Ok(MemoryItem::Plane(plane)),
@@ -969,11 +1023,7 @@ pub async fn start_sketch_on(args: Args) -> Result<MemoryItem, KclError> {
 #[stdlib {
     name = "startSketchOn",
 }]
-async fn inner_start_sketch_on(
-    data: SketchData,
-    tag: Option<SketchOnFaceTag>,
-    args: Args,
-) -> Result<SketchSurface, KclError> {
+async fn inner_start_sketch_on(data: SketchData, tag: Option<FaceTag>, args: Args) -> Result<SketchSurface, KclError> {
     match data {
         SketchData::Plane(plane_data) => {
             let plane = start_sketch_on_plane(plane_data, args).await?;
@@ -992,82 +1042,12 @@ async fn inner_start_sketch_on(
     }
 }
 
-/// A tag for sketch on face.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, FromStr, Display)]
-#[ts(export)]
-#[serde(rename_all = "snake_case", untagged)]
-#[display("{0}")]
-pub enum SketchOnFaceTag {
-    StartOrEnd(StartOrEnd),
-    /// A string tag for the face you want to sketch on.
-    String(String),
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, FromStr, Display)]
-#[ts(export)]
-#[serde(rename_all = "snake_case")]
-#[display(style = "snake_case")]
-pub enum StartOrEnd {
-    /// The start face as in before you extruded. This could also be known as the bottom
-    /// face. But we do not call it bottom because it would be the top face if you
-    /// extruded it in the opposite direction or flipped the camera.
-    #[serde(rename = "start", alias = "START")]
-    Start,
-    /// The end face after you extruded. This could also be known as the top
-    /// face. But we do not call it top because it would be the bottom face if you
-    /// extruded it in the opposite direction or flipped the camera.
-    #[serde(rename = "end", alias = "END")]
-    End,
-}
-
 async fn start_sketch_on_face(
     extrude_group: Box<ExtrudeGroup>,
-    tag: SketchOnFaceTag,
+    tag: FaceTag,
     args: Args,
 ) -> Result<Box<Face>, KclError> {
-    let extrude_plane_id = match tag {
-        SketchOnFaceTag::String(ref s) => {
-            if s.is_empty() {
-                return Err(KclError::Type(KclErrorDetails {
-                    message: "Expected a non-empty tag for the face to sketch on".to_string(),
-                    source_ranges: vec![args.source_range],
-                }));
-            }
-            extrude_group
-                .value
-                .iter()
-                .find_map(|extrude_surface| match extrude_surface {
-                    ExtrudeSurface::ExtrudePlane(extrude_plane) if extrude_plane.name == *s => {
-                        Some(Ok(extrude_plane.face_id))
-                    }
-                    ExtrudeSurface::ExtrudeArc(extrude_arc) if extrude_arc.name == *s => {
-                        Some(Err(KclError::Type(KclErrorDetails {
-                            message: format!("Cannot sketch on a non-planar surface: `{}`", tag),
-                            source_ranges: vec![args.source_range],
-                        })))
-                    }
-                    ExtrudeSurface::ExtrudePlane(_) | ExtrudeSurface::ExtrudeArc(_) => None,
-                })
-                .ok_or_else(|| {
-                    KclError::Type(KclErrorDetails {
-                        message: format!("Expected a face with the tag `{}`", tag),
-                        source_ranges: vec![args.source_range],
-                    })
-                })??
-        }
-        SketchOnFaceTag::StartOrEnd(StartOrEnd::Start) => extrude_group.start_cap_id.ok_or_else(|| {
-            KclError::Type(KclErrorDetails {
-                message: "Expected a start face to sketch on".to_string(),
-                source_ranges: vec![args.source_range],
-            })
-        })?,
-        SketchOnFaceTag::StartOrEnd(StartOrEnd::End) => extrude_group.end_cap_id.ok_or_else(|| {
-            KclError::Type(KclErrorDetails {
-                message: "Expected an end face to sketch on".to_string(),
-                source_ranges: vec![args.source_range],
-            })
-        })?,
-    };
+    let extrude_plane_id = tag.get_face_id(&extrude_group, &args, true)?;
 
     Ok(Box::new(Face {
         id: extrude_plane_id,
@@ -1936,35 +1916,35 @@ mod tests {
         assert_eq!(str_json, "\"start\"");
 
         str_json = "\"end\"".to_string();
-        let data: crate::std::sketch::SketchOnFaceTag = serde_json::from_str(&str_json).unwrap();
+        let data: crate::std::sketch::FaceTag = serde_json::from_str(&str_json).unwrap();
         assert_eq!(
             data,
-            crate::std::sketch::SketchOnFaceTag::StartOrEnd(crate::std::sketch::StartOrEnd::End)
+            crate::std::sketch::FaceTag::StartOrEnd(crate::std::sketch::StartOrEnd::End)
         );
 
         str_json = "\"thing\"".to_string();
-        let data: crate::std::sketch::SketchOnFaceTag = serde_json::from_str(&str_json).unwrap();
-        assert_eq!(data, crate::std::sketch::SketchOnFaceTag::String("thing".to_string()));
+        let data: crate::std::sketch::FaceTag = serde_json::from_str(&str_json).unwrap();
+        assert_eq!(data, crate::std::sketch::FaceTag::String("thing".to_string()));
 
         str_json = "\"END\"".to_string();
-        let data: crate::std::sketch::SketchOnFaceTag = serde_json::from_str(&str_json).unwrap();
+        let data: crate::std::sketch::FaceTag = serde_json::from_str(&str_json).unwrap();
         assert_eq!(
             data,
-            crate::std::sketch::SketchOnFaceTag::StartOrEnd(crate::std::sketch::StartOrEnd::End)
+            crate::std::sketch::FaceTag::StartOrEnd(crate::std::sketch::StartOrEnd::End)
         );
 
         str_json = "\"start\"".to_string();
-        let data: crate::std::sketch::SketchOnFaceTag = serde_json::from_str(&str_json).unwrap();
+        let data: crate::std::sketch::FaceTag = serde_json::from_str(&str_json).unwrap();
         assert_eq!(
             data,
-            crate::std::sketch::SketchOnFaceTag::StartOrEnd(crate::std::sketch::StartOrEnd::Start)
+            crate::std::sketch::FaceTag::StartOrEnd(crate::std::sketch::StartOrEnd::Start)
         );
 
         str_json = "\"START\"".to_string();
-        let data: crate::std::sketch::SketchOnFaceTag = serde_json::from_str(&str_json).unwrap();
+        let data: crate::std::sketch::FaceTag = serde_json::from_str(&str_json).unwrap();
         assert_eq!(
             data,
-            crate::std::sketch::SketchOnFaceTag::StartOrEnd(crate::std::sketch::StartOrEnd::Start)
+            crate::std::sketch::FaceTag::StartOrEnd(crate::std::sketch::StartOrEnd::Start)
         );
     }
 }

--- a/src/wasm-lib/kcl/src/std/sketch.rs
+++ b/src/wasm-lib/kcl/src/std/sketch.rs
@@ -1831,54 +1831,28 @@ async fn inner_hole(
     sketch_group: Box<SketchGroup>,
     args: Args,
 ) -> Result<Box<SketchGroup>, KclError> {
-    //TODO: batch these (once we have batch)
+    let hole_sketch_groups: Vec<Box<SketchGroup>> = hole_sketch_group.into();
+    for hole_sketch_group in hole_sketch_groups {
+        args.batch_modeling_cmd(
+            uuid::Uuid::new_v4(),
+            ModelingCmd::Solid2DAddHole {
+                object_id: sketch_group.id,
+                hole_id: hole_sketch_group.id,
+            },
+        )
+        .await?;
 
-    match hole_sketch_group {
-        SketchGroupSet::SketchGroup(hole_sketch_group) => {
-            args.batch_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                ModelingCmd::Solid2DAddHole {
-                    object_id: sketch_group.id,
-                    hole_id: hole_sketch_group.id,
-                },
-            )
-            .await?;
-            // suggestion (mike)
-            // we also hide the source hole since its essentially "consumed" by this operation
-            args.batch_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                ModelingCmd::ObjectVisible {
-                    object_id: hole_sketch_group.id,
-                    hidden: true,
-                },
-            )
-            .await?;
-        }
-        SketchGroupSet::SketchGroups(hole_sketch_groups) => {
-            for hole_sketch_group in hole_sketch_groups {
-                args.batch_modeling_cmd(
-                    uuid::Uuid::new_v4(),
-                    ModelingCmd::Solid2DAddHole {
-                        object_id: sketch_group.id,
-                        hole_id: hole_sketch_group.id,
-                    },
-                )
-                .await?;
-                // suggestion (mike)
-                // we also hide the source hole since its essentially "consumed" by this operation
-                args.batch_modeling_cmd(
-                    uuid::Uuid::new_v4(),
-                    ModelingCmd::ObjectVisible {
-                        object_id: hole_sketch_group.id,
-                        hidden: true,
-                    },
-                )
-                .await?;
-            }
-        }
+        // suggestion (mike)
+        // we also hide the source hole since its essentially "consumed" by this operation
+        args.batch_modeling_cmd(
+            uuid::Uuid::new_v4(),
+            ModelingCmd::ObjectVisible {
+                object_id: hole_sketch_group.id,
+                hidden: true,
+            },
+        )
+        .await?;
     }
-
-    // TODO: should we modify the sketch group to include the hole data, probably?
 
     Ok(sketch_group)
 }

--- a/src/wasm-lib/tests/executor/main.rs
+++ b/src/wasm-lib/tests/executor/main.rs
@@ -1218,7 +1218,7 @@ const part002 = startSketchOn(part001, "here")
     assert!(result.is_err());
     assert_eq!(
         result.err().unwrap().to_string(),
-        r#"type: KclErrorDetails { source_ranges: [SourceRange([281, 311])], message: "Cannot sketch on a non-planar surface: `here`" }"#
+        r#"type: KclErrorDetails { source_ranges: [SourceRange([281, 311])], message: "Tag `here` is a non-planar surface" }"#
     );
 }
 
@@ -1897,7 +1897,7 @@ const secondSketch = startSketchOn(part001, '')
     assert!(result.is_err());
     assert_eq!(
         result.err().unwrap().to_string(),
-        r#"type: KclErrorDetails { source_ranges: [SourceRange([272, 298])], message: "Expected a non-empty tag for the face to sketch on" }"#
+        r#"type: KclErrorDetails { source_ranges: [SourceRange([272, 298])], message: "Expected a non-empty tag for the face" }"#
     );
 }
 

--- a/src/wasm-lib/tests/executor/main.rs
+++ b/src/wasm-lib/tests/executor/main.rs
@@ -2393,7 +2393,7 @@ const part001 = cube([0,0], 20)
     assert!(result.is_err());
     assert_eq!(
         result.err().unwrap().to_string(),
-        r#"type: KclErrorDetails { source_ranges: [SourceRange([272, 365])], message: "You can only tag one edge at a time with a tagged chamfer. Either delete the tag for the chamfer fn if you don't need it OR seperate into individial chamfer functions for each tag." }"#
+        r#"type: KclErrorDetails { source_ranges: [SourceRange([272, 365])], message: "You can only tag one edge at a time with a tagged chamfer. Either delete the tag for the chamfer fn if you don't need it OR separate into individual chamfer functions for each tag." }"#
     );
 }
 

--- a/src/wasm-lib/tests/executor/main.rs
+++ b/src/wasm-lib/tests/executor/main.rs
@@ -2398,6 +2398,7 @@ const part001 = cube([0,0], 20)
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore] // Ignore until this is fixed in the engine: https://github.com/KittyCAD/engine/issues/2260
 async fn serial_test_sketch_on_face_of_chamfer() {
     let code = r#"fn cube = (pos, scale) => {
   const sg = startSketchOn('XY')


### PR DESCRIPTION
This does not work in engine yet see https://github.com/KittyCAD/engine/issues/2260 but when it does we can re-enable the test.

This PR does make it possible, and cleans up a bunch of stuff like querying for faces so worth merging.