### PR TITLE
Fix to not crash when there's no var declaration

### DIFF
--- a/src/lang/queryAst.ts
+++ b/src/lang/queryAst.ts
@@ -869,6 +869,7 @@ export function hasSketchPipeBeenExtruded(selection: Selection, ast: Program) {
   )
   if (err(_varDec)) return false
   const varDec = _varDec.node
+  if (varDec.type !== 'VariableDeclarator') return false
   let extruded = false
   traverse(ast as any, {
     enter(node) {


### PR DESCRIPTION
Fixes #3134.

I'd like to make a follow-up PR that makes the types more accurate, which would have prevented this issue.