### PR TITLE
KCL executor: accept and send 'replay' flag, track session data

### DIFF
--- a/src/wasm-lib/Cargo.lock
+++ b/src/wasm-lib/Cargo.lock
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-lib"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "approx",

--- a/src/wasm-lib/Cargo.lock
+++ b/src/wasm-lib/Cargo.lock
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-lib"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "approx",
@@ -1482,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9621df809fa105ae28b01586c52ce46561e166702babb50e5bcc5097a8ce62"
+checksum = "fbb7c076d64ad00a29ae900108707d1bbb583944d4b2d005e1eca9914a18c7c2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1870,7 +1870,7 @@ dependencies = [
  "bincode",
  "either",
  "fnv",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "nom",
  "quick-xml",

--- a/src/wasm-lib/Cargo.toml
+++ b/src/wasm-lib/Cargo.toml
@@ -71,7 +71,7 @@ members = [
 
 [workspace.dependencies]
 http = "0.2.12"
-kittycad = { version = "0.3.16", default-features = false, features = ["js", "requests"] }
+kittycad = { version = "0.3.17", default-features = false, features = ["js", "requests"] }
 kittycad-modeling-session = "0.1.4"
 
 [[test]]

--- a/src/wasm-lib/kcl/Cargo.toml
+++ b/src/wasm-lib/kcl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-lib"
 description = "KittyCAD Language implementation and tools"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/src/wasm-lib/kcl/Cargo.toml
+++ b/src/wasm-lib/kcl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-lib"
 description = "KittyCAD Language implementation and tools"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/src/wasm-lib/kcl/src/engine/mod.rs
+++ b/src/wasm-lib/kcl/src/engine/mod.rs
@@ -13,7 +13,9 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use kittycad::types::{Color, ModelingCmd, ModelingCmdReq, OkWebSocketResponseData, WebSocketRequest};
+use kittycad::types::{
+    Color, ModelingCmd, ModelingCmdReq, ModelingSessionData, OkWebSocketResponseData, WebSocketRequest,
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -489,6 +491,12 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
         self.flush_batch(false, Default::default()).await?;
 
         Ok(())
+    }
+
+    /// Get session data, if it has been received.
+    /// Returns None if the server never sent it.
+    fn get_session_data(&self) -> Option<ModelingSessionData> {
+        None
     }
 }
 

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -1613,8 +1613,11 @@ pub struct ExecutorSettings {
     pub highlight_edges: bool,
     /// Whether or not Screen Space Ambient Occlusion (SSAO) is enabled.
     pub enable_ssao: bool,
-    // Show grid?
+    /// Show grid?
     pub show_grid: bool,
+    /// Should engine store this for replay?
+    /// If so, under what name?
+    pub replay: Option<String>,
 }
 
 impl Default for ExecutorSettings {
@@ -1624,6 +1627,7 @@ impl Default for ExecutorSettings {
             highlight_edges: true,
             enable_ssao: false,
             show_grid: false,
+            replay: None,
         }
     }
 }
@@ -1635,6 +1639,7 @@ impl From<crate::settings::types::Configuration> for ExecutorSettings {
             highlight_edges: config.settings.modeling.highlight_edges.into(),
             enable_ssao: config.settings.modeling.enable_ssao.into(),
             show_grid: config.settings.modeling.show_scale_grid,
+            replay: None,
         }
     }
 }
@@ -1646,6 +1651,7 @@ impl From<crate::settings::types::project::ProjectConfiguration> for ExecutorSet
             highlight_edges: config.settings.modeling.highlight_edges.into(),
             enable_ssao: config.settings.modeling.enable_ssao.into(),
             show_grid: config.settings.modeling.show_scale_grid,
+            replay: None,
         }
     }
 }
@@ -1657,6 +1663,7 @@ impl From<crate::settings::types::ModelingSettings> for ExecutorSettings {
             highlight_edges: modeling.highlight_edges.into(),
             enable_ssao: modeling.enable_ssao.into(),
             show_grid: modeling.show_scale_grid,
+            replay: None,
         }
     }
 }
@@ -1679,6 +1686,7 @@ impl ExecutorContext {
                 } else {
                     None
                 },
+                settings.replay.clone(),
                 if settings.show_grid { Some(true) } else { None },
                 None,
                 None,
@@ -1755,6 +1763,7 @@ impl ExecutorContext {
                 highlight_edges: true,
                 enable_ssao: false,
                 show_grid: false,
+                replay: None,
             },
         )
         .await?;

--- a/src/wasm-lib/kcl/src/test_server.rs
+++ b/src/wasm-lib/kcl/src/test_server.rs
@@ -63,6 +63,7 @@ async fn new_context(units: UnitLength) -> anyhow::Result<ExecutorContext> {
             highlight_edges: true,
             enable_ssao: false,
             show_grid: false,
+            replay: None,
         },
     )
     .await?;


### PR DESCRIPTION
Part of https://github.com/KittyCAD/engine/issues/2504:

The engine accepts this 'replay' flag now, so, accept it too and send it up to the engine.

Part of https://github.com/KittyCAD/cli/issues/847

The engine sends 'session data' now (like the API Call ID). The CLI executes KCL using this executor, and would like to get the session data after execution.