### PR TITLE
fix source code ranges for function calls

### DIFF
--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -16,7 +16,7 @@ use crate::{
     errors::{KclError, KclErrorDetails},
     fs::FileManager,
     settings::types::UnitLength,
-    std::{FnAsArg, FunctionKind, StdLib},
+    std::{FnAsArg, StdLib},
 };
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
@@ -1638,38 +1638,7 @@ impl ExecutorContext {
                     if let Value::PipeExpression(pipe_expr) = &expression_statement.expression {
                         pipe_expr.get_result(memory, &pipe_info, self).await?;
                     } else if let Value::CallExpression(call_expr) = &expression_statement.expression {
-                        let fn_name = call_expr.callee.name.to_string();
-                        let mut args: Vec<MemoryItem> = Vec::new();
-                        for arg in &call_expr.arguments {
-                            let metadata = Metadata {
-                                source_range: SourceRange([arg.start(), arg.end()]),
-                            };
-                            let mem_item = self
-                                .arg_into_mem_item(arg, memory, &pipe_info, &metadata, StatementKind::Expression)
-                                .await?;
-                            args.push(mem_item);
-                        }
-                        match self.stdlib.get_either(&call_expr.callee.name) {
-                            FunctionKind::Core(func) => {
-                                let args = crate::std::Args::new(args, call_expr.into(), self.clone(), memory.clone());
-                                let result = func.std_lib_fn()(args).await?;
-                                memory.return_ = Some(ProgramReturn::Value(result));
-                            }
-                            FunctionKind::Std(func) => {
-                                let mut newmem = memory.clone();
-                                let result = self.inner_execute(func.program(), &mut newmem, BodyType::Block).await?;
-                                memory.return_ = result.return_;
-                            }
-                            FunctionKind::UserDefined => {
-                                // TODO: Why do we change the source range to
-                                // the call expression instead of keeping the
-                                // range of the callee?
-                                let func = memory.get(&fn_name, call_expr.into())?;
-                                let result = func.call_fn(args.clone(), self.clone()).await?;
-
-                                memory.return_ = result;
-                            }
-                        }
+                        call_expr.execute(memory, &pipe_info, self).await?;
                     }
                 }
                 BodyItem::VariableDeclaration(variable_declaration) => {


### PR DESCRIPTION
closes https://github.com/KittyCAD/modeling-app/issues/3141

actually really glad you called that out @paultag because the problem was we werent using the execute function where we should but it is literally the line i put in the issue that allows this :)
<img width="597" alt="Screenshot 2024-07-28 at 11 24 06 PM" src="https://github.com/user-attachments/assets/b7ea14c2-9064-4da6-adc2-9ce06cc43da2">

