### PR TITLE
Don't paste in code for "Closing settings modal should..." test

### DIFF
--- a/e2e/playwright/testing-settings.spec.ts
+++ b/e2e/playwright/testing-settings.spec.ts
@@ -364,44 +364,47 @@ test.describe('Testing settings', () => {
     async ({ browser: _ }, testInfo) => {
       const { electronApp, page } = await setupElectron({
         testInfo,
-        folderSetupFn: async () => {},
+        folderSetupFn: async (dir) => {
+          const bracketDir = join(dir, 'project-000')
+          await fsp.mkdir(bracketDir, { recursive: true })
+          await fsp.copyFile(
+            executorInputPath('cube.kcl'),
+            join(bracketDir, 'main.kcl')
+          )
+          await fsp.copyFile(
+            executorInputPath('cylinder.kcl'),
+            join(bracketDir, '2.kcl')
+          )
+        },
       })
+      const kclCube = await fsp.readFile(executorInputPath('cube.kcl'), 'utf-8')
+      const kclCylinder = await fsp.readFile(
+        executorInputPath('cylinder.kcl'),
+        'utf8'
+      )
 
       const {
         openKclCodePanel,
         openFilePanel,
-        createAndSelectProject,
-        pasteCodeInEditor,
-        createNewFileAndSelect,
+        waitForPageLoad,
+        selectFile,
         editorTextMatches,
       } = await getUtils(page, test)
 
       await page.setViewportSize({ width: 1200, height: 500 })
       page.on('console', console.log)
 
-      await test.step('Precondition: No projects exist', async () => {
+      await test.step('Precondition: Open to second project file', async () => {
         await expect(page.getByTestId('home-section')).toBeVisible()
-        const projectLinksPre = page.getByTestId('project-link')
-        await expect(projectLinksPre).toHaveCount(0)
+        await page.getByText('project-000').click()
+        await waitForPageLoad()
+        await openKclCodePanel()
+        await openFilePanel()
+        await editorTextMatches(kclCube)
+
+        await selectFile('2.kcl')
+        await editorTextMatches(kclCylinder)
       })
-
-      await createAndSelectProject('project-000')
-
-      await openKclCodePanel()
-      const kclCube = await fsp.readFile(
-        'src/wasm-lib/tests/executor/inputs/cube.kcl',
-        'utf-8'
-      )
-      await pasteCodeInEditor(kclCube)
-
-      await openFilePanel()
-      await createNewFileAndSelect('2.kcl')
-
-      const kclCylinder = await fsp.readFile(
-        'src/wasm-lib/tests/executor/inputs/cylinder.kcl',
-        'utf-8'
-      )
-      await pasteCodeInEditor(kclCylinder)
 
       const settingsOpenButton = page.getByRole('link', {
         name: 'settings Settings',
@@ -410,6 +413,9 @@ test.describe('Testing settings', () => {
 
       await test.step('Open and close settings', async () => {
         await settingsOpenButton.click()
+        await expect(
+          page.getByRole('heading', { name: 'Settings', exact: true })
+        ).toBeVisible()
         await settingsCloseButton.click()
       })
 


### PR DESCRIPTION
This test has until now created a project from scratch, and created two files within that project, filling their contents by pasting it into the KCL editor. However, this pasting operation is immediately followed by navigating to the next file, without waiting to verify that we have persisted the code to the file system. This created a race; if the code persistence was fast enough it will pass (this is nearly always the case locally), but if not it would fail, showing an "empty code pane".

Since we already have tests for creating a project and files manually, I think any other tests should forego that and instead use the convenience `setupFolderFn`, so we're less likely to include races in the setup.