### PR TITLE
Remove ill-advised CSS added during #3794

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -50,14 +50,6 @@ body.dark {
   @apply text-chalkboard-10;
 }
 
-@media (prefers-color-scheme: dark) {
-  body,
-  .body-bg,
-  .dark .body-bg {
-    @apply bg-chalkboard-100;
-  }
-}
-
 select {
   @apply bg-chalkboard-20;
 }


### PR DESCRIPTION
Reverts part of #3794 which was ultimately unnecessary and caused regressions in theme application when the OS theme and the app/project theme were opposites.

The "flash" on window open problem was fixed in that PR without these lines, which you can verify by testing the electron app and noting that the window still matches the OS theme even with them removed.

However, with these lines removed you will no longer experience the strange half-application of the theme present before.