### PR TITLE
The electron-builder updater on 0.25.0 is pointing to the wrong directory

### DIFF
--- a/.github/workflows/build-test-publish-apps.yml
+++ b/.github/workflows/build-test-publish-apps.yml
@@ -245,6 +245,15 @@ jobs:
           parent: false
           destination: ${{ env.BUCKET_DIR }}
 
+      # TODO: remove workaround introduced in https://github.com/KittyCAD/modeling-app/issues/3817
+      - name: Upload release files to public bucket (test/electron-builder workaround)
+        uses: google-github-actions/upload-cloud-storage@v2.2.0
+        with:
+          path: out
+          glob: 'Zoo*'
+          parent: false
+          destination: '${{ env.BUCKET_DIR }}/test/electron-builder'
+
       - name: Upload update endpoint to public bucket
         uses: google-github-actions/upload-cloud-storage@v2.2.0
         with:
@@ -252,6 +261,15 @@ jobs:
           glob: 'latest*'
           parent: false
           destination: ${{ env.BUCKET_DIR }}
+
+      # TODO: remove workaround introduced in https://github.com/KittyCAD/modeling-app/issues/3817
+      - name: Upload update endpoint to public bucket (test/electron-builder workaround)
+        uses: google-github-actions/upload-cloud-storage@v2.2.0
+        with:
+          path: out
+          glob: 'latest*'
+          parent: false
+          destination: '${{ env.BUCKET_DIR }}/test/electron-builder'
 
       - name: Upload download endpoint to public bucket
         uses: google-github-actions/upload-cloud-storage@v2.2.0

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -79,5 +79,5 @@ linux:
 
 publish:
   - provider: generic
-    url: https://dl.zoo.dev/releases/modeling-app/test/electron-builder
+    url: https://dl.zoo.dev/releases/modeling-app
     channel: latest


### PR DESCRIPTION
Contributes to fixing #3817