### PR TITLE
Add a test for onboarding code reset confirmation and persistence

### DIFF
--- a/e2e/playwright/flow-tests.spec.ts
+++ b/e2e/playwright/flow-tests.spec.ts
@@ -2265,6 +2265,51 @@ test.describe('Onboarding tests', () => {
     await expect(page.locator('.cm-content')).toContainText('// Shelf Bracket')
   })
 
+  test('Code resets after confirmation', async ({ context }) => {
+    const initialCode = `const sketch001 = startSketchOn('XZ')`
+
+    // Load the page up with some code so we see the confirmation warning
+    // when we go to replay onboarding
+    await context.addInitScript((code) => {
+      localStorage.setItem('persistCode', code)
+    }, initialCode)
+    const page = await context.newPage()
+
+    const u = await getUtils(page)
+    await page.setViewportSize({ width: 1200, height: 500 })
+    await u.waitForAuthSkipAppStart()
+
+    // Replay the onboarding
+    await page.getByRole('link', { name: 'Settings' }).last().click()
+    const replayButton = page.getByRole('button', { name: 'Replay onboarding' })
+    await expect(replayButton).toBeVisible()
+    await replayButton.click()
+
+    // Ensure we see the warning, and that the code has not yet updated
+    await expect(
+      page.getByText('Replaying onboarding resets your code')
+    ).toBeVisible()
+    await expect(page.locator('.cm-content')).toHaveText(initialCode)
+
+    const nextButton = page.getByTestId('onboarding-next')
+    await expect(nextButton).toBeVisible()
+    await nextButton.click()
+
+    // Ensure we see the introduction and that the code has been reset
+    await expect(page.getByText('Welcome to Modeling App!')).toBeVisible()
+    await expect(page.locator('.cm-content')).toContainText('// Shelf Bracket')
+
+    // Ensure we persisted the code to local storage.
+    // Playwright's addInitScript method unfortunately will reset
+    // this code if we try reloading the page as a test,
+    // so this is our best way to test persistence afaik.
+    expect(
+      await page.evaluate(() => {
+        return localStorage.getItem('persistCode')
+      })
+    ).toContain('// Shelf Bracket')
+  })
+
   test('Click through each onboarding step', async ({ page }) => {
     const u = await getUtils(page)
 

--- a/e2e/playwright/flow-tests.spec.ts
+++ b/e2e/playwright/flow-tests.spec.ts
@@ -2265,15 +2265,14 @@ test.describe('Onboarding tests', () => {
     await expect(page.locator('.cm-content')).toContainText('// Shelf Bracket')
   })
 
-  test('Code resets after confirmation', async ({ context }) => {
+  test('Code resets after confirmation', async ({ page }) => {
     const initialCode = `const sketch001 = startSketchOn('XZ')`
 
     // Load the page up with some code so we see the confirmation warning
     // when we go to replay onboarding
-    await context.addInitScript((code) => {
+    await page.addInitScript((code) => {
       localStorage.setItem('persistCode', code)
     }, initialCode)
-    const page = await context.newPage()
 
     const u = await getUtils(page)
     await page.setViewportSize({ width: 1200, height: 500 })

--- a/src/routes/Onboarding/index.tsx
+++ b/src/routes/Onboarding/index.tsx
@@ -86,7 +86,7 @@ export function useDemoCode() {
       await kclManager.executeCode(true).then(() => {
         kclManager.isFirstRender = false
       })
-      codeManager.writeToFile()
+      await codeManager.writeToFile()
     })
   }, [editorManager.editorView])
 }


### PR DESCRIPTION
Adds a Playwright test for the two scenarios fixed in #3151. Note that because our method for seeding the browser local storage with code (`page` or `context.addInitScript`) runs before any browser-level navigation, including `page.reload()`, the only way I could find to test persistence was to open the black box a little bit and look at the localStorage to confirm it was written to. I would love to just look at the code pane after a normal reload.