### PR TITLE
Add the unexpected token to the error message

### DIFF
--- a/e2e/playwright/code-pane-and-errors.spec.ts
+++ b/e2e/playwright/code-pane-and-errors.spec.ts
@@ -84,7 +84,7 @@ test.describe('Code pane and errors', () => {
 
     // error text on hover
     await page.hover('.cm-lint-marker-error')
-    await expect(page.getByText('Unexpected token').first()).toBeVisible()
+    await expect(page.getByText('Unexpected token: |').first()).toBeVisible()
 
     // Close the code pane
     await codePaneButton.click()
@@ -107,7 +107,7 @@ test.describe('Code pane and errors', () => {
 
     // error text on hover
     await page.hover('.cm-lint-marker-error')
-    await expect(page.getByText('Unexpected token').first()).toBeVisible()
+    await expect(page.getByText('Unexpected token: |').first()).toBeVisible()
   })
 
   test('When error is not in view you can click the badge to scroll to it', async ({

--- a/e2e/playwright/editor-tests.spec.ts
+++ b/e2e/playwright/editor-tests.spec.ts
@@ -354,7 +354,7 @@ test.describe('Editor tests', () => {
 
     // error text on hover
     await page.hover('.cm-lint-marker-error')
-    await expect(page.getByText('Unexpected token').first()).toBeVisible()
+    await expect(page.getByText('Unexpected token: $').first()).toBeVisible()
 
     // select the line that's causing the error and delete it
     await page.getByText('$ error').click()

--- a/e2e/playwright/regression-tests.spec.ts
+++ b/e2e/playwright/regression-tests.spec.ts
@@ -194,7 +194,7 @@ const sketch001 = startSketchAt([-0, -0])
 
     // error text on hover
     await page.hover('.cm-lint-marker-error')
-    await expect(page.getByText('Unexpected token').first()).toBeVisible()
+    await expect(page.getByText('Unexpected token: |').first()).toBeVisible()
 
     // Okay execution finished, let's start editing text below the error.
     await u.codeLocator.click()

--- a/src/lang/abstractSyntaxTree.test.ts
+++ b/src/lang/abstractSyntaxTree.test.ts
@@ -2026,7 +2026,7 @@ describe('parsing errors', () => {
     expect(result).toBeInstanceOf(KCLError)
     const error = result as KCLError
     expect(error.kind).toBe('syntax')
-    expect(error.msg).toBe('Unexpected token')
+    expect(error.msg).toBe('Unexpected token: (')
     expect(error.sourceRanges).toEqual([[27, 28]])
   })
 })

--- a/src/wasm-lib/kcl/src/ast/types.rs
+++ b/src/wasm-lib/kcl/src/ast/types.rs
@@ -6039,7 +6039,7 @@ const thickness = sqrt(distance * p * FOS * 6 / (sigmaAllow * width))"#;
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err().to_string(),
-            r#"syntax: KclErrorDetails { source_ranges: [SourceRange([57, 59])], message: "Unexpected token" }"#
+            r#"syntax: KclErrorDetails { source_ranges: [SourceRange([57, 59])], message: "Unexpected token: |>" }"#
         );
     }
 

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -2898,7 +2898,7 @@ let notTagIdentifier = !myTag";
             // a runtime error instead.
             parse_execute(code10).await.unwrap_err().downcast::<KclError>().unwrap(),
             KclError::Syntax(KclErrorDetails {
-                message: "Unexpected token".to_owned(),
+                message: "Unexpected token: !".to_owned(),
                 source_ranges: vec![SourceRange([14, 15])],
             })
         );
@@ -2911,7 +2911,7 @@ let notPipeSub = 1 |> identity(!%))";
             // a runtime error instead.
             parse_execute(code11).await.unwrap_err().downcast::<KclError>().unwrap(),
             KclError::Syntax(KclErrorDetails {
-                message: "Unexpected token".to_owned(),
+                message: "Unexpected token: |>".to_owned(),
                 source_ranges: vec![SourceRange([54, 56])],
             })
         );

--- a/src/wasm-lib/kcl/src/parser/parser_impl.rs
+++ b/src/wasm-lib/kcl/src/parser/parser_impl.rs
@@ -1594,7 +1594,7 @@ mod tests {
         let tokens = crate::token::lexer("|").unwrap();
         let err: KclError = program.parse(&tokens).unwrap_err().into();
         assert_eq!(err.source_ranges(), vec![SourceRange([0, 1])]);
-        assert_eq!(err.message(), "Unexpected token");
+        assert_eq!(err.message(), "Unexpected token: |");
     }
 
     #[test]
