### PR TITLE
Fix sketch groups and extrude groups when used inside objects

### DIFF
--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -294,11 +294,19 @@ impl KclValue {
             KclValue::SketchGroup(s) => Ok(SketchGroupSet::SketchGroup(s.clone())),
             KclValue::SketchGroups { value } => Ok(SketchGroupSet::SketchGroups(value.clone())),
             KclValue::UserVal(value) => {
-                if let Ok(sg) = serde_json::from_value::<Vec<Box<SketchGroup>>>(value.value.clone()) {
-                    return Ok(sg.into());
-                }
-                if let Ok(sg) = serde_json::from_value::<Box<SketchGroup>>(value.value.clone()) {
-                    return Ok(sg.into());
+                let value = value.value.clone();
+                match value {
+                    JValue::Null | JValue::Bool(_) | JValue::Number(_) | JValue::String(_) => {}
+                    JValue::Array(_) => {
+                        if let Ok(sg) = serde_json::from_value::<Vec<Box<SketchGroup>>>(value) {
+                            return Ok(sg.into());
+                        }
+                    }
+                    JValue::Object(_) => {
+                        if let Ok(sg) = serde_json::from_value::<Box<SketchGroup>>(value) {
+                            return Ok(sg.into());
+                        }
+                    }
                 }
                 Err(anyhow::anyhow!("Failed to deserialize sketch group set from JSON"))
             }
@@ -311,11 +319,19 @@ impl KclValue {
             KclValue::ExtrudeGroup(e) => Ok(ExtrudeGroupSet::ExtrudeGroup(e.clone())),
             KclValue::ExtrudeGroups { value } => Ok(ExtrudeGroupSet::ExtrudeGroups(value.clone())),
             KclValue::UserVal(value) => {
-                if let Ok(eg) = serde_json::from_value::<Vec<Box<ExtrudeGroup>>>(value.value.clone()) {
-                    return Ok(eg.into());
-                }
-                if let Ok(eg) = serde_json::from_value::<Box<ExtrudeGroup>>(value.value.clone()) {
-                    return Ok(eg.into());
+                let value = value.value.clone();
+                match value {
+                    JValue::Null | JValue::Bool(_) | JValue::Number(_) | JValue::String(_) => {}
+                    JValue::Array(_) => {
+                        if let Ok(eg) = serde_json::from_value::<Vec<Box<ExtrudeGroup>>>(value) {
+                            return Ok(eg.into());
+                        }
+                    }
+                    JValue::Object(_) => {
+                        if let Ok(eg) = serde_json::from_value::<Box<ExtrudeGroup>>(value) {
+                            return Ok(eg.into());
+                        }
+                    }
                 }
                 Err(anyhow::anyhow!("Failed to deserialize extrude group set from JSON"))
             }

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -296,19 +296,17 @@ impl KclValue {
             KclValue::UserVal(value) => {
                 let value = value.value.clone();
                 match value {
-                    JValue::Null | JValue::Bool(_) | JValue::Number(_) | JValue::String(_) => {}
-                    JValue::Array(_) => {
-                        if let Ok(sg) = serde_json::from_value::<Vec<Box<SketchGroup>>>(value) {
-                            return Ok(sg.into());
-                        }
-                    }
-                    JValue::Object(_) => {
-                        if let Ok(sg) = serde_json::from_value::<Box<SketchGroup>>(value) {
-                            return Ok(sg.into());
-                        }
-                    }
+                    JValue::Null | JValue::Bool(_) | JValue::Number(_) | JValue::String(_) => Err(anyhow::anyhow!(
+                        "Failed to deserialize sketch group set from JSON {}",
+                        human_friendly_type(&value)
+                    )),
+                    JValue::Array(_) => serde_json::from_value::<Vec<Box<SketchGroup>>>(value)
+                        .map(SketchGroupSet::from)
+                        .map_err(|e| anyhow::anyhow!("Failed to deserialize array of sketch groups from JSON: {}", e)),
+                    JValue::Object(_) => serde_json::from_value::<Box<SketchGroup>>(value)
+                        .map(SketchGroupSet::from)
+                        .map_err(|e| anyhow::anyhow!("Failed to deserialize sketch group from JSON: {}", e)),
                 }
-                Err(anyhow::anyhow!("Failed to deserialize sketch group set from JSON"))
             }
             _ => anyhow::bail!("Not a sketch group or sketch groups: {:?}", self),
         }
@@ -321,19 +319,17 @@ impl KclValue {
             KclValue::UserVal(value) => {
                 let value = value.value.clone();
                 match value {
-                    JValue::Null | JValue::Bool(_) | JValue::Number(_) | JValue::String(_) => {}
-                    JValue::Array(_) => {
-                        if let Ok(eg) = serde_json::from_value::<Vec<Box<ExtrudeGroup>>>(value) {
-                            return Ok(eg.into());
-                        }
-                    }
-                    JValue::Object(_) => {
-                        if let Ok(eg) = serde_json::from_value::<Box<ExtrudeGroup>>(value) {
-                            return Ok(eg.into());
-                        }
-                    }
+                    JValue::Null | JValue::Bool(_) | JValue::Number(_) | JValue::String(_) => Err(anyhow::anyhow!(
+                        "Failed to deserialize extrude group set from JSON {}",
+                        human_friendly_type(&value)
+                    )),
+                    JValue::Array(_) => serde_json::from_value::<Vec<Box<ExtrudeGroup>>>(value)
+                        .map(ExtrudeGroupSet::from)
+                        .map_err(|e| anyhow::anyhow!("Failed to deserialize array of extrude groups from JSON: {}", e)),
+                    JValue::Object(_) => serde_json::from_value::<Box<ExtrudeGroup>>(value)
+                        .map(ExtrudeGroupSet::from)
+                        .map_err(|e| anyhow::anyhow!("Failed to deserialize extrude group from JSON: {}", e)),
                 }
-                Err(anyhow::anyhow!("Failed to deserialize extrude group set from JSON"))
             }
             _ => anyhow::bail!("Not a extrude group or extrude groups: {:?}", self),
         }

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -294,9 +294,13 @@ impl KclValue {
             KclValue::SketchGroup(s) => Ok(SketchGroupSet::SketchGroup(s.clone())),
             KclValue::SketchGroups { value } => Ok(SketchGroupSet::SketchGroups(value.clone())),
             KclValue::UserVal(value) => {
-                let sg: Vec<Box<SketchGroup>> = serde_json::from_value(value.value.clone())
-                    .map_err(|e| anyhow::anyhow!("Failed to deserialize array of sketch groups from JSON: {}", e))?;
-                Ok(sg.into())
+                if let Ok(sg) = serde_json::from_value::<Vec<Box<SketchGroup>>>(value.value.clone()) {
+                    return Ok(sg.into());
+                }
+                if let Ok(sg) = serde_json::from_value::<Box<SketchGroup>>(value.value.clone()) {
+                    return Ok(sg.into());
+                }
+                Err(anyhow::anyhow!("Failed to deserialize sketch group set from JSON"))
             }
             _ => anyhow::bail!("Not a sketch group or sketch groups: {:?}", self),
         }
@@ -307,9 +311,13 @@ impl KclValue {
             KclValue::ExtrudeGroup(e) => Ok(ExtrudeGroupSet::ExtrudeGroup(e.clone())),
             KclValue::ExtrudeGroups { value } => Ok(ExtrudeGroupSet::ExtrudeGroups(value.clone())),
             KclValue::UserVal(value) => {
-                let eg: Vec<Box<ExtrudeGroup>> = serde_json::from_value(value.value.clone())
-                    .map_err(|e| anyhow::anyhow!("Failed to deserialize array of extrude groups from JSON: {}", e))?;
-                Ok(eg.into())
+                if let Ok(eg) = serde_json::from_value::<Vec<Box<ExtrudeGroup>>>(value.value.clone()) {
+                    return Ok(eg.into());
+                }
+                if let Ok(eg) = serde_json::from_value::<Box<ExtrudeGroup>>(value.value.clone()) {
+                    return Ok(eg.into());
+                }
+                Err(anyhow::anyhow!("Failed to deserialize extrude group set from JSON"))
             }
             _ => anyhow::bail!("Not a extrude group or extrude groups: {:?}", self),
         }

--- a/src/wasm-lib/tests/executor/inputs/no_visuals/sketch_group_in_object.kcl
+++ b/src/wasm-lib/tests/executor/inputs/no_visuals/sketch_group_in_object.kcl
@@ -1,0 +1,27 @@
+fn test = () => {
+  return startSketchOn('XY')
+  |> startProfileAt([0, 0], %)
+  |> line([0, 1], %)
+  |> line([1, 0], %)
+  |> line([0, -1], %)
+  |> close(%)
+}
+
+fn test2 = () => {
+  return {
+    thing: startSketchOn('XY')
+      |> startProfileAt([0, 0], %)
+      |> line([0, 1], %)
+      |> line([1, 0], %)
+      |> line([0, -1], %)
+      |> close(%)
+  }
+}
+
+const x = test()
+x
+  |> extrude(-10, %)
+
+const x2 = test2()
+x2.thing
+  |> extrude(10, %)

--- a/src/wasm-lib/tests/executor/no_visuals.rs
+++ b/src/wasm-lib/tests/executor/no_visuals.rs
@@ -85,3 +85,4 @@ gen_test_fail!(
     object_prop_not_found,
     "undefined value: Property 'age' not found in object"
 );
+gen_test!(sketch_group_in_object);


### PR DESCRIPTION
Fixes #3338.

Putting them inside an object and using them later should work now.

```kcl
fn buildSketch = () => {
  return {
    thing: startSketchOn('XY')
      |> startProfileAt([0, 0], %)
      |> line([0, 1], %)
      |> line([1, 0], %)
      |> line([0, -1], %)
      |> close(%)
  }
}

let x = buildSketch()

x.thing
  |> extrude(10, %)
```