### PR TITLE
Test: restart electron with settings intact

### DIFF
--- a/e2e/playwright/projects.spec.ts
+++ b/e2e/playwright/projects.spec.ts
@@ -774,3 +774,46 @@ test(
     await electronApp.close()
   }
 )
+
+test(
+  'Settings persist across restarts',
+  { tag: '@electron' },
+  async ({ browserName }, testInfo) => {
+    await test.step('We can change a user setting like theme', async () => {
+      const { electronApp, page } = await setupElectron({
+        testInfo,
+      })
+      await page.setViewportSize({ width: 1200, height: 500 })
+
+      page.on('console', console.log)
+
+      await page.getByTestId('user-sidebar-toggle').click()
+
+      await page.getByTestId('user-settings').click()
+
+      await expect(page.getByTestId('app-theme')).toHaveValue('dark')
+
+      await page.getByTestId('app-theme').selectOption('light')
+
+      await electronApp.close()
+    })
+
+    await test.step('Starting the app again and we can see the same theme', async () => {
+      let { electronApp, page } = await setupElectron({
+        testInfo,
+        cleanProjectDir: false,
+      })
+      await page.setViewportSize({ width: 1200, height: 500 })
+
+      page.on('console', console.log)
+
+      await page.getByTestId('user-sidebar-toggle').click()
+
+      await page.getByTestId('user-settings').click()
+
+      await expect(page.getByTestId('app-theme')).toHaveValue('light')
+
+      await electronApp.close()
+    })
+  }
+)

--- a/e2e/playwright/testing-selections.spec.ts
+++ b/e2e/playwright/testing-selections.spec.ts
@@ -795,18 +795,18 @@ const extrude001 = extrude(50, sketch001)
     await page.waitForTimeout(200)
     await expect(
       await u.getGreatestPixDiff(extrudeWall, hoverColor)
-    ).toBeLessThan(5)
+    ).toBeLessThan(6)
     await page.mouse.click(extrudeWall.x, extrudeWall.y)
     await expect(page.locator('.cm-activeLine')).toHaveText(`|> ${extrudeText}`)
     await page.waitForTimeout(200)
     await expect(
       await u.getGreatestPixDiff(extrudeWall, selectColor)
-    ).toBeLessThan(5)
+    ).toBeLessThan(6)
     await page.waitForTimeout(1000)
     // check color stays there, i.e. not overridden (this was a bug previously)
     await expect(
       await u.getGreatestPixDiff(extrudeWall, selectColor)
-    ).toBeLessThan(5)
+    ).toBeLessThan(6)
 
     await page.mouse.move(nothing.x, nothing.y)
     await page.waitForTimeout(300)
@@ -817,21 +817,21 @@ const extrude001 = extrude(50, sketch001)
     hoverColor = [134, 134, 134]
     selectColor = [158, 162, 110]
 
-    await expect(await u.getGreatestPixDiff(cap, noHoverColor)).toBeLessThan(5)
+    await expect(await u.getGreatestPixDiff(cap, noHoverColor)).toBeLessThan(6)
     await page.mouse.move(cap.x, cap.y)
     await expect(page.getByTestId('hover-highlight').first()).toBeVisible()
     await expect(page.getByTestId('hover-highlight').first()).toContainText(
       removeAfterFirstParenthesis(capText)
     )
     await page.waitForTimeout(200)
-    await expect(await u.getGreatestPixDiff(cap, hoverColor)).toBeLessThan(5)
+    await expect(await u.getGreatestPixDiff(cap, hoverColor)).toBeLessThan(6)
     await page.mouse.click(cap.x, cap.y)
     await expect(page.locator('.cm-activeLine')).toHaveText(`|> ${capText}`)
     await page.waitForTimeout(200)
-    await expect(await u.getGreatestPixDiff(cap, selectColor)).toBeLessThan(5)
+    await expect(await u.getGreatestPixDiff(cap, selectColor)).toBeLessThan(6)
     await page.waitForTimeout(1000)
     // check color stays there, i.e. not overridden (this was a bug previously)
-    await expect(await u.getGreatestPixDiff(cap, selectColor)).toBeLessThan(5)
+    await expect(await u.getGreatestPixDiff(cap, selectColor)).toBeLessThan(6)
   })
   test("Various pipe expressions should and shouldn't allow edit and or extrude", async ({
     page,


### PR DESCRIPTION
Pretty straightforward. Had to modify the setup to allow me to disable project dir cleaning.

Closes https://github.com/KittyCAD/modeling-app/issues/3371.