### PR TITLE
Fix broken test from 'no const/let' PR

### DIFF
--- a/src/wasm-lib/tests/executor/main.rs
+++ b/src/wasm-lib/tests/executor/main.rs
@@ -2041,7 +2041,7 @@ const extrusion = extrude(10, sketch001)
     assert!(result.is_err());
     assert_eq!(
         result.err().unwrap().to_string(),
-        r#"type: KclErrorDetails { source_ranges: [SourceRange([74, 131])], message: "Cannot have an x constrained angle of 90 degrees" }"#
+        r#"type: KclErrorDetails { source_ranges: [SourceRange([68, 125])], message: "Cannot have an x constrained angle of 90 degrees" }"#
     );
 }
 


### PR DESCRIPTION
I must have missed this amongst all the "websocket closed early" noise, sorry.