### PR TITLE
[WIP]: Update types ready for new selections

### DIFF
--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -22,6 +22,7 @@ import {
 } from 'lib/toolbar'
 import { isDesktop } from 'lib/isDesktop'
 import { openExternalBrowserIfDesktop } from 'lib/openWindow'
+import { convertSelectionsToOld } from 'lib/selections'
 
 export function Toolbar({
   className = '',
@@ -38,12 +39,17 @@ export function Toolbar({
     '!border-transparent hover:!border-chalkboard-20 dark:enabled:hover:!border-primary pressed:!border-primary ui-open:!border-primary'
 
   const sketchPathId = useMemo(() => {
-    if (!isSingleCursorInPipe(context.selectionRanges, kclManager.ast)) {
+    if (
+      !isSingleCursorInPipe(
+        convertSelectionsToOld(context.selectionRanges),
+        kclManager.ast
+      )
+    ) {
       return false
     }
     return isCursorInSketchCommandRange(
       engineCommandManager.artifactGraph,
-      context.selectionRanges
+      convertSelectionsToOld(context.selectionRanges)
     )
   }, [engineCommandManager.artifactGraph, context.selectionRanges])
 

--- a/src/clientSideScene/sceneEntities.ts
+++ b/src/clientSideScene/sceneEntities.ts
@@ -77,7 +77,7 @@ import {
   createPipeSubstitution,
   findUniqueName,
 } from 'lang/modifyAst'
-import { Selections, getEventForSegmentSelection } from 'lib/selections'
+import { Selections__old, getEventForSegmentSelection } from 'lib/selections'
 import { createGridHelper, orthoScale, perspScale } from './helpers'
 import { Models } from '@kittycad/lib'
 import { uuidv4 } from 'lib/utils'
@@ -374,7 +374,7 @@ export class SceneEntities {
     forward: [number, number, number]
     up: [number, number, number]
     position?: [number, number, number]
-    selectionRanges?: Selections
+    selectionRanges?: Selections__old
   }): Promise<{
     truncatedAst: Program
     programMemoryOverride: ProgramMemory

--- a/src/clientSideScene/sceneEntities.ts
+++ b/src/clientSideScene/sceneEntities.ts
@@ -1171,6 +1171,7 @@ export class SceneEntities {
       },
       onMove: () => {},
       onClick: (args) => {
+        console.log('onClick', args)
         if (args?.mouseEvent.which !== 1) return
         if (!args || !args.selected) {
           sceneInfra.modelingSend({
@@ -1183,6 +1184,7 @@ export class SceneEntities {
         }
         const { selected } = args
         const event = getEventForSegmentSelection(selected)
+        console.log('event', event)
         if (!event) return
         sceneInfra.modelingSend(event)
       },

--- a/src/components/AvailableVarsHelpers.tsx
+++ b/src/components/AvailableVarsHelpers.tsx
@@ -12,6 +12,7 @@ import { useKclContext } from 'lang/KclProvider'
 import { useModelingContext } from 'hooks/useModelingContext'
 import { executeAst } from 'lang/langHelpers'
 import { trap } from 'lib/trap'
+import { convertSelectionsToOld } from 'lib/selections'
 
 export const AvailableVars = ({
   onVarClick,
@@ -96,7 +97,8 @@ export function useCalc({
 } {
   const { programMemory } = useKclContext()
   const { context } = useModelingContext()
-  const selectionRange = context.selectionRanges.codeBasedSelections[0].range
+  const selectionRange = convertSelectionsToOld(context.selectionRanges)
+    .codeBasedSelections[0].range
   const inputRef = useRef<HTMLInputElement>(null)
   const [availableVarInfo, setAvailableVarInfo] = useState<
     ReturnType<typeof findAllPreviousVariables>

--- a/src/components/CommandBar/CommandBarHeader.tsx
+++ b/src/components/CommandBar/CommandBarHeader.tsx
@@ -2,7 +2,7 @@ import { useCommandsContext } from 'hooks/useCommandsContext'
 import { CustomIcon } from '../CustomIcon'
 import React, { useState } from 'react'
 import { ActionButton } from '../ActionButton'
-import { Selections, getSelectionTypeDisplayText } from 'lib/selections'
+import { Selections__old, getSelectionTypeDisplayText } from 'lib/selections'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { KclCommandValue, KclExpressionWithVariable } from 'lib/commandTypes'
 import Tooltip from 'components/Tooltip'
@@ -125,7 +125,9 @@ function CommandBarHeader({ children }: React.PropsWithChildren<{}>) {
                     <span data-testid="header-arg-value">
                       {argValue ? (
                         arg.inputType === 'selection' ? (
-                          getSelectionTypeDisplayText(argValue as Selections)
+                          getSelectionTypeDisplayText(
+                            argValue as Selections__old
+                          )
                         ) : arg.inputType === 'kcl' ? (
                           roundOff(
                             Number(

--- a/src/components/CommandBar/CommandBarSelectionInput.tsx
+++ b/src/components/CommandBar/CommandBarSelectionInput.tsx
@@ -3,7 +3,7 @@ import { useCommandsContext } from 'hooks/useCommandsContext'
 import { useKclContext } from 'lang/KclProvider'
 import { CommandArgument } from 'lib/commandTypes'
 import {
-  Selection,
+  Selection__old,
   canSubmitSelectionArg,
   getSelectionType,
   getSelectionTypeDisplayText,
@@ -12,13 +12,15 @@ import { modelingMachine } from 'machines/modelingMachine'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { StateFrom } from 'xstate'
 
-const semanticEntityNames: { [key: string]: Array<Selection['type']> } = {
+const semanticEntityNames: { [key: string]: Array<Selection__old['type']> } = {
   face: ['extrude-wall', 'start-cap', 'end-cap'],
   edge: ['edge', 'line', 'arc'],
   point: ['point', 'line-end', 'line-mid'],
 }
 
-function getSemanticSelectionType(selectionType: Array<Selection['type']>) {
+function getSemanticSelectionType(
+  selectionType: Array<Selection__old['type']>
+) {
   const semanticSelectionType = new Set()
   selectionType.forEach((type) => {
     Object.entries(semanticEntityNames).forEach(([entity, entityTypes]) => {

--- a/src/components/CommandBar/CommandBarSelectionInput.tsx
+++ b/src/components/CommandBar/CommandBarSelectionInput.tsx
@@ -5,6 +5,8 @@ import { CommandArgument } from 'lib/commandTypes'
 import {
   Selection__old,
   canSubmitSelectionArg,
+  convertSelectionToOld,
+  convertSelectionsToOld,
   getSelectionType,
   getSelectionTypeDisplayText,
 } from 'lib/selections'
@@ -51,10 +53,14 @@ function CommandBarSelectionInput({
   const [hasSubmitted, setHasSubmitted] = useState(false)
   const selection = useSelector(arg.machineActor, selectionSelector)
   const selectionsByType = useMemo(() => {
-    const selectionRangeEnd = selection?.codeBasedSelections[0]?.range[1]
-    return !selectionRangeEnd || selectionRangeEnd === code.length
+    const selectionRangeEnd = !selection
+      ? null
+      : convertSelectionsToOld(selection)?.codeBasedSelections[0]?.range[1]
+    return !selectionRangeEnd || selectionRangeEnd === code.length || !selection
       ? 'none'
-      : getSelectionType(selection)
+      : !selection
+      ? 'none'
+      : getSelectionType(convertSelectionsToOld(selection))
   }, [selection, code])
   const canSubmitSelection = useMemo<boolean>(
     () => canSubmitSelectionArg(selectionsByType, arg),
@@ -89,6 +95,8 @@ function CommandBarSelectionInput({
     onSubmit(selection)
   }
 
+  const selectionOld = selection && convertSelectionsToOld(selection)
+
   return (
     <form id="arg-form" onSubmit={handleSubmit}>
       <label
@@ -98,7 +106,7 @@ function CommandBarSelectionInput({
         }
       >
         {canSubmitSelection
-          ? getSelectionTypeDisplayText(selection) + ' selected'
+          ? getSelectionTypeDisplayText(selectionOld) + ' selected'
           : `Please select ${
               arg.multiple ? 'one or more ' : 'one '
             }${getSemanticSelectionType(arg.selectionTypes).join(' or ')}`}

--- a/src/components/EngineCommands.tsx
+++ b/src/components/EngineCommands.tsx
@@ -21,6 +21,7 @@ export const EngineCommands = () => {
   const [engineCommands, clearEngineCommands] = useEngineCommands()
   const [containsFilter, setContainsFilter] = useState('')
   const [customCmd, setCustomCmd] = useState('')
+  console.log(JSON.stringify(engineCommands, null, 2))
   return (
     <div>
       <input
@@ -64,7 +65,10 @@ export const EngineCommands = () => {
           )
         })}
       </div>
-      <button data-testid="clear-commands" onClick={clearEngineCommands}>
+      <button
+        data-testid="clear-commands"
+        onClick={() => clearEngineCommands()}
+      >
         Clear
       </button>
       <br />

--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -37,7 +37,7 @@ import {
 } from './Toolbar/SetAngleBetween'
 import { applyConstraintAngleLength } from './Toolbar/setAngleLength'
 import {
-  Selections,
+  Selections__old,
   canSweepSelection,
   handleSelectionBatch,
   isSelectionLastLine,
@@ -275,7 +275,7 @@ export const ModelingMachineProvider = ({
                 })
               })
             }
-            let selections: Selections = {
+            let selections: Selections__old = {
               codeBasedSelections: [],
               otherSelections: [],
             }

--- a/src/components/Toolbar/EqualAngle.tsx
+++ b/src/components/Toolbar/EqualAngle.tsx
@@ -1,5 +1,5 @@
 import { toolTips } from 'lang/langHelpers'
-import { Selections } from 'lib/selections'
+import { Selections__old } from 'lib/selections'
 import { Program, Expr, VariableDeclarator } from '../../lang/wasm'
 import {
   getNodePathFromSourceRange,
@@ -18,7 +18,7 @@ import { TransformInfo } from 'lang/std/stdTypes'
 export function equalAngleInfo({
   selectionRanges,
 }: {
-  selectionRanges: Selections
+  selectionRanges: Selections__old
 }):
   | {
       transforms: TransformInfo[]
@@ -82,7 +82,7 @@ export function equalAngleInfo({
 export function applyConstraintEqualAngle({
   selectionRanges,
 }: {
-  selectionRanges: Selections
+  selectionRanges: Selections__old
 }):
   | {
       modifiedAst: Program

--- a/src/components/Toolbar/EqualLength.tsx
+++ b/src/components/Toolbar/EqualLength.tsx
@@ -1,5 +1,5 @@
 import { toolTips } from 'lang/langHelpers'
-import { Selections } from 'lib/selections'
+import { Selections__old } from 'lib/selections'
 import { Program, Expr, VariableDeclarator } from '../../lang/wasm'
 import {
   getNodePathFromSourceRange,
@@ -18,7 +18,7 @@ import { err } from 'lib/trap'
 export function setEqualLengthInfo({
   selectionRanges,
 }: {
-  selectionRanges: Selections
+  selectionRanges: Selections__old
 }):
   | {
       transforms: TransformInfo[]
@@ -83,7 +83,7 @@ export function setEqualLengthInfo({
 export function applyConstraintEqualLength({
   selectionRanges,
 }: {
-  selectionRanges: Selections
+  selectionRanges: Selections__old
 }):
   | {
       modifiedAst: Program

--- a/src/components/Toolbar/HorzVert.tsx
+++ b/src/components/Toolbar/HorzVert.tsx
@@ -1,5 +1,5 @@
 import { toolTips } from 'lang/langHelpers'
-import { Selections } from 'lib/selections'
+import { Selections__old } from 'lib/selections'
 import { Program, ProgramMemory, Expr } from '../../lang/wasm'
 import {
   getNodePathFromSourceRange,
@@ -15,7 +15,7 @@ import { kclManager } from 'lib/singletons'
 import { err } from 'lib/trap'
 
 export function horzVertInfo(
-  selectionRanges: Selections,
+  selectionRanges: Selections__old,
   horOrVert: 'vertical' | 'horizontal'
 ):
   | {
@@ -53,7 +53,7 @@ export function horzVertInfo(
 }
 
 export function applyConstraintHorzVert(
-  selectionRanges: Selections,
+  selectionRanges: Selections__old,
   horOrVert: 'vertical' | 'horizontal',
   ast: Program,
   programMemory: ProgramMemory

--- a/src/components/Toolbar/Intersect.tsx
+++ b/src/components/Toolbar/Intersect.tsx
@@ -1,6 +1,6 @@
 import { toolTips } from 'lang/langHelpers'
-import { Selections } from 'lib/selections'
 import { Program, Expr, VariableDeclarator } from '../../lang/wasm'
+import { Selections__old } from 'lib/selections'
 import {
   getNodePathFromSourceRange,
   getNodeFromPath,
@@ -25,12 +25,12 @@ const getModalInfo = createInfoModal(GetInfoModal)
 export function intersectInfo({
   selectionRanges,
 }: {
-  selectionRanges: Selections
+  selectionRanges: Selections__old
 }):
   | {
       transforms: TransformInfo[]
       enabled: boolean
-      forcedSelectionRanges: Selections
+      forcedSelectionRanges: Selections__old
     }
   | Error {
   if (selectionRanges.codeBasedSelections.length < 2) {
@@ -134,7 +134,7 @@ export function intersectInfo({
 export async function applyConstraintIntersect({
   selectionRanges,
 }: {
-  selectionRanges: Selections
+  selectionRanges: Selections__old
 }): Promise<{
   modifiedAst: Program
   pathToNodeMap: PathToNodeMap

--- a/src/components/Toolbar/RemoveConstrainingValues.tsx
+++ b/src/components/Toolbar/RemoveConstrainingValues.tsx
@@ -1,5 +1,5 @@
 import { toolTips } from 'lang/langHelpers'
-import { Selection, Selections } from 'lib/selections'
+import { Selection__old, Selections__old } from 'lib/selections'
 import { PathToNode, Program, Expr } from '../../lang/wasm'
 import {
   getNodePathFromSourceRange,
@@ -18,13 +18,13 @@ export function removeConstrainingValuesInfo({
   selectionRanges,
   pathToNodes,
 }: {
-  selectionRanges: Selections
+  selectionRanges: Selections__old
   pathToNodes?: Array<PathToNode>
 }):
   | {
       transforms: TransformInfo[]
       enabled: boolean
-      updatedSelectionRanges: Selections
+      updatedSelectionRanges: Selections__old
     }
   | Error {
   const paths =
@@ -45,7 +45,7 @@ export function removeConstrainingValuesInfo({
     ? {
         otherSelections: [],
         codeBasedSelections: nodes.map(
-          (node): Selection => ({
+          (node): Selection__old => ({
             range: [node.start, node.end],
             type: 'default',
           })
@@ -73,7 +73,7 @@ export function applyRemoveConstrainingValues({
   selectionRanges,
   pathToNodes,
 }: {
-  selectionRanges: Selections
+  selectionRanges: Selections__old
   pathToNodes?: Array<PathToNode>
 }):
   | {

--- a/src/components/Toolbar/SetAbsDistance.tsx
+++ b/src/components/Toolbar/SetAbsDistance.tsx
@@ -1,6 +1,6 @@
 import { toolTips } from 'lang/langHelpers'
-import { Selections } from 'lib/selections'
 import { Program, Expr } from '../../lang/wasm'
+import { Selections__old } from 'lib/selections'
 import {
   getNodePathFromSourceRange,
   getNodeFromPath,
@@ -32,7 +32,7 @@ export function absDistanceInfo({
   selectionRanges,
   constraint,
 }: {
-  selectionRanges: Selections
+  selectionRanges: Selections__old
   constraint: Constraint
 }):
   | {
@@ -93,7 +93,7 @@ export async function applyConstraintAbsDistance({
   selectionRanges,
   constraint,
 }: {
-  selectionRanges: Selections
+  selectionRanges: Selections__old
   constraint: 'xAbs' | 'yAbs'
 }): Promise<{
   modifiedAst: Program
@@ -157,7 +157,7 @@ export function applyConstraintAxisAlign({
   selectionRanges,
   constraint,
 }: {
-  selectionRanges: Selections
+  selectionRanges: Selections__old
   constraint: 'snapToYAxis' | 'snapToXAxis'
 }):
   | {

--- a/src/components/Toolbar/SetAngleBetween.tsx
+++ b/src/components/Toolbar/SetAngleBetween.tsx
@@ -1,6 +1,6 @@
 import { toolTips } from 'lang/langHelpers'
-import { Selections } from 'lib/selections'
 import { Program, Expr, VariableDeclarator } from '../../lang/wasm'
+import { Selections__old } from 'lib/selections'
 import {
   getNodePathFromSourceRange,
   getNodeFromPath,
@@ -24,7 +24,7 @@ const getModalInfo = createInfoModal(GetInfoModal)
 export function angleBetweenInfo({
   selectionRanges,
 }: {
-  selectionRanges: Selections
+  selectionRanges: Selections__old
 }):
   | {
       transforms: TransformInfo[]
@@ -90,7 +90,7 @@ export async function applyConstraintAngleBetween({
   selectionRanges,
 }: // constraint,
 {
-  selectionRanges: Selections
+  selectionRanges: Selections__old
   // constraint: 'setHorzDistance' | 'setVertDistance'
 }): Promise<{
   modifiedAst: Program

--- a/src/components/Toolbar/SetHorzVertDistance.tsx
+++ b/src/components/Toolbar/SetHorzVertDistance.tsx
@@ -16,7 +16,7 @@ import { GetInfoModal, createInfoModal } from '../SetHorVertDistanceModal'
 import { createLiteral, createVariableDeclaration } from '../../lang/modifyAst'
 import { removeDoubleNegatives } from '../AvailableVarsHelpers'
 import { kclManager } from 'lib/singletons'
-import { Selections } from 'lib/selections'
+import { Selections__old } from 'lib/selections'
 import { cleanErrs, err } from 'lib/trap'
 
 const getModalInfo = createInfoModal(GetInfoModal)
@@ -25,7 +25,7 @@ export function horzVertDistanceInfo({
   selectionRanges,
   constraint,
 }: {
-  selectionRanges: Selections
+  selectionRanges: Selections__old
   constraint: 'setHorzDistance' | 'setVertDistance'
 }):
   | {
@@ -95,7 +95,7 @@ export async function applyConstraintHorzVertDistance({
   // TODO align will always be false (covered by synconous applyConstraintHorzVertAlign), remove it
   isAlign = false,
 }: {
-  selectionRanges: Selections
+  selectionRanges: Selections__old
   constraint: 'setHorzDistance' | 'setVertDistance'
   isAlign?: false
 }): Promise<{
@@ -181,7 +181,7 @@ export function applyConstraintHorzVertAlign({
   selectionRanges,
   constraint,
 }: {
-  selectionRanges: Selections
+  selectionRanges: Selections__old
   constraint: 'setHorzDistance' | 'setVertDistance'
 }):
   | {

--- a/src/components/Toolbar/setAngleLength.tsx
+++ b/src/components/Toolbar/setAngleLength.tsx
@@ -1,6 +1,6 @@
 import { toolTips } from 'lang/langHelpers'
-import { Selections } from 'lib/selections'
 import { Program, Expr } from '../../lang/wasm'
+import { Selections__old } from 'lib/selections'
 import {
   getNodePathFromSourceRange,
   getNodeFromPath,
@@ -32,7 +32,7 @@ export function angleLengthInfo({
   selectionRanges,
   angleOrLength = 'setLength',
 }: {
-  selectionRanges: Selections
+  selectionRanges: Selections__old
   angleOrLength?: 'setLength' | 'setAngle'
 }):
   | {
@@ -74,7 +74,7 @@ export async function applyConstraintAngleLength({
   selectionRanges,
   angleOrLength = 'setLength',
 }: {
-  selectionRanges: Selections
+  selectionRanges: Selections__old
   angleOrLength?: 'setLength' | 'setAngle'
 }): Promise<{
   modifiedAst: Program

--- a/src/editor/manager.ts
+++ b/src/editor/manager.ts
@@ -2,7 +2,11 @@ import { EditorView, ViewUpdate } from '@codemirror/view'
 import { EditorSelection, Annotation, Transaction } from '@codemirror/state'
 import { engineCommandManager } from 'lib/singletons'
 import { modelingMachine, ModelingMachineEvent } from 'machines/modelingMachine'
-import { Selections, processCodeMirrorRanges, Selection } from 'lib/selections'
+import {
+  Selections__old,
+  Selection__old,
+  processCodeMirrorRanges,
+} from 'lib/selections'
 import { undo, redo } from '@codemirror/commands'
 import { CommandBarMachineEvent } from 'machines/commandBarMachine'
 import { addLineHighlight, addLineHighlightEvent } from './highlightextension'
@@ -31,7 +35,7 @@ export default class EditorManager {
   private _copilotEnabled: boolean = true
 
   private _isShiftDown: boolean = false
-  private _selectionRanges: Selections = {
+  private _selectionRanges: Selections__old = {
     otherSelections: [],
     codeBasedSelections: [],
   }
@@ -73,7 +77,7 @@ export default class EditorManager {
     this._isShiftDown = isShiftDown
   }
 
-  set selectionRanges(selectionRanges: Selections) {
+  set selectionRanges(selectionRanges: Selections__old) {
     this._selectionRanges = selectionRanges
   }
 
@@ -97,7 +101,7 @@ export default class EditorManager {
     return this._highlightRange
   }
 
-  setHighlightRange(selections: Array<Selection['range']>): void {
+  setHighlightRange(selections: Array<Selection__old['range']>): void {
     this._highlightRange = selections
 
     const selectionsWithSafeEnds = selections.map((s): [number, number] => {
@@ -203,7 +207,7 @@ export default class EditorManager {
     return false
   }
 
-  selectRange(selections: Selections) {
+  selectRange(selections: Selections__old) {
     if (selections.codeBasedSelections.length === 0) {
       return
     }

--- a/src/hooks/useEngineConnectionSubscriptions.ts
+++ b/src/hooks/useEngineConnectionSubscriptions.ts
@@ -9,10 +9,9 @@ import { useModelingContext } from './useModelingContext'
 import { getEventForSelectWithPoint } from 'lib/selections'
 import {
   getCapCodeRef,
-  getSweepEdgeCodeRef,
   getSweepFromSuspectedSweepSurface,
-  getSolid2dCodeRef,
   getWallCodeRef,
+  getCodeRefsByArtifactId,
 } from 'lang/std/artifactGraph'
 import { err, reportRejection } from 'lib/trap'
 import { DefaultPlaneStr, getFaceDetails } from 'clientSideScene/sceneEntities'
@@ -29,52 +28,14 @@ export function useEngineConnectionSubscriptions() {
       event: 'highlight_set_entity',
       callback: ({ data }) => {
         if (data?.entity_id) {
-          const artifact = engineCommandManager.artifactGraph.get(
-            data.entity_id
+          const codeRefs = getCodeRefsByArtifactId(
+            data.entity_id,
+            engineCommandManager.artifactGraph
           )
-          if (artifact?.type === 'solid2D') {
-            const codeRef = getSolid2dCodeRef(
-              artifact,
-              engineCommandManager.artifactGraph
-            )
-            if (err(codeRef)) return
-            editorManager.setHighlightRange([codeRef.range])
-          } else if (artifact?.type === 'cap') {
-            const codeRef = getCapCodeRef(
-              artifact,
-              engineCommandManager.artifactGraph
-            )
-            if (err(codeRef)) return
-            editorManager.setHighlightRange([codeRef.range])
-          } else if (artifact?.type === 'wall') {
-            const extrusion = getSweepFromSuspectedSweepSurface(
-              data.entity_id,
-              engineCommandManager.artifactGraph
-            )
-            const codeRef = getWallCodeRef(
-              artifact,
-              engineCommandManager.artifactGraph
-            )
-            if (err(codeRef)) return
-            editorManager.setHighlightRange(
-              err(extrusion)
-                ? [codeRef.range]
-                : [codeRef.range, extrusion.codeRef.range]
-            )
-          } else if (artifact?.type === 'sweepEdge') {
-            const codeRef = getSweepEdgeCodeRef(
-              artifact,
-              engineCommandManager.artifactGraph
-            )
-            if (err(codeRef)) return
-            editorManager.setHighlightRange([codeRef.range])
-          } else if (artifact?.type === 'segment') {
-            editorManager.setHighlightRange([
-              artifact?.codeRef?.range || [0, 0],
-            ])
-          } else {
-            editorManager.setHighlightRange([[0, 0]])
+          if (codeRefs) {
+            editorManager.setHighlightRange(codeRefs.map(({ range }) => range))
           }
+          editorManager.setHighlightRange([[0, 0]])
         } else if (
           !editorManager.highlightRange ||
           (editorManager.highlightRange[0][0] !== 0 &&

--- a/src/hooks/useToolbarGuards.ts
+++ b/src/hooks/useToolbarGuards.ts
@@ -11,6 +11,7 @@ import { useModelingContext } from './useModelingContext'
 import { PathToNode, SourceRange } from 'lang/wasm'
 import { useKclContext } from 'lang/KclProvider'
 import { toSync } from 'lib/utils'
+import { convertSelectionsToOld } from 'lib/selections'
 
 export const getVarNameModal = createSetVarNameModal(SetVarNameModal)
 
@@ -28,14 +29,19 @@ export function useConvertToVariable(range?: SourceRange) {
 
     const meta = isNodeSafeToReplace(
       parsed,
-      range || context.selectionRanges.codeBasedSelections?.[0]?.range || []
+      range ||
+        convertSelectionsToOld(context.selectionRanges).codeBasedSelections?.[0]
+          ?.range ||
+        []
     )
     if (trap(meta)) return
 
     const { isSafe, value } = meta
     const canReplace = isSafe && value.type !== 'Identifier'
     const isOnlyOneSelection =
-      !!range || context.selectionRanges.codeBasedSelections.length === 1
+      !!range ||
+      convertSelectionsToOld(context.selectionRanges).codeBasedSelections
+        .length === 1
 
     setEnabled(canReplace && isOnlyOneSelection)
   }, [context.selectionRanges])
@@ -52,7 +58,9 @@ export function useConvertToVariable(range?: SourceRange) {
         moveValueIntoNewVariable(
           ast,
           kclManager.programMemory,
-          range || context.selectionRanges.codeBasedSelections[0].range,
+          range ||
+            convertSelectionsToOld(context.selectionRanges)
+              .codeBasedSelections[0].range,
           variableName
         )
 

--- a/src/lang/KclSingleton.ts
+++ b/src/lang/KclSingleton.ts
@@ -1,5 +1,5 @@
 import { executeAst, lintAst } from 'lang/langHelpers'
-import { Selections } from 'lib/selections'
+import { Selections__old } from 'lib/selections'
 import { KCLError, kclErrorsToDiagnostics } from './errors'
 import { uuidv4 } from 'lib/utils'
 import { EngineCommandManager } from './std/engineConnection'
@@ -425,14 +425,14 @@ export class KclManager {
     }
   ): Promise<{
     newAst: Program
-    selections?: Selections
+    selections?: Selections__old
   }> {
     const newCode = recast(ast)
     if (err(newCode)) return Promise.reject(newCode)
 
     const astWithUpdatedSource = this.safeParse(newCode)
     if (!astWithUpdatedSource) return Promise.reject(new Error('bad ast'))
-    let returnVal: Selections | undefined = undefined
+    let returnVal: Selections__old | undefined = undefined
 
     if (optionalParams?.focusPath) {
       returnVal = {

--- a/src/lang/modifyAst.ts
+++ b/src/lang/modifyAst.ts
@@ -1,5 +1,5 @@
-import { Selection } from 'lib/selections'
 import { err, reportRejection, trap } from 'lib/trap'
+import { Selection__old } from 'lib/selections'
 import {
   Program,
   CallExpression,
@@ -762,7 +762,7 @@ export function createBinaryExpressionWithUnary([left, right]: [
 
 export function giveSketchFnCallTag(
   ast: Program,
-  range: Selection['range'],
+  range: Selection__old['range'],
   tag?: string
 ):
   | {
@@ -836,7 +836,7 @@ export function moveValueIntoNewVariablePath(
 export function moveValueIntoNewVariable(
   ast: Program,
   programMemory: ProgramMemory,
-  sourceRange: Selection['range'],
+  sourceRange: Selection__old['range'],
   variableName: string
 ): {
   modifiedAst: Program
@@ -955,7 +955,7 @@ export function removeSingleConstraintInfo(
 
 export async function deleteFromSelection(
   ast: Program,
-  selection: Selection,
+  selection: Selection__old,
   programMemory: ProgramMemory,
   getFaceDetails: (id: string) => Promise<Models['FaceIsPlanar_type']> = () =>
     ({} as any)

--- a/src/lang/modifyAst/addFillet.test.ts
+++ b/src/lang/modifyAst/addFillet.test.ts
@@ -19,7 +19,7 @@ import {
 import { getNodeFromPath, getNodePathFromSourceRange } from '../queryAst'
 import { createLiteral } from 'lang/modifyAst'
 import { err } from 'lib/trap'
-import { Selections } from 'lib/selections'
+import { Selections__old } from 'lib/selections'
 import { engineCommandManager, kclManager } from 'lib/singletons'
 import { VITE_KC_DEV_TOKEN } from 'env'
 import { KclCommandValue } from 'lib/commandTypes'
@@ -106,7 +106,7 @@ const runGetPathToExtrudeForSegmentSelectionTest = async (
     code.indexOf(selectedSegmentSnippet),
     code.indexOf(selectedSegmentSnippet) + selectedSegmentSnippet.length,
   ]
-  const selection: Selections = {
+  const selection: Selections__old = {
     codeBasedSelections: [
       {
         range: segmentRange,
@@ -469,7 +469,7 @@ const runModifyAstWithFilletAndTagTest = async (
       code.indexOf(selectionSnippet) + selectionSnippet.length,
     ]
   )
-  const selection: Selections = {
+  const selection: Selections__old = {
     codeBasedSelections: segmentRanges.map((segmentRange) => ({
       range: segmentRange,
       type: 'default',
@@ -730,7 +730,7 @@ describe('Testing button states', () => {
         ]
       : [ast.end, ast.end] // empty line in the end of the code
 
-    const selectionRanges: Selections = {
+    const selectionRanges: Selections__old = {
       codeBasedSelections: [
         {
           range,

--- a/src/lang/modifyAst/addFillet.ts
+++ b/src/lang/modifyAst/addFillet.ts
@@ -31,7 +31,7 @@ import {
   sketchLineHelperMap,
 } from '../std/sketch'
 import { err, trap } from 'lib/trap'
-import { Selections, canFilletSelection } from 'lib/selections'
+import { Selections__old, canFilletSelection } from 'lib/selections'
 import { KclCommandValue } from 'lib/commandTypes'
 import {
   ArtifactGraph,
@@ -45,7 +45,7 @@ import { kclManager, engineCommandManager, editorManager } from 'lib/singletons'
 
 export function applyFilletToSelection(
   ast: Program,
-  selection: Selections,
+  selection: Selections__old,
   radius: KclCommandValue
 ): void | Error {
   // 1. clone ast
@@ -63,7 +63,7 @@ export function applyFilletToSelection(
 
 export function modifyAstWithFilletAndTag(
   ast: Program,
-  selection: Selections,
+  selection: Selections__old,
   radius: KclCommandValue
 ): { modifiedAst: Program; pathToFilletNode: Array<PathToNode> } | Error {
   const astResult = insertRadiusIntoAst(ast, radius)
@@ -130,7 +130,7 @@ function insertRadiusIntoAst(
 
 export function getPathToExtrudeForSegmentSelection(
   ast: Program,
-  selection: Selections,
+  selection: Selections__old,
   programMemory: ProgramMemory,
   artifactGraph: ArtifactGraph
 ): { pathToSegmentNode: PathToNode; pathToExtrudeNode: PathToNode } | Error {
@@ -447,7 +447,7 @@ export const hasValidFilletSelection = ({
   ast,
   code,
 }: {
-  selectionRanges: Selections
+  selectionRanges: Selections__old
   ast: Program
   code: string
 }) => {

--- a/src/lang/queryAst.ts
+++ b/src/lang/queryAst.ts
@@ -1,5 +1,5 @@
 import { ToolTip } from 'lang/langHelpers'
-import { Selection, Selections } from 'lib/selections'
+import { Selection__old, Selections__old } from 'lib/selections'
 import {
   ArrayExpression,
   BinaryExpression,
@@ -120,7 +120,7 @@ export function getNodeFromPathCurry(
 
 function moreNodePathFromSourceRange(
   node: Expr | ExpressionStatement | VariableDeclaration | ReturnStatement,
-  sourceRange: Selection['range'],
+  sourceRange: Selection__old['range'],
   previousPath: PathToNode = [['body', '']]
 ): PathToNode {
   const [start, end] = sourceRange
@@ -315,7 +315,7 @@ function moreNodePathFromSourceRange(
 
 export function getNodePathFromSourceRange(
   node: Program,
-  sourceRange: Selection['range'],
+  sourceRange: Selection__old['range'],
   previousPath: PathToNode = [['body', '']]
 ): PathToNode {
   const [start, end] = sourceRange || []
@@ -493,7 +493,7 @@ export function findAllPreviousVariablesPath(
 export function findAllPreviousVariables(
   ast: Program,
   programMemory: ProgramMemory,
-  sourceRange: Selection['range'],
+  sourceRange: Selection__old['range'],
   type: 'number' | 'string' = 'number'
 ): {
   variables: PrevVariable<typeof type extends 'number' ? number : string>[]
@@ -639,8 +639,8 @@ export function isValueZero(val?: Expr): boolean {
 export function isLinesParallelAndConstrained(
   ast: Program,
   programMemory: ProgramMemory,
-  primaryLine: Selection,
-  secondaryLine: Selection
+  primaryLine: Selection__old,
+  secondaryLine: Selection__old
 ):
   | {
       isParallelAndConstrained: boolean
@@ -735,7 +735,7 @@ export function doesPipeHaveCallExp({
 }: {
   calleeName: string
   ast: Program
-  selection: Selection
+  selection: Selection__old
 }): boolean {
   const pathToNode = getNodePathFromSourceRange(ast, selection.range)
   const pipeExpressionMeta = getNodeFromPath<PipeExpression>(
@@ -762,7 +762,7 @@ export function hasExtrudeSketchGroup({
   programMemory,
 }: {
   ast: Program
-  selection: Selection
+  selection: Selection__old
   programMemory: ProgramMemory
 }): boolean {
   const pathToNode = getNodePathFromSourceRange(ast, selection.range)
@@ -786,7 +786,7 @@ export function hasExtrudeSketchGroup({
 }
 
 export function isSingleCursorInPipe(
-  selectionRanges: Selections,
+  selectionRanges: Selections__old,
   ast: Program
 ) {
   if (selectionRanges.codeBasedSelections.length !== 1) return false
@@ -860,7 +860,10 @@ export function findUsesOfTagInPipe(
   return dependentRanges
 }
 
-export function hasSketchPipeBeenExtruded(selection: Selection, ast: Program) {
+export function hasSketchPipeBeenExtruded(
+  selection: Selection__old,
+  ast: Program
+) {
   const path = getNodePathFromSourceRange(ast, selection.range)
   const _node = getNodeFromPath<PipeExpression>(ast, path, 'PipeExpression')
   if (err(_node)) return false

--- a/src/lang/std/artifactGraph.ts
+++ b/src/lang/std/artifactGraph.ts
@@ -9,7 +9,7 @@ interface BaseArtifact {
   id: ArtifactId
 }
 
-interface CodeRef {
+export interface CodeRef {
   range: SourceRange
   pathToNode: PathToNode
 }
@@ -774,4 +774,34 @@ export function getSweepFromSuspectedPath(
     { key: path.sweepId, types: ['sweep'] },
     artifactGraph
   )
+}
+
+export function getCodeRefsByArtifactId(
+  id: string,
+  artifactGraph: ArtifactGraph
+): Array<CodeRef> | null {
+  const artifact = artifactGraph.get(id)
+  if (artifact?.type === 'solid2D') {
+    const codeRef = getSolid2dCodeRef(artifact, artifactGraph)
+    if (err(codeRef)) return null
+    return [codeRef]
+    // editorManager.setHighlightRange([codeRef.range])
+  } else if (artifact?.type === 'cap') {
+    const codeRef = getCapCodeRef(artifact, artifactGraph)
+    if (err(codeRef)) return null
+    return [codeRef]
+  } else if (artifact?.type === 'wall') {
+    const extrusion = getSweepFromSuspectedSweepSurface(id, artifactGraph)
+    const codeRef = getWallCodeRef(artifact, artifactGraph)
+    if (err(codeRef)) return null
+    return err(extrusion) ? [codeRef] : [codeRef, extrusion.codeRef]
+  } else if (artifact?.type === 'sweepEdge') {
+    const codeRef = getSweepEdgeCodeRef(artifact, artifactGraph)
+    if (err(codeRef)) return null
+    return [codeRef]
+  } else if (artifact?.type === 'segment') {
+    return [artifact.codeRef]
+  } else {
+    return null
+  }
 }

--- a/src/lang/std/artifactGraph.ts
+++ b/src/lang/std/artifactGraph.ts
@@ -5,86 +5,90 @@ import { err } from 'lib/trap'
 
 export type ArtifactId = string
 
-interface CommonCommandProperties {
+interface BaseArtifact {
+  id: ArtifactId
+}
+
+interface CodeRef {
   range: SourceRange
   pathToNode: PathToNode
 }
 
-export interface PlaneArtifact {
+export interface PlaneArtifact extends BaseArtifact {
   type: 'plane'
   pathIds: Array<ArtifactId>
-  codeRef: CommonCommandProperties
+  codeRef: CodeRef
 }
-export interface PlaneArtifactRich {
+export interface PlaneArtifactRich extends BaseArtifact {
   type: 'plane'
   paths: Array<PathArtifact>
-  codeRef: CommonCommandProperties
+  codeRef: CodeRef
 }
 
-export interface PathArtifact {
+export interface PathArtifact extends BaseArtifact {
   type: 'path'
   planeId: ArtifactId
   segIds: Array<ArtifactId>
   sweepId: ArtifactId
   solid2dId?: ArtifactId
-  codeRef: CommonCommandProperties
+  codeRef: CodeRef
 }
 
-interface solid2D {
+interface solid2D extends BaseArtifact {
   type: 'solid2D'
   pathId: ArtifactId
 }
-export interface PathArtifactRich {
+export interface PathArtifactRich extends BaseArtifact {
   type: 'path'
   plane: PlaneArtifact | WallArtifact
   segments: Array<SegmentArtifact>
   sweep: SweepArtifact
-  codeRef: CommonCommandProperties
+  codeRef: CodeRef
 }
 
-interface SegmentArtifact {
+interface SegmentArtifact extends BaseArtifact {
   type: 'segment'
   pathId: ArtifactId
   surfaceId: ArtifactId
   edgeIds: Array<ArtifactId>
   edgeCutId?: ArtifactId
-  codeRef: CommonCommandProperties
+  codeRef: CodeRef
 }
-interface SegmentArtifactRich {
+interface SegmentArtifactRich extends BaseArtifact {
   type: 'segment'
   path: PathArtifact
   surf: WallArtifact
   edges: Array<SweepEdge>
   edgeCut?: EdgeCut
-  codeRef: CommonCommandProperties
+  codeRef: CodeRef
 }
 
 /** A Sweep is a more generic term for extrude, revolve, loft and sweep*/
-interface SweepArtifact {
+interface SweepArtifact extends BaseArtifact {
   type: 'sweep'
   subType: 'extrusion' | 'revolve'
   pathId: string
   surfaceIds: Array<string>
   edgeIds: Array<string>
-  codeRef: CommonCommandProperties
+  codeRef: CodeRef
 }
-interface SweepArtifactRich {
+interface SweepArtifactRich extends BaseArtifact {
   type: 'sweep'
   subType: 'extrusion' | 'revolve'
   path: PathArtifact
   surfaces: Array<WallArtifact | CapArtifact>
   edges: Array<SweepEdge>
-  codeRef: CommonCommandProperties
+  codeRef: CodeRef
 }
 
-interface WallArtifact {
+interface WallArtifact extends BaseArtifact {
   type: 'wall'
   segId: ArtifactId
   edgeCutEdgeIds: Array<ArtifactId>
   sweepId: ArtifactId
   pathIds: Array<ArtifactId>
 }
-interface CapArtifact {
+interface CapArtifact extends BaseArtifact {
   type: 'cap'
   subType: 'start' | 'end'
   edgeCutEdgeIds: Array<ArtifactId>
@@ -92,7 +96,7 @@ interface CapArtifact {
   pathIds: Array<ArtifactId>
 }
 
-interface SweepEdge {
+interface SweepEdge extends BaseArtifact {
   type: 'sweepEdge'
   segId: ArtifactId
   sweepId: ArtifactId
@@ -100,16 +104,16 @@ interface SweepEdge {
 }
 
 /** A edgeCut is a more generic term for both fillet or chamfer */
-interface EdgeCut {
+interface EdgeCut extends BaseArtifact {
   type: 'edgeCut'
   subType: 'fillet' | 'chamfer'
   consumedEdgeId: ArtifactId
   edgeIds: Array<ArtifactId>
   surfaceId: ArtifactId
-  codeRef: CommonCommandProperties
+  codeRef: CodeRef
 }
 
-interface EdgeCutEdge {
+interface EdgeCutEdge extends BaseArtifact {
   type: 'edgeCutEdge'
   edgeCutId: ArtifactId
   surfaceId: ArtifactId
@@ -258,6 +262,7 @@ export function getArtifactsToUpdate({
           id: currentPlaneId,
           artifact: {
             type: 'wall',
+            id,
             segId: existingPlane.segId,
             edgeCutEdgeIds: existingPlane.edgeCutEdgeIds,
             sweepId: existingPlane.sweepId,
@@ -267,7 +272,10 @@ export function getArtifactsToUpdate({
       ]
     } else {
       return [
-        { id: currentPlaneId, artifact: { type: 'plane', pathIds, codeRef } },
+        {
+          id: currentPlaneId,
+          artifact: { type: 'plane', id: currentPlaneId, pathIds, codeRef },
+        },
       ]
     }
   } else if (cmd.type === 'start_path') {
@@ -275,6 +283,7 @@ export function getArtifactsToUpdate({
       id,
       artifact: {
         type: 'path',
+        id,
         segIds: [],
         planeId: currentPlaneId,
         sweepId: '',
@@ -287,7 +296,7 @@ export function getArtifactsToUpdate({
     if (plane?.type === 'plane') {
       returnArr.push({
         id: currentPlaneId,
-        artifact: { type: 'plane', pathIds: [id], codeRef },
+        artifact: { type: 'plane', id: currentPlaneId, pathIds: [id], codeRef },
       })
     }
     if (plane?.type === 'wall') {
@@ -295,6 +304,7 @@ export function getArtifactsToUpdate({
         id: currentPlaneId,
         artifact: {
           type: 'wall',
+          id,
           segId: plane.segId,
           edgeCutEdgeIds: plane.edgeCutEdgeIds,
           sweepId: plane.sweepId,
@@ -309,6 +319,7 @@ export function getArtifactsToUpdate({
       id,
       artifact: {
         type: 'segment',
+        id,
         pathId,
         surfaceId: '',
         edgeIds: [],
@@ -327,7 +338,11 @@ export function getArtifactsToUpdate({
     ) {
       returnArr.push({
         id: response.data.modeling_response.data.face_id,
-        artifact: { type: 'solid2D', pathId },
+        artifact: {
+          type: 'solid2D',
+          id: response.data.modeling_response.data.face_id,
+          pathId,
+        },
       })
       const path = getArtifact(pathId)
       if (path?.type === 'path')
@@ -347,6 +362,7 @@ export function getArtifactsToUpdate({
       artifact: {
         type: 'sweep',
         subType: subType,
+        id,
         pathId: cmd.target,
         surfaceIds: [],
         edgeIds: [],
@@ -378,6 +394,7 @@ export function getArtifactsToUpdate({
               id: face_id,
               artifact: {
                 type: 'wall',
+                id: face_id,
                 segId: curve_id,
                 edgeCutEdgeIds: [],
                 sweepId: path.sweepId,
@@ -410,6 +427,7 @@ export function getArtifactsToUpdate({
             id: face_id,
             artifact: {
               type: 'cap',
+              id: face_id,
               subType: cap === 'bottom' ? 'start' : 'end',
               edgeCutEdgeIds: [],
               sweepId: path.sweepId,
@@ -456,6 +474,7 @@ export function getArtifactsToUpdate({
         id: response.data.modeling_response.data.edge,
         artifact: {
           type: 'sweepEdge',
+          id: response.data.modeling_response.data.edge,
           subType:
             cmd.type === 'solid3d_get_prev_adjacent_edge'
               ? 'adjacent'
@@ -484,6 +503,7 @@ export function getArtifactsToUpdate({
       id,
       artifact: {
         type: 'edgeCut',
+        id,
         subType: cmd.cut_type,
         consumedEdgeId: cmd.edge_id,
         edgeIds: [],
@@ -574,6 +594,7 @@ export function expandPlane(
   )
   return {
     type: 'plane',
+    id: plane.id,
     paths: Array.from(paths.values()),
     codeRef: plane.codeRef,
   }
@@ -602,6 +623,7 @@ export function expandPath(
   if (err(plane)) return plane
   return {
     type: 'path',
+    id: path.id,
     segments: Array.from(segs.values()),
     sweep,
     plane,
@@ -629,6 +651,7 @@ export function expandSweep(
   return {
     type: 'sweep',
     subType: 'extrusion',
+    id: sweep.id,
     surfaces: Array.from(surfs.values()),
     edges: Array.from(edges.values()),
     path,
@@ -664,6 +687,7 @@ export function expandSegment(
 
   return {
     type: 'segment',
+    id: segment.id,
     path,
     surf,
     edges: Array.from(edges.values()),
@@ -675,7 +699,7 @@ export function expandSegment(
 export function getCapCodeRef(
   cap: CapArtifact,
   artifactGraph: ArtifactGraph
-): CommonCommandProperties | Error {
+): CodeRef | Error {
   const sweep = getArtifactOfTypes(
     { key: cap.sweepId, types: ['sweep'] },
     artifactGraph
@@ -692,7 +716,7 @@ export function getCapCodeRef(
 export function getSolid2dCodeRef(
   solid2D: solid2D,
   artifactGraph: ArtifactGraph
-): CommonCommandProperties | Error {
+): CodeRef | Error {
   const path = getArtifactOfTypes(
     { key: solid2D.pathId, types: ['path'] },
     artifactGraph
@@ -704,7 +728,7 @@ export function getSolid2dCodeRef(
 export function getWallCodeRef(
   wall: WallArtifact,
   artifactGraph: ArtifactGraph
-): CommonCommandProperties | Error {
+): CodeRef | Error {
   const seg = getArtifactOfTypes(
     { key: wall.segId, types: ['segment'] },
     artifactGraph
@@ -716,7 +740,7 @@ export function getWallCodeRef(
 export function getSweepEdgeCodeRef(
   edge: SweepEdge,
   artifactGraph: ArtifactGraph
-): CommonCommandProperties | Error {
+): CodeRef | Error {
   const seg = getArtifactOfTypes(
     { key: edge.segId, types: ['segment'] },
     artifactGraph

--- a/src/lang/std/sketch.ts
+++ b/src/lang/std/sketch.ts
@@ -1917,7 +1917,7 @@ export function getConstraintInfo(
     code,
     pathToNode
   )
-  console.log('result path', result[0].pathToNode)
+  // console.log('result path', result[0].pathToNode)
   return result
 }
 

--- a/src/lang/std/sketch.ts
+++ b/src/lang/std/sketch.ts
@@ -1912,11 +1912,13 @@ export function getConstraintInfo(
 ): ConstrainInfo[] {
   const fnName = callExpression?.callee?.name || ''
   if (!(fnName in sketchLineHelperMap)) return []
-  return sketchLineHelperMap[fnName].getConstraintInfo(
+  const result = sketchLineHelperMap[fnName].getConstraintInfo(
     callExpression,
     code,
     pathToNode
   )
+  console.log('result path', result[0].pathToNode)
+  return result
 }
 
 export function compareVec2Epsilon(

--- a/src/lang/std/sketchConstraints.test.ts
+++ b/src/lang/std/sketchConstraints.test.ts
@@ -11,7 +11,7 @@ import {
   transformAstSketchLines,
 } from './sketchcombos'
 import { getSketchSegmentFromSourceRange } from './sketchConstraints'
-import { Selection } from 'lib/selections'
+import { Selection__old } from 'lib/selections'
 import { enginelessExecutor } from '../../lib/testHelpers'
 import { err } from 'lib/trap'
 
@@ -33,7 +33,7 @@ async function testingSwapSketchFnCall({
   originalRange: [number, number]
 }> {
   const startIndex = inputCode.indexOf(callToSwap)
-  const range: Selection = {
+  const range: Selection__old = {
     type: 'default',
     range: [startIndex, startIndex + callToSwap.length],
   }

--- a/src/lang/std/sketchcombos.test.ts
+++ b/src/lang/std/sketchcombos.test.ts
@@ -9,7 +9,7 @@ import {
   getConstraintLevelFromSourceRange,
 } from './sketchcombos'
 import { ToolTip } from 'lang/langHelpers'
-import { Selections } from 'lib/selections'
+import { Selections__old } from 'lib/selections'
 import { err } from 'lib/trap'
 import { enginelessExecutor } from '../../lib/testHelpers'
 
@@ -87,8 +87,8 @@ function getConstraintTypeFromSourceHelper2(
 }
 
 function makeSelections(
-  codeBaseSelections: Selections['codeBasedSelections']
-): Selections {
+  codeBaseSelections: Selections__old['codeBasedSelections']
+): Selections__old {
   return {
     codeBasedSelections: codeBaseSelections,
     otherSelections: [],
@@ -208,7 +208,7 @@ const part001 = startSketchOn('XY')
     const ast = parse(inputScript)
     if (err(ast)) return Promise.reject(ast)
 
-    const selectionRanges: Selections['codeBasedSelections'] = inputScript
+    const selectionRanges: Selections__old['codeBasedSelections'] = inputScript
       .split('\n')
       .filter((ln) => ln.includes('//'))
       .map((ln) => {
@@ -299,7 +299,7 @@ const part001 = startSketchOn('XY')
     const ast = parse(inputScript)
     if (err(ast)) return Promise.reject(ast)
 
-    const selectionRanges: Selections['codeBasedSelections'] = inputScript
+    const selectionRanges: Selections__old['codeBasedSelections'] = inputScript
       .split('\n')
       .filter((ln) => ln.includes('// select for horizontal constraint'))
       .map((ln) => {
@@ -361,7 +361,7 @@ const part001 = startSketchOn('XY')
     const ast = parse(inputScript)
     if (err(ast)) return Promise.reject(ast)
 
-    const selectionRanges: Selections['codeBasedSelections'] = inputScript
+    const selectionRanges: Selections__old['codeBasedSelections'] = inputScript
       .split('\n')
       .filter((ln) => ln.includes('// select for vertical constraint'))
       .map((ln) => {
@@ -434,7 +434,7 @@ const part001 = startSketchOn('XY')
        segEndY(seg01) + 2.93
      ], %) // xRelative`)
     })
-    it('testing for yRelative to horizontal distance', async () => {
+    it.only('testing for yRelative to horizontal distance', async () => {
       const expectedCode = await helperThing(
         inputScript,
         ['// base selection', '// yRelative'],
@@ -456,7 +456,7 @@ async function helperThing(
   const ast = parse(inputScript)
   if (err(ast)) return Promise.reject(ast)
 
-  const selectionRanges: Selections['codeBasedSelections'] = inputScript
+  const selectionRanges: Selections__old['codeBasedSelections'] = inputScript
     .split('\n')
     .filter((ln) =>
       linesOfInterest.some((lineOfInterest) => ln.includes(lineOfInterest))

--- a/src/lang/std/sketchcombos.ts
+++ b/src/lang/std/sketchcombos.ts
@@ -7,7 +7,7 @@ import {
   TransformInfo,
 } from './stdTypes'
 import { ToolTip, toolTips } from 'lang/langHelpers'
-import { Selections, Selection } from 'lib/selections'
+import { Selections__old, Selection__old } from 'lib/selections'
 import { cleanErrs, err } from 'lib/trap'
 import {
   CallExpression,
@@ -1470,7 +1470,7 @@ export function getConstraintType(
 }
 
 export function getTransformInfos(
-  selectionRanges: Selections,
+  selectionRanges: Selections__old,
   ast: Program,
   constraintType: ConstraintType
 ): TransformInfo[] {
@@ -1502,7 +1502,7 @@ export function getTransformInfos(
 }
 
 export function getRemoveConstraintsTransforms(
-  selectionRanges: Selections,
+  selectionRanges: Selections__old,
   ast: Program,
   constraintType: ConstraintType
 ): TransformInfo[] | Error {
@@ -1542,7 +1542,7 @@ export function transformSecondarySketchLinesTagFirst({
   forceValueUsedInTransform,
 }: {
   ast: Program
-  selectionRanges: Selections
+  selectionRanges: Selections__old
   transformInfos: TransformInfo[]
   programMemory: ProgramMemory
   forceSegName?: string
@@ -1613,12 +1613,12 @@ export function transformAstSketchLines({
   referencedSegmentRange,
 }: {
   ast: Program
-  selectionRanges: Selections | PathToNode[]
+  selectionRanges: Selections__old | PathToNode[]
   transformInfos: TransformInfo[]
   programMemory: ProgramMemory
   referenceSegName: string
+  referencedSegmentRange?: Selection__old['range']
   forceValueUsedInTransform?: BinaryPart
-  referencedSegmentRange?: Selection['range']
 }):
   | {
       modifiedAst: Program
@@ -1658,6 +1658,7 @@ export function transformAstSketchLines({
       ''
     const inputs: InputArgs = []
 
+    console.log('getConstraintInfo', callExp.node, _pathToNode)
     getConstraintInfo(callExp.node, '', _pathToNode).forEach((a) => {
       if (
         a.type === 'tangentialWithPrevious' ||
@@ -1822,7 +1823,7 @@ function getArgLiteralVal(arg: Literal): number | Error {
 export type ConstraintLevel = 'free' | 'partial' | 'full'
 
 export function getConstraintLevelFromSourceRange(
-  cursorRange: Selection['range'],
+  cursorRange: Selection__old['range'],
   ast: Program | Error
 ): Error | { range: [number, number]; level: ConstraintLevel } {
   if (err(ast)) return ast

--- a/src/lang/util.ts
+++ b/src/lang/util.ts
@@ -1,4 +1,4 @@
-import { Selections } from 'lib/selections'
+import { Selections__old } from 'lib/selections'
 import { Program, PathToNode } from './wasm'
 import { getNodeFromPath } from './queryAst'
 import { ArtifactGraph, filterArtifacts } from 'lang/std/artifactGraph'
@@ -7,10 +7,10 @@ import { err } from 'lib/trap'
 
 export function pathMapToSelections(
   ast: Program,
-  prevSelections: Selections,
+  prevSelections: Selections__old,
   pathToNodeMap: { [key: number]: PathToNode }
-): Selections {
-  const newSelections: Selections = {
+): Selections__old {
+  const newSelections: Selections__old = {
     ...prevSelections,
     codeBasedSelections: [],
   }
@@ -47,7 +47,7 @@ export function updatePathToNodeFromMap(
 
 export function isCursorInSketchCommandRange(
   artifactGraph: ArtifactGraph,
-  selectionRanges: Selections
+  selectionRanges: Selections__old
 ): string | false {
   const overlappingEntries = filterArtifacts(
     {

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -2,7 +2,7 @@ import { Models } from '@kittycad/lib'
 import { StateMachineCommandSetConfig, KclCommandValue } from 'lib/commandTypes'
 import { KCL_DEFAULT_LENGTH, KCL_DEFAULT_DEGREE } from 'lib/constants'
 import { components } from 'lib/machine-api'
-import { Selections } from 'lib/selections'
+import { Selections__old } from 'lib/selections'
 import { machineManager } from 'lib/machineManager'
 import { modelingMachine, SketchTool } from 'machines/modelingMachine'
 
@@ -28,17 +28,17 @@ export type ModelingCommandSchema = {
     machine: components['schemas']['MachineInfoResponse']
   }
   Extrude: {
-    selection: Selections // & { type: 'face' } would be cool to lock that down
+    selection: Selections__old // & { type: 'face' } would be cool to lock that down
     // result: (typeof EXTRUSION_RESULTS)[number]
     distance: KclCommandValue
   }
   Revolve: {
-    selection: Selections
+    selection: Selections__old
     angle: KclCommandValue
   }
   Fillet: {
     // todo
-    selection: Selections
+    selection: Selections__old
     radius: KclCommandValue
   }
   'change tool': {

--- a/src/lib/commandTypes.ts
+++ b/src/lib/commandTypes.ts
@@ -1,7 +1,7 @@
 import { CustomIconName } from 'components/CustomIcon'
 import { AllMachines } from 'hooks/useStateMachineCommands'
 import { Actor, AnyStateMachine, ContextFrom, EventFrom } from 'xstate'
-import { Selection } from './selections'
+import { Selection__old } from './selections'
 import { Identifier, Expr, VariableDeclaration } from 'lang/wasm'
 import { commandBarMachine } from 'machines/commandBarMachine'
 import { ReactNode } from 'react'
@@ -140,7 +140,7 @@ export type CommandArgumentConfig<
     }
   | {
       inputType: 'selection'
-      selectionTypes: Selection['type'][]
+      selectionTypes: Selection__old['type'][]
       multiple: boolean
     }
   | { inputType: 'kcl'; defaultValue?: string } // KCL expression inputs have simple strings as default values
@@ -213,7 +213,7 @@ export type CommandArgument<
     }
   | {
       inputType: 'selection'
-      selectionTypes: Selection['type'][]
+      selectionTypes: Selection__old['type'][]
       multiple: boolean
     }
   | { inputType: 'kcl'; defaultValue?: string } // KCL expression inputs have simple strings as default value

--- a/src/lib/useCalculateKclExpression.ts
+++ b/src/lib/useCalculateKclExpression.ts
@@ -7,6 +7,7 @@ import { ProgramMemory, Expr, parse } from 'lang/wasm'
 import { useEffect, useRef, useState } from 'react'
 import { executeAst } from 'lang/langHelpers'
 import { err, trap } from 'lib/trap'
+import { convertSelectionsToOld } from './selections'
 
 const isValidVariableName = (name: string) =>
   /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)
@@ -34,9 +35,10 @@ export function useCalculateKclExpression({
 } {
   const { programMemory, code } = useKclContext()
   const { context } = useModelingContext()
+  const selectionOld = convertSelectionsToOld(context.selectionRanges)
   const selectionRange:
-    | (typeof context.selectionRanges.codeBasedSelections)[number]['range']
-    | undefined = context.selectionRanges.codeBasedSelections[0]?.range
+    | (typeof selectionOld.codeBasedSelections)[number]['range']
+    | undefined = selectionOld.codeBasedSelections[0]?.range
   const inputRef = useRef<HTMLInputElement>(null)
   const [availableVarInfo, setAvailableVarInfo] = useState<
     ReturnType<typeof findAllPreviousVariables>

--- a/src/lib/usePreviousVariables.ts
+++ b/src/lib/usePreviousVariables.ts
@@ -3,12 +3,13 @@ import { kclManager } from 'lib/singletons'
 import { useKclContext } from 'lang/KclProvider'
 import { findAllPreviousVariables } from 'lang/queryAst'
 import { useEffect, useState } from 'react'
+import { convertSelectionsToOld } from './selections'
 
 export function usePreviousVariables() {
   const { programMemory, code } = useKclContext()
   const { context } = useModelingContext()
-  const selectionRange = context.selectionRanges.codeBasedSelections[0]
-    ?.range || [code.length, code.length]
+  const selectionRange = convertSelectionsToOld(context.selectionRanges)
+    .codeBasedSelections[0]?.range || [code.length, code.length]
   const [previousVariablesInfo, setPreviousVariablesInfo] = useState<
     ReturnType<typeof findAllPreviousVariables>
   >({

--- a/src/machines/commandBarMachine.ts
+++ b/src/machines/commandBarMachine.ts
@@ -5,14 +5,14 @@ import {
   CommandArgumentWithName,
   KclCommandValue,
 } from 'lib/commandTypes'
-import { Selections } from 'lib/selections'
+import { Selections__old } from 'lib/selections'
 import { getCommandArgumentKclValuesOnly } from 'lib/commandUtils'
 
 export type CommandBarContext = {
   commands: Command[]
   selectedCommand?: Command
   currentArgument?: CommandArgument<unknown> & { name: string }
-  selectionRanges: Selections
+  selectionRanges: Selections__old
   argumentsToSubmit: { [x: string]: unknown }
 }
 

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -5,7 +5,12 @@ import {
   parse,
   recast,
 } from 'lang/wasm'
-import { Axis, Selection, Selections, updateSelections } from 'lib/selections'
+import {
+  Axis,
+  Selection__old,
+  Selections__old,
+  updateSelections,
+} from 'lib/selections'
 import { assign, fromPromise, setup } from 'xstate'
 import { SidebarType } from 'components/ModelingSidebar/ModelingPanes'
 import {
@@ -70,7 +75,7 @@ export const MODELING_PERSIST_KEY = 'MODELING_PERSIST_KEY'
 export type SetSelections =
   | {
       selectionType: 'singleCodeCursor'
-      selection?: Selection
+      selection?: Selection__old
     }
   | {
       selectionType: 'otherSelection'
@@ -78,12 +83,12 @@ export type SetSelections =
     }
   | {
       selectionType: 'completeSelection'
-      selection: Selections
+      selection: Selections__old
       updatedPathToNode?: PathToNode
     }
   | {
       selectionType: 'mirrorCodeMirrorSelections'
-      selection: Selections
+      selection: Selections__old
     }
 
 export type MouseState =
@@ -283,7 +288,7 @@ export interface ModelingMachineContext {
   currentMode: ToolbarModeName
   currentTool: SketchTool
   selection: string[]
-  selectionRanges: Selections
+  selectionRanges: Selections__old
   sketchDetails: SketchDetails | null
   sketchPlaneId: string
   sketchEnginePathId: string


### PR DESCRIPTION
Makes a start on https://github.com/KittyCAD/modeling-app/issues/3837

The main changes in this PR is the new types in [selecitons.ts](https://github.com/KittyCAD/modeling-app/pull/3836/files#diff-cbfdb1c1f91506eba7d5317cd631d1ce31769080940fa9d5d525940c0c708132) but because existing types were renamed the diff effects a lot of files.
Also @jtran had mentioned previously that we should add id as a property to artifacts so that was done in https://github.com/KittyCAD/modeling-app/pull/3836/files#diff-e5df7b9a5553b8d6e0ff1032a824829c2dc3880b9f986a52b5c545de19b21ec4 as it will be needed if selections are `Artifact[]`, alternatively we could make selections `ArtifatId[] // string[]` instead so the we still have access to the original id, but `Artifact[]` seems good since the having to pass around the `Artifact` and it id separately is a PITA.