### PR TITLE
[Experimental] Recursion using the Y combinator

### DIFF
--- a/src/wasm-lib/kcl/src/parser/parser_impl.rs
+++ b/src/wasm-lib/kcl/src/parser/parser_impl.rs
@@ -299,6 +299,7 @@ fn binary_operator(i: TokenSlice) -> PResult<BinaryOperator> {
             "*" => BinaryOperator::Mul,
             "%" => BinaryOperator::Mod,
             "^" => BinaryOperator::Pow,
+            "||" => BinaryOperator::LogicalOr,
             _ => {
                 return Err(KclError::Syntax(KclErrorDetails {
                     source_ranges: token.as_source_ranges(),
@@ -1136,11 +1137,11 @@ fn unary_expression(i: TokenSlice) -> PResult<UnaryExpression> {
     let (operator, op_token) = any
         .try_map(|token: Token| match token.token_type {
             TokenType::Operator if token.value == "-" => Ok((UnaryOperator::Neg, token)),
-            // TODO: negation. Original parser doesn't support `not` yet.
             TokenType::Operator => Err(KclError::Syntax(KclErrorDetails {
                 source_ranges: token.as_source_ranges(),
                 message: format!("{EXPECTED} but found {} which is an operator, but not a unary one (unary operators apply to just a single operand, your operator applies to two or more operands)", token.value.as_str(),),
             })),
+            TokenType::Bang => Ok((UnaryOperator::Not, token)),
             other => Err(KclError::Syntax(KclErrorDetails { source_ranges: token.as_source_ranges(), message: format!("{EXPECTED} but found {} which is {}", token.value.as_str(), other,) })),
         })
         .context(expected("a unary expression, e.g. -x or -3"))

--- a/src/wasm-lib/kcl/src/parser/parser_impl/error.rs
+++ b/src/wasm-lib/kcl/src/parser/parser_impl/error.rs
@@ -79,7 +79,7 @@ impl From<ParseError<&[Token], ContextError>> for KclError {
         // See https://github.com/KittyCAD/modeling-app/issues/784
         KclError::Syntax(KclErrorDetails {
             source_ranges: bad_token.as_source_ranges(),
-            message: "Unexpected token".to_string(),
+            message: format!("Unexpected token: {}", bad_token.value),
         })
     }
 }

--- a/src/wasm-lib/kcl/src/token/tokeniser.rs
+++ b/src/wasm-lib/kcl/src/token/tokeniser.rs
@@ -90,7 +90,7 @@ fn word(i: &mut Located<&str>) -> PResult<Token> {
 
 fn operator(i: &mut Located<&str>) -> PResult<Token> {
     let (value, range) = alt((
-        ">=", "<=", "==", "=>", "!= ", "|>", "*", "+", "-", "/", "%", "=", "<", ">", r"\", "|", "^",
+        ">=", "<=", "==", "=>", "!= ", "|>", "*", "+", "-", "/", "%", "=", "<", ">", r"\", "||", "|", "^",
     ))
     .with_span()
     .parse_next(i)?;


### PR DESCRIPTION
This is a proof of concept that's not meant to be merged. It implements a [fixed-piont combinator](https://en.wikipedia.org/wiki/Fixed-point_combinator), more commonly known as the Y combinator. Using this, we can do recursion in KCL.

I implemented a recursive `isEven()` function as a test case to prove that it works.

The few things missing that I also implemented were:

- Short-circuiting OR using `||`
- Logical NOT using `!`
- Improved parse error messages

I bumped into a few rough edges of the parser while implementing the Y combinator, but they're already separate issues.

Reference:

- [Why Y? Deriving the Y Combinator in JavaScript](https://raganwald.com/2018/09/10/why-y.html)
closes https://github.com/KittyCAD/modeling-app/issues/745