### PR TITLE
KCL: Pattern repetitions now pattern instances

### DIFF
--- a/docs/kcl/patternCircular2d.md
+++ b/docs/kcl/patternCircular2d.md
@@ -36,7 +36,7 @@ exampleSketch = startSketchOn('XZ')
   |> close(%)
   |> patternCircular2d({
        center: [0, 0],
-       repetitions: 12,
+       instances: 13,
        arcDegrees: 360,
        rotateDuplicates: true
      }, %)

--- a/docs/kcl/patternCircular3d.md
+++ b/docs/kcl/patternCircular3d.md
@@ -35,7 +35,7 @@ example = extrude(-5, exampleSketch)
   |> patternCircular3d({
        axis: [1, -1, 0],
        center: [10, -20, 0],
-       repetitions: 10,
+       instances: 11,
        arcDegrees: 360,
        rotateDuplicates: true
      }, %)

--- a/docs/kcl/patternLinear2d.md
+++ b/docs/kcl/patternLinear2d.md
@@ -32,7 +32,7 @@ exampleSketch = startSketchOn('XZ')
   |> circle({ center: [0, 0], radius: 1 }, %)
   |> patternLinear2d({
        axis: [1, 0],
-       repetitions: 6,
+       instances: 7,
        distance: 4
      }, %)
 