@@ -2426,7 +2426,8 @@ const mySk1 = startSketchAt([0, 0])"#;
         let parser = crate::parser::Parser::new(tokens);
         let result = parser.ast();
         assert!(result.is_err());
-        assert!(result.err().unwrap().to_string().contains("Unexpected token"));
+        let actual = result.err().unwrap().to_string();
+        assert!(actual.contains("Unexpected token: |"), "actual={actual:?}");
     }
 
     #[test]
@@ -2523,7 +2524,7 @@ const secondExtrude = startSketchOn('XY')
         let parser = crate::parser::Parser::new(tokens);
         let result = parser.ast();
         assert!(result.is_err());
-        assert!(result.err().unwrap().to_string().contains("Unexpected token"));
+        assert!(result.err().unwrap().to_string().contains("Unexpected token: |"));
     }
 
     #[test]
@@ -2533,7 +2534,7 @@ const secondExtrude = startSketchOn('XY')
         let err = parser.ast().unwrap_err();
         assert_eq!(
             err.to_string(),
-            r#"syntax: KclErrorDetails { source_ranges: [SourceRange([0, 1])], message: "Unexpected token" }"#
+            r#"syntax: KclErrorDetails { source_ranges: [SourceRange([0, 1])], message: "Unexpected token: >" }"#
         );
     }
 
@@ -2545,7 +2546,7 @@ const secondExtrude = startSketchOn('XY')
         assert!(result.is_err());
         assert_eq!(
             result.err().unwrap().to_string(),
-            r#"syntax: KclErrorDetails { source_ranges: [SourceRange([1, 2])], message: "Unexpected token" }"#
+            r#"syntax: KclErrorDetails { source_ranges: [SourceRange([1, 2])], message: "Unexpected token: %" }"#
         );
     }
 
@@ -2600,7 +2601,7 @@ z(-[["#,
         assert!(result.is_err());
         assert_eq!(
             result.err().unwrap().to_string(),
-            r#"syntax: KclErrorDetails { source_ranges: [SourceRange([3, 4])], message: "Unexpected token" }"#
+            r#"syntax: KclErrorDetails { source_ranges: [SourceRange([3, 4])], message: "Unexpected token: (" }"#
         );
     }
 
@@ -2612,7 +2613,7 @@ z(-[["#,
         assert!(result.is_err());
         assert_eq!(
             result.err().unwrap().to_string(),
-            r#"syntax: KclErrorDetails { source_ranges: [SourceRange([2, 3])], message: "Unexpected token" }"#
+            r#"syntax: KclErrorDetails { source_ranges: [SourceRange([2, 3])], message: "Unexpected token: (" }"#
         );
     }
 
@@ -2657,7 +2658,8 @@ e
         let parser = crate::parser::Parser::new(tokens);
         let result = parser.ast();
         assert!(result.is_err());
-        assert!(result.err().unwrap().to_string().contains("Unexpected token"));
+        let actual = result.err().unwrap().to_string();
+        assert!(actual.contains("Unexpected token: +"), "actual={actual:?}");
     }
 
     #[test]
@@ -3006,7 +3008,7 @@ thing(false)
         // It should say that the compiler is expecting a function expression on the RHS.
         assert_eq!(
             result.err().unwrap().to_string(),
-            r#"syntax: KclErrorDetails { source_ranges: [SourceRange([11, 18])], message: "Unexpected token" }"#
+            r#"syntax: KclErrorDetails { source_ranges: [SourceRange([11, 18])], message: "Unexpected token: \"thing\"" }"#
         );
     }
 

--- a/src/wasm-lib/kcl/src/parser/parser_impl/error.rs
+++ b/src/wasm-lib/kcl/src/parser/parser_impl/error.rs
@@ -79,7 +79,7 @@ impl From<ParseError<&[Token], ContextError>> for KclError {
         // See https://github.com/KittyCAD/modeling-app/issues/784
         KclError::Syntax(KclErrorDetails {
             source_ranges: bad_token.as_source_ranges(),
-            message: "Unexpected token".to_string(),
+            message: format!("Unexpected token: {}", bad_token.value),
         })
     }
 }


### PR DESCRIPTION
Before, when there was a syntax error, it would say, `Unexpected token`.

Now, it will include the token that was unexpected, as in, `Unexpected token: )`.

This is helpful during development where there's nothing to underline or point at the problem in the editor.

Addresses #784 (doesn't close it)