### PR TITLE
Fix perspective camera toggle in debug pane to update immediately

### DIFF
--- a/src/clientSideScene/CameraControls.ts
+++ b/src/clientSideScene/CameraControls.ts
@@ -518,9 +518,9 @@ export class CameraControls {
     direction.normalize()
     this.camera.position.copy(this.target).addScaledVector(direction, distance)
   }
-  usePerspectiveCamera = async () => {
+  usePerspectiveCamera = async (forceSend = false) => {
     this._usePerspectiveCamera()
-    if (this.syncDirection === 'clientToEngine') {
+    if (forceSend || this.syncDirection === 'clientToEngine') {
       await this.engineCommandManager.sendSceneCommand({
         type: 'modeling_cmd_req',
         cmd_id: uuidv4(),

--- a/src/clientSideScene/ClientSideSceneComp.tsx
+++ b/src/clientSideScene/ClientSideSceneComp.tsx
@@ -717,7 +717,7 @@ export const CamDebugSettings = () => {
           if (camSettings.type === 'perspective') {
             sceneInfra.camControls.useOrthographicCamera()
           } else {
-            sceneInfra.camControls.usePerspectiveCamera()
+            sceneInfra.camControls.usePerspectiveCamera(true)
           }
         }}
       />


### PR DESCRIPTION
Steps to reproduce:

1. Open the debug pane
2. Click "perspective cam" checkbox to change camera to orthographic. Scene view should update immediately.
3. Click same checkbox again to change camera back to perspective

I expected the 3D scene view to update immediately back to a perspective camera, but it doesn't. You need to adjust the FOV slider for it to register that you're back in perspective mode.