### PR TITLE
Mark Loft as "KCL only" in toolbar, add a link to docs

### DIFF
--- a/src/lib/toolbar.ts
+++ b/src/lib/toolbar.ts
@@ -129,12 +129,16 @@ export const toolbarConfig: Record<ToolbarModeName, ToolbarMode> = {
         id: 'loft',
         onClick: () => console.error('Loft not yet implemented'),
         icon: 'loft',
-        status: 'unavailable',
+        status: 'kcl-only',
         title: 'Loft',
         hotkey: 'L',
         description:
           'Create a 3D body by blending between two or more sketches.',
         links: [
+          {
+            label: 'KCL docs',
+            url: 'https://zoo.dev/docs/kcl/loft',
+          },
           {
             label: 'GitHub discussion',
             url: 'https://github.com/KittyCAD/modeling-app/discussions/613',


### PR DESCRIPTION
We recently enabled an initial version of Lofts in KCL, so our Toolbar should show that.

closes https://github.com/KittyCAD/modeling-app/issues/3785