### PR TITLE
Fixing bug in convertThreeCamValuesToEngineCam

### DIFF
--- a/src/clientSideScene/CameraControls.ts
+++ b/src/clientSideScene/CameraControls.ts
@@ -541,7 +541,7 @@ export class CameraControls {
     const oldFov = this.camera.fov
 
     const viewHeightFactor = (fov: number) => {
-      /*       * 
+      /*       *
               /|
              / |
             /  |
@@ -1175,7 +1175,7 @@ function convertThreeCamValuesToEngineCam({
   const lookAt = buildLookAt(64 / zoom, target, position)
   return {
     center: new Vector3(lookAt.center.x, lookAt.center.y, lookAt.center.z),
-    up: new Vector3(0, 0, 1),
+    up: new Vector3(upVector.x, upVector.y, upVector.z),
     vantage: new Vector3(lookAt.eye.x, lookAt.eye.y, lookAt.eye.z),
   }
 }


### PR DESCRIPTION
closes https://github.com/KittyCAD/modeling-app/issues/3307


Looking at this table, the previous hard coded vector of `<0,0,1>` worked because the up vector of the camera was the same orientation for `XZ` and `YZ`. For `XY` the up vector is not `<0,0,1>` the up vector should be `<0,1,0>` since `Y` is now up for the camera.  

| planes | engine + edit sketch synced |
|----|----|
| `-XY` | :x:  | 
| `XY` | :x:  | 
| `-XZ` | :heavy_check_mark:   | 
| `XZ` | :heavy_check_mark:   | 
| `-YZ` | :heavy_check_mark:   | 
| `YZ` | :heavy_check_mark:   | 
