### PR TITLE
set global test timeout using the Playwright config

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,6 +10,7 @@ import { defineConfig, devices } from '@playwright/test'
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
+  timeout: 120_000, // override the default 30s timeout
   testDir: './e2e/playwright',
   /* Run tests in files in parallel */
   fullyParallel: true,


### PR DESCRIPTION
I'm seeing an increased `"Test timeout of 30000ms"` related failures in axiom

![Screenshot from 2024-08-08 20-09-55](https://github.com/user-attachments/assets/4fa6ca9a-ea5e-459b-b321-cfc92dc5f89e)
 

In the original `e2e/playwright/flow-tests.spec.ts`
Tucked away in this file, we specify the global test timeout here ...

https://github.com/KittyCAD/modeling-app/blob/3f082c82222ab810ffb5f87daf1dc6c31ab1bfff/e2e/playwright/flow-tests.spec.ts#L97


This was removed by this PR
https://github.com/KittyCAD/modeling-app/pull/3297/

This pr re-instates the 2 minute test timeout via the Playwright config

