### PR TITLE
Simplify the KCL stdlib test codegen

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -649,6 +649,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,6 +2406,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99314c8a2152b8ddb211f924cdae532d8c5e4c8bb54728e12fff1b0cd5963a10"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "num-traits",
+ "png",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2589,6 +2607,7 @@ dependencies = [
  "futures",
  "git_rev",
  "gltf-json",
+ "image",
  "js-sys",
  "kittycad",
  "lazy_static",

--- a/src/wasm-lib/derive-docs/src/lib.rs
+++ b/src/wasm-lib/derive-docs/src/lib.rs
@@ -766,85 +766,10 @@ fn generate_code_block_test(fn_name: &str, code_block: &str, index: usize) -> pr
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
         async fn #test_name() {
-            let user_agent = concat!(env!("CARGO_PKG_NAME"), ".rs/", env!("CARGO_PKG_VERSION"),);
-            let http_client = reqwest::Client::builder()
-                .user_agent(user_agent)
-                // For file conversions we need this to be long.
-                .timeout(std::time::Duration::from_secs(600))
-                .connect_timeout(std::time::Duration::from_secs(60));
-            let ws_client = reqwest::Client::builder()
-                .user_agent(user_agent)
-                // For file conversions we need this to be long.
-                .timeout(std::time::Duration::from_secs(600))
-                .connect_timeout(std::time::Duration::from_secs(60))
-                .connection_verbose(true)
-                .tcp_keepalive(std::time::Duration::from_secs(600))
-                .http1_only();
-
-            let token = std::env::var("KITTYCAD_API_TOKEN").expect("KITTYCAD_API_TOKEN not set");
-
-            // Create the client.
-            let mut client = kittycad::Client::new_from_reqwest(token, http_client, ws_client);
-            // Set a local engine address if it's set.
-            if let Ok(addr) = std::env::var("LOCAL_ENGINE_ADDR") {
-                client.set_base_url(addr);
-            }
-
-            let tokens = crate::token::lexer(#code_block).unwrap();
-            let parser = crate::parser::Parser::new(tokens);
-            let program = parser.ast().unwrap();
-            let ctx = crate::executor::ExecutorContext::new(&client, Default::default()).await.unwrap();
-
-            ctx.run(&program, None).await.unwrap();
-
-            // Ensure it lints.
-            let results = program.lint_all().unwrap();
-            if !results.is_empty() {
-                panic!("Linting failed: {:?}", results);
-            }
-
-            // Zoom to fit.
-            ctx.engine
-                .send_modeling_cmd(
-                    uuid::Uuid::new_v4(),
-                    crate::executor::SourceRange::default(),
-                    kittycad::types::ModelingCmd::ZoomToFit {
-                        object_ids: Default::default(),
-                        padding: 0.1,
-                    },
-                )
-                .await.unwrap();
-
-            // Send a snapshot request to the engine.
-            let resp = ctx
-                .engine
-                .send_modeling_cmd(
-                    uuid::Uuid::new_v4(),
-                    crate::executor::SourceRange::default(),
-                    kittycad::types::ModelingCmd::TakeSnapshot {
-                        format: kittycad::types::ImageFormat::Png,
-                    },
-                )
-                .await.unwrap();
-
-            // Create a temporary file to write the output to.
-            let output_file = std::env::temp_dir().join(format!("kcl_output_{}.png", uuid::Uuid::new_v4()));
-
-            if let kittycad::types::OkWebSocketResponseData::Modeling {
-                modeling_response: kittycad::types::OkModelingCmdResponse::TakeSnapshot { data },
-            } = &resp
-            {
-                // Save the snapshot locally.
-                std::fs::write(&output_file, &data.contents.0).unwrap();
-            } else {
-                panic!("Unexpected response from engine: {:?}", resp);
-            }
-
-
-            // Read the output file.
-            let actual = image::io::Reader::open(output_file).unwrap().decode().unwrap();
-            twenty_twenty::assert_image(&format!("tests/outputs/{}.png", #test_name_str), &actual, 0.99);
-
+            let code = #code_block;
+            // Note, `crate` must be kcl_lib
+            let result = crate::test_server::execute_and_snapshot(code, crate::settings::types::UnitLength::Mm).await.unwrap();
+            twenty_twenty::assert_image(&format!("tests/outputs/{}.png", #test_name_str), &result, 0.99);
         }
     }
 }

--- a/src/wasm-lib/derive-docs/tests/args_with_lifetime.gen
+++ b/src/wasm-lib/derive-docs/tests/args_with_lifetime.gen
@@ -21,76 +21,14 @@ mod test_examples_someFn {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn serial_test_example_someFn0() {
-        let user_agent = concat!(env!("CARGO_PKG_NAME"), ".rs/", env!("CARGO_PKG_VERSION"),);
-        let http_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60));
-        let ws_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60))
-            .connection_verbose(true)
-            .tcp_keepalive(std::time::Duration::from_secs(600))
-            .http1_only();
-        let token = std::env::var("KITTYCAD_API_TOKEN").expect("KITTYCAD_API_TOKEN not set");
-        let mut client = kittycad::Client::new_from_reqwest(token, http_client, ws_client);
-        if let Ok(addr) = std::env::var("LOCAL_ENGINE_ADDR") {
-            client.set_base_url(addr);
-        }
-
-        let tokens = crate::token::lexer("someFn()").unwrap();
-        let parser = crate::parser::Parser::new(tokens);
-        let program = parser.ast().unwrap();
-        let ctx = crate::executor::ExecutorContext::new(&client, Default::default())
-            .await
-            .unwrap();
-        ctx.run(&program, None).await.unwrap();
-        let results = program.lint_all().unwrap();
-        if !results.is_empty() {
-            panic!("Linting failed: {:?}", results);
-        }
-
-        ctx.engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::ZoomToFit {
-                    object_ids: Default::default(),
-                    padding: 0.1,
-                },
-            )
-            .await
-            .unwrap();
-        let resp = ctx
-            .engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::TakeSnapshot {
-                    format: kittycad::types::ImageFormat::Png,
-                },
-            )
-            .await
-            .unwrap();
-        let output_file =
-            std::env::temp_dir().join(format!("kcl_output_{}.png", uuid::Uuid::new_v4()));
-        if let kittycad::types::OkWebSocketResponseData::Modeling {
-            modeling_response: kittycad::types::OkModelingCmdResponse::TakeSnapshot { data },
-        } = &resp
-        {
-            std::fs::write(&output_file, &data.contents.0).unwrap();
-        } else {
-            panic!("Unexpected response from engine: {:?}", resp);
-        }
-
-        let actual = image::io::Reader::open(output_file)
-            .unwrap()
-            .decode()
-            .unwrap();
+        let code = "someFn()";
+        let result =
+            crate::test_server::execute_and_snapshot(code, crate::settings::types::UnitLength::Mm)
+                .await
+                .unwrap();
         twenty_twenty::assert_image(
             &format!("tests/outputs/{}.png", "serial_test_example_someFn0"),
-            &actual,
+            &result,
             0.99,
         );
     }

