### PR TITLE
Nadro/3686/file swapping while executing

### DIFF
--- a/src/lang/KclSingleton.ts
+++ b/src/lang/KclSingleton.ts
@@ -122,6 +122,7 @@ export class KclManager {
   get isExecuting() {
     return this._isExecuting
   }
+
   set isExecuting(isExecuting) {
     this._isExecuting = isExecuting
     // If we have finished executing, but the execute is stale, we should
@@ -232,6 +233,12 @@ export class KclManager {
   async executeAst(args: ExecuteArgs = {}): Promise<void> {
     if (this.isExecuting) {
       this.executeIsStale = args
+      // Previous execution will be rejected and finish, execution will be marked as stale
+      // new executeAst will start. This will reject previous AST calls while the user is typing
+      // in the editor
+      this.engineCommandManager.rejectAllCommands(
+        `Force interrupt, executionIsStale, new AST requested`
+      )
       // Exit early if we are already executing.
       return
     }
@@ -245,44 +252,47 @@ export class KclManager {
     // Make sure we clear before starting again. End session will do this.
     this.engineCommandManager?.endSession()
     await this.ensureWasmInit()
-    const { logs, errors, programMemory } = await executeAst({
+    const { logs, errors, programMemory, isInterrupted } = await executeAst({
       ast,
       engineCommandManager: this.engineCommandManager,
     })
 
-    this.lints = await lintAst({ ast: ast })
+    // Program was not interrupted, setup the scene
+    // Do not send send scene commands if the program was interrupted, go to clean up
+    if (!isInterrupted) {
+      this.lints = await lintAst({ ast: ast })
 
-    sceneInfra.modelingSend({ type: 'code edit during sketch' })
-    defaultSelectionFilter(programMemory, this.engineCommandManager)
-    await this.engineCommandManager.waitForAllCommands()
+      sceneInfra.modelingSend({ type: 'code edit during sketch' })
+      defaultSelectionFilter(programMemory, this.engineCommandManager)
 
-    if (args.zoomToFit) {
-      let zoomObjectId: string | undefined = ''
-      if (args.zoomOnRangeAndType) {
-        zoomObjectId = this.engineCommandManager?.mapRangeToObjectId(
-          args.zoomOnRangeAndType.range,
-          args.zoomOnRangeAndType.type
-        )
+      if (args.zoomToFit) {
+        let zoomObjectId: string | undefined = ''
+        if (args.zoomOnRangeAndType) {
+          zoomObjectId = this.engineCommandManager?.mapRangeToObjectId(
+            args.zoomOnRangeAndType.range,
+            args.zoomOnRangeAndType.type
+          )
+        }
+
+        await this.engineCommandManager.sendSceneCommand({
+          type: 'modeling_cmd_req',
+          cmd_id: uuidv4(),
+          cmd: {
+            type: 'zoom_to_fit',
+            object_ids: zoomObjectId ? [zoomObjectId] : [], // leave empty to zoom to all objects
+            padding: 0.1, // padding around the objects
+          },
+        })
+        await this.engineCommandManager.sendSceneCommand({
+          type: 'modeling_cmd_req',
+          cmd_id: uuidv4(),
+          cmd: {
+            type: 'zoom_to_fit',
+            object_ids: zoomObjectId ? [zoomObjectId] : [], // leave empty to zoom to all objects
+            padding: 0.1, // padding around the objects
+          },
+        })
       }
-
-      await this.engineCommandManager.sendSceneCommand({
-        type: 'modeling_cmd_req',
-        cmd_id: uuidv4(),
-        cmd: {
-          type: 'zoom_to_fit',
-          object_ids: zoomObjectId ? [zoomObjectId] : [], // leave empty to zoom to all objects
-          padding: 0.1, // padding around the objects
-        },
-      })
-      await this.engineCommandManager.sendSceneCommand({
-        type: 'modeling_cmd_req',
-        cmd_id: uuidv4(),
-        cmd: {
-          type: 'zoom_to_fit',
-          object_ids: zoomObjectId ? [zoomObjectId] : [], // leave empty to zoom to all objects
-          padding: 0.1, // padding around the objects
-        },
-      })
     }
 
     this.isExecuting = false
@@ -293,7 +303,8 @@ export class KclManager {
       return
     }
     this.logs = logs
-    this.addKclErrors(errors)
+    // Do not add the errors since the program was interrupted and the error is not a real KCL error
+    this.addKclErrors(isInterrupted ? [] : errors)
     this.programMemory = programMemory
     this.ast = { ...ast }
     this._executeCallback()
@@ -301,6 +312,7 @@ export class KclManager {
       type: 'execution-done',
       data: null,
     })
+
     this._cancelTokens.delete(currentExecutionId)
   }
   // NOTE: this always updates the code state and editor.

--- a/src/lang/langHelpers.ts
+++ b/src/lang/langHelpers.ts
@@ -73,13 +73,23 @@ export async function executeAst({
       logs: [],
       errors: [],
       programMemory,
+      isInterrupted: false,
     }
   } catch (e: any) {
+    let isInterrupted = false
     if (e instanceof KCLError) {
+      // Detect if it is a force interrupt error which is not a KCL processing error.
+      if (
+        e.msg ===
+        'Failed to wait for promise from engine: JsValue("Force interrupt, executionIsStale, new AST requested")'
+      ) {
+        isInterrupted = true
+      }
       return {
         errors: [e],
         logs: [],
         programMemory: ProgramMemory.empty(),
+        isInterrupted,
       }
     } else {
       console.log(e)
@@ -87,6 +97,7 @@ export async function executeAst({
         logs: [e],
         errors: [],
         programMemory: ProgramMemory.empty(),
+        isInterrupted,
       }
     }
   }

--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -52,8 +52,8 @@ interface WebRTCClientMetrics extends ClientMetrics {
 type Value<T, U> = U extends undefined
   ? { type: T; value: U }
   : U extends void
-  ? { type: T }
-  : { type: T; value: U }
+    ? { type: T }
+    : { type: T; value: U }
 
 type State<T, U> = Value<T, U>
 
@@ -297,8 +297,10 @@ class EngineConnection extends EventTarget {
   private engineCommandManager: EngineCommandManager
 
   private pingPongSpan: { ping?: Date; pong?: Date }
-  private pingIntervalId: ReturnType<typeof setInterval> = setInterval(() => {},
-  60_000)
+  private pingIntervalId: ReturnType<typeof setInterval> = setInterval(
+    () => {},
+    60_000
+  )
   isUsingConnectionLite: boolean = false
 
   constructor({
@@ -1364,7 +1366,7 @@ export class EngineCommandManager extends EventTarget {
   }
 
   private getAst: () => Program = () =>
-    ({ start: 0, end: 0, body: [], nonCodeMeta: {} } as any)
+    ({ start: 0, end: 0, body: [], nonCodeMeta: {} }) as any
   set getAstCb(cb: () => Program) {
     this.getAst = cb
   }
@@ -1991,6 +1993,7 @@ export class EngineCommandManager extends EventTarget {
       range: message.range,
       idToRangeMap: message.idToRangeMap,
     }
+
     if (message.command.type === 'modeling_cmd_req') {
       this.orderedCommands.push({
         command: message.command,
@@ -2037,6 +2040,18 @@ export class EngineCommandManager extends EventTarget {
       this.deferredArtifactPopulated(null)
     }
   }
+
+  /**
+   * Reject all of the pendingCommands created from sendModelingCommandFromWasm
+   * This interrupts the runtime of executeAst. Stops the AST processing and stops sending commands
+   * to the engine
+   */
+  rejectAllCommands(rejectionMessage: string) {
+    Object.values(this.pendingCommands).forEach((a) => {
+      a.reject(rejectionMessage)
+    })
+  }
+
   async initPlanes() {
     if (this.planesInitialized()) return
     const planes = await this.makeDefaultPlanes()

--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -1938,7 +1938,13 @@ export class EngineCommandManager extends EventTarget {
       command,
       idToRangeMap: {},
       range: [0, 0],
-    }).then(([a]) => a)
+    })
+      .then(([a]) => a)
+      .catch((e) => {
+        // TODO: Previously was never caught, since adding rejectAllCommands how should we handle this
+        // error?
+        /*noop*/
+      })
   }
   /**
    * A wrapper around the sendCommand where all inputs are JSON strings


### PR DESCRIPTION
closes https://github.com/KittyCAD/modeling-app/issues/3686
related to https://github.com/KittyCAD/modeling-app/issues/3470

**Technical bits**

I implemented a promise rejection on the `pendingCommands` which sends an error to the KCL code then we can catch it within the JS `_executor` function as well as propagating it through the `executeAst` call. 

- After we interrupt the `executeAst` don't run some scene setup since we will be immediately starting a new scene, only run the cleanup. 
- I detect the custom reject error within `langHelper's` `executeAst` to detect a KCL error that isn't actually a KCL error. It is my custom error. This allows me to say the commands will be interrupted. 
- TODO, `sendSceneCommand` had an uncaught promise handler. I've added a TODO one. This showed up because of my promise rejection code. 


**Benefits**

- When using the Project Files Pane you can switch between files that are big and small and it will cancel the previous load and start loading the new file you clicked.
- When using a large file (lego 9x18) you will be able to edit within the codemirror pane and it will restart the entire rendering instead of waiting for the entire renderer to finish before using your new code input. 
