### PR TITLE
Add serde-kcl library for working with KCL objects/values

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-ignore-words-list: crate,everytime,inout,co-ordinate,ot,nwo,absolutey,atleast,ue,afterall
+ignore-words-list: crate,everytime,inout,co-ordinate,ot,nwo,absolutey,atleast,ue,afterall,ser
 skip: **/target,node_modules,build,**/Cargo.lock,./docs/kcl/*.md,./src-tauri/gen/schemas

--- a/src/wasm-lib/Cargo.lock
+++ b/src/wasm-lib/Cargo.lock
@@ -2591,6 +2591,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-kcl"
+version = "0.1.0"
+dependencies = [
+ "ryu",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/wasm-lib/Cargo.toml
+++ b/src/wasm-lib/Cargo.toml
@@ -67,6 +67,7 @@ members = [
 	"kcl",
 	"kcl-macros",
 	"kcl-test-server",
+	"serde-kcl",
 ]
 
 [workspace.dependencies]

--- a/src/wasm-lib/serde-kcl/Cargo.toml
+++ b/src/wasm-lib/serde-kcl/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "serde-kcl"
+description = "KittyCAD Language object model"
+version = "0.1.0"
+edition = "2021"
+repository = "https://github.com/KittyCAD/modeling-app"
+rust-version = "1.80"
+license = "MIT"
+authors = ["Jess Frazelle", "Adam Chalmers", "Jon Tran", "KittyCAD, Inc"]
+keywords = ["kcl", "KittyCAD", "CAD"]
+
+[dependencies]
+ryu = "1.0"
+serde = "1.0.207"
+thiserror = "1.0.63"
+
+[dev-dependencies]
+serde = { version = "1.0.207", features = ["derive"]}

--- a/src/wasm-lib/serde-kcl/src/error.rs
+++ b/src/wasm-lib/serde-kcl/src/error.rs
@@ -1,5 +1,7 @@
 use std::{fmt::Display, num::TryFromIntError};
 
+/// Errors that can occur when converting between
+/// Rust types and KCL types.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("{0}")]
@@ -8,6 +10,8 @@ pub enum Error {
     NumberTooBig,
     #[error("You cannot use this as a key of a KCL object")]
     InvalidKey,
+    #[error("Invalid syntax")]
+    Syntax,
 }
 
 impl From<TryFromIntError> for Error {

--- a/src/wasm-lib/serde-kcl/src/error.rs
+++ b/src/wasm-lib/serde-kcl/src/error.rs
@@ -4,14 +4,15 @@ use std::{fmt::Display, num::TryFromIntError};
 /// Rust types and KCL types.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// Some error not covered by other cases.
     #[error("{0}")]
     Message(String),
+    /// Number is too big.
     #[error("Number is too big")]
     NumberTooBig,
+    /// Invalid key for a KCL object.
     #[error("You cannot use this as a key of a KCL object")]
     InvalidKey,
-    #[error("Invalid syntax")]
-    Syntax,
 }
 
 impl From<TryFromIntError> for Error {

--- a/src/wasm-lib/serde-kcl/src/error.rs
+++ b/src/wasm-lib/serde-kcl/src/error.rs
@@ -1,0 +1,29 @@
+use std::{fmt::Display, num::TryFromIntError};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("{0}")]
+    Message(String),
+    #[error("Number is too big")]
+    NumberTooBig,
+    #[error("You cannot use this as a key of a KCL object")]
+    InvalidKey,
+}
+
+impl From<TryFromIntError> for Error {
+    fn from(_: TryFromIntError) -> Self {
+        Self::NumberTooBig
+    }
+}
+
+impl serde::ser::Error for Error {
+    fn custom<T: Display>(msg: T) -> Self {
+        Self::Message(msg.to_string())
+    }
+}
+
+impl serde::de::Error for Error {
+    fn custom<T: Display>(msg: T) -> Self {
+        Self::Message(msg.to_string())
+    }
+}

--- a/src/wasm-lib/serde-kcl/src/lib.rs
+++ b/src/wasm-lib/serde-kcl/src/lib.rs
@@ -1,8 +1,6 @@
 use serde::Serialize;
 
-pub use crate::error::Error;
-pub use crate::object::Object;
-pub use crate::value::Value;
+pub use crate::{error::Error, object::Object, value::Value};
 
 mod error;
 mod object;
@@ -65,7 +63,7 @@ mod tests {
 
     #[test]
     fn ser_struct_into_kcl_object() {
-        let val = to_value(&Person::adam()).expect("Serializing to KCL object should pass");
+        let val = to_value(Person::adam()).expect("Serializing to KCL object should pass");
         let obj = val.as_object().unwrap();
         let expected = Object {
             properties: std::collections::HashMap::from([

--- a/src/wasm-lib/serde-kcl/src/lib.rs
+++ b/src/wasm-lib/serde-kcl/src/lib.rs
@@ -1,3 +1,9 @@
+//! # Serde KCL
+//!
+//! KCL (KittyCAD Language) has an object model similar to JSON.
+//! This crate works similarly to serde_json.
+#![deny(missing_docs)]
+
 use serde::Serialize;
 
 pub use crate::{error::Error, object::Object, value::Value};

--- a/src/wasm-lib/serde-kcl/src/lib.rs
+++ b/src/wasm-lib/serde-kcl/src/lib.rs
@@ -8,6 +8,8 @@ mod error;
 mod object;
 mod value;
 
+/// Convert a `T` into `serde_kcl::Value` which is an enum that can represent
+/// any valid KCL data.
 pub fn to_value<T>(value: T) -> Result<Value, Error>
 where
     T: Serialize,
@@ -15,23 +17,55 @@ where
     value.serialize(crate::value::ser::Serializer)
 }
 
+/// Interpret a `serde_kcl::Value` as an instance of type `T`.
+pub fn from_value<T>(value: Value) -> Result<T, Error>
+where
+    T: serde::de::DeserializeOwned,
+{
+    T::deserialize(value)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn structs_into_kcl_object() {
-        #[derive(serde::Serialize)]
-        struct Person {
-            name: String,
-            age: u8,
-        }
+    #[derive(serde::Serialize, serde::Deserialize, Eq, PartialEq, Debug)]
+    struct Person {
+        name: String,
+        age: u8,
+    }
 
-        let adam = Person {
-            name: "Adam".to_owned(),
-            age: 32,
-        };
-        let val = to_value(&adam).expect("Serializing to KCL object should pass");
+    impl Person {
+        fn adam() -> Self {
+            Person {
+                name: "Adam".to_owned(),
+                age: 32,
+            }
+        }
+    }
+
+    #[test]
+    fn roundtrip_person() {
+        let before = Person::adam();
+        let after = from_value(to_value(&before).unwrap()).unwrap();
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn deser_struct_from_kcl_object() {
+        let serialized = Value::Object(Object {
+            properties: std::collections::HashMap::from([
+                ("name".to_owned(), Value::from("Adam".to_owned())),
+                ("age".to_owned(), Value::from(32)),
+            ]),
+        });
+        let actual: Person = from_value(serialized).unwrap();
+        assert_eq!(actual, Person::adam());
+    }
+
+    #[test]
+    fn ser_struct_into_kcl_object() {
+        let val = to_value(&Person::adam()).expect("Serializing to KCL object should pass");
         let obj = val.as_object().unwrap();
         let expected = Object {
             properties: std::collections::HashMap::from([

--- a/src/wasm-lib/serde-kcl/src/lib.rs
+++ b/src/wasm-lib/serde-kcl/src/lib.rs
@@ -1,0 +1,44 @@
+use serde::Serialize;
+
+pub use crate::error::Error;
+pub use crate::object::Object;
+pub use crate::value::Value;
+
+mod error;
+mod object;
+mod value;
+
+pub fn to_value<T>(value: T) -> Result<Value, Error>
+where
+    T: Serialize,
+{
+    value.serialize(crate::value::ser::Serializer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn structs_into_kcl_object() {
+        #[derive(serde::Serialize)]
+        struct Person {
+            name: String,
+            age: u8,
+        }
+
+        let adam = Person {
+            name: "Adam".to_owned(),
+            age: 32,
+        };
+        let val = to_value(&adam).expect("Serializing to KCL object should pass");
+        let obj = val.as_object().unwrap();
+        let expected = Object {
+            properties: std::collections::HashMap::from([
+                ("name".to_owned(), Value::from("Adam".to_owned())),
+                ("age".to_owned(), Value::from(32)),
+            ]),
+        };
+        assert_eq!(obj.properties, expected.properties);
+    }
+}

--- a/src/wasm-lib/serde-kcl/src/object.rs
+++ b/src/wasm-lib/serde-kcl/src/object.rs
@@ -14,10 +14,17 @@ impl Object {
     pub fn new() -> Self {
         Self::default()
     }
+
+    /// Does the object have any properties?
+    pub fn is_empty(&self) -> bool {
+        self.properties.is_empty()
+    }
+
     /// How many properties does this object have?
     pub fn len(&self) -> usize {
         self.properties.len()
     }
+
     /// Add a new property to the object.
     /// If the object already has a property with this name, overwrites it.
     pub fn insert(&mut self, property: String, value: Value) {

--- a/src/wasm-lib/serde-kcl/src/object.rs
+++ b/src/wasm-lib/serde-kcl/src/object.rs
@@ -1,0 +1,35 @@
+use std::collections::HashMap;
+
+use crate::Value;
+
+/// A KCL object.
+#[derive(Debug, Default, PartialEq)]
+pub struct Object {
+    /// The object's properties.
+    pub properties: HashMap<String, Value>,
+}
+
+impl Object {
+    /// Create a new object with no properties.
+    pub fn new() -> Self {
+        Self::default()
+    }
+    /// How many properties does this object have?
+    pub fn len(&self) -> usize {
+        self.properties.len()
+    }
+    /// Add a new property to the object.
+    /// If the object already has a property with this name, overwrites it.
+    pub fn insert(&mut self, property: String, value: Value) {
+        self.properties.insert(property, value);
+    }
+}
+
+/// Given a list of (key, value) pairs, you can make a KCL object.
+impl<const N: usize> From<[(String, Value); N]> for Object {
+    fn from(value: [(String, Value); N]) -> Self {
+        Self {
+            properties: HashMap::from(value),
+        }
+    }
+}

--- a/src/wasm-lib/serde-kcl/src/value.rs
+++ b/src/wasm-lib/serde-kcl/src/value.rs
@@ -1,5 +1,6 @@
 use crate::Object;
 
+pub(crate) mod de;
 pub(crate) mod ser;
 
 #[derive(Debug, PartialEq)]

--- a/src/wasm-lib/serde-kcl/src/value.rs
+++ b/src/wasm-lib/serde-kcl/src/value.rs
@@ -3,6 +3,7 @@ use crate::Object;
 pub(crate) mod de;
 pub(crate) mod ser;
 
+/// Values that can be represented in KCL.
 #[derive(Debug, PartialEq)]
 pub enum Value {
     /// A value to use when the specific value isn't really important.
@@ -33,6 +34,7 @@ pub enum Value {
 
 macro_rules! impl_as {
     ($name:ident, $variant:ident, $return_type:ty) => {
+        /// If the KCL value matches this type, return it.
         pub fn $name(&self) -> Option<&$return_type> {
             match self {
                 Self::$variant(x) => Some(x),
@@ -60,6 +62,7 @@ impl Value {
     impl_as!(as_array, Array, Vec<Value>);
     impl_as!(as_object, Object, Object);
     impl_as!(as_binary, Bytes, Vec<u8>);
+    /// If the KCL value matches this type, return it.
     pub fn as_unit(&self) -> Option<()> {
         match self {
             Self::Unit => Some(()),

--- a/src/wasm-lib/serde-kcl/src/value.rs
+++ b/src/wasm-lib/serde-kcl/src/value.rs
@@ -1,0 +1,84 @@
+use crate::Object;
+
+pub(crate) mod ser;
+
+#[derive(Debug, PartialEq)]
+pub enum Value {
+    /// A value to use when the specific value isn't really important.
+    /// For example, this is the return type of functions that don't return
+    /// any other value.
+    ///
+    /// Don't worry about it too much.
+    ///
+    /// Kind of like 'null' in other languages, but it doesn't have the
+    /// connotation that nothing was missing. It probably means nothing was
+    /// required, not nothing was found.
+    Unit,
+    /// Either true or false.
+    Boolean(bool),
+    /// Text.
+    String(String),
+    /// Whole numbers (positive, negative or zero).
+    Integer(i64),
+    /// Numbers with a fractional part.
+    Float(f64),
+    /// A list of other values.
+    Array(Vec<Value>),
+    /// A set of properties. Each property has a name (aka "key") and a value.
+    Object(Object),
+    /// Binary data
+    Bytes(Vec<u8>),
+}
+
+macro_rules! impl_as {
+    ($name:ident, $variant:ident, $return_type:ty) => {
+        pub fn $name(&self) -> Option<&$return_type> {
+            match self {
+                Self::$variant(x) => Some(x),
+                _ => None,
+            }
+        }
+    };
+}
+
+macro_rules! impl_from {
+    ($variant:ident, $t:ty) => {
+        impl From<$t> for Value {
+            fn from(t: $t) -> Self {
+                Self::$variant(t.into())
+            }
+        }
+    };
+}
+
+impl Value {
+    impl_as!(as_boolean, Boolean, bool);
+    impl_as!(as_string, String, String);
+    impl_as!(as_integer, Integer, i64);
+    impl_as!(as_float, Float, f64);
+    impl_as!(as_array, Array, Vec<Value>);
+    impl_as!(as_object, Object, Object);
+    impl_as!(as_binary, Bytes, Vec<u8>);
+    pub fn as_unit(&self) -> Option<()> {
+        match self {
+            Self::Unit => Some(()),
+            _ => None,
+        }
+    }
+}
+impl_from!(String, String);
+impl_from!(Boolean, bool);
+impl_from!(Integer, i64);
+impl_from!(Integer, i32);
+impl_from!(Integer, u32);
+impl_from!(Integer, u8);
+impl_from!(Integer, i8);
+impl_from!(Float, f64);
+impl_from!(Float, f32);
+impl_from!(Bytes, Vec<u8>);
+
+impl From<()> for Value {
+    fn from(_: ()) -> Self {
+        Self::Unit
+    }
+}

--- a/src/wasm-lib/serde-kcl/src/value/de.rs
+++ b/src/wasm-lib/serde-kcl/src/value/de.rs
@@ -1,0 +1,802 @@
+use serde::de::{
+    self, Deserialize, DeserializeSeed, EnumAccess, Expected, IntoDeserializer, MapAccess, SeqAccess, Unexpected,
+    VariantAccess, Visitor,
+};
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::fmt;
+use std::vec;
+
+use crate::{value::Value, Error, Object};
+
+// We only use our own error type; no need for From conversions provided by the
+// standard library's try! macro. This reduces lines of LLVM IR by 4%.
+macro_rules! tri {
+    ($e:expr $(,)?) => {
+        match $e {
+            core::result::Result::Ok(val) => val,
+            core::result::Result::Err(err) => return core::result::Result::Err(err),
+        }
+    };
+}
+macro_rules! deserialize_number {
+    ($method:ident) => {
+        fn $method<V>(self, visitor: V) -> Result<V::Value, Error>
+        where
+            V: Visitor<'de>,
+        {
+            match self {
+                Value::Integer(n) => visitor.visit_i64(n),
+                Value::Float(n) => visitor.visit_f64(n),
+                _ => Err(self.invalid_type(&visitor)),
+            }
+        }
+    };
+}
+
+impl<'de> Deserialize<'de> for Value {
+    #[inline]
+    fn deserialize<D>(deserializer: D) -> Result<Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct ValueVisitor;
+
+        impl<'de> Visitor<'de> for ValueVisitor {
+            type Value = Value;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("any valid JSON value")
+            }
+
+            #[inline]
+            fn visit_bool<E>(self, value: bool) -> Result<Value, E> {
+                Ok(Value::Boolean(value))
+            }
+
+            #[inline]
+            fn visit_i64<E>(self, value: i64) -> Result<Value, E> {
+                Ok(Value::Integer(value.into()))
+            }
+
+            #[inline]
+            fn visit_u32<E>(self, value: u32) -> Result<Value, E> {
+                Ok(Value::Integer(value.into()))
+            }
+
+            #[inline]
+            fn visit_i32<E>(self, value: i32) -> Result<Value, E> {
+                Ok(Value::Integer(value.into()))
+            }
+
+            #[inline]
+            fn visit_i8<E>(self, value: i8) -> Result<Value, E> {
+                Ok(Value::Integer(value.into()))
+            }
+
+            #[inline]
+            fn visit_u8<E>(self, value: u8) -> Result<Value, E> {
+                Ok(Value::Integer(value.into()))
+            }
+
+            #[inline]
+            fn visit_f64<E>(self, value: f64) -> Result<Value, E> {
+                Ok(Value::Float(value))
+            }
+            #[inline]
+            fn visit_f32<E>(self, value: f32) -> Result<Value, E> {
+                Ok(Value::Float(value.into()))
+            }
+
+            #[inline]
+            fn visit_str<E>(self, value: &str) -> Result<Value, E>
+            where
+                E: serde::de::Error,
+            {
+                self.visit_string(String::from(value))
+            }
+
+            #[inline]
+            fn visit_string<E>(self, value: String) -> Result<Value, E> {
+                Ok(Value::String(value))
+            }
+
+            #[inline]
+            fn visit_none<E>(self) -> Result<Value, E> {
+                Ok(Value::Unit)
+            }
+
+            #[inline]
+            fn visit_some<D>(self, deserializer: D) -> Result<Value, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                Deserialize::deserialize(deserializer)
+            }
+
+            #[inline]
+            fn visit_unit<E>(self) -> Result<Value, E> {
+                Ok(Value::Unit)
+            }
+
+            #[inline]
+            fn visit_seq<V>(self, mut visitor: V) -> Result<Value, V::Error>
+            where
+                V: SeqAccess<'de>,
+            {
+                let mut vec = Vec::new();
+
+                while let Some(elem) = tri!(visitor.next_element()) {
+                    vec.push(elem);
+                }
+
+                Ok(Value::Array(vec))
+            }
+
+            fn visit_map<V>(self, mut visitor: V) -> Result<Value, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                match tri!(visitor.next_key_seed(KeyClassifier)) {
+                    Some(KeyClass::Map(first_key)) => {
+                        let mut values = Object::new();
+
+                        values.insert(first_key, tri!(visitor.next_value()));
+                        while let Some((key, value)) = tri!(visitor.next_entry()) {
+                            values.insert(key, value);
+                        }
+
+                        Ok(Value::Object(values))
+                    }
+                    None => Ok(Value::Object(Object::new())),
+                }
+            }
+        }
+
+        deserializer.deserialize_any(ValueVisitor)
+    }
+}
+
+struct KeyClassifier;
+
+enum KeyClass {
+    Map(String),
+}
+
+impl<'de> DeserializeSeed<'de> for KeyClassifier {
+    type Value = KeyClass;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(self)
+    }
+}
+
+impl<'de> Visitor<'de> for KeyClassifier {
+    type Value = KeyClass;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a string key")
+    }
+
+    fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        match s {
+            _ => Ok(KeyClass::Map(s.to_owned())),
+        }
+    }
+
+    fn visit_string<E>(self, s: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        match s.as_str() {
+            _ => Ok(KeyClass::Map(s)),
+        }
+    }
+}
+
+impl<'de> serde::Deserializer<'de> for Value {
+    type Error = Error;
+
+    #[inline]
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Value::Unit => visitor.visit_unit(),
+            Value::Boolean(v) => visitor.visit_bool(v),
+            Value::Integer(n) => visitor.visit_i64(n),
+            Value::Float(n) => visitor.visit_f64(n),
+            Value::String(v) => visitor.visit_string(v),
+            Value::Bytes(b) => visitor.visit_bytes(&b),
+            Value::Array(v) => visit_array(v, visitor),
+            Value::Object(v) => visit_object(v, visitor),
+        }
+    }
+
+    deserialize_number!(deserialize_i8);
+    deserialize_number!(deserialize_i16);
+    deserialize_number!(deserialize_i32);
+    deserialize_number!(deserialize_i64);
+    deserialize_number!(deserialize_i128);
+    deserialize_number!(deserialize_u8);
+    deserialize_number!(deserialize_u16);
+    deserialize_number!(deserialize_u32);
+    deserialize_number!(deserialize_u64);
+    deserialize_number!(deserialize_u128);
+    deserialize_number!(deserialize_f32);
+    deserialize_number!(deserialize_f64);
+
+    #[inline]
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Value::Unit => visitor.visit_none(),
+            _ => visitor.visit_some(self),
+        }
+    }
+
+    #[inline]
+    fn deserialize_enum<V>(self, _name: &str, _variants: &'static [&'static str], visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (variant, value) = match self {
+            Value::Object(value) => {
+                let mut iter = value.properties.into_iter();
+                let (variant, value) = match iter.next() {
+                    Some(v) => v,
+                    None => {
+                        return Err(serde::de::Error::invalid_value(
+                            Unexpected::Map,
+                            &"map with a single key",
+                        ));
+                    }
+                };
+                // enums are encoded in json as maps with a single key:value pair
+                if iter.next().is_some() {
+                    return Err(serde::de::Error::invalid_value(
+                        Unexpected::Map,
+                        &"map with a single key",
+                    ));
+                }
+                (variant, Some(value))
+            }
+            Value::String(variant) => (variant, None),
+            other => {
+                return Err(serde::de::Error::invalid_type(other.unexpected(), &"string or map"));
+            }
+        };
+
+        visitor.visit_enum(EnumDeserializer { variant, value })
+    }
+
+    #[inline]
+    fn deserialize_newtype_struct<V>(self, name: &'static str, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let _ = name;
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Value::Boolean(v) => visitor.visit_bool(v),
+            _ => Err(self.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_string(visitor)
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_string(visitor)
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Value::String(v) => visitor.visit_string(v),
+            _ => Err(self.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_byte_buf(visitor)
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Value::String(v) => visitor.visit_string(v),
+            Value::Array(v) => visit_array(v, visitor),
+            _ => Err(self.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Value::Unit => visitor.visit_unit(),
+            _ => Err(self.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_unit(visitor)
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Value::Array(v) => visit_array(v, visitor),
+            _ => Err(self.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_tuple_struct<V>(self, _name: &'static str, _len: usize, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Value::Object(v) => visit_object(v, visitor),
+            _ => Err(self.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Value::Array(v) => visit_array(v, visitor),
+            Value::Object(v) => visit_object(v, visitor),
+            _ => Err(self.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_string(visitor)
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        drop(self);
+        visitor.visit_unit()
+    }
+}
+fn visit_array<'de, V>(array: Vec<Value>, visitor: V) -> Result<V::Value, Error>
+where
+    V: Visitor<'de>,
+{
+    let len = array.len();
+    let mut deserializer = SeqDeserializer::new(array);
+    let seq = tri!(visitor.visit_seq(&mut deserializer));
+    let remaining = deserializer.iter.len();
+    if remaining == 0 {
+        Ok(seq)
+    } else {
+        Err(serde::de::Error::invalid_length(len, &"fewer elements in array"))
+    }
+}
+fn visit_object<'de, V>(object: Object, visitor: V) -> Result<V::Value, Error>
+where
+    V: Visitor<'de>,
+{
+    let len = object.len();
+    let mut deserializer = MapDeserializer::new(object.properties);
+    let map = tri!(visitor.visit_map(&mut deserializer));
+    let remaining = deserializer.iter.len();
+    if remaining == 0 {
+        Ok(map)
+    } else {
+        Err(serde::de::Error::invalid_length(len, &"fewer elements in map"))
+    }
+}
+
+impl Value {
+    fn invalid_type<E>(&self, exp: &dyn Expected) -> E
+    where
+        E: serde::de::Error,
+    {
+        serde::de::Error::invalid_type(self.unexpected(), exp)
+    }
+    fn unexpected(&self) -> Unexpected {
+        match self {
+            Value::Unit => Unexpected::Unit,
+            Value::Boolean(b) => Unexpected::Bool(*b),
+            Value::Float(n) => Unexpected::Float(*n),
+            Value::Integer(n) => Unexpected::Signed(*n),
+            Value::String(s) => Unexpected::Str(s),
+            Value::Array(_) => Unexpected::Seq,
+            Value::Object(_) => Unexpected::Map,
+            Value::Bytes(b) => Unexpected::Bytes(b),
+        }
+    }
+}
+
+struct EnumDeserializer {
+    variant: String,
+    value: Option<Value>,
+}
+
+impl<'de> EnumAccess<'de> for EnumDeserializer {
+    type Error = Error;
+    type Variant = VariantDeserializer;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, VariantDeserializer), Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let variant = self.variant.into_deserializer();
+        let visitor = VariantDeserializer { value: self.value };
+        seed.deserialize(variant).map(|v| (v, visitor))
+    }
+}
+
+struct VariantDeserializer {
+    value: Option<Value>,
+}
+
+impl<'de> VariantAccess<'de> for VariantDeserializer {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<(), Error> {
+        match self.value {
+            Some(value) => Deserialize::deserialize(value),
+            None => Ok(()),
+        }
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.value {
+            Some(value) => seed.deserialize(value),
+            None => Err(serde::de::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"newtype variant",
+            )),
+        }
+    }
+
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            Some(Value::Array(v)) => {
+                if v.is_empty() {
+                    visitor.visit_unit()
+                } else {
+                    visit_array(v, visitor)
+                }
+            }
+            Some(other) => Err(serde::de::Error::invalid_type(other.unexpected(), &"tuple variant")),
+            None => Err(serde::de::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"tuple variant",
+            )),
+        }
+    }
+
+    fn struct_variant<V>(self, _fields: &'static [&'static str], visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            Some(Value::Object(v)) => visit_object(v, visitor),
+            Some(other) => Err(serde::de::Error::invalid_type(other.unexpected(), &"struct variant")),
+            None => Err(serde::de::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"struct variant",
+            )),
+        }
+    }
+}
+struct SeqDeserializer {
+    iter: vec::IntoIter<Value>,
+}
+
+impl SeqDeserializer {
+    fn new(vec: Vec<Value>) -> Self {
+        SeqDeserializer { iter: vec.into_iter() }
+    }
+}
+
+impl<'de> SeqAccess<'de> for SeqDeserializer {
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some(value) => seed.deserialize(value).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        match self.iter.size_hint() {
+            (lower, Some(upper)) if lower == upper => Some(upper),
+            _ => None,
+        }
+    }
+}
+
+struct MapDeserializer {
+    iter: <HashMap<String, Value> as IntoIterator>::IntoIter,
+    value: Option<Value>,
+}
+
+impl MapDeserializer {
+    fn new(map: HashMap<String, Value>) -> Self {
+        MapDeserializer {
+            iter: map.into_iter(),
+            value: None,
+        }
+    }
+}
+
+impl<'de> MapAccess<'de> for MapDeserializer {
+    type Error = Error;
+
+    fn next_key_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some((key, value)) => {
+                self.value = Some(value);
+                let key_de = MapKeyDeserializer { key: Cow::Owned(key) };
+                seed.deserialize(key_de).map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn next_value_seed<T>(&mut self, seed: T) -> Result<T::Value, Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.value.take() {
+            Some(value) => seed.deserialize(value),
+            None => Err(serde::de::Error::custom("value is missing")),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        match self.iter.size_hint() {
+            (lower, Some(upper)) if lower == upper => Some(upper),
+            _ => None,
+        }
+    }
+}
+
+struct MapKeyDeserializer<'de> {
+    key: Cow<'de, str>,
+}
+
+macro_rules! deserialize_numeric_key {
+    ($method:ident) => {
+        deserialize_numeric_key!($method, deserialize_number);
+    };
+
+    ($method:ident, $using:ident) => {
+        fn $method<V>(self, _visitor: V) -> Result<V::Value, Error>
+        where
+            V: Visitor<'de>,
+        {
+            todo!("I don't think we need to handle this case because KCL keys are always strings.")
+        }
+    };
+}
+
+impl<'de> serde::Deserializer<'de> for MapKeyDeserializer<'de> {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        BorrowedCowStrDeserializer::new(self.key).deserialize_any(visitor)
+    }
+
+    deserialize_numeric_key!(deserialize_i8);
+    deserialize_numeric_key!(deserialize_i16);
+    deserialize_numeric_key!(deserialize_i32);
+    deserialize_numeric_key!(deserialize_i64);
+    deserialize_numeric_key!(deserialize_u8);
+    deserialize_numeric_key!(deserialize_u16);
+    deserialize_numeric_key!(deserialize_u32);
+    deserialize_numeric_key!(deserialize_u64);
+    deserialize_numeric_key!(deserialize_f32);
+    deserialize_numeric_key!(deserialize_f64);
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        if self.key == "true" {
+            visitor.visit_bool(true)
+        } else if self.key == "false" {
+            visitor.visit_bool(false)
+        } else {
+            Err(serde::de::Error::invalid_type(Unexpected::Str(&self.key), &visitor))
+        }
+    }
+
+    #[inline]
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        // Map keys cannot be null.
+        visitor.visit_some(self)
+    }
+
+    #[inline]
+    fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.key.into_deserializer().deserialize_enum(name, variants, visitor)
+    }
+
+    serde::forward_to_deserialize_any! {
+        char str string bytes byte_buf unit unit_struct seq tuple tuple_struct
+        map struct identifier ignored_any
+    }
+}
+
+struct BorrowedCowStrDeserializer<'de> {
+    value: Cow<'de, str>,
+}
+
+impl<'de> BorrowedCowStrDeserializer<'de> {
+    fn new(value: Cow<'de, str>) -> Self {
+        BorrowedCowStrDeserializer { value }
+    }
+}
+
+impl<'de> de::Deserializer<'de> for BorrowedCowStrDeserializer<'de> {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.value {
+            Cow::Borrowed(string) => visitor.visit_borrowed_str(string),
+            Cow::Owned(string) => visitor.visit_string(string),
+        }
+    }
+
+    fn deserialize_enum<V>(self, _name: &str, _variants: &'static [&'static str], visitor: V) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_enum(self)
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct identifier ignored_any
+    }
+}
+
+impl<'de> de::EnumAccess<'de> for BorrowedCowStrDeserializer<'de> {
+    type Error = Error;
+    type Variant = UnitOnly;
+
+    fn variant_seed<T>(self, seed: T) -> Result<(T::Value, Self::Variant), Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        let value = tri!(seed.deserialize(self));
+        Ok((value, UnitOnly))
+    }
+}
+
+struct UnitOnly;
+
+impl<'de> de::VariantAccess<'de> for UnitOnly {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn newtype_variant_seed<T>(self, _seed: T) -> Result<T::Value, Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        Err(de::Error::invalid_type(Unexpected::UnitVariant, &"newtype variant"))
+    }
+
+    fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        Err(de::Error::invalid_type(Unexpected::UnitVariant, &"tuple variant"))
+    }
+
+    fn struct_variant<V>(self, _fields: &'static [&'static str], _visitor: V) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        Err(de::Error::invalid_type(Unexpected::UnitVariant, &"struct variant"))
+    }
+}

--- a/src/wasm-lib/serde-kcl/src/value/de.rs
+++ b/src/wasm-lib/serde-kcl/src/value/de.rs
@@ -1,11 +1,9 @@
+use std::{borrow::Cow, collections::HashMap, fmt, vec};
+
 use serde::de::{
     self, Deserialize, DeserializeSeed, EnumAccess, Expected, IntoDeserializer, MapAccess, SeqAccess, Unexpected,
     VariantAccess, Visitor,
 };
-use std::borrow::Cow;
-use std::collections::HashMap;
-use std::fmt;
-use std::vec;
 
 use crate::{value::Value, Error, Object};
 
@@ -56,7 +54,7 @@ impl<'de> Deserialize<'de> for Value {
 
             #[inline]
             fn visit_i64<E>(self, value: i64) -> Result<Value, E> {
-                Ok(Value::Integer(value.into()))
+                Ok(Value::Integer(value))
             }
 
             #[inline]
@@ -185,18 +183,14 @@ impl<'de> Visitor<'de> for KeyClassifier {
     where
         E: de::Error,
     {
-        match s {
-            _ => Ok(KeyClass::Map(s.to_owned())),
-        }
+        Ok(KeyClass::Map(s.to_owned()))
     }
 
     fn visit_string<E>(self, s: String) -> Result<Self::Value, E>
     where
         E: de::Error,
     {
-        match s.as_str() {
-            _ => Ok(KeyClass::Map(s)),
-        }
+        Ok(KeyClass::Map(s))
     }
 }
 

--- a/src/wasm-lib/serde-kcl/src/value/ser.rs
+++ b/src/wasm-lib/serde-kcl/src/value/ser.rs
@@ -1,5 +1,4 @@
-use serde::ser::Impossible;
-use serde::Serialize;
+use serde::{ser::Impossible, Serialize};
 
 use crate::{to_value, value::Value, Error, Object};
 
@@ -429,7 +428,7 @@ impl serde::Serializer for Serializer {
     }
 
     fn serialize_i64(self, value: i64) -> Result<Value> {
-        Ok(Value::Integer(value.into()))
+        Ok(Value::Integer(value))
     }
 
     #[inline]
@@ -562,10 +561,8 @@ impl serde::Serializer for Serializer {
             next_key: None,
         })
     }
-    fn serialize_struct(self, name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
-        match name {
-            _ => self.serialize_map(Some(len)),
-        }
+    fn serialize_struct(self, _name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
+        self.serialize_map(Some(len))
     }
 
     fn serialize_struct_variant(

--- a/src/wasm-lib/serde-kcl/src/value/ser.rs
+++ b/src/wasm-lib/serde-kcl/src/value/ser.rs
@@ -1,8 +1,7 @@
 use serde::ser::Impossible;
 use serde::Serialize;
 
-use crate::value::Value;
-use crate::{to_value, Error, Object};
+use crate::{to_value, value::Value, Error, Object};
 
 // We only use our own error type; no need for From conversions provided by the
 // standard library's try! macro. This reduces lines of LLVM IR by 4%.

--- a/src/wasm-lib/serde-kcl/src/value/ser.rs
+++ b/src/wasm-lib/serde-kcl/src/value/ser.rs
@@ -1,0 +1,591 @@
+use serde::ser::Impossible;
+use serde::Serialize;
+
+use crate::value::Value;
+use crate::{to_value, Error, Object};
+
+// We only use our own error type; no need for From conversions provided by the
+// standard library's try! macro. This reduces lines of LLVM IR by 4%.
+macro_rules! tri {
+    ($e:expr $(,)?) => {
+        match $e {
+            core::result::Result::Ok(val) => val,
+            core::result::Result::Err(err) => return core::result::Result::Err(err),
+        }
+    };
+}
+
+impl Serialize for Value {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: ::serde::Serializer,
+    {
+        match self {
+            Self::Unit => serializer.serialize_unit(),
+            Self::Boolean(b) => serializer.serialize_bool(*b),
+            Self::String(s) => serializer.serialize_str(s),
+            Self::Integer(x) => serializer.serialize_i64(*x),
+            Self::Float(x) => serializer.serialize_f64(*x),
+            Self::Bytes(b) => serializer.serialize_bytes(b),
+            Self::Array(v) => serializer.collect_seq(v),
+            Self::Object(o) => {
+                use serde::ser::SerializeMap;
+                let mut map = serializer.serialize_map(Some(o.len()))?;
+                for (k, v) in &o.properties {
+                    map.serialize_entry(k, v)?;
+                }
+                map.end()
+            }
+        }
+    }
+}
+
+pub(crate) struct Serializer;
+
+type Result<T> = std::result::Result<T, Error>;
+
+pub struct SerializeVec {
+    vec: Vec<Value>,
+}
+
+impl serde::ser::SerializeSeq for SerializeVec {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.vec.push(tri!(to_value(value)));
+        Ok(())
+    }
+
+    fn end(self) -> Result<Value> {
+        Ok(Value::Array(self.vec))
+    }
+}
+
+impl serde::ser::SerializeTuple for SerializeVec {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        serde::ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Value> {
+        serde::ser::SerializeSeq::end(self)
+    }
+}
+
+impl serde::ser::SerializeTupleStruct for SerializeVec {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        serde::ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Value> {
+        serde::ser::SerializeSeq::end(self)
+    }
+}
+
+struct MapKeySerializer;
+
+fn key_must_be_a_string() -> Error {
+    Error::InvalidKey
+}
+
+fn float_key_must_be_finite() -> Error {
+    Error::InvalidKey
+}
+
+impl serde::Serializer for MapKeySerializer {
+    type Ok = String;
+    type Error = Error;
+
+    type SerializeSeq = Impossible<String, Error>;
+    type SerializeTuple = Impossible<String, Error>;
+    type SerializeTupleStruct = Impossible<String, Error>;
+    type SerializeTupleVariant = Impossible<String, Error>;
+    type SerializeMap = Impossible<String, Error>;
+    type SerializeStruct = Impossible<String, Error>;
+    type SerializeStructVariant = Impossible<String, Error>;
+
+    #[inline]
+    fn serialize_unit_variant(self, _name: &'static str, _variant_index: u32, variant: &'static str) -> Result<String> {
+        Ok(variant.to_owned())
+    }
+
+    #[inline]
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<String>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_bool(self, value: bool) -> Result<String> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_i8(self, value: i8) -> Result<String> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_i16(self, value: i16) -> Result<String> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_i32(self, value: i32) -> Result<String> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_i64(self, value: i64) -> Result<String> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_u8(self, value: u8) -> Result<String> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_u16(self, value: u16) -> Result<String> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_u32(self, value: u32) -> Result<String> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_u64(self, value: u64) -> Result<String> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_f32(self, value: f32) -> Result<String> {
+        if value.is_finite() {
+            Ok(ryu::Buffer::new().format_finite(value).to_owned())
+        } else {
+            Err(float_key_must_be_finite())
+        }
+    }
+
+    fn serialize_f64(self, value: f64) -> Result<String> {
+        if value.is_finite() {
+            Ok(ryu::Buffer::new().format_finite(value).to_owned())
+        } else {
+            Err(float_key_must_be_finite())
+        }
+    }
+
+    #[inline]
+    fn serialize_char(self, value: char) -> Result<String> {
+        Ok({
+            let mut s = String::new();
+            s.push(value);
+            s
+        })
+    }
+
+    #[inline]
+    fn serialize_str(self, value: &str) -> Result<String> {
+        Ok(value.to_owned())
+    }
+
+    fn serialize_bytes(self, _value: &[u8]) -> Result<String> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_unit(self) -> Result<String> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<String> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<String>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_none(self) -> Result<String> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_some<T>(self, _value: &T) -> Result<String>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_tuple_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeTupleStruct> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant> {
+        Err(key_must_be_a_string())
+    }
+
+    fn collect_str<T>(self, value: &T) -> Result<String>
+    where
+        T: ?Sized + std::fmt::Display,
+    {
+        Ok(value.to_string())
+    }
+}
+
+pub struct SerializeTupleVariant {
+    name: String,
+    vec: Vec<Value>,
+}
+
+impl serde::ser::SerializeTupleVariant for SerializeTupleVariant {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.vec.push(to_value(value)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Value> {
+        let mut object = Object::new();
+
+        object.insert(self.name, Value::Array(self.vec));
+
+        Ok(Value::Object(object))
+    }
+}
+
+pub enum SerializeMap {
+    Map { map: Object, next_key: Option<String> },
+}
+
+impl serde::ser::SerializeMap for SerializeMap {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_key<T>(&mut self, key: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        match self {
+            SerializeMap::Map { next_key, .. } => {
+                *next_key = Some(tri!(key.serialize(MapKeySerializer)));
+                Ok(())
+            }
+        }
+    }
+
+    fn serialize_value<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        match self {
+            SerializeMap::Map { map, next_key } => {
+                let key = next_key.take();
+                // Panic because this indicates a bug in the program rather than an
+                // expected failure.
+                let key = key.expect("serialize_value called before serialize_key");
+                map.insert(key, tri!(to_value(value)));
+                Ok(())
+            }
+        }
+    }
+
+    fn end(self) -> Result<Value> {
+        match self {
+            SerializeMap::Map { map, .. } => Ok(Value::Object(map)),
+        }
+    }
+}
+
+impl serde::ser::SerializeStruct for SerializeMap {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        match self {
+            SerializeMap::Map { .. } => serde::ser::SerializeMap::serialize_entry(self, key, value),
+        }
+    }
+
+    fn end(self) -> Result<Value> {
+        match self {
+            SerializeMap::Map { .. } => serde::ser::SerializeMap::end(self),
+        }
+    }
+}
+
+pub struct SerializeStructVariant {
+    name: String,
+    map: Object,
+}
+
+impl serde::ser::SerializeStructVariant for SerializeStructVariant {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.map.insert(String::from(key), tri!(to_value(value)));
+        Ok(())
+    }
+
+    fn end(self) -> Result<Value> {
+        let mut object = Object::new();
+
+        object.insert(self.name, Value::Object(self.map));
+
+        Ok(Value::Object(object))
+    }
+}
+
+impl serde::Serializer for Serializer {
+    type Ok = Value;
+    type Error = Error;
+
+    type SerializeSeq = SerializeVec;
+    type SerializeTuple = SerializeVec;
+    type SerializeTupleStruct = SerializeVec;
+    type SerializeTupleVariant = SerializeTupleVariant;
+    type SerializeMap = SerializeMap;
+    type SerializeStruct = SerializeMap;
+    type SerializeStructVariant = SerializeStructVariant;
+
+    #[inline]
+    fn serialize_bool(self, value: bool) -> Result<Value> {
+        Ok(Value::Boolean(value))
+    }
+
+    #[inline]
+    fn serialize_i8(self, value: i8) -> Result<Value> {
+        self.serialize_i64(value as i64)
+    }
+
+    #[inline]
+    fn serialize_i16(self, value: i16) -> Result<Value> {
+        self.serialize_i64(value as i64)
+    }
+
+    #[inline]
+    fn serialize_i32(self, value: i32) -> Result<Value> {
+        self.serialize_i64(value as i64)
+    }
+
+    fn serialize_i64(self, value: i64) -> Result<Value> {
+        Ok(Value::Integer(value.into()))
+    }
+
+    #[inline]
+    fn serialize_u8(self, value: u8) -> Result<Value> {
+        self.serialize_u64(value as u64)
+    }
+
+    #[inline]
+    fn serialize_u16(self, value: u16) -> Result<Value> {
+        self.serialize_u64(value as u64)
+    }
+
+    #[inline]
+    fn serialize_u32(self, value: u32) -> Result<Value> {
+        self.serialize_u64(value as u64)
+    }
+
+    #[inline]
+    fn serialize_u64(self, value: u64) -> Result<Value> {
+        Ok(Value::Integer(value.try_into()?))
+    }
+
+    #[inline]
+    fn serialize_f32(self, float: f32) -> Result<Value> {
+        Ok(Value::Float(float.into()))
+    }
+
+    #[inline]
+    fn serialize_f64(self, float: f64) -> Result<Value> {
+        Ok(Value::Float(float))
+    }
+
+    #[inline]
+    fn serialize_char(self, value: char) -> Result<Value> {
+        let mut s = String::new();
+        s.push(value);
+        Ok(Value::String(s))
+    }
+
+    #[inline]
+    fn serialize_str(self, value: &str) -> Result<Value> {
+        Ok(Value::String(value.to_owned()))
+    }
+
+    fn serialize_bytes(self, value: &[u8]) -> Result<Value> {
+        let vec = value.to_owned();
+        Ok(Value::Bytes(vec))
+    }
+
+    #[inline]
+    fn serialize_unit(self) -> Result<Value> {
+        Ok(Value::Unit)
+    }
+
+    #[inline]
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Value> {
+        self.serialize_unit()
+    }
+
+    #[inline]
+    fn serialize_unit_variant(self, _name: &'static str, _variant_index: u32, variant: &'static str) -> Result<Value> {
+        self.serialize_str(variant)
+    }
+
+    #[inline]
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<Value>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Value>
+    where
+        T: ?Sized + Serialize,
+    {
+        let mut values = Object::default();
+        values.insert(String::from(variant), to_value(value)?);
+        Ok(Value::Object(values))
+    }
+    #[inline]
+    fn serialize_none(self) -> Result<Value> {
+        self.serialize_unit()
+    }
+
+    #[inline]
+    fn serialize_some<T>(self, value: &T) -> Result<Value>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
+        Ok(SerializeVec {
+            vec: Vec::with_capacity(len.unwrap_or(0)),
+        })
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_struct(self, _name: &'static str, len: usize) -> Result<Self::SerializeTupleStruct> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant> {
+        Ok(SerializeTupleVariant {
+            name: String::from(variant),
+            vec: Vec::with_capacity(len),
+        })
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
+        Ok(SerializeMap::Map {
+            map: Object::new(),
+            next_key: None,
+        })
+    }
+    fn serialize_struct(self, name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
+        match name {
+            _ => self.serialize_map(Some(len)),
+        }
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant> {
+        Ok(SerializeStructVariant {
+            name: String::from(variant),
+            map: Object::new(),
+        })
+    }
+
+    fn collect_str<T>(self, value: &T) -> Result<Value>
+    where
+        T: ?Sized + std::fmt::Display,
+    {
+        Ok(Value::String(value.to_string()))
+    }
+}


### PR DESCRIPTION
This defines:

 - serde_kcl::Value (an enum of all possible values KCL can represent)
 - serde_kcl::Object (KCL objects, like JSON objects)
 - serde_kcl::to_val (takes a Rust type and 'serializes' it into KCL object)
 - serde_kcl::from_val (takes a KCL object and 'deserializes' it into a Rust type)

All similar to their equivalents in `serde_json`.

Part of #1130