### PR TITLE
Cut release v0.24.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "untitled-app",
-  "version": "0.24.6",
+  "version": "0.24.7",
   "private": true,
   "dependencies": {
     "@codemirror/autocomplete": "^6.17.0",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -80,5 +80,5 @@
     }
   },
   "productName": "Zoo Modeling App",
-  "version": "0.24.6"
+  "version": "0.24.7"
 }


### PR DESCRIPTION
## What's Changed
* Show default planes on empty scene (#3237)
* Re-get the openPanes from localStorage when navigating between projects (#3241)
* Have links clickable within tooltips without clicking content below them (#3204)
* Fix link to keybindings tab in help menu on Windows (#3236)
* Fix cryptic error (#3234)
* Rm error pane show badge on code (#3233)
* Open file with url encoded space (#3231)


**Full Changelog**: https://github.com/KittyCAD/modeling-app/compare/v0.24.6...v0.24.7