--- a/src/wasm-lib/derive-docs/tests/args_with_refs.gen
+++ b/src/wasm-lib/derive-docs/tests/args_with_refs.gen
@@ -21,76 +21,14 @@ mod test_examples_someFn {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn serial_test_example_someFn0() {
-        let user_agent = concat!(env!("CARGO_PKG_NAME"), ".rs/", env!("CARGO_PKG_VERSION"),);
-        let http_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60));
-        let ws_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60))
-            .connection_verbose(true)
-            .tcp_keepalive(std::time::Duration::from_secs(600))
-            .http1_only();
-        let token = std::env::var("KITTYCAD_API_TOKEN").expect("KITTYCAD_API_TOKEN not set");
-        let mut client = kittycad::Client::new_from_reqwest(token, http_client, ws_client);
-        if let Ok(addr) = std::env::var("LOCAL_ENGINE_ADDR") {
-            client.set_base_url(addr);
-        }
-
-        let tokens = crate::token::lexer("someFn()").unwrap();
-        let parser = crate::parser::Parser::new(tokens);
-        let program = parser.ast().unwrap();
-        let ctx = crate::executor::ExecutorContext::new(&client, Default::default())
-            .await
-            .unwrap();
-        ctx.run(&program, None).await.unwrap();
-        let results = program.lint_all().unwrap();
-        if !results.is_empty() {
-            panic!("Linting failed: {:?}", results);
-        }
-
-        ctx.engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::ZoomToFit {
-                    object_ids: Default::default(),
-                    padding: 0.1,
-                },
-            )
-            .await
-            .unwrap();
-        let resp = ctx
-            .engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::TakeSnapshot {
-                    format: kittycad::types::ImageFormat::Png,
-                },
-            )
-            .await
-            .unwrap();
-        let output_file =
-            std::env::temp_dir().join(format!("kcl_output_{}.png", uuid::Uuid::new_v4()));
-        if let kittycad::types::OkWebSocketResponseData::Modeling {
-            modeling_response: kittycad::types::OkModelingCmdResponse::TakeSnapshot { data },
-        } = &resp
-        {
-            std::fs::write(&output_file, &data.contents.0).unwrap();
-        } else {
-            panic!("Unexpected response from engine: {:?}", resp);
-        }
-
-        let actual = image::io::Reader::open(output_file)
-            .unwrap()
-            .decode()
-            .unwrap();
+        let code = "someFn()";
+        let result =
+            crate::test_server::execute_and_snapshot(code, crate::settings::types::UnitLength::Mm)
+                .await
+                .unwrap();
         twenty_twenty::assert_image(
             &format!("tests/outputs/{}.png", "serial_test_example_someFn0"),
-            &actual,
+            &result,
             0.99,
         );
     }

--- a/src/wasm-lib/derive-docs/tests/array.gen
+++ b/src/wasm-lib/derive-docs/tests/array.gen
@@ -21,76 +21,14 @@ mod test_examples_show {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn serial_test_example_show0() {
-        let user_agent = concat!(env!("CARGO_PKG_NAME"), ".rs/", env!("CARGO_PKG_VERSION"),);
-        let http_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60));
-        let ws_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60))
-            .connection_verbose(true)
-            .tcp_keepalive(std::time::Duration::from_secs(600))
-            .http1_only();
-        let token = std::env::var("KITTYCAD_API_TOKEN").expect("KITTYCAD_API_TOKEN not set");
-        let mut client = kittycad::Client::new_from_reqwest(token, http_client, ws_client);
-        if let Ok(addr) = std::env::var("LOCAL_ENGINE_ADDR") {
-            client.set_base_url(addr);
-        }
-
-        let tokens = crate::token::lexer("This is another code block.\nyes sirrr.\nshow").unwrap();
-        let parser = crate::parser::Parser::new(tokens);
-        let program = parser.ast().unwrap();
-        let ctx = crate::executor::ExecutorContext::new(&client, Default::default())
-            .await
-            .unwrap();
-        ctx.run(&program, None).await.unwrap();
-        let results = program.lint_all().unwrap();
-        if !results.is_empty() {
-            panic!("Linting failed: {:?}", results);
-        }
-
-        ctx.engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::ZoomToFit {
-                    object_ids: Default::default(),
-                    padding: 0.1,
-                },
-            )
-            .await
-            .unwrap();
-        let resp = ctx
-            .engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::TakeSnapshot {
-                    format: kittycad::types::ImageFormat::Png,
-                },
-            )
-            .await
-            .unwrap();
-        let output_file =
-            std::env::temp_dir().join(format!("kcl_output_{}.png", uuid::Uuid::new_v4()));
-        if let kittycad::types::OkWebSocketResponseData::Modeling {
-            modeling_response: kittycad::types::OkModelingCmdResponse::TakeSnapshot { data },
-        } = &resp
-        {
-            std::fs::write(&output_file, &data.contents.0).unwrap();
-        } else {
-            panic!("Unexpected response from engine: {:?}", resp);
-        }
-
-        let actual = image::io::Reader::open(output_file)
-            .unwrap()
-            .decode()
-            .unwrap();
+        let code = "This is another code block.\nyes sirrr.\nshow";
+        let result =
+            crate::test_server::execute_and_snapshot(code, crate::settings::types::UnitLength::Mm)
+                .await
+                .unwrap();
         twenty_twenty::assert_image(
             &format!("tests/outputs/{}.png", "serial_test_example_show0"),
-            &actual,
+            &result,
             0.99,
         );
     }
@@ -116,76 +54,14 @@ mod test_examples_show {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn serial_test_example_show1() {
-        let user_agent = concat!(env!("CARGO_PKG_NAME"), ".rs/", env!("CARGO_PKG_VERSION"),);
-        let http_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60));
-        let ws_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60))
-            .connection_verbose(true)
-            .tcp_keepalive(std::time::Duration::from_secs(600))
-            .http1_only();
-        let token = std::env::var("KITTYCAD_API_TOKEN").expect("KITTYCAD_API_TOKEN not set");
-        let mut client = kittycad::Client::new_from_reqwest(token, http_client, ws_client);
-        if let Ok(addr) = std::env::var("LOCAL_ENGINE_ADDR") {
-            client.set_base_url(addr);
-        }
-
-        let tokens = crate::token::lexer("This is code.\nIt does other shit.\nshow").unwrap();
-        let parser = crate::parser::Parser::new(tokens);
-        let program = parser.ast().unwrap();
-        let ctx = crate::executor::ExecutorContext::new(&client, Default::default())
-            .await
-            .unwrap();
-        ctx.run(&program, None).await.unwrap();
-        let results = program.lint_all().unwrap();
-        if !results.is_empty() {
-            panic!("Linting failed: {:?}", results);
-        }
-
-        ctx.engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::ZoomToFit {
-                    object_ids: Default::default(),
-                    padding: 0.1,
-                },
-            )
-            .await
-            .unwrap();
-        let resp = ctx
-            .engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::TakeSnapshot {
-                    format: kittycad::types::ImageFormat::Png,
-                },
-            )
-            .await
-            .unwrap();
-        let output_file =
-            std::env::temp_dir().join(format!("kcl_output_{}.png", uuid::Uuid::new_v4()));
-        if let kittycad::types::OkWebSocketResponseData::Modeling {
-            modeling_response: kittycad::types::OkModelingCmdResponse::TakeSnapshot { data },
-        } = &resp
-        {
-            std::fs::write(&output_file, &data.contents.0).unwrap();
-        } else {
-            panic!("Unexpected response from engine: {:?}", resp);
-        }
-
-        let actual = image::io::Reader::open(output_file)
-            .unwrap()
-            .decode()
-            .unwrap();
+        let code = "This is code.\nIt does other shit.\nshow";
+        let result =
+            crate::test_server::execute_and_snapshot(code, crate::settings::types::UnitLength::Mm)
+                .await
+                .unwrap();
         twenty_twenty::assert_image(
             &format!("tests/outputs/{}.png", "serial_test_example_show1"),
-            &actual,
+            &result,
             0.99,
         );
     }

