### PR TITLE
Fix to preserve types using structuredClone

### DIFF
--- a/packages/codemirror-lsp-client/src/client/server-capability-registration.ts
+++ b/packages/codemirror-lsp-client/src/client/server-capability-registration.ts
@@ -42,8 +42,8 @@ function registerServerCapability(
   serverCapabilities: ServerCapabilities,
   registration: Registration
 ): ServerCapabilities | Error {
-  const serverCapabilitiesCopy = JSON.parse(
-    JSON.stringify(serverCapabilities)
+  const serverCapabilitiesCopy = structuredClone(
+    serverCapabilities
   ) as IFlexibleServerCapabilities
   const { method, registerOptions } = registration
   const providerName = ServerCapabilitiesProviders[method]
@@ -54,7 +54,7 @@ function registerServerCapability(
     } else {
       serverCapabilitiesCopy[providerName] = Object.assign(
         {},
-        JSON.parse(JSON.stringify(registerOptions))
+        structuredClone(registerOptions)
       )
     }
   } else {
@@ -68,8 +68,8 @@ function unregisterServerCapability(
   serverCapabilities: ServerCapabilities,
   unregistration: Unregistration
 ): ServerCapabilities {
-  const serverCapabilitiesCopy = JSON.parse(
-    JSON.stringify(serverCapabilities)
+  const serverCapabilitiesCopy = structuredClone(
+    serverCapabilities
   ) as IFlexibleServerCapabilities
   const { method } = unregistration
   const providerName = ServerCapabilitiesProviders[method]

--- a/src/clientSideScene/sceneEntities.ts
+++ b/src/clientSideScene/sceneEntities.ts
@@ -535,7 +535,7 @@ export class SceneEntities {
     segmentName: 'line' | 'tangentialArcTo' = 'line',
     shouldTearDown = true
   ) => {
-    const _ast = JSON.parse(JSON.stringify(kclManager.ast))
+    const _ast = structuredClone(kclManager.ast)
 
     const _node1 = getNodeFromPath<VariableDeclaration>(
       _ast,
@@ -694,7 +694,7 @@ export class SceneEntities {
     sketchOrigin: [number, number, number],
     rectangleOrigin: [x: number, y: number]
   ) => {
-    let _ast = JSON.parse(JSON.stringify(kclManager.ast))
+    let _ast = structuredClone(kclManager.ast)
 
     const _node1 = getNodeFromPath<VariableDeclaration>(
       _ast,
@@ -725,7 +725,9 @@ export class SceneEntities {
       ...getRectangleCallExpressions(rectangleOrigin, tags),
     ])
 
-    _ast = parse(recast(_ast))
+    let _recastAst = parse(recast(_ast))
+    if (trap(_recastAst)) return Promise.reject(_recastAst)
+    _ast = _recastAst
 
     const { programMemoryOverride, truncatedAst } = await this.setupSketch({
       sketchPathToNode,
@@ -739,7 +741,7 @@ export class SceneEntities {
     sceneInfra.setCallbacks({
       onMove: async (args) => {
         // Update the width and height of the draft rectangle
-        const pathToNodeTwo = JSON.parse(JSON.stringify(sketchPathToNode))
+        const pathToNodeTwo = structuredClone(sketchPathToNode)
         pathToNodeTwo[1][0] = 0
 
         const _node = getNodeFromPath<VariableDeclaration>(
@@ -801,7 +803,9 @@ export class SceneEntities {
         if (sketchInit.type === 'PipeExpression') {
           updateRectangleSketch(sketchInit, x, y, tags[0])
 
-          _ast = parse(recast(_ast))
+          let _recastAst = parse(recast(_ast))
+          if (trap(_recastAst)) return Promise.reject(_recastAst)
+          _ast = _recastAst
 
           // Update the primary AST and unequip the rectangle tool
           await kclManager.executeAstMock(_ast)
@@ -1005,10 +1009,14 @@ export class SceneEntities {
       PROFILE_START,
     ])
     if (!group) return
-    const pathToNode: PathToNode = JSON.parse(
-      JSON.stringify(group.userData.pathToNode)
-    )
-    const varDecIndex = JSON.parse(JSON.stringify(pathToNode[1][0]))
+    const pathToNode: PathToNode = structuredClone(group.userData.pathToNode)
+    const varDecIndex = pathToNode[1][0]
+    if (typeof varDecIndex !== 'number') {
+      console.error(
+        `Expected varDecIndex to be a number, but found: ${typeof varDecIndex} ${varDecIndex}`
+      )
+      return
+    }
     if (draftInfo) {
       pathToNode[1][0] = 0
     }
@@ -1758,7 +1766,7 @@ function prepareTruncatedMemoryAndAst(
     }
   | Error {
   const bodyIndex = Number(sketchPathToNode?.[1]?.[0]) || 0
-  const _ast = JSON.parse(JSON.stringify(ast))
+  const _ast = structuredClone(ast)
 
   const _node = getNodeFromPath<VariableDeclaration>(
     _ast,
@@ -1817,7 +1825,7 @@ function prepareTruncatedMemoryAndAst(
   }
   const truncatedAst: Program = {
     ..._ast,
-    body: [JSON.parse(JSON.stringify(_ast.body[bodyIndex]))],
+    body: [structuredClone(_ast.body[bodyIndex])],
   }
 
   // Grab all the TagDeclarators and TagIdentifiers from memory.
@@ -1851,10 +1859,7 @@ function prepareTruncatedMemoryAndAst(
     if (!memoryItem) {
       continue
     }
-    const error = programMemoryOverride.set(
-      name,
-      JSON.parse(JSON.stringify(memoryItem))
-    )
+    const error = programMemoryOverride.set(name, structuredClone(memoryItem))
     if (err(error)) return error
   }
   return {

--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -495,7 +495,7 @@ export const ModelingMachineProvider = ({
           if (kclManager.ast.body.length) {
             // this assumes no changes have been made to the sketch besides what we did when entering the sketch
             // i.e. doesn't account for user's adding code themselves, maybe we need store a flag userEditedSinceSketchMode?
-            const newAst: Program = JSON.parse(JSON.stringify(kclManager.ast))
+            const newAst = structuredClone(kclManager.ast)
             const varDecIndex = sketchDetails.sketchPathToNode[1][0]
             // remove body item at varDecIndex
             newAst.body = newAst.body.filter((_, i) => i !== varDecIndex)

--- a/src/components/Toolbar/Intersect.tsx
+++ b/src/components/Toolbar/Intersect.tsx
@@ -145,7 +145,7 @@ export async function applyConstraintIntersect({
   const { transforms, forcedSelectionRanges } = info
 
   const transform1 = transformSecondarySketchLinesTagFirst({
-    ast: JSON.parse(JSON.stringify(kclManager.ast)),
+    ast: structuredClone(kclManager.ast),
     selectionRanges: forcedSelectionRanges,
     transformInfos: transforms,
     programMemory: kclManager.programMemory,

--- a/src/components/Toolbar/SetAbsDistance.tsx
+++ b/src/components/Toolbar/SetAbsDistance.tsx
@@ -106,7 +106,7 @@ export async function applyConstraintAbsDistance({
   const transformInfos = info.transforms
 
   const transform1 = transformAstSketchLines({
-    ast: JSON.parse(JSON.stringify(kclManager.ast)),
+    ast: structuredClone(kclManager.ast),
     selectionRanges: selectionRanges,
     transformInfos,
     programMemory: kclManager.programMemory,
@@ -128,7 +128,7 @@ export async function applyConstraintAbsDistance({
   )
 
   const transform2 = transformAstSketchLines({
-    ast: JSON.parse(JSON.stringify(kclManager.ast)),
+    ast: structuredClone(kclManager.ast),
     selectionRanges: selectionRanges,
     transformInfos,
     programMemory: kclManager.programMemory,
@@ -176,7 +176,7 @@ export function applyConstraintAxisAlign({
   let finalValue = createIdentifier('ZERO')
 
   return transformAstSketchLines({
-    ast: JSON.parse(JSON.stringify(kclManager.ast)),
+    ast: structuredClone(kclManager.ast),
     selectionRanges: selectionRanges,
     transformInfos,
     programMemory: kclManager.programMemory,

--- a/src/components/Toolbar/SetAngleBetween.tsx
+++ b/src/components/Toolbar/SetAngleBetween.tsx
@@ -100,7 +100,7 @@ export async function applyConstraintAngleBetween({
   const transformInfos = info.transforms
 
   const transformed1 = transformSecondarySketchLinesTagFirst({
-    ast: JSON.parse(JSON.stringify(kclManager.ast)),
+    ast: structuredClone(kclManager.ast),
     selectionRanges,
     transformInfos,
     programMemory: kclManager.programMemory,

--- a/src/components/Toolbar/SetHorzVertDistance.tsx
+++ b/src/components/Toolbar/SetHorzVertDistance.tsx
@@ -108,7 +108,7 @@ export async function applyConstraintHorzVertDistance({
   if (err(info)) return Promise.reject(info)
   const transformInfos = info.transforms
   const transformed = transformSecondarySketchLinesTagFirst({
-    ast: JSON.parse(JSON.stringify(kclManager.ast)),
+    ast: structuredClone(kclManager.ast),
     selectionRanges,
     transformInfos,
     programMemory: kclManager.programMemory,

--- a/src/components/Toolbar/setAngleLength.tsx
+++ b/src/components/Toolbar/setAngleLength.tsx
@@ -84,7 +84,7 @@ export async function applyConstraintAngleLength({
 
   const { transforms } = angleLength
   const sketched = transformAstSketchLines({
-    ast: JSON.parse(JSON.stringify(kclManager.ast)),
+    ast: structuredClone(kclManager.ast),
     selectionRanges,
     transformInfos: transforms,
     programMemory: kclManager.programMemory,
@@ -139,7 +139,7 @@ export async function applyConstraintAngleLength({
   }
 
   const retval = transformAstSketchLines({
-    ast: JSON.parse(JSON.stringify(kclManager.ast)),
+    ast: structuredClone(kclManager.ast),
     selectionRanges,
     transformInfos: transforms,
     programMemory: kclManager.programMemory,

--- a/src/lang/modifyAst.ts
+++ b/src/lang/modifyAst.ts
@@ -725,7 +725,7 @@ export function moveValueIntoNewVariablePath(
     programMemory,
     pathToNode
   )
-  let _node = JSON.parse(JSON.stringify(ast))
+  let _node = structuredClone(ast)
   const boop = replacer(_node, variableName)
   if (trap(boop)) return { modifiedAst: ast }
 
@@ -757,7 +757,7 @@ export function moveValueIntoNewVariable(
     programMemory,
     sourceRange
   )
-  let _node = JSON.parse(JSON.stringify(ast))
+  let _node = structuredClone(ast)
   const replaced = replacer(_node, variableName)
   if (trap(replaced)) return { modifiedAst: ast }
 
@@ -782,7 +782,7 @@ export function deleteSegmentFromPipeExpression(
   code: string,
   pathToNode: PathToNode
 ): Program | Error {
-  let _modifiedAst: Program = JSON.parse(JSON.stringify(modifiedAst))
+  let _modifiedAst = structuredClone(modifiedAst)
 
   dependentRanges.forEach((range) => {
     const path = getNodePathFromSourceRange(_modifiedAst, range)
@@ -899,7 +899,7 @@ export async function deleteFromSelection(
   getFaceDetails: (id: string) => Promise<Models['FaceIsPlanar_type']> = () =>
     ({} as any)
 ): Promise<Program | Error> {
-  const astClone = JSON.parse(JSON.stringify(ast))
+  const astClone = structuredClone(ast)
   const range = selection.range
   const path = getNodePathFromSourceRange(ast, range)
   const varDec = getNodeFromPath<VariableDeclarator>(

--- a/src/lang/modifyAst/addFillet.ts
+++ b/src/lang/modifyAst/addFillet.ts
@@ -38,8 +38,8 @@ export function addFillet(
   radius = createLiteral(5) as Value
   // shouldPipe = false, // TODO: Implement this feature
 ): { modifiedAst: Program; pathToFilletNode: PathToNode } | Error {
-  // close ast to make mutations safe
-  let _node: Program = JSON.parse(JSON.stringify(node))
+  // clone ast to make mutations safe
+  let _node = structuredClone(node)
 
   /**
    * Add Tag to the Segment Expression

--- a/src/lang/queryAst.test.ts
+++ b/src/lang/queryAst.test.ts
@@ -86,10 +86,7 @@ const yo2 = hmm([identifierGuy + 5])`
     expect(result.isSafe).toBe(true)
     expect(result.value?.type).toBe('BinaryExpression')
     expect(code.slice(result.value.start, result.value.end)).toBe('100 + 100')
-    const replaced = result.replacer(
-      JSON.parse(JSON.stringify(ast)),
-      'replaceName'
-    )
+    const replaced = result.replacer(structuredClone(ast), 'replaceName')
     if (err(replaced)) throw replaced
     const outCode = recast(replaced.modifiedAst)
     expect(outCode).toContain(`angledLine([replaceName, 3.09], %)`)
@@ -113,10 +110,7 @@ const yo2 = hmm([identifierGuy + 5])`
     expect(result.isSafe).toBe(true)
     expect(result.value?.type).toBe('CallExpression')
     expect(code.slice(result.value.start, result.value.end)).toBe("def('yo')")
-    const replaced = result.replacer(
-      JSON.parse(JSON.stringify(ast)),
-      'replaceName'
-    )
+    const replaced = result.replacer(structuredClone(ast), 'replaceName')
     if (err(replaced)) throw replaced
     const outCode = recast(replaced.modifiedAst)
     expect(outCode).toContain(`angledLine([replaceName, 3.09], %)`)
@@ -153,10 +147,7 @@ const yo2 = hmm([identifierGuy + 5])`
     expect(result.isSafe).toBe(true)
     expect(result.value?.type).toBe('BinaryExpression')
     expect(code.slice(result.value.start, result.value.end)).toBe('5 + 6')
-    const replaced = result.replacer(
-      JSON.parse(JSON.stringify(ast)),
-      'replaceName'
-    )
+    const replaced = result.replacer(structuredClone(ast), 'replaceName')
     if (err(replaced)) throw replaced
     const outCode = recast(replaced.modifiedAst)
     expect(outCode).toContain(`const yo = replaceName`)
@@ -172,10 +163,7 @@ const yo2 = hmm([identifierGuy + 5])`
     expect(code.slice(result.value.start, result.value.end)).toBe(
       "jkl('yo') + 2"
     )
-    const replaced = result.replacer(
-      JSON.parse(JSON.stringify(ast)),
-      'replaceName'
-    )
+    const replaced = result.replacer(structuredClone(ast), 'replaceName')
     if (err(replaced)) throw replaced
     const { modifiedAst } = replaced
     const outCode = recast(modifiedAst)
@@ -194,10 +182,7 @@ const yo2 = hmm([identifierGuy + 5])`
     expect(code.slice(result.value.start, result.value.end)).toBe(
       'identifierGuy + 5'
     )
-    const replaced = result.replacer(
-      JSON.parse(JSON.stringify(ast)),
-      'replaceName'
-    )
+    const replaced = result.replacer(structuredClone(ast), 'replaceName')
     if (err(replaced)) throw replaced
     const { modifiedAst } = replaced
     const outCode = recast(modifiedAst)

--- a/src/lang/queryAst.ts
+++ b/src/lang/queryAst.ts
@@ -545,8 +545,14 @@ export function isNodeSafeToReplacePath(
   const replaceNodeWithIdentifier: ReplacerFn = (_ast, varName) => {
     const identifier = createIdentifier(varName)
     const last = finPath[finPath.length - 1]
-    const pathToReplaced = JSON.parse(JSON.stringify(finPath))
-    pathToReplaced[1][0] = pathToReplaced[1][0] + 1
+    const pathToReplaced = structuredClone(finPath)
+    const index = pathToReplaced[1][0]
+    if (typeof index !== 'number') {
+      return new Error(
+        `Expected number index, but found: ${typeof index} ${index}`
+      )
+    }
+    pathToReplaced[1][0] = index + 1
     const startPath = finPath.slice(0, -1)
     const _nodeToReplace = getNodeFromPath(_ast, startPath)
     if (err(_nodeToReplace)) return _nodeToReplace

--- a/src/lang/std/sketch.ts
+++ b/src/lang/std/sketch.ts
@@ -1696,7 +1696,7 @@ export function addNewSketchLn({
       pathToNode: PathToNode
     }
   | Error {
-  const node = JSON.parse(JSON.stringify(_node))
+  const node = structuredClone(_node)
   const { add, updateArgs } = sketchLineHelperMap?.[fnName] || {}
   if (!add || !updateArgs) {
     return new Error('not a sketch line helper')

--- a/src/lang/std/sketchcombos.ts
+++ b/src/lang/std/sketchcombos.ts
@@ -1496,7 +1496,7 @@ export function transformSecondarySketchLinesTagFirst({
       }
     }
   | Error {
-  // let node = JSON.parse(JSON.stringify(ast))
+  // let node = structuredClone(ast)
   const primarySelection = selectionRanges.codeBasedSelections[0].range
 
   const _tag = giveSketchFnCallTag(ast, primarySelection, forceSegName)
@@ -1565,7 +1565,7 @@ export function transformAstSketchLines({
     }
   | Error {
   // deep clone since we are mutating in a loop, of which any could fail
-  let node = JSON.parse(JSON.stringify(ast))
+  let node = structuredClone(ast)
   let _valueUsedInTransform // TODO should this be an array?
   const pathToNodeMap: PathToNodeMap = {}
 

--- a/src/lang/util.ts
+++ b/src/lang/util.ts
@@ -38,7 +38,7 @@ export function updatePathToNodeFromMap(
   oldPath: PathToNode,
   pathToNodeMap: { [key: number]: PathToNode }
 ): PathToNode {
-  const updatedPathToNode = JSON.parse(JSON.stringify(oldPath))
+  const updatedPathToNode = structuredClone(oldPath)
   let max = 0
   Object.values(pathToNodeMap).forEach((path) => {
     const index = Number(path[1][0])

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -197,7 +197,7 @@ export class ProgramMemory {
    * Returns a deep copy.
    */
   clone(): ProgramMemory {
-    return ProgramMemory.fromRaw(JSON.parse(JSON.stringify(this.toRaw())))
+    return ProgramMemory.fromRaw(structuredClone(this.toRaw()))
   }
 
   has(name: string): boolean {
@@ -268,7 +268,7 @@ export class ProgramMemory {
           continue
         }
         // Deep copy.
-        bindings[name] = JSON.parse(JSON.stringify(value))
+        bindings[name] = structuredClone(value)
       }
       environments.push({ bindings, parent: env.parent })
     }

--- a/src/lib/coredump.ts
+++ b/src/lib/coredump.ts
@@ -1,4 +1,4 @@
-import { EngineCommandManager } from 'lang/std/engineConnection'
+import { CommandLog, EngineCommandManager } from 'lang/std/engineConnection'
 import { WebrtcStats } from 'wasm-lib/kcl/bindings/WebrtcStats'
 import { OsInfo } from 'wasm-lib/kcl/bindings/OsInfo'
 import { isTauri } from 'lib/isTauri'
@@ -142,16 +142,6 @@ export class CoreDumpManager {
   // Currently just a placeholder to begin loading singleton and xstate data into
   getClientState(): Promise<string> {
     /**
-     * Deep clone a JavaScript Object
-     * - NOTE: this function throws on parse errors from things like circular references
-     * - It is also synchronous and could be more performant
-     * - There is a whole rabbit hole to explore here if you like.
-     * - This works for our use case.
-     * @param {object} obj - The object to clone.
-     */
-    const deepClone = (obj: any) => JSON.parse(JSON.stringify(obj))
-
-    /**
      * Check if a function is private method
      */
     const isPrivateMethod = (key: string) => {
@@ -173,7 +163,7 @@ export class CoreDumpManager {
       // singletons
       engine_command_manager: {
         artifact_map: {},
-        command_logs: [],
+        command_logs: [] as CommandLog[],
         engine_connection: { state: { type: '' } },
         default_planes: {},
         scene_command_artifacts: {},
@@ -208,7 +198,7 @@ export class CoreDumpManager {
           'CoreDump: Engine Command Manager artifact map',
           this.engineCommandManager.artifactMap
         )
-        clientState.engine_command_manager.artifact_map = deepClone(
+        clientState.engine_command_manager.artifact_map = structuredClone(
           this.engineCommandManager.artifactMap
         )
       }
@@ -219,7 +209,7 @@ export class CoreDumpManager {
           'CoreDump: Engine Command Manager command logs',
           this.engineCommandManager.commandLogs
         )
-        clientState.engine_command_manager.command_logs = deepClone(
+        clientState.engine_command_manager.command_logs = structuredClone(
           this.engineCommandManager.commandLogs
         )
       }
@@ -230,7 +220,7 @@ export class CoreDumpManager {
           'CoreDump: Engine Command Manager default planes',
           this.engineCommandManager.defaultPlanes
         )
-        clientState.engine_command_manager.default_planes = deepClone(
+        clientState.engine_command_manager.default_planes = structuredClone(
           this.engineCommandManager.defaultPlanes
         )
       }
@@ -271,9 +261,8 @@ export class CoreDumpManager {
           'CoreDump: Engine Command Manager scene command artifacts',
           this.engineCommandManager.sceneCommandArtifacts
         )
-        clientState.engine_command_manager.scene_command_artifacts = deepClone(
-          this.engineCommandManager.sceneCommandArtifacts
-        )
+        clientState.engine_command_manager.scene_command_artifacts =
+          structuredClone(this.engineCommandManager.sceneCommandArtifacts)
       }
 
       // KCL Manager - globalThis?.window?.kclManager
@@ -284,13 +273,15 @@ export class CoreDumpManager {
         // KCL Manager AST
         debugLog('CoreDump: KCL Manager AST', kclManager?.ast)
         if (kclManager?.ast) {
-          clientState.kcl_manager.ast = deepClone(kclManager.ast)
+          clientState.kcl_manager.ast = structuredClone(kclManager.ast)
         }
 
         // KCL Errors
         debugLog('CoreDump: KCL Errors', kclManager?.kclErrors)
         if (kclManager?.kclErrors) {
-          clientState.kcl_manager.kcl_errors = deepClone(kclManager.kclErrors)
+          clientState.kcl_manager.kcl_errors = structuredClone(
+            kclManager.kclErrors
+          )
         }
 
         // KCL isExecuting
@@ -302,13 +293,15 @@ export class CoreDumpManager {
         // KCL logs
         debugLog('CoreDump: KCL logs', kclManager?.logs)
         if (kclManager?.logs) {
-          ;(clientState.kcl_manager as any).logs = deepClone(kclManager.logs)
+          ;(clientState.kcl_manager as any).logs = structuredClone(
+            kclManager.logs
+          )
         }
 
         // KCL programMemory
         debugLog('CoreDump: KCL programMemory', kclManager?.programMemory)
         if (kclManager?.programMemory) {
-          ;(clientState.kcl_manager as any).programMemory = deepClone(
+          ;(clientState.kcl_manager as any).programMemory = structuredClone(
             kclManager.programMemory
           )
         }
@@ -363,7 +356,7 @@ export class CoreDumpManager {
         )
         if (sceneEntitiesManager?.activeSegments) {
           ;(clientState.scene_entities_manager as any).activeSegments =
-            deepClone(sceneEntitiesManager.activeSegments)
+            structuredClone(sceneEntitiesManager.activeSegments)
         }
       }
 
@@ -387,7 +380,7 @@ export class CoreDumpManager {
         editorManagerKeys.forEach((key: string) => {
           debugLog('CoreDump: Editor Manager', key, editorManager[key])
           try {
-            ;(clientState.editor_manager as any)[key] = deepClone(
+            ;(clientState.editor_manager as any)[key] = structuredClone(
               editorManager[key]
             )
           } catch (error) {


### PR DESCRIPTION
# Overview

Instead of cloning objects by serializing through JSON, use the built-in [`structuredClone()`](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone) function. The benefit is that the return value preserves the type of the input value, avoiding the dreaded `any` type which disables the TS type-checker.

**Important:** Similar to going through JSON, it still only works with plain JS objects using literal syntax like `{ foo: 123 }`. If an object is an instance of a class or has any other prototype, that won't be preserved, and the type will be incorrect. For example, methods won't be present.