### PR TITLE
Remove ProgramReturn

### DIFF
--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -21,7 +21,6 @@ import init, {
 import { KCLError } from './errors'
 import { KclError as RustKclError } from '../wasm-lib/kcl/bindings/KclError'
 import { EngineCommandManager } from './std/engineConnection'
-import { ProgramReturn } from '../wasm-lib/kcl/bindings/ProgramReturn'
 import { Discovered } from '../wasm-lib/kcl/bindings/Discovered'
 import { KclValue } from '../wasm-lib/kcl/bindings/KclValue'
 import type { Program } from '../wasm-lib/kcl/bindings/Program'
@@ -159,7 +158,7 @@ function emptyEnvironment(): Environment {
 interface RawProgramMemory {
   environments: Environment[]
   currentEnv: EnvironmentRef
-  return: ProgramReturn | null
+  return: KclValue | null
 }
 
 /**
@@ -170,7 +169,7 @@ interface RawProgramMemory {
 export class ProgramMemory {
   private environments: Environment[]
   private currentEnv: EnvironmentRef
-  private return: ProgramReturn | null
+  private return: KclValue | null
 
   /**
    * Empty memory doesn't include prelude definitions.
@@ -186,7 +185,7 @@ export class ProgramMemory {
   constructor(
     environments: Environment[] = [emptyEnvironment()],
     currentEnv: EnvironmentRef = ROOT_ENVIRONMENT_REF,
-    returnVal: ProgramReturn | null = null
+    returnVal: KclValue | null = null
   ) {
     this.environments = environments
     this.currentEnv = currentEnv

--- a/src/wasm-lib/kcl/src/ast/types.rs
+++ b/src/wasm-lib/kcl/src/ast/types.rs
@@ -1479,8 +1479,6 @@ impl CallExpression {
                         source_ranges: vec![self.into()],
                     })
                 })?;
-
-                let result = result.get_value()?;
                 Ok(result)
             }
             FunctionKind::UserDefined => {
@@ -1505,7 +1503,6 @@ impl CallExpression {
                         source_ranges,
                     })
                 })?;
-                let result = result.get_value()?;
 
                 Ok(result)
             }

--- a/src/wasm-lib/kcl/src/function_param.rs
+++ b/src/wasm-lib/kcl/src/function_param.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 use crate::{
     ast::types::FunctionExpression,
     errors::KclError,
-    executor::{DynamicState, ExecutorContext, KclValue, MemoryFunction, Metadata, ProgramMemory, ProgramReturn},
+    executor::{DynamicState, ExecutorContext, KclValue, MemoryFunction, Metadata, ProgramMemory},
 };
 
 /// A function being used as a parameter into a stdlib function.
@@ -17,7 +17,7 @@ pub struct FunctionParam<'a> {
 }
 
 impl<'a> FunctionParam<'a> {
-    pub async fn call(&self, args: Vec<KclValue>) -> Result<Option<ProgramReturn>, KclError> {
+    pub async fn call(&self, args: Vec<KclValue>) -> Result<Option<KclValue>, KclError> {
         (self.inner)(
             args,
             self.memory.clone(),

--- a/src/wasm-lib/kcl/src/std/patterns.rs
+++ b/src/wasm-lib/kcl/src/std/patterns.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     errors::{KclError, KclErrorDetails},
     executor::{
-        ExtrudeGroup, ExtrudeGroupSet, Geometries, Geometry, KclValue, Point3d, ProgramReturn, SketchGroup,
-        SketchGroupSet, SourceRange, UserVal,
+        ExtrudeGroup, ExtrudeGroupSet, Geometries, Geometry, KclValue, Point3d, SketchGroup, SketchGroupSet,
+        SourceRange, UserVal,
     },
     function_param::FunctionParam,
     std::{types::Uint, Args},
@@ -218,12 +218,6 @@ async fn make_transform<'a>(
             source_ranges: source_ranges.clone(),
         })
     })?;
-    let ProgramReturn::Value(transform_fn_return) = transform_fn_return else {
-        return Err(KclError::Semantic(KclErrorDetails {
-            message: "Transform function must return a value".to_string(),
-            source_ranges: source_ranges.clone(),
-        }));
-    };
     let KclValue::UserVal(transform) = transform_fn_return else {
         return Err(KclError::Semantic(KclErrorDetails {
             message: "Transform function must return a transform object".to_string(),


### PR DESCRIPTION
`ProgramReturn::Arguments` variant is never instantiated and should go away. This would make `ProgramReturn` an unnecessary wrapper around `KclValue`, so the whole type should go away.

Part of https://github.com/KittyCAD/modeling-app/issues/3379