### PR TITLE
Add updater-test back after electron migration

### DIFF
--- a/.github/workflows/build-test-publish-apps.yml
+++ b/.github/workflows/build-test-publish-apps.yml
@@ -13,7 +13,7 @@ on:
   # Will checkout the last commit from the default branch (main as of 2023-10-04)
 
 env:
-  CUT_RELEASE_PR: true
+  CUT_RELEASE_PR: false
   BUILD_RELEASE: true
 
 concurrency:
@@ -186,15 +186,15 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: write
-    if: ${{ github.event_name == 'release' || github.event_name == 'schedule' }}
+    # if: ${{ github.event_name == 'release' || github.event_name == 'schedule' }}
     needs: [prepare-files, build-apps]
     env:
       VERSION_NO_V: ${{ needs.prepare-files.outputs.version }}
       VERSION: ${{ github.event_name == 'schedule' && needs.prepare-files.outputs.version || format('v{0}', needs.prepare-files.outputs.version) }}
       PUB_DATE: ${{ github.event_name == 'release' && github.event.release.created_at || github.event.repository.updated_at }}
-      NOTES: ${{ github.event_name == 'release' && github.event.release.body || format('Non-release build, commit {0}', github.sha) }}
-      BUCKET_DIR: ${{ github.event_name == 'schedule' && 'dl.kittycad.io/releases/modeling-app/nightly' || 'dl.kittycad.io/releases/modeling-app' }}
-      WEBSITE_DIR: ${{ github.event_name == 'schedule' && 'dl.zoo.dev/releases/modeling-app/nightly' || 'dl.zoo.dev/releases/modeling-app' }}
+      NOTES: ${{ github.event_name == 'release' && github.event.release.body || format('Updater test build, commit {0}', github.sha) }}
+      BUCKET_DIR: ${{ github.event_name == 'schedule' && 'dl.kittycad.io/releases/modeling-app/nightly' || 'dl.kittycad.io/releases/modeling-app/updater-test' }}
+      WEBSITE_DIR: ${{ github.event_name == 'schedule' && 'dl.zoo.dev/releases/modeling-app/nightly' || 'dl.zoo.dev/releases/modeling-app/updater-test' }}
       URL_CODED_NAME: ${{ github.event_name == 'schedule' && 'Zoo%20Modeling%20App%20%28Nightly%29' || 'Zoo%20Modeling%20App' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-test-publish-apps.yml
+++ b/.github/workflows/build-test-publish-apps.yml
@@ -53,6 +53,16 @@ jobs:
 
       # TODO: see if we need to inject updater nightly URL here https://dl.zoo.dev/releases/modeling-app/nightly/last_update.json
 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: prepared-files
+          path: |
+            package.json
+            src/wasm-lib/pkg/wasm_lib*
+
+      - id: export_version
+        run: echo "version=`cat package.json | jq -r '.version'`" >> "$GITHUB_OUTPUT"
+
       - name: Prepare electron-builder.yml file for updater test
         if: ${{ env.CUT_RELEASE_PR == 'true' }}
         run: |
@@ -60,14 +70,9 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: prepared-files
+          name: prepared-files-updater-test
           path: |
-            package.json
-            src/wasm-lib/pkg/wasm_lib*
             electron-builder.yml
-
-      - id: export_version
-        run: echo "version=`cat package.json | jq -r '.version'`" >> "$GITHUB_OUTPUT"
 
 
   build-apps:
@@ -154,11 +159,15 @@ jobs:
 
       # TODO: add the 'Build for Mac TestFlight (nightly)' stage back
 
+      - uses: actions/download-artifact@v3
+        if: ${{ env.CUT_RELEASE_PR == 'true' }}
+        name: prepared-files-updater-test
+
       - name: Copy updated electron-builder.yml file for updater test
         if: ${{ env.CUT_RELEASE_PR == 'true' }}
         run: |
-          ls -R prepared-files
-          cp prepared-files/electron-builder.yml electron-builder.yml
+          ls -R prepared-files-updater-test
+          cp prepared-files-updater-test/electron-builder.yml electron-builder.yml
 
       - name: Build the app (updater-test)
         if: ${{ env.CUT_RELEASE_PR == 'true' }}

--- a/.github/workflows/build-test-publish-apps.yml
+++ b/.github/workflows/build-test-publish-apps.yml
@@ -13,8 +13,8 @@ on:
   # Will checkout the last commit from the default branch (main as of 2023-10-04)
 
 env:
-  CUT_RELEASE_PR: true
-  BUILD_RELEASE: true
+  CUT_RELEASE_PR: ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.title, 'Cut release v')) }}
+  BUILD_RELEASE: ${{ github.event_name == 'release' || github.event_name == 'schedule' || github.event_name == 'pull_request' && (contains(github.event.pull_request.title, 'Cut release v')) }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/build-test-publish-apps.yml
+++ b/.github/workflows/build-test-publish-apps.yml
@@ -13,7 +13,7 @@ on:
   # Will checkout the last commit from the default branch (main as of 2023-10-04)
 
 env:
-  CUT_RELEASE_PR: false
+  CUT_RELEASE_PR: true
   BUILD_RELEASE: true
 
 concurrency:
@@ -186,15 +186,15 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: write
-    # if: ${{ github.event_name == 'release' || github.event_name == 'schedule' }}
+    if: ${{ github.event_name == 'release' || github.event_name == 'schedule' }}
     needs: [prepare-files, build-apps]
     env:
       VERSION_NO_V: ${{ needs.prepare-files.outputs.version }}
       VERSION: ${{ github.event_name == 'schedule' && needs.prepare-files.outputs.version || format('v{0}', needs.prepare-files.outputs.version) }}
       PUB_DATE: ${{ github.event_name == 'release' && github.event.release.created_at || github.event.repository.updated_at }}
-      NOTES: ${{ github.event_name == 'release' && github.event.release.body || format('Updater test build, commit {0}', github.sha) }}
-      BUCKET_DIR: ${{ github.event_name == 'schedule' && 'dl.kittycad.io/releases/modeling-app/nightly' || 'dl.kittycad.io/releases/modeling-app/updater-test' }}
-      WEBSITE_DIR: ${{ github.event_name == 'schedule' && 'dl.zoo.dev/releases/modeling-app/nightly' || 'dl.zoo.dev/releases/modeling-app/updater-test' }}
+      NOTES: ${{ github.event_name == 'release' && github.event.release.body || format('Non-release build, commit {0}', github.sha) }}
+      BUCKET_DIR: ${{ github.event_name == 'schedule' && 'dl.kittycad.io/releases/modeling-app/nightly' || 'dl.kittycad.io/releases/modeling-app' }}
+      WEBSITE_DIR: ${{ github.event_name == 'schedule' && 'dl.zoo.dev/releases/modeling-app/nightly' || 'dl.zoo.dev/releases/modeling-app' }}
       URL_CODED_NAME: ${{ github.event_name == 'schedule' && 'Zoo%20Modeling%20App%20%28Nightly%29' || 'Zoo%20Modeling%20App' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-test-publish-apps.yml
+++ b/.github/workflows/build-test-publish-apps.yml
@@ -13,8 +13,8 @@ on:
   # Will checkout the last commit from the default branch (main as of 2023-10-04)
 
 env:
-  CUT_RELEASE_PR: ${{ github.event_name == 'pull_request' && (contains(github.event.pull_request.title, 'Cut release v')) }}
-  BUILD_RELEASE: ${{ github.event_name == 'release' || github.event_name == 'schedule' || github.event_name == 'pull_request' && (contains(github.event.pull_request.title, 'Cut release v')) }}
+  CUT_RELEASE_PR: true
+  BUILD_RELEASE: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -52,7 +52,11 @@ jobs:
           VERSION=$(date +'%-y.%-m.%-d') yarn bump-jsons
 
       # TODO: see if we need to inject updater nightly URL here https://dl.zoo.dev/releases/modeling-app/nightly/last_update.json
-      # TODO: see if we ned to add updater test URL here https://dl.zoo.dev/releases/modeling-app/updater-test/last_update.json
+
+      - name: Prepare electron-builder.yml file for updater test
+        if: ${{ env.CUT_RELEASE_PR == 'true' }}
+        run: |
+          yq -i '.publish[0].url = "https://dl.zoo.dev/releases/modeling-app/updater-test"' electron-builder.yml
 
       - uses: actions/upload-artifact@v3
         with:
@@ -60,6 +64,7 @@ jobs:
           path: |
             package.json
             src/wasm-lib/pkg/wasm_lib*
+            electron-builder.yml
 
       - id: export_version
         run: echo "version=`cat package.json | jq -r '.version'`" >> "$GITHUB_OUTPUT"
@@ -149,7 +154,23 @@ jobs:
 
       # TODO: add the 'Build for Mac TestFlight (nightly)' stage back
 
-      # TODO: add the updater tests back
+      - name: Copy updated electron-builder.yml file for updater test
+        if: ${{ env.CUT_RELEASE_PR == 'true' }}
+        run: |
+          ls -R prepared-files
+          cp prepared-files/electron-builder.yml electron-builder.yml
+
+      - name: Build the app (updater-test)
+        if: ${{ env.CUT_RELEASE_PR == 'true' }}
+        run: yarn electron-builder --config ${{ env.BUILD_RELEASE && '--publish always' || '' }}
+
+      - uses: actions/upload-artifact@v3
+        if: ${{ env.CUT_RELEASE_PR == 'true' }}
+        with:
+          name: updater-test-${{ matrix.os }}
+          path: |
+            out/Zoo*.*
+            out/latest*.yml
 
 
   publish-apps-release:

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,12 +1,9 @@
 appId: dev.zoo.modeling-app
-
 directories:
   output: out
   buildResources: assets
-
 files:
   - .vite/**
-
 mac:
   category: public.app-category.developer-tools
   artifactName: "${productName}-${version}-${arch}-${os}.${ext}"
@@ -28,7 +25,6 @@ mac:
       description: Zoo KCL File
       role: Editor
       rank: Owner
-
 win:
   artifactName: "${productName}-${version}-${arch}-${os}.${ext}"
   target:
@@ -43,7 +39,7 @@ win:
   signingHashAlgorithms:
     - sha256
   sign: "./sign-win.js"
-  publisherName: "KittyCAD Inc"  # needs to be exactly like on Digicert
+  publisherName: "KittyCAD Inc" # needs to be exactly like on Digicert
   icon: "assets/icon.ico"
   fileAssociations:
     - ext: kcl
@@ -51,18 +47,15 @@ win:
       mimeType: text/vnd.zoo.kcl
       description: Zoo KCL File
       role: Editor
-
 msi:
   oneClick: false
   perMachine: true
-
 nsis:
   oneClick: false
   perMachine: true
   allowElevation: true
   installerIcon: "assets/icon.ico"
   include: "./installer.nsh"
-
 linux:
   artifactName: "${productName}-${version}-${arch}-${os}.${ext}"
   target:
@@ -76,7 +69,6 @@ linux:
       mimeType: text/vnd.zoo.kcl
       description: Zoo KCL File
       role: Editor
-
 publish:
   - provider: generic
     url: https://dl.zoo.dev/releases/modeling-app

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zoo-modeling-app",
-  "version": "0.999.999",
+  "version": "0.255.255",
   "private": true,
   "productName": "Zoo Modeling App",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zoo-modeling-app",
-  "version": "0.25.1",
+  "version": "0.999.999",
   "private": true,
   "productName": "Zoo Modeling App",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zoo-modeling-app",
-  "version": "0.255.255",
+  "version": "0.25.1",
   "private": true,
   "productName": "Zoo Modeling App",
   "author": {


### PR DESCRIPTION
Fixes #3871

Process: on a Cut release PR, go to Checks > build-publish-apps and scroll at the bottom to get the special updater-test artifacts. These points to an updater-test bucket that contains a 0.255.255 version and should always trigger an auto update on all three platforms