### PR TITLE
Bump max_frame_size

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ After it runs you should just need the push the branch and open a PR.
 
 The PR may then serve as a place to discuss the human-readable changelog and extra QA. The `make-release.sh` tool suggests a changelog for you too to be used as PR description, just make sure to delete lines that are not user facing.
 
-#### 2. Smoke test artifacs from the Cut Release PR
+#### 2. Smoke test artifacts from the Cut Release PR
 
 The release builds can be find under the `artifact` zip, at the very bottom of the `ci` action page for each commit on this branch.
 

--- a/src/wasm-lib/kcl/src/engine/conn.rs
+++ b/src/wasm-lib/kcl/src/engine/conn.rs
@@ -168,10 +168,13 @@ impl EngineConnection {
         // See the `impl Default for WebSocketConfig` in
         // `tungstenite/protocol/mod.rs`
 
-        #[allow(clippy::field_reassign_with_default)]
         let mut wsconfig = tokio_tungstenite::tungstenite::protocol::WebSocketConfig::default();
         // 4294967296 bytes, which is around 4.2 GB.
+
+        #[allow(clippy::field_reassign_with_default)]
         wsconfig.max_message_size = Some(0x100000000);
+
+        #[allow(clippy::field_reassign_with_default)]
         wsconfig.max_frame_size = Some(0x100000000);
 
         let ws_stream = tokio_tungstenite::WebSocketStream::from_raw_socket(

--- a/src/wasm-lib/kcl/src/engine/conn.rs
+++ b/src/wasm-lib/kcl/src/engine/conn.rs
@@ -161,6 +161,14 @@ impl EngineConnection {
     }
 
     pub async fn new(ws: reqwest::Upgraded) -> Result<EngineConnection> {
+        // allowing the field_reassign_with_default lint here because the
+        // defaults for this object don't match the type defaults. We want
+        // to inherent the default config
+        //
+        // See the `impl Default for WebSocketConfig` in
+        // `tungstenite/protocol/mod.rs`
+
+        #[allow(clippy::field_reassign_with_default)]
         let mut wsconfig = tokio_tungstenite::tungstenite::protocol::WebSocketConfig::default();
         // 4294967296 bytes, which is around 4.2 GB.
         wsconfig.max_message_size = Some(0x100000000);

--- a/src/wasm-lib/kcl/src/engine/conn.rs
+++ b/src/wasm-lib/kcl/src/engine/conn.rs
@@ -160,6 +160,7 @@ impl EngineConnection {
         Ok(())
     }
 
+    #[allow(clippy::field_reassign_with_default)]
     pub async fn new(ws: reqwest::Upgraded) -> Result<EngineConnection> {
         // allowing the field_reassign_with_default lint here because the
         // defaults for this object don't match the type defaults. We want
@@ -170,11 +171,7 @@ impl EngineConnection {
 
         let mut wsconfig = tokio_tungstenite::tungstenite::protocol::WebSocketConfig::default();
         // 4294967296 bytes, which is around 4.2 GB.
-
-        #[allow(clippy::field_reassign_with_default)]
         wsconfig.max_message_size = Some(0x100000000);
-
-        #[allow(clippy::field_reassign_with_default)]
         wsconfig.max_frame_size = Some(0x100000000);
 
         let ws_stream = tokio_tungstenite::WebSocketStream::from_raw_socket(

--- a/src/wasm-lib/kcl/src/engine/conn.rs
+++ b/src/wasm-lib/kcl/src/engine/conn.rs
@@ -161,10 +161,15 @@ impl EngineConnection {
     }
 
     pub async fn new(ws: reqwest::Upgraded) -> Result<EngineConnection> {
+        let mut wsconfig = tokio_tungstenite::tungstenite::protocol::WebSocketConfig::default();
+        // 4294967296 bytes, which is around 4.2 GB.
+        wsconfig.max_message_size = Some(0x100000000);
+        wsconfig.max_frame_size = Some(0x100000000);
+
         let ws_stream = tokio_tungstenite::WebSocketStream::from_raw_socket(
             ws,
             tokio_tungstenite::tungstenite::protocol::Role::Client,
-            Some(tokio_tungstenite::tungstenite::protocol::WebSocketConfig { ..Default::default() }),
+            Some(wsconfig),
         )
         .await;
 


### PR DESCRIPTION
We use the WebSocket connection to send binary data (in the form of shapefiles) from the engine to the client. These can very easily get larger than the default 16MB limit on the max_frame_size. I don't understand why it won't stich multiple frames together - but given what I can see when this crashes, the max_message_size isn't the LIMFAC, max_frame_size is.

That's an issue for future-us.