--- a/docs/kcl/patternLinear3d.md
+++ b/docs/kcl/patternLinear3d.md
@@ -38,7 +38,7 @@ exampleSketch = startSketchOn('XZ')
 example = extrude(1, exampleSketch)
   |> patternLinear3d({
        axis: [1, 0, 1],
-       repetitions: 6,
+       instances: 7,
        distance: 6
      }, %)
 ```

--- a/docs/kcl/types/CircularPattern2dData.md
+++ b/docs/kcl/types/CircularPattern2dData.md
@@ -16,7 +16,7 @@ Data for a circular pattern on a 2D sketch.
 
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
-| `repetitions` |[`Uint`](/docs/kcl/types/Uint)| The number of repetitions. Must be greater than 0. This excludes the original entity. For example, if `repetitions` is 1, the original entity will be copied once. | No |
+| `instances` |[`Uint`](/docs/kcl/types/Uint)| The number of total instances. Must be greater than or equal to 1. This includes the original entity. For example, if instances is 2, there will be two copies -- the original, and one new copy. If instances is 1, this has no effect. | No |
 | `center` |`[number, number]`| The center about which to make the pattern. This is a 2D vector. | No |
 | `arcDegrees` |`number`| The arc angle (in degrees) to place the repetitions. Must be greater than 0. | No |
 | `rotateDuplicates` |`boolean`| Whether or not to rotate the duplicates as they are copied. | No |

--- a/docs/kcl/types/CircularPattern3dData.md
+++ b/docs/kcl/types/CircularPattern3dData.md
@@ -16,7 +16,7 @@ Data for a circular pattern on a 3D model.
 
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
-| `repetitions` |[`Uint`](/docs/kcl/types/Uint)| The number of repetitions. Must be greater than 0. This excludes the original entity. For example, if `repetitions` is 1, the original entity will be copied once. | No |
+| `instances` |[`Uint`](/docs/kcl/types/Uint)| The number of total instances. Must be greater than or equal to 1. This includes the original entity. For example, if instances is 2, there will be two copies -- the original, and one new copy. If instances is 1, this has no effect. | No |
 | `axis` |`[number, number, number]`| The axis around which to make the pattern. This is a 3D vector. | No |
 | `center` |`[number, number, number]`| The center about which to make the pattern. This is a 3D vector. | No |
 | `arcDegrees` |`number`| The arc angle (in degrees) to place the repetitions. Must be greater than 0. | No |

--- a/docs/kcl/types/LinearPattern2dData.md
+++ b/docs/kcl/types/LinearPattern2dData.md
@@ -16,7 +16,7 @@ Data for a linear pattern on a 2D sketch.
 
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
-| `repetitions` |[`Uint`](/docs/kcl/types/Uint)| The number of repetitions. Must be greater than 0. This excludes the original entity. For example, if `repetitions` is 1, the original entity will be copied once. | No |
+| `instances` |[`Uint`](/docs/kcl/types/Uint)| The number of total instances. Must be greater than or equal to 1. This includes the original entity. For example, if instances is 2, there will be two copies -- the original, and one new copy. If instances is 1, this has no effect. | No |
 | `distance` |`number`| The distance between each repetition. This can also be referred to as spacing. | No |
 | `axis` |`[number, number]`| The axis of the pattern. This is a 2D vector. | No |
 

--- a/docs/kcl/types/LinearPattern3dData.md
+++ b/docs/kcl/types/LinearPattern3dData.md
@@ -16,7 +16,7 @@ Data for a linear pattern on a 3D model.
 
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
-| `repetitions` |[`Uint`](/docs/kcl/types/Uint)| The number of repetitions. Must be greater than 0. This excludes the original entity. For example, if `repetitions` is 1, the original entity will be copied once. | No |
+| `instances` |[`Uint`](/docs/kcl/types/Uint)| The number of total instances. Must be greater than or equal to 1. This includes the original entity. For example, if instances is 2, there will be two copies -- the original, and one new copy. If instances is 1, this has no effect. | No |
 | `distance` |`number`| The distance between each repetition. This can also be referred to as spacing. | No |
 | `axis` |`[number, number, number]`| The axis of the pattern. | No |
 

--- a/src/wasm-lib/kcl/src/docs/mod.rs
+++ b/src/wasm-lib/kcl/src/docs/mod.rs
@@ -859,7 +859,7 @@ mod tests {
         assert_eq!(
             snippet,
             r#"patternCircular3d({
-	repetitions: ${0:10},
+	instances: ${0:10},
 	axis: [${1:3.14}, ${2:3.14}, ${3:3.14}],
 	center: [${4:3.14}, ${5:3.14}, ${6:3.14}],
 	arcDegrees: ${7:3.14},
@@ -921,7 +921,7 @@ mod tests {
         assert_eq!(
             snippet,
             r#"patternLinear2d({
-	repetitions: ${0:10},
+	instances: ${0:10},
 	distance: ${1:3.14},
 	axis: [${2:3.14}, ${3:3.14}],
 }, ${4:%})${}"#

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -452,6 +452,15 @@ pub enum Geometries {
     Solids(Vec<Box<Solid>>),
 }
 
+impl From<Geometry> for Geometries {
+    fn from(value: Geometry) -> Self {
+        match value {
+            Geometry::Sketch(x) => Self::Sketches(vec![x]),
+            Geometry::Solid(x) => Self::Solids(vec![x]),
+        }
+    }
+}
+
 /// A sketch or a group of sketches.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]

--- a/src/wasm-lib/kcl/src/std/patterns.rs
+++ b/src/wasm-lib/kcl/src/std/patterns.rs
@@ -285,6 +285,12 @@ async fn inner_pattern_transform<'a>(
 ) -> Result<Vec<Box<Solid>>, KclError> {
     // Build the vec of transforms, one for each repetition.
     let mut transform = Vec::with_capacity(usize::try_from(total_instances).unwrap());
+    if total_instances < 1 {
+        return Err(KclError::Syntax(KclErrorDetails {
+            source_ranges: vec![args.source_range],
+            message: MUST_HAVE_ONE_INSTANCE.to_owned(),
+        }));
+    }
     for i in 1..total_instances {
         let t = make_transform(i, &transform_function, args.source_range, exec_state).await?;
         transform.push(t);

--- a/src/wasm-lib/kcl/src/std/patterns.rs
+++ b/src/wasm-lib/kcl/src/std/patterns.rs
@@ -1,5 +1,7 @@
 //! Standard library patterns.
 
+use std::cmp::Ordering;
+
 use anyhow::Result;
 use derive_docs::stdlib;
 use kcmc::{
@@ -23,15 +25,18 @@ use crate::{
     std::{types::Uint, Args},
 };
 
+const MUST_HAVE_ONE_INSTANCE: &str = "There must be at least 1 instance of your geometry";
+
 /// Data for a linear pattern on a 2D sketch.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct LinearPattern2dData {
-    /// The number of repetitions. Must be greater than 0.
-    /// This excludes the original entity. For example, if `repetitions` is 1,
-    /// the original entity will be copied once.
-    pub repetitions: Uint,
+    /// The number of total instances. Must be greater than or equal to 1.
+    /// This includes the original entity. For example, if instances is 2,
+    /// there will be two copies -- the original, and one new copy.
+    /// If instances is 1, this has no effect.
+    pub instances: Uint,
     /// The distance between each repetition. This can also be referred to as spacing.
     pub distance: f64,
     /// The axis of the pattern. This is a 2D vector.
@@ -43,10 +48,11 @@ pub struct LinearPattern2dData {
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct LinearPattern3dData {
-    /// The number of repetitions. Must be greater than 0.
-    /// This excludes the original entity. For example, if `repetitions` is 1,
-    /// the original entity will be copied once.
-    pub repetitions: Uint,
+    /// The number of total instances. Must be greater than or equal to 1.
+    /// This includes the original entity. For example, if instances is 2,
+    /// there will be two copies -- the original, and one new copy.
+    /// If instances is 1, this has no effect.
+    pub instances: Uint,
     /// The distance between each repetition. This can also be referred to as spacing.
     pub distance: f64,
     /// The axis of the pattern.
@@ -66,11 +72,12 @@ impl LinearPattern {
         }
     }
 
-    pub fn repetitions(&self) -> u32 {
-        match self {
-            LinearPattern::TwoD(lp) => lp.repetitions.u32(),
-            LinearPattern::ThreeD(lp) => lp.repetitions.u32(),
-        }
+    fn repetitions(&self) -> RepetitionsNeeded {
+        let n = match self {
+            LinearPattern::TwoD(lp) => lp.instances.u32(),
+            LinearPattern::ThreeD(lp) => lp.instances.u32(),
+        };
+        RepetitionsNeeded::from(n)
     }
 
     pub fn distance(&self) -> f64 {
@@ -498,7 +505,7 @@ pub async fn pattern_linear_2d(exec_state: &mut ExecState, args: Args) -> Result
 ///   |> circle({ center: [0, 0], radius: 1 }, %)
 ///   |> patternLinear2d({
 ///        axis: [1, 0],
-///        repetitions: 6,
+///        instances: 7,
 ///        distance: 4
 ///      }, %)
 ///
@@ -573,7 +580,7 @@ pub async fn pattern_linear_3d(exec_state: &mut ExecState, args: Args) -> Result
 /// const example = extrude(1, exampleSketch)
 ///   |> patternLinear3d({
 ///        axis: [1, 0, 1],
-///        repetitions: 6,
+///        instances: 7,
 ///       distance: 6
 ///     }, %)
 /// ```
