### PR TITLE
playwright order in github actions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -38,9 +38,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         shardIndex: [1, 2, 3, 4]
         shardTotal: [4]
-        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     needs: check-rust-changes
     steps:


### PR DESCRIPTION
I want to see if this changes the order that things show up in github actions so that it's

```
playwright-chrome, (windows, 1, 4)
playwright-chrome, (windows, 2, 4)
playwright-chrome, (windows, 3, 4)
playwright-chrome, (windows, 4, 4)
play....
```
Instead of 

```
playwright-chrome, (windows, 1, 4)
playwright-chrome, (ubuntu, 1, 4)
playwright-chrome, (windows, 2, 4)
playwright-chrome, (ubuntu, 2, 4)
play....
```