### PR TITLE
editor repaints any errors when rendered

### DIFF
--- a/e2e/playwright/flow-tests.spec.ts
+++ b/e2e/playwright/flow-tests.spec.ts
@@ -8248,7 +8248,7 @@ test('Opening and closing the code pane will consistenly show error diagnostics'
     localStorage.setItem('persistCode', code)
   }, bracket)
 
-  await page.setViewportSize({ width: 1200, height: 500 })
+  await page.setViewportSize({ width: 1200, height: 900 })
   await u.waitForAuthSkipAppStart()
 
   // wait for execution done
@@ -8257,7 +8257,7 @@ test('Opening and closing the code pane will consistenly show error diagnostics'
   await u.closeDebugPanel()
 
   // Ensure we have no errors in the gutter.
-  await expect(page.locator('.cm-lint-marker-error')).toBeVisible()
+  await expect(page.locator('.cm-lint-marker-error')).not.toBeVisible()
 
   // Ensure no badge is present
   const codePaneButton = page.getByRole('button', { name: 'KCL Code pane' })
@@ -8286,7 +8286,7 @@ test('Opening and closing the code pane will consistenly show error diagnostics'
   // Ensure that a badge appears on the button
   await expect(codePaneButton).toContainText('notification')
   // Ensure we have no errors in the gutter.
-  await expect(page.locator('.cm-lint-marker-error')).toBeVisible()
+  await expect(page.locator('.cm-lint-marker-error')).not.toBeVisible()
 
   // Open the code pane
   u.openKclCodePanel()

--- a/e2e/playwright/flow-tests.spec.ts
+++ b/e2e/playwright/flow-tests.spec.ts
@@ -8238,7 +8238,7 @@ test('Typing KCL errors induces a badge on the error logs pane button', async ({
   await expect(codePaneButton).toContainText('notification')
 })
 
-test('Opening and closing the code pane will consistenly show error diagnostics', async ({
+test('Opening and closing the code pane will consistently show error diagnostics', async ({
   page,
 }) => {
   const u = await getUtils(page)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2775,7 +2775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -4638,9 +4638,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.121"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
+checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
 dependencies = [
  "indexmap 2.2.6",
  "itoa 1.0.11",

--- a/src/components/ModelingSidebar/ModelingPanes/KclEditorPane.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/KclEditorPane.tsx
@@ -193,6 +193,10 @@ export const KclEditorPane = () => {
           if (_editorView === null) return
 
           editorManager.setEditorView(_editorView)
+
+          // On first load of this component, ensure we show the current errors
+          // in the editor.
+          kclManager.setDiagnosticsForCurrentErrors()
         }}
       />
     </div>

--- a/src/lang/KclSingleton.ts
+++ b/src/lang/KclSingleton.ts
@@ -91,12 +91,16 @@ export class KclManager {
   set kclErrors(kclErrors) {
     if (kclErrors === this._kclErrors && this.lints.length === 0) return
     this._kclErrors = kclErrors
-    let diagnostics = kclErrorsToDiagnostics(kclErrors)
+    this.setDiagnosticsForCurrentErrors()
+    this._kclErrorsCallBack(kclErrors)
+  }
+
+  setDiagnosticsForCurrentErrors() {
+    let diagnostics = kclErrorsToDiagnostics(this.kclErrors)
     if (this.lints.length > 0) {
       diagnostics = diagnostics.concat(this.lints)
     }
     editorManager.setDiagnostics(diagnostics)
-    this._kclErrorsCallBack(kclErrors)
   }
 
   addKclErrors(kclErrors: KCLError[]) {
@@ -343,6 +347,7 @@ export class KclManager {
     })
   }
   async executeCode(zoomToFit?: boolean): Promise<void> {
+    console.log('executeCode', zoomToFit)
     const ast = this.safeParse(codeManager.code)
     if (!ast) {
       this.clearAst()

--- a/src/lang/KclSingleton.ts
+++ b/src/lang/KclSingleton.ts
@@ -347,7 +347,6 @@ export class KclManager {
     })
   }
   async executeCode(zoomToFit?: boolean): Promise<void> {
-    console.log('executeCode', zoomToFit)
     const ast = this.safeParse(codeManager.code)
     if (!ast) {
       this.clearAst()


### PR DESCRIPTION
fixes https://github.com/KittyCAD/modeling-app/issues/3209
fixes https://github.com/KittyCAD/modeling-app/issues/3258


this adds a test for code pane open close, but after switch to electron we will want playwright tests, saying tauri tests just for findability in github search 