### PR TITLE
Fix canExtrudeSelectionItem and getSelectionType for multiple selections

### DIFF
--- a/src/lib/selections.ts
+++ b/src/lib/selections.ts
@@ -433,10 +433,14 @@ export function canFilletSelection(selection: Selections) {
 }
 
 function canExtrudeSelectionItem(selection: Selections, i: number) {
+  const isolatedSelection = {
+    ...selection,
+    codeBasedSelections: [selection.codeBasedSelections[i]],
+  }
   const commonNode = buildCommonNodeFromSelection(selection, i)
 
   return (
-    !!isSketchPipe(selection) &&
+    !!isSketchPipe(isolatedSelection) &&
     nodeHasClose(commonNode) &&
     !nodeHasExtrude(commonNode)
   )

--- a/src/lib/selections.ts
+++ b/src/lib/selections.ts
@@ -459,25 +459,17 @@ export type ResolvedSelectionType = [Selection['type'] | 'other', number]
 export function getSelectionType(
   selection: Selections
 ): ResolvedSelectionType[] {
-  return selection.codeBasedSelections
-    .map((s, i) => {
-      if (canExtrudeSelectionItem(selection, i)) {
-        return ['extrude-wall', 1] as ResolvedSelectionType // This is implicitly determining what a face is, which is bad
-      } else {
-        return ['other', 1] as ResolvedSelectionType
-      }
-    })
-    .reduce((acc, [type, count]) => {
-      const foundIndex = acc.findIndex((item) => item && item[0] === type)
+  const extrudableCount = selection.codeBasedSelections.filter((_, i) => {
+    const singleSelection = {
+      ...selection,
+      codeBasedSelections: [selection.codeBasedSelections[i]],
+    }
+    return canExtrudeSelectionItem(singleSelection, 0)
+  }).length
 
-      if (foundIndex === -1) {
-        return [...acc, [type, count]]
-      } else {
-        const temp = [...acc]
-        temp[foundIndex][1] += count
-        return temp
-      }
-    }, [] as ResolvedSelectionType[])
+  return extrudableCount === selection.codeBasedSelections.length
+    ? [['extrude-wall', extrudableCount]]
+    : [['other', selection.codeBasedSelections.length]]
 }
 
 export function getSelectionTypeDisplayText(


### PR DESCRIPTION
This pr closes: #3834
It is a part of bigger project: #2606

## PR Description:
This PR addresses and fixes two key issues within the selection logic in the `canExtrudeSelectionItem` and `getSelectionType` functions. The previous implementation had limitations when handling multiple selections, resulting in incorrect selection typing and behavior for mixed sets of selections:

**Example:**
it would return: `['extrude-wall', 1]` for a selection of single edge, which is correct
but for 2 edges it would return `['other', 2]`, which is incorrect and expected to be `['extrude-wall', 2]`

**Data Flow:**
1. `getSelectionType` uses `canExtrudeSelectionItem` to determine whether a selection is an `extrude-wall` or not, and passes the whole `selection` with all currently selected ranges stored in the `selection.codeBasedSelections` array and the `index` of the item that shall be checked.
2. `canExtrudeSelectionItem` performs a triple check of the selected item with: `isSketchPipe`, `nodeHasClose`, and `nodeHasExtrude`. 
3. `isSketchPipe` does not have an `index` argument, only `selection`. It checks the selection with `isSingleCursorInPipe` and always returns `false` in the case of multiple selections. It has to be fixed.


## Key Changes:
1. **Fixed `canExtrudeSelectionItem`:**
   - The issue arose due to the function calling `isSketchPipe`, which is only capable of handling single selections.
   - The solution was to isolate each selection when calling `isSketchPipe`, ensuring it works correctly for each item in the selection list. This fix allows `canExtrudeSelectionItem` to return the correct result for each selection, even in cases where multiple selections are made.

2. **Improved `getSelectionType`:**
   - Previously, the function only compared subsequent selections to the first one. If the first selection was of type `other`, any subsequent `extrude-wall` types would be ignored, and vice versa.
   - The fix ensures that all selections are evaluated before determining the final type. If all selections are extrudable, the result is `extrude-wall`. If there’s any non-extrudable selection, the type defaults to `other`, accurately reflecting the mixed nature of the selection set.

These changes ensure the selection logic works as expected for both single and multiple selections.

### Other Findings:
1. Generalization: Currently, everything is marked as an `extrude-wall`, including not-extruded sketches, faces, and edges. Since it does not block me from multiple fillets and will be addressed in the PR mentioned above by @Irev-Dev - I am ignoring it.
2. `nodeHasExtrude`: Returns `true` even if an extrude does not exist. Shall I fix it in a separate PR ?

### Next steps:
I am 1 step away from the multiple fillets working, only one thing left to address is:
```
const updatedAst = await kclManager.updateAst(modifiedAst, true, {
    focusPath: pathToFilletNode,
  })
```
commenting out the `focusPath` works:
<img width="696" alt="Screenshot 2024-09-14 at 19 36 34" src="https://github.com/user-attachments/assets/d6ca0e02-6eca-4558-86c9-7a54f90acdee">

<img width="563" alt="Screenshot 2024-09-14 at 19 36 11" src="https://github.com/user-attachments/assets/30f22593-13cc-4561-b3ca-1ef912216538">


