### PR TITLE
Bug fix: Stop modelStateIndicator flashing on camera drag

### DIFF
--- a/src/components/ModelStateIndicator.tsx
+++ b/src/components/ModelStateIndicator.tsx
@@ -5,7 +5,8 @@ import { CustomIcon } from './CustomIcon'
 export const ModelStateIndicator = () => {
   const [commands] = useEngineCommands()
 
-  const lastCommandType = commands[commands.length - 1]?.type
+  const lastCommand = commands[commands.length - 1]
+  const lastCommandType = lastCommand?.type
 
   let className = 'w-6 h-6 '
   let icon = <Spinner className={className} />
@@ -13,7 +14,7 @@ export const ModelStateIndicator = () => {
 
   if (lastCommandType === 'receive-reliable') {
     className +=
-      'bg-chalkboard-20 dark:bg-chalkboard-80 !group-disabled:bg-chalkboard-30 !dark:group-disabled:bg-chalkboard-80 rounded-sm bg-succeed-10/30 dark:bg-succeed'
+      'border-6 border border-solid border-chalkboard-60 dark:border-chalkboard-80 bg-chalkboard-20 dark:bg-chalkboard-80 !group-disabled:bg-chalkboard-30 !dark:group-disabled:bg-chalkboard-80 rounded-sm bg-succeed-10/30 dark:bg-succeed'
     icon = (
       <CustomIcon
         data-testid={dataTestId + '-receive-reliable'}
@@ -30,6 +31,18 @@ export const ModelStateIndicator = () => {
       />
     )
   } else if (lastCommandType === 'export-done') {
+    className +=
+      'border-6 border border-solid border-chalkboard-60 dark:border-chalkboard-80 bg-chalkboard-20 dark:bg-chalkboard-80 !group-disabled:bg-chalkboard-30 !dark:group-disabled:bg-chalkboard-80 rounded-sm bg-succeed-10/30 dark:bg-succeed'
+    icon = (
+      <CustomIcon data-testid={dataTestId + '-export-done'} name="checkmark" />
+    )
+  } else if (
+    lastCommand?.type === 'send-scene' &&
+    lastCommand.data.type === 'modeling_cmd_req' &&
+    (lastCommand.data.cmd.type === 'camera_drag_start' ||
+      lastCommand.data.cmd.type === 'camera_drag_end' ||
+      lastCommand.data.cmd.type === 'default_camera_zoom')
+  ) {
     className +=
       'border-6 border border-solid border-chalkboard-60 dark:border-chalkboard-80 bg-chalkboard-20 dark:bg-chalkboard-80 !group-disabled:bg-chalkboard-30 !dark:group-disabled:bg-chalkboard-80 rounded-sm bg-succeed-10/30 dark:bg-succeed'
     icon = (


### PR DESCRIPTION

https://github.com/user-attachments/assets/d391c5ef-6554-4039-b000-22a6d5363b9f

Question I ask in the video is if this spinner should instead by checking if there are pending commands that are not scene commands instead of checking the last command? because that would keep it spinning when as the model is still building.