--- a/src/wasm-lib/derive-docs/tests/box.gen
+++ b/src/wasm-lib/derive-docs/tests/box.gen
@@ -21,76 +21,14 @@ mod test_examples_show {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn serial_test_example_show0() {
-        let user_agent = concat!(env!("CARGO_PKG_NAME"), ".rs/", env!("CARGO_PKG_VERSION"),);
-        let http_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60));
-        let ws_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60))
-            .connection_verbose(true)
-            .tcp_keepalive(std::time::Duration::from_secs(600))
-            .http1_only();
-        let token = std::env::var("KITTYCAD_API_TOKEN").expect("KITTYCAD_API_TOKEN not set");
-        let mut client = kittycad::Client::new_from_reqwest(token, http_client, ws_client);
-        if let Ok(addr) = std::env::var("LOCAL_ENGINE_ADDR") {
-            client.set_base_url(addr);
-        }
-
-        let tokens = crate::token::lexer("This is code.\nIt does other shit.\nshow").unwrap();
-        let parser = crate::parser::Parser::new(tokens);
-        let program = parser.ast().unwrap();
-        let ctx = crate::executor::ExecutorContext::new(&client, Default::default())
-            .await
-            .unwrap();
-        ctx.run(&program, None).await.unwrap();
-        let results = program.lint_all().unwrap();
-        if !results.is_empty() {
-            panic!("Linting failed: {:?}", results);
-        }
-
-        ctx.engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::ZoomToFit {
-                    object_ids: Default::default(),
-                    padding: 0.1,
-                },
-            )
-            .await
-            .unwrap();
-        let resp = ctx
-            .engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::TakeSnapshot {
-                    format: kittycad::types::ImageFormat::Png,
-                },
-            )
-            .await
-            .unwrap();
-        let output_file =
-            std::env::temp_dir().join(format!("kcl_output_{}.png", uuid::Uuid::new_v4()));
-        if let kittycad::types::OkWebSocketResponseData::Modeling {
-            modeling_response: kittycad::types::OkModelingCmdResponse::TakeSnapshot { data },
-        } = &resp
-        {
-            std::fs::write(&output_file, &data.contents.0).unwrap();
-        } else {
-            panic!("Unexpected response from engine: {:?}", resp);
-        }
-
-        let actual = image::io::Reader::open(output_file)
-            .unwrap()
-            .decode()
-            .unwrap();
+        let code = "This is code.\nIt does other shit.\nshow";
+        let result =
+            crate::test_server::execute_and_snapshot(code, crate::settings::types::UnitLength::Mm)
+                .await
+                .unwrap();
         twenty_twenty::assert_image(
             &format!("tests/outputs/{}.png", "serial_test_example_show0"),
-            &actual,
+            &result,
             0.99,
         );
     }

--- a/src/wasm-lib/derive-docs/tests/doc_comment_with_code.gen
+++ b/src/wasm-lib/derive-docs/tests/doc_comment_with_code.gen
@@ -22,77 +22,14 @@ mod test_examples_my_func {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn serial_test_example_my_func0() {
-        let user_agent = concat!(env!("CARGO_PKG_NAME"), ".rs/", env!("CARGO_PKG_VERSION"),);
-        let http_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60));
-        let ws_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60))
-            .connection_verbose(true)
-            .tcp_keepalive(std::time::Duration::from_secs(600))
-            .http1_only();
-        let token = std::env::var("KITTYCAD_API_TOKEN").expect("KITTYCAD_API_TOKEN not set");
-        let mut client = kittycad::Client::new_from_reqwest(token, http_client, ws_client);
-        if let Ok(addr) = std::env::var("LOCAL_ENGINE_ADDR") {
-            client.set_base_url(addr);
-        }
-
-        let tokens =
-            crate::token::lexer("This is another code block.\nyes sirrr.\nmyFunc").unwrap();
-        let parser = crate::parser::Parser::new(tokens);
-        let program = parser.ast().unwrap();
-        let ctx = crate::executor::ExecutorContext::new(&client, Default::default())
-            .await
-            .unwrap();
-        ctx.run(&program, None).await.unwrap();
-        let results = program.lint_all().unwrap();
-        if !results.is_empty() {
-            panic!("Linting failed: {:?}", results);
-        }
-
-        ctx.engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::ZoomToFit {
-                    object_ids: Default::default(),
-                    padding: 0.1,
-                },
-            )
-            .await
-            .unwrap();
-        let resp = ctx
-            .engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::TakeSnapshot {
-                    format: kittycad::types::ImageFormat::Png,
-                },
-            )
-            .await
-            .unwrap();
-        let output_file =
-            std::env::temp_dir().join(format!("kcl_output_{}.png", uuid::Uuid::new_v4()));
-        if let kittycad::types::OkWebSocketResponseData::Modeling {
-            modeling_response: kittycad::types::OkModelingCmdResponse::TakeSnapshot { data },
-        } = &resp
-        {
-            std::fs::write(&output_file, &data.contents.0).unwrap();
-        } else {
-            panic!("Unexpected response from engine: {:?}", resp);
-        }
-
-        let actual = image::io::Reader::open(output_file)
-            .unwrap()
-            .decode()
-            .unwrap();
+        let code = "This is another code block.\nyes sirrr.\nmyFunc";
+        let result =
+            crate::test_server::execute_and_snapshot(code, crate::settings::types::UnitLength::Mm)
+                .await
+                .unwrap();
         twenty_twenty::assert_image(
             &format!("tests/outputs/{}.png", "serial_test_example_my_func0"),
-            &actual,
+            &result,
             0.99,
         );
     }