@@ -629,13 +636,26 @@ async fn pattern_linear(
 ) -> Result<Geometries, KclError> {
     let id = exec_state.id_generator.next_uuid();
 
+    let num_repetitions = match data.repetitions() {
+        RepetitionsNeeded::More(n) => n,
+        RepetitionsNeeded::None => {
+            return Ok(Geometries::from(geometry));
+        }
+        RepetitionsNeeded::Invalid => {
+            return Err(KclError::Syntax(KclErrorDetails {
+                source_ranges: vec![args.source_range],
+                message: MUST_HAVE_ONE_INSTANCE.to_owned(),
+            }));
+        }
+    };
+
     let resp = args
         .send_modeling_cmd(
             id,
             ModelingCmd::from(mcmd::EntityLinearPattern {
                 axis: kcmc::shared::Point3d::from(data.axis()),
                 entity_id: geometry.id(),
-                num_repetitions: data.repetitions(),
+                num_repetitions,
                 spacing: LengthUnit(data.distance()),
             }),
         )
@@ -680,10 +700,11 @@ async fn pattern_linear(
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct CircularPattern2dData {
-    /// The number of repetitions. Must be greater than 0.
-    /// This excludes the original entity. For example, if `repetitions` is 1,
-    /// the original entity will be copied once.
-    pub repetitions: Uint,
+    /// The number of total instances. Must be greater than or equal to 1.
+    /// This includes the original entity. For example, if instances is 2,
+    /// there will be two copies -- the original, and one new copy.
+    /// If instances is 1, this has no effect.
+    pub instances: Uint,
     /// The center about which to make the pattern. This is a 2D vector.
     pub center: [f64; 2],
     /// The arc angle (in degrees) to place the repetitions. Must be greater than 0.
@@ -697,10 +718,11 @@ pub struct CircularPattern2dData {
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct CircularPattern3dData {
-    /// The number of repetitions. Must be greater than 0.
-    /// This excludes the original entity. For example, if `repetitions` is 1,
-    /// the original entity will be copied once.
-    pub repetitions: Uint,
+    /// The number of total instances. Must be greater than or equal to 1.
+    /// This includes the original entity. For example, if instances is 2,
+    /// there will be two copies -- the original, and one new copy.
+    /// If instances is 1, this has no effect.
+    pub instances: Uint,
     /// The axis around which to make the pattern. This is a 3D vector.
     pub axis: [f64; 3],
     /// The center about which to make the pattern. This is a 3D vector.
@@ -714,6 +736,25 @@ pub struct CircularPattern3dData {
 pub enum CircularPattern {
     ThreeD(CircularPattern3dData),
     TwoD(CircularPattern2dData),
+}
+
+enum RepetitionsNeeded {
+    /// Add this number of repetitions
+    More(u32),
+    /// No repetitions needed
+    None,
+    /// Invalid number of total instances.
+    Invalid,
+}
+
+impl From<u32> for RepetitionsNeeded {
+    fn from(n: u32) -> Self {
+        match n.cmp(&1) {
+            Ordering::Less => Self::Invalid,
+            Ordering::Equal => Self::None,
+            Ordering::Greater => Self::More(n - 1),
+        }
+    }
 }
 
 impl CircularPattern {
@@ -731,11 +772,12 @@ impl CircularPattern {
         }
     }
 
-    pub fn repetitions(&self) -> u32 {
-        match self {
-            CircularPattern::TwoD(lp) => lp.repetitions.u32(),
-            CircularPattern::ThreeD(lp) => lp.repetitions.u32(),
-        }
+    fn repetitions(&self) -> RepetitionsNeeded {
+        let n = match self {
+            CircularPattern::TwoD(lp) => lp.instances.u32(),
+            CircularPattern::ThreeD(lp) => lp.instances.u32(),
+        };
+        RepetitionsNeeded::from(n)
     }
 
     pub fn arc_degrees(&self) -> f64 {
@@ -775,7 +817,7 @@ pub async fn pattern_circular_2d(exec_state: &mut ExecState, args: Args) -> Resu
 ///   |> close(%)
 ///   |> patternCircular2d({
 ///        center: [0, 0],
-///        repetitions: 12,
+///        instances: 13,
 ///        arcDegrees: 360,
 ///        rotateDuplicates: true
 ///      }, %)
@@ -841,7 +883,7 @@ pub async fn pattern_circular_3d(exec_state: &mut ExecState, args: Args) -> Resu
 ///   |> patternCircular3d({
 ///        axis: [1, -1, 0],
 ///        center: [10, -20, 0],
-///        repetitions: 10,
+///        instances: 11,
 ///        arcDegrees: 360,
 ///        rotateDuplicates: true
 ///      }, %)
@@ -897,6 +939,18 @@ async fn pattern_circular(
     args: Args,
 ) -> Result<Geometries, KclError> {
     let id = exec_state.id_generator.next_uuid();
+    let num_repetitions = match data.repetitions() {
+        RepetitionsNeeded::More(n) => n,
+        RepetitionsNeeded::None => {
+            return Ok(Geometries::from(geometry));
+        }
+        RepetitionsNeeded::Invalid => {
+            return Err(KclError::Syntax(KclErrorDetails {
+                source_ranges: vec![args.source_range],
+                message: MUST_HAVE_ONE_INSTANCE.to_owned(),
+            }));
+        }
+    };
 
     let center = data.center();
     let resp = args
@@ -910,7 +964,7 @@ async fn pattern_circular(
                     y: LengthUnit(center[1]),
                     z: LengthUnit(center[2]),
                 },
-                num_repetitions: data.repetitions(),
+                num_repetitions,
                 arc_degrees: data.arc_degrees(),
                 rotate_duplicates: data.rotate_duplicates(),
             }),

--- a/src/wasm-lib/tests/executor/inputs/focusrite_scarlett_mounting_braket.kcl
+++ b/src/wasm-lib/tests/executor/inputs/focusrite_scarlett_mounting_braket.kcl
@@ -97,7 +97,7 @@ const tabsR = startSketchOn(tabPlane)
      }, %)
   |> patternLinear3d({
        axis: [0, -1, 0],
-       repetitions: 1,
+       instances: 2,
        distance: length + 2 * thk - (tabLength * 4 / 3)
      }, %)
 
@@ -125,7 +125,7 @@ const tabsL = startSketchOn(tabPlane)
      }, %)
   |> patternLinear3d({
        axis: [0, -1, 0],
-       repetitions: 1,
+       instances: 2,
        distance: length + 2 * thk - (tabLength * 4 / 3)
      }, %)
 

--- a/src/wasm-lib/tests/executor/inputs/global-tags.kcl
+++ b/src/wasm-lib/tests/executor/inputs/global-tags.kcl
@@ -97,7 +97,7 @@ const tabsR = startSketchOn(tabPlane)
      }, %)
   |> patternLinear3d({
        axis: [0, -1, 0],
-       repetitions: 1,
+       instances: 2,
        distance: length + 2 * thk - (tabLength * 4 / 3)
      }, %)
 
@@ -125,7 +125,7 @@ const tabsL = startSketchOn(tabPlane)
      }, %)
   |> patternLinear3d({
        axis: [0, -1, 0],
-       repetitions: 1,
+       instances: 2,
        distance: length + 2 * thk - (tabLength * 4 / 3)
      }, %)
 

