### PR TITLE
bugfix: KCL Test Server should clear scene properly

### DIFF
--- a/src/wasm-lib/kcl-test-server/src/lib.rs
+++ b/src/wasm-lib/kcl-test-server/src/lib.rs
@@ -166,7 +166,9 @@ async fn snapshot_endpoint(body: Bytes, state: ExecutorContext) -> Response<Body
         Err(e) => return bad_request(format!("Parse error: {e}")),
     };
     eprintln!("Executing {test_name}");
-    if let Err(e) = state.reset_scene().await {
+    // This is a shitty source range, I don't know what else to use for it though.
+    // There's no actual KCL associated with this reset_scene call.
+    if let Err(e) = state.reset_scene(kcl_lib::executor::SourceRange::default()).await {
         return kcl_err(e);
     }
     // Let users know if the test is taking a long time.

--- a/src/wasm-lib/kcl/src/engine/mod.rs
+++ b/src/wasm-lib/kcl/src/engine/mod.rs
@@ -45,7 +45,7 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
     ) -> Result<DefaultPlanes, crate::errors::KclError>;
 
     /// Helpers to be called after clearing a scene.
-    /// (These really only apply to wasm for now.
+    /// (These really only apply to wasm for now).
     async fn clear_scene_post_hook(
         &self,
         source_range: crate::executor::SourceRange,

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -1061,6 +1061,12 @@ pub enum BodyType {
 #[ts(export)]
 pub struct SourceRange(#[ts(type = "[number, number]")] pub [usize; 2]);
 
+impl From<[usize; 2]> for SourceRange {
+    fn from(value: [usize; 2]) -> Self {
+        Self(value)
+    }
+}
+
 impl SourceRange {
     /// Create a new source range.
     pub fn new(start: usize, end: usize) -> Self {
@@ -1587,15 +1593,8 @@ impl ExecutorContext {
         Ok(ctx)
     }
 
-    /// Clear everything in the scene.
-    pub async fn reset_scene(&self) -> Result<()> {
-        self.engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                SourceRange::default(),
-                kittycad::types::ModelingCmd::SceneClearAll {},
-            )
-            .await?;
+    pub async fn reset_scene(&self, source_range: crate::executor::SourceRange) -> Result<()> {
+        self.engine.clear_scene(source_range).await?;
         Ok(())
     }
 


### PR DESCRIPTION
Problem: My KCL test server was clearing the scene before starting each KCL program, but that meant the default sketch planes were gone.

Solution: There was already a Reset Scene method which properly cleaned up the 3D modeling scene. I didn't know about it, so I wrote my own. But my own one didn't call the necessary post-clear hooks, so it didn't recreate the default planes.

This PR calls the right Reset Scene method, so the default planes get recreated after the scene is cleared.