### PR TITLE
Bug: Fillet Button - selecting edge without tag caused an Error rev2

### DIFF
--- a/src/lang/modifyAst/addFillet.ts
+++ b/src/lang/modifyAst/addFillet.ts
@@ -469,9 +469,9 @@ export const hasValidFilletSelection = ({
       if (segmentNode.node.type === 'CallExpression') {
         const segmentName = segmentNode.node.callee.name
         if (segmentName in sketchLineHelperMap) {
-          // add check wheather tag exists at all:
+          // Add check whether the tag exists at all
           if (!(segmentNode.node.arguments.length === 3)) return true
-          // if tag exists, check if it is already filleted
+          // If the tag exists, check if it is already filleted
           const edges = isTagUsedInFillet({
             ast,
             callExp: segmentNode.node,

--- a/src/lang/modifyAst/addFillet.ts
+++ b/src/lang/modifyAst/addFillet.ts
@@ -469,6 +469,9 @@ export const hasValidFilletSelection = ({
       if (segmentNode.node.type === 'CallExpression') {
         const segmentName = segmentNode.node.callee.name
         if (segmentName in sketchLineHelperMap) {
+          // add check wether tag exists at all:
+          if (!(segmentNode.node.arguments.length === 3)) return true
+          // if tag exists, check if it is already filleted
           const edges = isTagUsedInFillet({
             ast,
             callExp: segmentNode.node,

--- a/src/lang/modifyAst/addFillet.ts
+++ b/src/lang/modifyAst/addFillet.ts
@@ -469,7 +469,7 @@ export const hasValidFilletSelection = ({
       if (segmentNode.node.type === 'CallExpression') {
         const segmentName = segmentNode.node.callee.name
         if (segmentName in sketchLineHelperMap) {
-          // add check wether tag exists at all:
+          // add check wheather tag exists at all:
           if (!(segmentNode.node.arguments.length === 3)) return true
           // if tag exists, check if it is already filleted
           const edges = isTagUsedInFillet({

--- a/src/lang/modifyAst/addFillet.ts
+++ b/src/lang/modifyAst/addFillet.ts
@@ -469,7 +469,7 @@ export const hasValidFilletSelection = ({
       if (segmentNode.node.type === 'CallExpression') {
         const segmentName = segmentNode.node.callee.name
         if (segmentName in sketchLineHelperMap) {
-          // Add check whether the tag exists at all
+          // Add check whether the tag exists at all:
           if (!(segmentNode.node.arguments.length === 3)) return true
           // If the tag exists, check if it is already filleted
           const edges = isTagUsedInFillet({


### PR DESCRIPTION
### Prevent Error When Selecting Non-Tagged Edges:

This PR addresses an issue where selecting an edge without a tag caused an error in the fillet button state. The fix adds a condition to check the tag name only for segments that are tagged, preventing the function from attempting to process untagged edges