@@ -118,76 +55,14 @@ mod test_examples_my_func {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn serial_test_example_my_func1() {
-        let user_agent = concat!(env!("CARGO_PKG_NAME"), ".rs/", env!("CARGO_PKG_VERSION"),);
-        let http_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60));
-        let ws_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60))
-            .connection_verbose(true)
-            .tcp_keepalive(std::time::Duration::from_secs(600))
-            .http1_only();
-        let token = std::env::var("KITTYCAD_API_TOKEN").expect("KITTYCAD_API_TOKEN not set");
-        let mut client = kittycad::Client::new_from_reqwest(token, http_client, ws_client);
-        if let Ok(addr) = std::env::var("LOCAL_ENGINE_ADDR") {
-            client.set_base_url(addr);
-        }
-
-        let tokens = crate::token::lexer("This is code.\nIt does other shit.\nmyFunc").unwrap();
-        let parser = crate::parser::Parser::new(tokens);
-        let program = parser.ast().unwrap();
-        let ctx = crate::executor::ExecutorContext::new(&client, Default::default())
-            .await
-            .unwrap();
-        ctx.run(&program, None).await.unwrap();
-        let results = program.lint_all().unwrap();
-        if !results.is_empty() {
-            panic!("Linting failed: {:?}", results);
-        }
-
-        ctx.engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::ZoomToFit {
-                    object_ids: Default::default(),
-                    padding: 0.1,
-                },
-            )
-            .await
-            .unwrap();
-        let resp = ctx
-            .engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::TakeSnapshot {
-                    format: kittycad::types::ImageFormat::Png,
-                },
-            )
-            .await
-            .unwrap();
-        let output_file =
-            std::env::temp_dir().join(format!("kcl_output_{}.png", uuid::Uuid::new_v4()));
-        if let kittycad::types::OkWebSocketResponseData::Modeling {
-            modeling_response: kittycad::types::OkModelingCmdResponse::TakeSnapshot { data },
-        } = &resp
-        {
-            std::fs::write(&output_file, &data.contents.0).unwrap();
-        } else {
-            panic!("Unexpected response from engine: {:?}", resp);
-        }
-
-        let actual = image::io::Reader::open(output_file)
-            .unwrap()
-            .decode()
-            .unwrap();
+        let code = "This is code.\nIt does other shit.\nmyFunc";
+        let result =
+            crate::test_server::execute_and_snapshot(code, crate::settings::types::UnitLength::Mm)
+                .await
+                .unwrap();
         twenty_twenty::assert_image(
             &format!("tests/outputs/{}.png", "serial_test_example_my_func1"),
-            &actual,
+            &result,
             0.99,
         );
     }

--- a/src/wasm-lib/derive-docs/tests/lineTo.gen
+++ b/src/wasm-lib/derive-docs/tests/lineTo.gen
@@ -22,77 +22,14 @@ mod test_examples_line_to {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn serial_test_example_line_to0() {
-        let user_agent = concat!(env!("CARGO_PKG_NAME"), ".rs/", env!("CARGO_PKG_VERSION"),);
-        let http_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60));
-        let ws_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60))
-            .connection_verbose(true)
-            .tcp_keepalive(std::time::Duration::from_secs(600))
-            .http1_only();
-        let token = std::env::var("KITTYCAD_API_TOKEN").expect("KITTYCAD_API_TOKEN not set");
-        let mut client = kittycad::Client::new_from_reqwest(token, http_client, ws_client);
-        if let Ok(addr) = std::env::var("LOCAL_ENGINE_ADDR") {
-            client.set_base_url(addr);
-        }
-
-        let tokens =
-            crate::token::lexer("This is another code block.\nyes sirrr.\nlineTo").unwrap();
-        let parser = crate::parser::Parser::new(tokens);
-        let program = parser.ast().unwrap();
-        let ctx = crate::executor::ExecutorContext::new(&client, Default::default())
-            .await
-            .unwrap();
-        ctx.run(&program, None).await.unwrap();
-        let results = program.lint_all().unwrap();
-        if !results.is_empty() {
-            panic!("Linting failed: {:?}", results);
-        }
-
-        ctx.engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::ZoomToFit {
-                    object_ids: Default::default(),
-                    padding: 0.1,
-                },
-            )
-            .await
-            .unwrap();
-        let resp = ctx
-            .engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::TakeSnapshot {
-                    format: kittycad::types::ImageFormat::Png,
-                },
-            )
-            .await
-            .unwrap();
-        let output_file =
-            std::env::temp_dir().join(format!("kcl_output_{}.png", uuid::Uuid::new_v4()));
-        if let kittycad::types::OkWebSocketResponseData::Modeling {
-            modeling_response: kittycad::types::OkModelingCmdResponse::TakeSnapshot { data },
-        } = &resp
-        {
-            std::fs::write(&output_file, &data.contents.0).unwrap();
-        } else {
-            panic!("Unexpected response from engine: {:?}", resp);
-        }
-
-        let actual = image::io::Reader::open(output_file)
-            .unwrap()
-            .decode()
-            .unwrap();
+        let code = "This is another code block.\nyes sirrr.\nlineTo";
+        let result =
+            crate::test_server::execute_and_snapshot(code, crate::settings::types::UnitLength::Mm)
+                .await
+                .unwrap();
         twenty_twenty::assert_image(
             &format!("tests/outputs/{}.png", "serial_test_example_line_to0"),
-            &actual,
+            &result,
             0.99,
         );
     }
@@ -118,76 +55,14 @@ mod test_examples_line_to {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn serial_test_example_line_to1() {
-        let user_agent = concat!(env!("CARGO_PKG_NAME"), ".rs/", env!("CARGO_PKG_VERSION"),);
-        let http_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60));
-        let ws_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60))
-            .connection_verbose(true)
-            .tcp_keepalive(std::time::Duration::from_secs(600))
-            .http1_only();
-        let token = std::env::var("KITTYCAD_API_TOKEN").expect("KITTYCAD_API_TOKEN not set");
-        let mut client = kittycad::Client::new_from_reqwest(token, http_client, ws_client);
-        if let Ok(addr) = std::env::var("LOCAL_ENGINE_ADDR") {
-            client.set_base_url(addr);
-        }
-
-        let tokens = crate::token::lexer("This is code.\nIt does other shit.\nlineTo").unwrap();
-        let parser = crate::parser::Parser::new(tokens);
-        let program = parser.ast().unwrap();
-        let ctx = crate::executor::ExecutorContext::new(&client, Default::default())
-            .await
-            .unwrap();
-        ctx.run(&program, None).await.unwrap();
-        let results = program.lint_all().unwrap();
-        if !results.is_empty() {
-            panic!("Linting failed: {:?}", results);
-        }
-
-        ctx.engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::ZoomToFit {
-                    object_ids: Default::default(),
-                    padding: 0.1,
-                },
-            )
-            .await
-            .unwrap();
-        let resp = ctx
-            .engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::TakeSnapshot {
-                    format: kittycad::types::ImageFormat::Png,
-                },
-            )
-            .await
-            .unwrap();
-        let output_file =
-            std::env::temp_dir().join(format!("kcl_output_{}.png", uuid::Uuid::new_v4()));
-        if let kittycad::types::OkWebSocketResponseData::Modeling {
-            modeling_response: kittycad::types::OkModelingCmdResponse::TakeSnapshot { data },
-        } = &resp
-        {
-            std::fs::write(&output_file, &data.contents.0).unwrap();
-        } else {
-            panic!("Unexpected response from engine: {:?}", resp);
-        }
-
-        let actual = image::io::Reader::open(output_file)
-            .unwrap()
-            .decode()
-            .unwrap();
+        let code = "This is code.\nIt does other shit.\nlineTo";
+        let result =
+            crate::test_server::execute_and_snapshot(code, crate::settings::types::UnitLength::Mm)
+                .await
+                .unwrap();
         twenty_twenty::assert_image(
             &format!("tests/outputs/{}.png", "serial_test_example_line_to1"),
-            &actual,
+            &result,
             0.99,
         );
     }

