### PR TITLE
Adding extra checks in file exporting to make sure the spinner resolves 

### DIFF
--- a/e2e/playwright/desktop-export.spec.ts
+++ b/e2e/playwright/desktop-export.spec.ts
@@ -109,6 +109,13 @@ test(
         // clean up output.gltf
         await fsp.rm('output.gltf')
       })
+
+      await test.step('Spinner should say export-done', async () => {
+        const modelStateIndicator = page.getByTestId(
+          'model-state-indicator-export-done'
+        )
+        await expect(modelStateIndicator).toBeVisible({ timeout: 60000 })
+      })
     })
 
     await test.step('on open of file in file pane', async () => {
@@ -182,6 +189,13 @@ test(
 
         // clean up output.gltf
         await fsp.rm('output.gltf')
+      })
+
+      await test.step('Spinner should say export-done', async () => {
+        const modelStateIndicator = page.getByTestId(
+          'model-state-indicator-export-done'
+        )
+        await expect(modelStateIndicator).toBeVisible({ timeout: 60000 })
       })
       await electronApp.close()
     })


### PR DESCRIPTION
closes https://github.com/KittyCAD/modeling-app/issues/3767


I've updated the two tests that do desktop file exporting to check that after the export is completed that the model state indicator goes to `export-done`. 