### PR TITLE
Adding projects folder change test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ out/
 
 src-tauri/target
 electron-test-projects-dir
+electron-test-projects-dir-2

--- a/e2e/playwright/projects.spec.ts
+++ b/e2e/playwright/projects.spec.ts
@@ -656,7 +656,7 @@ test(
         .inputValue()
 
       // Can't use Playwright filechooser since this is happening in electron.
-      electronApp.evaluate(
+      const handleFile = electronApp.evaluate(
         async ({ dialog }, filePaths) => {
           dialog.showOpenDialog = () =>
             Promise.resolve({ canceled: false, filePaths })
@@ -664,6 +664,7 @@ test(
         [newProjectDirName]
       )
       await page.getByTestId('project-directory-button').click()
+      await handleFile
 
       await expect(page.locator('section#projectDirectory input')).toHaveValue(
         newProjectDirName
@@ -686,7 +687,7 @@ test(
 
       await page.getByTestId('project-directory-settings-link').click()
 
-      electronApp.evaluate(
+      const handleFile = electronApp.evaluate(
         async ({ dialog }, filePaths) => {
           dialog.showOpenDialog = () =>
             Promise.resolve({ canceled: false, filePaths })
@@ -696,6 +697,7 @@ test(
       await expect(page.getByTestId('project-directory-button')).toBeVisible()
 
       await page.getByTestId('project-directory-button').click()
+      await handleFile
 
       await expect(page.locator('section#projectDirectory input')).toHaveValue(
         originalProjectDirName

--- a/e2e/playwright/projects.spec.ts
+++ b/e2e/playwright/projects.spec.ts
@@ -633,8 +633,6 @@ test(
 
     page.on('console', console.log)
 
-    await page.waitForTimeout(1_000)
-
     // we'll grab this from the settings on screen before we switch
     let originalProjectDirName: string
     const newProjectDirName = testInfo.outputPath(
@@ -650,9 +648,7 @@ test(
         page.getByTestId('project-directory-settings-link')
       ).toBeVisible()
 
-      await page.waitForTimeout(100)
-
-      page.getByTestId('project-directory-settings-link').click()
+      await page.getByTestId('project-directory-settings-link').click()
 
       await expect(page.getByTestId('project-directory-button')).toBeVisible()
       originalProjectDirName = await page
@@ -667,14 +663,13 @@ test(
         },
         [newProjectDirName]
       )
-      page.getByTestId('project-directory-button').click()
+      await page.getByTestId('project-directory-button').click()
 
       await expect(page.locator('section#projectDirectory input')).toHaveValue(
         newProjectDirName
       )
 
-      page.getByTestId('settings-close-button').click()
-      await page.waitForTimeout(100)
+      await page.getByTestId('settings-close-button').click()
 
       await expect(page.getByText('No Projects found')).toBeVisible()
       await page.getByRole('button', { name: 'New project' }).click()
@@ -689,7 +684,7 @@ test(
         page.getByTestId('project-directory-settings-link')
       ).toBeVisible()
 
-      page.getByTestId('project-directory-settings-link').click()
+      await page.getByTestId('project-directory-settings-link').click()
 
       electronApp.evaluate(
         async ({ dialog }, filePaths) => {
@@ -700,14 +695,13 @@ test(
       )
       await expect(page.getByTestId('project-directory-button')).toBeVisible()
 
-      page.getByTestId('project-directory-button').click()
+      await page.getByTestId('project-directory-button').click()
 
       await expect(page.locator('section#projectDirectory input')).toHaveValue(
         originalProjectDirName
       )
 
-      page.getByTestId('settings-close-button').click()
-      await page.waitForTimeout(100)
+      await page.getByTestId('settings-close-button').click()
 
       await expect(page.getByText('bracket')).toBeVisible()
       await expect(page.getByText('router-template-slate')).toBeVisible()

--- a/e2e/playwright/test-utils.ts
+++ b/e2e/playwright/test-utils.ts
@@ -699,6 +699,9 @@ export async function setupElectron({
       TEST_SETTINGS_FILE_KEY: projectDirName,
       IS_PLAYWRIGHT: 'true',
     },
+    ...(process.env.ELECTRON_OVERRIDE_DIST_PATH
+      ? { executablePath: process.env.ELECTRON_OVERRIDE_DIST_PATH + 'electron' }
+      : {}),
   })
   const context = electronApp.context()
   const page = await electronApp.firstWindow()

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,9 @@
 
             nodejs_22
             yarn
+
             electron
+            playwright-driver.browsers
           ]) ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs; [
             libiconv 
             darwin.apple_sdk.frameworks.Security
@@ -67,6 +69,10 @@
           TARGET_CC = "${pkgs.stdenv.cc}/bin/${pkgs.stdenv.cc.targetPrefix}cc";
           LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
           ELECTRON_OVERRIDE_DIST_PATH = "${pkgs.electron}/bin/";
+          PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = true;
+          PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH = "${pkgs.playwright-driver.browsers}/chromium-1091/chrome-linux/chrome";
+          PLAYWRIGHT_BROWSERS_PATH = "${pkgs.playwright-driver.browsers}";
+          NODE_ENV = "development";
         };
       });
     };

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -48,6 +48,13 @@ export default defineConfig({
           /* Chromium is the only one with these permission types */
           permissions: ['clipboard-write', 'clipboard-read'],
         },
+        launchOptions: {
+          ...(process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+            ? {
+                executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+              }
+            : {}),
+        },
       }, // or 'chrome-beta'
     },
     {

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -280,6 +280,7 @@ const Home = () => {
           <p className="my-4 text-sm text-chalkboard-80 dark:text-chalkboard-30">
             Loaded from{' '}
             <Link
+              data-testid="project-directory-settings-link"
               to={`${PATHS.HOME + PATHS.SETTINGS_USER}#projectDirectory`}
               className="text-chalkboard-90 dark:text-chalkboard-20 underline underline-offset-2"
             >


### PR DESCRIPTION
Closes https://github.com/KittyCAD/modeling-app/issues/3369

This is my first playwright test for modeling-app so please nitpick! Just copy-pasta from other tests and some digging on the weird hoop for handling file chooser. I added a new testid as well as it made it much easier to select the right thing in the DOM.

The rest of the changes are necessary to support Nixos. I'm happy to tweak them if desired but I do need to be able to point to specific executables and not the stuff playwright & electron both download.