### PR TITLE
Add saving artifact ID from click selection

### DIFF
--- a/src/lang/std/artifactGraph.ts
+++ b/src/lang/std/artifactGraph.ts
@@ -215,7 +215,7 @@ function mergeArtifacts(
  * It does not mutate the map directly, but returns an array of artifacts to update
  *
  * @param currentPlaneId is only needed for `start_path` commands because this command does not have a pathId
- * instead it relies on the id used with the `enable_sketch_mode` command, so this much be kept track of
+ * instead it relies on the id used with the `enable_sketch_mode` command, so this must be kept track of
  * outside of this function. It would be good to update the `start_path` command to include the planeId so we
  * can remove this.
  */

--- a/src/lang/util.ts
+++ b/src/lang/util.ts
@@ -1,45 +1,7 @@
 import { Selections } from 'lib/selections'
-import { Program, PathToNode } from './wasm'
-import { getNodeFromPath } from './queryAst'
+import { PathToNode } from './wasm'
 import { ArtifactGraph, filterArtifacts } from 'lang/std/artifactGraph'
 import { isOverlap } from 'lib/utils'
-import { err } from 'lib/trap'
-
-export function pathMapToSelections(
-  ast: Program,
-  prevSelections: Selections,
-  pathToNodeMap: { [key: number]: PathToNode }
-): Selections {
-  const newSelections: Selections = {
-    ...prevSelections,
-    codeBasedSelections: [],
-  }
-  Object.entries(pathToNodeMap).forEach(([index, path]) => {
-    const nodeMeta = getNodeFromPath<any>(ast, path)
-    if (err(nodeMeta)) return
-    const node = nodeMeta.node as any
-    const selection = prevSelections.codeBasedSelections[Number(index)]
-    if (node) {
-      if (
-        selection.type === 'base-edgeCut' ||
-        selection.type === 'adjacent-edgeCut' ||
-        selection.type === 'opposite-edgeCut'
-      ) {
-        newSelections.codeBasedSelections.push({
-          range: [node.start, node.end],
-          type: selection.type,
-          secondaryRange: selection.secondaryRange,
-        })
-      } else {
-        newSelections.codeBasedSelections.push({
-          range: [node.start, node.end],
-          type: selection.type,
-        })
-      }
-    }
-  })
-  return newSelections
-}
 
 export function updatePathToNodeFromMap(
   oldPath: PathToNode,

--- a/src/lib/selections.ts
+++ b/src/lib/selections.ts
@@ -63,7 +63,7 @@ export type Selection =
     }
   | {
       type: 'opposite-edgeCut' | 'adjacent-edgeCut' | 'base-edgeCut'
-      artifactId?: ArtifactId
+      artifactId: ArtifactId
       range: SourceRange
       // TODO this is a temporary measure that well be made redundant with: https://github.com/KittyCAD/modeling-app/pull/3836
       secondaryRange: SourceRange
@@ -175,7 +175,11 @@ export async function getEventForSelectWithPoint({
         type: 'Set selection',
         data: {
           selectionType: 'singleCodeCursor',
-          selection: { range: codeRef.range, type: 'adjacent-edge' },
+          selection: {
+            artifactId: data.entity_id,
+            range: codeRef.range,
+            type: 'adjacent-edge',
+          },
         },
       }
     }
@@ -183,7 +187,11 @@ export async function getEventForSelectWithPoint({
       type: 'Set selection',
       data: {
         selectionType: 'singleCodeCursor',
-        selection: { range: codeRef.range, type: 'edge' },
+        selection: {
+          artifactId: data.entity_id,
+          range: codeRef.range,
+          type: 'edge',
+        },
       },
     }
   }
@@ -197,7 +205,11 @@ export async function getEventForSelectWithPoint({
         type: 'Set selection',
         data: {
           selectionType: 'singleCodeCursor',
-          selection: { range: _artifact.codeRef.range, type: 'default' },
+          selection: {
+            artifactId: data.entity_id,
+            range: _artifact.codeRef.range,
+            type: 'default',
+          },
         },
       }
     if (consumedEdge.type === 'segment') {
@@ -206,6 +218,7 @@ export async function getEventForSelectWithPoint({
         data: {
           selectionType: 'singleCodeCursor',
           selection: {
+            artifactId: data.entity_id,
             range: _artifact.codeRef.range,
             type: 'base-edgeCut',
             secondaryRange: consumedEdge.codeRef.range,
@@ -223,6 +236,7 @@ export async function getEventForSelectWithPoint({
       data: {
         selectionType: 'singleCodeCursor',
         selection: {
+          artifactId: data.entity_id,
           range: _artifact.codeRef.range,
           type:
             consumedEdge.subType === 'adjacent'
@@ -272,6 +286,7 @@ export function getEventForSegmentSelection(
     type: 'Set selection',
     data: {
       selectionType: 'singleCodeCursor',
+      // What is the artifactId for this selection?
       selection: { range, type: 'default' },
     },
   }
@@ -347,6 +362,7 @@ export function processCodeMirrorRanges({
   if (!isChange) return null
   const codeBasedSelections: Selections['codeBasedSelections'] =
     codeMirrorRanges.map(({ from, to }) => {
+      // What is the artifactId for this selection?
       return {
         type: 'default',
         range: [from, to],

--- a/src/lib/selections.ts
+++ b/src/lib/selections.ts
@@ -58,10 +58,12 @@ export type Selection =
         | 'line'
         | 'arc'
         | 'all'
+      artifactId?: ArtifactId
       range: SourceRange
     }
   | {
       type: 'opposite-edgeCut' | 'adjacent-edgeCut' | 'base-edgeCut'
+      artifactId?: ArtifactId
       range: SourceRange
       // TODO this is a temporary measure that well be made redundant with: https://github.com/KittyCAD/modeling-app/pull/3836
       secondaryRange: SourceRange
@@ -108,7 +110,11 @@ export async function getEventForSelectWithPoint({
       type: 'Set selection',
       data: {
         selectionType: 'singleCodeCursor',
-        selection: { range: codeRef.range, type: 'solid2D' },
+        selection: {
+          artifactId: data.entity_id,
+          range: codeRef.range,
+          type: 'solid2D',
+        },
       },
     }
   }
@@ -120,6 +126,7 @@ export async function getEventForSelectWithPoint({
       data: {
         selectionType: 'singleCodeCursor',
         selection: {
+          artifactId: data.entity_id,
           range: codeRef.range,
           type: _artifact?.subType === 'end' ? 'end-cap' : 'start-cap',
         },
@@ -136,7 +143,11 @@ export async function getEventForSelectWithPoint({
       type: 'Set selection',
       data: {
         selectionType: 'singleCodeCursor',
-        selection: { range: codeRef.range, type: 'extrude-wall' },
+        selection: {
+          artifactId: data.entity_id,
+          range: codeRef.range,
+          type: 'extrude-wall',
+        },
       },
     }
   }
@@ -145,7 +156,11 @@ export async function getEventForSelectWithPoint({
       type: 'Set selection',
       data: {
         selectionType: 'singleCodeCursor',
-        selection: { range: _artifact.codeRef.range, type: 'default' },
+        selection: {
+          artifactId: data.entity_id,
+          range: _artifact.codeRef.range,
+          type: 'default',
+        },
       },
     }
   }
@@ -807,16 +822,18 @@ export function updateSelections(
         selection?.type === 'opposite-edgeCut'
       )
         return {
+          artifactId: selection?.artifactId,
           range: [node.start, node.end],
           type: selection?.type,
           secondaryRange: selection?.secondaryRange,
         }
       return {
+        artifactId: selection?.artifactId,
         range: [node.start, node.end],
         type: selection?.type,
       }
     })
-    .filter((x?: Selection) => x !== undefined) as Selection[]
+    .filter((x?: Selection) => x !== undefined)
 
   return {
     codeBasedSelections:


### PR DESCRIPTION
This change stores the artifact ID (i.e. the UUID) when a selection is made. There are a couple cases where the ID is unavailable, so the `artifactId` must be nullable in a few cases.

- Selecting from the Three.js scene in sketch mode
- Selecting from the text editor
- `intersectInfo()` in `Intersect.tsx` seems to build a selection, possibly from the previous segment

It might be possible to fill in the artifact ID in some of the above with more work, but I'm not sure we care yet.

---

Status: We decided we want to wait for stable artifact IDs before merging this because it has limited use without being stable across executions.

Depends on: #4101 
May be superseded by: #3836 or #4381