--- a/src/wasm-lib/derive-docs/tests/min.gen
+++ b/src/wasm-lib/derive-docs/tests/min.gen
@@ -21,76 +21,14 @@ mod test_examples_min {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn serial_test_example_min0() {
-        let user_agent = concat!(env!("CARGO_PKG_NAME"), ".rs/", env!("CARGO_PKG_VERSION"),);
-        let http_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60));
-        let ws_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60))
-            .connection_verbose(true)
-            .tcp_keepalive(std::time::Duration::from_secs(600))
-            .http1_only();
-        let token = std::env::var("KITTYCAD_API_TOKEN").expect("KITTYCAD_API_TOKEN not set");
-        let mut client = kittycad::Client::new_from_reqwest(token, http_client, ws_client);
-        if let Ok(addr) = std::env::var("LOCAL_ENGINE_ADDR") {
-            client.set_base_url(addr);
-        }
-
-        let tokens = crate::token::lexer("This is another code block.\nyes sirrr.\nmin").unwrap();
-        let parser = crate::parser::Parser::new(tokens);
-        let program = parser.ast().unwrap();
-        let ctx = crate::executor::ExecutorContext::new(&client, Default::default())
-            .await
-            .unwrap();
-        ctx.run(&program, None).await.unwrap();
-        let results = program.lint_all().unwrap();
-        if !results.is_empty() {
-            panic!("Linting failed: {:?}", results);
-        }
-
-        ctx.engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::ZoomToFit {
-                    object_ids: Default::default(),
-                    padding: 0.1,
-                },
-            )
-            .await
-            .unwrap();
-        let resp = ctx
-            .engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::TakeSnapshot {
-                    format: kittycad::types::ImageFormat::Png,
-                },
-            )
-            .await
-            .unwrap();
-        let output_file =
-            std::env::temp_dir().join(format!("kcl_output_{}.png", uuid::Uuid::new_v4()));
-        if let kittycad::types::OkWebSocketResponseData::Modeling {
-            modeling_response: kittycad::types::OkModelingCmdResponse::TakeSnapshot { data },
-        } = &resp
-        {
-            std::fs::write(&output_file, &data.contents.0).unwrap();
-        } else {
-            panic!("Unexpected response from engine: {:?}", resp);
-        }
-
-        let actual = image::io::Reader::open(output_file)
-            .unwrap()
-            .decode()
-            .unwrap();
+        let code = "This is another code block.\nyes sirrr.\nmin";
+        let result =
+            crate::test_server::execute_and_snapshot(code, crate::settings::types::UnitLength::Mm)
+                .await
+                .unwrap();
         twenty_twenty::assert_image(
             &format!("tests/outputs/{}.png", "serial_test_example_min0"),
-            &actual,
+            &result,
             0.99,
         );
     }
@@ -116,76 +54,14 @@ mod test_examples_min {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn serial_test_example_min1() {
-        let user_agent = concat!(env!("CARGO_PKG_NAME"), ".rs/", env!("CARGO_PKG_VERSION"),);
-        let http_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60));
-        let ws_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60))
-            .connection_verbose(true)
-            .tcp_keepalive(std::time::Duration::from_secs(600))
-            .http1_only();
-        let token = std::env::var("KITTYCAD_API_TOKEN").expect("KITTYCAD_API_TOKEN not set");
-        let mut client = kittycad::Client::new_from_reqwest(token, http_client, ws_client);
-        if let Ok(addr) = std::env::var("LOCAL_ENGINE_ADDR") {
-            client.set_base_url(addr);
-        }
-
-        let tokens = crate::token::lexer("This is code.\nIt does other shit.\nmin").unwrap();
-        let parser = crate::parser::Parser::new(tokens);
-        let program = parser.ast().unwrap();
-        let ctx = crate::executor::ExecutorContext::new(&client, Default::default())
-            .await
-            .unwrap();
-        ctx.run(&program, None).await.unwrap();
-        let results = program.lint_all().unwrap();
-        if !results.is_empty() {
-            panic!("Linting failed: {:?}", results);
-        }
-
-        ctx.engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::ZoomToFit {
-                    object_ids: Default::default(),
-                    padding: 0.1,
-                },
-            )
-            .await
-            .unwrap();
-        let resp = ctx
-            .engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::TakeSnapshot {
-                    format: kittycad::types::ImageFormat::Png,
-                },
-            )
-            .await
-            .unwrap();
-        let output_file =
-            std::env::temp_dir().join(format!("kcl_output_{}.png", uuid::Uuid::new_v4()));
-        if let kittycad::types::OkWebSocketResponseData::Modeling {
-            modeling_response: kittycad::types::OkModelingCmdResponse::TakeSnapshot { data },
-        } = &resp
-        {
-            std::fs::write(&output_file, &data.contents.0).unwrap();
-        } else {
-            panic!("Unexpected response from engine: {:?}", resp);
-        }
-
-        let actual = image::io::Reader::open(output_file)
-            .unwrap()
-            .decode()
-            .unwrap();
+        let code = "This is code.\nIt does other shit.\nmin";
+        let result =
+            crate::test_server::execute_and_snapshot(code, crate::settings::types::UnitLength::Mm)
+                .await
+                .unwrap();
         twenty_twenty::assert_image(
             &format!("tests/outputs/{}.png", "serial_test_example_min1"),
-            &actual,
+            &result,
             0.99,
         );
     }

