### PR TITLE
Use a macro to make KCL snapshot tests easier

### DIFF
--- a/src/wasm-lib/tests/executor/main.rs
+++ b/src/wasm-lib/tests/executor/main.rs
@@ -12,90 +12,50 @@ macro_rules! kcl_input {
     };
 }
 
+macro_rules! kcl_test {
+    ($file:literal, $test_name:ident) => {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn $test_name() {
+            let code = kcl_input!($file);
+
+            let result = execute_and_snapshot(code, UnitLength::Mm).await.unwrap();
+            assert_out($file, &result);
+        }
+    };
+}
+
 fn assert_out(test_name: &str, result: &image::DynamicImage) {
     twenty_twenty::assert_image(format!("tests/executor/outputs/{test_name}.png"), result, MIN_DIFF);
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn kcl_test_sketch_on_face() {
-    let code = kcl_input!("sketch_on_face");
-
-    let result = execute_and_snapshot(code, UnitLength::Mm).await.unwrap();
-    assert_out("sketch_on_face", &result);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn kcl_test_riddle_small() {
-    let code = kcl_input!("riddle_small");
-    let result = execute_and_snapshot(code, UnitLength::Mm).await.unwrap();
-    assert_out("riddle_small", &result);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn kcl_test_tan_arc_x_line() {
-    let code = kcl_input!("tan_arc_x_line");
-    let result = execute_and_snapshot(code, UnitLength::Mm).await.unwrap();
-    assert_out("tan_arc_x_line", &result);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn kcl_test_lego() {
-    let code = kcl_input!("lego");
-    let result = execute_and_snapshot(code, UnitLength::Mm).await.unwrap();
-    assert_out("lego", &result);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn kcl_test_computed_var() {
-    let code = kcl_input!("computed_var");
-    let result = execute_and_snapshot(code, UnitLength::Mm).await.unwrap();
-    assert_out("computed_var", &result);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn kcl_test_pipe_as_arg() {
-    let code = kcl_input!("pipe_as_arg");
-    let result = execute_and_snapshot(code, UnitLength::Mm).await.unwrap();
-    assert_out("pipe_as_arg", &result);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn kcl_test_pentagon_fillet_sugar() {
-    let code = kcl_input!("pentagon_fillet_sugar");
-    let result = execute_and_snapshot(code, UnitLength::Cm).await.unwrap();
-    assert_out("pentagon_fillet_sugar", &result);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn kcl_test_sketch_on_face_start() {
-    let code = kcl_input!("sketch_on_face_start");
-
-    let result = execute_and_snapshot(code, UnitLength::Mm).await.unwrap();
-    assert_out("sketch_on_face_start", &result);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn kcl_test_mike_stress_lines() {
-    let code = kcl_input!("mike_stress_test");
-    let result = execute_and_snapshot(code, UnitLength::Mm).await.unwrap();
-    assert_out("mike_stress_test", &result);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn kcl_test_sketch_on_face_end() {
-    let code = kcl_input!("sketch_on_face_end");
-
-    let result = execute_and_snapshot(code, UnitLength::Mm).await.unwrap();
-    assert_out("sketch_on_face_end", &result);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn kcl_test_sketch_on_face_end_negative_extrude() {
-    let code = kcl_input!("sketch_on_face_end_negative_extrude");
-
-    let result = execute_and_snapshot(code, UnitLength::Mm).await.unwrap();
-    assert_out("sketch_on_face_end_negative_extrude", &result);
-}
+kcl_test!("sketch_on_face", kcl_test_sketch_on_face);
+kcl_test!("basic_fillet_cube_start", kcl_test_basic_fillet_cube_start);
+kcl_test!(
+    "basic_fillet_cube_next_adjacent",
+    kcl_test_basic_fillet_cube_next_adjacent
+);
+kcl_test!(
+    "basic_fillet_cube_previous_adjacent",
+    kcl_test_basic_fillet_cube_previous_adjacent
+);
+kcl_test!("basic_fillet_cube_end", kcl_test_basic_fillet_cube_end);
+kcl_test!(
+    "basic_fillet_cube_close_opposite",
+    kcl_test_basic_fillet_cube_close_opposite
+);
+kcl_test!("sketch_on_face_end", kcl_test_sketch_on_face_end);
+kcl_test!("sketch_on_face_start", kcl_test_sketch_on_face_start);
+kcl_test!(
+    "sketch_on_face_end_negative_extrude",
+    kcl_test_sketch_on_face_end_negative_extrude
+);
+kcl_test!("mike_stress_test", kcl_test_mike_stress_test);
+kcl_test!("pentagon_fillet_sugar", pentagon_fillet_sugar);
+kcl_test!("pipe_as_arg", pipe_as_arg);
+kcl_test!("computed_var", computed_var);
+kcl_test!("lego", kcl_test_lego);
+kcl_test!("riddle_small", kcl_test_riddle_small);
+kcl_test!("tan_arc_x_line", kcl_test_tan_arc_x_line);
 
 #[tokio::test(flavor = "multi_thread")]
 async fn kcl_test_fillet_duplicate_tags() {
@@ -107,44 +67,6 @@ async fn kcl_test_fillet_duplicate_tags() {
         result.err().unwrap().to_string(),
         r#"type: KclErrorDetails { source_ranges: [SourceRange([203, 249])], message: "Duplicate tags are not allowed." }"#,
     );
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn kcl_test_basic_fillet_cube_start() {
-    let code = kcl_input!("basic_fillet_cube_start");
-    let result = execute_and_snapshot(code, UnitLength::Mm).await.unwrap();
-    assert_out("basic_fillet_cube_start", &result);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn kcl_test_basic_fillet_cube_end() {
-    let code = kcl_input!("basic_fillet_cube_end");
-    let result = execute_and_snapshot(code, UnitLength::Mm).await.unwrap();
-    assert_out("basic_fillet_cube_end", &result);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn kcl_test_basic_fillet_cube_close_opposite() {
-    let code = kcl_input!("basic_fillet_cube_close_opposite");
-
-    let result = execute_and_snapshot(code, UnitLength::Mm).await.unwrap();
-    assert_out("basic_fillet_cube_close_opposite", &result);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn kcl_test_basic_fillet_cube_next_adjacent() {
-    let code = kcl_input!("basic_fillet_cube_next_adjacent");
-
-    let result = execute_and_snapshot(code, UnitLength::Mm).await.unwrap();
-    assert_out("basic_fillet_cube_next_adjacent", &result);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn kcl_test_basic_fillet_cube_previous_adjacent() {
-    let code = kcl_input!("basic_fillet_cube_previous_adjacent");
-
-    let result = execute_and_snapshot(code, UnitLength::Mm).await.unwrap();
-    assert_out("basic_fillet_cube_previous_adjacent", &result);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Now the process for adding a new KCL test is:

 - Write a new .kcl file e.g. `tests/inputs/foo.kcl`
 - In `tests/executor/main.rs` add `kcl_test!("foo", kcl_test_foo);`
     - I'm sorry about the duplication here, all the ways I can currently think of which would deduplicate it just create more work later in other steps.
 - Run `just new-test foo`
 - Commit changes and open a PR