### PR TITLE
checking isDragging from persisted this.selected drag state

### DIFF
--- a/src/clientSideScene/sceneInfra.ts
+++ b/src/clientSideScene/sceneInfra.ts
@@ -411,7 +411,7 @@ export class SceneInfra {
         // console.log('onDragStart', this.selected)
       }
       if (
-        hasBeenDragged &&
+        this.selected.hasBeenDragged &&
         planeIntersectPoint &&
         planeIntersectPoint.twoD &&
         planeIntersectPoint.threeD


### PR DESCRIPTION
Fixes #1410.
In onMouseMove, the isDragging check was previously conditioned on hasBeenDragged, which is recomputed every mouse move event.  Now, it is conditioned on this.selected.hasBeenDragged which is set the first time the user's mouse is more than 0.02 away from the drag start position.  