--- a/src/wasm-lib/tests/executor/inputs/lego.kcl
+++ b/src/wasm-lib/tests/executor/inputs/lego.kcl
@@ -45,12 +45,12 @@ const peg = startSketchOn(s, "end")
      ], radius: bumpDiam / 2 }, %)
   |> patternLinear2d({
        axis: [1, 0],
-       repetitions: 5,
+       instances: 6,
        distance: 7
      }, %)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: 9,
+       instances: 10,
        distance: 7
      }, %)
   |> extrude(bumpHeight, %)

--- a/src/wasm-lib/tests/executor/inputs/server-rack-heavy.kcl
+++ b/src/wasm-lib/tests/executor/inputs/server-rack-heavy.kcl
@@ -712,7 +712,7 @@ const sketch004fl = startSketchOn(extrude002fl, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude004fl = extrude(-thickness, sketch004fl)
@@ -733,7 +733,7 @@ const sketch005fl = startSketchOn(extrude002fl, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude005fl = extrude(-thickness, sketch005fl)
@@ -757,7 +757,7 @@ const sketch006fl = startSketchOn(extrude002fl, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude006fl = extrude(-thickness, sketch006fl)
@@ -778,7 +778,7 @@ const sketch007fl = startSketchOn(extrude001fl, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude007fl = extrude(-thickness, sketch007fl)
@@ -799,7 +799,7 @@ const sketch008fl = startSketchOn(extrude001fl, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude008fl = extrude(-thickness, sketch008fl)
@@ -823,7 +823,7 @@ const sketch009fl = startSketchOn(extrude001fl, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude009fl = extrude(-thickness, sketch009fl)
@@ -841,7 +841,7 @@ const sketch010fl = startSketchOn(extrude001fl, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: 1,
+       instances: 2,
        distance: 1.22
      }, %)
 const extrude010fl = extrude(-thickness, sketch010fl)
@@ -879,7 +879,7 @@ const sketch012fl = startSketchOn(extrude001fl, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, -1],
-       repetitions: 1,
+       instances: 2,
        distance: 1.22
      }, %)
 const extrude012fl = extrude(-thickness, sketch012fl)
@@ -994,7 +994,7 @@ const sketch004fr = startSketchOn(extrude002fr, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude004fr = extrude(-thickness, sketch004fr)
@@ -1018,7 +1018,7 @@ const sketch005fr = startSketchOn(extrude002fr, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude005fr = extrude(-thickness, sketch005fr)
@@ -1042,7 +1042,7 @@ const sketch006fr = startSketchOn(extrude002fr, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude006fr = extrude(-thickness, sketch006fr)
@@ -1066,7 +1066,7 @@ const sketch007fr = startSketchOn(extrude001fr, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude007fr = extrude(-thickness, sketch007fr)
@@ -1090,7 +1090,7 @@ const sketch008fr = startSketchOn(extrude001fr, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude008fr = extrude(-thickness, sketch008fr)
@@ -1114,7 +1114,7 @@ const sketch009fr = startSketchOn(extrude001fr, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude009fr = extrude(-thickness, sketch009fr)
@@ -1135,7 +1135,7 @@ const sketch010fr = startSketchOn(extrude001fr, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: 1,
+       instances: 2,
        distance: 1.22
      }, %)
 const extrude010fr = extrude(-thickness, sketch010fr)
@@ -1173,7 +1173,7 @@ const sketch012fr = startSketchOn(extrude001fr, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, -1],
-       repetitions: 1,
+       instances: 2,
        distance: 1.22
      }, %)
 const extrude012fr = extrude(-thickness, sketch012fr)
@@ -1288,7 +1288,7 @@ const sketch004rr = startSketchOn(extrude002rr, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude004rr = extrude(-thickness, sketch004rr)
@@ -1312,7 +1312,7 @@ const sketch005rr = startSketchOn(extrude002rr, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude005rr = extrude(-thickness, sketch005rr)
@@ -1336,7 +1336,7 @@ const sketch006rr = startSketchOn(extrude002rr, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude006rr = extrude(-thickness, sketch006rr)
@@ -1360,7 +1360,7 @@ const sketch007rr = startSketchOn(extrude001rr, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude007rr = extrude(-thickness, sketch007rr)
@@ -1384,7 +1384,7 @@ const sketch008rr = startSketchOn(extrude001rr, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude008rr = extrude(-thickness, sketch008rr)
@@ -1408,7 +1408,7 @@ const sketch009rr = startSketchOn(extrude001rr, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude009rr = extrude(-thickness, sketch009rr)
@@ -1429,7 +1429,7 @@ const sketch010rr = startSketchOn(extrude001rr, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: 1,
+       instances: 2,
        distance: 1.22
      }, %)
 const extrude010rr = extrude(-thickness, sketch010rr)
@@ -1467,7 +1467,7 @@ const sketch012rr = startSketchOn(extrude001rr, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, -1],
-       repetitions: 1,
+       instances: 2,
        distance: 1.22
      }, %)
 const extrude012rr = extrude(-thickness, sketch012rr)
@@ -1581,7 +1581,7 @@ const sketch004rl = startSketchOn(extrude002rl, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude004rl = extrude(-thickness, sketch004rl)
@@ -1605,7 +1605,7 @@ const sketch005rl = startSketchOn(extrude002rl, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude005rl = extrude(-thickness, sketch005rl)
@@ -1629,7 +1629,7 @@ const sketch006rl = startSketchOn(extrude002rl, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude006rl = extrude(-thickness, sketch006rl)
@@ -1653,7 +1653,7 @@ const sketch007rl = startSketchOn(extrude001rl, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude007rl = extrude(-thickness, sketch007rl)
@@ -1677,7 +1677,7 @@ const sketch008rl = startSketchOn(extrude001rl, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude008rl = extrude(-thickness, sketch008rl)
@@ -1701,7 +1701,7 @@ const sketch009rl = startSketchOn(extrude001rl, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: railHeight - 1,
+       instances: railHeight,
        distance: 0.62 + 0.62 + 0.5
      }, %)
 const extrude009rl = extrude(-thickness, sketch009rl)
@@ -1722,7 +1722,7 @@ const sketch010rl = startSketchOn(extrude001rl, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: 1,
+       instances: 2,
        distance: 1.22
      }, %)
 const extrude010rl = extrude(-thickness, sketch010rl)
@@ -1760,7 +1760,7 @@ const sketch012rl = startSketchOn(extrude001rl, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, -1],
-       repetitions: 1,
+       instances: 2,
        distance: 1.22
      }, %)
 const extrude012rl = extrude(-thickness, sketch012rl)

--- a/src/wasm-lib/tests/executor/inputs/server-rack-lite.kcl
+++ b/src/wasm-lib/tests/executor/inputs/server-rack-lite.kcl
@@ -721,7 +721,7 @@ const sketch010fl = startSketchOn(extrude001fl, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: 1,
+       instances: 2,
        distance: 1.22
      }, %)
 const extrude010fl = extrude(-thickness, sketch010fl)
@@ -759,7 +759,7 @@ const sketch012fl = startSketchOn(extrude001fl, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, -1],
-       repetitions: 1,
+       instances: 2,
        distance: 1.22
      }, %)
 const extrude012fl = extrude(-thickness, sketch012fl)
@@ -871,7 +871,7 @@ const sketch010fr = startSketchOn(extrude001fr, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: 1,
+       instances: 2,
        distance: 1.22
      }, %)
 const extrude010fr = extrude(-thickness, sketch010fr)
@@ -909,7 +909,7 @@ const sketch012fr = startSketchOn(extrude001fr, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, -1],
-       repetitions: 1,
+       instances: 2,
        distance: 1.22
      }, %)
 const extrude012fr = extrude(-thickness, sketch012fr)
@@ -1021,7 +1021,7 @@ const sketch010rr = startSketchOn(extrude001rr, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: 1,
+       instances: 2,
        distance: 1.22
      }, %)
 const extrude010rr = extrude(-thickness, sketch010rr)
@@ -1059,7 +1059,7 @@ const sketch012rr = startSketchOn(extrude001rr, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, -1],
-       repetitions: 1,
+       instances: 2,
        distance: 1.22
      }, %)
 const extrude012rr = extrude(-thickness, sketch012rr)
@@ -1170,7 +1170,7 @@ const sketch010rl = startSketchOn(extrude001rl, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: 1,
+       instances: 2,
        distance: 1.22
      }, %)
 const extrude010rl = extrude(-thickness, sketch010rl)
