### PR TITLE
Lock the rust toolchain version

### DIFF
--- a/src/wasm-lib/rust-toolchain.toml
+++ b/src/wasm-lib/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.80.1"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
This has several benefits:

- Rust [occasionally makes](https://internals.rust-lang.org/t/type-inference-breakage-in-1-80-has-not-been-handled-well/21374) breaking changes, and locking allows us to easily git bisect. #3128 is an example.
- Consistent, reproducible builds for a given commit instead of the exact toolchain changing over time
- New toolchain versions can introduce new, non-trivial warnings which block CI until fixed. Locking prevents a rust release at an arbitrary time from block our team.
- Documents what version an arbitrary commit was intended to build on

The drawbacks are:

- We need to manually update. Dependabot doesn't currently do this. https://github.com/dependabot/dependabot-core/issues/1702
- You need to manually [override](https://rust-lang.github.io/rustup/overrides.html) the toolchain if you want to build with a different rust version than what's committed