### PR TITLE
Rename kcl Value to Expr

### DIFF
--- a/src/clientSideScene/ClientSideSceneComp.tsx
+++ b/src/clientSideScene/ClientSideSceneComp.tsx
@@ -26,7 +26,7 @@ import {
   PathToNode,
   Program,
   SourceRange,
-  Value,
+  Expr,
   parse,
   recast,
 } from 'lang/wasm'
@@ -550,7 +550,7 @@ const ConstraintSymbol = ({
     varNameMap[_type as LineInputsType]?.implicitConstraintDesc
 
   const _node = useMemo(
-    () => getNodeFromPath<Value>(kclManager.ast, pathToNode),
+    () => getNodeFromPath<Expr>(kclManager.ast, pathToNode),
     [kclManager.ast, pathToNode]
   )
   if (err(_node)) return

--- a/src/components/AvailableVarsHelpers.tsx
+++ b/src/components/AvailableVarsHelpers.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react'
-import { parse, BinaryPart, Value, ProgramMemory } from '../lang/wasm'
+import { parse, BinaryPart, Expr, ProgramMemory } from '../lang/wasm'
 import {
   createIdentifier,
   createLiteral,
@@ -86,7 +86,7 @@ export function useCalc({
   initialVariableName?: string
 }): {
   inputRef: React.RefObject<HTMLInputElement>
-  valueNode: Value | null
+  valueNode: Expr | null
   calcResult: string
   prevVariables: PrevVariable<unknown>[]
   newVariableName: string
@@ -105,7 +105,7 @@ export function useCalc({
     insertIndex: 0,
     bodyPath: [],
   })
-  const [valueNode, setValueNode] = useState<Value | null>(null)
+  const [valueNode, setValueNode] = useState<Expr | null>(null)
   const [calcResult, setCalcResult] = useState('NAN')
   const [newVariableName, setNewVariableName] = useState('')
   const [isNewVariableNameUnique, setIsNewVariableNameUnique] = useState(true)

--- a/src/components/SetAngleLengthModal.tsx
+++ b/src/components/SetAngleLengthModal.tsx
@@ -1,7 +1,7 @@
 import { Dialog, Transition } from '@headlessui/react'
 import { Fragment, useState } from 'react'
 import { type InstanceProps, create } from 'react-modal-promise'
-import { Value } from '../lang/wasm'
+import { Expr } from '../lang/wasm'
 import {
   AvailableVars,
   addToInputHelper,
@@ -13,7 +13,7 @@ import { useCalculateKclExpression } from 'lib/useCalculateKclExpression'
 type ModalResolve = {
   value: string
   sign: number
-  valueNode: Value
+  valueNode: Expr
   variableName?: string
   newVariableInsertIndex: number
 }

--- a/src/components/SetHorVertDistanceModal.tsx
+++ b/src/components/SetHorVertDistanceModal.tsx
@@ -1,7 +1,7 @@
 import { Dialog, Transition } from '@headlessui/react'
 import { Fragment, useState } from 'react'
 import { type InstanceProps, create } from 'react-modal-promise'
-import { Value } from '../lang/wasm'
+import { Expr } from '../lang/wasm'
 import {
   AvailableVars,
   addToInputHelper,
@@ -13,7 +13,7 @@ import { useCalculateKclExpression } from 'lib/useCalculateKclExpression'
 type ModalResolve = {
   value: string
   segName: string
-  valueNode: Value
+  valueNode: Expr
   variableName?: string
   newVariableInsertIndex: number
   sign: number

--- a/src/components/Toolbar/EqualAngle.tsx
+++ b/src/components/Toolbar/EqualAngle.tsx
@@ -1,6 +1,6 @@
 import { toolTips } from 'lang/langHelpers'
 import { Selections } from 'lib/selections'
-import { Program, Value, VariableDeclarator } from '../../lang/wasm'
+import { Program, Expr, VariableDeclarator } from '../../lang/wasm'
 import {
   getNodePathFromSourceRange,
   getNodeFromPath,
@@ -29,13 +29,13 @@ export function equalAngleInfo({
     getNodePathFromSourceRange(kclManager.ast, range)
   )
   const _nodes = paths.map((pathToNode) => {
-    const tmp = getNodeFromPath<Value>(kclManager.ast, pathToNode)
+    const tmp = getNodeFromPath<Expr>(kclManager.ast, pathToNode)
     if (err(tmp)) return tmp
     return tmp.node
   })
   const _err1 = _nodes.find(err)
   if (err(_err1)) return _err1
-  const nodes = _nodes as Value[]
+  const nodes = _nodes as Expr[]
 
   const _varDecs = paths.map((pathToNode) => {
     const tmp = getNodeFromPath<VariableDeclarator>(

--- a/src/components/Toolbar/EqualLength.tsx
+++ b/src/components/Toolbar/EqualLength.tsx
@@ -1,6 +1,6 @@
 import { toolTips } from 'lang/langHelpers'
 import { Selections } from 'lib/selections'
-import { Program, Value, VariableDeclarator } from '../../lang/wasm'
+import { Program, Expr, VariableDeclarator } from '../../lang/wasm'
 import {
   getNodePathFromSourceRange,
   getNodeFromPath,
@@ -29,13 +29,13 @@ export function setEqualLengthInfo({
     getNodePathFromSourceRange(kclManager.ast, range)
   )
   const _nodes = paths.map((pathToNode) => {
-    const tmp = getNodeFromPath<Value>(kclManager.ast, pathToNode)
+    const tmp = getNodeFromPath<Expr>(kclManager.ast, pathToNode)
     if (err(tmp)) return tmp
     return tmp.node
   })
   const _err1 = _nodes.find(err)
   if (err(_err1)) return _err1
-  const nodes = _nodes as Value[]
+  const nodes = _nodes as Expr[]
 
   const _varDecs = paths.map((pathToNode) => {
     const tmp = getNodeFromPath<VariableDeclarator>(

--- a/src/components/Toolbar/HorzVert.tsx
+++ b/src/components/Toolbar/HorzVert.tsx
@@ -1,6 +1,6 @@
 import { toolTips } from 'lang/langHelpers'
 import { Selections } from 'lib/selections'
-import { Program, ProgramMemory, Value } from '../../lang/wasm'
+import { Program, ProgramMemory, Expr } from '../../lang/wasm'
 import {
   getNodePathFromSourceRange,
   getNodeFromPath,
@@ -27,13 +27,13 @@ export function horzVertInfo(
     getNodePathFromSourceRange(kclManager.ast, range)
   )
   const _nodes = paths.map((pathToNode) => {
-    const tmp = getNodeFromPath<Value>(kclManager.ast, pathToNode)
+    const tmp = getNodeFromPath<Expr>(kclManager.ast, pathToNode)
     if (err(tmp)) return tmp
     return tmp.node
   })
   const _err1 = _nodes.find(err)
   if (err(_err1)) return _err1
-  const nodes = _nodes as Value[]
+  const nodes = _nodes as Expr[]
 
   const isAllTooltips = nodes.every(
     (node) =>

--- a/src/components/Toolbar/Intersect.tsx
+++ b/src/components/Toolbar/Intersect.tsx
@@ -1,6 +1,6 @@
 import { toolTips } from 'lang/langHelpers'
 import { Selections } from 'lib/selections'
-import { BinaryPart, Program, Value, VariableDeclarator } from '../../lang/wasm'
+import { BinaryPart, Program, Expr, VariableDeclarator } from '../../lang/wasm'
 import {
   getNodePathFromSourceRange,
   getNodeFromPath,
@@ -72,13 +72,13 @@ export function intersectInfo({
     getNodePathFromSourceRange(kclManager.ast, range)
   )
   const _nodes = paths.map((pathToNode) => {
-    const tmp = getNodeFromPath<Value>(kclManager.ast, pathToNode)
+    const tmp = getNodeFromPath<Expr>(kclManager.ast, pathToNode)
     if (err(tmp)) return tmp
     return tmp.node
   })
   const _err1 = _nodes.find(err)
   if (err(_err1)) return _err1
-  const nodes = _nodes as Value[]
+  const nodes = _nodes as Expr[]
 
   const _varDecs = paths.map((pathToNode) => {
     const tmp = getNodeFromPath<VariableDeclarator>(

--- a/src/components/Toolbar/RemoveConstrainingValues.tsx
+++ b/src/components/Toolbar/RemoveConstrainingValues.tsx
@@ -1,6 +1,6 @@
 import { toolTips } from 'lang/langHelpers'
 import { Selection, Selections } from 'lib/selections'
-import { PathToNode, Program, Value } from '../../lang/wasm'
+import { PathToNode, Program, Expr } from '../../lang/wasm'
 import {
   getNodePathFromSourceRange,
   getNodeFromPath,
@@ -33,13 +33,13 @@ export function removeConstrainingValuesInfo({
       getNodePathFromSourceRange(kclManager.ast, range)
     )
   const _nodes = paths.map((pathToNode) => {
-    const tmp = getNodeFromPath<Value>(kclManager.ast, pathToNode)
+    const tmp = getNodeFromPath<Expr>(kclManager.ast, pathToNode)
     if (err(tmp)) return tmp
     return tmp.node
   })
   const _err1 = _nodes.find(err)
   if (err(_err1)) return _err1
-  const nodes = _nodes as Value[]
+  const nodes = _nodes as Expr[]
 
   const updatedSelectionRanges = pathToNodes
     ? {

--- a/src/components/Toolbar/SetAbsDistance.tsx
+++ b/src/components/Toolbar/SetAbsDistance.tsx
@@ -1,6 +1,6 @@
 import { toolTips } from 'lang/langHelpers'
 import { Selections } from 'lib/selections'
-import { BinaryPart, Program, Value } from '../../lang/wasm'
+import { BinaryPart, Program, Expr } from '../../lang/wasm'
 import {
   getNodePathFromSourceRange,
   getNodeFromPath,
@@ -49,7 +49,7 @@ export function absDistanceInfo({
     getNodePathFromSourceRange(kclManager.ast, range)
   )
   const _nodes = paths.map((pathToNode) => {
-    const tmp = getNodeFromPath<Value>(
+    const tmp = getNodeFromPath<Expr>(
       kclManager.ast,
       pathToNode,
       'CallExpression'
@@ -59,7 +59,7 @@ export function absDistanceInfo({
   })
   const _err1 = _nodes.find(err)
   if (err(_err1)) return _err1
-  const nodes = _nodes as Value[]
+  const nodes = _nodes as Expr[]
 
   const isAllTooltips = nodes.every(
     (node) =>

--- a/src/components/Toolbar/SetAngleBetween.tsx
+++ b/src/components/Toolbar/SetAngleBetween.tsx
@@ -1,6 +1,6 @@
 import { toolTips } from 'lang/langHelpers'
 import { Selections } from 'lib/selections'
-import { BinaryPart, Program, Value, VariableDeclarator } from '../../lang/wasm'
+import { BinaryPart, Program, Expr, VariableDeclarator } from '../../lang/wasm'
 import {
   getNodePathFromSourceRange,
   getNodeFromPath,
@@ -35,13 +35,13 @@ export function angleBetweenInfo({
   )
 
   const _nodes = paths.map((pathToNode) => {
-    const tmp = getNodeFromPath<Value>(kclManager.ast, pathToNode)
+    const tmp = getNodeFromPath<Expr>(kclManager.ast, pathToNode)
     if (err(tmp)) return tmp
     return tmp.node
   })
   const _err1 = _nodes.find(err)
   if (err(_err1)) return _err1
-  const nodes = _nodes as Value[]
+  const nodes = _nodes as Expr[]
 
   const _varDecs = paths.map((pathToNode) => {
     const tmp = getNodeFromPath<VariableDeclarator>(

--- a/src/components/Toolbar/SetHorzVertDistance.tsx
+++ b/src/components/Toolbar/SetHorzVertDistance.tsx
@@ -1,5 +1,5 @@
 import { toolTips } from 'lang/langHelpers'
-import { BinaryPart, Program, Value, VariableDeclarator } from '../../lang/wasm'
+import { BinaryPart, Program, Expr, VariableDeclarator } from '../../lang/wasm'
 import {
   getNodePathFromSourceRange,
   getNodeFromPath,
@@ -36,14 +36,14 @@ export function horzVertDistanceInfo({
     getNodePathFromSourceRange(kclManager.ast, range)
   )
   const _nodes = paths.map((pathToNode) => {
-    const tmp = getNodeFromPath<Value>(kclManager.ast, pathToNode)
+    const tmp = getNodeFromPath<Expr>(kclManager.ast, pathToNode)
     if (err(tmp)) return tmp
     return tmp.node
   })
   const [hasErr, , nodesWErrs] = cleanErrs(_nodes)
 
   if (hasErr) return nodesWErrs[0]
-  const nodes = _nodes as Value[]
+  const nodes = _nodes as Expr[]
 
   const _varDecs = paths.map((pathToNode) => {
     const tmp = getNodeFromPath<VariableDeclarator>(

--- a/src/components/Toolbar/setAngleLength.tsx
+++ b/src/components/Toolbar/setAngleLength.tsx
@@ -1,6 +1,6 @@
 import { toolTips } from 'lang/langHelpers'
 import { Selections } from 'lib/selections'
-import { BinaryPart, Program, Value } from '../../lang/wasm'
+import { BinaryPart, Program, Expr } from '../../lang/wasm'
 import {
   getNodePathFromSourceRange,
   getNodeFromPath,
@@ -44,7 +44,7 @@ export function angleLengthInfo({
   )
 
   const nodes = paths.map((pathToNode) =>
-    getNodeFromPath<Value>(kclManager.ast, pathToNode, 'CallExpression')
+    getNodeFromPath<Expr>(kclManager.ast, pathToNode, 'CallExpression')
   )
   const _err1 = nodes.find(err)
   if (err(_err1)) return _err1

--- a/src/lang/modifyAst.ts
+++ b/src/lang/modifyAst.ts
@@ -6,7 +6,7 @@ import {
   PipeExpression,
   VariableDeclaration,
   VariableDeclarator,
-  Value,
+  Expr,
   Literal,
   PipeSubstitution,
   Identifier,
@@ -195,10 +195,7 @@ export function findUniqueName(
   return findUniqueName(searchStr, name, pad, index + 1)
 }
 
-export function mutateArrExp(
-  node: Value,
-  updateWith: ArrayExpression
-): boolean {
+export function mutateArrExp(node: Expr, updateWith: ArrayExpression): boolean {
   if (node.type === 'ArrayExpression') {
     node.elements.forEach((element, i) => {
       if (isLiteralArrayOrStatic(element)) {
@@ -211,7 +208,7 @@ export function mutateArrExp(
 }
 
 export function mutateObjExpProp(
-  node: Value,
+  node: Expr,
   updateWith: Literal | ArrayExpression,
   key: string
 ): boolean {
@@ -254,7 +251,7 @@ export function extrudeSketch(
   node: Program,
   pathToNode: PathToNode,
   shouldPipe = false,
-  distance = createLiteral(4) as Value
+  distance = createLiteral(4) as Expr
 ):
   | {
       modifiedAst: Program
@@ -608,7 +605,7 @@ export function createVariableDeclaration(
 }
 
 export function createObjectExpression(properties: {
-  [key: string]: Value
+  [key: string]: Expr
 }): ObjectExpression {
   return {
     type: 'ObjectExpression',

--- a/src/lang/modifyAst/addFillet.test.ts
+++ b/src/lang/modifyAst/addFillet.test.ts
@@ -3,7 +3,7 @@ import {
   recast,
   initPromise,
   PathToNode,
-  Value,
+  Expr,
   Program,
   CallExpression,
 } from '../wasm'
@@ -25,7 +25,7 @@ const runFilletTest = async (
   code: string,
   segmentSnippet: string,
   extrudeSnippet: string,
-  radius = createLiteral(5) as Value,
+  radius = createLiteral(5) as Expr,
   expectedCode: string
 ) => {
   const astOrError = parse(code)
@@ -57,7 +57,7 @@ const runFilletTest = async (
     return new Error('Path to extrude node not found')
   }
 
-  // const radius = createLiteral(5) as Value
+  // const radius = createLiteral(5) as Expr
 
   const result = addFillet(ast, pathToSegmentNode, pathToExtrudeNode, radius)
   if (err(result)) {
@@ -90,7 +90,7 @@ describe('Testing addFillet', () => {
     `
     const segmentSnippet = `line([60.04, -55.72], %)`
     const extrudeSnippet = `const extrude001 = extrude(50, sketch001)`
-    const radius = createLiteral(5) as Value
+    const radius = createLiteral(5) as Expr
     const expectedCode = `const sketch001 = startSketchOn('XZ')
   |> startProfileAt([2.16, 49.67], %)
   |> line([101.49, 139.93], %)
@@ -133,7 +133,7 @@ const extrude001 = extrude(50, sketch001)
       `
     const segmentSnippet = `line([60.04, -55.72], %)`
     const extrudeSnippet = `const extrude001 = extrude(50, sketch001)`
-    const radius = createLiteral(5) as Value
+    const radius = createLiteral(5) as Expr
     const expectedCode = `const sketch001 = startSketchOn('XZ')
   |> startProfileAt([2.16, 49.67], %)
   |> line([101.49, 139.93], %)
@@ -176,7 +176,7 @@ const extrude001 = extrude(50, sketch001)
       `
     const segmentSnippet = `line([-87.24, -47.08], %, $seg03)`
     const extrudeSnippet = `const extrude001 = extrude(50, sketch001)`
-    const radius = createLiteral(5) as Value
+    const radius = createLiteral(5) as Expr
     const expectedCode = `const sketch001 = startSketchOn('XZ')
   |> startProfileAt([2.16, 49.67], %)
   |> line([101.49, 139.93], %)
@@ -218,7 +218,7 @@ const extrude001 = extrude(50, sketch001)
             |> fillet({ radius: 10, tags: [seg03] }, %)`
     const segmentSnippet = `line([60.04, -55.72], %)`
     const extrudeSnippet = `const extrude001 = extrude(50, sketch001)`
-    const radius = createLiteral(5) as Value
+    const radius = createLiteral(5) as Expr
     const expectedCode = `const sketch001 = startSketchOn('XZ')
   |> startProfileAt([2.16, 49.67], %)
   |> line([101.49, 139.93], %)

--- a/src/lang/modifyAst/addFillet.ts
+++ b/src/lang/modifyAst/addFillet.ts
@@ -4,7 +4,7 @@ import {
   ObjectExpression,
   PathToNode,
   Program,
-  Value,
+  Expr,
   VariableDeclaration,
   VariableDeclarator,
 } from '../wasm'
@@ -35,7 +35,7 @@ export function addFillet(
   node: Program,
   pathToSegmentNode: PathToNode,
   pathToExtrudeNode: PathToNode,
-  radius = createLiteral(5) as Value
+  radius = createLiteral(5) as Expr
   // shouldPipe = false, // TODO: Implement this feature
 ): { modifiedAst: Program; pathToFilletNode: PathToNode } | Error {
   // clone ast to make mutations safe

--- a/src/lang/queryAst.ts
+++ b/src/lang/queryAst.ts
@@ -13,7 +13,7 @@ import {
   SketchGroup,
   SourceRange,
   SyntaxType,
-  Value,
+  Expr,
   VariableDeclaration,
   VariableDeclarator,
 } from './wasm'
@@ -118,7 +118,7 @@ export function getNodeFromPathCurry(
 }
 
 function moreNodePathFromSourceRange(
-  node: Value | ExpressionStatement | VariableDeclaration | ReturnStatement,
+  node: Expr | ExpressionStatement | VariableDeclaration | ReturnStatement,
   sourceRange: Selection['range'],
   previousPath: PathToNode = [['body', '']]
 ): PathToNode {
@@ -337,7 +337,7 @@ export function getNodePathFromSourceRange(
 }
 
 type KCLNode =
-  | Value
+  | Expr
   | ExpressionStatement
   | VariableDeclaration
   | VariableDeclarator
@@ -514,7 +514,7 @@ export function isNodeSafeToReplacePath(
 ):
   | {
       isSafe: boolean
-      value: Value
+      value: Expr
       replacer: ReplacerFn
     }
   | Error {
@@ -538,7 +538,7 @@ export function isNodeSafeToReplacePath(
 
   // binaryExpression should take precedence
   const [finVal, finPath] =
-    (binValue as Value)?.type === 'BinaryExpression'
+    (binValue as Expr)?.type === 'BinaryExpression'
       ? [binValue, outBinPath]
       : [value, outPath]
 
@@ -561,7 +561,7 @@ export function isNodeSafeToReplacePath(
     return { modifiedAst: _ast, pathToReplaced }
   }
 
-  const hasPipeSub = isTypeInValue(finVal as Value, 'PipeSubstitution')
+  const hasPipeSub = isTypeInValue(finVal as Expr, 'PipeSubstitution')
   const isIdentifierCallee = path[path.length - 1][0] !== 'callee'
   return {
     isSafe:
@@ -569,7 +569,7 @@ export function isNodeSafeToReplacePath(
       isIdentifierCallee &&
       acceptedNodeTypes.includes((finVal as any)?.type) &&
       finPath.map(([_, type]) => type).includes('VariableDeclaration'),
-    value: finVal as Value,
+    value: finVal as Expr,
     replacer: replaceNodeWithIdentifier,
   }
 }
@@ -580,7 +580,7 @@ export function isNodeSafeToReplace(
 ):
   | {
       isSafe: boolean
-      value: Value
+      value: Expr
       replacer: ReplacerFn
     }
   | Error {
@@ -588,7 +588,7 @@ export function isNodeSafeToReplace(
   return isNodeSafeToReplacePath(ast, path)
 }
 
-export function isTypeInValue(node: Value, syntaxType: SyntaxType): boolean {
+export function isTypeInValue(node: Expr, syntaxType: SyntaxType): boolean {
   if (node.type === syntaxType) return true
   if (node.type === 'BinaryExpression') return isTypeInBinExp(node, syntaxType)
   if (node.type === 'CallExpression') return isTypeInCallExp(node, syntaxType)
@@ -625,7 +625,7 @@ function isTypeInArrayExp(
   return node.elements.some((el) => isTypeInValue(el, syntaxType))
 }
 
-export function isValueZero(val?: Value): boolean {
+export function isValueZero(val?: Expr): boolean {
   return (
     (val?.type === 'Literal' && Number(val.value) === 0) ||
     (val?.type === 'UnaryExpression' &&

--- a/src/lang/std/sketch.ts
+++ b/src/lang/std/sketch.ts
@@ -8,7 +8,7 @@ import {
   PipeExpression,
   CallExpression,
   VariableDeclarator,
-  Value,
+  Expr,
   Literal,
   VariableDeclaration,
   Identifier,
@@ -72,8 +72,8 @@ export function getCoordsFromPaths(skGroup: SketchGroup, index = 0): Coords2d {
 
 export function createFirstArg(
   sketchFn: ToolTip,
-  val: Value | [Value, Value] | [Value, Value, Value]
-): Value | Error {
+  val: Expr | [Expr, Expr] | [Expr, Expr, Expr]
+): Expr | Error {
   if (Array.isArray(val)) {
     if (
       [
@@ -338,7 +338,7 @@ export const lineTo: SketchLineHelper = {
     if (err(nodeMeta)) return nodeMeta
     const { node: pipe } = nodeMeta
 
-    const newVals: [Value, Value] = [
+    const newVals: [Expr, Expr] = [
       createLiteral(roundOff(to[0], 2)),
       createLiteral(roundOff(to[1], 2)),
     ]
@@ -1839,7 +1839,7 @@ export function getTagFromCallExpression(
   return new Error(`"${callExp.callee.name}" is not a sketch line helper`)
 }
 
-function isAngleLiteral(lineArugement: Value): boolean {
+function isAngleLiteral(lineArugement: Expr): boolean {
   return lineArugement?.type === 'ArrayExpression'
     ? isLiteralArrayOrStatic(lineArugement.elements[0])
     : lineArugement?.type === 'ObjectExpression'
@@ -1907,8 +1907,8 @@ export function getXComponent(
 
 function getFirstArgValuesForXYFns(callExpression: CallExpression):
   | {
-      val: [Value, Value]
-      tag?: Value
+      val: [Expr, Expr]
+      tag?: Expr
     }
   | Error {
   // used for lineTo, line
@@ -1929,8 +1929,8 @@ function getFirstArgValuesForXYFns(callExpression: CallExpression):
 
 function getFirstArgValuesForAngleFns(callExpression: CallExpression):
   | {
-      val: [Value, Value]
-      tag?: Value
+      val: [Expr, Expr]
+      tag?: Expr
     }
   | Error {
   // used for angledLine, angledLineOfXLength, angledLineToX, angledLineOfYLength, angledLineToY
@@ -1957,8 +1957,8 @@ function getFirstArgValuesForAngleFns(callExpression: CallExpression):
 }
 
 function getFirstArgValuesForXYLineFns(callExpression: CallExpression): {
-  val: Value
-  tag?: Value
+  val: Expr
+  tag?: Expr
 } {
   // used for xLine, yLine, xLineTo, yLineTo
   const firstArg = callExpression.arguments[0]
@@ -1988,8 +1988,8 @@ const getAngledLineThatIntersects = (
   callExp: CallExpression
 ):
   | {
-      val: [Value, Value, Value]
-      tag?: Value
+      val: [Expr, Expr, Expr]
+      tag?: Expr
     }
   | Error => {
   const firstArg = callExp.arguments[0]
@@ -2011,8 +2011,8 @@ const getAngledLineThatIntersects = (
 
 export function getFirstArg(callExp: CallExpression):
   | {
-      val: Value | [Value, Value] | [Value, Value, Value]
-      tag?: Value
+      val: Expr | [Expr, Expr] | [Expr, Expr, Expr]
+      tag?: Expr
     }
   | Error {
   const name = callExp?.callee?.name

--- a/src/lang/std/sketchConstraints.ts
+++ b/src/lang/std/sketchConstraints.ts
@@ -8,7 +8,7 @@ import {
   SourceRange,
   Path,
   PathToNode,
-  Value,
+  Expr,
 } from '../wasm'
 import { err } from 'lib/trap'
 
@@ -25,7 +25,7 @@ export function getSketchSegmentFromPathToNode(
   // TODO: once pathTodNode is stored on program memory as part of execution,
   // we can check if the pathToNode matches the pathToNode of the sketchGroup.
   // For now we fall back to the sourceRange
-  const nodeMeta = getNodeFromPath<Value>(ast, pathToNode)
+  const nodeMeta = getNodeFromPath<Expr>(ast, pathToNode)
   if (err(nodeMeta)) return nodeMeta
 
   const node = nodeMeta.node

--- a/src/lang/std/sketchcombos.test.ts
+++ b/src/lang/std/sketchcombos.test.ts
@@ -1,4 +1,4 @@
-import { parse, Value, recast, initPromise } from '../wasm'
+import { parse, Expr, recast, initPromise } from '../wasm'
 import {
   getConstraintType,
   getTransformInfos,
@@ -69,8 +69,8 @@ function getConstraintTypeFromSourceHelper(
   if (err(ast)) return ast
 
   const args = (ast.body[0] as any).expression.arguments[0].elements as [
-    Value,
-    Value
+    Expr,
+    Expr
   ]
   const fnName = (ast.body[0] as any).expression.callee.name as ToolTip
   return getConstraintType(args, fnName)
@@ -81,7 +81,7 @@ function getConstraintTypeFromSourceHelper2(
   const ast = parse(code)
   if (err(ast)) return ast
 
-  const arg = (ast.body[0] as any).expression.arguments[0] as Value
+  const arg = (ast.body[0] as any).expression.arguments[0] as Expr
   const fnName = (ast.body[0] as any).expression.callee.name as ToolTip
   return getConstraintType(arg, fnName)
 }

--- a/src/lang/std/sketchcombos.ts
+++ b/src/lang/std/sketchcombos.ts
@@ -5,7 +5,7 @@ import { cleanErrs, err } from 'lib/trap'
 import {
   CallExpression,
   Program,
-  Value,
+  Expr,
   BinaryPart,
   VariableDeclarator,
   PathToNode,
@@ -68,8 +68,8 @@ export type ConstraintType =
 
 function createCallWrapper(
   a: ToolTip,
-  val: [Value, Value] | Value,
-  tag?: Value,
+  val: [Expr, Expr] | Expr,
+  tag?: Expr,
   valueUsedInTransform?: number
 ): ReturnType<TransformCallback> {
   const args = [createFirstArg(a, val), createPipeSubstitution()]
@@ -103,8 +103,8 @@ function createCallWrapper(
  */
 function createStdlibCallExpression(
   tool: ToolTip,
-  val: Value,
-  tag?: Value,
+  val: Expr,
+  tag?: Expr,
   valueUsedInTransform?: number
 ): ReturnType<TransformCallback> {
   const args = [val, createPipeSubstitution()]
@@ -126,10 +126,10 @@ function intersectCallWrapper({
   valueUsedInTransform,
 }: {
   fnName: string
-  angleVal: Value
-  offsetVal: Value
-  intersectTag: Value
-  tag?: Value
+  angleVal: Expr
+  offsetVal: Expr
+  intersectTag: Expr
+  tag?: Expr
   valueUsedInTransform?: number
 }): ReturnType<TransformCallback> {
   const firstArg: any = {
@@ -137,7 +137,7 @@ function intersectCallWrapper({
     offset: offsetVal,
     intersectTag,
   }
-  const args: Value[] = [
+  const args: Expr[] = [
     createObjectExpression(firstArg),
     createPipeSubstitution(),
   ]
@@ -154,11 +154,11 @@ export type TransformInfo = {
   tooltip: ToolTip
   createNode: (a: {
     varValues: VarValues
-    varValA: Value // x / angle
-    varValB: Value // y / length or x y for angledLineOfXlength etc
+    varValA: Expr // x / angle
+    varValB: Expr // y / length or x y for angledLineOfXlength etc
     referenceSegName: string
-    tag?: Value
-    forceValueUsedInTransform?: Value
+    tag?: Expr
+    forceValueUsedInTransform?: Expr
   }) => TransformCallback
 }
 
@@ -234,8 +234,8 @@ const angledLineAngleCreateNode: TransformInfo['createNode'] =
 
 const getMinAndSegLenVals = (
   referenceSegName: string,
-  varVal: Value
-): [Value, BinaryPart] => {
+  varVal: Expr
+): [Expr, BinaryPart] => {
   const segLenVal = createSegLen(referenceSegName)
   return [
     createCallExpression('min', [segLenVal, varVal]),
@@ -245,9 +245,9 @@ const getMinAndSegLenVals = (
 
 const getMinAndSegAngVals = (
   referenceSegName: string,
-  varVal: Value,
+  varVal: Expr,
   fnName: 'legAngX' | 'legAngY' = 'legAngX'
-): [Value, BinaryPart] => {
+): [Expr, BinaryPart] => {
   const minVal = createCallExpression('min', [
     createSegLen(referenceSegName),
     varVal,
@@ -259,12 +259,12 @@ const getMinAndSegAngVals = (
   return [minVal, legAngle]
 }
 
-const getSignedLeg = (arg: Value, legLenVal: BinaryPart) =>
+const getSignedLeg = (arg: Expr, legLenVal: BinaryPart) =>
   arg.type === 'Literal' && Number(arg.value) < 0
     ? createUnaryExpression(legLenVal)
     : legLenVal
 
-const getLegAng = (arg: Value, legAngleVal: BinaryPart) => {
+const getLegAng = (arg: Expr, legAngleVal: BinaryPart) => {
   const ang = (arg.type === 'Literal' && Number(arg.value)) || 0
   const normalisedAngle = ((ang % 360) + 360) % 360 // between 0 and 360
   const truncatedTo90 = Math.floor(normalisedAngle / 90) * 90
@@ -275,14 +275,14 @@ const getLegAng = (arg: Value, legAngleVal: BinaryPart) => {
   return truncatedTo90 === 0 ? legAngleVal : binExp
 }
 
-const getAngleLengthSign = (arg: Value, legAngleVal: BinaryPart) => {
+const getAngleLengthSign = (arg: Expr, legAngleVal: BinaryPart) => {
   const ang = (arg.type === 'Literal' && Number(arg.value)) || 0
   const normalisedAngle = ((ang % 180) + 180) % 180 // between 0 and 180
   return normalisedAngle > 90 ? createUnaryExpression(legAngleVal) : legAngleVal
 }
 
 function getClosesAngleDirection(
-  arg: Value,
+  arg: Expr,
   refAngle: number,
   angleVal: BinaryPart
 ) {
@@ -305,7 +305,7 @@ const setHorzVertDistanceCreateNode =
         getArgLiteralVal(args?.[index]) - (referencedSegment?.to?.[index] || 0),
         2
       )
-      let finalValue: Value = createBinaryExpressionWithUnary([
+      let finalValue: Expr = createBinaryExpressionWithUnary([
         createSegEnd(referenceSegName, !index),
         (forceValueUsedInTransform as BinaryPart) ||
           createLiteral(valueUsedInTransform),
@@ -1374,7 +1374,7 @@ export function getTransformInfo(
 }
 
 export function getConstraintType(
-  val: Value | [Value, Value] | [Value, Value, Value],
+  val: Expr | [Expr, Expr] | [Expr, Expr, Expr],
   fnName: ToolTip
 ): LineInputsType | null {
   // this function assumes that for two val sketch functions that one arg is locked down not both
@@ -1416,7 +1416,7 @@ export function getTransformInfos(
     getNodePathFromSourceRange(ast, range)
   )
   const nodes = paths.map((pathToNode) =>
-    getNodeFromPath<Value>(ast, pathToNode, 'CallExpression')
+    getNodeFromPath<Expr>(ast, pathToNode, 'CallExpression')
   )
 
   try {
@@ -1449,7 +1449,7 @@ export function getRemoveConstraintsTransforms(
     getNodePathFromSourceRange(ast, selectionRange.range)
   )
   const nodes = paths.map((pathToNode) =>
-    getNodeFromPath<Value>(ast, pathToNode)
+    getNodeFromPath<Expr>(ast, pathToNode)
   )
 
   const theTransforms = nodes.map((nodeMeta) => {
@@ -1484,7 +1484,7 @@ export function transformSecondarySketchLinesTagFirst({
   transformInfos: TransformInfo[]
   programMemory: ProgramMemory
   forceSegName?: string
-  forceValueUsedInTransform?: Value
+  forceValueUsedInTransform?: Expr
 }):
   | {
       modifiedAst: Program
@@ -1555,7 +1555,7 @@ export function transformAstSketchLines({
   transformInfos: TransformInfo[]
   programMemory: ProgramMemory
   referenceSegName: string
-  forceValueUsedInTransform?: Value
+  forceValueUsedInTransform?: Expr
   referencedSegmentRange?: Selection['range']
 }):
   | {
@@ -1609,7 +1609,7 @@ export function transformAstSketchLines({
       )
         return
 
-      const nodeMeta = getNodeFromPath<Value>(ast, a.pathToNode)
+      const nodeMeta = getNodeFromPath<Expr>(ast, a.pathToNode)
       if (err(nodeMeta)) return
 
       if (a?.argPosition?.type === 'arrayItem') {
@@ -1712,11 +1712,11 @@ export function transformAstSketchLines({
   }
 }
 
-function createSegLen(referenceSegName: string): Value {
+function createSegLen(referenceSegName: string): Expr {
   return createCallExpression('segLen', [createIdentifier(referenceSegName)])
 }
 
-function createSegAngle(referenceSegName: string): Value {
+function createSegAngle(referenceSegName: string): Expr {
   return createCallExpression('segAng', [createIdentifier(referenceSegName)])
 }
 
@@ -1732,7 +1732,7 @@ function createLastSeg(isX: boolean): CallExpression {
   ])
 }
 
-function getArgLiteralVal(arg: Value): number {
+function getArgLiteralVal(arg: Expr): number {
   return arg?.type === 'Literal' ? Number(arg.value) : 0
 }
 
@@ -1776,7 +1776,7 @@ export function getConstraintLevelFromSourceRange(
 }
 
 export function isLiteralArrayOrStatic(
-  val: Value | [Value, Value] | [Value, Value, Value] | undefined
+  val: Expr | [Expr, Expr] | [Expr, Expr, Expr] | undefined
 ): boolean {
   if (!val) return false
 
@@ -1792,7 +1792,7 @@ export function isLiteralArrayOrStatic(
 }
 
 export function isNotLiteralArrayOrStatic(
-  val: Value | [Value, Value] | [Value, Value, Value]
+  val: Expr | [Expr, Expr] | [Expr, Expr, Expr]
 ): boolean {
   if (Array.isArray(val)) {
     const a = val[0]

--- a/src/lang/std/stdTypes.ts
+++ b/src/lang/std/stdTypes.ts
@@ -4,7 +4,7 @@ import {
   Path,
   SourceRange,
   Program,
-  Value,
+  Expr,
   PathToNode,
   CallExpression,
   Literal,
@@ -85,7 +85,7 @@ export type _VarValue<T> =
   | ObjectPropertyInput<T>
   | ArrayOrObjItemInput<T>
 
-export type VarValue = _VarValue<Value>
+export type VarValue = _VarValue<Expr>
 export type RawValue = _VarValue<Literal>
 
 export type VarValues = Array<VarValue>
@@ -99,11 +99,11 @@ type SimplifiedVarValue =
   | { type: 'objectProperty'; key: VarValueKeys }
 
 export type TransformCallback = (
-  args: [Value, Value],
+  args: [Expr, Expr],
   literalValues: RawValues,
   referencedSegment?: Path
 ) => {
-  callExp: Value
+  callExp: Expr
   valueUsedInTransform?: number
 }
 

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -39,7 +39,7 @@ import { ProjectRoute } from 'wasm-lib/kcl/bindings/ProjectRoute'
 import { err } from 'lib/trap'
 
 export type { Program } from '../wasm-lib/kcl/bindings/Program'
-export type { Value } from '../wasm-lib/kcl/bindings/Value'
+export type { Expr } from '../wasm-lib/kcl/bindings/Expr'
 export type { ObjectExpression } from '../wasm-lib/kcl/bindings/ObjectExpression'
 export type { MemberExpression } from '../wasm-lib/kcl/bindings/MemberExpression'
 export type { PipeExpression } from '../wasm-lib/kcl/bindings/PipeExpression'

--- a/src/lib/commandTypes.ts
+++ b/src/lib/commandTypes.ts
@@ -7,7 +7,7 @@ import {
   InterpreterFrom,
 } from 'xstate'
 import { Selection } from './selections'
-import { Identifier, Value, VariableDeclaration } from 'lang/wasm'
+import { Identifier, Expr, VariableDeclaration } from 'lang/wasm'
 import { commandBarMachine } from 'machines/commandBarMachine'
 
 type Icon = CustomIconName
@@ -20,7 +20,7 @@ const INPUT_TYPES = [
   'boolean',
 ] as const
 export interface KclExpression {
-  valueAst: Value
+  valueAst: Expr
   valueText: string
   valueCalculated: string
 }

--- a/src/lib/selections.ts
+++ b/src/lib/selections.ts
@@ -5,7 +5,7 @@ import {
   kclManager,
   sceneEntitiesManager,
 } from 'lib/singletons'
-import { CallExpression, SourceRange, Value, parse, recast } from 'lang/wasm'
+import { CallExpression, SourceRange, Expr, parse, recast } from 'lang/wasm'
 import { ModelingMachineEvent } from 'machines/modelingMachine'
 import { uuidv4 } from 'lib/utils'
 import { EditorSelection, SelectionRange } from '@codemirror/state'
@@ -639,7 +639,7 @@ export function updateSelections(
 
   const newSelections = Object.entries(pathToNodeMap)
     .map(([index, pathToNode]): Selection | undefined => {
-      const nodeMeta = getNodeFromPath<Value>(ast, pathToNode)
+      const nodeMeta = getNodeFromPath<Expr>(ast, pathToNode)
       if (err(nodeMeta)) return undefined
       const node = nodeMeta.node
       return {

--- a/src/lib/useCalculateKclExpression.ts
+++ b/src/lib/useCalculateKclExpression.ts
@@ -3,7 +3,7 @@ import { kclManager, engineCommandManager } from 'lib/singletons'
 import { useKclContext } from 'lang/KclProvider'
 import { findUniqueName } from 'lang/modifyAst'
 import { PrevVariable, findAllPreviousVariables } from 'lang/queryAst'
-import { ProgramMemory, Value, parse } from 'lang/wasm'
+import { ProgramMemory, Expr, parse } from 'lang/wasm'
 import { useEffect, useRef, useState } from 'react'
 import { executeAst } from 'lang/langHelpers'
 import { err, trap } from 'lib/trap'
@@ -24,7 +24,7 @@ export function useCalculateKclExpression({
   initialVariableName?: string
 }): {
   inputRef: React.RefObject<HTMLInputElement>
-  valueNode: Value | null
+  valueNode: Expr | null
   calcResult: string
   prevVariables: PrevVariable<unknown>[]
   newVariableName: string
@@ -45,7 +45,7 @@ export function useCalculateKclExpression({
     insertIndex: 0,
     bodyPath: [],
   })
-  const [valueNode, setValueNode] = useState<Value | null>(null)
+  const [valueNode, setValueNode] = useState<Expr | null>(null)
   const [calcResult, setCalcResult] = useState('NAN')
   const [newVariableName, setNewVariableName] = useState('')
   const [isNewVariableNameUnique, setIsNewVariableNameUnique] = useState(true)

--- a/src/wasm-lib/kcl-macros/tests/macro_test.rs
+++ b/src/wasm-lib/kcl-macros/tests/macro_test.rs
@@ -1,6 +1,6 @@
 extern crate alloc;
 use kcl_lib::ast::types::{
-    BodyItem, Identifier, Literal, LiteralValue, NonCodeMeta, Program, Value, VariableDeclaration, VariableDeclarator,
+    BodyItem, Expr, Identifier, Literal, LiteralValue, NonCodeMeta, Program, VariableDeclaration, VariableDeclarator,
     VariableKind,
 };
 use kcl_macros::parse;
@@ -24,7 +24,7 @@ fn basic() {
                     name: "y".to_owned(),
                     digest: None,
                 },
-                init: Value::Literal(Box::new(Literal {
+                init: Expr::Literal(Box::new(Literal {
                     start: 10,
                     end: 11,
                     value: LiteralValue::IInteger(4),

--- a/src/wasm-lib/kcl/src/ast/types/literal_value.rs
+++ b/src/wasm-lib/kcl/src/ast/types/literal_value.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JValue;
 
-use crate::ast::types::{Literal, Value};
+use crate::ast::types::{Expr, Literal};
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake)]
 #[databake(path = kcl_lib::ast::types)]
@@ -33,9 +33,9 @@ impl LiteralValue {
     }
 }
 
-impl From<Literal> for Value {
+impl From<Literal> for Expr {
     fn from(literal: Literal) -> Self {
-        Value::Literal(Box::new(literal))
+        Expr::Literal(Box::new(literal))
     }
 }
 

--- a/src/wasm-lib/kcl/src/lsp/kcl/mod.rs
+++ b/src/wasm-lib/kcl/src/lsp/kcl/mod.rs
@@ -40,7 +40,7 @@ use tower_lsp::{
 };
 
 use crate::{
-    ast::types::{Value, VariableKind},
+    ast::types::{Expr, VariableKind},
     executor::SourceRange,
     lsp::{backend::Backend as _, util::IntoDiagnostic},
     parser::PIPE_OPERATOR,
@@ -370,7 +370,7 @@ impl Backend {
                         crate::walk::Node::VariableDeclarator(variable) => {
                             let sr: SourceRange = (&variable.id).into();
                             if sr.contains(source_range.start()) {
-                                if let Value::FunctionExpression(_) = &variable.init {
+                                if let Expr::FunctionExpression(_) = &variable.init {
                                     let mut ti = token_index.lock().map_err(|_| anyhow::anyhow!("mutex"))?;
                                     *ti = match self.get_semantic_token_type_index(&SemanticTokenType::FUNCTION) {
                                         Some(index) => index,

--- a/src/wasm-lib/kcl/src/std/kcl_stdlib.rs
+++ b/src/wasm-lib/kcl/src/std/kcl_stdlib.rs
@@ -4,7 +4,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ast::types::{BodyItem, FunctionExpression, Program, Value},
+    ast::types::{BodyItem, Expr, FunctionExpression, Program},
     docs::{StdLibFn, StdLibFnData},
     token::lexer,
 };
@@ -89,7 +89,7 @@ pub fn extract_function(source: &str) -> Option<(Program, Box<FunctionExpression
     let BodyItem::ExpressionStatement(expr) = src.body.last()? else {
         panic!("expected expression statement");
     };
-    let Value::FunctionExpression(function) = expr.expression.clone() else {
+    let Expr::FunctionExpression(function) = expr.expression.clone() else {
         panic!("expected function expr");
     };
     Some((src, function))

--- a/src/wasm-lib/kcl/src/walk/ast_walk.rs
+++ b/src/wasm-lib/kcl/src/walk/ast_walk.rs
@@ -2,8 +2,8 @@ use anyhow::Result;
 
 use crate::{
     ast::types::{
-        BinaryPart, BodyItem, LiteralIdentifier, MemberExpression, MemberObject, ObjectExpression, ObjectProperty,
-        Parameter, Program, UnaryExpression, Value, VariableDeclarator,
+        BinaryPart, BodyItem, Expr, LiteralIdentifier, MemberExpression, MemberObject, ObjectExpression,
+        ObjectProperty, Parameter, Program, UnaryExpression, VariableDeclarator,
     },
     walk::Node,
 };
@@ -108,20 +108,20 @@ where
     }
 }
 
-fn walk_value<'a, WalkT>(node: &'a Value, f: &WalkT) -> Result<bool>
+fn walk_value<'a, WalkT>(node: &'a Expr, f: &WalkT) -> Result<bool>
 where
     WalkT: Walker<'a>,
 {
     match node {
-        Value::Literal(lit) => f.walk(lit.as_ref().into()),
-        Value::TagDeclarator(tag) => f.walk(tag.as_ref().into()),
+        Expr::Literal(lit) => f.walk(lit.as_ref().into()),
+        Expr::TagDeclarator(tag) => f.walk(tag.as_ref().into()),
 
-        Value::Identifier(id) => {
+        Expr::Identifier(id) => {
             // sometimes there's a bare Identifier without a Value::Identifier.
             f.walk(id.as_ref().into())
         }
 
-        Value::BinaryExpression(be) => {
+        Expr::BinaryExpression(be) => {
             if !f.walk(be.as_ref().into())? {
                 return Ok(false);
             }
@@ -130,7 +130,7 @@ where
             }
             walk_binary_part(&be.right, f)
         }
-        Value::FunctionExpression(fe) => {
+        Expr::FunctionExpression(fe) => {
             if !f.walk(fe.as_ref().into())? {
                 return Ok(false);
             }
@@ -142,7 +142,7 @@ where
             }
             walk(&fe.body, f)
         }
-        Value::CallExpression(ce) => {
+        Expr::CallExpression(ce) => {
             if !f.walk(ce.as_ref().into())? {
                 return Ok(false);
             }
@@ -157,7 +157,7 @@ where
             }
             Ok(true)
         }
-        Value::PipeExpression(pe) => {
+        Expr::PipeExpression(pe) => {
             if !f.walk(pe.as_ref().into())? {
                 return Ok(false);
             }
@@ -169,8 +169,8 @@ where
             }
             Ok(true)
         }
-        Value::PipeSubstitution(ps) => f.walk(ps.as_ref().into()),
-        Value::ArrayExpression(ae) => {
+        Expr::PipeSubstitution(ps) => f.walk(ps.as_ref().into()),
+        Expr::ArrayExpression(ae) => {
             if !f.walk(ae.as_ref().into())? {
                 return Ok(false);
             }
@@ -181,10 +181,10 @@ where
             }
             Ok(true)
         }
-        Value::ObjectExpression(oe) => walk_object_expression(oe, f),
-        Value::MemberExpression(me) => walk_member_expression(me, f),
-        Value::UnaryExpression(ue) => walk_unary_expression(ue, f),
-        Value::None(_) => Ok(true),
+        Expr::ObjectExpression(oe) => walk_object_expression(oe, f),
+        Expr::MemberExpression(me) => walk_member_expression(me, f),
+        Expr::UnaryExpression(ue) => walk_unary_expression(ue, f),
+        Expr::None(_) => Ok(true),
     }
 }
 


### PR DESCRIPTION
As @jtran  pointed out, kcl's `Value` enum is actually an expression. "2+2" isn't a value, it's an expression, which can compute a value. So I renamed it `Expr`.