### PR TITLE
Bugfix: update sketch mode colors on theme change

### DIFF
--- a/src/clientSideScene/sceneEntities.ts
+++ b/src/clientSideScene/sceneEntities.ts
@@ -1483,9 +1483,11 @@ export class SceneEntities {
     Object.values(this.activeSegments).forEach((group) => {
       group.userData.baseColor = newColorThreeJs
       group.traverse((child) => {
-        if (child instanceof Mesh) {
-          const mat = child.material as MeshBasicMaterial
-          mat.color.set(newColorThreeJs)
+        if (
+          child instanceof Mesh &&
+          child.material instanceof MeshBasicMaterial
+        ) {
+          child.material.color.set(newColorThreeJs)
         }
       })
     })

--- a/src/clientSideScene/sceneEntities.ts
+++ b/src/clientSideScene/sceneEntities.ts
@@ -102,7 +102,7 @@ import {
   getRectangleCallExpressions,
   updateRectangleSketch,
 } from 'lib/rectangleTool'
-import { getThemeColorForThreeJs } from 'lib/theme'
+import { getThemeColorForThreeJs, Themes } from 'lib/theme'
 import { err, reportRejection, trap } from 'lib/trap'
 import { CSS2DObject } from 'three/examples/jsm/renderers/CSS2DRenderer'
 import { Point3d } from 'wasm-lib/kcl/bindings/Point3d'
@@ -1472,6 +1472,23 @@ export class SceneEntities {
         from,
         to,
       })
+  }
+  /**
+   * Update the base color of each of the THREEjs meshes
+   * that represent each of the sketch segments, to get the
+   * latest value from `sceneInfra._theme`
+   */
+  updateSegmentBaseColor(newColor: Themes.Light | Themes.Dark) {
+    const newColorThreeJs = getThemeColorForThreeJs(newColor)
+    Object.values(this.activeSegments).forEach((group) => {
+      group.userData.baseColor = newColorThreeJs
+      group.traverse((child) => {
+        if (child instanceof Mesh) {
+          const mat = child.material as MeshBasicMaterial
+          mat.color.set(newColorThreeJs)
+        }
+      })
+    })
   }
   removeSketchGrid() {
     if (this.axisGroup) this.scene.remove(this.axisGroup)

--- a/src/components/SettingsAuthProvider.tsx
+++ b/src/components/SettingsAuthProvider.tsx
@@ -17,7 +17,12 @@ import decamelize from 'decamelize'
 import { Actor, AnyStateMachine, ContextFrom, Prop, StateFrom } from 'xstate'
 import { isDesktop } from 'lib/isDesktop'
 import { authCommandBarConfig } from 'lib/commandBarConfigs/authCommandConfig'
-import { kclManager, sceneInfra, engineCommandManager } from 'lib/singletons'
+import {
+  kclManager,
+  sceneInfra,
+  engineCommandManager,
+  sceneEntitiesManager,
+} from 'lib/singletons'
 import { uuidv4 } from 'lib/utils'
 import { IndexLoaderData } from 'lib/types'
 import { settings } from 'lib/settings/initialSettings'
@@ -137,6 +142,7 @@ export const SettingsAuthProviderBase = ({
         setClientTheme: ({ context }) => {
           const opposingTheme = getOppositeTheme(context.app.theme.current)
           sceneInfra.theme = opposingTheme
+          sceneEntitiesManager.updateSegmentBaseColor(opposingTheme)
         },
         setEngineEdges: ({ context }) => {
           // eslint-disable-next-line @typescript-eslint/no-floating-promises


### PR DESCRIPTION
Fixes #2564. We were calling something that attempted to update the client-side scene's colors, but upon investigation it wasn't doing so properly or thoroughly. This ensures it does so, and adds an E2E test to verify it.