### PR TITLE
Don't navigate when Backspace/Delete is pressed on the home screen

### DIFF
--- a/e2e/playwright/flow-tests.spec.ts
+++ b/e2e/playwright/flow-tests.spec.ts
@@ -7641,6 +7641,31 @@ test('Basic default modeling and sketch hotkeys work', async ({ page }) => {
   await expect(page.locator('.cm-content')).toContainText('extrude(')
 })
 
+test('Delete key does not navigate back', async ({ page }) => {
+  await page.setViewportSize({ width: 1200, height: 500 })
+  await page.goto('/')
+  await page.waitForURL('**/file/**', { waitUntil: 'domcontentloaded' })
+
+  const settingsButton = page.getByRole('link', {
+    name: 'Settings',
+    exact: false,
+  })
+  const settingsCloseButton = page.getByTestId('settings-close-button')
+
+  await settingsButton.click()
+  await expect(page.url()).toContain('/settings')
+
+  // Make sure that delete doesn't go back from settings
+  await page.keyboard.press('Delete')
+  await expect(page.url()).toContain('/settings')
+
+  // Now close the settings and try delete again,
+  // make sure it doesn't go back to settings
+  await settingsCloseButton.click()
+  await page.keyboard.press('Delete')
+  await expect(page.url()).not.toContain('/settings')
+})
+
 test('Sketch on face', async ({ page }) => {
   test.setTimeout(90_000)
   const u = await getUtils(page)

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -57,6 +57,9 @@ const Home = () => {
     kclManager.cancelAllExecutions()
   }, [])
 
+  useHotkeys('backspace', (e) => {
+    e.preventDefault()
+  })
   useHotkeys(
     isTauri() ? 'mod+,' : 'shift+mod+,',
     () => navigate(paths.HOME + paths.SETTINGS),


### PR DESCRIPTION
A Tauri-side remnant of the issue resolved for the modeling screen with #1367. Closes #2460. Adds a playwright test for the behavior added in #1367, but does not yet add tauri tests for the behavior I'm adding now.