### PR TITLE
add multiple selections support for focusPath

### DIFF
--- a/src/lang/KclSingleton.ts
+++ b/src/lang/KclSingleton.ts
@@ -416,7 +416,7 @@ export class KclManager {
     ast: Program,
     execute: boolean,
     optionalParams?: {
-      focusPath?: PathToNode
+      focusPath?: Array<PathToNode>
       zoomToFit?: boolean
       zoomOnRangeAndType?: {
         range: SourceRange
@@ -435,27 +435,34 @@ export class KclManager {
     let returnVal: Selections | undefined = undefined
 
     if (optionalParams?.focusPath) {
-      const _node1 = getNodeFromPath<any>(
-        astWithUpdatedSource,
-        optionalParams?.focusPath
-      )
-      if (err(_node1)) return Promise.reject(_node1)
-      const { node } = _node1
-
-      const { start, end } = node
-      if (!start || !end)
-        return {
-          selections: undefined,
-          newAst: astWithUpdatedSource,
-        }
       returnVal = {
-        codeBasedSelections: [
-          {
+        codeBasedSelections: [],
+        otherSelections: [],
+      }
+
+      for (const path of optionalParams.focusPath) {
+        const getNodeFromPathResult = getNodeFromPath<any>(
+          astWithUpdatedSource,
+          path
+        )
+        if (err(getNodeFromPathResult))
+          return Promise.reject(getNodeFromPathResult)
+        const { node } = getNodeFromPathResult
+
+        const { start, end } = node
+
+        if (!start || !end)
+          return {
+            selections: undefined,
+            newAst: astWithUpdatedSource,
+          }
+
+        if (start && end) {
+          returnVal.codeBasedSelections.push({
             type: 'default',
             range: [start, end],
-          },
-        ],
-        otherSelections: [],
+          })
+        }
       }
     }
 

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -555,7 +555,7 @@ export const modelingMachine = setup({
 
         store.videoElement?.pause()
         const updatedAst = await kclManager.updateAst(modifiedAst, true, {
-          focusPath: pathToExtrudeArg,
+          focusPath: [pathToExtrudeArg],
           zoomToFit: true,
           zoomOnRangeAndType: {
             range: selection.codeBasedSelections[0].range,
@@ -602,7 +602,7 @@ export const modelingMachine = setup({
 
         store.videoElement?.pause()
         const updatedAst = await kclManager.updateAst(modifiedAst, true, {
-          focusPath: pathToRevolveArg,
+          focusPath: [pathToRevolveArg],
           zoomToFit: true,
           zoomOnRangeAndType: {
             range: selection.codeBasedSelections[0].range,


### PR DESCRIPTION
closes #3943
this PR is part of #2606 project

### Problem:
The current implementation of `focusPath` only supports single selections. When handling multiple selections, it fails to set focus on the new variables in the KCL code editor after operations such as `addFillet`.

### Solution:
1. **Updated `focusPath`**: 
   Previously, `focusPath` was defined as `focusPath?: PathToNode`, which only supported a single selection. This has now been replaced with `focusPath?: Array<PathToNode>` to handle multiple selections.

2. **Loop through selections**: 
   In the original implementation, `getNodeFromPath` was called for a single selection. I updated this to loop through the provided array of selections, ensuring each selection is properly processed and focused.

### Existing Calls:
Additionally, there have been a couple calls to `focusPath` throughout the codebase, and I have updated them to pass the `focusPath` as an array to ensure consistency with the new implementation.

### Additional Fix:
While implementing these changes, I discovered a bug in the `addFillet` AST mod where selections for the `focusPath` after the first selection were incorrect. This happened because `getPathToExtrudeForSegmentSelection` relies on the `artifactGraph`, which becomes disconnected from the modified AST after the first loop of adding fillets. Since the `artifactGraph` doesn't update with the changes in each loop, it resulted in incorrect selections. To resolve this, I modified the approach to feed an unchanged clone of the original AST into `getPathToExtrudeForSegmentSelection` for each loop, rather than the modified AST. This ensures the selections are processed correctly, and the issue is now resolved.

**Positive Impact**: Once this branch is merged, multiple selections will work in dev mode, enabling everyone to test the feature.

**Next Steps**: I will refactor the `addFillet` logic to consolidate all new fillets into a single fillet expression in future work.