### PR TITLE
Bugfix: double map

### DIFF
--- a/src/wasm-lib/tests/executor/inputs/no_visuals/double_map.kcl
+++ b/src/wasm-lib/tests/executor/inputs/no_visuals/double_map.kcl
@@ -1,0 +1,5 @@
+fn increment = (i) => { return i + 1 }
+
+xs = [0..2]
+|> map(%, increment)
+|> map(%, increment)

--- a/src/wasm-lib/tests/executor/inputs/no_visuals/double_map.kcl
+++ b/src/wasm-lib/tests/executor/inputs/no_visuals/double_map.kcl
@@ -1,5 +1,6 @@
 fn increment = (i) => { return i + 1 }
 
 xs = [0..2]
+ys = xs
 |> map(%, increment)
 |> map(%, increment)

--- a/src/wasm-lib/tests/executor/no_visuals.rs
+++ b/src/wasm-lib/tests/executor/no_visuals.rs
@@ -102,3 +102,4 @@ gen_test!(if_else);
 // );
 gen_test_fail!(comparisons_multiple, "syntax: Invalid number: true");
 gen_test!(add_lots);
+gen_test!(double_map);

--- a/src/wasm-lib/tests/executor/no_visuals.rs
+++ b/src/wasm-lib/tests/executor/no_visuals.rs
@@ -28,7 +28,15 @@ macro_rules! gen_test_fail {
 async fn run(code: &str) {
     let (ctx, program, id_generator) = setup(code).await;
 
-    ctx.run(&program, None, id_generator).await.unwrap();
+    let res = ctx.run(&program, None, id_generator).await;
+    match res {
+        Ok(state) => {
+            println!("{:#?}", state.memory);
+        }
+        Err(e) => {
+            panic!("{e}");
+        }
+    }
 }
 
 async fn setup(program: &str) -> (ExecutorContext, Program, IdGenerator) {


### PR DESCRIPTION
Previously running `map` would change the output of the array, it would go from array of numbers to an array of objects that contain numbers. Fixed now.

We should do https://github.com/KittyCAD/modeling-app/issues/1130 to make this impossible in the future.