### PR TITLE
Rename MemoryItem to KclValue

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4638,9 +4638,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.122"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
+checksum = "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
 dependencies = [
  "indexmap 2.2.6",
  "itoa 1.0.11",

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -23,7 +23,7 @@ import { KclError as RustKclError } from '../wasm-lib/kcl/bindings/KclError'
 import { EngineCommandManager } from './std/engineConnection'
 import { ProgramReturn } from '../wasm-lib/kcl/bindings/ProgramReturn'
 import { Discovered } from '../wasm-lib/kcl/bindings/Discovered'
-import { MemoryItem } from '../wasm-lib/kcl/bindings/MemoryItem'
+import { KclValue } from '../wasm-lib/kcl/bindings/KclValue'
 import type { Program } from '../wasm-lib/kcl/bindings/Program'
 import type { Token } from '../wasm-lib/kcl/bindings/Token'
 import { Coords2d } from './std/sketch'
@@ -81,7 +81,7 @@ export type { SourceRange } from '../wasm-lib/kcl/bindings/SourceRange'
 export type { Path } from '../wasm-lib/kcl/bindings/Path'
 export type { SketchGroup } from '../wasm-lib/kcl/bindings/SketchGroup'
 export type { ExtrudeGroup } from '../wasm-lib/kcl/bindings/ExtrudeGroup'
-export type { MemoryItem } from '../wasm-lib/kcl/bindings/MemoryItem'
+export type { KclValue } from '../wasm-lib/kcl/bindings/KclValue'
 export type { ExtrudeSurface } from '../wasm-lib/kcl/bindings/ExtrudeSurface'
 
 export const wasmUrl = () => {
@@ -140,7 +140,7 @@ export const parse = (code: string | Error): Program | Error => {
 export type PathToNode = [string | number, string][]
 
 interface Memory {
-  [key: string]: MemoryItem
+  [key: string]: KclValue
 }
 
 type EnvironmentRef = number
@@ -215,7 +215,7 @@ export class ProgramMemory {
     return false
   }
 
-  get(name: string): MemoryItem | null {
+  get(name: string): KclValue | null {
     let envRef = this.currentEnv
     while (true) {
       const env = this.environments[envRef]
@@ -230,7 +230,7 @@ export class ProgramMemory {
     return null
   }
 
-  set(name: string, value: MemoryItem): Error | null {
+  set(name: string, value: KclValue): Error | null {
     if (this.environments.length === 0) {
       return new Error('No environment to set memory in')
     }
@@ -240,14 +240,14 @@ export class ProgramMemory {
   }
 
   /**
-   * Returns a new ProgramMemory with only `MemoryItem`s that pass the
+   * Returns a new ProgramMemory with only `KclValue`s that pass the
    * predicate.  Values are deep copied.
    *
    * Note: Return value of the returned ProgramMemory is always null.
    */
   filterVariables(
     keepPrelude: boolean,
-    predicate: (value: MemoryItem) => boolean
+    predicate: (value: KclValue) => boolean
   ): ProgramMemory | Error {
     const environments: Environment[] = []
     for (const [i, env] of this.environments.entries()) {
@@ -290,8 +290,8 @@ export class ProgramMemory {
    *
    * This should only be used to display in the MemoryPane UI.
    */
-  visibleEntries(): Map<string, MemoryItem> {
-    const map = new Map<string, MemoryItem>()
+  visibleEntries(): Map<string, KclValue> {
+    const map = new Map<string, KclValue>()
     let envRef = this.currentEnv
     while (true) {
       const env = this.environments[envRef]

--- a/src/wasm-lib/derive-docs/src/lib.rs
+++ b/src/wasm-lib/derive-docs/src/lib.rs
@@ -389,7 +389,7 @@ fn do_stdlib_inner(
         fn #boxed_fn_name_ident(
             args: crate::std::Args,
         ) -> std::pin::Pin<
-            Box<dyn std::future::Future<Output = anyhow::Result<crate::executor::MemoryItem, crate::errors::KclError>> + Send>,
+            Box<dyn std::future::Future<Output = anyhow::Result<crate::executor::KclValue, crate::errors::KclError>> + Send>,
         > {
             Box::pin(#fn_name_ident(args))
         }

--- a/src/wasm-lib/derive-docs/tests/args_with_lifetime.gen
+++ b/src/wasm-lib/derive-docs/tests/args_with_lifetime.gen
@@ -48,7 +48,7 @@ fn boxed_someFn(
 ) -> std::pin::Pin<
     Box<
         dyn std::future::Future<
-                Output = anyhow::Result<crate::executor::MemoryItem, crate::errors::KclError>,
+                Output = anyhow::Result<crate::executor::KclValue, crate::errors::KclError>,
             > + Send,
     >,
 > {

--- a/src/wasm-lib/derive-docs/tests/args_with_refs.gen
+++ b/src/wasm-lib/derive-docs/tests/args_with_refs.gen
@@ -48,7 +48,7 @@ fn boxed_someFn(
 ) -> std::pin::Pin<
     Box<
         dyn std::future::Future<
-                Output = anyhow::Result<crate::executor::MemoryItem, crate::errors::KclError>,
+                Output = anyhow::Result<crate::executor::KclValue, crate::errors::KclError>,
             > + Send,
     >,
 > {

--- a/src/wasm-lib/derive-docs/tests/array.gen
+++ b/src/wasm-lib/derive-docs/tests/array.gen
@@ -81,7 +81,7 @@ fn boxed_show(
 ) -> std::pin::Pin<
     Box<
         dyn std::future::Future<
-                Output = anyhow::Result<crate::executor::MemoryItem, crate::errors::KclError>,
+                Output = anyhow::Result<crate::executor::KclValue, crate::errors::KclError>,
             > + Send,
     >,
 > {

--- a/src/wasm-lib/derive-docs/tests/box.gen
+++ b/src/wasm-lib/derive-docs/tests/box.gen
@@ -48,7 +48,7 @@ fn boxed_show(
 ) -> std::pin::Pin<
     Box<
         dyn std::future::Future<
-                Output = anyhow::Result<crate::executor::MemoryItem, crate::errors::KclError>,
+                Output = anyhow::Result<crate::executor::KclValue, crate::errors::KclError>,
             > + Send,
     >,
 > {

--- a/src/wasm-lib/derive-docs/tests/doc_comment_with_code.gen
+++ b/src/wasm-lib/derive-docs/tests/doc_comment_with_code.gen
@@ -82,7 +82,7 @@ fn boxed_my_func(
 ) -> std::pin::Pin<
     Box<
         dyn std::future::Future<
-                Output = anyhow::Result<crate::executor::MemoryItem, crate::errors::KclError>,
+                Output = anyhow::Result<crate::executor::KclValue, crate::errors::KclError>,
             > + Send,
     >,
 > {

--- a/src/wasm-lib/derive-docs/tests/lineTo.gen
+++ b/src/wasm-lib/derive-docs/tests/lineTo.gen
@@ -82,7 +82,7 @@ fn boxed_line_to(
 ) -> std::pin::Pin<
     Box<
         dyn std::future::Future<
-                Output = anyhow::Result<crate::executor::MemoryItem, crate::errors::KclError>,
+                Output = anyhow::Result<crate::executor::KclValue, crate::errors::KclError>,
             > + Send,
     >,
 > {

--- a/src/wasm-lib/derive-docs/tests/min.gen
+++ b/src/wasm-lib/derive-docs/tests/min.gen
@@ -81,7 +81,7 @@ fn boxed_min(
 ) -> std::pin::Pin<
     Box<
         dyn std::future::Future<
-                Output = anyhow::Result<crate::executor::MemoryItem, crate::errors::KclError>,
+                Output = anyhow::Result<crate::executor::KclValue, crate::errors::KclError>,
             > + Send,
     >,
 > {

--- a/src/wasm-lib/derive-docs/tests/option.gen
+++ b/src/wasm-lib/derive-docs/tests/option.gen
@@ -48,7 +48,7 @@ fn boxed_show(
 ) -> std::pin::Pin<
     Box<
         dyn std::future::Future<
-                Output = anyhow::Result<crate::executor::MemoryItem, crate::errors::KclError>,
+                Output = anyhow::Result<crate::executor::KclValue, crate::errors::KclError>,
             > + Send,
     >,
 > {

--- a/src/wasm-lib/derive-docs/tests/option_input_format.gen
+++ b/src/wasm-lib/derive-docs/tests/option_input_format.gen
@@ -48,7 +48,7 @@ fn boxed_import(
 ) -> std::pin::Pin<
     Box<
         dyn std::future::Future<
-                Output = anyhow::Result<crate::executor::MemoryItem, crate::errors::KclError>,
+                Output = anyhow::Result<crate::executor::KclValue, crate::errors::KclError>,
             > + Send,
     >,
 > {

--- a/src/wasm-lib/derive-docs/tests/return_vec_box_sketch_group.gen
+++ b/src/wasm-lib/derive-docs/tests/return_vec_box_sketch_group.gen
@@ -48,7 +48,7 @@ fn boxed_import(
 ) -> std::pin::Pin<
     Box<
         dyn std::future::Future<
-                Output = anyhow::Result<crate::executor::MemoryItem, crate::errors::KclError>,
+                Output = anyhow::Result<crate::executor::KclValue, crate::errors::KclError>,
             > + Send,
     >,
 > {

--- a/src/wasm-lib/derive-docs/tests/return_vec_sketch_group.gen
+++ b/src/wasm-lib/derive-docs/tests/return_vec_sketch_group.gen
@@ -48,7 +48,7 @@ fn boxed_import(
 ) -> std::pin::Pin<
     Box<
         dyn std::future::Future<
-                Output = anyhow::Result<crate::executor::MemoryItem, crate::errors::KclError>,
+                Output = anyhow::Result<crate::executor::KclValue, crate::errors::KclError>,
             > + Send,
     >,
 > {

--- a/src/wasm-lib/derive-docs/tests/show.gen
+++ b/src/wasm-lib/derive-docs/tests/show.gen
@@ -48,7 +48,7 @@ fn boxed_show(
 ) -> std::pin::Pin<
     Box<
         dyn std::future::Future<
-                Output = anyhow::Result<crate::executor::MemoryItem, crate::errors::KclError>,
+                Output = anyhow::Result<crate::executor::KclValue, crate::errors::KclError>,
             > + Send,
     >,
 > {

--- a/src/wasm-lib/kcl/src/ast/types/none.rs
+++ b/src/wasm-lib/kcl/src/ast/types/none.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     ast::types::ConstraintLevel,
-    executor::{MemoryItem, SourceRange, UserVal},
+    executor::{KclValue, SourceRange, UserVal},
 };
 
 /// KCL value for an optional parameter which was not given an argument.
@@ -37,10 +37,10 @@ impl From<&KclNone> for UserVal {
     }
 }
 
-impl From<&KclNone> for MemoryItem {
+impl From<&KclNone> for KclValue {
     fn from(none: &KclNone) -> Self {
         let val = UserVal::from(none);
-        MemoryItem::UserVal(val)
+        KclValue::UserVal(val)
     }
 }
 

--- a/src/wasm-lib/kcl/src/function_param.rs
+++ b/src/wasm-lib/kcl/src/function_param.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 use crate::{
     ast::types::FunctionExpression,
     errors::KclError,
-    executor::{DynamicState, ExecutorContext, MemoryFunction, MemoryItem, Metadata, ProgramMemory, ProgramReturn},
+    executor::{DynamicState, ExecutorContext, KclValue, MemoryFunction, Metadata, ProgramMemory, ProgramReturn},
 };
 
 /// A function being used as a parameter into a stdlib function.
@@ -17,7 +17,7 @@ pub struct FunctionParam<'a> {
 }
 
 impl<'a> FunctionParam<'a> {
-    pub async fn call(&self, args: Vec<MemoryItem>) -> Result<Option<ProgramReturn>, KclError> {
+    pub async fn call(&self, args: Vec<KclValue>) -> Result<Option<ProgramReturn>, KclError> {
         (self.inner)(
             args,
             self.memory.clone(),

--- a/src/wasm-lib/kcl/src/std/args.rs
+++ b/src/wasm-lib/kcl/src/std/args.rs
@@ -8,14 +8,14 @@ use crate::{
     ast::types::{parse_json_number_as_f64, TagDeclarator},
     errors::{KclError, KclErrorDetails},
     executor::{
-        DynamicState, ExecutorContext, ExtrudeGroup, ExtrudeGroupSet, ExtrudeSurface, MemoryItem, Metadata,
+        DynamicState, ExecutorContext, ExtrudeGroup, ExtrudeGroupSet, ExtrudeSurface, KclValue, Metadata,
         ProgramMemory, SketchGroup, SketchGroupSet, SketchSurface, SourceRange, TagIdentifier,
     },
 };
 
 #[derive(Debug, Clone)]
 pub struct Args {
-    pub args: Vec<MemoryItem>,
+    pub args: Vec<KclValue>,
     pub source_range: SourceRange,
     pub ctx: ExecutorContext,
     pub current_program_memory: ProgramMemory,
@@ -24,7 +24,7 @@ pub struct Args {
 
 impl Args {
     pub fn new(
-        args: Vec<MemoryItem>,
+        args: Vec<KclValue>,
         source_range: SourceRange,
         ctx: ExecutorContext,
         current_program_memory: ProgramMemory,
@@ -72,7 +72,7 @@ impl Args {
         &'a self,
         tag: &'a TagIdentifier,
     ) -> Result<&'a crate::executor::TagEngineInfo, KclError> {
-        if let MemoryItem::TagIdentifier(t) = self.current_program_memory.get(&tag.value, self.source_range)? {
+        if let KclValue::TagIdentifier(t) = self.current_program_memory.get(&tag.value, self.source_range)? {
             Ok(t.info.as_ref().ok_or_else(|| {
                 KclError::Type(KclErrorDetails {
                     message: format!("Tag `{}` does not have engine info", tag.value),
@@ -167,8 +167,8 @@ impl Args {
         Ok(())
     }
 
-    fn make_user_val_from_json(&self, j: serde_json::Value) -> Result<MemoryItem, KclError> {
-        Ok(MemoryItem::UserVal(crate::executor::UserVal {
+    fn make_user_val_from_json(&self, j: serde_json::Value) -> Result<KclValue, KclError> {
+        Ok(KclValue::UserVal(crate::executor::UserVal {
             value: j,
             meta: vec![Metadata {
                 source_range: self.source_range,
@@ -176,15 +176,15 @@ impl Args {
         }))
     }
 
-    pub(crate) fn make_null_user_val(&self) -> Result<MemoryItem, KclError> {
+    pub(crate) fn make_null_user_val(&self) -> Result<KclValue, KclError> {
         self.make_user_val_from_json(serde_json::Value::Null)
     }
 
-    pub(crate) fn make_user_val_from_i64(&self, n: i64) -> Result<MemoryItem, KclError> {
+    pub(crate) fn make_user_val_from_i64(&self, n: i64) -> Result<KclValue, KclError> {
         self.make_user_val_from_json(serde_json::Value::Number(serde_json::Number::from(n)))
     }
 
-    pub(crate) fn make_user_val_from_f64(&self, f: f64) -> Result<MemoryItem, KclError> {
+    pub(crate) fn make_user_val_from_f64(&self, f: f64) -> Result<KclValue, KclError> {
         self.make_user_val_from_json(serde_json::Value::Number(serde_json::Number::from_f64(f).ok_or_else(
             || {
                 KclError::Type(KclErrorDetails {
@@ -195,7 +195,7 @@ impl Args {
         )?))
     }
 
-    pub(crate) fn make_user_val_from_f64_array(&self, f: Vec<f64>) -> Result<MemoryItem, KclError> {
+    pub(crate) fn make_user_val_from_f64_array(&self, f: Vec<f64>) -> Result<KclValue, KclError> {
         let mut arr = Vec::new();
         for n in f {
             arr.push(serde_json::Value::Number(serde_json::Number::from_f64(n).ok_or_else(
@@ -281,7 +281,7 @@ impl Args {
 
     pub(crate) fn get_data_and_optional_tag<'a, T>(&'a self) -> Result<(T, Option<FaceTag>), KclError>
     where
-        T: serde::de::DeserializeOwned + FromMemoryItem<'a> + Sized,
+        T: serde::de::DeserializeOwned + FromKclValue<'a> + Sized,
     {
         FromArgs::from_args(self, 0)
     }
@@ -304,7 +304,7 @@ impl Args {
         &'a self,
     ) -> Result<(T, Box<SketchGroup>, Option<TagDeclarator>), KclError>
     where
-        T: serde::de::DeserializeOwned + FromMemoryItem<'a> + Sized,
+        T: serde::de::DeserializeOwned + FromKclValue<'a> + Sized,
     {
         FromArgs::from_args(self, 0)
     }
@@ -313,21 +313,21 @@ impl Args {
         &'a self,
     ) -> Result<(T, SketchSurface, Option<TagDeclarator>), KclError>
     where
-        T: serde::de::DeserializeOwned + FromMemoryItem<'a> + Sized,
+        T: serde::de::DeserializeOwned + FromKclValue<'a> + Sized,
     {
         FromArgs::from_args(self, 0)
     }
 
     pub(crate) fn get_data_and_extrude_group_set<'a, T>(&'a self) -> Result<(T, ExtrudeGroupSet), KclError>
     where
-        T: serde::de::DeserializeOwned + FromMemoryItem<'a> + Sized,
+        T: serde::de::DeserializeOwned + FromKclValue<'a> + Sized,
     {
         FromArgs::from_args(self, 0)
     }
 
     pub(crate) fn get_data_and_extrude_group<'a, T>(&'a self) -> Result<(T, Box<ExtrudeGroup>), KclError>
     where
-        T: serde::de::DeserializeOwned + FromMemoryItem<'a> + Sized,
+        T: serde::de::DeserializeOwned + FromKclValue<'a> + Sized,
     {
         FromArgs::from_args(self, 0)
     }
@@ -336,7 +336,7 @@ impl Args {
         &'a self,
     ) -> Result<(T, Box<ExtrudeGroup>, Option<TagDeclarator>), KclError>
     where
-        T: serde::de::DeserializeOwned + FromMemoryItem<'a> + Sized,
+        T: serde::de::DeserializeOwned + FromKclValue<'a> + Sized,
     {
         FromArgs::from_args(self, 0)
     }
@@ -443,15 +443,15 @@ pub trait FromArgs<'a>: Sized {
     fn from_args(args: &'a Args, index: usize) -> Result<Self, KclError>;
 }
 
-/// Types which impl this trait can be extracted from a `MemoryItem`.
-pub trait FromMemoryItem<'a>: Sized {
-    /// Try to convert a MemoryItem into this type.
-    fn from_mem_item(arg: &'a MemoryItem) -> Option<Self>;
+/// Types which impl this trait can be extracted from a `KclValue`.
+pub trait FromKclValue<'a>: Sized {
+    /// Try to convert a KclValue into this type.
+    fn from_mem_item(arg: &'a KclValue) -> Option<Self>;
 }
 
 impl<'a, T> FromArgs<'a> for T
 where
-    T: FromMemoryItem<'a> + Sized,
+    T: FromKclValue<'a> + Sized,
 {
     fn from_args(args: &'a Args, i: usize) -> Result<Self, KclError> {
         let Some(arg) = args.args.get(i) else {
@@ -475,7 +475,7 @@ where
 
 impl<'a, T> FromArgs<'a> for Option<T>
 where
-    T: FromMemoryItem<'a> + Sized,
+    T: FromKclValue<'a> + Sized,
 {
     fn from_args(args: &'a Args, i: usize) -> Result<Self, KclError> {
         let Some(arg) = args.args.get(i) else { return Ok(None) };
@@ -533,27 +533,27 @@ where
     }
 }
 
-impl<'a> FromMemoryItem<'a> for &'a str {
-    fn from_mem_item(arg: &'a MemoryItem) -> Option<Self> {
+impl<'a> FromKclValue<'a> for &'a str {
+    fn from_mem_item(arg: &'a KclValue) -> Option<Self> {
         arg.as_user_val().and_then(|uv| uv.value.as_str())
     }
 }
 
-impl<'a> FromMemoryItem<'a> for TagDeclarator {
-    fn from_mem_item(arg: &'a MemoryItem) -> Option<Self> {
+impl<'a> FromKclValue<'a> for TagDeclarator {
+    fn from_mem_item(arg: &'a KclValue) -> Option<Self> {
         arg.get_tag_declarator().ok()
     }
 }
 
-impl<'a> FromMemoryItem<'a> for TagIdentifier {
-    fn from_mem_item(arg: &'a MemoryItem) -> Option<Self> {
+impl<'a> FromKclValue<'a> for TagIdentifier {
+    fn from_mem_item(arg: &'a KclValue) -> Option<Self> {
         arg.get_tag_identifier().ok()
     }
 }
 
-impl<'a> FromMemoryItem<'a> for &'a SketchGroup {
-    fn from_mem_item(arg: &'a MemoryItem) -> Option<Self> {
-        let MemoryItem::SketchGroup(s) = arg else {
+impl<'a> FromKclValue<'a> for &'a SketchGroup {
+    fn from_mem_item(arg: &'a KclValue) -> Option<Self> {
+        let KclValue::SketchGroup(s) = arg else {
             return None;
         };
         Some(s.as_ref())
@@ -562,8 +562,8 @@ impl<'a> FromMemoryItem<'a> for &'a SketchGroup {
 
 macro_rules! impl_from_arg_via_json {
     ($typ:path) => {
-        impl<'a> FromMemoryItem<'a> for $typ {
-            fn from_mem_item(arg: &'a MemoryItem) -> Option<Self> {
+        impl<'a> FromKclValue<'a> for $typ {
+            fn from_mem_item(arg: &'a KclValue) -> Option<Self> {
                 from_user_val(arg)
             }
         }
@@ -572,20 +572,20 @@ macro_rules! impl_from_arg_via_json {
 
 macro_rules! impl_from_arg_for_array {
     ($n:literal) => {
-        impl<'a, T> FromMemoryItem<'a> for [T; $n]
+        impl<'a, T> FromKclValue<'a> for [T; $n]
         where
-            T: serde::de::DeserializeOwned + FromMemoryItem<'a>,
+            T: serde::de::DeserializeOwned + FromKclValue<'a>,
         {
-            fn from_mem_item(arg: &'a MemoryItem) -> Option<Self> {
+            fn from_mem_item(arg: &'a KclValue) -> Option<Self> {
                 from_user_val(arg)
             }
         }
     };
 }
 
-fn from_user_val<T: DeserializeOwned>(arg: &MemoryItem) -> Option<T> {
+fn from_user_val<T: DeserializeOwned>(arg: &KclValue) -> Option<T> {
     let v = match arg {
-        MemoryItem::UserVal(v) => v.value.clone(),
+        KclValue::UserVal(v) => v.value.clone(),
         other => serde_json::to_value(other).ok()?,
     };
     serde_json::from_value(v).ok()
@@ -619,64 +619,64 @@ impl_from_arg_via_json!(bool);
 impl_from_arg_for_array!(2);
 impl_from_arg_for_array!(3);
 
-impl<'a> FromMemoryItem<'a> for &'a Box<SketchGroup> {
-    fn from_mem_item(arg: &'a MemoryItem) -> Option<Self> {
-        let MemoryItem::SketchGroup(s) = arg else {
+impl<'a> FromKclValue<'a> for &'a Box<SketchGroup> {
+    fn from_mem_item(arg: &'a KclValue) -> Option<Self> {
+        let KclValue::SketchGroup(s) = arg else {
             return None;
         };
         Some(s)
     }
 }
 
-impl<'a> FromMemoryItem<'a> for Box<SketchGroup> {
-    fn from_mem_item(arg: &'a MemoryItem) -> Option<Self> {
-        let MemoryItem::SketchGroup(s) = arg else {
+impl<'a> FromKclValue<'a> for Box<SketchGroup> {
+    fn from_mem_item(arg: &'a KclValue) -> Option<Self> {
+        let KclValue::SketchGroup(s) = arg else {
             return None;
         };
         Some(s.to_owned())
     }
 }
 
-impl<'a> FromMemoryItem<'a> for Box<ExtrudeGroup> {
-    fn from_mem_item(arg: &'a MemoryItem) -> Option<Self> {
-        let MemoryItem::ExtrudeGroup(s) = arg else {
+impl<'a> FromKclValue<'a> for Box<ExtrudeGroup> {
+    fn from_mem_item(arg: &'a KclValue) -> Option<Self> {
+        let KclValue::ExtrudeGroup(s) = arg else {
             return None;
         };
         Some(s.to_owned())
     }
 }
 
-impl<'a> FromMemoryItem<'a> for FnAsArg<'a> {
-    fn from_mem_item(arg: &'a MemoryItem) -> Option<Self> {
+impl<'a> FromKclValue<'a> for FnAsArg<'a> {
+    fn from_mem_item(arg: &'a KclValue) -> Option<Self> {
         arg.get_function()
     }
 }
 
-impl<'a> FromMemoryItem<'a> for ExtrudeGroupSet {
-    fn from_mem_item(arg: &'a MemoryItem) -> Option<Self> {
+impl<'a> FromKclValue<'a> for ExtrudeGroupSet {
+    fn from_mem_item(arg: &'a KclValue) -> Option<Self> {
         arg.get_extrude_group_set().ok()
     }
 }
-impl<'a> FromMemoryItem<'a> for SketchGroupSet {
-    fn from_mem_item(arg: &'a MemoryItem) -> Option<Self> {
+impl<'a> FromKclValue<'a> for SketchGroupSet {
+    fn from_mem_item(arg: &'a KclValue) -> Option<Self> {
         arg.get_sketch_group_set().ok()
     }
 }
-impl<'a> FromMemoryItem<'a> for SketchSurfaceOrGroup {
-    fn from_mem_item(arg: &'a MemoryItem) -> Option<Self> {
+impl<'a> FromKclValue<'a> for SketchSurfaceOrGroup {
+    fn from_mem_item(arg: &'a KclValue) -> Option<Self> {
         match arg {
-            MemoryItem::SketchGroup(sg) => Some(Self::SketchGroup(sg.clone())),
-            MemoryItem::Plane(sg) => Some(Self::SketchSurface(SketchSurface::Plane(sg.clone()))),
-            MemoryItem::Face(sg) => Some(Self::SketchSurface(SketchSurface::Face(sg.clone()))),
+            KclValue::SketchGroup(sg) => Some(Self::SketchGroup(sg.clone())),
+            KclValue::Plane(sg) => Some(Self::SketchSurface(SketchSurface::Plane(sg.clone()))),
+            KclValue::Face(sg) => Some(Self::SketchSurface(SketchSurface::Face(sg.clone()))),
             _ => None,
         }
     }
 }
-impl<'a> FromMemoryItem<'a> for SketchSurface {
-    fn from_mem_item(arg: &'a MemoryItem) -> Option<Self> {
+impl<'a> FromKclValue<'a> for SketchSurface {
+    fn from_mem_item(arg: &'a KclValue) -> Option<Self> {
         match arg {
-            MemoryItem::Plane(sg) => Some(Self::Plane(sg.clone())),
-            MemoryItem::Face(sg) => Some(Self::Face(sg.clone())),
+            KclValue::Plane(sg) => Some(Self::Plane(sg.clone())),
+            KclValue::Face(sg) => Some(Self::Face(sg.clone())),
             _ => None,
         }
     }

--- a/src/wasm-lib/kcl/src/std/assert.rs
+++ b/src/wasm-lib/kcl/src/std/assert.rs
@@ -6,7 +6,7 @@ use schemars::JsonSchema;
 
 use crate::{
     errors::{KclError, KclErrorDetails},
-    executor::MemoryItem,
+    executor::KclValue,
     std::Args,
 };
 
@@ -22,7 +22,7 @@ async fn _assert(value: bool, message: &str, args: &Args) -> Result<(), KclError
 
 /// Check that the provided value is true, or raise a [KclError]
 /// with the provided description.
-pub async fn assert(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn assert(args: Args) -> Result<KclValue, KclError> {
     let (data, description): (bool, String) = args.get_data()?;
     inner_assert(data, &description, &args).await?;
     args.make_null_user_val()
@@ -42,7 +42,7 @@ async fn inner_assert(data: bool, message: &str, args: &Args) -> Result<(), KclE
     _assert(data, message, args).await
 }
 
-pub async fn assert_lt(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn assert_lt(args: Args) -> Result<KclValue, KclError> {
     let (left, right, description): (f64, f64, String) = args.get_data()?;
     inner_assert_lt(left, right, &description, &args).await?;
     args.make_null_user_val()
@@ -61,7 +61,7 @@ async fn inner_assert_lt(left: f64, right: f64, message: &str, args: &Args) -> R
     _assert(left < right, message, args).await
 }
 
-pub async fn assert_gt(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn assert_gt(args: Args) -> Result<KclValue, KclError> {
     let (left, right, description): (f64, f64, String) = args.get_data()?;
     inner_assert_gt(left, right, &description, &args).await?;
     args.make_null_user_val()
@@ -82,7 +82,7 @@ async fn inner_assert_equal(left: f64, right: f64, epsilon: f64, message: &str, 
     _assert((right - left).abs() < epsilon, message, args).await
 }
 
-pub async fn assert_equal(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn assert_equal(args: Args) -> Result<KclValue, KclError> {
     let (left, right, epsilon, description): (f64, f64, f64, String) = args.get_data()?;
     inner_assert_equal(left, right, epsilon, &description, &args).await?;
     args.make_null_user_val()
@@ -101,7 +101,7 @@ async fn inner_assert_gt(left: f64, right: f64, message: &str, args: &Args) -> R
     _assert(left > right, message, args).await
 }
 
-pub async fn assert_lte(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn assert_lte(args: Args) -> Result<KclValue, KclError> {
     let (left, right, description): (f64, f64, String) = args.get_data()?;
     inner_assert_lte(left, right, &description, &args).await?;
     args.make_null_user_val()
@@ -121,7 +121,7 @@ async fn inner_assert_lte(left: f64, right: f64, message: &str, args: &Args) -> 
     _assert(left <= right, message, args).await
 }
 
-pub async fn assert_gte(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn assert_gte(args: Args) -> Result<KclValue, KclError> {
     let (left, right, description): (f64, f64, String) = args.get_data()?;
     inner_assert_gte(left, right, &description, &args).await?;
     args.make_null_user_val()

--- a/src/wasm-lib/kcl/src/std/chamfer.rs
+++ b/src/wasm-lib/kcl/src/std/chamfer.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     ast::types::TagDeclarator,
     errors::{KclError, KclErrorDetails},
-    executor::{ChamferSurface, ExtrudeGroup, ExtrudeSurface, FilletOrChamfer, GeoMeta, MemoryItem},
+    executor::{ChamferSurface, ExtrudeGroup, ExtrudeSurface, FilletOrChamfer, GeoMeta, KclValue},
     std::{fillet::EdgeReference, Args},
 };
 
@@ -27,12 +27,12 @@ pub struct ChamferData {
 }
 
 /// Create chamfers on tagged paths.
-pub async fn chamfer(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn chamfer(args: Args) -> Result<KclValue, KclError> {
     let (data, extrude_group, tag): (ChamferData, Box<ExtrudeGroup>, Option<TagDeclarator>) =
         args.get_data_and_extrude_group_and_tag()?;
 
     let extrude_group = inner_chamfer(data, extrude_group, tag, args).await?;
-    Ok(MemoryItem::ExtrudeGroup(extrude_group))
+    Ok(KclValue::ExtrudeGroup(extrude_group))
 }
 
 /// Cut a straight transitional edge along a tagged path.

--- a/src/wasm-lib/kcl/src/std/convert.rs
+++ b/src/wasm-lib/kcl/src/std/convert.rs
@@ -5,7 +5,7 @@ use schemars::JsonSchema;
 
 use crate::{
     errors::{KclError, KclErrorDetails},
-    executor::{MemoryItem, SourceRange},
+    executor::{KclValue, SourceRange},
     std::Args,
 };
 
@@ -31,7 +31,7 @@ impl ConversionError {
 }
 
 /// Converts a number to integer.
-pub async fn int(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn int(args: Args) -> Result<KclValue, KclError> {
     let num = args.get_number()?;
     let converted = inner_int(num).map_err(|err| err.into_kcl_error(args.source_range))?;
 

--- a/src/wasm-lib/kcl/src/std/extrude.rs
+++ b/src/wasm-lib/kcl/src/std/extrude.rs
@@ -8,14 +8,14 @@ use uuid::Uuid;
 use crate::{
     errors::{KclError, KclErrorDetails},
     executor::{
-        ExtrudeGroup, ExtrudeGroupSet, ExtrudeSurface, GeoMeta, MemoryItem, Path, SketchGroup, SketchGroupSet,
+        ExtrudeGroup, ExtrudeGroupSet, ExtrudeSurface, GeoMeta, KclValue, Path, SketchGroup, SketchGroupSet,
         SketchSurface,
     },
     std::Args,
 };
 
 /// Extrudes by a given amount.
-pub async fn extrude(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn extrude(args: Args) -> Result<KclValue, KclError> {
     let (length, sketch_group_set) = args.get_number_sketch_group_set()?;
 
     let result = inner_extrude(length, sketch_group_set, args).await?;

--- a/src/wasm-lib/kcl/src/std/fillet.rs
+++ b/src/wasm-lib/kcl/src/std/fillet.rs
@@ -11,7 +11,7 @@ use crate::{
     ast::types::TagDeclarator,
     errors::{KclError, KclErrorDetails},
     executor::{
-        ExtrudeGroup, ExtrudeSurface, FilletOrChamfer, FilletSurface, GeoMeta, MemoryItem, TagIdentifier, UserVal,
+        ExtrudeGroup, ExtrudeSurface, FilletOrChamfer, FilletSurface, GeoMeta, KclValue, TagIdentifier, UserVal,
     },
     std::Args,
 };
@@ -41,12 +41,12 @@ pub enum EdgeReference {
 }
 
 /// Create fillets on tagged paths.
-pub async fn fillet(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn fillet(args: Args) -> Result<KclValue, KclError> {
     let (data, extrude_group, tag): (FilletData, Box<ExtrudeGroup>, Option<TagDeclarator>) =
         args.get_data_and_extrude_group_and_tag()?;
 
     let extrude_group = inner_fillet(data, extrude_group, tag, args).await?;
-    Ok(MemoryItem::ExtrudeGroup(extrude_group))
+    Ok(KclValue::ExtrudeGroup(extrude_group))
 }
 
 /// Blend a transitional edge along a tagged path, smoothing the sharp edge.
@@ -145,11 +145,11 @@ async fn inner_fillet(
 }
 
 /// Get the opposite edge to the edge given.
-pub async fn get_opposite_edge(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn get_opposite_edge(args: Args) -> Result<KclValue, KclError> {
     let tag: TagIdentifier = args.get_data()?;
 
     let edge = inner_get_opposite_edge(tag, args.clone()).await?;
-    Ok(MemoryItem::UserVal(UserVal {
+    Ok(KclValue::UserVal(UserVal {
         value: serde_json::to_value(edge).map_err(|e| {
             KclError::Type(KclErrorDetails {
                 message: format!("Failed to convert Uuid to json: {}", e),
@@ -222,11 +222,11 @@ async fn inner_get_opposite_edge(tag: TagIdentifier, args: Args) -> Result<Uuid,
 }
 
 /// Get the next adjacent edge to the edge given.
-pub async fn get_next_adjacent_edge(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn get_next_adjacent_edge(args: Args) -> Result<KclValue, KclError> {
     let tag: TagIdentifier = args.get_data()?;
 
     let edge = inner_get_next_adjacent_edge(tag, args.clone()).await?;
-    Ok(MemoryItem::UserVal(UserVal {
+    Ok(KclValue::UserVal(UserVal {
         value: serde_json::to_value(edge).map_err(|e| {
             KclError::Type(KclErrorDetails {
                 message: format!("Failed to convert Uuid to json: {}", e),
@@ -304,11 +304,11 @@ async fn inner_get_next_adjacent_edge(tag: TagIdentifier, args: Args) -> Result<
 }
 
 /// Get the previous adjacent edge to the edge given.
-pub async fn get_previous_adjacent_edge(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn get_previous_adjacent_edge(args: Args) -> Result<KclValue, KclError> {
     let tag: TagIdentifier = args.get_data()?;
 
     let edge = inner_get_previous_adjacent_edge(tag, args.clone()).await?;
-    Ok(MemoryItem::UserVal(UserVal {
+    Ok(KclValue::UserVal(UserVal {
         value: serde_json::to_value(edge).map_err(|e| {
             KclError::Type(KclErrorDetails {
                 message: format!("Failed to convert Uuid to json: {}", e),

--- a/src/wasm-lib/kcl/src/std/helix.rs
+++ b/src/wasm-lib/kcl/src/std/helix.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     errors::KclError,
-    executor::{ExtrudeGroup, MemoryItem},
+    executor::{ExtrudeGroup, KclValue},
     std::Args,
 };
 
@@ -31,11 +31,11 @@ pub struct HelixData {
 }
 
 /// Create a helix on a cylinder.
-pub async fn helix(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn helix(args: Args) -> Result<KclValue, KclError> {
     let (data, extrude_group): (HelixData, Box<ExtrudeGroup>) = args.get_data_and_extrude_group()?;
 
     let extrude_group = inner_helix(data, extrude_group, args).await?;
-    Ok(MemoryItem::ExtrudeGroup(extrude_group))
+    Ok(KclValue::ExtrudeGroup(extrude_group))
 }
 
 /// Create a helix on a cylinder.

--- a/src/wasm-lib/kcl/src/std/import.rs
+++ b/src/wasm-lib/kcl/src/std/import.rs
@@ -9,7 +9,7 @@ use schemars::JsonSchema;
 
 use crate::{
     errors::{KclError, KclErrorDetails},
-    executor::{ImportedGeometry, MemoryItem},
+    executor::{ImportedGeometry, KclValue},
     fs::FileSystem,
     std::Args,
 };
@@ -117,11 +117,11 @@ impl From<ImportFormat> for kittycad::types::InputFormat {
 ///
 /// Import paths are relative to the current project directory. This only works in the desktop app
 /// not in browser.
-pub async fn import(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn import(args: Args) -> Result<KclValue, KclError> {
     let (file_path, options): (String, Option<ImportFormat>) = args.get_import_data()?;
 
     let imported_geometry = inner_import(file_path, options, args).await?;
-    Ok(MemoryItem::ImportedGeometry(imported_geometry))
+    Ok(KclValue::ImportedGeometry(imported_geometry))
 }
 
 /// Import a CAD file.

--- a/src/wasm-lib/kcl/src/std/math.rs
+++ b/src/wasm-lib/kcl/src/std/math.rs
@@ -6,12 +6,12 @@ use schemars::JsonSchema;
 
 use crate::{
     errors::{KclError, KclErrorDetails},
-    executor::MemoryItem,
+    executor::KclValue,
     std::Args,
 };
 
 /// Compute the cosine of a number (in radians).
-pub async fn cos(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn cos(args: Args) -> Result<KclValue, KclError> {
     let num = args.get_number()?;
     let result = inner_cos(num)?;
 
@@ -41,7 +41,7 @@ fn inner_cos(num: f64) -> Result<f64, KclError> {
 }
 
 /// Compute the sine of a number (in radians).
-pub async fn sin(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn sin(args: Args) -> Result<KclValue, KclError> {
     let num = args.get_number()?;
     let result = inner_sin(num)?;
 
@@ -71,7 +71,7 @@ fn inner_sin(num: f64) -> Result<f64, KclError> {
 }
 
 /// Compute the tangent of a number (in radians).
-pub async fn tan(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn tan(args: Args) -> Result<KclValue, KclError> {
     let num = args.get_number()?;
     let result = inner_tan(num)?;
 
@@ -101,7 +101,7 @@ fn inner_tan(num: f64) -> Result<f64, KclError> {
 }
 
 /// Return the value of `pi`. Archimedes’ constant (π).
-pub async fn pi(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn pi(args: Args) -> Result<KclValue, KclError> {
     let result = inner_pi()?;
 
     args.make_user_val_from_f64(result)
@@ -126,7 +126,7 @@ fn inner_pi() -> Result<f64, KclError> {
 }
 
 /// Compute the square root of a number.
-pub async fn sqrt(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn sqrt(args: Args) -> Result<KclValue, KclError> {
     let num = args.get_number()?;
     let result = inner_sqrt(num)?;
 
@@ -156,7 +156,7 @@ fn inner_sqrt(num: f64) -> Result<f64, KclError> {
 }
 
 /// Compute the absolute value of a number.
-pub async fn abs(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn abs(args: Args) -> Result<KclValue, KclError> {
     let num = args.get_number()?;
     let result = inner_abs(num)?;
 
@@ -193,7 +193,7 @@ fn inner_abs(num: f64) -> Result<f64, KclError> {
 }
 
 /// Compute the largest integer less than or equal to a number.
-pub async fn floor(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn floor(args: Args) -> Result<KclValue, KclError> {
     let num = args.get_number()?;
     let result = inner_floor(num)?;
 
@@ -221,7 +221,7 @@ fn inner_floor(num: f64) -> Result<f64, KclError> {
 }
 
 /// Compute the smallest integer greater than or equal to a number.
-pub async fn ceil(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn ceil(args: Args) -> Result<KclValue, KclError> {
     let num = args.get_number()?;
     let result = inner_ceil(num)?;
 
@@ -249,7 +249,7 @@ fn inner_ceil(num: f64) -> Result<f64, KclError> {
 }
 
 /// Compute the minimum of the given arguments.
-pub async fn min(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn min(args: Args) -> Result<KclValue, KclError> {
     let nums = args.get_number_array()?;
     let result = inner_min(nums);
 
@@ -286,7 +286,7 @@ fn inner_min(args: Vec<f64>) -> f64 {
 }
 
 /// Compute the maximum of the given arguments.
-pub async fn max(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn max(args: Args) -> Result<KclValue, KclError> {
     let nums = args.get_number_array()?;
     let result = inner_max(nums);
 
@@ -323,7 +323,7 @@ fn inner_max(args: Vec<f64>) -> f64 {
 }
 
 /// Compute the number to a power.
-pub async fn pow(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn pow(args: Args) -> Result<KclValue, KclError> {
     let nums = args.get_number_array()?;
     if nums.len() > 2 {
         return Err(KclError::Type(KclErrorDetails {
@@ -367,7 +367,7 @@ fn inner_pow(num: f64, pow: f64) -> Result<f64, KclError> {
 }
 
 /// Compute the arccosine of a number (in radians).
-pub async fn acos(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn acos(args: Args) -> Result<KclValue, KclError> {
     let num = args.get_number()?;
     let result = inner_acos(num)?;
 
@@ -398,7 +398,7 @@ fn inner_acos(num: f64) -> Result<f64, KclError> {
 }
 
 /// Compute the arcsine of a number (in radians).
-pub async fn asin(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn asin(args: Args) -> Result<KclValue, KclError> {
     let num = args.get_number()?;
     let result = inner_asin(num)?;
 
@@ -428,7 +428,7 @@ fn inner_asin(num: f64) -> Result<f64, KclError> {
 }
 
 /// Compute the arctangent of a number (in radians).
-pub async fn atan(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn atan(args: Args) -> Result<KclValue, KclError> {
     let num = args.get_number()?;
     let result = inner_atan(num)?;
 
@@ -462,7 +462,7 @@ fn inner_atan(num: f64) -> Result<f64, KclError> {
 /// The result might not be correctly rounded owing to implementation
 /// details; `log2()` can produce more accurate results for base 2,
 /// and `log10()` can produce more accurate results for base 10.
-pub async fn log(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn log(args: Args) -> Result<KclValue, KclError> {
     let nums = args.get_number_array()?;
     if nums.len() > 2 {
         return Err(KclError::Type(KclErrorDetails {
@@ -507,7 +507,7 @@ fn inner_log(num: f64, base: f64) -> Result<f64, KclError> {
 }
 
 /// Compute the base 2 logarithm of the number.
-pub async fn log2(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn log2(args: Args) -> Result<KclValue, KclError> {
     let num = args.get_number()?;
     let result = inner_log2(num)?;
 
@@ -535,7 +535,7 @@ fn inner_log2(num: f64) -> Result<f64, KclError> {
 }
 
 /// Compute the base 10 logarithm of the number.
-pub async fn log10(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn log10(args: Args) -> Result<KclValue, KclError> {
     let num = args.get_number()?;
     let result = inner_log10(num)?;
 
@@ -563,7 +563,7 @@ fn inner_log10(num: f64) -> Result<f64, KclError> {
 }
 
 /// Compute the natural logarithm of the number.
-pub async fn ln(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn ln(args: Args) -> Result<KclValue, KclError> {
     let num = args.get_number()?;
     let result = inner_ln(num)?;
 
@@ -591,7 +591,7 @@ fn inner_ln(num: f64) -> Result<f64, KclError> {
 }
 
 /// Return the value of Euler’s number `e`.
-pub async fn e(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn e(args: Args) -> Result<KclValue, KclError> {
     let result = inner_e()?;
 
     args.make_user_val_from_f64(result)
@@ -620,7 +620,7 @@ fn inner_e() -> Result<f64, KclError> {
 }
 
 /// Return the value of `tau`. The full circle constant (τ). Equal to 2π.
-pub async fn tau(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn tau(args: Args) -> Result<KclValue, KclError> {
     let result = inner_tau()?;
 
     args.make_user_val_from_f64(result)
@@ -649,7 +649,7 @@ fn inner_tau() -> Result<f64, KclError> {
 }
 
 /// Converts a number from degrees to radians.
-pub async fn to_radians(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn to_radians(args: Args) -> Result<KclValue, KclError> {
     let num = args.get_number()?;
     let result = inner_to_radians(num)?;
 
@@ -679,7 +679,7 @@ fn inner_to_radians(num: f64) -> Result<f64, KclError> {
 }
 
 /// Converts a number from radians to degrees.
-pub async fn to_degrees(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn to_degrees(args: Args) -> Result<KclValue, KclError> {
     let num = args.get_number()?;
     let result = inner_to_degrees(num)?;
 

--- a/src/wasm-lib/kcl/src/std/mod.rs
+++ b/src/wasm-lib/kcl/src/std/mod.rs
@@ -34,11 +34,11 @@ use crate::{
     ast::types::FunctionExpression,
     docs::StdLibFn,
     errors::KclError,
-    executor::{MemoryItem, ProgramMemory, SketchGroup, SketchSurface},
+    executor::{KclValue, ProgramMemory, SketchGroup, SketchSurface},
     std::kcl_stdlib::KclStdLibFn,
 };
 
-pub type StdFn = fn(Args) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<MemoryItem, KclError>> + Send>>;
+pub type StdFn = fn(Args) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<KclValue, KclError>> + Send>>;
 
 pub type FnMap = HashMap<String, StdFn>;
 
@@ -213,7 +213,7 @@ pub enum FunctionKind {
 }
 
 /// Compute the length of the given leg.
-pub async fn leg_length(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn leg_length(args: Args) -> Result<KclValue, KclError> {
     let (hypotenuse, leg) = args.get_hypotenuse_leg()?;
     let result = inner_leg_length(hypotenuse, leg);
     args.make_user_val_from_f64(result)
@@ -233,7 +233,7 @@ fn inner_leg_length(hypotenuse: f64, leg: f64) -> f64 {
 }
 
 /// Compute the angle of the given leg for x.
-pub async fn leg_angle_x(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn leg_angle_x(args: Args) -> Result<KclValue, KclError> {
     let (hypotenuse, leg) = args.get_hypotenuse_leg()?;
     let result = inner_leg_angle_x(hypotenuse, leg);
     args.make_user_val_from_f64(result)
@@ -253,7 +253,7 @@ fn inner_leg_angle_x(hypotenuse: f64, leg: f64) -> f64 {
 }
 
 /// Compute the angle of the given leg for y.
-pub async fn leg_angle_y(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn leg_angle_y(args: Args) -> Result<KclValue, KclError> {
     let (hypotenuse, leg) = args.get_hypotenuse_leg()?;
     let result = inner_leg_angle_y(hypotenuse, leg);
     args.make_user_val_from_f64(result)

--- a/src/wasm-lib/kcl/src/std/patterns.rs
+++ b/src/wasm-lib/kcl/src/std/patterns.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     errors::{KclError, KclErrorDetails},
     executor::{
-        ExtrudeGroup, ExtrudeGroupSet, Geometries, Geometry, MemoryItem, Point3d, ProgramReturn, SketchGroup,
+        ExtrudeGroup, ExtrudeGroupSet, Geometries, Geometry, KclValue, Point3d, ProgramReturn, SketchGroup,
         SketchGroupSet, SourceRange, UserVal,
     },
     function_param::FunctionParam,
@@ -77,7 +77,7 @@ impl LinearPattern {
 /// A linear pattern
 /// Each element in the pattern repeats a particular piece of geometry.
 /// The repetitions can be transformed by the `transform` parameter.
-pub async fn pattern_transform(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn pattern_transform(args: Args) -> Result<KclValue, KclError> {
     let (num_repetitions, transform, extr) = args.get_pattern_transform_args()?;
 
     let extrude_groups = inner_pattern_transform(
@@ -94,7 +94,7 @@ pub async fn pattern_transform(args: Args) -> Result<MemoryItem, KclError> {
         &args,
     )
     .await?;
-    Ok(MemoryItem::ExtrudeGroups { value: extrude_groups })
+    Ok(KclValue::ExtrudeGroups { value: extrude_groups })
 }
 
 /// Repeat a 3-dimensional solid by successively applying a transformation (such
@@ -203,7 +203,7 @@ async fn make_transform<'a>(
     source_range: SourceRange,
 ) -> Result<kittycad::types::LinearTransform, KclError> {
     // Call the transform fn for this repetition.
-    let repetition_num = MemoryItem::UserVal(UserVal {
+    let repetition_num = KclValue::UserVal(UserVal {
         value: serde_json::Value::Number(i.into()),
         meta: vec![source_range.into()],
     });
@@ -224,7 +224,7 @@ async fn make_transform<'a>(
             source_ranges: source_ranges.clone(),
         }));
     };
-    let MemoryItem::UserVal(transform) = transform_fn_return else {
+    let KclValue::UserVal(transform) = transform_fn_return else {
         return Err(KclError::Semantic(KclErrorDetails {
             message: "Transform function must return a transform object".to_string(),
             source_ranges: source_ranges.clone(),
@@ -303,7 +303,7 @@ mod tests {
 }
 
 /// A linear pattern on a 2D sketch.
-pub async fn pattern_linear_2d(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn pattern_linear_2d(args: Args) -> Result<KclValue, KclError> {
     let (data, sketch_group_set): (LinearPattern2dData, SketchGroupSet) = args.get_data_and_sketch_group_set()?;
 
     if data.axis == [0.0, 0.0] {
@@ -370,7 +370,7 @@ async fn inner_pattern_linear_2d(
 }
 
 /// A linear pattern on a 3D model.
-pub async fn pattern_linear_3d(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn pattern_linear_3d(args: Args) -> Result<KclValue, KclError> {
     let (data, extrude_group_set): (LinearPattern3dData, ExtrudeGroupSet) = args.get_data_and_extrude_group_set()?;
 
     if data.axis == [0.0, 0.0, 0.0] {
@@ -578,7 +578,7 @@ impl CircularPattern {
 }
 
 /// A circular pattern on a 2D sketch.
-pub async fn pattern_circular_2d(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn pattern_circular_2d(args: Args) -> Result<KclValue, KclError> {
     let (data, sketch_group_set): (CircularPattern2dData, SketchGroupSet) = args.get_data_and_sketch_group_set()?;
 
     let sketch_groups = inner_pattern_circular_2d(data, sketch_group_set, args).await?;
@@ -643,7 +643,7 @@ async fn inner_pattern_circular_2d(
 }
 
 /// A circular pattern on a 3D model.
-pub async fn pattern_circular_3d(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn pattern_circular_3d(args: Args) -> Result<KclValue, KclError> {
     let (data, extrude_group_set): (CircularPattern3dData, ExtrudeGroupSet) = args.get_data_and_extrude_group_set()?;
 
     let extrude_groups = inner_pattern_circular_3d(data, extrude_group_set, args).await?;

--- a/src/wasm-lib/kcl/src/std/polar.rs
+++ b/src/wasm-lib/kcl/src/std/polar.rs
@@ -5,7 +5,7 @@ use derive_docs::stdlib;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{errors::KclError, executor::MemoryItem, std::Args};
+use crate::{errors::KclError, executor::KclValue, std::Args};
 
 /// Data for polar coordinates.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
@@ -19,7 +19,7 @@ pub struct PolarCoordsData {
 }
 
 /// Convert from polar/sphere coordinates to cartesian coordinates.
-pub async fn polar(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn polar(args: Args) -> Result<KclValue, KclError> {
     let data: PolarCoordsData = args.get_data()?;
     let result = inner_polar(&data)?;
 

--- a/src/wasm-lib/kcl/src/std/revolve.rs
+++ b/src/wasm-lib/kcl/src/std/revolve.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     errors::{KclError, KclErrorDetails},
-    executor::{ExtrudeGroup, MemoryItem, SketchGroup},
+    executor::{ExtrudeGroup, KclValue, SketchGroup},
     std::{
         extrude::do_post_extrude,
         fillet::{EdgeReference, DEFAULT_TOLERANCE},
@@ -98,11 +98,11 @@ impl RevolveAxisAndOrigin {
 }
 
 /// Revolve a sketch around an axis.
-pub async fn revolve(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn revolve(args: Args) -> Result<KclValue, KclError> {
     let (data, sketch_group): (RevolveData, Box<SketchGroup>) = args.get_data_and_sketch_group()?;
 
     let extrude_group = inner_revolve(data, sketch_group, args).await?;
-    Ok(MemoryItem::ExtrudeGroup(extrude_group))
+    Ok(KclValue::ExtrudeGroup(extrude_group))
 }
 
 /// Rotate a sketch around some provided axis, creating a solid from its extent.

--- a/src/wasm-lib/kcl/src/std/segment.rs
+++ b/src/wasm-lib/kcl/src/std/segment.rs
@@ -6,12 +6,12 @@ use schemars::JsonSchema;
 
 use crate::{
     errors::{KclError, KclErrorDetails},
-    executor::{MemoryItem, SketchGroup, TagIdentifier},
+    executor::{KclValue, SketchGroup, TagIdentifier},
     std::{utils::between, Args},
 };
 
 /// Returns the segment end of x.
-pub async fn segment_end_x(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn segment_end_x(args: Args) -> Result<KclValue, KclError> {
     let tag: TagIdentifier = args.get_data()?;
     let result = inner_segment_end_x(&tag, args.clone())?;
 
@@ -47,7 +47,7 @@ fn inner_segment_end_x(tag: &TagIdentifier, args: Args) -> Result<f64, KclError>
 }
 
 /// Returns the segment end of y.
-pub async fn segment_end_y(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn segment_end_y(args: Args) -> Result<KclValue, KclError> {
     let tag: TagIdentifier = args.get_data()?;
     let result = inner_segment_end_y(&tag, args.clone())?;
 
@@ -84,7 +84,7 @@ fn inner_segment_end_y(tag: &TagIdentifier, args: Args) -> Result<f64, KclError>
 }
 
 /// Returns the last segment of x.
-pub async fn last_segment_x(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn last_segment_x(args: Args) -> Result<KclValue, KclError> {
     let sketch_group = args.get_sketch_group()?;
     let result = inner_last_segment_x(sketch_group, args.clone())?;
 
@@ -127,7 +127,7 @@ fn inner_last_segment_x(sketch_group: Box<SketchGroup>, args: Args) -> Result<f6
 }
 
 /// Returns the last segment of y.
-pub async fn last_segment_y(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn last_segment_y(args: Args) -> Result<KclValue, KclError> {
     let sketch_group = args.get_sketch_group()?;
     let result = inner_last_segment_y(sketch_group, args.clone())?;
 
@@ -170,7 +170,7 @@ fn inner_last_segment_y(sketch_group: Box<SketchGroup>, args: Args) -> Result<f6
 }
 
 /// Returns the length of the segment.
-pub async fn segment_length(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn segment_length(args: Args) -> Result<KclValue, KclError> {
     let tag: TagIdentifier = args.get_data()?;
     let result = inner_segment_length(&tag, args.clone())?;
     args.make_user_val_from_f64(result)
@@ -215,7 +215,7 @@ fn inner_segment_length(tag: &TagIdentifier, args: Args) -> Result<f64, KclError
 }
 
 /// Returns the angle of the segment.
-pub async fn segment_angle(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn segment_angle(args: Args) -> Result<KclValue, KclError> {
     let tag: TagIdentifier = args.get_data()?;
 
     let result = inner_segment_angle(&tag, args.clone())?;
@@ -255,7 +255,7 @@ fn inner_segment_angle(tag: &TagIdentifier, args: Args) -> Result<f64, KclError>
 }
 
 /// Returns the angle to match the given length for x.
-pub async fn angle_to_match_length_x(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn angle_to_match_length_x(args: Args) -> Result<KclValue, KclError> {
     let (tag, to, sketch_group) = args.get_tag_to_number_sketch_group()?;
     let result = inner_angle_to_match_length_x(&tag, to, sketch_group, args.clone())?;
     args.make_user_val_from_f64(result)
@@ -320,7 +320,7 @@ fn inner_angle_to_match_length_x(
 }
 
 /// Returns the angle to match the given length for y.
-pub async fn angle_to_match_length_y(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn angle_to_match_length_y(args: Args) -> Result<KclValue, KclError> {
     let (tag, to, sketch_group) = args.get_tag_to_number_sketch_group()?;
     let result = inner_angle_to_match_length_y(&tag, to, sketch_group, args.clone())?;
     args.make_user_val_from_f64(result)

--- a/src/wasm-lib/kcl/src/std/shapes.rs
+++ b/src/wasm-lib/kcl/src/std/shapes.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     ast::types::TagDeclarator,
     errors::KclError,
-    executor::MemoryItem,
+    executor::KclValue,
     std::{Args, SketchGroup, SketchSurface},
 };
 
@@ -22,12 +22,12 @@ pub enum SketchSurfaceOrGroup {
 }
 
 /// Sketch a circle.
-pub async fn circle(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn circle(args: Args) -> Result<KclValue, KclError> {
     let (center, radius, sketch_surface_or_group, tag): ([f64; 2], f64, SketchSurfaceOrGroup, Option<TagDeclarator>) =
         args.get_circle_args()?;
 
     let sketch_group = inner_circle(center, radius, sketch_surface_or_group, tag, args).await?;
-    Ok(MemoryItem::SketchGroup(sketch_group))
+    Ok(KclValue::SketchGroup(sketch_group))
 }
 
 /// Construct a 2-dimensional circle, of the specified radius, centered at

--- a/src/wasm-lib/kcl/src/std/shell.rs
+++ b/src/wasm-lib/kcl/src/std/shell.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     errors::{KclError, KclErrorDetails},
-    executor::{ExtrudeGroup, MemoryItem},
+    executor::{ExtrudeGroup, KclValue},
     std::{sketch::FaceTag, Args},
 };
 
@@ -24,11 +24,11 @@ pub struct ShellData {
 }
 
 /// Create a shell.
-pub async fn shell(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn shell(args: Args) -> Result<KclValue, KclError> {
     let (data, extrude_group): (ShellData, Box<ExtrudeGroup>) = args.get_data_and_extrude_group()?;
 
     let extrude_group = inner_shell(data, extrude_group, args).await?;
-    Ok(MemoryItem::ExtrudeGroup(extrude_group))
+    Ok(KclValue::ExtrudeGroup(extrude_group))
 }
 
 /// Remove volume from a 3-dimensional shape such that a wall of the

--- a/src/wasm-lib/kcl/src/std/sketch.rs
+++ b/src/wasm-lib/kcl/src/std/sketch.rs
@@ -13,7 +13,7 @@ use crate::{
     ast::types::TagDeclarator,
     errors::{KclError, KclErrorDetails},
     executor::{
-        BasePath, ExtrudeGroup, Face, GeoMeta, MemoryItem, Path, Plane, PlaneType, Point2d, Point3d, SketchGroup,
+        BasePath, ExtrudeGroup, Face, GeoMeta, KclValue, Path, Plane, PlaneType, Point2d, Point3d, SketchGroup,
         SketchGroupSet, SketchSurface, SourceRange, TagEngineInfo, TagIdentifier, UserVal,
     },
     std::{
@@ -89,12 +89,12 @@ pub enum StartOrEnd {
 }
 
 /// Draw a line to a point.
-pub async fn line_to(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn line_to(args: Args) -> Result<KclValue, KclError> {
     let (to, sketch_group, tag): ([f64; 2], Box<SketchGroup>, Option<TagDeclarator>) =
         args.get_data_and_sketch_group_and_tag()?;
 
     let new_sketch_group = inner_line_to(to, sketch_group, tag, args).await?;
-    Ok(MemoryItem::SketchGroup(new_sketch_group))
+    Ok(KclValue::SketchGroup(new_sketch_group))
 }
 
 /// Draw a line from the current origin to some absolute (x, y) point.
@@ -160,12 +160,12 @@ async fn inner_line_to(
 }
 
 /// Draw a line to a point on the x-axis.
-pub async fn x_line_to(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn x_line_to(args: Args) -> Result<KclValue, KclError> {
     let (to, sketch_group, tag): (f64, Box<SketchGroup>, Option<TagDeclarator>) =
         args.get_data_and_sketch_group_and_tag()?;
 
     let new_sketch_group = inner_x_line_to(to, sketch_group, tag, args).await?;
-    Ok(MemoryItem::SketchGroup(new_sketch_group))
+    Ok(KclValue::SketchGroup(new_sketch_group))
 }
 
 /// Draw a line parallel to the X axis, that ends at the given X.
@@ -208,12 +208,12 @@ async fn inner_x_line_to(
 }
 
 /// Draw a line to a point on the y-axis.
-pub async fn y_line_to(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn y_line_to(args: Args) -> Result<KclValue, KclError> {
     let (to, sketch_group, tag): (f64, Box<SketchGroup>, Option<TagDeclarator>) =
         args.get_data_and_sketch_group_and_tag()?;
 
     let new_sketch_group = inner_y_line_to(to, sketch_group, tag, args).await?;
-    Ok(MemoryItem::SketchGroup(new_sketch_group))
+    Ok(KclValue::SketchGroup(new_sketch_group))
 }
 
 /// Draw a line parallel to the Y axis, that ends at the given Y.
@@ -248,12 +248,12 @@ async fn inner_y_line_to(
 }
 
 /// Draw a line.
-pub async fn line(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn line(args: Args) -> Result<KclValue, KclError> {
     let (delta, sketch_group, tag): ([f64; 2], Box<SketchGroup>, Option<TagDeclarator>) =
         args.get_data_and_sketch_group_and_tag()?;
 
     let new_sketch_group = inner_line(delta, sketch_group, tag, args).await?;
-    Ok(MemoryItem::SketchGroup(new_sketch_group))
+    Ok(KclValue::SketchGroup(new_sketch_group))
 }
 
 /// Draw a line relative to the current origin to a specified (x, y) away
@@ -333,12 +333,12 @@ async fn inner_line(
 }
 
 /// Draw a line on the x-axis.
-pub async fn x_line(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn x_line(args: Args) -> Result<KclValue, KclError> {
     let (length, sketch_group, tag): (f64, Box<SketchGroup>, Option<TagDeclarator>) =
         args.get_data_and_sketch_group_and_tag()?;
 
     let new_sketch_group = inner_x_line(length, sketch_group, tag, args).await?;
-    Ok(MemoryItem::SketchGroup(new_sketch_group))
+    Ok(KclValue::SketchGroup(new_sketch_group))
 }
 
 /// Draw a line relative to the current origin to a specified distance away
@@ -376,12 +376,12 @@ async fn inner_x_line(
 }
 
 /// Draw a line on the y-axis.
-pub async fn y_line(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn y_line(args: Args) -> Result<KclValue, KclError> {
     let (length, sketch_group, tag): (f64, Box<SketchGroup>, Option<TagDeclarator>) =
         args.get_data_and_sketch_group_and_tag()?;
 
     let new_sketch_group = inner_y_line(length, sketch_group, tag, args).await?;
-    Ok(MemoryItem::SketchGroup(new_sketch_group))
+    Ok(KclValue::SketchGroup(new_sketch_group))
 }
 
 /// Draw a line relative to the current origin to a specified distance away
@@ -430,12 +430,12 @@ pub enum AngledLineData {
 }
 
 /// Draw an angled line.
-pub async fn angled_line(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn angled_line(args: Args) -> Result<KclValue, KclError> {
     let (data, sketch_group, tag): (AngledLineData, Box<SketchGroup>, Option<TagDeclarator>) =
         args.get_data_and_sketch_group_and_tag()?;
 
     let new_sketch_group = inner_angled_line(data, sketch_group, tag, args).await?;
-    Ok(MemoryItem::SketchGroup(new_sketch_group))
+    Ok(KclValue::SketchGroup(new_sketch_group))
 }
 
 /// Draw a line segment relative to the current origin using the polar
@@ -519,12 +519,12 @@ async fn inner_angled_line(
 }
 
 /// Draw an angled line of a given x length.
-pub async fn angled_line_of_x_length(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn angled_line_of_x_length(args: Args) -> Result<KclValue, KclError> {
     let (data, sketch_group, tag): (AngledLineData, Box<SketchGroup>, Option<TagDeclarator>) =
         args.get_data_and_sketch_group_and_tag()?;
 
     let new_sketch_group = inner_angled_line_of_x_length(data, sketch_group, tag, args).await?;
-    Ok(MemoryItem::SketchGroup(new_sketch_group))
+    Ok(KclValue::SketchGroup(new_sketch_group))
 }
 
 /// Create a line segment from the current 2-dimensional sketch origin
@@ -587,12 +587,12 @@ pub struct AngledLineToData {
 }
 
 /// Draw an angled line to a given x coordinate.
-pub async fn angled_line_to_x(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn angled_line_to_x(args: Args) -> Result<KclValue, KclError> {
     let (data, sketch_group, tag): (AngledLineToData, Box<SketchGroup>, Option<TagDeclarator>) =
         args.get_data_and_sketch_group_and_tag()?;
 
     let new_sketch_group = inner_angled_line_to_x(data, sketch_group, tag, args).await?;
-    Ok(MemoryItem::SketchGroup(new_sketch_group))
+    Ok(KclValue::SketchGroup(new_sketch_group))
 }
 
 /// Create a line segment from the current 2-dimensional sketch origin
@@ -644,13 +644,13 @@ async fn inner_angled_line_to_x(
 }
 
 /// Draw an angled line of a given y length.
-pub async fn angled_line_of_y_length(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn angled_line_of_y_length(args: Args) -> Result<KclValue, KclError> {
     let (data, sketch_group, tag): (AngledLineData, Box<SketchGroup>, Option<TagDeclarator>) =
         args.get_data_and_sketch_group_and_tag()?;
 
     let new_sketch_group = inner_angled_line_of_y_length(data, sketch_group, tag, args).await?;
 
-    Ok(MemoryItem::SketchGroup(new_sketch_group))
+    Ok(KclValue::SketchGroup(new_sketch_group))
 }
 
 /// Create a line segment from the current 2-dimensional sketch origin
@@ -704,12 +704,12 @@ async fn inner_angled_line_of_y_length(
 }
 
 /// Draw an angled line to a given y coordinate.
-pub async fn angled_line_to_y(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn angled_line_to_y(args: Args) -> Result<KclValue, KclError> {
     let (data, sketch_group, tag): (AngledLineToData, Box<SketchGroup>, Option<TagDeclarator>) =
         args.get_data_and_sketch_group_and_tag()?;
 
     let new_sketch_group = inner_angled_line_to_y(data, sketch_group, tag, args).await?;
-    Ok(MemoryItem::SketchGroup(new_sketch_group))
+    Ok(KclValue::SketchGroup(new_sketch_group))
 }
 
 /// Create a line segment from the current 2-dimensional sketch origin
@@ -775,11 +775,11 @@ pub struct AngledLineThatIntersectsData {
 }
 
 /// Draw an angled line that intersects with a given line.
-pub async fn angled_line_that_intersects(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn angled_line_that_intersects(args: Args) -> Result<KclValue, KclError> {
     let (data, sketch_group, tag): (AngledLineThatIntersectsData, Box<SketchGroup>, Option<TagDeclarator>) =
         args.get_data_and_sketch_group_and_tag()?;
     let new_sketch_group = inner_angled_line_that_intersects(data, sketch_group, tag, args).await?;
-    Ok(MemoryItem::SketchGroup(new_sketch_group))
+    Ok(KclValue::SketchGroup(new_sketch_group))
 }
 
 /// Draw an angled line from the current origin, constructing a line segment
@@ -831,11 +831,11 @@ async fn inner_angled_line_that_intersects(
 }
 
 /// Start a sketch at a given point.
-pub async fn start_sketch_at(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn start_sketch_at(args: Args) -> Result<KclValue, KclError> {
     let data: [f64; 2] = args.get_data()?;
 
     let sketch_group = inner_start_sketch_at(data, args).await?;
-    Ok(MemoryItem::SketchGroup(sketch_group))
+    Ok(KclValue::SketchGroup(sketch_group))
 }
 
 /// Start a new 2-dimensional sketch at a given point on the 'XY' plane.
@@ -1006,12 +1006,12 @@ impl From<PlaneData> for Plane {
 }
 
 /// Start a sketch on a specific plane or face.
-pub async fn start_sketch_on(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn start_sketch_on(args: Args) -> Result<KclValue, KclError> {
     let (data, tag): (SketchData, Option<FaceTag>) = args.get_data_and_optional_tag()?;
 
     match inner_start_sketch_on(data, tag, args).await? {
-        SketchSurface::Plane(plane) => Ok(MemoryItem::Plane(plane)),
-        SketchSurface::Face(face) => Ok(MemoryItem::Face(face)),
+        SketchSurface::Plane(plane) => Ok(KclValue::Plane(plane)),
+        SketchSurface::Face(face) => Ok(KclValue::Face(face)),
     }
 }
 
@@ -1199,12 +1199,12 @@ async fn start_sketch_on_plane(data: PlaneData, args: Args) -> Result<Box<Plane>
 }
 
 /// Start a new profile at a given point.
-pub async fn start_profile_at(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn start_profile_at(args: Args) -> Result<KclValue, KclError> {
     let (start, sketch_surface, tag): ([f64; 2], SketchSurface, Option<TagDeclarator>) =
         args.get_data_and_sketch_surface()?;
 
     let sketch_group = inner_start_profile_at(start, sketch_surface, tag, args).await?;
-    Ok(MemoryItem::SketchGroup(sketch_group))
+    Ok(KclValue::SketchGroup(sketch_group))
 }
 
 /// Start a new profile at a given point.
@@ -1328,7 +1328,7 @@ pub(crate) async fn inner_start_profile_at(
 }
 
 /// Returns the X component of the sketch profile start point.
-pub async fn profile_start_x(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn profile_start_x(args: Args) -> Result<KclValue, KclError> {
     let sketch_group: Box<SketchGroup> = args.get_sketch_group()?;
     let x = inner_profile_start_x(sketch_group)?;
     args.make_user_val_from_f64(x)
@@ -1352,7 +1352,7 @@ pub(crate) fn inner_profile_start_x(sketch_group: Box<SketchGroup>) -> Result<f6
 }
 
 /// Returns the Y component of the sketch profile start point.
-pub async fn profile_start_y(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn profile_start_y(args: Args) -> Result<KclValue, KclError> {
     let sketch_group: Box<SketchGroup> = args.get_sketch_group()?;
     let x = inner_profile_start_y(sketch_group)?;
     args.make_user_val_from_f64(x)
@@ -1375,10 +1375,10 @@ pub(crate) fn inner_profile_start_y(sketch_group: Box<SketchGroup>) -> Result<f6
 }
 
 /// Returns the sketch profile start point.
-pub async fn profile_start(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn profile_start(args: Args) -> Result<KclValue, KclError> {
     let sketch_group: Box<SketchGroup> = args.get_sketch_group()?;
     let point = inner_profile_start(sketch_group)?;
-    Ok(MemoryItem::UserVal(UserVal {
+    Ok(KclValue::UserVal(UserVal {
         value: serde_json::to_value(point).map_err(|e| {
             KclError::Type(KclErrorDetails {
                 message: format!("Failed to convert point to json: {}", e),
@@ -1409,12 +1409,12 @@ pub(crate) fn inner_profile_start(sketch_group: Box<SketchGroup>) -> Result<[f64
 }
 
 /// Close the current sketch.
-pub async fn close(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn close(args: Args) -> Result<KclValue, KclError> {
     let (sketch_group, tag): (Box<SketchGroup>, Option<TagDeclarator>) = args.get_sketch_group_and_optional_tag()?;
 
     let new_sketch_group = inner_close(sketch_group, tag, args).await?;
 
-    Ok(MemoryItem::SketchGroup(new_sketch_group))
+    Ok(KclValue::SketchGroup(new_sketch_group))
 }
 
 /// Construct a line segment from the current origin back to the profile's
@@ -1516,12 +1516,12 @@ pub enum ArcData {
 }
 
 /// Draw an arc.
-pub async fn arc(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn arc(args: Args) -> Result<KclValue, KclError> {
     let (data, sketch_group, tag): (ArcData, Box<SketchGroup>, Option<TagDeclarator>) =
         args.get_data_and_sketch_group_and_tag()?;
 
     let new_sketch_group = inner_arc(data, sketch_group, tag, args).await?;
-    Ok(MemoryItem::SketchGroup(new_sketch_group))
+    Ok(KclValue::SketchGroup(new_sketch_group))
 }
 
 /// Starting at the current sketch's origin, draw a curved line segment along
@@ -1639,12 +1639,12 @@ pub enum TangentialArcData {
 }
 
 /// Draw a tangential arc.
-pub async fn tangential_arc(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn tangential_arc(args: Args) -> Result<KclValue, KclError> {
     let (data, sketch_group, tag): (TangentialArcData, Box<SketchGroup>, Option<TagDeclarator>) =
         args.get_data_and_sketch_group_and_tag()?;
 
     let new_sketch_group = inner_tangential_arc(data, sketch_group, tag, args).await?;
-    Ok(MemoryItem::SketchGroup(new_sketch_group))
+    Ok(KclValue::SketchGroup(new_sketch_group))
 }
 
 /// Starting at the current sketch's origin, draw a curved line segment along
@@ -1787,7 +1787,7 @@ fn get_arg<I: Iterator>(it: &mut I, src: SourceRange) -> Result<I::Item, KclErro
 }
 
 /// Draw a tangential arc to a specific point.
-pub async fn tangential_arc_to(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn tangential_arc_to(args: Args) -> Result<KclValue, KclError> {
     let src = args.source_range;
 
     // Get arguments to function call
@@ -1801,7 +1801,7 @@ pub async fn tangential_arc_to(args: Args) -> Result<MemoryItem, KclError> {
     };
 
     let new_sketch_group = inner_tangential_arc_to(to, sketch_group, tag, args).await?;
-    Ok(MemoryItem::SketchGroup(new_sketch_group))
+    Ok(KclValue::SketchGroup(new_sketch_group))
 }
 
 /// Starting at the current sketch's origin, draw a curved line segment along
@@ -1887,12 +1887,12 @@ pub struct BezierData {
 }
 
 /// Draw a bezier curve.
-pub async fn bezier_curve(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn bezier_curve(args: Args) -> Result<KclValue, KclError> {
     let (data, sketch_group, tag): (BezierData, Box<SketchGroup>, Option<TagDeclarator>) =
         args.get_data_and_sketch_group_and_tag()?;
 
     let new_sketch_group = inner_bezier_curve(data, sketch_group, tag, args).await?;
-    Ok(MemoryItem::SketchGroup(new_sketch_group))
+    Ok(KclValue::SketchGroup(new_sketch_group))
 }
 
 /// Draw a smooth, continuous, curved line segment from the current origin to
@@ -1979,11 +1979,11 @@ async fn inner_bezier_curve(
 }
 
 /// Use a sketch to cut a hole in another sketch.
-pub async fn hole(args: Args) -> Result<MemoryItem, KclError> {
+pub async fn hole(args: Args) -> Result<KclValue, KclError> {
     let (hole_sketch_group, sketch_group): (SketchGroupSet, Box<SketchGroup>) = args.get_sketch_groups()?;
 
     let new_sketch_group = inner_hole(hole_sketch_group, sketch_group, args).await?;
-    Ok(MemoryItem::SketchGroup(new_sketch_group))
+    Ok(KclValue::SketchGroup(new_sketch_group))
 }
 
 /// Use a 2-dimensional sketch to cut a hole in another 2-dimensional sketch.

--- a/src/wasm-lib/tests/modify/main.rs
+++ b/src/wasm-lib/tests/modify/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use kcl_lib::{
     ast::{modify::modify_ast_for_sketch, types::Program},
-    executor::{ExecutorContext, MemoryItem, PlaneType, SourceRange},
+    executor::{ExecutorContext, KclValue, PlaneType, SourceRange},
 };
 use kittycad::types::{ModelingCmd, Point3D};
 use pretty_assertions::assert_eq;
@@ -39,7 +39,7 @@ async fn setup(code: &str, name: &str) -> Result<(ExecutorContext, Program, uuid
 
     // We need to get the sketch ID.
     // Get the sketch group ID from memory.
-    let MemoryItem::SketchGroup(sketch_group) = memory.get(name, SourceRange::default()).unwrap() else {
+    let KclValue::SketchGroup(sketch_group) = memory.get(name, SourceRange::default()).unwrap() else {
         anyhow::bail!("part001 not found in memory: {:?}", memory);
     };
     let sketch_id = sketch_group.id;


### PR DESCRIPTION
As @jon points out, "It's not only used in ProgramMemory. It's also used as the return value of functions and as what gets substituted in for the pipe substitution symbol %"