### PR TITLE
Cut release v0.25.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zoo-modeling-app",
-  "version": "0.25.4",
+  "version": "0.25.5",
   "private": true,
   "productName": "Zoo Modeling App",
   "author": {


### PR DESCRIPTION
## What's Changed
* Add a user-level projection setting, command, and toggle (#3983)
* Opening KCL sample now overwrites units (#3970)
* Add in min max data (#4029)
* More recursive docs types (#4028)
* One more pass of docs (#4026)
* Recusive docs (#4023)
*  preserve order of struct in autocomplete (#4018)
* Renames sketch group/extrude group (#4016)
* Updates path docs for website (#4019)
* KCL: Global rotation is fixed (#4017)
* Make engine stream react to `prefers-color-scheme` media query change (#4008)
* Kcl std lib docs use handlebars now so making changes should be better (1st pass) (#4007)
* Fix type-check error due to field addition (#4010)
* Add max-min to schemars (#4005)
* KCL: Better docs for patternTransform and int (#4002)
* Fix once cell version (#4004)
* KCL: 'rem' fn in stdlib (#3999)
* Remove .only error (#4003)
* KCL: Rotations in pattern transform (#3979)
* Disable failing step export test (#4000)
* Sketch on chamfer UI (#3918)
* 2D unclosed sketch Mirror (#3851)
* Fix dumb logic bug in indexing auto complete snippets (#3972)
* In-app toasts for electron-updater notifications (#3902)
* UI bug fix: padding-inline logic regression (#3967)
* Add ability to open KCL samples in-app (#3912)

**Full Changelog**: https://github.com/KittyCAD/modeling-app/compare/v0.25.4...v0.25.5
