### PR TITLE
Add a little dropdown arrow menu to gizmo with view settings

### DIFF
--- a/e2e/playwright/flow-tests.spec.ts
+++ b/e2e/playwright/flow-tests.spec.ts
@@ -7603,7 +7603,7 @@ test.describe('Testing Gizmo', () => {
     })
   }
 
-  test('Context menu', async ({ page }) => {
+  test('Context menu and popover menu', async ({ page }) => {
     const testCase = {
       testDescription: 'Right view',
       expectedCameraPosition: { x: 5660.02, y: -152, z: 26 },
@@ -7698,6 +7698,16 @@ test.describe('Testing Gizmo', () => {
         testCase.expectedCameraTarget.z.toString()
       ),
     ])
+
+    // Now test the popover menu.
+    // It has the same click handlers, so we can just
+    // test that it opens and contains the same content.
+    const gizmoPopoverButton = page.getByRole('button', {
+      name: 'view settings',
+    })
+    await expect(gizmoPopoverButton).toBeVisible()
+    await gizmoPopoverButton.click()
+    await expect(buttonToTest).toBeVisible()
   })
 })
 


### PR DESCRIPTION
That right-click menu on the gizmo is completely undiscoverable. This adds a little dropdown above and right of the gizmo with exactly the same menu attached to it, so users can get to the menu either way. Adds to our context menu playwright test to ensure the popover works. 


## Demo

https://github.com/user-attachments/assets/d3040d02-29a0-4bb5-b962-964a0dfa666e

