### PR TITLE
Cut release v0.23.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/download-artifact@v3
+        if: github.event_name == 'schedule'
 
       - name: Copy updated .json files
         if: github.event_name == 'schedule'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "untitled-app",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "private": true,
   "dependencies": {
     "@codemirror/autocomplete": "^6.17.0",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -69,7 +69,10 @@
         }
       ],
       "desktop": {
-        "schemes": ["zoo", "zoo-modeling-app"]
+        "schemes": [
+          "zoo",
+          "zoo-modeling-app"
+        ]
       }
     },
     "shell": {
@@ -77,5 +80,5 @@
     }
   },
   "productName": "Zoo Modeling App",
-  "version": "0.23.0"
+  "version": "0.23.1"
 }


### PR DESCRIPTION
## What's Changed
* Fix an updater issue found in v0.22.7 and v0.23.0 Windows builds. If you're stuck here please head over to [the website](https://zoo.dev/modeling-app/download) upgrade manually. Sorry for the inconvenience! (#2914)
* Add message "click plane to sketch on" to toolbar after clicking start sketch (#2591)
* Fix core dump screenshot (#2911)
* Pause stream when exiting sketch or extruding (#2900)
* Hide the view until the scene is initially built (#2894)
* Zoom out on extruded object (#2819)
* More codemirror enhancements (#2912)
* Remove react-codemirror and update all the codemirror libs (#2901)
* Cleanup annotations, makes it easier to read (#2905)
* Update release docs (#2906)
* Small codemirror changes (#2898)

**Full Changelog**: https://github.com/KittyCAD/modeling-app/compare/v0.23.0...v0.23.1