### PR TITLE
Don't mutate the user's `codeBasedSelections` when they apply a multi-selection constraint

### DIFF
--- a/src/lang/std/sketchcombos.ts
+++ b/src/lang/std/sketchcombos.ts
@@ -1562,9 +1562,10 @@ export function transformSecondarySketchLinesTagFirst({
 
   // We need to sort the selections by their start position
   // so that we can process them in dependency order and not write invalid KCL.
-  const sortedCodeBasedSelections = selectionRanges.codeBasedSelections.toSorted(
-    (a, b) => a.range[0] - b.range[0]
-  )
+  const sortedCodeBasedSelections =
+    selectionRanges.codeBasedSelections.toSorted(
+      (a, b) => a.range[0] - b.range[0]
+    )
   const primarySelection = sortedCodeBasedSelections[0].range
   const secondarySelections = sortedCodeBasedSelections.slice(1)
 

--- a/src/lang/std/sketchcombos.ts
+++ b/src/lang/std/sketchcombos.ts
@@ -1559,9 +1559,14 @@ export function transformSecondarySketchLinesTagFirst({
     }
   | Error {
   // let node = structuredClone(ast)
-  const primarySelection = selectionRanges.codeBasedSelections.sort(
+
+  // We need to sort the selections by their start position
+  // so that we can process them in dependency order and not write invalid KCL.
+  const sortedCodeBasedSelections = selectionRanges.codeBasedSelections.sort(
     (a, b) => a.range[0] - b.range[0]
-  )[0].range
+  )
+  const primarySelection = sortedCodeBasedSelections[0].range
+  const secondarySelections = sortedCodeBasedSelections.slice(1)
 
   const _tag = giveSketchFnCallTag(ast, primarySelection, forceSegName)
   if (err(_tag)) return _tag
@@ -1571,7 +1576,7 @@ export function transformSecondarySketchLinesTagFirst({
     ast: modifiedAst,
     selectionRanges: {
       ...selectionRanges,
-      codeBasedSelections: selectionRanges.codeBasedSelections.slice(1),
+      codeBasedSelections: secondarySelections,
     },
     referencedSegmentRange: primarySelection,
     transformInfos,

--- a/src/lang/std/sketchcombos.ts
+++ b/src/lang/std/sketchcombos.ts
@@ -1562,7 +1562,7 @@ export function transformSecondarySketchLinesTagFirst({
 
   // We need to sort the selections by their start position
   // so that we can process them in dependency order and not write invalid KCL.
-  const sortedCodeBasedSelections = selectionRanges.codeBasedSelections.sort(
+  const sortedCodeBasedSelections = selectionRanges.codeBasedSelections.toSorted(
     (a, b) => a.range[0] - b.range[0]
   )
   const primarySelection = sortedCodeBasedSelections[0].range


### PR DESCRIPTION
@jtran pointed out that mutating the user's selections could have impacts on as-yet-untested user flows, so the more responsible way to implement the fix for #2667 would be to create a separate sorted array of the `codeBasedSelections` to operate on.