### PR TITLE
Change mouse controls display to be easier to understand

### DIFF
--- a/src/clientSideScene/CameraControls.ts
+++ b/src/clientSideScene/CameraControls.ts
@@ -1,4 +1,4 @@
-import { MouseGuard } from 'lib/cameraControls'
+import { cameraMouseDragGuards, MouseGuard } from 'lib/cameraControls'
 import {
   Euler,
   MathUtils,
@@ -81,24 +81,7 @@ export class CameraControls {
   pendingZoom: number | null = null
   pendingRotation: Vector2 | null = null
   pendingPan: Vector2 | null = null
-  interactionGuards: MouseGuard = {
-    pan: {
-      description: 'Right click + Shift + drag or middle click + drag',
-      callback: (e) => !!(e.buttons & 4) && !e.ctrlKey,
-    },
-    zoom: {
-      description: 'Scroll wheel or Right click + Ctrl + drag',
-      dragCallback: (e) => e.button === 2 && e.ctrlKey,
-      scrollCallback: () => true,
-    },
-    rotate: {
-      description: 'Right click + drag',
-      callback: (e) => {
-        console.log('event', e)
-        return !!(e.buttons & 2)
-      },
-    },
-  }
+  interactionGuards: MouseGuard = cameraMouseDragGuards.KittyCAD
   isFovAnimationInProgress = false
   fovBeforeOrtho = 45
   get isPerspective() {

--- a/src/lib/cameraControls.ts
+++ b/src/lib/cameraControls.ts
@@ -1,4 +1,12 @@
 import { MouseControlType } from 'wasm-lib/kcl/bindings/MouseControlType'
+import { platform } from './utils'
+
+const PLATFORM = platform()
+const META =
+  PLATFORM === 'macos' ? 'Cmd' : PLATFORM === 'windows' ? 'Win' : 'Super'
+const ALT = PLATFORM === 'macos' ? 'Option' : 'Alt'
+// Apple mouse scrolls without a wheel.
+const SCROLL = PLATFORM === 'macos' ? 'Scroll' : 'Scroll wheel'
 
 const noModifiersPressed = (e: React.MouseEvent) =>
   !e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey
@@ -73,99 +81,99 @@ export const btnName = (e: React.MouseEvent) => ({
 export const cameraMouseDragGuards: Record<CameraSystem, MouseGuard> = {
   KittyCAD: {
     pan: {
-      description: 'Right click + Shift + drag or middle click + drag',
+      description: 'Shift + Right click drag or middle click drag',
       callback: (e) =>
         (btnName(e).middle && noModifiersPressed(e)) ||
         (btnName(e).right && e.shiftKey),
     },
     zoom: {
-      description: 'Scroll wheel or Right click + Ctrl + drag',
+      description: `${SCROLL} or Ctrl + Right click drag`,
       dragCallback: (e) => !!(e.buttons & 2) && e.ctrlKey,
       scrollCallback: () => true,
     },
     rotate: {
-      description: 'Right click + drag',
+      description: 'Right click drag',
       callback: (e) => btnName(e).right && noModifiersPressed(e),
     },
   },
   OnShape: {
     pan: {
-      description: 'Right click + Ctrl + drag or middle click + drag',
+      description: 'Ctrl + Right click drag or middle click drag',
       callback: (e) =>
         (btnName(e).right && e.ctrlKey) ||
         (btnName(e).middle && noModifiersPressed(e)),
     },
     zoom: {
-      description: 'Scroll wheel',
+      description: `${SCROLL}`,
       dragCallback: () => false,
       scrollCallback: () => true,
     },
     rotate: {
-      description: 'Right click + drag',
+      description: 'Right click drag',
       callback: (e) => btnName(e).right && noModifiersPressed(e),
     },
   },
   'Trackpad Friendly': {
     pan: {
-      description: 'Left click + Alt + Shift + drag or middle click + drag',
+      description: `${ALT} + Shift + Left click drag or middle click drag`,
       callback: (e) =>
         (btnName(e).left && e.altKey && e.shiftKey && !e.metaKey) ||
         (btnName(e).middle && noModifiersPressed(e)),
     },
     zoom: {
-      description: 'Scroll wheel or Left click + Alt + OS + drag',
+      description: `${SCROLL} or ${ALT} + ${META} + Left click drag`,
       dragCallback: (e) => btnName(e).left && e.altKey && e.metaKey,
       scrollCallback: () => true,
     },
     rotate: {
-      description: 'Left click + Alt + drag',
+      description: `${ALT} + Left click drag`,
       callback: (e) => btnName(e).left && e.altKey && !e.shiftKey && !e.metaKey,
       lenientDragStartButton: 0,
     },
   },
   Solidworks: {
     pan: {
-      description: 'Right click + Ctrl + drag',
+      description: 'Ctrl + Right click drag',
       callback: (e) => btnName(e).right && e.ctrlKey,
       lenientDragStartButton: 2,
     },
     zoom: {
-      description: 'Scroll wheel or Middle click + Shift + drag',
+      description: `${SCROLL} or Shift + Middle click drag`,
       dragCallback: (e) => btnName(e).middle && e.shiftKey,
       scrollCallback: () => true,
     },
     rotate: {
-      description: 'Middle click + drag',
+      description: 'Middle click drag',
       callback: (e) => btnName(e).middle && noModifiersPressed(e),
     },
   },
   NX: {
     pan: {
-      description: 'Middle click + Shift + drag',
+      description: 'Shift + Middle click drag',
       callback: (e) => btnName(e).middle && e.shiftKey,
     },
     zoom: {
-      description: 'Scroll wheel or Middle click + Ctrl + drag',
+      description: `${SCROLL} or Ctrl + Middle click drag`,
       dragCallback: (e) => btnName(e).middle && e.ctrlKey,
       scrollCallback: () => true,
     },
     rotate: {
-      description: 'Middle click + drag',
+      description: 'Middle click drag',
       callback: (e) => btnName(e).middle && noModifiersPressed(e),
     },
   },
   Creo: {
     pan: {
-      description: 'Left click + Ctrl + drag',
+      description: 'Ctrl + Left click drag',
       callback: (e) => btnName(e).left && !btnName(e).right && e.ctrlKey,
     },
     zoom: {
-      description: 'Scroll wheel or Right click + Ctrl + drag',
+      description: `${SCROLL} or Ctrl + Right click drag`,
       dragCallback: (e) => btnName(e).right && !btnName(e).left && e.ctrlKey,
       scrollCallback: () => true,
     },
     rotate: {
-      description: 'Middle (or Left + Right) click + Ctrl + drag',
+      description: 'Ctrl + Middle (or Left + Right) click drag',
       callback: (e) => {
         const b = btnName(e)
         return (b.middle || (b.left && b.right)) && e.ctrlKey
@@ -174,16 +182,16 @@ export const cameraMouseDragGuards: Record<CameraSystem, MouseGuard> = {
   },
   AutoCAD: {
     pan: {
-      description: 'Middle click + drag',
+      description: 'Middle click drag',
       callback: (e) => btnName(e).middle && noModifiersPressed(e),
     },
     zoom: {
-      description: 'Scroll wheel',
+      description: `${SCROLL}`,
       dragCallback: () => false,
       scrollCallback: () => true,
     },
     rotate: {
-      description: 'Middle click + Shift + drag',
+      description: 'Shift + Middle click drag',
       callback: (e) => btnName(e).middle && e.shiftKey,
     },
   },

--- a/src/lib/cameraControls.ts
+++ b/src/lib/cameraControls.ts
@@ -5,8 +5,6 @@ const PLATFORM = platform()
 const META =
   PLATFORM === 'macos' ? 'Cmd' : PLATFORM === 'windows' ? 'Win' : 'Super'
 const ALT = PLATFORM === 'macos' ? 'Option' : 'Alt'
-// Apple mouse scrolls without a wheel.
-const SCROLL = PLATFORM === 'macos' ? 'Scroll' : 'Scroll wheel'
 
 const noModifiersPressed = (e: React.MouseEvent) =>
   !e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey
@@ -87,7 +85,7 @@ export const cameraMouseDragGuards: Record<CameraSystem, MouseGuard> = {
         (btnName(e).right && e.shiftKey),
     },
     zoom: {
-      description: `${SCROLL} or Ctrl + Right click drag`,
+      description: 'Scroll or Ctrl + Right click drag',
       dragCallback: (e) => !!(e.buttons & 2) && e.ctrlKey,
       scrollCallback: () => true,
     },
@@ -104,7 +102,7 @@ export const cameraMouseDragGuards: Record<CameraSystem, MouseGuard> = {
         (btnName(e).middle && noModifiersPressed(e)),
     },
     zoom: {
-      description: `${SCROLL}`,
+      description: 'Scroll',
       dragCallback: () => false,
       scrollCallback: () => true,
     },
@@ -121,7 +119,7 @@ export const cameraMouseDragGuards: Record<CameraSystem, MouseGuard> = {
         (btnName(e).middle && noModifiersPressed(e)),
     },
     zoom: {
-      description: `${SCROLL} or ${ALT} + ${META} + Left click drag`,
+      description: `Scroll or ${ALT} + ${META} + Left click drag`,
       dragCallback: (e) => btnName(e).left && e.altKey && e.metaKey,
       scrollCallback: () => true,
     },
@@ -138,7 +136,7 @@ export const cameraMouseDragGuards: Record<CameraSystem, MouseGuard> = {
       lenientDragStartButton: 2,
     },
     zoom: {
-      description: `${SCROLL} or Shift + Middle click drag`,
+      description: 'Scroll or Shift + Middle click drag',
       dragCallback: (e) => btnName(e).middle && e.shiftKey,
       scrollCallback: () => true,
     },
@@ -153,7 +151,7 @@ export const cameraMouseDragGuards: Record<CameraSystem, MouseGuard> = {
       callback: (e) => btnName(e).middle && e.shiftKey,
     },
     zoom: {
-      description: `${SCROLL} or Ctrl + Middle click drag`,
+      description: 'Scroll or Ctrl + Middle click drag',
       dragCallback: (e) => btnName(e).middle && e.ctrlKey,
       scrollCallback: () => true,
     },
@@ -168,7 +166,7 @@ export const cameraMouseDragGuards: Record<CameraSystem, MouseGuard> = {
       callback: (e) => btnName(e).left && !btnName(e).right && e.ctrlKey,
     },
     zoom: {
-      description: `${SCROLL} or Ctrl + Right click drag`,
+      description: 'Scroll or Ctrl + Right click drag',
       dragCallback: (e) => btnName(e).right && !btnName(e).left && e.ctrlKey,
       scrollCallback: () => true,
     },
@@ -186,7 +184,7 @@ export const cameraMouseDragGuards: Record<CameraSystem, MouseGuard> = {
       callback: (e) => btnName(e).middle && noModifiersPressed(e),
     },
     zoom: {
-      description: `${SCROLL}`,
+      description: 'Scroll',
       dragCallback: () => false,
       scrollCallback: () => true,
     },


### PR DESCRIPTION
Resolves #3095.

No functionality change, just different UI labels.

- OS &rarr; Win/Super/Cmd
- Alt &rarr; Alt/Option
- Scroll wheel &rarr; Scroll

"Right-click drag" is a single gesture to me, so I find it easier to read "{modifier} + {gesture}". Using a mouse, first, the non-dominant hand presses the modifier key(s), and then the dominant hand does the dragging gesture.

Contrast this with "Right click + {modifier} + drag". I need to mentally combine "Reft click" and "drag", and re-order the modifier press first. Then drag with the Right button.

---

Windows

<img width="588" alt="Screenshot 2024-08-26 at 1 48 11 PM" src="https://github.com/user-attachments/assets/1633e801-e372-44c2-92cc-d8301510bce5">

---

Linux

<img width="590" alt="Screenshot 2024-08-26 at 1 48 30 PM" src="https://github.com/user-attachments/assets/c7fbde78-9f0a-421a-a1ae-a3104a743d32">

---

macOS

<img width="590" alt="Screenshot 2024-08-23 at 6 22 35 PM" src="https://github.com/user-attachments/assets/c1102708-f26c-4822-91a3-84cd293fb2bb">

