### PR TITLE
Fix CI action for checking if Cargo.lock is stale

### DIFF
--- a/.github/workflows/cargo-clippy.yml
+++ b/.github/workflows/cargo-clippy.yml
@@ -63,5 +63,4 @@ jobs:
       # If this fails, run "cargo check" to update Cargo.lock,
       # then add Cargo.lock to the PR.
       - name: Check Cargo.lock doesn't need updating
-        run: |
-          cargo check --locked || echo "Pls run cargo check and commit the changed Cargo.lock"
+        run: "./scripts/check-tauri-lockfile.sh"

--- a/scripts/check-tauri-lockfile.sh
+++ b/scripts/check-tauri-lockfile.sh
@@ -1,0 +1,8 @@
+DIR=src-tauri
+cd $DIR
+if cargo check --locked ; then
+    echo "Seems $DIR/Cargo.lock is up to date."
+else
+    echo "Pls run cargo check and commit the changed $DIR/Cargo.lock, because it's out of date."
+fi
+cd -


### PR DESCRIPTION
It was falsely passing GH Action CI even when it shouldn't have.