### PR TITLE
chore: added new command log for export done

### DIFF
--- a/src/components/ModelStateIndicator.tsx
+++ b/src/components/ModelStateIndicator.tsx
@@ -29,6 +29,12 @@ export const ModelStateIndicator = () => {
         name="checkmark"
       />
     )
+  } else if (lastCommandType === 'export-done') {
+    className +=
+      'border-6 border border-solid border-chalkboard-60 dark:border-chalkboard-80 bg-chalkboard-20 dark:bg-chalkboard-80 !group-disabled:bg-chalkboard-30 !dark:group-disabled:bg-chalkboard-80 rounded-sm bg-succeed-10/30 dark:bg-succeed'
+    icon = (
+      <CustomIcon data-testid={dataTestId + '-export-done'} name="checkmark" />
+    )
   }
 
   return (

--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -1252,6 +1252,10 @@ export type CommandLog =
       type: 'execution-done'
       data: null
     }
+  | {
+      type: 'export-done'
+      data: null
+    }
 
 export enum EngineCommandManagerEvents {
   // engineConnection is available but scene setup may not have run
@@ -1918,7 +1922,13 @@ export class EngineCommandManager extends EventTarget {
     } else if (cmd.type === 'export') {
       const promise = new Promise<null>((resolve, reject) => {
         this.pendingExport = {
-          resolve,
+          resolve: (passThrough) => {
+            this.addCommandLog({
+              type: 'export-done',
+              data: null,
+            })
+            resolve(passThrough)
+          },
           reject: (reason: string) => {
             this.exportIntent = null
             reject(reason)


### PR DESCRIPTION
closes https://github.com/KittyCAD/modeling-app/issues/3767

# Steps to reproduce

- Export a object
- You will see the spinner hang forever

# Fix

The spinner stops when an `execution-done` or `receive-reliable` event is pushed into the commandLog from the modeling app side. The modeling app sends an `export` event to the engine but the workflow when the export is completed does not emit any event into the commandLog so we don't know if the export is completed or not.

I added a new `export-done` log that will be sent to the command log. 

I updated the spinner icon to copy and paste the execution done for the time being. Don't know if we want a custom icon for it.