--- a/src/wasm-lib/derive-docs/tests/option.gen
+++ b/src/wasm-lib/derive-docs/tests/option.gen
@@ -21,76 +21,14 @@ mod test_examples_show {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn serial_test_example_show0() {
-        let user_agent = concat!(env!("CARGO_PKG_NAME"), ".rs/", env!("CARGO_PKG_VERSION"),);
-        let http_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60));
-        let ws_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60))
-            .connection_verbose(true)
-            .tcp_keepalive(std::time::Duration::from_secs(600))
-            .http1_only();
-        let token = std::env::var("KITTYCAD_API_TOKEN").expect("KITTYCAD_API_TOKEN not set");
-        let mut client = kittycad::Client::new_from_reqwest(token, http_client, ws_client);
-        if let Ok(addr) = std::env::var("LOCAL_ENGINE_ADDR") {
-            client.set_base_url(addr);
-        }
-
-        let tokens = crate::token::lexer("This is code.\nIt does other shit.\nshow").unwrap();
-        let parser = crate::parser::Parser::new(tokens);
-        let program = parser.ast().unwrap();
-        let ctx = crate::executor::ExecutorContext::new(&client, Default::default())
-            .await
-            .unwrap();
-        ctx.run(&program, None).await.unwrap();
-        let results = program.lint_all().unwrap();
-        if !results.is_empty() {
-            panic!("Linting failed: {:?}", results);
-        }
-
-        ctx.engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::ZoomToFit {
-                    object_ids: Default::default(),
-                    padding: 0.1,
-                },
-            )
-            .await
-            .unwrap();
-        let resp = ctx
-            .engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::TakeSnapshot {
-                    format: kittycad::types::ImageFormat::Png,
-                },
-            )
-            .await
-            .unwrap();
-        let output_file =
-            std::env::temp_dir().join(format!("kcl_output_{}.png", uuid::Uuid::new_v4()));
-        if let kittycad::types::OkWebSocketResponseData::Modeling {
-            modeling_response: kittycad::types::OkModelingCmdResponse::TakeSnapshot { data },
-        } = &resp
-        {
-            std::fs::write(&output_file, &data.contents.0).unwrap();
-        } else {
-            panic!("Unexpected response from engine: {:?}", resp);
-        }
-
-        let actual = image::io::Reader::open(output_file)
-            .unwrap()
-            .decode()
-            .unwrap();
+        let code = "This is code.\nIt does other shit.\nshow";
+        let result =
+            crate::test_server::execute_and_snapshot(code, crate::settings::types::UnitLength::Mm)
+                .await
+                .unwrap();
         twenty_twenty::assert_image(
             &format!("tests/outputs/{}.png", "serial_test_example_show0"),
-            &actual,
+            &result,
             0.99,
         );
     }

--- a/src/wasm-lib/derive-docs/tests/option_input_format.gen
+++ b/src/wasm-lib/derive-docs/tests/option_input_format.gen
@@ -21,76 +21,14 @@ mod test_examples_import {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn serial_test_example_import0() {
-        let user_agent = concat!(env!("CARGO_PKG_NAME"), ".rs/", env!("CARGO_PKG_VERSION"),);
-        let http_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60));
-        let ws_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60))
-            .connection_verbose(true)
-            .tcp_keepalive(std::time::Duration::from_secs(600))
-            .http1_only();
-        let token = std::env::var("KITTYCAD_API_TOKEN").expect("KITTYCAD_API_TOKEN not set");
-        let mut client = kittycad::Client::new_from_reqwest(token, http_client, ws_client);
-        if let Ok(addr) = std::env::var("LOCAL_ENGINE_ADDR") {
-            client.set_base_url(addr);
-        }
-
-        let tokens = crate::token::lexer("This is code.\nIt does other shit.\nimport").unwrap();
-        let parser = crate::parser::Parser::new(tokens);
-        let program = parser.ast().unwrap();
-        let ctx = crate::executor::ExecutorContext::new(&client, Default::default())
-            .await
-            .unwrap();
-        ctx.run(&program, None).await.unwrap();
-        let results = program.lint_all().unwrap();
-        if !results.is_empty() {
-            panic!("Linting failed: {:?}", results);
-        }
-
-        ctx.engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::ZoomToFit {
-                    object_ids: Default::default(),
-                    padding: 0.1,
-                },
-            )
-            .await
-            .unwrap();
-        let resp = ctx
-            .engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::TakeSnapshot {
-                    format: kittycad::types::ImageFormat::Png,
-                },
-            )
-            .await
-            .unwrap();
-        let output_file =
-            std::env::temp_dir().join(format!("kcl_output_{}.png", uuid::Uuid::new_v4()));
-        if let kittycad::types::OkWebSocketResponseData::Modeling {
-            modeling_response: kittycad::types::OkModelingCmdResponse::TakeSnapshot { data },
-        } = &resp
-        {
-            std::fs::write(&output_file, &data.contents.0).unwrap();
-        } else {
-            panic!("Unexpected response from engine: {:?}", resp);
-        }
-
-        let actual = image::io::Reader::open(output_file)
-            .unwrap()
-            .decode()
-            .unwrap();
+        let code = "This is code.\nIt does other shit.\nimport";
+        let result =
+            crate::test_server::execute_and_snapshot(code, crate::settings::types::UnitLength::Mm)
+                .await
+                .unwrap();
         twenty_twenty::assert_image(
             &format!("tests/outputs/{}.png", "serial_test_example_import0"),
-            &actual,
+            &result,
             0.99,
         );
     }

--- a/src/wasm-lib/derive-docs/tests/return_vec_box_sketch_group.gen
+++ b/src/wasm-lib/derive-docs/tests/return_vec_box_sketch_group.gen
@@ -21,76 +21,14 @@ mod test_examples_import {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn serial_test_example_import0() {
-        let user_agent = concat!(env!("CARGO_PKG_NAME"), ".rs/", env!("CARGO_PKG_VERSION"),);
-        let http_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60));
-        let ws_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60))
-            .connection_verbose(true)
-            .tcp_keepalive(std::time::Duration::from_secs(600))
-            .http1_only();
-        let token = std::env::var("KITTYCAD_API_TOKEN").expect("KITTYCAD_API_TOKEN not set");
-        let mut client = kittycad::Client::new_from_reqwest(token, http_client, ws_client);
-        if let Ok(addr) = std::env::var("LOCAL_ENGINE_ADDR") {
-            client.set_base_url(addr);
-        }
-
-        let tokens = crate::token::lexer("This is code.\nIt does other shit.\nimport").unwrap();
-        let parser = crate::parser::Parser::new(tokens);
-        let program = parser.ast().unwrap();
-        let ctx = crate::executor::ExecutorContext::new(&client, Default::default())
-            .await
-            .unwrap();
-        ctx.run(&program, None).await.unwrap();
-        let results = program.lint_all().unwrap();
-        if !results.is_empty() {
-            panic!("Linting failed: {:?}", results);
-        }
-
-        ctx.engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::ZoomToFit {
-                    object_ids: Default::default(),
-                    padding: 0.1,
-                },
-            )
-            .await
-            .unwrap();
-        let resp = ctx
-            .engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::TakeSnapshot {
-                    format: kittycad::types::ImageFormat::Png,
-                },
-            )
-            .await
-            .unwrap();
-        let output_file =
-            std::env::temp_dir().join(format!("kcl_output_{}.png", uuid::Uuid::new_v4()));
-        if let kittycad::types::OkWebSocketResponseData::Modeling {
-            modeling_response: kittycad::types::OkModelingCmdResponse::TakeSnapshot { data },
-        } = &resp
-        {
-            std::fs::write(&output_file, &data.contents.0).unwrap();
-        } else {
-            panic!("Unexpected response from engine: {:?}", resp);
-        }
-
-        let actual = image::io::Reader::open(output_file)
-            .unwrap()
-            .decode()
-            .unwrap();
+        let code = "This is code.\nIt does other shit.\nimport";
+        let result =
+            crate::test_server::execute_and_snapshot(code, crate::settings::types::UnitLength::Mm)
+                .await
+                .unwrap();
         twenty_twenty::assert_image(
             &format!("tests/outputs/{}.png", "serial_test_example_import0"),
-            &actual,
+            &result,
             0.99,
         );
     }

