### PR TITLE
Set BASE_URL so auth works against dev

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,7 +2,9 @@ NODE_ENV=development
 DEV=true
 VITE_KC_API_WS_MODELING_URL=wss://api.dev.zoo.dev/ws/modeling/commands
 VITE_KC_API_BASE_URL=https://api.dev.zoo.dev
+BASE_URL=https://api.dev.zoo.dev
 VITE_KC_SITE_BASE_URL=https://dev.zoo.dev
 VITE_KC_SKIP_AUTH=false
 VITE_KC_CONNECTION_TIMEOUT_MS=5000
-VITE_KC_DEV_TOKEN="your token from dev.zoo.dev should go in .env.development.local"
+# ONLY uncomment if you want to skip auth, otherwise this token takes precedence!
+#VITE_KC_DEV_TOKEN="your token from dev.zoo.dev should go in .env.development.local"

--- a/.env.development
+++ b/.env.development
@@ -6,5 +6,5 @@ BASE_URL=https://api.dev.zoo.dev
 VITE_KC_SITE_BASE_URL=https://dev.zoo.dev
 VITE_KC_SKIP_AUTH=false
 VITE_KC_CONNECTION_TIMEOUT_MS=5000
-# ONLY uncomment if you want to skip auth, otherwise this token takes precedence!
+# ONLY add your token in .env.development.local if you want to skip auth, otherwise this token takes precedence!
 #VITE_KC_DEV_TOKEN="your token from dev.zoo.dev should go in .env.development.local"

--- a/interface.d.ts
+++ b/interface.d.ts
@@ -30,7 +30,6 @@ export interface IElectronAPI {
   join: typeof path.join
   sep: typeof path.sep
   rename: (prev: string, next: string) => typeof fs.rename
-  setBaseUrl: (value: string) => void
   packageJson: {
     name: string
   }

--- a/src/lib/desktop.ts
+++ b/src/lib/desktop.ts
@@ -8,7 +8,6 @@ import {
   parseProjectSettings,
 } from 'lang/wasm'
 import {
-  DEFAULT_HOST,
   PROJECT_ENTRYPOINT,
   PROJECT_FOLDER,
   PROJECT_SETTINGS_FILE_NAME,
@@ -556,28 +555,6 @@ export const getUser = async (
   token: string,
   hostname: string
 ): Promise<Models['User_type']> => {
-  // Use the host passed in if it's set.
-  // Otherwise, use the default host.
-  const host = !hostname ? DEFAULT_HOST : hostname
-
-  // Change the baseURL to the one we want.
-  let baseurl = host
-  if (!(host.indexOf('http://') === 0) && !(host.indexOf('https://') === 0)) {
-    baseurl = `https://${host}`
-    if (host.indexOf('localhost') === 0) {
-      baseurl = `http://${host}`
-    }
-  }
-
-  // Use kittycad library to fetch the user info from /user/me
-  if (baseurl !== DEFAULT_HOST) {
-    // The TypeScript generated library uses environment variables for this
-    // because it was intended for NodeJS.
-    // Needs to stay like this because window.electron.kittycad needs it
-    // internally.
-    window.electron.setBaseUrl(baseurl)
-  }
-
   try {
     const user = await window.electron.kittycad('users.get_user_self', {
       client: { token },

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -93,9 +93,6 @@ contextBridge.exposeInMainWorld('electron', {
     isWindows,
     isLinux,
   },
-  // IMPORTANT NOTE: kittycad.ts reads process.env.BASE_URL. But there is
-  // no way to set it across the bridge boundary. We need to make it a command.
-  setBaseUrl: (value: string) => (process.env.BASE_URL = value),
   process: {
     // Setter/getter has to be created because
     // these are read-only over the boundary.


### PR DESCRIPTION
Using the device access token oauth flow now works on dev. Our current utility we set at in preload.ts doesn't actually affect any change on the BASE_URL, at least that the kittycad lib is able to see in node. So, we just set it for the entire process in the `.env.development` file. This means for local dev we can fully test the oauth flow ourselves!