### PR TITLE
Bug fix: Stop modelStateIndicator flashing on camera drag 

### DIFF
--- a/e2e/playwright/desktop-export.spec.ts
+++ b/e2e/playwright/desktop-export.spec.ts
@@ -54,6 +54,11 @@ test(
       const modelStateIndicator = page.getByTestId(
         'model-state-indicator-execution-done'
       )
+      const modelStateIndicatorLoading = page.getByTestId(
+        'model-state-indicator-loading'
+      )
+
+      await expect(modelStateIndicatorLoading).toBeVisible()
       await expect(modelStateIndicator).toBeVisible({ timeout: 60000 })
 
       const gltfOption = page.getByText('glTF')

--- a/src/components/ModelStateIndicator.tsx
+++ b/src/components/ModelStateIndicator.tsx
@@ -1,58 +1,27 @@
-import { useEngineCommands } from './EngineCommands'
 import { Spinner } from './Spinner'
 import { CustomIcon } from './CustomIcon'
+import { useKclContext } from 'lang/KclProvider'
 
 export const ModelStateIndicator = () => {
-  const [commands] = useEngineCommands()
+  const { isExecuting } = useKclContext()
 
-  const lastCommand = commands[commands.length - 1]
-  const lastCommandType = lastCommand?.type
-
-  let className = 'w-6 h-6 '
-  let icon = <Spinner className={className} />
-  let dataTestId = 'model-state-indicator'
-
-  if (lastCommandType === 'receive-reliable') {
-    className +=
-      'border-6 border border-solid border-chalkboard-60 dark:border-chalkboard-80 bg-chalkboard-20 dark:bg-chalkboard-80 !group-disabled:bg-chalkboard-30 !dark:group-disabled:bg-chalkboard-80 rounded-sm bg-succeed-10/30 dark:bg-succeed'
-    icon = (
-      <CustomIcon
-        data-testid={dataTestId + '-receive-reliable'}
-        name="checkmark"
-      />
+  if (isExecuting)
+    return (
+      <div className="w-6 h-6" data-testid="model-state-indicator">
+        <Spinner className="w-6 h-6" />
+      </div>
     )
-  } else if (lastCommandType === 'execution-done') {
-    className +=
-      'border-6 border border-solid border-chalkboard-60 dark:border-chalkboard-80 bg-chalkboard-20 dark:bg-chalkboard-80 !group-disabled:bg-chalkboard-30 !dark:group-disabled:bg-chalkboard-80 rounded-sm bg-succeed-10/30 dark:bg-succeed'
-    icon = (
-      <CustomIcon
-        data-testid={dataTestId + '-execution-done'}
-        name="checkmark"
-      />
-    )
-  } else if (lastCommandType === 'export-done') {
-    className +=
-      'border-6 border border-solid border-chalkboard-60 dark:border-chalkboard-80 bg-chalkboard-20 dark:bg-chalkboard-80 !group-disabled:bg-chalkboard-30 !dark:group-disabled:bg-chalkboard-80 rounded-sm bg-succeed-10/30 dark:bg-succeed'
-    icon = (
-      <CustomIcon data-testid={dataTestId + '-export-done'} name="checkmark" />
-    )
-  } else if (
-    lastCommand?.type === 'send-scene' &&
-    lastCommand.data.type === 'modeling_cmd_req' &&
-    (lastCommand.data.cmd.type === 'camera_drag_start' ||
-      lastCommand.data.cmd.type === 'camera_drag_end' ||
-      lastCommand.data.cmd.type === 'default_camera_zoom')
-  ) {
-    className +=
-      'border-6 border border-solid border-chalkboard-60 dark:border-chalkboard-80 bg-chalkboard-20 dark:bg-chalkboard-80 !group-disabled:bg-chalkboard-30 !dark:group-disabled:bg-chalkboard-80 rounded-sm bg-succeed-10/30 dark:bg-succeed'
-    icon = (
-      <CustomIcon data-testid={dataTestId + '-export-done'} name="checkmark" />
-    )
-  }
 
   return (
-    <div className={className} data-testid="model-state-indicator">
-      {icon}
+    <div
+      className="border-6 border border-solid border-chalkboard-60 dark:border-chalkboard-80 bg-chalkboard-20 dark:bg-chalkboard-80 !group-disabled:bg-chalkboard-30 !dark:group-disabled:bg-chalkboard-80 rounded-sm bg-succeed-10/30 dark:bg-succeed"
+      data-testid="model-state-indicator"
+    >
+      <CustomIcon
+        data-testid="model-state-indicator-export-done"
+        name="checkmark"
+        className="w-6 h-6"
+      />
     </div>
   )
 }

--- a/src/components/ModelStateIndicator.tsx
+++ b/src/components/ModelStateIndicator.tsx
@@ -18,7 +18,7 @@ export const ModelStateIndicator = () => {
       data-testid="model-state-indicator"
     >
       <CustomIcon
-        data-testid="model-state-indicator-export-done"
+        data-testid="model-state-indicator-execution-done"
         name="checkmark"
         className="w-6 h-6"
       />

--- a/src/components/ModelStateIndicator.tsx
+++ b/src/components/ModelStateIndicator.tsx
@@ -5,7 +5,8 @@ import { CustomIcon } from './CustomIcon'
 export const ModelStateIndicator = () => {
   const [commands] = useEngineCommands()
 
-  const lastCommandType = commands[commands.length - 1]?.type
+  const lastCommand = commands[commands.length - 1]
+  const lastCommandType = lastCommand?.type
 
   let className = 'w-6 h-6 '
   let icon = <Spinner className={className} />
@@ -13,7 +14,7 @@ export const ModelStateIndicator = () => {
 
   if (lastCommandType === 'receive-reliable') {
     className +=
-      'bg-chalkboard-20 dark:bg-chalkboard-80 !group-disabled:bg-chalkboard-30 !dark:group-disabled:bg-chalkboard-80 rounded-sm bg-succeed-10/30 dark:bg-succeed'
+      'border-6 border border-solid border-chalkboard-60 dark:border-chalkboard-80 bg-chalkboard-20 dark:bg-chalkboard-80 !group-disabled:bg-chalkboard-30 !dark:group-disabled:bg-chalkboard-80 rounded-sm bg-succeed-10/30 dark:bg-succeed'
     icon = (
       <CustomIcon
         data-testid={dataTestId + '-receive-reliable'}
@@ -30,6 +31,18 @@ export const ModelStateIndicator = () => {
       />
     )
   } else if (lastCommandType === 'export-done') {
+    className +=
+      'border-6 border border-solid border-chalkboard-60 dark:border-chalkboard-80 bg-chalkboard-20 dark:bg-chalkboard-80 !group-disabled:bg-chalkboard-30 !dark:group-disabled:bg-chalkboard-80 rounded-sm bg-succeed-10/30 dark:bg-succeed'
+    icon = (
+      <CustomIcon data-testid={dataTestId + '-export-done'} name="checkmark" />
+    )
+  } else if (
+    lastCommand?.type === 'send-scene' &&
+    lastCommand.data.type === 'modeling_cmd_req' &&
+    (lastCommand.data.cmd.type === 'camera_drag_start' ||
+      lastCommand.data.cmd.type === 'camera_drag_end' ||
+      lastCommand.data.cmd.type === 'default_camera_zoom')
+  ) {
     className +=
       'border-6 border border-solid border-chalkboard-60 dark:border-chalkboard-80 bg-chalkboard-20 dark:bg-chalkboard-80 !group-disabled:bg-chalkboard-30 !dark:group-disabled:bg-chalkboard-80 rounded-sm bg-succeed-10/30 dark:bg-succeed'
     icon = (

--- a/src/components/ModelStateIndicator.tsx
+++ b/src/components/ModelStateIndicator.tsx
@@ -7,7 +7,7 @@ export const ModelStateIndicator = () => {
 
   if (isExecuting)
     return (
-      <div className="w-6 h-6" data-testid="model-state-indicator">
+      <div className="w-6 h-6" data-testid="model-state-indicator-loading">
         <Spinner className="w-6 h-6" />
       </div>
     )


### PR DESCRIPTION
loading indicator would flash the spinner under all sorts of circumstances when it shouldn't. Dragging the mouse, or zooming, or even moving the cursor in the editor. I think it was looking at the wrong data. Can this just be as simple as using the isExecuting var?