--- a/src/wasm-lib/derive-docs/tests/return_vec_sketch_group.gen
+++ b/src/wasm-lib/derive-docs/tests/return_vec_sketch_group.gen
@@ -21,76 +21,14 @@ mod test_examples_import {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn serial_test_example_import0() {
-        let user_agent = concat!(env!("CARGO_PKG_NAME"), ".rs/", env!("CARGO_PKG_VERSION"),);
-        let http_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60));
-        let ws_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60))
-            .connection_verbose(true)
-            .tcp_keepalive(std::time::Duration::from_secs(600))
-            .http1_only();
-        let token = std::env::var("KITTYCAD_API_TOKEN").expect("KITTYCAD_API_TOKEN not set");
-        let mut client = kittycad::Client::new_from_reqwest(token, http_client, ws_client);
-        if let Ok(addr) = std::env::var("LOCAL_ENGINE_ADDR") {
-            client.set_base_url(addr);
-        }
-
-        let tokens = crate::token::lexer("This is code.\nIt does other shit.\nimport").unwrap();
-        let parser = crate::parser::Parser::new(tokens);
-        let program = parser.ast().unwrap();
-        let ctx = crate::executor::ExecutorContext::new(&client, Default::default())
-            .await
-            .unwrap();
-        ctx.run(&program, None).await.unwrap();
-        let results = program.lint_all().unwrap();
-        if !results.is_empty() {
-            panic!("Linting failed: {:?}", results);
-        }
-
-        ctx.engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::ZoomToFit {
-                    object_ids: Default::default(),
-                    padding: 0.1,
-                },
-            )
-            .await
-            .unwrap();
-        let resp = ctx
-            .engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::TakeSnapshot {
-                    format: kittycad::types::ImageFormat::Png,
-                },
-            )
-            .await
-            .unwrap();
-        let output_file =
-            std::env::temp_dir().join(format!("kcl_output_{}.png", uuid::Uuid::new_v4()));
-        if let kittycad::types::OkWebSocketResponseData::Modeling {
-            modeling_response: kittycad::types::OkModelingCmdResponse::TakeSnapshot { data },
-        } = &resp
-        {
-            std::fs::write(&output_file, &data.contents.0).unwrap();
-        } else {
-            panic!("Unexpected response from engine: {:?}", resp);
-        }
-
-        let actual = image::io::Reader::open(output_file)
-            .unwrap()
-            .decode()
-            .unwrap();
+        let code = "This is code.\nIt does other shit.\nimport";
+        let result =
+            crate::test_server::execute_and_snapshot(code, crate::settings::types::UnitLength::Mm)
+                .await
+                .unwrap();
         twenty_twenty::assert_image(
             &format!("tests/outputs/{}.png", "serial_test_example_import0"),
-            &actual,
+            &result,
             0.99,
         );
     }

--- a/src/wasm-lib/derive-docs/tests/show.gen
+++ b/src/wasm-lib/derive-docs/tests/show.gen
@@ -21,76 +21,14 @@ mod test_examples_show {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn serial_test_example_show0() {
-        let user_agent = concat!(env!("CARGO_PKG_NAME"), ".rs/", env!("CARGO_PKG_VERSION"),);
-        let http_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60));
-        let ws_client = reqwest::Client::builder()
-            .user_agent(user_agent)
-            .timeout(std::time::Duration::from_secs(600))
-            .connect_timeout(std::time::Duration::from_secs(60))
-            .connection_verbose(true)
-            .tcp_keepalive(std::time::Duration::from_secs(600))
-            .http1_only();
-        let token = std::env::var("KITTYCAD_API_TOKEN").expect("KITTYCAD_API_TOKEN not set");
-        let mut client = kittycad::Client::new_from_reqwest(token, http_client, ws_client);
-        if let Ok(addr) = std::env::var("LOCAL_ENGINE_ADDR") {
-            client.set_base_url(addr);
-        }
-
-        let tokens = crate::token::lexer("This is code.\nIt does other shit.\nshow").unwrap();
-        let parser = crate::parser::Parser::new(tokens);
-        let program = parser.ast().unwrap();
-        let ctx = crate::executor::ExecutorContext::new(&client, Default::default())
-            .await
-            .unwrap();
-        ctx.run(&program, None).await.unwrap();
-        let results = program.lint_all().unwrap();
-        if !results.is_empty() {
-            panic!("Linting failed: {:?}", results);
-        }
-
-        ctx.engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::ZoomToFit {
-                    object_ids: Default::default(),
-                    padding: 0.1,
-                },
-            )
-            .await
-            .unwrap();
-        let resp = ctx
-            .engine
-            .send_modeling_cmd(
-                uuid::Uuid::new_v4(),
-                crate::executor::SourceRange::default(),
-                kittycad::types::ModelingCmd::TakeSnapshot {
-                    format: kittycad::types::ImageFormat::Png,
-                },
-            )
-            .await
-            .unwrap();
-        let output_file =
-            std::env::temp_dir().join(format!("kcl_output_{}.png", uuid::Uuid::new_v4()));
-        if let kittycad::types::OkWebSocketResponseData::Modeling {
-            modeling_response: kittycad::types::OkModelingCmdResponse::TakeSnapshot { data },
-        } = &resp
-        {
-            std::fs::write(&output_file, &data.contents.0).unwrap();
-        } else {
-            panic!("Unexpected response from engine: {:?}", resp);
-        }
-
-        let actual = image::io::Reader::open(output_file)
-            .unwrap()
-            .decode()
-            .unwrap();
+        let code = "This is code.\nIt does other shit.\nshow";
+        let result =
+            crate::test_server::execute_and_snapshot(code, crate::settings::types::UnitLength::Mm)
+                .await
+                .unwrap();
         twenty_twenty::assert_image(
             &format!("tests/outputs/{}.png", "serial_test_example_show0"),
-            &actual,
+            &result,
             0.99,
         );
     }

--- a/src/wasm-lib/kcl/Cargo.toml
+++ b/src/wasm-lib/kcl/Cargo.toml
@@ -25,6 +25,7 @@ form_urlencoded = "1.2.1"
 futures = { version = "0.3.30" }
 git_rev = "0.1.0"
 gltf-json = "1.4.1"