@@ -1208,7 +1208,7 @@ const sketch012rl = startSketchOn(extrude001rl, 'START')
   |> close(%)
   |> patternLinear2d({
        axis: [0, -1],
-       repetitions: 1,
+       instances: 2,
        distance: 1.22
      }, %)
 const extrude012rl = extrude(-thickness, sketch012rl)

--- a/src/wasm-lib/tests/executor/inputs/slow_lego.kcl.tmpl
+++ b/src/wasm-lib/tests/executor/inputs/slow_lego.kcl.tmpl
@@ -68,12 +68,12 @@ const peg = startSketchOn(s, 'end')
      ], radius: bumpDiam / 2 }, %)
   |> patternLinear2d({
        axis: [1, 0],
-       repetitions: wbumps-1,
+       instances: wbumps,
        distance: pitch
      }, %)
   |> patternLinear2d({
        axis: [0, 1],
-       repetitions: lbumps-1,
+       instances: lbumps,
        distance: pitch
      }, %)
   |> extrude(bumpHeight, %)

--- a/src/wasm-lib/tests/executor/main.rs
+++ b/src/wasm-lib/tests/executor/main.rs
@@ -382,7 +382,7 @@ async fn kcl_test_patterns_linear_basic_with_math() {
 distance = 5
 part =  startSketchOn('XY')
     |> circle({ center: [0,0], radius: 2 }, %)
-    |> patternLinear2d({axis: [0,1], repetitions: num -1, distance: distance - 1}, %)
+    |> patternLinear2d({axis: [0,1], instances: num, distance: distance - 1}, %)
     |> extrude(1, %)
 "#;
 
@@ -394,7 +394,7 @@ part =  startSketchOn('XY')
 async fn kcl_test_patterns_linear_basic() {
     let code = r#"part =  startSketchOn('XY')
     |> circle({ center: [0,0], radius: 2 }, %)
-    |> patternLinear2d({axis: [0,1], repetitions: 12, distance: 4}, %)
+    |> patternLinear2d({axis: [0,1], instances: 13, distance: 4}, %)
     |> extrude(1, %)
 "#;
 
@@ -411,7 +411,7 @@ async fn kcl_test_patterns_linear_basic_3d() {
     |> line([0, -1], %)
     |> close(%)
     |> extrude(1, %)
-    |> patternLinear3d({axis: [1, 0, 1], repetitions: 3, distance: 6}, %)
+    |> patternLinear3d({axis: [1, 0, 1], instances: 4, distance: 6}, %)
 "#;
 
     let result = execute_and_snapshot(code, UnitLength::Mm).await.unwrap();
@@ -422,7 +422,7 @@ async fn kcl_test_patterns_linear_basic_3d() {
 async fn kcl_test_patterns_linear_basic_negative_distance() {
     let code = r#"part = startSketchOn('XY')
     |> circle({ center: [0,0], radius: 2 }, %)
-    |> patternLinear2d({axis: [0,1], repetitions: 12, distance: -2}, %)
+    |> patternLinear2d({axis: [0,1], instances: 13, distance: -2}, %)
     |> extrude(1, %)
 "#;
 
@@ -434,7 +434,7 @@ async fn kcl_test_patterns_linear_basic_negative_distance() {
 async fn kcl_test_patterns_linear_basic_negative_axis() {
     let code = r#"part = startSketchOn('XY')
     |> circle({ center: [0,0], radius: 2 }, %)
-    |> patternLinear2d({axis: [0,-1], repetitions: 12, distance: 2}, %)
+    |> patternLinear2d({axis: [0,-1], instances: 13, distance: 2}, %)
     |> extrude(1, %)
 "#;
 
@@ -446,7 +446,7 @@ async fn kcl_test_patterns_linear_basic_negative_axis() {
 async fn kcl_test_patterns_linear_basic_holes() {
     let code = r#"circles = startSketchOn('XY')
     |> circle({ center: [5, 5], radius: 1 }, %)
-    |> patternLinear2d({axis: [1,1], repetitions: 12, distance: 3}, %)
+    |> patternLinear2d({axis: [1,1], instances: 13, distance: 3}, %)
 
 rectangle = startSketchOn('XY')
   |> startProfileAt([0, 0], %)
@@ -467,7 +467,7 @@ rectangle = startSketchOn('XY')
 async fn kcl_test_patterns_circular_basic_2d() {
     let code = r#"part = startSketchOn('XY')
     |> circle({ center: [0,0], radius: 2 }, %)
-    |> patternCircular2d({center: [20, 20], repetitions: 12, arcDegrees: 210, rotateDuplicates: true}, %)
+    |> patternCircular2d({center: [20, 20], instances: 13, arcDegrees: 210, rotateDuplicates: true}, %)
     |> extrude(1, %)
 "#;
 
@@ -484,7 +484,7 @@ async fn kcl_test_patterns_circular_basic_3d() {
     |> line([0, -1], %)
     |> close(%)
     |> extrude(1, %)
-    |> patternCircular3d({axis: [0,0, 1], center: [-20, -20, -20], repetitions: 40, arcDegrees: 360, rotateDuplicates: false}, %)
+    |> patternCircular3d({axis: [0,0, 1], center: [-20, -20, -20], instances: 41, arcDegrees: 360, rotateDuplicates: false}, %)
 "#;
 
     let result = execute_and_snapshot(code, UnitLength::Mm).await.unwrap();
@@ -500,7 +500,7 @@ async fn kcl_test_patterns_circular_3d_tilted_axis() {
     |> line([0, -1], %)
     |> close(%)
     |> extrude(1, %)
-    |> patternCircular3d({axis: [1,1,0], center: [10, 0, 10], repetitions: 10, arcDegrees: 360, rotateDuplicates: true}, %)
+    |> patternCircular3d({axis: [1,1,0], center: [10, 0, 10], instances: 11, arcDegrees: 360, rotateDuplicates: true}, %)
 "#;
 
     let result = execute_and_snapshot(code, UnitLength::Mm).await.unwrap();
@@ -1429,14 +1429,14 @@ async fn kcl_test_linear_pattern3d_a_pattern() {
 
 pattn1 = patternLinear3d({
        axis: [1, 0, 0],
-       repetitions: 6,
+       instances: 7,
        distance: 6
      }, exampleSketch)
 
 pattn2 = patternLinear3d({
        axis: [0, 0, 1],
        distance: 1,
-       repetitions: 6
+       instances: 7
      }, pattn1)
 "#;
 
@@ -1456,11 +1456,11 @@ async fn kcl_test_circular_pattern3d_a_pattern() {
 
 pattn1 = patternLinear3d({
        axis: [1, 0, 0],
-       repetitions: 6,
+       instances: 7,
        distance: 6
      }, exampleSketch)
 
-pattn2 = patternCircular3d({axis: [0,0, 1], center: [-20, -20, -20], repetitions: 40, arcDegrees: 360, rotateDuplicates: false}, pattn1)
+pattn2 = patternCircular3d({axis: [0,0, 1], center: [-20, -20, -20], instances: 41, arcDegrees: 360, rotateDuplicates: false}, pattn1)
 "#;
 
     let result = execute_and_snapshot(code, UnitLength::Mm).await.unwrap();
@@ -1586,7 +1586,7 @@ let extrudes = [sketch001, sketch002]
 
 pattn1 = patternLinear3d({
        axis: [0, 1, 0],
-       repetitions: 2,
+       instances: 3,
        distance: 20
      }, extrudes)
 "#;
@@ -1732,7 +1732,7 @@ part001 = cube([0,0], 20)
 
 pattn1 = patternLinear3d({
        axis: [1, 0, 0],
-       repetitions: 3,
+       instances: 4,
        distance: 40
      }, part001)
 
@@ -1761,7 +1761,7 @@ part001 = cube([0,0], 20)
     tags: [getOppositeEdge(line1)]
   }, %)
 
-pattn2 = patternCircular3d({axis: [0,0, 1], center: [-20, -20, -20], repetitions: 4, arcDegrees: 360, rotateDuplicates: false}, part001) 
+pattn2 = patternCircular3d({axis: [0,0, 1], center: [-20, -20, -20], instances: 5, arcDegrees: 360, rotateDuplicates: false}, part001) 
 
 "#;
 
@@ -1788,7 +1788,7 @@ part001 = cube([0,0], 20)
     tags: [getOppositeEdge(line1)]
   }, %)
 
-pattn2 = patternCircular3d({axis: [0,0, 1], center: [-20, -20, -20], repetitions: 4, arcDegrees: 360, rotateDuplicates: false}, part001) 
+pattn2 = patternCircular3d({axis: [0,0, 1], center: [-20, -20, -20], instances: 5, arcDegrees: 360, rotateDuplicates: false}, part001) 
 
 "#;
 
@@ -1915,7 +1915,7 @@ async fn kcl_test_arc_error_same_start_end() {
   |> patternCircular2d({
        arcDegrees: 360,
        center: [0, 0],
-       repetitions: 5,
+       instances: 6,
        rotateDuplicates: true
      }, %)
 "#;


### PR DESCRIPTION
@jgomez720 requests pattern calculations take the total number of instances, not the number of extra repetitions to do. This is how we designed the patternTransform API, but we didn't do that for patternLinear/Circular.

Also enforced that the number of instances must be >= 1.

This is a **breaking change**.