### PR TITLE
badge scale on hover

### DIFF
--- a/src/components/ModelingSidebar/ModelingSidebar.tsx
+++ b/src/components/ModelingSidebar/ModelingSidebar.tsx
@@ -295,7 +295,7 @@ function ModelingPaneButton({
         <p
           id={`${paneConfig.id}-badge`}
           className={
-            'absolute m-0 p-0 top-1 right-0 w-3 h-3 flex items-center justify-center text-[10px] font-semibold text-white bg-primary hue-rotate-90 rounded-full border border-chalkboard-10 dark:border-chalkboard-80 z-50 hover:cursor-pointer'
+            'absolute m-0 p-0 top-1 right-0 w-3 h-3 flex items-center justify-center text-[10px] font-semibold text-white bg-primary hue-rotate-90 rounded-full border border-chalkboard-10 dark:border-chalkboard-80 z-50 hover:cursor-pointer hover:scale-[2] transition-transform duration-200'
           }
           onClick={showBadge.onClick}
           title={`Click to view ${showBadge.value} notification${


### PR DESCRIPTION
After the badge was added, I tried to use it to scroll to the error, and it wasn't obvious to me I had to click the badge itself, I thought the codePane button would scroll, trying to make it more obvious to users.


https://github.com/user-attachments/assets/1fe23b45-371b-40a4-8552-a691a72d8f9b

