### PR TITLE
Fix flash of white background in electron dark mode

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -50,6 +50,19 @@ body.dark {
   @apply text-chalkboard-10;
 }
 
+@media (prefers-color-scheme: dark) {
+  body,
+  .body-bg,
+  .dark .body-bg {
+    @apply bg-chalkboard-100;
+  }
+
+  body {
+    scrollbar-color: var(--color-chalkboard-70) var(--color-chalkboard-90);
+    @apply text-chalkboard-10;
+  }
+}
+
 select {
   @apply bg-chalkboard-20;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,14 @@
 // template that ElectronJS provides.
 
 import dotenv from 'dotenv'
-import { app, BrowserWindow, ipcMain, dialog, shell } from 'electron'
+import {
+  app,
+  BrowserWindow,
+  ipcMain,
+  dialog,
+  shell,
+  nativeTheme,
+} from 'electron'
 import path from 'path'
 import { Issuer } from 'openid-client'
 import { Bonjour, Service } from 'bonjour-service'
@@ -75,6 +82,7 @@ const createWindow = (filePath?: string): BrowserWindow => {
     icon: path.resolve(process.cwd(), 'assets', 'icon.png'),
     frame: os.platform() !== 'darwin',
     titleBarStyle: 'hiddenInset',
+    backgroundColor: nativeTheme.shouldUseDarkColors ? '#1C1C1C' : '#FCFCFC',
   })
 
   // and load the index.html of the app.


### PR DESCRIPTION
If user has dark mode set on their OS, they still see a flash of white whenever the app is opened or refreshed. This fixes that by setting the Electron window background to a theme-appropriate value.

## Sources
1. [Electron docs](https://www.electronjs.org/docs/latest/tutorial/dark-mode)
2. [This Replit issue](https://github.com/replit/desktop/pull/101)

## Demo

https://github.com/user-attachments/assets/8dee5126-05c9-4132-b390-f5729f36cce3

