### PR TITLE
Nadro/3079/screenshot improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,13 +337,47 @@ For individual testing:
 yarn test abstractSyntaxTree -t "unexpected closed curly brace" --silent=false
 ```
 
-Which will run our suite of [Vitest unit](https://vitest.dev/) and [React Testing Library E2E](https://testing-library.com/docs/react-testing-library/intro/) tests, in interactive mode by default.
+Which will run our suite of [Vitest unit](https://vitest.dev/) and [React Testing Library E2E](https://testing-library.com/docs/react-testing-library/intro/** tests, in interactive mode by default.
 
 ### Rust tests
 
-```bash
+**Dependencies**
+
+- `KITTYCAD_API_TOKEN`
+- `cargo-nextest`
+- `just`
+
+#### Setting KITTYCAD_API_TOKEN
+Use the production zoo.dev token, set this environment variable before running the tests
+
+#### Installing cargonextest
+
+```
 cd src/wasm-lib
-KITTYCAD_API_TOKEN=XXX cargo test -- --test-threads=1
+cargo search cargo-nextest
+cargo install cargo-nextest
+```
+
+#### just
+install [`just`](https://github.com/casey/just?tab=readme-ov-file#pre-built-binaries)
+
+#### Running the tests
+
+```bash
+# With just
+# Make sure KITTYCAD_API_TOKEN=<prod zoo.dev token> is set
+# Make sure you installed cargo-nextest
+# Make sure you installed just
+cd src/wasm-lib
+just test
+```
+
+```bash
+# Without just
+# Make sure KITTYCAD_API_TOKEN=<prod zoo.dev token> is set
+# Make sure you installed cargo-nextest
+cd src/wasm-lib
+export RUST_BRACKTRACE="full" && cargo nextest run --workspace --test-threads=1
 ```
 
 Where `XXX` is an API token from the production engine (NOT the dev environment).

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ For individual testing:
 yarn test abstractSyntaxTree -t "unexpected closed curly brace" --silent=false
 ```
 
-Which will run our suite of [Vitest unit](https://vitest.dev/) and [React Testing Library E2E](https://testing-library.com/docs/react-testing-library/intro/** tests, in interactive mode by default.
+Which will run our suite of [Vitest unit](https://vitest.dev/) and [React Testing Library E2E](https://testing-library.com/docs/react-testing-library/intro) tests, in interactive mode by default.
 
 ### Rust tests
 

--- a/interface.d.ts
+++ b/interface.d.ts
@@ -11,6 +11,13 @@ export interface IElectronAPI {
   open: typeof dialog.showOpenDialog
   save: typeof dialog.showSaveDialog
   openExternal: typeof shell.openExternal
+  takeElectronWindowScreenshot: ({
+    width,
+    height,
+  }: {
+    width: number
+    height: number
+  }) => Promise<string>
   showInFolder: typeof shell.showItemInFolder
   /** Require to be called first before {@link loginWithDeviceFlow} */
   startDeviceFlow: (host: string) => Promise<string>

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "diff": "^7.0.0",
     "electron-updater": "6.3.0",
     "fuse.js": "^7.0.0",
+    "html2canvas-pro": "^1.5.8",
     "isomorphic-fetch": "^3.0.0",
     "json-rpc-2.0": "^1.6.0",
     "jszip": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "diff": "^7.0.0",
     "electron-updater": "6.3.0",
     "fuse.js": "^7.0.0",
-    "html2canvas-pro": "^1.5.8",
     "isomorphic-fetch": "^3.0.0",
     "json-rpc-2.0": "^1.6.0",
     "jszip": "^3.10.1",

--- a/src/lib/screenshot.ts
+++ b/src/lib/screenshot.ts
@@ -1,4 +1,4 @@
-function takeScreenShotOfVideoStreamCanvas() {
+function takeScreenshotOfVideoStreamCanvas() {
   const canvas = document.querySelector('[data-engine]')
   const video = document.getElementById('video-stream')
   if (
@@ -35,9 +35,9 @@ export default async function screenshot(): Promise<string> {
         width: canvas?.width || 500,
         height: canvas?.height || 500,
       })
-      return url !== '' ? url : takeScreenShotOfVideoStreamCanvas()
+      return url !== '' ? url : takeScreenshotOfVideoStreamCanvas()
     }
   }
 
-  return takeScreenShotOfVideoStreamCanvas()
+  return takeScreenshotOfVideoStreamCanvas()
 }

--- a/src/lib/screenshot.ts
+++ b/src/lib/screenshot.ts
@@ -1,3 +1,19 @@
+function takeScreenShotOfVideoStreamCanvas() {
+  const canvas = document.querySelector('[data-engine]')
+  const video = document.getElementById('video-stream')
+  if (canvas && video) {
+    const videoCanvas = document.createElement('canvas')
+    videoCanvas.width = canvas.width
+    videoCanvas.height = canvas.height
+    const context = videoCanvas.getContext('2d')
+    context.drawImage(video, 0, 0, videoCanvas.width, videoCanvas.height)
+    const url = videoCanvas.toDataURL('image/png')
+    return url
+  } else {
+    return ''
+  }
+}
+
 export default async function screenshot(): Promise<string> {
   if (typeof window === 'undefined') {
     return Promise.reject(
@@ -7,26 +23,14 @@ export default async function screenshot(): Promise<string> {
     )
   }
 
-  return new Promise((resolve, reject) => {
+  if (window.electron) {
     const canvas = document.querySelector('[data-engine]')
-    const video = document.getElementById('video-stream')
+    const url = await window.electron.takeElectronWindowScreenshot({
+      width: canvas.width || 500,
+      height: canvas.height || 500,
+    })
+    return url !== '' ? url : takeScreenShotOfVideoStreamCanvas()
+  }
 
-    // overlay the sketch canvas as well?
-    // Update the github issue to indicate that we cannot take screenshots?
-    // Implement screenshots in electron?
-
-    if (canvas && video) {
-      const videoCanvas = document.createElement('canvas')
-      videoCanvas.width = canvas.width
-      videoCanvas.height = canvas.height
-      const context = videoCanvas.getContext('2d')
-      context.drawImage(video, 0, 0, videoCanvas.width, videoCanvas.height)
-      const url = videoCanvas.toDataURL('image/png')
-      resolve(url)
-    } else {
-      reject(
-        'no canvas or multiple canvas were found with attribute data-engine'
-      )
-    }
-  })
+  return takeScreenShotOfVideoStreamCanvas()
 }

--- a/src/lib/screenshot.ts
+++ b/src/lib/screenshot.ts
@@ -1,12 +1,17 @@
 function takeScreenShotOfVideoStreamCanvas() {
   const canvas = document.querySelector('[data-engine]')
   const video = document.getElementById('video-stream')
-  if (canvas && video) {
+  if (
+    canvas &&
+    video &&
+    canvas instanceof HTMLCanvasElement &&
+    video instanceof HTMLVideoElement
+  ) {
     const videoCanvas = document.createElement('canvas')
     videoCanvas.width = canvas.width
     videoCanvas.height = canvas.height
     const context = videoCanvas.getContext('2d')
-    context.drawImage(video, 0, 0, videoCanvas.width, videoCanvas.height)
+    context?.drawImage(video, 0, 0, videoCanvas.width, videoCanvas.height)
     const url = videoCanvas.toDataURL('image/png')
     return url
   } else {
@@ -25,11 +30,14 @@ export default async function screenshot(): Promise<string> {
 
   if (window.electron) {
     const canvas = document.querySelector('[data-engine]')
-    const url = await window.electron.takeElectronWindowScreenshot({
-      width: canvas.width || 500,
-      height: canvas.height || 500,
-    })
-    return url !== '' ? url : takeScreenShotOfVideoStreamCanvas()
+    if (canvas instanceof HTMLCanvasElement) {
+      const url = await window.electron.takeElectronWindowScreenshot({
+        width: canvas?.width || 500,
+        height: canvas?.height || 500,
+      })
+      console.log('url', url)
+      return url !== '' ? url : takeScreenShotOfVideoStreamCanvas()
+    }
   }
 
   return takeScreenShotOfVideoStreamCanvas()

--- a/src/lib/screenshot.ts
+++ b/src/lib/screenshot.ts
@@ -35,7 +35,6 @@ export default async function screenshot(): Promise<string> {
         width: canvas?.width || 500,
         height: canvas?.height || 500,
       })
-      console.log('url', url)
       return url !== '' ? url : takeScreenShotOfVideoStreamCanvas()
     }
   }

--- a/src/lib/screenshot.ts
+++ b/src/lib/screenshot.ts
@@ -1,6 +1,3 @@
-import html2canvas from 'html2canvas-pro'
-
-// Return a data URL (png format) of the screenshot of the current page.
 export default async function screenshot(): Promise<string> {
   if (typeof window === 'undefined') {
     return Promise.reject(
@@ -9,11 +6,27 @@ export default async function screenshot(): Promise<string> {
       )
     )
   }
-  return html2canvas(document.documentElement)
-    .then((canvas) => {
-      return canvas.toDataURL()
-    })
-    .catch((error) => {
-      return Promise.reject(error)
-    })
+
+  return new Promise((resolve, reject) => {
+    const canvas = document.querySelector('[data-engine]')
+    const video = document.getElementById('video-stream')
+
+    // overlay the sketch canvas as well?
+    // Update the github issue to indicate that we cannot take screenshots?
+    // Implement screenshots in electron?
+
+    if (canvas && video) {
+      const videoCanvas = document.createElement('canvas')
+      videoCanvas.width = canvas.width
+      videoCanvas.height = canvas.height
+      const context = videoCanvas.getContext('2d')
+      context.drawImage(video, 0, 0, videoCanvas.width, videoCanvas.height)
+      const url = videoCanvas.toDataURL('image/png')
+      resolve(url)
+    } else {
+      reject(
+        'no canvas or multiple canvas were found with attribute data-engine'
+      )
+    }
+  })
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -190,8 +190,10 @@ ipcMain.handle(
       thumbnailSize: { width: data.width, height: data.height },
     })
 
+    console.log('here!', sources)
     for (const source of sources) {
       if (source.name === 'Zoo Modeling App') {
+        // @ts-ignore image/png is real.
         return sources[0].thumbnail.toDataURL('image/png') // The image to display the screenshot
       }
     }
@@ -254,10 +256,7 @@ ipcMain.handle('startDeviceFlow', async (_, host: string) => {
 ipcMain.handle('kittycad', (event, data) => {
   return data.access
     .split('.')
-    .reduce(
-      (obj: any, prop: any) => obj[prop],
-      kittycad
-    )(data.args)
+    .reduce((obj: any, prop: any) => obj[prop], kittycad)(data.args)
 })
 
 ipcMain.handle('find_machine_api', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,8 @@ import os from 'node:os'
 import { reportRejection } from 'lib/trap'
 import argvFromYargs from './commandLineArgs'
 
+import * as packageJSON from '../package.json'
+
 let mainWindow: BrowserWindow | null = null
 
 // Check the command line arguments for a project path
@@ -191,7 +193,8 @@ ipcMain.handle(
     })
 
     for (const source of sources) {
-      if (source.name === 'Zoo Modeling App') {
+      // electron-builder uses the value of productName in package.json for the title of the application
+      if (source.name === packageJSON.productName) {
         // @ts-ignore image/png is real.
         return source.thumbnail.toDataURL('image/png') // The image to display the screenshot
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import {
   dialog,
   shell,
   nativeTheme,
+  desktopCapturer,
 } from 'electron'
 import path from 'path'
 import { Issuer } from 'openid-client'
@@ -181,6 +182,24 @@ ipcMain.handle('shell.openExternal', (event, data) => {
   return shell.openExternal(data)
 })
 
+ipcMain.handle(
+  'take.screenshot',
+  async (event, data: { width: number; height: number }) => {
+    const sources = await desktopCapturer.getSources({
+      types: ['window'],
+      thumbnailSize: { width: data.width, height: data.height },
+    })
+
+    for (const source of sources) {
+      if (source.name === 'Zoo Modeling App') {
+        return sources[0].thumbnail.toDataURL('image/png') // The image to display the screenshot
+      }
+    }
+
+    return ''
+  }
+)
+
 ipcMain.handle('argv.parser', (event, data) => {
   return argvFromYargs
 })
@@ -235,10 +254,7 @@ ipcMain.handle('startDeviceFlow', async (_, host: string) => {
 ipcMain.handle('kittycad', (event, data) => {
   return data.access
     .split('.')
-    .reduce(
-      (obj: any, prop: any) => obj[prop],
-      kittycad
-    )(data.args)
+    .reduce((obj: any, prop: any) => obj[prop], kittycad)(data.args)
 })
 
 ipcMain.handle('find_machine_api', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -256,7 +256,10 @@ ipcMain.handle('startDeviceFlow', async (_, host: string) => {
 ipcMain.handle('kittycad', (event, data) => {
   return data.access
     .split('.')
-    .reduce((obj: any, prop: any) => obj[prop], kittycad)(data.args)
+    .reduce(
+      (obj: any, prop: any) => obj[prop],
+      kittycad
+    )(data.args)
 })
 
 ipcMain.handle('find_machine_api', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -254,7 +254,10 @@ ipcMain.handle('startDeviceFlow', async (_, host: string) => {
 ipcMain.handle('kittycad', (event, data) => {
   return data.access
     .split('.')
-    .reduce((obj: any, prop: any) => obj[prop], kittycad)(data.args)
+    .reduce(
+      (obj: any, prop: any) => obj[prop],
+      kittycad
+    )(data.args)
 })
 
 ipcMain.handle('find_machine_api', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -193,7 +193,7 @@ ipcMain.handle(
     for (const source of sources) {
       if (source.name === 'Zoo Modeling App') {
         // @ts-ignore image/png is real.
-        return sources[0].thumbnail.toDataURL('image/png') // The image to display the screenshot
+        return source.thumbnail.toDataURL('image/png') // The image to display the screenshot
       }
     }
 
@@ -255,7 +255,10 @@ ipcMain.handle('startDeviceFlow', async (_, host: string) => {
 ipcMain.handle('kittycad', (event, data) => {
   return data.access
     .split('.')
-    .reduce((obj: any, prop: any) => obj[prop], kittycad)(data.args)
+    .reduce(
+      (obj: any, prop: any) => obj[prop],
+      kittycad
+    )(data.args)
 })
 
 ipcMain.handle('find_machine_api', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -190,7 +190,6 @@ ipcMain.handle(
       thumbnailSize: { width: data.width, height: data.height },
     })
 
-    console.log('here!', sources)
     for (const source of sources) {
       if (source.name === 'Zoo Modeling App') {
         // @ts-ignore image/png is real.
@@ -256,10 +255,7 @@ ipcMain.handle('startDeviceFlow', async (_, host: string) => {
 ipcMain.handle('kittycad', (event, data) => {
   return data.access
     .split('.')
-    .reduce(
-      (obj: any, prop: any) => obj[prop],
-      kittycad
-    )(data.args)
+    .reduce((obj: any, prop: any) => obj[prop], kittycad)(data.args)
 })
 
 ipcMain.handle('find_machine_api', () => {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -18,7 +18,7 @@ const takeElectronWindowScreenshot = ({
 }: {
   width: number
   height: number
-}) => ipcRenderer.invoke('take.screenshot', args)
+}) => ipcRenderer.invoke('take.screenshot', { width, height })
 const showInFolder = (path: string) =>
   ipcRenderer.invoke('shell.showItemInFolder', path)
 const startDeviceFlow = (host: string): Promise<string> =>

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -12,8 +12,13 @@ const resizeWindow = (width: number, height: number) =>
 const open = (args: any) => ipcRenderer.invoke('dialog.showOpenDialog', args)
 const save = (args: any) => ipcRenderer.invoke('dialog.showSaveDialog', args)
 const openExternal = (url: any) => ipcRenderer.invoke('shell.openExternal', url)
-const takeElectronWindowScreenshot = ({ width: number, height: number }) =>
-  ipcRenderer.invoke('take.screenshot', args)
+const takeElectronWindowScreenshot = ({
+  width,
+  height,
+}: {
+  width: number
+  height: number
+}) => ipcRenderer.invoke('take.screenshot', args)
 const showInFolder = (path: string) =>
   ipcRenderer.invoke('shell.showItemInFolder', path)
 const startDeviceFlow = (host: string): Promise<string> =>

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -12,6 +12,8 @@ const resizeWindow = (width: number, height: number) =>
 const open = (args: any) => ipcRenderer.invoke('dialog.showOpenDialog', args)
 const save = (args: any) => ipcRenderer.invoke('dialog.showSaveDialog', args)
 const openExternal = (url: any) => ipcRenderer.invoke('shell.openExternal', url)
+const takeElectronWindowScreenshot = ({ width: number, height: number }) =>
+  ipcRenderer.invoke('take.screenshot', args)
 const showInFolder = (path: string) =>
   ipcRenderer.invoke('shell.showItemInFolder', path)
 const startDeviceFlow = (host: string): Promise<string> =>
@@ -160,6 +162,7 @@ contextBridge.exposeInMainWorld('electron', {
   version: process.version,
   join: path.join,
   sep: path.sep,
+  takeElectronWindowScreenshot,
   os: {
     isMac,
     isWindows,

--- a/src/wasm-lib/justfile
+++ b/src/wasm-lib/justfile
@@ -31,3 +31,5 @@ new-sim-test test_name render_to_png="true":
     {{cita}} -p kcl-lib -- simulation_tests::{{test_name}}::unparse
     TWENTY_TWENTY=overwrite {{cita}} -p kcl-lib -- tests::{{test_name}}::kcl_test_execute
 
+test:
+    export RUST_BRACKTRACE="full" && cargo nextest run --workspace --test-threads=1

--- a/src/wasm-lib/kcl/src/coredump/mod.rs
+++ b/src/wasm-lib/kcl/src/coredump/mod.rs
@@ -162,10 +162,9 @@ impl CoreDumpInfo {
             r#"[Add a title above and insert a description of the issue here]
 
 ![Screenshot]({screenshot_url})
-<!--
-  If you are capturing from a browser there is limited support for screenshots, only captures the modeling scene.
-  If you are on MacOS native screenshots may be disabled by default. To enable native screenshots add Zoo Modeling App to System Settings -> Screen & SystemAudio Recording for native screenshots.
--->
+
+> _Note: If you are capturing from a browser there is limited support for screenshots, only captures the modeling scene.
+  If you are on MacOS native screenshots may be disabled by default. To enable native screenshots add Zoo Modeling App to System Settings -> Screen & SystemAudio Recording for native screenshots._
 
 <details>
 <summary><b>Core Dump</b></summary>

--- a/src/wasm-lib/kcl/src/coredump/mod.rs
+++ b/src/wasm-lib/kcl/src/coredump/mod.rs
@@ -162,7 +162,10 @@ impl CoreDumpInfo {
             r#"[Add a title above and insert a description of the issue here]
 
 ![Screenshot]({screenshot_url})
-<!-- Limited support for browser screenshots. Only captures modeling scene. -->
+<!--
+  If you are capturing from a browser there is limited support for screenshots, only captures the modeling scene.
+  If you are on MacOS native screenshots may be disabled by default. To enable native screenshots add Zoo Modeling App to System Settings -> Screen & SystemAudio Recording for native screenshots.
+-->
 
 <details>
 <summary><b>Core Dump</b></summary>

--- a/src/wasm-lib/kcl/src/coredump/mod.rs
+++ b/src/wasm-lib/kcl/src/coredump/mod.rs
@@ -162,6 +162,7 @@ impl CoreDumpInfo {
             r#"[Add a title above and insert a description of the issue here]
 
 ![Screenshot]({screenshot_url})
+<!-- Limited support for browser screenshots. Only captures modeling scene. -->
 
 <details>
 <summary><b>Core Dump</b></summary>


### PR DESCRIPTION
closes https://github.com/KittyCAD/modeling-app/issues/3079

Documentation https://www.electronjs.org/docs/latest/api/desktop-capturer


#### Issue

`html2canvas` or `html2canvas-pro` work but are fragile and not robust enough. Overtime with libraries being updated or new components we create the "screenshot" feature with this library will break. 


#### Proof of breaking
`html2canvas-pro` is broken in  electron, chrome browser, and edge browser while using linux OS. 

![electron-broken-modeling-view](https://github.com/user-attachments/assets/2d81ce5b-7069-479f-ac69-6476a4462b1b)
![chrome-linux-broken-modeling-view](https://github.com/user-attachments/assets/421e7195-4d98-45ea-8706-0286c0ddc8eb)
![edge-linux-broken-modeling-view](https://github.com/user-attachments/assets/5c0852ba-7d6d-4e9a-93fa-650cee33dd1d)

#### Solution

If users are using the browser based application the screenshot tool will default to taking a snapshot from the `video` element.

If users are using the desktop application in electron it will default to the native desktop solution in electron to take a screenshot. If the electron desktop screenshot fails, it will fall back to `video` element stream.

I added an extra comment to the github issue to indicate that browser screenshots are limited.

I removed the `html2canvas-pro` package.


**Example from browser**
![example1](https://github.com/user-attachments/assets/2faa178b-ff70-4b2a-a069-1e5e1b695fef)

**Example from electron**
![example2](https://github.com/user-attachments/assets/fa7f940a-75f6-4e89-8dfc-2a9bc55f27fd)



