### PR TITLE
Disable msi builds for now

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -32,10 +32,10 @@ win:
       arch:
         - x64
         - arm64
-    - target: msi
-      arch:
-        - x64
-        - arm64
+    # - target: msi
+    #   arch:
+    #     - x64
+    #     - arm64
   signingHashAlgorithms:
     - sha256
   sign: "./sign-win.js"
@@ -47,9 +47,9 @@ win:
       mimeType: text/vnd.zoo.kcl
       description: Zoo KCL File
       role: Editor
-msi:
-  oneClick: false
-  perMachine: true
+# msi:
+#   oneClick: false
+#   perMachine: true
 nsis:
   oneClick: false
   perMachine: true


### PR DESCRIPTION
Fixes #4083

> Both installers https://zoo.dev/modeling-app/download and updaters https://dl.zoo.dev/releases/modeling-app/latest.yml use NSIS (.exe) at the moment. We're building and uploading .msi files, which doubles the size of the windows artifacts for no reason. Let's comment it out for now.
