### PR TITLE
Remove double upload workaround for 0.25.1 release

### DIFF
--- a/.github/workflows/build-test-publish-apps.yml
+++ b/.github/workflows/build-test-publish-apps.yml
@@ -245,15 +245,6 @@ jobs:
           parent: false
           destination: ${{ env.BUCKET_DIR }}
 
-      # TODO: remove workaround introduced in https://github.com/KittyCAD/modeling-app/issues/3817
-      - name: Upload release files to public bucket (test/electron-builder workaround)
-        uses: google-github-actions/upload-cloud-storage@v2.2.0
-        with:
-          path: out
-          glob: 'Zoo*'
-          parent: false
-          destination: '${{ env.BUCKET_DIR }}/test/electron-builder'
-
       - name: Upload update endpoint to public bucket
         uses: google-github-actions/upload-cloud-storage@v2.2.0
         with:
@@ -261,15 +252,6 @@ jobs:
           glob: 'latest*'
           parent: false
           destination: ${{ env.BUCKET_DIR }}
-
-      # TODO: remove workaround introduced in https://github.com/KittyCAD/modeling-app/issues/3817
-      - name: Upload update endpoint to public bucket (test/electron-builder workaround)
-        uses: google-github-actions/upload-cloud-storage@v2.2.0
-        with:
-          path: out
-          glob: 'latest*'
-          parent: false
-          destination: '${{ env.BUCKET_DIR }}/test/electron-builder'
 
       - name: Upload download endpoint to public bucket
         uses: google-github-actions/upload-cloud-storage@v2.2.0


### PR DESCRIPTION
Closes #3817 (last PR). v0.25.1 is pointing to the standard location in the bucket, ahead of the next release.