+image = { version = "0.25.1", default-features = false, features = ["png"] }
 kittycad = { workspace = true, features = ["clap"] }
 lazy_static = "1.5.0"
 mime_guess = "2.0.5"

--- a/src/wasm-lib/kcl/src/lib.rs
+++ b/src/wasm-lib/kcl/src/lib.rs
@@ -26,6 +26,7 @@ pub mod lsp;
 pub mod parser;
 pub mod settings;
 pub mod std;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod test_server;
 pub mod thread;
 pub mod token;

--- a/src/wasm-lib/kcl/src/test_server.rs
+++ b/src/wasm-lib/kcl/src/test_server.rs
@@ -1,8 +1,70 @@
 //! Types used to send data to the test server.
 
+use crate::{
+    executor::{ExecutorContext, ExecutorSettings},
+    settings::types::UnitLength,
+};
+
 #[derive(serde::Deserialize, serde::Serialize)]
 pub struct RequestBody {
     pub kcl_program: String,
     #[serde(default)]
     pub test_name: String,
+}
+
+/// Executes a kcl program and takes a snapshot of the result.
+/// This returns the bytes of the snapshot.
+pub async fn execute_and_snapshot(code: &str, units: UnitLength) -> anyhow::Result<image::DynamicImage> {
+    let ctx = new_context(units).await?;
+    let tokens = crate::token::lexer(code)?;
+    let parser = crate::parser::Parser::new(tokens);
+    let program = parser.ast()?;
+
+    let snapshot = ctx.execute_and_prepare_snapshot(&program).await?;
+
+    // Create a temporary file to write the output to.
+    let output_file = std::env::temp_dir().join(format!("kcl_output_{}.png", uuid::Uuid::new_v4()));
+    // Save the snapshot locally, to that temporary file.
+    std::fs::write(&output_file, snapshot.contents.0)?;
+    // Decode the snapshot, return it.
+    let img = image::io::Reader::open(output_file).unwrap().decode()?;
+    Ok(img)
+}
+
+async fn new_context(units: UnitLength) -> anyhow::Result<ExecutorContext> {
+    let user_agent = concat!(env!("CARGO_PKG_NAME"), ".rs/", env!("CARGO_PKG_VERSION"),);
+    let http_client = reqwest::Client::builder()
+        .user_agent(user_agent)
+        // For file conversions we need this to be long.
+        .timeout(std::time::Duration::from_secs(600))
+        .connect_timeout(std::time::Duration::from_secs(60));
+    let ws_client = reqwest::Client::builder()
+        .user_agent(user_agent)
+        // For file conversions we need this to be long.
+        .timeout(std::time::Duration::from_secs(600))
+        .connect_timeout(std::time::Duration::from_secs(60))
+        .connection_verbose(true)
+        .tcp_keepalive(std::time::Duration::from_secs(600))
+        .http1_only();
+
+    let token = std::env::var("KITTYCAD_API_TOKEN").expect("KITTYCAD_API_TOKEN not set");
+
+    // Create the client.
+    let mut client = kittycad::Client::new_from_reqwest(token, http_client, ws_client);
+    // Set a local engine address if it's set.
+    if let Ok(addr) = std::env::var("LOCAL_ENGINE_ADDR") {
+        client.set_base_url(addr);
+    }
+
+    let ctx = ExecutorContext::new(
+        &client,
+        ExecutorSettings {
+            units,
+            highlight_edges: true,
+            enable_ssao: false,
+            show_grid: false,
+        },
+    )
+    .await?;
+    Ok(ctx)
 }

--- a/src/wasm-lib/tests/executor/main.rs
+++ b/src/wasm-lib/tests/executor/main.rs
@@ -1,8 +1,4 @@
-use anyhow::Result;
-use kcl_lib::{
-    executor::{ExecutorContext, ExecutorSettings},
-    settings::types::UnitLength,
-};
+use kcl_lib::{settings::types::UnitLength, test_server::execute_and_snapshot};
 
 /// The minimum permissible difference between asserted twenty-twenty images.
 /// i.e. how different the current model snapshot can be from the previous saved one.
@@ -18,63 +14,6 @@ macro_rules! kcl_input {
 
 fn assert_out(test_name: &str, result: &image::DynamicImage) {
     twenty_twenty::assert_image(format!("tests/executor/outputs/{test_name}.png"), result, MIN_DIFF);
-}
-
-async fn new_context(units: UnitLength) -> Result<ExecutorContext> {
-    let user_agent = concat!(env!("CARGO_PKG_NAME"), ".rs/", env!("CARGO_PKG_VERSION"),);
-    let http_client = reqwest::Client::builder()
-        .user_agent(user_agent)
-        // For file conversions we need this to be long.
-        .timeout(std::time::Duration::from_secs(600))
-        .connect_timeout(std::time::Duration::from_secs(60));
-    let ws_client = reqwest::Client::builder()
-        .user_agent(user_agent)
-        // For file conversions we need this to be long.
-        .timeout(std::time::Duration::from_secs(600))
-        .connect_timeout(std::time::Duration::from_secs(60))
-        .connection_verbose(true)
-        .tcp_keepalive(std::time::Duration::from_secs(600))
-        .http1_only();
-
-    let token = std::env::var("KITTYCAD_API_TOKEN").expect("KITTYCAD_API_TOKEN not set");
-
-    // Create the client.
-    let mut client = kittycad::Client::new_from_reqwest(token, http_client, ws_client);
-    // Set a local engine address if it's set.
-    if let Ok(addr) = std::env::var("LOCAL_ENGINE_ADDR") {
-        client.set_base_url(addr);
-    }
-
-    let ctx = ExecutorContext::new(
-        &client,
-        ExecutorSettings {
-            units,
-            highlight_edges: true,
-            enable_ssao: false,
-            show_grid: false,
-        },
-    )
-    .await?;
-    Ok(ctx)
-}
-
-/// Executes a kcl program and takes a snapshot of the result.
-/// This returns the bytes of the snapshot.
-async fn execute_and_snapshot(code: &str, units: UnitLength) -> Result<image::DynamicImage> {
-    let ctx = new_context(units).await?;
-    let tokens = kcl_lib::token::lexer(code)?;
-    let parser = kcl_lib::parser::Parser::new(tokens);
-    let program = parser.ast()?;
-
-    let snapshot = ctx.execute_and_prepare_snapshot(&program).await?;
-
-    // Create a temporary file to write the output to.
-    let output_file = std::env::temp_dir().join(format!("kcl_output_{}.png", uuid::Uuid::new_v4()));
-    // Save the snapshot locally, to that temporary file.
-    std::fs::write(&output_file, snapshot.contents.0)?;
-    // Decode the snapshot, return it.
-    let img = image::io::Reader::open(output_file).unwrap().decode()?;
-    Ok(img)
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
This will ensure that the KCL snapshot tests all use the same logic, whether they're in `tests/executor/main.rs` or in the KCL stdlib modules.