### PR TITLE
Add "report a bug" mention to user menu onboarding step

### DIFF
--- a/e2e/playwright/flow-tests.spec.ts
+++ b/e2e/playwright/flow-tests.spec.ts
@@ -2535,18 +2535,29 @@ test.describe('Onboarding tests', () => {
     await page.waitForURL('**/file/**', { waitUntil: 'domcontentloaded' })
 
     // Test that the text in this step is correct
-    const avatarLocator = await page
-      .getByTestId('user-sidebar-toggle')
-      .locator('img')
-    const onboardingOverlayLocator = await page
+    const sidebar = page.getByTestId('user-sidebar-toggle')
+    const avatar = sidebar.locator('img')
+    const onboardingOverlayLocator = page
       .getByTestId('onboarding-content')
       .locator('div')
       .nth(1)
 
     // Expect the avatar to be visible and for the text to reference it
-    await expect(avatarLocator).not.toBeVisible()
+    await expect(avatar).not.toBeVisible()
     await expect(onboardingOverlayLocator).toBeVisible()
     await expect(onboardingOverlayLocator).toContainText('the menu button')
+
+    // Test we mention what else is in this menu for https://github.com/KittyCAD/modeling-app/issues/2939
+    // which doesn't deserver its own full test spun up
+    const userMenuFeatures = [
+      'manage your account',
+      'report a bug',
+      'request a feature',
+      'sign out',
+    ]
+    for (const feature of userMenuFeatures) {
+      await expect(onboardingOverlayLocator).toContainText(feature)
+    }
   })
 })
 

--- a/src/routes/Onboarding/UserMenu.tsx
+++ b/src/routes/Onboarding/UserMenu.tsx
@@ -43,8 +43,8 @@ export default function UserMenu() {
           <h2 className="text-2xl font-bold">User Menu</h2>
           <p className="my-4">
             Click {buttonDescription} in the upper right to open the user menu.
-            You can change your user-level settings, sign out, or request a
-            feature.
+            You can change your user-level settings, sign out, report a bug,
+            manage your account, request a feature, and more.
           </p>
           <p className="my-4">
             Many settings can be set either a user or per-project level. User


### PR DESCRIPTION
Closes #2939, and adds to a test we have of the user menu step to ensure all the important stuff is mentioned (I don't think it deserves its own full test).