### PR TITLE
Add lexical scope and redefining variables in functions

### DIFF
--- a/src/clientSideScene/sceneEntities.ts
+++ b/src/clientSideScene/sceneEntities.ts
@@ -1083,7 +1083,7 @@ export class SceneEntities {
 
       const maybeSketchGroup = programMemory.get(variableDeclarationName)
       let sketchGroup = undefined
-      if (maybeSketchGroup.type === 'SketchGroup') {
+      if (maybeSketchGroup?.type === 'SketchGroup') {
         sketchGroup = maybeSketchGroup
       } else if ((maybeSketchGroup as ExtrudeGroup).sketchGroup) {
         sketchGroup = (maybeSketchGroup as ExtrudeGroup).sketchGroup
@@ -1901,7 +1901,7 @@ export function sketchGroupFromPathToNode({
   )
   if (err(_varDec)) return _varDec
   const varDec = _varDec.node
-  const result = programMemory.root[varDec?.id?.name || '']
+  const result = programMemory.get(varDec?.id?.name || '')
   if (result?.type === 'ExtrudeGroup') {
     return result.sketchGroup
   }

--- a/src/clientSideScene/sceneEntities.ts
+++ b/src/clientSideScene/sceneEntities.ts
@@ -1829,27 +1829,31 @@ function prepareTruncatedMemoryAndAst(
 
   // Grab all the TagDeclarators and TagIdentifiers from memory.
   let start = _node.node.start
-  for (const key in programMemory.root) {
-    const value = programMemory.root[key]
-    if (!('__meta' in value)) {
-      continue
-    }
-    if (
-      value.__meta === undefined ||
-      value.__meta.length === 0 ||
-      value.__meta[0].sourceRange === undefined
-    ) {
-      continue
-    }
+  const allEnvs = programMemory.allEnvironments()
+  for (const env of allEnvs) {
+    const newEnvRef = programMemoryOverride.addNewEnvironment()
+    for (const key in env.bindings) {
+      const value = env.bindings[key]
+      if (!('__meta' in value)) {
+        continue
+      }
+      if (
+        value.__meta === undefined ||
+        value.__meta.length === 0 ||
+        value.__meta[0].sourceRange === undefined
+      ) {
+        continue
+      }
 
-    if (value.__meta[0].sourceRange[0] >= start) {
-      // We only want things before our start point.
-      continue
-    }
+      if (value.__meta[0].sourceRange[0] >= start) {
+        // We only want things before our start point.
+        continue
+      }
 
-    if (value.type === 'TagIdentifier') {
-      const error = programMemoryOverride.set(key, JSON.parse(JSON.stringify(value)))
-      if (err(error)) return error
+      if (value.type === 'TagIdentifier') {
+        const error = programMemoryOverride.setInEnv(newEnvRef, key, JSON.parse(JSON.stringify(value)))
+        if (err(error)) return error
+      }
     }
   }
 

--- a/src/clientSideScene/sceneEntities.ts
+++ b/src/clientSideScene/sceneEntities.ts
@@ -1826,7 +1826,7 @@ function prepareTruncatedMemoryAndAst(
 
   // Grab all the TagDeclarators and TagIdentifiers from memory.
   let start = _node.node.start
-  const programMemoryOverride = programMemory.filterVariables((value) => {
+  const programMemoryOverride = programMemory.filterVariables(true, (value) => {
     if (
       !('__meta' in value) ||
       value.__meta === undefined ||
@@ -1843,6 +1843,7 @@ function prepareTruncatedMemoryAndAst(
 
     return value.type === 'TagIdentifier'
   })
+  if (err(programMemoryOverride)) return programMemoryOverride
 
   for (let i = 0; i < bodyIndex; i++) {
     const node = _ast.body[i]

--- a/src/clientSideScene/sceneEntities.ts
+++ b/src/clientSideScene/sceneEntities.ts
@@ -1851,7 +1851,11 @@ function prepareTruncatedMemoryAndAst(
       }
 
       if (value.type === 'TagIdentifier') {
-        const error = programMemoryOverride.setInEnv(newEnvRef, key, JSON.parse(JSON.stringify(value)))
+        const error = programMemoryOverride.setInEnv(
+          newEnvRef,
+          key,
+          JSON.parse(JSON.stringify(value))
+        )
         if (err(error)) return error
       }
     }
@@ -1867,7 +1871,10 @@ function prepareTruncatedMemoryAndAst(
     if (!memoryItem) {
       continue
     }
-    const error = programMemoryOverride.set(name, JSON.parse(JSON.stringify(memoryItem)))
+    const error = programMemoryOverride.set(
+      name,
+      JSON.parse(JSON.stringify(memoryItem))
+    )
     if (err(error)) return error
   }
   return {

--- a/src/components/AvailableVarsHelpers.tsx
+++ b/src/components/AvailableVarsHelpers.tsx
@@ -144,7 +144,11 @@ export function useCalc({
       if (trap(ast)) return
       const _programMem: ProgramMemory = ProgramMemory.empty()
       for (const { key, value } of availableVarInfo.variables) {
-        const error = _programMem.set(key, { type: 'userVal', value, __meta: [] })
+        const error = _programMem.set(key, {
+          type: 'userVal',
+          value,
+          __meta: [],
+        })
         if (trap(error)) return
       }
       executeAst({

--- a/src/components/AvailableVarsHelpers.tsx
+++ b/src/components/AvailableVarsHelpers.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react'
-import { parse, BinaryPart, Value } from '../lang/wasm'
+import { parse, BinaryPart, Value, ProgramMemory } from '../lang/wasm'
 import {
   createIdentifier,
   createLiteral,
@@ -120,8 +120,7 @@ export function useCalc({
   }, [])
 
   useEffect(() => {
-    const allVarNames = Object.keys(programMemory.root)
-    if (allVarNames.includes(newVariableName)) {
+    if (programMemory.has(newVariableName)) {
       setIsNewVariableNameUnique(false)
     } else {
       setIsNewVariableNameUnique(true)
@@ -143,10 +142,11 @@ export function useCalc({
       const code = `const __result__ = ${value}`
       const ast = parse(code)
       if (trap(ast)) return
-      const _programMem: any = { root: {}, return: null }
-      availableVarInfo.variables.forEach(({ key, value }) => {
-        _programMem.root[key] = { type: 'userVal', value, __meta: [] }
-      })
+      const _programMem: ProgramMemory = ProgramMemory.empty()
+      for (const { key, value } of availableVarInfo.variables) {
+        const error = _programMem.set(key, { type: 'userVal', value, __meta: [] })
+        if (trap(error)) return
+      }
       executeAst({
         ast,
         engineCommandManager,
@@ -163,7 +163,7 @@ export function useCalc({
         const init =
           resultDeclaration?.type === 'VariableDeclaration' &&
           resultDeclaration?.declarations?.[0]?.init
-        const result = programMemory?.root?.__result__?.value
+        const result = programMemory?.get('__result__')?.value
         setCalcResult(typeof result === 'number' ? String(result) : 'NAN')
         init && setValueNode(init)
       })

--- a/src/components/AvailableVarsHelpers.tsx
+++ b/src/components/AvailableVarsHelpers.tsx
@@ -155,9 +155,7 @@ export function useCalc({
         ast,
         engineCommandManager,
         useFakeExecutor: true,
-        programMemoryOverride: JSON.parse(
-          JSON.stringify(kclManager.programMemory)
-        ),
+        programMemoryOverride: kclManager.programMemory.clone(),
       }).then(({ programMemory }) => {
         const resultDeclaration = ast.body.find(
           (a) =>

--- a/src/components/AvailableVarsHelpers.tsx
+++ b/src/components/AvailableVarsHelpers.tsx
@@ -145,7 +145,7 @@ export function useCalc({
       const _programMem: ProgramMemory = ProgramMemory.empty()
       for (const { key, value } of availableVarInfo.variables) {
         const error = _programMem.set(key, {
-          type: 'userVal',
+          type: 'UserVal',
           value,
           __meta: [],
         })

--- a/src/components/ModelingSidebar/ModelingPanes/MemoryPane.test.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/MemoryPane.test.tsx
@@ -1,6 +1,6 @@
 import { processMemory } from './MemoryPane'
 import { enginelessExecutor } from '../../../lib/testHelpers'
-import { initPromise, parse } from '../../../lang/wasm'
+import { initPromise, parse, ProgramMemory } from '../../../lang/wasm'
 
 beforeAll(async () => {
   await initPromise
@@ -29,10 +29,7 @@ describe('processMemory', () => {
     |> lineTo([2.15, 4.32], %)
     // |> rx(90, %)`
     const ast = parse(code)
-    const programMemory = await enginelessExecutor(ast, {
-      root: {},
-      return: null,
-    })
+    const programMemory = await enginelessExecutor(ast, ProgramMemory.empty())
     const output = processMemory(programMemory)
     expect(output.myVar).toEqual(5)
     expect(output.otherVar).toEqual(3)

--- a/src/components/ModelingSidebar/ModelingPanes/MemoryPane.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/MemoryPane.tsx
@@ -82,7 +82,7 @@ export const MemoryPane = () => {
 
 export const processMemory = (programMemory: ProgramMemory) => {
   const processedMemory: any = {}
-  for (const [key, val] of programMemory?.flatEntries()) {
+  for (const [key, val] of programMemory?.visibleEntries()) {
     if (typeof val.value !== 'function') {
       if (val.type === 'SketchGroup') {
         processedMemory[key] = val.value.map(({ __geoMeta, ...rest }: Path) => {

--- a/src/components/ModelingSidebar/ModelingPanes/MemoryPane.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/MemoryPane.tsx
@@ -82,8 +82,7 @@ export const MemoryPane = () => {
 
 export const processMemory = (programMemory: ProgramMemory) => {
   const processedMemory: any = {}
-  Object.keys(programMemory?.root || {}).forEach((key) => {
-    const val = programMemory.root[key]
+  for (const [key, val] of programMemory?.flatEntries()) {
     if (typeof val.value !== 'function') {
       if (val.type === 'SketchGroup') {
         processedMemory[key] = val.value.map(({ __geoMeta, ...rest }: Path) => {
@@ -103,6 +102,6 @@ export const processMemory = (programMemory: ProgramMemory) => {
     } else if (key !== 'log') {
       processedMemory[key] = '__function__'
     }
-  })
+  }
   return processedMemory
 }

--- a/src/lang/KclSingleton.ts
+++ b/src/lang/KclSingleton.ts
@@ -503,7 +503,7 @@ function defaultSelectionFilter(
   engineCommandManager: EngineCommandManager
 ) {
   const firstSketchOrExtrudeGroup = programMemory
-    .values()
+    .visibleValues()
     .find(
       (node) => node.type === 'ExtrudeGroup' || node.type === 'SketchGroup'
     ) as SketchGroup | ExtrudeGroup

--- a/src/lang/KclSingleton.ts
+++ b/src/lang/KclSingleton.ts
@@ -502,9 +502,11 @@ function defaultSelectionFilter(
   programMemory: ProgramMemory,
   engineCommandManager: EngineCommandManager
 ) {
-  const firstSketchOrExtrudeGroup = programMemory.values().find(
-    (node) => node.type === 'ExtrudeGroup' || node.type === 'SketchGroup'
-  ) as SketchGroup | ExtrudeGroup
+  const firstSketchOrExtrudeGroup = programMemory
+    .values()
+    .find(
+      (node) => node.type === 'ExtrudeGroup' || node.type === 'SketchGroup'
+    ) as SketchGroup | ExtrudeGroup
   firstSketchOrExtrudeGroup &&
     engineCommandManager.sendSceneCommand({
       type: 'modeling_cmd_req',

--- a/src/lang/KclSingleton.ts
+++ b/src/lang/KclSingleton.ts
@@ -33,10 +33,7 @@ export class KclManager {
     },
     digest: null,
   }
-  private _programMemory: ProgramMemory = {
-    root: {},
-    return: null,
-  }
+  private _programMemory: ProgramMemory = ProgramMemory.empty()
   private _logs: string[] = []
   private _kclErrors: KCLError[] = []
   private _isExecuting = false
@@ -505,7 +502,7 @@ function defaultSelectionFilter(
   programMemory: ProgramMemory,
   engineCommandManager: EngineCommandManager
 ) {
-  const firstSketchOrExtrudeGroup = Object.values(programMemory.root).find(
+  const firstSketchOrExtrudeGroup = programMemory.values().find(
     (node) => node.type === 'ExtrudeGroup' || node.type === 'SketchGroup'
   ) as SketchGroup | ExtrudeGroup
   firstSketchOrExtrudeGroup &&

--- a/src/lang/KclSingleton.ts
+++ b/src/lang/KclSingleton.ts
@@ -14,9 +14,7 @@ import {
   Program,
   ProgramMemory,
   recast,
-  SketchGroup,
   SourceRange,
-  ExtrudeGroup,
 } from 'lang/wasm'
 import { getNodeFromPath } from './queryAst'
 import { codeManager, editorManager, sceneInfra } from 'lib/singletons'
@@ -502,12 +500,7 @@ function defaultSelectionFilter(
   programMemory: ProgramMemory,
   engineCommandManager: EngineCommandManager
 ) {
-  const firstSketchOrExtrudeGroup = programMemory
-    .visibleValues()
-    .find(
-      (node) => node.type === 'ExtrudeGroup' || node.type === 'SketchGroup'
-    ) as SketchGroup | ExtrudeGroup
-  firstSketchOrExtrudeGroup &&
+  programMemory.hasSketchOrExtrudeGroup() &&
     engineCommandManager.sendSceneCommand({
       type: 'modeling_cmd_req',
       cmd_id: uuidv4(),

--- a/src/lang/artifact.test.ts
+++ b/src/lang/artifact.test.ts
@@ -16,7 +16,7 @@ const mySketch001 = startSketchOn('XY')
   // |> rx(45, %)`
     const programMemory = await enginelessExecutor(parse(code))
     // @ts-ignore
-    const sketch001 = programMemory?.root?.mySketch001
+    const sketch001 = programMemory?.get('mySketch001')
     expect(sketch001).toEqual({
       type: 'SketchGroup',
       on: expect.any(Object),
@@ -66,7 +66,7 @@ const mySketch001 = startSketchOn('XY')
   |> extrude(2, %)`
     const programMemory = await enginelessExecutor(parse(code))
     // @ts-ignore
-    const sketch001 = programMemory?.root?.mySketch001
+    const sketch001 = programMemory?.get('mySketch001')
     expect(sketch001).toEqual({
       type: 'ExtrudeGroup',
       id: expect.any(String),
@@ -146,7 +146,7 @@ const sk2 = startSketchOn('XY')
 `
     const programMemory = await enginelessExecutor(parse(code))
     // @ts-ignore
-    const geos = [programMemory?.root?.theExtrude, programMemory?.root?.sk2]
+    const geos = [programMemory?.get('theExtrude'), programMemory?.get('sk2')]
     expect(geos).toEqual([
       {
         type: 'ExtrudeGroup',

--- a/src/lang/executor.test.ts
+++ b/src/lang/executor.test.ts
@@ -12,25 +12,25 @@ describe('test executor', () => {
   it('test assigning two variables, the second summing with the first', async () => {
     const code = `const myVar = 5
 const newVar = myVar + 1`
-    const { root } = await exe(code)
-    expect(root.myVar.value).toBe(5)
-    expect(root.newVar.value).toBe(6)
+    const mem = await exe(code)
+    expect(mem.get('myVar')?.value).toBe(5)
+    expect(mem.get('newVar')?.value).toBe(6)
   })
   it('test assigning a var with a string', async () => {
     const code = `const myVar = "a str"`
-    const { root } = await exe(code)
-    expect(root.myVar.value).toBe('a str')
+    const mem = await exe(code)
+    expect(mem.get('myVar')?.value).toBe('a str')
   })
   it('test assigning a var by cont concatenating two strings string execute', async () => {
     const code = fs.readFileSync(
       './src/lang/testExamples/variableDeclaration.cado',
       'utf-8'
     )
-    const { root } = await exe(code)
-    expect(root.myVar.value).toBe('a str another str')
+    const mem = await exe(code)
+    expect(mem.get('myVar')?.value).toBe('a str another str')
   })
   it('fn funcN = () => {} execute', async () => {
-    const { root } = await exe(
+    const mem = await exe(
       [
         'fn funcN = (a, b) => {',
         '  return a + b',
@@ -39,8 +39,8 @@ const newVar = myVar + 1`
         'const magicNum = funcN(9, theVar)',
       ].join('\n')
     )
-    expect(root.theVar.value).toBe(60)
-    expect(root.magicNum.value).toBe(69)
+    expect(mem.get('theVar')?.value).toBe(60)
+    expect(mem.get('magicNum')?.value).toBe(69)
   })
   it('sketch declaration', async () => {
     let code = `const mySketch = startSketchOn('XY')
@@ -50,9 +50,9 @@ const newVar = myVar + 1`
   |> lineTo([5,-1], %, "rightPath")
   // |> close(%)
 `
-    const { root } = await exe(code)
+    const mem = await exe(code)
     // geo is three js buffer geometry and is very bloated to have in tests
-    const minusGeo = root.mySketch.value
+    const minusGeo = mem.get('mySketch')?.value
     expect(minusGeo).toEqual([
       {
         type: 'ToPoint',
@@ -104,8 +104,8 @@ const newVar = myVar + 1`
       'fn myFn = (a) => { return a + 1 }',
       'const myVar = 5 + 1 |> myFn(%)',
     ].join('\n')
-    const { root } = await exe(code)
-    expect(root.myVar.value).toBe(7)
+    const mem = await exe(code)
+    expect(mem.get('myVar')?.value).toBe(7)
   })
 
   // Enable rotations #152
@@ -117,16 +117,16 @@ const newVar = myVar + 1`
   //     '  |> lineTo([1, 1], %)',
   //     'const rotated = rx(90, mySk1)',
   //   ].join('\n')
-  //   const { root } = await exe(code)
-  //   expect(root.mySk1.value).toHaveLength(3)
-  //   expect(root?.rotated?.type).toBe('SketchGroup')
+  //   const mem = await exe(code)
+  //   expect(mem.get('mySk1')?.value).toHaveLength(3)
+  //   expect(mem.get('rotated')?.type).toBe('SketchGroup')
   //   if (
-  //     root?.mySk1?.type !== 'SketchGroup' ||
-  //     root?.rotated?.type !== 'SketchGroup'
+  //     mem.get('mySk1')?.type !== 'SketchGroup' ||
+  //     mem.get('rotated')?.type !== 'SketchGroup'
   //   )
   //     throw new Error('not a sketch group')
-  //   expect(root.mySk1.rotation).toEqual([0, 0, 0, 1])
-  //   expect(root.rotated.rotation.map((a) => a.toFixed(4))).toEqual([
+  //   expect(mem.get('mySk1')?.rotation).toEqual([0, 0, 0, 1])
+  //   expect(mem.get('rotated')?.rotation.map((a) => a.toFixed(4))).toEqual([
   //     '0.7071',
   //     '0.0000',
   //     '0.0000',
@@ -144,8 +144,8 @@ const newVar = myVar + 1`
       '  |> lineTo([1,1], %)',
       // '  |> rx(90, %)',
     ].join('\n')
-    const { root } = await exe(code)
-    expect(root.mySk1).toEqual({
+    const mem = await exe(code)
+    expect(mem.get('mySk1')).toEqual({
       type: 'SketchGroup',
       on: expect.any(Object),
       start: {
@@ -214,9 +214,9 @@ const newVar = myVar + 1`
     const code = ['const three = 3', "const yo = [1, '2', three, 4 + 5]"].join(
       '\n'
     )
-    const { root } = await exe(code)
+    const mem = await exe(code)
     // TODO path to node is probably wrong here, zero indexes are not correct
-    expect(root).toEqual({
+    expect(mem.allEnvironments()).toEqual([{
       three: {
         type: 'UserVal',
         value: 3,
@@ -235,15 +235,15 @@ const newVar = myVar + 1`
           },
         ],
       },
-    })
+    }])
   })
   it('execute object expression', async () => {
     const code = [
       'const three = 3',
       "const yo = {aStr: 'str', anum: 2, identifier: three, binExp: 4 + 5}",
     ].join('\n')
-    const { root } = await exe(code)
-    expect(root.yo).toEqual({
+    const mem = await exe(code)
+    expect(mem.get('yo')).toEqual({
       type: 'UserVal',
       value: { aStr: 'str', anum: 2, identifier: 3, binExp: 9 },
       __meta: [
@@ -257,8 +257,8 @@ const newVar = myVar + 1`
     const code = ["const yo = {a: {b: '123'}}", "const myVar = yo.a['b']"].join(
       '\n'
     )
-    const { root } = await exe(code)
-    expect(root.myVar).toEqual({
+    const mem = await exe(code)
+    expect(mem.get('myVar')).toEqual({
       type: 'UserVal',
       value: '123',
       __meta: [
@@ -273,81 +273,81 @@ const newVar = myVar + 1`
 describe('testing math operators', () => {
   it('can sum', async () => {
     const code = ['const myVar = 1 + 2'].join('\n')
-    const { root } = await exe(code)
-    expect(root.myVar.value).toBe(3)
+    const mem = await exe(code)
+    expect(mem.get('myVar')?.value).toBe(3)
   })
   it('can subtract', async () => {
     const code = ['const myVar = 1 - 2'].join('\n')
-    const { root } = await exe(code)
-    expect(root.myVar.value).toBe(-1)
+    const mem = await exe(code)
+    expect(mem.get('myVar')?.value).toBe(-1)
   })
   it('can multiply', async () => {
     const code = ['const myVar = 1 * 2'].join('\n')
-    const { root } = await exe(code)
-    expect(root.myVar.value).toBe(2)
+    const mem = await exe(code)
+    expect(mem.get('myVar')?.value).toBe(2)
   })
   it('can divide', async () => {
     const code = ['const myVar = 1 / 2'].join('\n')
-    const { root } = await exe(code)
-    expect(root.myVar.value).toBe(0.5)
+    const mem = await exe(code)
+    expect(mem.get('myVar')?.value).toBe(0.5)
   })
   it('can modulus', async () => {
     const code = ['const myVar = 5 % 2'].join('\n')
-    const { root } = await exe(code)
-    expect(root.myVar.value).toBe(1)
+    const mem = await exe(code)
+    expect(mem.get('myVar')?.value).toBe(1)
   })
   it('can do multiple operations', async () => {
     const code = ['const myVar = 1 + 2 * 3'].join('\n')
-    const { root } = await exe(code)
-    expect(root.myVar.value).toBe(7)
+    const mem = await exe(code)
+    expect(mem.get('myVar')?.value).toBe(7)
   })
   it('big example with parans', async () => {
     const code = ['const myVar = 1 + 2 * (3 - 4) / -5 + 6'].join('\n')
-    const { root } = await exe(code)
-    expect(root.myVar.value).toBe(7.4)
+    const mem = await exe(code)
+    expect(mem.get('myVar')?.value).toBe(7.4)
   })
   it('with identifier', async () => {
     const code = ['const yo = 6', 'const myVar = yo / 2'].join('\n')
-    const { root } = await exe(code)
-    expect(root.myVar.value).toBe(3)
+    const mem = await exe(code)
+    expect(mem.get('myVar')?.value).toBe(3)
   })
   it('with lots of testing', async () => {
     const code = ['const myVar = 2 * ((2 + 3 ) / 4 + 5)'].join('\n')
-    const { root } = await exe(code)
-    expect(root.myVar.value).toBe(12.5)
+    const mem = await exe(code)
+    expect(mem.get('myVar')?.value).toBe(12.5)
   })
   it('with callExpression at start', async () => {
     const code = 'const myVar = min(4, 100) + 2'
-    const { root } = await exe(code)
-    expect(root.myVar.value).toBe(6)
+    const mem = await exe(code)
+    expect(mem.get('myVar')?.value).toBe(6)
   })
   it('with callExpression at end', async () => {
     const code = 'const myVar = 2 + min(4, 100)'
-    const { root } = await exe(code)
-    expect(root.myVar.value).toBe(6)
+    const mem = await exe(code)
+    expect(mem.get('myVar')?.value).toBe(6)
   })
   it('with nested callExpression', async () => {
     const code = 'const myVar = 2 + min(100, legLen(5, 3))'
-    const { root } = await exe(code)
-    expect(root.myVar.value).toBe(6)
+    const mem = await exe(code)
+    expect(mem.get('myVar')?.value).toBe(6)
   })
   it('with unaryExpression', async () => {
     const code = 'const myVar = -min(100, 3)'
-    const { root } = await exe(code)
-    expect(root.myVar.value).toBe(-3)
+    const mem = await exe(code)
+    expect(mem.get('myVar')?.value).toBe(-3)
   })
   it('with unaryExpression in callExpression', async () => {
     const code = 'const myVar = min(-legLen(5, 4), 5)'
     const code2 = 'const myVar = min(5 , -legLen(5, 4))'
-    const { root } = await exe(code)
-    const { root: root2 } = await exe(code2)
-    expect(root.myVar.value).toBe(-3)
-    expect(root.myVar.value).toBe(root2.myVar.value)
+    const mem = await exe(code)
+    const mem2 = await exe(code2)
+    expect(mem.get('myVar')?.value).toBe(-3)
+    expect(mem.get('myVar')?.value).toBe(mem2.get('myVar')?.value)
   })
   it('with unaryExpression in ArrayExpression', async () => {
     const code = 'const myVar = [1,-legLen(5, 4)]'
-    const { root } = await exe(code)
-    expect(root.myVar.value).toEqual([1, -3])
+    const mem = await exe(code)
+    expect(mem.get('myVar')?.value).toEqual([1, -3])
   })
   it('with unaryExpression in ArrayExpression in CallExpression, checking nothing funny happens when used in a sketch', async () => {
     const code = [
@@ -355,8 +355,8 @@ describe('testing math operators', () => {
       '  |> startProfileAt([0, 0], %)',
       '|> line([-2.21, -legLen(5, min(3, 999))], %)',
     ].join('\n')
-    const { root } = await exe(code)
-    const sketch = root.part001
+    const mem = await exe(code)
+    const sketch = mem.get('part001')
     // result of `-legLen(5, min(3, 999))` should be -4
     const yVal = (sketch as SketchGroup).value?.[0]?.to?.[1]
     expect(yVal).toBe(-4)
@@ -373,8 +373,8 @@ describe('testing math operators', () => {
       `], %)`,
       ``,
     ].join('\n')
-    const { root } = await exe(code)
-    const sketch = root.part001
+    const mem = await exe(code)
+    const sketch = mem.get('part001')
     // expect -legLen(segLen('seg01', %), myVar) to equal -4 setting the y value back to 0
     expect((sketch as SketchGroup).value?.[1]?.from).toEqual([3, 4])
     expect((sketch as SketchGroup).value?.[1]?.to).toEqual([6, 0])
@@ -382,18 +382,18 @@ describe('testing math operators', () => {
       `-legLen(segLen('seg01', %), myVar)`,
       `legLen(segLen('seg01', %), myVar)`
     )
-    const { root: removedUnaryExpRoot } = await exe(removedUnaryExp)
-    const removedUnaryExpRootSketch = removedUnaryExpRoot.part001
+    const removedUnaryExpMem = await exe(removedUnaryExp)
+    const removedUnaryExpMemSketch = removedUnaryExpMem.get('part001')
 
     // without the minus sign, the y value should be 8
-    expect((removedUnaryExpRootSketch as SketchGroup).value?.[1]?.to).toEqual([
+    expect((removedUnaryExpMemSketch as SketchGroup).value?.[1]?.to).toEqual([
       6, 8,
     ])
   })
   it('with nested callExpression and binaryExpression', async () => {
     const code = 'const myVar = 2 + min(100, -1 + legLen(5, 3))'
-    const { root } = await exe(code)
-    expect(root.myVar.value).toBe(5)
+    const mem = await exe(code)
+    expect(mem.get('myVar')?.value).toBe(5)
   })
 })
 

--- a/src/lang/executor.test.ts
+++ b/src/lang/executor.test.ts
@@ -216,28 +216,27 @@ const newVar = myVar + 1`
     )
     const mem = await exe(code)
     // TODO path to node is probably wrong here, zero indexes are not correct
-    expect(mem.allEnvironments()).toEqual([
-      {
-        three: {
-          type: 'UserVal',
-          value: 3,
-          __meta: [
-            {
-              sourceRange: [14, 15],
-            },
-          ],
+    expect(mem.get('three')).toEqual({
+      type: 'UserVal',
+      value: 3,
+      __meta: [
+        {
+          sourceRange: [14, 15],
         },
-        yo: {
-          type: 'UserVal',
-          value: [1, '2', 3, 9],
-          __meta: [
-            {
-              sourceRange: [27, 49],
-            },
-          ],
+      ],
+    })
+    expect(mem.get('yo')).toEqual({
+      type: 'UserVal',
+      value: [1, '2', 3, 9],
+      __meta: [
+        {
+          sourceRange: [27, 49],
         },
-      },
-    ])
+      ],
+    })
+    // Check that there are no other variables or environments.
+    expect(mem.numEnvironments()).toBe(1)
+    expect(mem.numVariables(0)).toBe(2)
   })
   it('execute object expression', async () => {
     const code = [

--- a/src/lang/executor.test.ts
+++ b/src/lang/executor.test.ts
@@ -421,7 +421,7 @@ const theExtrude = startSketchOn('XY')
 
 async function exe(
   code: string,
-  programMemory: ProgramMemory = { root: {}, return: null }
+  programMemory: ProgramMemory = ProgramMemory.empty()
 ) {
   const ast = parse(code)
 

--- a/src/lang/executor.test.ts
+++ b/src/lang/executor.test.ts
@@ -216,26 +216,28 @@ const newVar = myVar + 1`
     )
     const mem = await exe(code)
     // TODO path to node is probably wrong here, zero indexes are not correct
-    expect(mem.allEnvironments()).toEqual([{
-      three: {
-        type: 'UserVal',
-        value: 3,
-        __meta: [
-          {
-            sourceRange: [14, 15],
-          },
-        ],
+    expect(mem.allEnvironments()).toEqual([
+      {
+        three: {
+          type: 'UserVal',
+          value: 3,
+          __meta: [
+            {
+              sourceRange: [14, 15],
+            },
+          ],
+        },
+        yo: {
+          type: 'UserVal',
+          value: [1, '2', 3, 9],
+          __meta: [
+            {
+              sourceRange: [27, 49],
+            },
+          ],
+        },
       },
-      yo: {
-        type: 'UserVal',
-        value: [1, '2', 3, 9],
-        __meta: [
-          {
-            sourceRange: [27, 49],
-          },
-        ],
-      },
-    }])
+    ])
   })
   it('execute object expression', async () => {
     const code = [

--- a/src/lang/langHelpers.ts
+++ b/src/lang/langHelpers.ts
@@ -79,20 +79,14 @@ export async function executeAst({
       return {
         errors: [e],
         logs: [],
-        programMemory: {
-          root: {},
-          return: null,
-        },
+        programMemory: ProgramMemory.empty(),
       }
     } else {
       console.log(e)
       return {
         logs: [e],
         errors: [],
-        programMemory: {
-          root: {},
-          return: null,
-        },
+        programMemory: ProgramMemory.empty(),
       }
     }
   }

--- a/src/lang/modifyAst.ts
+++ b/src/lang/modifyAst.ts
@@ -983,7 +983,7 @@ export async function deleteFromSelection(
           if (err(parent)) {
             return
           }
-          const sketchToPreserve = programMemory.root[sketchName] as SketchGroup
+          const sketchToPreserve = programMemory.get(sketchName) as SketchGroup
           console.log('sketchName', sketchName)
           // Can't kick off multiple requests at once as getFaceDetails
           // is three engine calls in one and they conflict

--- a/src/lang/queryAst.ts
+++ b/src/lang/queryAst.ts
@@ -130,8 +130,14 @@ function moreNodePathFromSourceRange(
 
   const isInRange = _node.start <= start && _node.end >= end
 
-  if ((_node.type === 'Identifier' || _node.type === 'Literal') && isInRange)
+  if (
+    (_node.type === 'Identifier' ||
+      _node.type === 'Literal' ||
+      _node.type === 'TagDeclarator') &&
+    isInRange
+  ) {
     return path
+  }
 
   if (_node.type === 'CallExpression' && isInRange) {
     const { callee, arguments: args } = _node
@@ -277,6 +283,15 @@ function moreNodePathFromSourceRange(
         }
       }
     }
+    return path
+  }
+  if (_node.type === 'ReturnStatement' && isInRange) {
+    const { argument } = _node
+    if (argument.start <= start && argument.end >= end) {
+      path.push(['argument', 'ReturnStatement'])
+      return moreNodePathFromSourceRange(argument, sourceRange, path)
+    }
+    return path
   }
   if (_node.type === 'MemberExpression' && isInRange) {
     const { object, property } = _node

--- a/src/lang/queryAst.ts
+++ b/src/lang/queryAst.ts
@@ -459,8 +459,8 @@ export function findAllPreviousVariablesPath(
   bodyItems?.forEach?.((item) => {
     if (item.type !== 'VariableDeclaration' || item.end > startRange) return
     const varName = item.declarations[0].id.name
-    const varValue = programMemory?.root[varName]
-    if (typeof varValue?.value !== type) return
+    const varValue = programMemory?.get(varName)
+    if (!varValue || typeof varValue?.value !== type) return
     variables.push({
       key: varName,
       value: varValue.value,
@@ -640,7 +640,7 @@ export function isLinesParallelAndConstrained(
     if (err(_varDec)) return _varDec
     const varDec = _varDec.node
     const varName = (varDec as VariableDeclaration)?.declarations[0]?.id?.name
-    const path = programMemory?.root[varName] as SketchGroup
+    const path = programMemory?.get(varName) as SketchGroup
     const _primarySegment = getSketchSegmentFromSourceRange(
       path,
       primaryLine.range
@@ -687,7 +687,7 @@ export function isLinesParallelAndConstrained(
       constraintType === 'angle' || constraintLevel === 'full'
 
     // get the previous segment
-    const prevSegment = (programMemory.root[varName] as SketchGroup).value[
+    const prevSegment = (programMemory.get(varName) as SketchGroup).value[
       secondaryIndex - 1
     ]
     const prevSourceRange = prevSegment.__geoMeta.sourceRange
@@ -757,7 +757,7 @@ export function hasExtrudeSketchGroup({
   const varDec = varDecMeta.node
   if (varDec.type !== 'VariableDeclaration') return false
   const varName = varDec.declarations[0].id.name
-  const varValue = programMemory?.root[varName]
+  const varValue = programMemory?.get(varName)
   return varValue?.type === 'ExtrudeGroup' || varValue?.type === 'SketchGroup'
 }
 

--- a/src/lang/std/sketch.ts
+++ b/src/lang/std/sketch.ts
@@ -1009,8 +1009,8 @@ export const angledLineOfXLength: SketchLineHelper = {
     const { node: varDec } = nodeMeta2
 
     const variableName = varDec.id.name
-    const sketch = previousProgramMemory?.root?.[variableName]
-    if (sketch.type !== 'SketchGroup') {
+    const sketch = previousProgramMemory?.get(variableName)
+    if (!sketch || sketch.type !== 'SketchGroup') {
       return new Error('not a SketchGroup')
     }
     const angle = createLiteral(roundOff(getAngle(from, to), 0))
@@ -1105,8 +1105,8 @@ export const angledLineOfYLength: SketchLineHelper = {
     if (err(nodeMeta2)) return nodeMeta2
     const { node: varDec } = nodeMeta2
     const variableName = varDec.id.name
-    const sketch = previousProgramMemory?.root?.[variableName]
-    if (sketch.type !== 'SketchGroup') {
+    const sketch = previousProgramMemory?.get(variableName)
+    if (!sketch || sketch.type !== 'SketchGroup') {
       return new Error('not a SketchGroup')
     }
 
@@ -1443,7 +1443,7 @@ export const angledLineThatIntersects: SketchLineHelper = {
 
     const { node: varDec } = nodeMeta2
     const varName = varDec.declarations[0].id.name
-    const sketchGroup = previousProgramMemory.root[varName] as SketchGroup
+    const sketchGroup = previousProgramMemory.get(varName) as SketchGroup
     const intersectPath = sketchGroup.value.find(
       ({ tag }: Path) => tag && tag.value === intersectTagName
     )

--- a/src/lang/std/sketchConstraints.test.ts
+++ b/src/lang/std/sketchConstraints.test.ts
@@ -363,7 +363,7 @@ const part001 = startSketchOn('XY')
     const programMemory = await enginelessExecutor(parse(code))
     const index = code.indexOf('// normal-segment') - 7
     const _segment = getSketchSegmentFromSourceRange(
-      programMemory.root['part001'] as SketchGroup,
+      programMemory.get('part001') as SketchGroup,
       [index, index]
     )
     if (err(_segment)) throw _segment
@@ -379,7 +379,7 @@ const part001 = startSketchOn('XY')
     const programMemory = await enginelessExecutor(parse(code))
     const index = code.indexOf('// segment-in-start') - 7
     const _segment = getSketchSegmentFromSourceRange(
-      programMemory.root['part001'] as SketchGroup,
+      programMemory.get('part001') as SketchGroup,
       [index, index]
     )
     if (err(_segment)) throw _segment

--- a/src/lang/std/sketchcombos.ts
+++ b/src/lang/std/sketchcombos.ts
@@ -1636,8 +1636,8 @@ export function transformAstSketchLines({
     })
 
     const varName = varDec.node.id.name
-    let sketchGroup = programMemory.root?.[varName]
-    if (sketchGroup.type === 'ExtrudeGroup') {
+    let sketchGroup = programMemory.get(varName)
+    if (sketchGroup?.type === 'ExtrudeGroup') {
       sketchGroup = sketchGroup.sketchGroup
     }
     if (!sketchGroup || sketchGroup.type !== 'SketchGroup')

--- a/src/lang/std/std.test.ts
+++ b/src/lang/std/std.test.ts
@@ -17,9 +17,9 @@ describe('testing angledLineThatIntersects', () => {
   offset: ${offset},
 }, %, "yo2")
 const intersect = segEndX('yo2', part001)`
-    const { root } = await enginelessExecutor(parse(code('-1')))
-    expect(root.intersect.value).toBe(1 + Math.sqrt(2))
-    const { root: noOffset } = await enginelessExecutor(parse(code('0')))
-    expect(noOffset.intersect.value).toBeCloseTo(1)
+    const mem = await enginelessExecutor(parse(code('-1')))
+    expect(mem.get('intersect')?.value).toBe(1 + Math.sqrt(2))
+    const noOffset = await enginelessExecutor(parse(code('0')))
+    expect(noOffset.get('intersect')?.value).toBeCloseTo(1)
   })
 })

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -266,8 +266,12 @@ export class ProgramMemory {
     return new ProgramMemory(environments, this.currentEnv, null)
   }
 
-  allEnvironments(): Environment[] {
-    return this.environments
+  numEnvironments(): number {
+    return this.environments.length
+  }
+
+  numVariables(envRef: EnvironmentRef): number {
+    return Object.keys(this.environments[envRef]).length
   }
 
   /**

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -184,7 +184,6 @@ export class ProgramMemory {
     currentEnv: EnvironmentRef = ROOT_ENVIRONMENT_REF,
     returnVal: ProgramReturn | null = null
   ) {
-    console.info('ProgramMemory.constructor', ...environments, currentEnv)
     this.environments = environments
     this.currentEnv = currentEnv
     this.return = returnVal
@@ -221,7 +220,6 @@ export class ProgramMemory {
   }
 
   set(name: string, value: MemoryItem): Error | null {
-    console.info('ProgramMemory.set', name, value)
     if (this.environments.length === 0) {
       return new Error('No environment to set memory in')
     }

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -143,9 +143,7 @@ interface Memory {
   [key: string]: MemoryItem
 }
 
-interface EnvironmentRef {
-  0: number
-}
+type EnvironmentRef = number
 
 interface Environment {
   bindings: Memory
@@ -176,7 +174,7 @@ export class ProgramMemory {
 
   constructor(
     environments: Environment[] = [emptyEnvironment()],
-    currentEnv: EnvironmentRef = [0],
+    currentEnv: EnvironmentRef = 0,
     returnVal: ProgramReturn | null = null
   ) {
     console.info('ProgramMemory.constructor', ...environments)
@@ -188,7 +186,7 @@ export class ProgramMemory {
   has(name: string): boolean {
     let envRef = this.currentEnv
     while (true) {
-      const env = this.environments[envRef[0]]
+      const env = this.environments[envRef]
       if (env.bindings.hasOwnProperty(name)) {
         return true
       }
@@ -203,7 +201,7 @@ export class ProgramMemory {
   get(name: string): MemoryItem | null {
     let envRef = this.currentEnv
     while (true) {
-      const env = this.environments[envRef[0]]
+      const env = this.environments[envRef]
       if (env.bindings.hasOwnProperty(name)) {
         return env.bindings[name]
       }
@@ -220,7 +218,7 @@ export class ProgramMemory {
     if (this.environments.length === 0) {
       return new Error('No environment to set memory in')
     }
-    const env = this.environments[this.currentEnv[0]]
+    const env = this.environments[this.currentEnv]
     env.bindings[name] = value
     return null
   }

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -177,7 +177,7 @@ export class ProgramMemory {
     currentEnv: EnvironmentRef = 0,
     returnVal: ProgramReturn | null = null
   ) {
-    console.info('ProgramMemory.constructor', ...environments)
+    console.info('ProgramMemory.constructor', ...environments, currentEnv)
     this.environments = environments
     this.currentEnv = currentEnv
     this.return = returnVal

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -162,6 +162,11 @@ interface RawProgramMemory {
   return: ProgramReturn | null
 }
 
+/**
+ * This duplicates logic in Rust.  The hope is to keep ProgramMemory internals
+ * isolated from the rest of the TypeScript code so that we can move it to Rust
+ * in the future.
+ */
 export class ProgramMemory {
   private environments: Environment[]
   private currentEnv: EnvironmentRef
@@ -494,6 +499,9 @@ export function getTangentialArcToInfo({
   }
 }
 
+/**
+ * Returns new ProgramMemory with prelude definitions.
+ */
 export function programMemoryInit(): ProgramMemory | Error {
   try {
     const memory: RawProgramMemory = program_memory_init()

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -143,14 +143,18 @@ interface Memory {
   [key: string]: MemoryItem
 }
 
+interface Environment {
+  bindings: Memory
+}
+
 export interface ProgramMemory {
-  root: Memory
+  environments: Environment[]
   return: ProgramReturn | null
 }
 
 export const executor = async (
   node: Program,
-  programMemory: ProgramMemory | Error = { root: {}, return: null },
+  programMemory: ProgramMemory | Error = { environments: [], return: null },
   engineCommandManager: EngineCommandManager,
   isMock: boolean = false
 ): Promise<ProgramMemory> => {
@@ -171,7 +175,7 @@ export const executor = async (
 
 export const _executor = async (
   node: Program,
-  programMemory: ProgramMemory | Error = { root: {}, return: null },
+  programMemory: ProgramMemory | Error = { environments: [], return: null },
   engineCommandManager: EngineCommandManager,
   isMock: boolean
 ): Promise<ProgramMemory> => {

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -252,10 +252,11 @@ export class ProgramMemory {
   }
 
   /**
-   * Returns all variable entries in memory.  Structure returned is flat.  If
-   * variables are shadowed, they're not included.
+   * Returns all variable entries in memory that are visible, in a flat
+   * structure.  If variables are shadowed, they're not visible, and therefore,
+   * not included.
    */
-  flatEntries(): Map<string, MemoryItem> {
+  visibleEntries(): Map<string, MemoryItem> {
     const map = new Map<string, MemoryItem>()
     let envRef = this.currentEnv
     while (true) {
@@ -275,10 +276,11 @@ export class ProgramMemory {
   }
 
   /**
-   * More local variables are sorted earlier than more global variables.
+   * Returns values of visible variables.  More local variables are sorted
+   * earlier than more global variables.
    */
-  values(): MemoryItem[] {
-    return Array.from(this.flatEntries().values())
+  visibleValues(): MemoryItem[] {
+    return Array.from(this.visibleEntries().values())
   }
 
   /**

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -177,7 +177,8 @@ export class ProgramMemory {
   constructor(
     environments: Environment[] = [emptyEnvironment()],
     currentEnv: EnvironmentRef = [0],
-    returnVal: ProgramReturn | null = null) {
+    returnVal: ProgramReturn | null = null
+  ) {
     console.info('ProgramMemory.constructor', ...environments)
     this.environments = environments
     this.currentEnv = currentEnv
@@ -215,7 +216,11 @@ export class ProgramMemory {
     return null
   }
 
-  setInEnv(envRef: EnvironmentRef, name: string, value: MemoryItem): Error | null {
+  setInEnv(
+    envRef: EnvironmentRef,
+    name: string,
+    value: MemoryItem
+  ): Error | null {
     console.info('ProgramMemory.set', envRef, name, value)
     const env = this.environments[envRef[0]]
     if (!env) {
@@ -272,7 +277,7 @@ export class ProgramMemory {
     return {
       environments: this.environments,
       currentEnv: this.currentEnv,
-      return: this.return
+      return: this.return,
     }
   }
 }
@@ -323,7 +328,11 @@ export const _executor = async (
       fileSystemManager,
       isMock
     )
-    return new ProgramMemory(memory.environments, memory.currentEnv, memory.return)
+    return new ProgramMemory(
+      memory.environments,
+      memory.currentEnv,
+      memory.return
+    )
   } catch (e: any) {
     console.log(e)
     const parsed: RustKclError = JSON.parse(e.toString())
@@ -461,7 +470,11 @@ export function getTangentialArcToInfo({
 export function programMemoryInit(): ProgramMemory | Error {
   try {
     const memory: RawProgramMemory = program_memory_init()
-    return new ProgramMemory(memory.environments, memory.currentEnv, memory.return)
+    return new ProgramMemory(
+      memory.environments,
+      memory.currentEnv,
+      memory.return
+    )
   } catch (e: any) {
     console.log(e)
     const parsed: RustKclError = JSON.parse(e.toString())

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -179,6 +179,10 @@ export class ProgramMemory {
     return new ProgramMemory()
   }
 
+  static fromRaw(raw: RawProgramMemory): ProgramMemory {
+    return new ProgramMemory(raw.environments, raw.currentEnv, raw.return)
+  }
+
   constructor(
     environments: Environment[] = [emptyEnvironment()],
     currentEnv: EnvironmentRef = ROOT_ENVIRONMENT_REF,
@@ -187,6 +191,13 @@ export class ProgramMemory {
     this.environments = environments
     this.currentEnv = currentEnv
     this.return = returnVal
+  }
+
+  /**
+   * Returns a deep copy.
+   */
+  clone(): ProgramMemory {
+    return ProgramMemory.fromRaw(JSON.parse(JSON.stringify(this.toRaw())))
   }
 
   has(name: string): boolean {
@@ -369,11 +380,7 @@ export const _executor = async (
       fileSystemManager,
       isMock
     )
-    return new ProgramMemory(
-      memory.environments,
-      memory.currentEnv,
-      memory.return
-    )
+    return ProgramMemory.fromRaw(memory)
   } catch (e: any) {
     console.log(e)
     const parsed: RustKclError = JSON.parse(e.toString())

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -226,17 +226,25 @@ export class ProgramMemory {
   /**
    * Returns a new ProgramMemory with only `MemoryItem`s that pass the
    * predicate.  Values are deep copied.
+   *
+   * Note: Return value of the returned ProgramMemory is always null.
    */
   filterVariables(predicate: (value: MemoryItem) => boolean): ProgramMemory {
-    const newEnvironments = this.environments.map((env) => {
-      const newBindings = Object.fromEntries(
-        Object.entries(env.bindings).filter(([key, value]) =>
-          predicate(value)
-        ).map(([key, value]) => [key, JSON.parse(JSON.stringify(value))])
+    const environments = this.environments.map((env) => {
+      const bindings = Object.fromEntries(
+        Object.entries(env.bindings)
+          .filter(([key, value]) =>
+            // Pass the predicate.
+            predicate(value)
+          )
+          .map(([key, value]) =>
+            // Deep copy.
+            [key, JSON.parse(JSON.stringify(value))]
+          )
       )
-      return { bindings: newBindings, parent: env.parent }
+      return { bindings, parent: env.parent }
     })
-    return new ProgramMemory(newEnvironments, this.currentEnv, this.return)
+    return new ProgramMemory(environments, this.currentEnv, null)
   }
 
   allEnvironments(): Environment[] {

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -276,6 +276,8 @@ export class ProgramMemory {
    * Returns all variable entries in memory that are visible, in a flat
    * structure.  If variables are shadowed, they're not visible, and therefore,
    * not included.
+   *
+   * This should only be used to display in the MemoryPane UI.
    */
   visibleEntries(): Map<string, MemoryItem> {
     const map = new Map<string, MemoryItem>()
@@ -297,15 +299,20 @@ export class ProgramMemory {
   }
 
   /**
-   * Returns values of visible variables.  More local variables are sorted
-   * earlier than more global variables.
+   * Returns true if any visible variables are a SketchGroup or ExtrudeGroup.
    */
-  visibleValues(): MemoryItem[] {
-    return Array.from(this.visibleEntries().values())
+  hasSketchOrExtrudeGroup(): boolean {
+    for (const node of this.visibleEntries().values()) {
+      if (node.type === 'ExtrudeGroup' || node.type === 'SketchGroup') {
+        return true
+      }
+    }
+    return false
   }
 
   /**
-   * Return the representation that can be serialized to JSON.
+   * Return the representation that can be serialized to JSON.  This should only
+   * be used within this module.
    */
   toRaw(): RawProgramMemory {
     return {

--- a/src/lib/testHelpers.ts
+++ b/src/lib/testHelpers.ts
@@ -75,7 +75,7 @@ class MockEngineCommandManager {
 
 export async function enginelessExecutor(
   ast: Program | Error,
-  pm: ProgramMemory | Error = { environments: {}, return: null }
+  pm: ProgramMemory | Error = ProgramMemory.empty()
 ): Promise<ProgramMemory> {
   if (err(ast)) return Promise.reject(ast)
   if (err(pm)) return Promise.reject(pm)
@@ -93,7 +93,7 @@ export async function enginelessExecutor(
 
 export async function executor(
   ast: Program,
-  pm: ProgramMemory = { environments: {}, return: null }
+  pm: ProgramMemory = ProgramMemory.empty()
 ): Promise<ProgramMemory> {
   const engineCommandManager = new EngineCommandManager()
   engineCommandManager.start({

--- a/src/lib/testHelpers.ts
+++ b/src/lib/testHelpers.ts
@@ -75,7 +75,7 @@ class MockEngineCommandManager {
 
 export async function enginelessExecutor(
   ast: Program | Error,
-  pm: ProgramMemory | Error = { root: {}, return: null }
+  pm: ProgramMemory | Error = { environments: {}, return: null }
 ): Promise<ProgramMemory> {
   if (err(ast)) return Promise.reject(ast)
   if (err(pm)) return Promise.reject(pm)
@@ -93,7 +93,7 @@ export async function enginelessExecutor(
 
 export async function executor(
   ast: Program,
-  pm: ProgramMemory = { root: {}, return: null }
+  pm: ProgramMemory = { environments: {}, return: null }
 ): Promise<ProgramMemory> {
   const engineCommandManager = new EngineCommandManager()
   engineCommandManager.start({

--- a/src/lib/useCalculateKclExpression.ts
+++ b/src/lib/useCalculateKclExpression.ts
@@ -101,9 +101,7 @@ export function useCalculateKclExpression({
         ast,
         engineCommandManager,
         useFakeExecutor: true,
-        programMemoryOverride: JSON.parse(
-          JSON.stringify(kclManager.programMemory)
-        ),
+        programMemoryOverride: kclManager.programMemory.clone(),
       })
       const resultDeclaration = ast.body.find(
         (a) =>

--- a/src/lib/useCalculateKclExpression.ts
+++ b/src/lib/useCalculateKclExpression.ts
@@ -90,7 +90,11 @@ export function useCalculateKclExpression({
 
       const _programMem: ProgramMemory = ProgramMemory.empty()
       for (const { key, value } of availableVarInfo.variables) {
-        const error = _programMem.set(key, { type: 'userVal', value, __meta: [] })
+        const error = _programMem.set(key, {
+          type: 'userVal',
+          value,
+          __meta: [],
+        })
         if (trap(error, { suppress: true })) return
       }
       const { programMemory } = await executeAst({

--- a/src/lib/useCalculateKclExpression.ts
+++ b/src/lib/useCalculateKclExpression.ts
@@ -91,7 +91,7 @@ export function useCalculateKclExpression({
       const _programMem: ProgramMemory = ProgramMemory.empty()
       for (const { key, value } of availableVarInfo.variables) {
         const error = _programMem.set(key, {
-          type: 'userVal',
+          type: 'UserVal',
           value,
           __meta: [],
         })

--- a/src/lib/useCalculateKclExpression.ts
+++ b/src/lib/useCalculateKclExpression.ts
@@ -3,7 +3,7 @@ import { kclManager, engineCommandManager } from 'lib/singletons'
 import { useKclContext } from 'lang/KclProvider'
 import { findUniqueName } from 'lang/modifyAst'
 import { PrevVariable, findAllPreviousVariables } from 'lang/queryAst'
-import { Value, parse } from 'lang/wasm'
+import { ProgramMemory, Value, parse } from 'lang/wasm'
 import { useEffect, useRef, useState } from 'react'
 import { executeAst } from 'lang/langHelpers'
 import { err, trap } from 'lib/trap'
@@ -88,7 +88,7 @@ export function useCalculateKclExpression({
       if (err(ast)) return
       if (trap(ast, { suppress: true })) return
 
-      const _programMem: any = { root: {}, return: null }
+      const _programMem: ProgramMemory = ProgramMemory.empty()
       for (const { key, value } of availableVarInfo.variables) {
         const error = _programMem.set(key, { type: 'userVal', value, __meta: [] })
         if (trap(error, { suppress: true })) return

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -1139,8 +1139,8 @@ export const modelingMachine = createMachine(
         )
         if (err(varDecNode)) return
         const sketchVar = varDecNode.node.declarations[0].id.name
-        const sketchGroup = kclManager.programMemory.root[sketchVar]
-        if (sketchGroup.type !== 'SketchGroup') return
+        const sketchGroup = kclManager.programMemory.get(sketchVar)
+        if (sketchGroup?.type !== 'SketchGroup') return
         const idArtifact = engineCommandManager.artifactMap[sketchGroup.id]
         if (idArtifact.commandType !== 'start_path') return
         const extrusionArtifactId = (idArtifact as any)?.extrusions?.[0]

--- a/src/wasm-lib/kcl/src/ast/types.rs
+++ b/src/wasm-lib/kcl/src/ast/types.rs
@@ -1388,7 +1388,7 @@ impl CallExpression {
             }
             FunctionKind::UserDefined => {
                 let func = memory.get(&fn_name, self.into())?;
-                let result = func.call_fn(fn_args, memory.clone(), ctx.clone()).await.map_err(|e| {
+                let result = func.call_fn(fn_args, ctx.clone()).await.map_err(|e| {
                     // Add the call expression to the source ranges.
                     e.add_source_ranges(vec![self.into()])
                 })?;

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -82,8 +82,9 @@ impl ProgramMemory {
     }
 
     /// Find all extrude groups in the memory that are on a specific sketch group id.
+    /// This does not look inside closures.  But as long as we do not allow
+    /// mutation of variables in KCL, closure memory should be a subset of this.
     pub fn find_extrude_groups_on_sketch_group(&self, sketch_group_id: uuid::Uuid) -> Vec<Box<ExtrudeGroup>> {
-        // TODO: This is broken since adding closures.
         self.environments
             .iter()
             .flat_map(|env| {

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -1789,6 +1789,9 @@ impl ExecutorContext {
                         })
                     },
                 );
+                // Cloning memory here is crucial for semantics so that we close
+                // over variables.  Variables defined lexically later shouldn't
+                // be available to the function body.
                 MemoryItem::Function {
                     expression: function_expression.clone(),
                     meta: vec![metadata.to_owned()],

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -84,6 +84,7 @@ impl ProgramMemory {
 
     /// Find all extrude groups in the memory that are on a specific sketch group id.
     pub fn find_extrude_groups_on_sketch_group(&self, sketch_group_id: uuid::Uuid) -> Vec<Box<ExtrudeGroup>> {
+        // TODO: This is broken since adding closures.
         self.environments
             .iter()
             .flat_map(|env| {

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -129,6 +129,7 @@ pub struct Environment {
 impl Environment {
     pub fn root() -> Self {
         Self {
+            // Prelude
             bindings: HashMap::from([
                 (
                     "ZERO".to_string(),

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -1774,8 +1774,9 @@ impl ExecutorContext {
                      ctx: ExecutorContext| {
                         Box::pin(async move {
                             // Create a new environment to execute the function
-                            // body in.  Its parent should be the environment of
-                            // the closure.
+                            // body in so that local variables shadow variables
+                            // in the parent scope.  The new environment's
+                            // parent should be the environment of the closure.
                             let mut body_memory = memory.clone();
                             let closure_env = memory.current_env;
                             let body_env = body_memory.new_env_for_call(closure_env);

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -47,7 +47,6 @@ impl ProgramMemory {
 
     /// Add to the program memory in the current scope.
     pub fn add(&mut self, key: &str, value: MemoryItem, source_range: SourceRange) -> Result<(), KclError> {
-        // TODO: Use the Entry API.
         if self.environments[self.current_env.index()].contains_key(key) {
             return Err(KclError::ValueAlreadyDefined(KclErrorDetails {
                 message: format!("Cannot redefine `{}`", key),

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -24,7 +24,7 @@ use crate::{
 #[serde(rename_all = "camelCase")]
 pub struct ProgramMemory {
     /// Stack of environments.  Each environment corresponds to a call frame.
-    environments: Vec<Environment>,
+    pub environments: Vec<Environment>,
     #[serde(rename = "return")]
     pub return_: Option<ProgramReturn>,
 }
@@ -118,7 +118,7 @@ impl EnvironmentRef {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
-struct Environment {
+pub struct Environment {
     bindings: HashMap<String, MemoryItem>,
 }
 

--- a/src/wasm-lib/kcl/src/std/mod.rs
+++ b/src/wasm-lib/kcl/src/std/mod.rs
@@ -31,7 +31,7 @@ use crate::{
     ast::types::FunctionExpression,
     docs::StdLibFn,
     errors::KclError,
-    executor::{MemoryItem, SketchGroup, SketchSurface},
+    executor::{MemoryItem, ProgramMemory, SketchGroup, SketchSurface},
     std::kcl_stdlib::KclStdLibFn,
 };
 pub use args::Args;
@@ -281,6 +281,7 @@ pub enum Primitive {
 pub struct FnAsArg<'a> {
     pub func: &'a crate::executor::MemoryFunction,
     pub expr: Box<FunctionExpression>,
+    pub memory: Box<ProgramMemory>,
 }
 
 #[cfg(test)]

--- a/src/wasm-lib/kcl/src/std/patterns.rs
+++ b/src/wasm-lib/kcl/src/std/patterns.rs
@@ -87,7 +87,7 @@ pub async fn pattern_transform(args: Args) -> Result<MemoryItem, KclError> {
             fn_expr: transform.expr,
             meta: vec![args.source_range.into()],
             ctx: args.ctx.clone(),
-            memory: args.current_program_memory.clone(),
+            memory: *transform.memory,
         },
         extr,
         &args,

--- a/src/wasm-lib/tests/executor/main.rs
+++ b/src/wasm-lib/tests/executor/main.rs
@@ -1802,15 +1802,15 @@ fn pentagon = (len, taga, tagb, tagc) => {
   |> startProfileAt([-len / 2, -len / 2], %)
   |> angledLine({ angle: 0, length: len }, %,taga)
   |> angledLine({
-       angle: segAng(a, %) + 180 - 108,
+       angle: segAng(taga, %) + 180 - 108,
        length: len
      }, %, tagb)
   |> angledLine({
-       angle: segAng(b, %) + 180 - 108,
+       angle: segAng(tagb, %) + 180 - 108,
        length: len
      }, %,tagc)
   |> angledLine({
-       angle: segAng(c, %) + 180 - 108,
+       angle: segAng(tagc, %) + 180 - 108,
        length: len
      }, %, $d)
   |> angledLine({

--- a/src/wasm-lib/tests/executor/main.rs
+++ b/src/wasm-lib/tests/executor/main.rs
@@ -1797,20 +1797,20 @@ async fn serial_test_plumbus_fillets() {
   return sg
 }
 
-fn pentagon = (len, taga, tagb, tagc) => {
+fn pentagon = (len) => {
   const sg = startSketchOn('XY')
   |> startProfileAt([-len / 2, -len / 2], %)
-  |> angledLine({ angle: 0, length: len }, %,taga)
+  |> angledLine({ angle: 0, length: len }, %, $a)
   |> angledLine({
-       angle: segAng(taga, %) + 180 - 108,
+       angle: segAng(a, %) + 180 - 108,
        length: len
-     }, %, tagb)
+     }, %, $b)
   |> angledLine({
-       angle: segAng(tagb, %) + 180 - 108,
+       angle: segAng(b, %) + 180 - 108,
        length: len
-     }, %,tagc)
+     }, %, $c)
   |> angledLine({
-       angle: segAng(tagc, %) + 180 - 108,
+       angle: segAng(c, %) + 180 - 108,
        length: len
      }, %, $d)
   |> angledLine({
@@ -1821,7 +1821,7 @@ fn pentagon = (len, taga, tagb, tagc) => {
   return sg
 }
 
-const p = pentagon(32, $a, $b, $c)
+const p = pentagon(32)
   |> extrude(10, %)
 
 const plumbus0 = make_circle(p,a,  $arc_a, [0, 0], 2.5)

--- a/src/wasm-lib/tests/executor/main.rs
+++ b/src/wasm-lib/tests/executor/main.rs
@@ -1784,14 +1784,14 @@ const part002 = startSketchOn(part001, 'end')
 
 #[tokio::test(flavor = "multi_thread")]
 async fn serial_test_plumbus_fillets() {
-    let code = r#"fn make_circle = (ext, face, tag ,pos, radius) => {
+    let code = r#"fn make_circle = (ext, face, pos, radius) => {
   const sg = startSketchOn(ext, face)
   |> startProfileAt([pos[0] + radius, pos[1]], %)
   |> arc({
        angle_end: 360,
        angle_start: 0,
        radius: radius
-     }, %, tag)
+     }, %, $arc1)
   |> close(%)
 
   return sg
@@ -1824,18 +1824,20 @@ fn pentagon = (len) => {
 const p = pentagon(32)
   |> extrude(10, %)
 
-const plumbus0 = make_circle(p,a,  $arc_a, [0, 0], 2.5)
+const circle0 = make_circle(p, p.sketchGroup.tags.a, [0, 0], 2.5)
+const plumbus0 = circle0
   |> extrude(10, %)
   |> fillet({
        radius: 0.5,
-       tags: [arc_a, getOppositeEdge(arc_a, %)]
+       tags: [circle0.tags.arc1, getOppositeEdge(circle0.tags.arc1, %)]
      }, %)
 
-const plumbus1 = make_circle(p, b,$arc_b, [0, 0], 2.5)
+const circle1 = make_circle(p, p.sketchGroup.tags.b, [0, 0], 2.5)
+const plumbus1 = circle1
    |> extrude(10, %)
    |> fillet({
         radius: 0.5,
-        tags: [arc_b, getOppositeEdge(arc_b, %)]
+        tags: [circle1.tags.arc1, getOppositeEdge(circle1.tags.arc1, %)]
       }, %)
 "#;
 

--- a/src/wasm-lib/tests/modify/main.rs
+++ b/src/wasm-lib/tests/modify/main.rs
@@ -39,7 +39,7 @@ async fn setup(code: &str, name: &str) -> Result<(ExecutorContext, Program, uuid
 
     // We need to get the sketch ID.
     // Get the sketch group ID from memory.
-    let MemoryItem::SketchGroup(sketch_group) = memory.root.get(name).unwrap() else {
+    let MemoryItem::SketchGroup(sketch_group) = memory.get(name, SourceRange::default()).unwrap() else {
         anyhow::bail!("part001 not found in memory: {:?}", memory);
     };
     let sketch_id = sketch_group.id;


### PR DESCRIPTION
Fixes #1285.

# Overview

Prior to this, KCL implemented dynamic scope. With dynamic scope, in order to determine whether a variable is defined at a given point and what its type is, you needed to execute the program to follow its flow. This becomes harder and harder for anyone reading KCL code, especially when we start adding loops, recursion, etc.

```kcl
// With dynamic scope, this works.
fn returnX = () => {
  // What does x refer to?
  return x
}

const x = 2
const answer = returnX()
```

This PR changes KCL to use [lexical scope](https://en.wikipedia.org/wiki/Scope_(computer_science)). This generally makes it easier to reason about a snippet of code because you can find an identifier's definition above it in the source to determine its type. The runtime call stack cannot affect it. This also opens the doors to static type checking, if we ever decide to go down that route.

```kcl
const x = 2

// With lexical scope, x must be defined above.
fn returnX = () => {
  // It's clear what x refers to.
  return x
}

const answer = returnX()
```

Functions now also have their own scope, so redefining an identifier inside a function that's already used outside is possible. It shadows whatever is defined in the parent scope.

```kcl
const x = 2

fn returnX = () => {
  const x = 42
  return x
}

// The answer is 42. Here, x is still 2.
const answer = returnX()
```

# Details

Variables and tags now need to be defined before use. When I say "before", I mean higher up in the source code. It's no longer about execution order. This is how almost all real programming languages work. This is how `let` and `const` in JavaScript work. Interestingly, `var` and `function` in JavaScript are [hoisted](https://developer.mozilla.org/en-US/docs/Glossary/Hoisting) to the beginning of the scope. We may want to add something like that in the future, especially if we ever want to allow mutually recursive functions. But there's a reason `let` and `const` are the new default for developers using modern JavaScript.

Another change this PR makes is hiding the implementation of ProgramMemory on the TypeScript side in a class. Besides hopefully making it easier to migrate to Rust one day, this should make it easier to change the internals of ProgramMemory going forward. One reason to change it again is to improve KCL runtime performance.

# Breaking Change

This is a breaking change because programs that used to look like this no longer work.

```kcl
fn returnX = () => {
  return x
}

const x = 2
const answer = returnX()
```

The way to fix it is to move the variable definition to (textually) above its use.

```kcl
const x = 2

fn returnX = () => {
  return x
}

const answer = returnX()
```