### PR TITLE
Cut release v0.24.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "untitled-app",
-  "version": "0.24.9",
+  "version": "0.24.10",
   "private": true,
   "dependencies": {
     "@codemirror/autocomplete": "^6.17.0",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -80,5 +80,5 @@
     }
   },
   "productName": "Zoo Modeling App",
-  "version": "0.24.9"
+  "version": "0.24.10"
 }


### PR DESCRIPTION
## What's Changed
* Fix test: Basic sketch › code pane open at start (#3188)
* Don't set firstRender from within a routeLoader (#3311)
* Switch projects fix (#3310)
* Split large (flow-tests) spec file into individual spec file per test suite (#3297)
* Persist theme - Reload everything on a disconnect (#3250)
* Start to rework some of our kcl docs (#3222)
* ArtifactGraph snapshot stability (#3305)
* Badge scale on hover (#3298)
* Bisect docs (#3304)
* Add a search bar to the projects/home page (#3301)
* Add a little dropdown arrow menu to gizmo with view settings (#3300)

**Full Changelog**: https://github.com/KittyCAD/modeling-app/compare/v0.24.9...v0.24.10