### PR TITLE
Stop duplicate tags for expression nodes

### DIFF
--- a/docs/kcl/types/ArrayExpression.md
+++ b/docs/kcl/types/ArrayExpression.md
@@ -1,0 +1,25 @@
+---
+title: "ArrayExpression"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`ArrayExpressionTag`](/docs/kcl/types/ArrayExpressionTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `elements` |`[` [`Expr`](/docs/kcl/types/Expr) `]`|  | No |
+| `nonCodeMeta` |[`NonCodeMeta`](/docs/kcl/types/NonCodeMeta)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/ArrayExpressionTag.md
+++ b/docs/kcl/types/ArrayExpressionTag.md
@@ -1,0 +1,16 @@
+---
+title: "ArrayExpressionTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`ArrayExpression`](/docs/kcl/types/ArrayExpression)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/ArrayRangeExpression.md
+++ b/docs/kcl/types/ArrayRangeExpression.md
@@ -1,0 +1,26 @@
+---
+title: "ArrayRangeExpression"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`ArrayRangeExpressionTag`](/docs/kcl/types/ArrayRangeExpressionTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `startElement` |[`Expr`](/docs/kcl/types/Expr)|  | No |
+| `endElement` |[`Expr`](/docs/kcl/types/Expr)|  | No |
+| `endInclusive` |`boolean`| Is the `end_element` included in the range? | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/ArrayRangeExpressionTag.md
+++ b/docs/kcl/types/ArrayRangeExpressionTag.md
@@ -1,0 +1,16 @@
+---
+title: "ArrayRangeExpressionTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`ArrayRangeExpression`](/docs/kcl/types/ArrayRangeExpression)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/BinaryExpression.md
+++ b/docs/kcl/types/BinaryExpression.md
@@ -1,0 +1,26 @@
+---
+title: "BinaryExpression"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`BinaryExpressionTag`](/docs/kcl/types/BinaryExpressionTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `operator` |[`BinaryOperator`](/docs/kcl/types/BinaryOperator)|  | No |
+| `left` |[`BinaryPart`](/docs/kcl/types/BinaryPart)|  | No |
+| `right` |[`BinaryPart`](/docs/kcl/types/BinaryPart)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/BinaryExpressionTag.md
+++ b/docs/kcl/types/BinaryExpressionTag.md
@@ -1,0 +1,16 @@
+---
+title: "BinaryExpressionTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`BinaryExpression`](/docs/kcl/types/BinaryExpression)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/BinaryPart.md
+++ b/docs/kcl/types/BinaryPart.md
@@ -8,153 +8,86 @@ layout: manual
 
 
 
+**This schema accepts any of the following:**
 
-**This schema accepts exactly one of the following:**
 
-
-**Type:** `object`
-
+[`Literal`](/docs/kcl/types/Literal)
 
 
 
 
-## Properties
 
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `Literal`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `value` |[`LiteralValue`](/docs/kcl/types/LiteralValue)|  | No |
-| `raw` |`string`|  | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
 
 
 ----
 
-**Type:** `object`
+[`Identifier`](/docs/kcl/types/Identifier)
 
 
 
 
 
-## Properties
 
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: [`Identifier`](/docs/kcl/types/Identifier)|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `name` |`string`|  | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 
 
 ----
 
-**Type:** `object`
+[`BinaryExpression`](/docs/kcl/types/BinaryExpression)
 
 
 
 
 
-## Properties
 
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `BinaryExpression`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `operator` |[`BinaryOperator`](/docs/kcl/types/BinaryOperator)|  | No |
-| `left` |[`BinaryPart`](/docs/kcl/types/BinaryPart)|  | No |
-| `right` |[`BinaryPart`](/docs/kcl/types/BinaryPart)|  | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 
 
 ----
 
-**Type:** `object`
+[`CallExpression`](/docs/kcl/types/CallExpression)
 
 
 
 
 
-## Properties
 
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `CallExpression`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `callee` |[`Identifier`](/docs/kcl/types/Identifier)|  | No |
-| `arguments` |`[` [`Expr`](/docs/kcl/types/Expr) `]`|  | No |
-| `optional` |`boolean`|  | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 
 
 ----
 
-**Type:** `object`
+[`UnaryExpression`](/docs/kcl/types/UnaryExpression)
 
 
 
 
 
-## Properties
 
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `UnaryExpression`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `operator` |[`UnaryOperator`](/docs/kcl/types/UnaryOperator)|  | No |
-| `argument` |[`BinaryPart`](/docs/kcl/types/BinaryPart)|  | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 
 
 ----
 
-**Type:** `object`
+[`MemberExpression`](/docs/kcl/types/MemberExpression)
 
 
 
 
 
-## Properties
 
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `MemberExpression`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `object` |[`MemberObject`](/docs/kcl/types/MemberObject)|  | No |
-| `property` |[`LiteralIdentifier`](/docs/kcl/types/LiteralIdentifier)|  | No |
-| `computed` |`boolean`|  | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 
 
 ----
 
-**Type:** `object`
+[`IfExpression`](/docs/kcl/types/IfExpression)
 
 
 
 
 
-## Properties
 
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `IfExpression`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `cond` |[`Expr`](/docs/kcl/types/Expr)|  | No |
-| `then_val` |[`Program`](/docs/kcl/types/Program)|  | No |
-| `else_ifs` |`[` [`ElseIf`](/docs/kcl/types/ElseIf) `]`|  | No |
-| `final_else` |[`Program`](/docs/kcl/types/Program)|  | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 
 
 ----
+
 
 
 

--- a/docs/kcl/types/BodyItem.md
+++ b/docs/kcl/types/BodyItem.md
@@ -8,89 +8,53 @@ layout: manual
 
 
 
+**This schema accepts any of the following:**
 
-**This schema accepts exactly one of the following:**
 
-
-**Type:** `object`
-
+[`ImportStatement`](/docs/kcl/types/ImportStatement)
 
 
 
 
-## Properties
 
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `ImportStatement`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `items` |`[` [`ImportItem`](/docs/kcl/types/ImportItem) `]`|  | No |
-| `path` |`string`|  | No |
-| `raw_path` |`string`|  | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
 
 
 ----
 
-**Type:** `object`
+[`ExpressionStatement`](/docs/kcl/types/ExpressionStatement)
 
 
 
 
 
-## Properties
 
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `ExpressionStatement`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `expression` |[`Expr`](/docs/kcl/types/Expr)|  | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 
 
 ----
 
-**Type:** `object`
+[`VariableDeclaration`](/docs/kcl/types/VariableDeclaration)
 
 
 
 
 
-## Properties
 
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `VariableDeclaration`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `declarations` |`[` [`VariableDeclarator`](/docs/kcl/types/VariableDeclarator) `]`|  | No |
-| `visibility` |[`ItemVisibility`](/docs/kcl/types/ItemVisibility)|  | No |
-| `kind` |[`VariableKind`](/docs/kcl/types/VariableKind)|  | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 
 
 ----
 
-**Type:** `object`
+[`ReturnStatement`](/docs/kcl/types/ReturnStatement)
 
 
 
 
 
-## Properties
 
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `ReturnStatement`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `argument` |[`Expr`](/docs/kcl/types/Expr)|  | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 
 
 ----
+
 
 
 

--- a/docs/kcl/types/CallExpression.md
+++ b/docs/kcl/types/CallExpression.md
@@ -1,0 +1,26 @@
+---
+title: "CallExpression"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`CallExpressionTag`](/docs/kcl/types/CallExpressionTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `callee` |[`Identifier`](/docs/kcl/types/Identifier)|  | No |
+| `arguments` |`[` [`Expr`](/docs/kcl/types/Expr) `]`|  | No |
+| `optional` |`boolean`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/CallExpressionTag.md
+++ b/docs/kcl/types/CallExpressionTag.md
@@ -1,0 +1,16 @@
+---
+title: "CallExpressionTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`CallExpression`](/docs/kcl/types/CallExpression)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/Expr.md
+++ b/docs/kcl/types/Expr.md
@@ -9,309 +9,189 @@ An expression can be evaluated to yield a single KCL value.
 
 
 
+**This schema accepts any of the following:**
 
-**This schema accepts exactly one of the following:**
+An expression can be evaluated to yield a single KCL value.
 
-
-**Type:** `object`
-
-
+[`Literal`](/docs/kcl/types/Literal)
 
 
 
-## Properties
 
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `Literal`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `value` |[`LiteralValue`](/docs/kcl/types/LiteralValue)| An expression can be evaluated to yield a single KCL value. | No |
-| `raw` |`string`|  | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+
+
+
+----
+An expression can be evaluated to yield a single KCL value.
+
+[`Identifier`](/docs/kcl/types/Identifier)
+
+
+
+
+
+
+
+
+----
+An expression can be evaluated to yield a single KCL value.
+
+[`TagDeclarator`](/docs/kcl/types#tag-declaration)
+
+
+
+
+
+
+
+
+----
+An expression can be evaluated to yield a single KCL value.
+
+[`BinaryExpression`](/docs/kcl/types/BinaryExpression)
+
+
+
+
+
+
+
+
+----
+An expression can be evaluated to yield a single KCL value.
+
+[`FunctionExpression`](/docs/kcl/types/FunctionExpression)
+
+
+
+
+
+
+
+
+----
+An expression can be evaluated to yield a single KCL value.
+
+[`CallExpression`](/docs/kcl/types/CallExpression)
+
+
+
+
+
+
+
+
+----
+An expression can be evaluated to yield a single KCL value.
+
+[`PipeExpression`](/docs/kcl/types/PipeExpression)
+
+
+
+
+
+
+
+
+----
+An expression can be evaluated to yield a single KCL value.
+
+[`PipeSubstitution`](/docs/kcl/types/PipeSubstitution)
+
+
+
+
+
+
+
+
+----
+An expression can be evaluated to yield a single KCL value.
+
+[`ArrayExpression`](/docs/kcl/types/ArrayExpression)
+
+
+
+
+
+
+
+
+----
+An expression can be evaluated to yield a single KCL value.
+
+[`ArrayRangeExpression`](/docs/kcl/types/ArrayRangeExpression)
+
+
+
+
+
+
+
+
+----
+An expression can be evaluated to yield a single KCL value.
+
+[`ObjectExpression`](/docs/kcl/types/ObjectExpression)
+
+
+
+
+
+
+
+
+----
+An expression can be evaluated to yield a single KCL value.
+
+[`MemberExpression`](/docs/kcl/types/MemberExpression)
+
+
+
+
+
+
+
+
+----
+An expression can be evaluated to yield a single KCL value.
+
+[`UnaryExpression`](/docs/kcl/types/UnaryExpression)
+
+
+
+
+
+
+
+
+----
+An expression can be evaluated to yield a single KCL value.
+
+[`IfExpression`](/docs/kcl/types/IfExpression)
+
+
+
+
+
+
+
+
+----
+An expression can be evaluated to yield a single KCL value.
+
+[`KclNone`](/docs/kcl/types/KclNone)
+
+
+
+
+
+
 
 
 ----
 
-**Type:** `object`
-
-
-
-
-
-## Properties
-
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: [`Identifier`](/docs/kcl/types/Identifier)|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `name` |`string`|  | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
-
-
-----
-
-**Type:** `object`
-
-
-
-
-
-## Properties
-
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: [`TagDeclarator`](/docs/kcl/types#tag-declaration)|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `value` |`string`|  | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
-
-
-----
-
-**Type:** `object`
-
-
-
-
-
-## Properties
-
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `BinaryExpression`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `operator` |[`BinaryOperator`](/docs/kcl/types/BinaryOperator)| An expression can be evaluated to yield a single KCL value. | No |
-| `left` |[`BinaryPart`](/docs/kcl/types/BinaryPart)| An expression can be evaluated to yield a single KCL value. | No |
-| `right` |[`BinaryPart`](/docs/kcl/types/BinaryPart)| An expression can be evaluated to yield a single KCL value. | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
-
-
-----
-
-**Type:** `object`
-
-
-
-
-
-## Properties
-
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: [`FunctionExpression`](/docs/kcl/types/FunctionExpression)|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `params` |`[` [`Parameter`](/docs/kcl/types/Parameter) `]`|  | No |
-| `body` |[`Program`](/docs/kcl/types/Program)| An expression can be evaluated to yield a single KCL value. | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
-
-
-----
-
-**Type:** `object`
-
-
-
-
-
-## Properties
-
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `CallExpression`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `callee` |[`Identifier`](/docs/kcl/types/Identifier)| An expression can be evaluated to yield a single KCL value. | No |
-| `arguments` |`[` [`Expr`](/docs/kcl/types/Expr) `]`|  | No |
-| `optional` |`boolean`|  | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
-
-
-----
-
-**Type:** `object`
-
-
-
-
-
-## Properties
-
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `PipeExpression`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `body` |`[` [`Expr`](/docs/kcl/types/Expr) `]`|  | No |
-| `nonCodeMeta` |[`NonCodeMeta`](/docs/kcl/types/NonCodeMeta)| An expression can be evaluated to yield a single KCL value. | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
-
-
-----
-
-**Type:** `object`
-
-
-
-
-
-## Properties
-
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `PipeSubstitution`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
-
-
-----
-
-**Type:** `object`
-
-
-
-
-
-## Properties
-
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `ArrayExpression`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `elements` |`[` [`Expr`](/docs/kcl/types/Expr) `]`|  | No |
-| `nonCodeMeta` |[`NonCodeMeta`](/docs/kcl/types/NonCodeMeta)| An expression can be evaluated to yield a single KCL value. | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
-
-
-----
-
-**Type:** `object`
-
-
-
-
-
-## Properties
-
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `ArrayRangeExpression`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `startElement` |[`Expr`](/docs/kcl/types/Expr)| An expression can be evaluated to yield a single KCL value. | No |
-| `endElement` |[`Expr`](/docs/kcl/types/Expr)| An expression can be evaluated to yield a single KCL value. | No |
-| `endInclusive` |`boolean`| Is the `end_element` included in the range? | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
-
-
-----
-
-**Type:** `object`
-
-
-
-
-
-## Properties
-
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `ObjectExpression`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `properties` |`[` [`ObjectProperty`](/docs/kcl/types/ObjectProperty) `]`|  | No |
-| `nonCodeMeta` |[`NonCodeMeta`](/docs/kcl/types/NonCodeMeta)| An expression can be evaluated to yield a single KCL value. | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
-
-
-----
-
-**Type:** `object`
-
-
-
-
-
-## Properties
-
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `MemberExpression`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `object` |[`MemberObject`](/docs/kcl/types/MemberObject)| An expression can be evaluated to yield a single KCL value. | No |
-| `property` |[`LiteralIdentifier`](/docs/kcl/types/LiteralIdentifier)| An expression can be evaluated to yield a single KCL value. | No |
-| `computed` |`boolean`|  | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
-
-
-----
-
-**Type:** `object`
-
-
-
-
-
-## Properties
-
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `UnaryExpression`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `operator` |[`UnaryOperator`](/docs/kcl/types/UnaryOperator)| An expression can be evaluated to yield a single KCL value. | No |
-| `argument` |[`BinaryPart`](/docs/kcl/types/BinaryPart)| An expression can be evaluated to yield a single KCL value. | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
-
-
-----
-
-**Type:** `object`
-
-
-
-
-
-## Properties
-
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `IfExpression`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `cond` |[`Expr`](/docs/kcl/types/Expr)| An expression can be evaluated to yield a single KCL value. | No |
-| `then_val` |[`Program`](/docs/kcl/types/Program)| An expression can be evaluated to yield a single KCL value. | No |
-| `else_ifs` |`[` [`ElseIf`](/docs/kcl/types/ElseIf) `]`|  | No |
-| `final_else` |[`Program`](/docs/kcl/types/Program)| An expression can be evaluated to yield a single KCL value. | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
-
-
-----
-KCL value for an optional parameter which was not given an argument. (remember, parameters are in the function declaration, arguments are in the function call/application).
-
-**Type:** `object`
-
-
-
-
-
-## Properties
-
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `None`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-
-
-----
 
 
 

--- a/docs/kcl/types/ExpressionStatement.md
+++ b/docs/kcl/types/ExpressionStatement.md
@@ -1,0 +1,23 @@
+---
+title: "ExpressionStatement"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `expression` |[`Expr`](/docs/kcl/types/Expr)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/FunctionExpression.md
+++ b/docs/kcl/types/FunctionExpression.md
@@ -15,6 +15,7 @@ layout: manual
 
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
+| `type` |[`FunctionExpressionTag`](/docs/kcl/types/FunctionExpressionTag)|  | No |
 | `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
 | `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
 | `params` |`[` [`Parameter`](/docs/kcl/types/Parameter) `]`|  | No |

--- a/docs/kcl/types/FunctionExpressionTag.md
+++ b/docs/kcl/types/FunctionExpressionTag.md
@@ -1,0 +1,16 @@
+---
+title: "FunctionExpressionTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`FunctionExpression`](/docs/kcl/types/FunctionExpression)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/Identifier.md
+++ b/docs/kcl/types/Identifier.md
@@ -15,6 +15,7 @@ layout: manual
 
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
+| `type` |[`IdentifierTag`](/docs/kcl/types/IdentifierTag)|  | No |
 | `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
 | `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
 | `name` |`string`|  | No |

--- a/docs/kcl/types/IdentifierTag.md
+++ b/docs/kcl/types/IdentifierTag.md
@@ -1,0 +1,16 @@
+---
+title: "IdentifierTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`Identifier`](/docs/kcl/types/Identifier)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/IfExpression.md
+++ b/docs/kcl/types/IfExpression.md
@@ -1,0 +1,26 @@
+---
+title: "IfExpression"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `cond` |[`Expr`](/docs/kcl/types/Expr)|  | No |
+| `then_val` |[`Program`](/docs/kcl/types/Program)|  | No |
+| `else_ifs` |`[` [`ElseIf`](/docs/kcl/types/ElseIf) `]`|  | No |
+| `final_else` |[`Program`](/docs/kcl/types/Program)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/ImportStatement.md
+++ b/docs/kcl/types/ImportStatement.md
@@ -1,0 +1,26 @@
+---
+title: "ImportStatement"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`ImportStatementTag`](/docs/kcl/types/ImportStatementTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `items` |`[` [`ImportItem`](/docs/kcl/types/ImportItem) `]`|  | No |
+| `path` |`string`|  | No |
+| `raw_path` |`string`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/ImportStatementTag.md
+++ b/docs/kcl/types/ImportStatementTag.md
@@ -1,0 +1,16 @@
+---
+title: "ImportStatementTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`ImportStatement`](/docs/kcl/types/ImportStatement)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/KclNone.md
+++ b/docs/kcl/types/KclNone.md
@@ -1,0 +1,23 @@
+---
+title: "KclNone"
+excerpt: "KCL value for an optional parameter which was not given an argument. (remember, parameters are in the function declaration, arguments are in the function call/application)."
+layout: manual
+---
+
+KCL value for an optional parameter which was not given an argument. (remember, parameters are in the function declaration, arguments are in the function call/application).
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`KclNoneTag`](/docs/kcl/types/KclNoneTag)| KCL value for an optional parameter which was not given an argument. (remember, parameters are in the function declaration, arguments are in the function call/application). | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+
+

--- a/docs/kcl/types/KclNoneTag.md
+++ b/docs/kcl/types/KclNoneTag.md
@@ -1,0 +1,16 @@
+---
+title: "KclNoneTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`KclNone`](/docs/kcl/types/KclNone)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/KclValue.md
+++ b/docs/kcl/types/KclValue.md
@@ -48,21 +48,13 @@ Any KCL value.
 
 ----
 
-**Type:** `object`
+[`TagDeclarator`](/docs/kcl/types#tag-declaration)
 
 
 
 
 
-## Properties
 
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: [`TagDeclarator`](/docs/kcl/types#tag-declaration)|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `value` |`string`|  | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 
 
 ----

--- a/docs/kcl/types/Literal.md
+++ b/docs/kcl/types/Literal.md
@@ -1,0 +1,25 @@
+---
+title: "Literal"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`LiteralTag`](/docs/kcl/types/LiteralTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `value` |[`LiteralValue`](/docs/kcl/types/LiteralValue)|  | No |
+| `raw` |`string`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/LiteralIdentifier.md
+++ b/docs/kcl/types/LiteralIdentifier.md
@@ -8,48 +8,31 @@ layout: manual
 
 
 
+**This schema accepts any of the following:**
 
-**This schema accepts exactly one of the following:**
 
-
-**Type:** `object`
-
+[`Identifier`](/docs/kcl/types/Identifier)
 
 
 
 
-## Properties
 
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: [`Identifier`](/docs/kcl/types/Identifier)|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `name` |`string`|  | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
 
 
 ----
 
-**Type:** `object`
+[`Literal`](/docs/kcl/types/Literal)
 
 
 
 
 
-## Properties
 
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `Literal`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `value` |[`LiteralValue`](/docs/kcl/types/LiteralValue)|  | No |
-| `raw` |`string`|  | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 
 
 ----
+
 
 
 

--- a/docs/kcl/types/LiteralTag.md
+++ b/docs/kcl/types/LiteralTag.md
@@ -1,0 +1,16 @@
+---
+title: "LiteralTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`Literal`](/docs/kcl/types/Literal)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/MemberExpression.md
+++ b/docs/kcl/types/MemberExpression.md
@@ -1,0 +1,26 @@
+---
+title: "MemberExpression"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`MemberExpressionTag`](/docs/kcl/types/MemberExpressionTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `object` |[`MemberObject`](/docs/kcl/types/MemberObject)|  | No |
+| `property` |[`LiteralIdentifier`](/docs/kcl/types/LiteralIdentifier)|  | No |
+| `computed` |`boolean`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/MemberExpressionTag.md
+++ b/docs/kcl/types/MemberExpressionTag.md
@@ -1,0 +1,16 @@
+---
+title: "MemberExpressionTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`MemberExpression`](/docs/kcl/types/MemberExpression)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/MemberObject.md
+++ b/docs/kcl/types/MemberObject.md
@@ -8,49 +8,31 @@ layout: manual
 
 
 
+**This schema accepts any of the following:**
 
-**This schema accepts exactly one of the following:**
 
-
-**Type:** `object`
-
+[`MemberExpression`](/docs/kcl/types/MemberExpression)
 
 
 
 
-## Properties
 
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `MemberExpression`|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `object` |[`MemberObject`](/docs/kcl/types/MemberObject)|  | No |
-| `property` |[`LiteralIdentifier`](/docs/kcl/types/LiteralIdentifier)|  | No |
-| `computed` |`boolean`|  | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
 
 
 ----
 
-**Type:** `object`
+[`Identifier`](/docs/kcl/types/Identifier)
 
 
 
 
 
-## Properties
 
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: [`Identifier`](/docs/kcl/types/Identifier)|  | No |
-| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
-| `name` |`string`|  | No |
-| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 
 
 ----
+
 
 
 

--- a/docs/kcl/types/ObjectExpression.md
+++ b/docs/kcl/types/ObjectExpression.md
@@ -1,0 +1,25 @@
+---
+title: "ObjectExpression"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`ObjectExpressionTag`](/docs/kcl/types/ObjectExpressionTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `properties` |`[` [`ObjectProperty`](/docs/kcl/types/ObjectProperty) `]`|  | No |
+| `nonCodeMeta` |[`NonCodeMeta`](/docs/kcl/types/NonCodeMeta)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/ObjectExpressionTag.md
+++ b/docs/kcl/types/ObjectExpressionTag.md
@@ -1,0 +1,16 @@
+---
+title: "ObjectExpressionTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`ObjectExpression`](/docs/kcl/types/ObjectExpression)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/PipeExpression.md
+++ b/docs/kcl/types/PipeExpression.md
@@ -1,0 +1,25 @@
+---
+title: "PipeExpression"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`PipeExpressionTag`](/docs/kcl/types/PipeExpressionTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `body` |`[` [`Expr`](/docs/kcl/types/Expr) `]`|  | No |
+| `nonCodeMeta` |[`NonCodeMeta`](/docs/kcl/types/NonCodeMeta)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/PipeExpressionTag.md
+++ b/docs/kcl/types/PipeExpressionTag.md
@@ -1,0 +1,16 @@
+---
+title: "PipeExpressionTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`PipeExpression`](/docs/kcl/types/PipeExpression)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/PipeSubstitution.md
+++ b/docs/kcl/types/PipeSubstitution.md
@@ -1,0 +1,23 @@
+---
+title: "PipeSubstitution"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`PipeSubstitutionTag`](/docs/kcl/types/PipeSubstitutionTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/PipeSubstitutionTag.md
+++ b/docs/kcl/types/PipeSubstitutionTag.md
@@ -1,0 +1,16 @@
+---
+title: "PipeSubstitutionTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`PipeSubstitution`](/docs/kcl/types/PipeSubstitution)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/ReturnStatement.md
+++ b/docs/kcl/types/ReturnStatement.md
@@ -1,0 +1,24 @@
+---
+title: "ReturnStatement"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`ReturnStatementTag`](/docs/kcl/types/ReturnStatementTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `argument` |[`Expr`](/docs/kcl/types/Expr)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/ReturnStatementTag.md
+++ b/docs/kcl/types/ReturnStatementTag.md
@@ -1,0 +1,16 @@
+---
+title: "ReturnStatementTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`ReturnStatement`](/docs/kcl/types/ReturnStatement)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/TagDeclaratorTag.md
+++ b/docs/kcl/types/TagDeclaratorTag.md
@@ -1,0 +1,16 @@
+---
+title: "TagDeclaratorTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`TagDeclarator`](/docs/kcl/types#tag-declaration)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/UnaryExpression.md
+++ b/docs/kcl/types/UnaryExpression.md
@@ -1,0 +1,25 @@
+---
+title: "UnaryExpression"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`UnaryExpressionTag`](/docs/kcl/types/UnaryExpressionTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `operator` |[`UnaryOperator`](/docs/kcl/types/UnaryOperator)|  | No |
+| `argument` |[`BinaryPart`](/docs/kcl/types/BinaryPart)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/UnaryExpressionTag.md
+++ b/docs/kcl/types/UnaryExpressionTag.md
@@ -1,0 +1,16 @@
+---
+title: "UnaryExpressionTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`UnaryExpression`](/docs/kcl/types/UnaryExpression)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/VariableDeclaration.md
+++ b/docs/kcl/types/VariableDeclaration.md
@@ -1,0 +1,26 @@
+---
+title: "VariableDeclaration"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`VariableDeclarationTag`](/docs/kcl/types/VariableDeclarationTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `declarations` |`[` [`VariableDeclarator`](/docs/kcl/types/VariableDeclarator) `]`|  | No |
+| `visibility` |[`ItemVisibility`](/docs/kcl/types/ItemVisibility)|  | No |
+| `kind` |[`VariableKind`](/docs/kcl/types/VariableKind)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/VariableDeclarationTag.md
+++ b/docs/kcl/types/VariableDeclarationTag.md
@@ -1,0 +1,16 @@
+---
+title: "VariableDeclarationTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`VariableDeclaration`](/docs/kcl/types/VariableDeclaration)
+
+
+
+
+
+
+
+

--- a/src/wasm-lib/kcl-macros/tests/macro_test.rs
+++ b/src/wasm-lib/kcl-macros/tests/macro_test.rs
@@ -13,18 +13,21 @@ fn basic() {
         start: 0,
         end: 11,
         body: vec![BodyItem::VariableDeclaration(VariableDeclaration {
+            r#type: Default::default(),
             start: 0,
             end: 11,
             declarations: vec![VariableDeclarator {
                 start: 6,
                 end: 11,
                 id: Identifier {
+                    r#type: Default::default(),
                     start: 6,
                     end: 7,
                     name: "y".to_owned(),
                     digest: None,
                 },
                 init: Expr::Literal(Box::new(Literal {
+                    r#type: Default::default(),
                     start: 10,
                     end: 11,
                     value: LiteralValue::IInteger(4),

--- a/src/wasm-lib/kcl/src/ast/types/none.rs
+++ b/src/wasm-lib/kcl/src/ast/types/none.rs
@@ -17,8 +17,8 @@ const KCL_NONE_ID: &str = "KCL_NONE_ID";
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake, Default)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(tag = "type")]
 pub struct KclNone {
+    pub r#type: super::KclNoneTag,
     // TODO: Convert this to be an Option<SourceRange>.
     pub start: usize,
     pub end: usize,
@@ -31,6 +31,7 @@ pub struct KclNone {
 impl KclNone {
     pub fn new(start: usize, end: usize) -> Self {
         Self {
+            r#type: Default::default(),
             start,
             end,
             __private: Private {},

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -3401,6 +3401,7 @@ let w = f() + f()
         }
         fn ident(s: &'static str) -> Identifier {
             Identifier {
+                r#type: Default::default(),
                 start: 0,
                 end: 0,
                 name: s.to_owned(),
@@ -3498,6 +3499,7 @@ let w = f() + f()
         ] {
             // Run each test.
             let func_expr = &FunctionExpression {
+                r#type: Default::default(),
                 start: 0,
                 end: 0,
                 params,

--- a/src/wasm-lib/kcl/src/parser/math.rs
+++ b/src/wasm-lib/kcl/src/parser/math.rs
@@ -29,6 +29,7 @@ fn evaluate(rpn: Vec<BinaryExpressionToken>) -> Result<BinaryExpression, KclErro
                     return Err(e);
                 };
                 BinaryPart::BinaryExpression(Box::new(BinaryExpression {
+                    r#type: Default::default(),
                     start: left.start(),
                     end: right.end(),
                     operator,
@@ -126,6 +127,7 @@ mod tests {
         /// Make a literal
         fn lit(n: u8) -> BinaryPart {
             BinaryPart::Literal(Box::new(Literal {
+                r#type: Default::default(),
                 start: 0,
                 end: 0,
                 value: n.into(),
@@ -143,6 +145,7 @@ mod tests {
                 lit(2).into(),
                 BinaryOperator::Div.into(),
                 BinaryPart::BinaryExpression(Box::new(BinaryExpression {
+                    r#type: Default::default(),
                     start: 0,
                     end: 0,
                     operator: BinaryOperator::Sub,

--- a/src/wasm-lib/kcl/src/parser/parser_impl.rs
+++ b/src/wasm-lib/kcl/src/parser/parser_impl.rs
@@ -195,6 +195,7 @@ fn pipe_expression(i: TokenSlice) -> PResult<PipeExpression> {
         }
     }
     Ok(PipeExpression {
+        r#type: Default::default(),
         start: values.first().unwrap().start(),
         end: values.last().unwrap().end().max(max_noncode_end),
         body: values,
@@ -216,6 +217,7 @@ fn bool_value(i: TokenSlice) -> PResult<Literal> {
         .context(expected("a boolean literal (either true or false)"))
         .parse_next(i)?;
     Ok(Literal {
+        r#type: Default::default(),
         start: token.start,
         end: token.end,
         value: LiteralValue::Bool(value),
@@ -246,6 +248,7 @@ pub fn string_literal(i: TokenSlice) -> PResult<Literal> {
         .context(expected("string literal (like \"myPart\""))
         .parse_next(i)?;
     Ok(Literal {
+        r#type: Default::default(),
         start: token.start,
         end: token.end,
         value,
@@ -280,6 +283,7 @@ pub(crate) fn unsigned_number_literal(i: TokenSlice) -> PResult<Literal> {
         .parse_next(i)?;
     Ok(Literal {
         start: token.start,
+        r#type: Default::default(),
         end: token.end,
         value,
         raw: token.value.clone(),
@@ -482,6 +486,7 @@ fn array_empty(i: TokenSlice) -> PResult<ArrayExpression> {
     ignore_whitespace(i);
     let end = close_bracket(i)?.end;
     Ok(ArrayExpression {
+        r#type: Default::default(),
         start,
         end,
         elements: Default::default(),
@@ -537,6 +542,7 @@ pub(crate) fn array_elem_by_elem(i: TokenSlice) -> PResult<ArrayExpression> {
         digest: None,
     };
     Ok(ArrayExpression {
+        r#type: Default::default(),
         start,
         end,
         elements,
@@ -556,6 +562,7 @@ fn array_end_start(i: TokenSlice) -> PResult<ArrayRangeExpression> {
     ignore_whitespace(i);
     let end = close_bracket(i)?.end;
     Ok(ArrayRangeExpression {
+        r#type: Default::default(),
         start,
         end,
         start_element,
@@ -638,6 +645,7 @@ pub(crate) fn object(i: TokenSlice) -> PResult<ObjectExpression> {
         ..Default::default()
     };
     Ok(ObjectExpression {
+        r#type: Default::default(),
         start,
         end,
         properties,
@@ -651,6 +659,7 @@ fn pipe_sub(i: TokenSlice) -> PResult<PipeSubstitution> {
     any.try_map(|token: Token| {
         if matches!(token.token_type, TokenType::Operator) && token.value == PIPE_SUBSTITUTION_OPERATOR {
             Ok(PipeSubstitution {
+                r#type: Default::default(),
                 start: token.start,
                 end: token.end,
                 digest: None,
@@ -801,6 +810,7 @@ fn function_expression(i: TokenSlice) -> PResult<FunctionExpression> {
     let body = function_body(i)?;
     let end = close_brace(i)?.end;
     Ok(FunctionExpression {
+        r#type: Default::default(),
         start,
         end,
         params,
@@ -855,6 +865,7 @@ fn member_expression(i: TokenSlice) -> PResult<MemberExpression> {
     let (property, end, computed) = members.remove(0);
     let start = id.start;
     let initial_member_expression = MemberExpression {
+        r#type: Default::default(),
         start,
         end,
         object: MemberObject::Identifier(Box::new(id)),
@@ -870,6 +881,7 @@ fn member_expression(i: TokenSlice) -> PResult<MemberExpression> {
         // and use it as the `object` of a new, bigger member expression.
         .fold(initial_member_expression, |accumulated, (property, end, computed)| {
             MemberExpression {
+                r#type: Default::default(),
                 start,
                 end,
                 object: MemberObject::MemberExpression(Box::new(accumulated)),
@@ -1183,6 +1195,7 @@ fn import_stmt(i: TokenSlice) -> PResult<Box<ImportStatement>> {
         ));
     }
     Ok(Box::new(ImportStatement {
+        r#type: Default::default(),
         items,
         path: path_string,
         raw_path: path.raw,
@@ -1249,6 +1262,7 @@ pub fn return_stmt(i: TokenSlice) -> PResult<ReturnStatement> {
     require_whitespace(i)?;
     let argument = expression(i)?;
     Ok(ReturnStatement {
+        r#type: Default::default(),
         start,
         end: argument.end(),
         argument,
@@ -1405,6 +1419,7 @@ fn declaration(i: TokenSlice) -> PResult<VariableDeclaration> {
 
     let end = val.end();
     Ok(VariableDeclaration {
+        r#type: Default::default(),
         start,
         end,
         declarations: vec![VariableDeclarator {
@@ -1426,6 +1441,7 @@ impl TryFrom<Token> for Identifier {
     fn try_from(token: Token) -> Result<Self, Self::Error> {
         if token.token_type == TokenType::Word {
             Ok(Identifier {
+                r#type: Default::default(),
                 start: token.start,
                 end: token.end,
                 name: token.value,
@@ -1454,6 +1470,7 @@ fn sketch_keyword(i: TokenSlice) -> PResult<Identifier> {
     any.try_map(|token: Token| {
         if token.token_type == TokenType::Type && token.value == "sketch" {
             Ok(Identifier {
+                r#type: Default::default(),
                 start: token.start,
                 end: token.end,
                 name: token.value,
@@ -1476,6 +1493,7 @@ impl TryFrom<Token> for TagDeclarator {
     fn try_from(token: Token) -> Result<Self, Self::Error> {
         if token.token_type == TokenType::Word {
             Ok(TagDeclarator {
+                r#type: Default::default(),
                 // We subtract 1 from the start because the tag starts with a `$`.
                 start: token.start - 1,
                 end: token.end,
@@ -1543,6 +1561,7 @@ fn unary_expression(i: TokenSlice) -> PResult<UnaryExpression> {
         .parse_next(i)?;
     let argument = operand.parse_next(i)?;
     Ok(UnaryExpression {
+        r#type: Default::default(),
         start: op_token.start,
         end: argument.end(),
         operator,
@@ -1927,6 +1946,7 @@ fn fn_call(i: TokenSlice) -> PResult<CallExpression> {
     }
     let end = preceded(opt(whitespace), close_paren).parse_next(i)?.end;
     Ok(CallExpression {
+        r#type: Default::default(),
         start: fn_name.start,
         end,
         callee: fn_name,
@@ -2108,6 +2128,7 @@ const mySk1 = startSketchAt([0, 0])"#;
         assert_eq!(
             expr,
             FunctionExpression {
+                r#type: Default::default(),
                 start: 0,
                 end: 47,
                 params: Default::default(),
@@ -2115,9 +2136,11 @@ const mySk1 = startSketchAt([0, 0])"#;
                     start: 7,
                     end: 47,
                     body: vec![BodyItem::ReturnStatement(ReturnStatement {
+                        r#type: Default::default(),
                         start: 25,
                         end: 33,
                         argument: Expr::Literal(Box::new(Literal {
+                            r#type: Default::default(),
                             start: 32,
                             end: 33,
                             value: 2u32.into(),
@@ -2284,6 +2307,7 @@ const mySk1 = startSketchAt([0, 0])"#;
         assert_eq!(
             rhs.right,
             BinaryPart::Literal(Box::new(Literal {
+                r#type: Default::default(),
                 start: 9,
                 end: 10,
                 value: 3u32.into(),
@@ -2650,10 +2674,12 @@ const mySk1 = startSketchAt([0, 0])"#;
         let tokens = crate::token::lexer(r#"5 + "a""#).unwrap();
         let actual = crate::parser::Parser::new(tokens).ast().unwrap().body;
         let expr = BinaryExpression {
+            r#type: Default::default(),
             start: 0,
             end: 7,
             operator: BinaryOperator::Add,
             left: BinaryPart::Literal(Box::new(Literal {
+                r#type: Default::default(),
                 start: 0,
                 end: 1,
                 value: 5u32.into(),
@@ -2661,6 +2687,7 @@ const mySk1 = startSketchAt([0, 0])"#;
                 digest: None,
             })),
             right: BinaryPart::Literal(Box::new(Literal {
+                r#type: Default::default(),
                 start: 4,
                 end: 7,
                 value: "a".into(),
@@ -2768,9 +2795,11 @@ const mySk1 = startSketchAt([0, 0])"#;
                 start: 0,
                 end: 4,
                 expression: Expr::BinaryExpression(Box::new(BinaryExpression {
+                    r#type: Default::default(),
                     start: 0,
                     end: 4,
                     left: BinaryPart::Literal(Box::new(Literal {
+                        r#type: Default::default(),
                         start: 0,
                         end: 1,
                         value: 5u32.into(),
@@ -2779,6 +2808,7 @@ const mySk1 = startSketchAt([0, 0])"#;
                     })),
                     operator: BinaryOperator::Add,
                     right: BinaryPart::Literal(Box::new(Literal {
+                        r#type: Default::default(),
                         start: 3,
                         end: 4,
                         value: 6u32.into(),
@@ -3071,6 +3101,7 @@ e
             (
                 vec![Parameter {
                     identifier: Identifier {
+                        r#type: Default::default(),
                         start: 0,
                         end: 0,
                         name: "a".to_owned(),
@@ -3085,6 +3116,7 @@ e
             (
                 vec![Parameter {
                     identifier: Identifier {
+                        r#type: Default::default(),
                         start: 0,
                         end: 0,
                         name: "a".to_owned(),
@@ -3100,6 +3132,7 @@ e
                 vec![
                     Parameter {
                         identifier: Identifier {
+                            r#type: Default::default(),
                             start: 0,
                             end: 0,
                             name: "a".to_owned(),
@@ -3111,6 +3144,7 @@ e
                     },
                     Parameter {
                         identifier: Identifier {
+                            r#type: Default::default(),
                             start: 0,
                             end: 0,
                             name: "b".to_owned(),
@@ -3127,6 +3161,7 @@ e
                 vec![
                     Parameter {
                         identifier: Identifier {
+                            r#type: Default::default(),
                             start: 0,
                             end: 0,
                             name: "a".to_owned(),
@@ -3138,6 +3173,7 @@ e
                     },
                     Parameter {
                         identifier: Identifier {
+                            r#type: Default::default(),
                             start: 0,
                             end: 0,
                             name: "b".to_owned(),

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__a.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__a.snap
@@ -9,14 +9,12 @@ expression: actual
   "operator": "+",
   "left": {
     "type": "Literal",
-    "type": "Literal",
     "start": 0,
     "end": 1,
     "value": 1,
     "raw": "1"
   },
   "right": {
-    "type": "Literal",
     "type": "Literal",
     "start": 4,
     "end": 5,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__b.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__b.snap
@@ -9,14 +9,12 @@ expression: actual
   "operator": "+",
   "left": {
     "type": "Literal",
-    "type": "Literal",
     "start": 0,
     "end": 1,
     "value": 1,
     "raw": "1"
   },
   "right": {
-    "type": "Literal",
     "type": "Literal",
     "start": 2,
     "end": 3,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__c.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__c.snap
@@ -9,14 +9,12 @@ expression: actual
   "operator": "-",
   "left": {
     "type": "Literal",
-    "type": "Literal",
     "start": 0,
     "end": 1,
     "value": 1,
     "raw": "1"
   },
   "right": {
-    "type": "Literal",
     "type": "Literal",
     "start": 3,
     "end": 4,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__d.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__d.snap
@@ -9,7 +9,6 @@ expression: actual
   "operator": "+",
   "left": {
     "type": "Literal",
-    "type": "Literal",
     "start": 0,
     "end": 1,
     "value": 1,
@@ -17,12 +16,10 @@ expression: actual
   },
   "right": {
     "type": "BinaryExpression",
-    "type": "BinaryExpression",
     "start": 4,
     "end": 9,
     "operator": "*",
     "left": {
-      "type": "Literal",
       "type": "Literal",
       "start": 4,
       "end": 5,
@@ -30,7 +27,6 @@ expression: actual
       "raw": "2"
     },
     "right": {
-      "type": "Literal",
       "type": "Literal",
       "start": 8,
       "end": 9,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__e.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__e.snap
@@ -9,7 +9,6 @@ expression: actual
   "operator": "*",
   "left": {
     "type": "Literal",
-    "type": "Literal",
     "start": 0,
     "end": 1,
     "value": 1,
@@ -17,12 +16,10 @@ expression: actual
   },
   "right": {
     "type": "BinaryExpression",
-    "type": "BinaryExpression",
     "start": 6,
     "end": 11,
     "operator": "+",
     "left": {
-      "type": "Literal",
       "type": "Literal",
       "start": 6,
       "end": 7,
@@ -30,7 +27,6 @@ expression: actual
       "raw": "2"
     },
     "right": {
-      "type": "Literal",
       "type": "Literal",
       "start": 10,
       "end": 11,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__f.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__f.snap
@@ -9,12 +9,10 @@ expression: actual
   "operator": "/",
   "left": {
     "type": "BinaryExpression",
-    "type": "BinaryExpression",
     "start": 0,
     "end": 11,
     "operator": "*",
     "left": {
-      "type": "Literal",
       "type": "Literal",
       "start": 0,
       "end": 1,
@@ -23,12 +21,10 @@ expression: actual
     },
     "right": {
       "type": "BinaryExpression",
-      "type": "BinaryExpression",
       "start": 6,
       "end": 11,
       "operator": "+",
       "left": {
-        "type": "Literal",
         "type": "Literal",
         "start": 6,
         "end": 7,
@@ -36,7 +32,6 @@ expression: actual
         "raw": "2"
       },
       "right": {
-        "type": "Literal",
         "type": "Literal",
         "start": 10,
         "end": 11,
@@ -46,7 +41,6 @@ expression: actual
     }
   },
   "right": {
-    "type": "Literal",
     "type": "Literal",
     "start": 16,
     "end": 17,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__g.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__g.snap
@@ -9,7 +9,6 @@ expression: actual
   "operator": "+",
   "left": {
     "type": "Literal",
-    "type": "Literal",
     "start": 0,
     "end": 1,
     "value": 1,
@@ -17,18 +16,15 @@ expression: actual
   },
   "right": {
     "type": "BinaryExpression",
-    "type": "BinaryExpression",
     "start": 6,
     "end": 17,
     "operator": "/",
     "left": {
       "type": "BinaryExpression",
-      "type": "BinaryExpression",
       "start": 6,
       "end": 11,
       "operator": "+",
       "left": {
-        "type": "Literal",
         "type": "Literal",
         "start": 6,
         "end": 7,
@@ -37,7 +33,6 @@ expression: actual
       },
       "right": {
         "type": "Literal",
-        "type": "Literal",
         "start": 10,
         "end": 11,
         "value": 3,
@@ -45,7 +40,6 @@ expression: actual
       }
     },
     "right": {
-      "type": "Literal",
       "type": "Literal",
       "start": 16,
       "end": 17,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__h.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__h.snap
@@ -9,7 +9,6 @@ expression: actual
   "operator": "*",
   "left": {
     "type": "Literal",
-    "type": "Literal",
     "start": 0,
     "end": 1,
     "value": 1,
@@ -17,24 +16,20 @@ expression: actual
   },
   "right": {
     "type": "BinaryExpression",
-    "type": "BinaryExpression",
     "start": 7,
     "end": 22,
     "operator": "+",
     "left": {
-      "type": "BinaryExpression",
       "type": "BinaryExpression",
       "start": 7,
       "end": 18,
       "operator": "/",
       "left": {
         "type": "BinaryExpression",
-        "type": "BinaryExpression",
         "start": 7,
         "end": 12,
         "operator": "+",
         "left": {
-          "type": "Literal",
           "type": "Literal",
           "start": 7,
           "end": 8,
@@ -42,7 +37,6 @@ expression: actual
           "raw": "2"
         },
         "right": {
-          "type": "Literal",
           "type": "Literal",
           "start": 11,
           "end": 12,
@@ -52,7 +46,6 @@ expression: actual
       },
       "right": {
         "type": "Literal",
-        "type": "Literal",
         "start": 17,
         "end": 18,
         "value": 4,
@@ -60,7 +53,6 @@ expression: actual
       }
     },
     "right": {
-      "type": "Literal",
       "type": "Literal",
       "start": 21,
       "end": 22,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__i.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__i.snap
@@ -9,7 +9,6 @@ expression: actual
   "operator": "*",
   "left": {
     "type": "Literal",
-    "type": "Literal",
     "start": 0,
     "end": 1,
     "value": 1,
@@ -17,12 +16,10 @@ expression: actual
   },
   "right": {
     "type": "BinaryExpression",
-    "type": "BinaryExpression",
     "start": 8,
     "end": 13,
     "operator": "+",
     "left": {
-      "type": "Literal",
       "type": "Literal",
       "start": 8,
       "end": 9,
@@ -30,7 +27,6 @@ expression: actual
       "raw": "2"
     },
     "right": {
-      "type": "Literal",
       "type": "Literal",
       "start": 12,
       "end": 13,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__j.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__j.snap
@@ -9,31 +9,26 @@ expression: actual
   "operator": "/",
   "left": {
     "type": "BinaryExpression",
-    "type": "BinaryExpression",
     "start": 0,
     "end": 22,
     "operator": "*",
     "left": {
-      "type": "BinaryExpression",
       "type": "BinaryExpression",
       "start": 0,
       "end": 18,
       "operator": "*",
       "left": {
         "type": "BinaryExpression",
-        "type": "BinaryExpression",
         "start": 0,
         "end": 12,
         "operator": "*",
         "left": {
-          "type": "Identifier",
           "type": "Identifier",
           "start": 0,
           "end": 8,
           "name": "distance"
         },
         "right": {
-          "type": "Identifier",
           "type": "Identifier",
           "start": 11,
           "end": 12,
@@ -42,14 +37,12 @@ expression: actual
       },
       "right": {
         "type": "Identifier",
-        "type": "Identifier",
         "start": 15,
         "end": 18,
         "name": "FOS"
       }
     },
     "right": {
-      "type": "Literal",
       "type": "Literal",
       "start": 21,
       "end": 22,
@@ -59,19 +52,16 @@ expression: actual
   },
   "right": {
     "type": "BinaryExpression",
-    "type": "BinaryExpression",
     "start": 26,
     "end": 44,
     "operator": "*",
     "left": {
-      "type": "Identifier",
       "type": "Identifier",
       "start": 26,
       "end": 36,
       "name": "sigmaAllow"
     },
     "right": {
-      "type": "Identifier",
       "type": "Identifier",
       "start": 39,
       "end": 44,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__k.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__k.snap
@@ -9,14 +9,12 @@ expression: actual
   "operator": "+",
   "left": {
     "type": "Literal",
-    "type": "Literal",
     "start": 0,
     "end": 1,
     "value": 2,
     "raw": "2"
   },
   "right": {
-    "type": "Literal",
     "type": "Literal",
     "start": 7,
     "end": 8,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__a.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__a.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 143,
       "declarations": [
@@ -24,12 +23,10 @@ expression: actual
           },
           "init": {
             "type": "PipeExpression",
-            "type": "PipeExpression",
             "start": 18,
             "end": 143,
             "body": [
               {
-                "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 18,
                 "end": 39,
@@ -42,12 +39,10 @@ expression: actual
                 "arguments": [
                   {
                     "type": "ArrayExpression",
-                    "type": "ArrayExpression",
                     "start": 32,
                     "end": 38,
                     "elements": [
                       {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 33,
                         "end": 34,
@@ -55,7 +50,6 @@ expression: actual
                         "raw": "0"
                       },
                       {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 36,
                         "end": 37,
@@ -69,7 +63,6 @@ expression: actual
               },
               {
                 "type": "CallExpression",
-                "type": "CallExpression",
                 "start": 47,
                 "end": 63,
                 "callee": {
@@ -81,12 +74,10 @@ expression: actual
                 "arguments": [
                   {
                     "type": "ArrayExpression",
-                    "type": "ArrayExpression",
                     "start": 52,
                     "end": 59,
                     "elements": [
                       {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 53,
                         "end": 54,
@@ -94,7 +85,6 @@ expression: actual
                         "raw": "0"
                       },
                       {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 56,
                         "end": 58,
@@ -105,7 +95,6 @@ expression: actual
                   },
                   {
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution",
                     "start": 61,
                     "end": 62
                   }
@@ -113,7 +102,6 @@ expression: actual
                 "optional": false
               },
               {
-                "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 71,
                 "end": 96,
@@ -126,18 +114,15 @@ expression: actual
                 "arguments": [
                   {
                     "type": "ArrayExpression",
-                    "type": "ArrayExpression",
                     "start": 85,
                     "end": 92,
                     "elements": [
                       {
                         "type": "UnaryExpression",
-                        "type": "UnaryExpression",
                         "start": 86,
                         "end": 88,
                         "operator": "-",
                         "argument": {
-                          "type": "Literal",
                           "type": "Literal",
                           "start": 87,
                           "end": 88,
@@ -146,7 +131,6 @@ expression: actual
                         }
                       },
                       {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 90,
                         "end": 91,
@@ -157,7 +141,6 @@ expression: actual
                   },
                   {
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution",
                     "start": 94,
                     "end": 95
                   }
@@ -165,7 +148,6 @@ expression: actual
                 "optional": false
               },
               {
-                "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 104,
                 "end": 121,
@@ -178,12 +160,10 @@ expression: actual
                 "arguments": [
                   {
                     "type": "ArrayExpression",
-                    "type": "ArrayExpression",
                     "start": 109,
                     "end": 117,
                     "elements": [
                       {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 110,
                         "end": 111,
@@ -192,12 +172,10 @@ expression: actual
                       },
                       {
                         "type": "UnaryExpression",
-                        "type": "UnaryExpression",
                         "start": 113,
                         "end": 116,
                         "operator": "-",
                         "argument": {
-                          "type": "Literal",
                           "type": "Literal",
                           "start": 114,
                           "end": 116,
@@ -209,7 +187,6 @@ expression: actual
                   },
                   {
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution",
                     "start": 119,
                     "end": 120
                   }
@@ -217,7 +194,6 @@ expression: actual
                 "optional": false
               },
               {
-                "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 129,
                 "end": 143,
@@ -230,14 +206,12 @@ expression: actual
                 "arguments": [
                   {
                     "type": "Literal",
-                    "type": "Literal",
                     "start": 137,
                     "end": 139,
                     "value": 10,
                     "raw": "10"
                   },
                   {
-                    "type": "PipeSubstitution",
                     "type": "PipeSubstitution",
                     "start": 141,
                     "end": 142

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__aa.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__aa.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 17,
       "declarations": [
@@ -24,12 +23,10 @@ expression: actual
           },
           "init": {
             "type": "UnaryExpression",
-            "type": "UnaryExpression",
             "start": 11,
             "end": 17,
             "operator": "-",
             "argument": {
-              "type": "Identifier",
               "type": "Identifier",
               "start": 12,
               "end": 17,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ab.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ab.snap
@@ -8,11 +8,9 @@ expression: actual
   "body": [
     {
       "type": "ExpressionStatement",
-      "type": "ExpressionStatement",
       "start": 0,
       "end": 23,
       "expression": {
-        "type": "CallExpression",
         "type": "CallExpression",
         "start": 0,
         "end": 23,
@@ -24,7 +22,6 @@ expression: actual
         },
         "arguments": [
           {
-            "type": "ObjectExpression",
             "type": "ObjectExpression",
             "start": 7,
             "end": 22,
@@ -41,12 +38,10 @@ expression: actual
                 },
                 "value": {
                   "type": "ArrayExpression",
-                  "type": "ArrayExpression",
                   "start": 13,
                   "end": 20,
                   "elements": [
                     {
-                      "type": "Literal",
                       "type": "Literal",
                       "start": 14,
                       "end": 15,
@@ -55,12 +50,10 @@ expression: actual
                     },
                     {
                       "type": "UnaryExpression",
-                      "type": "UnaryExpression",
                       "start": 17,
                       "end": 19,
                       "operator": "-",
                       "argument": {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 18,
                         "end": 19,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ac.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ac.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 23,
       "declarations": [
@@ -24,11 +23,9 @@ expression: actual
           },
           "init": {
             "type": "ArrayRangeExpression",
-            "type": "ArrayRangeExpression",
             "start": 16,
             "end": 23,
             "startElement": {
-              "type": "Literal",
               "type": "Literal",
               "start": 17,
               "end": 18,
@@ -36,7 +33,6 @@ expression: actual
               "raw": "0"
             },
             "endElement": {
-              "type": "Literal",
               "type": "Literal",
               "start": 20,
               "end": 22,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ad.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ad.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 5,
       "end": 57,
       "declarations": [
@@ -24,7 +23,6 @@ expression: actual
           },
           "init": {
             "type": "FunctionExpression",
-            "type": "FunctionExpression",
             "start": 27,
             "end": 57,
             "params": [],
@@ -34,11 +32,9 @@ expression: actual
               "body": [
                 {
                   "type": "ReturnStatement",
-                  "type": "ReturnStatement",
                   "start": 43,
                   "end": 51,
                   "argument": {
-                    "type": "Literal",
                     "type": "Literal",
                     "start": 50,
                     "end": 51,
@@ -55,11 +51,9 @@ expression: actual
     },
     {
       "type": "ExpressionStatement",
-      "type": "ExpressionStatement",
       "start": 62,
       "end": 80,
       "expression": {
-        "type": "CallExpression",
         "type": "CallExpression",
         "start": 62,
         "end": 80,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ae.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ae.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 49,
       "declarations": [
@@ -23,7 +22,6 @@ expression: actual
             "name": "thing"
           },
           "init": {
-            "type": "FunctionExpression",
             "type": "FunctionExpression",
             "start": 11,
             "end": 49,
@@ -45,11 +43,9 @@ expression: actual
               "body": [
                 {
                   "type": "ReturnStatement",
-                  "type": "ReturnStatement",
                   "start": 32,
                   "end": 43,
                   "argument": {
-                    "type": "Literal",
                     "type": "Literal",
                     "start": 39,
                     "end": 43,
@@ -66,11 +62,9 @@ expression: actual
     },
     {
       "type": "ExpressionStatement",
-      "type": "ExpressionStatement",
       "start": 54,
       "end": 66,
       "expression": {
-        "type": "CallExpression",
         "type": "CallExpression",
         "start": 54,
         "end": 66,
@@ -82,7 +76,6 @@ expression: actual
         },
         "arguments": [
           {
-            "type": "Literal",
             "type": "Literal",
             "start": 60,
             "end": 65,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__af.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__af.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 165,
       "declarations": [
@@ -24,12 +23,10 @@ expression: actual
           },
           "init": {
             "type": "PipeExpression",
-            "type": "PipeExpression",
             "start": 17,
             "end": 165,
             "body": [
               {
-                "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 17,
                 "end": 37,
@@ -42,12 +39,10 @@ expression: actual
                 "arguments": [
                   {
                     "type": "ArrayExpression",
-                    "type": "ArrayExpression",
                     "start": 31,
                     "end": 36,
                     "elements": [
                       {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 32,
                         "end": 33,
@@ -55,7 +50,6 @@ expression: actual
                         "raw": "0"
                       },
                       {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 34,
                         "end": 35,
@@ -69,7 +63,6 @@ expression: actual
               },
               {
                 "type": "CallExpression",
-                "type": "CallExpression",
                 "start": 49,
                 "end": 75,
                 "callee": {
@@ -81,12 +74,10 @@ expression: actual
                 "arguments": [
                   {
                     "type": "ArrayExpression",
-                    "type": "ArrayExpression",
                     "start": 56,
                     "end": 62,
                     "elements": [
                       {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 57,
                         "end": 58,
@@ -94,7 +85,6 @@ expression: actual
                         "raw": "0"
                       },
                       {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 60,
                         "end": 61,
@@ -105,12 +95,10 @@ expression: actual
                   },
                   {
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution",
                     "start": 64,
                     "end": 65
                   },
                   {
-                    "type": "TagDeclarator",
                     "type": "TagDeclarator",
                     "start": 67,
                     "end": 74,
@@ -120,7 +108,6 @@ expression: actual
                 "optional": false
               },
               {
-                "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 87,
                 "end": 104,
@@ -133,12 +120,10 @@ expression: actual
                 "arguments": [
                   {
                     "type": "ArrayExpression",
-                    "type": "ArrayExpression",
                     "start": 94,
                     "end": 100,
                     "elements": [
                       {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 95,
                         "end": 96,
@@ -146,7 +131,6 @@ expression: actual
                         "raw": "1"
                       },
                       {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 98,
                         "end": 99,
@@ -157,7 +141,6 @@ expression: actual
                   },
                   {
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution",
                     "start": 102,
                     "end": 103
                   }
@@ -165,7 +148,6 @@ expression: actual
                 "optional": false
               },
               {
-                "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 116,
                 "end": 145,
@@ -178,12 +160,10 @@ expression: actual
                 "arguments": [
                   {
                     "type": "ArrayExpression",
-                    "type": "ArrayExpression",
                     "start": 123,
                     "end": 129,
                     "elements": [
                       {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 124,
                         "end": 125,
@@ -191,7 +171,6 @@ expression: actual
                         "raw": "1"
                       },
                       {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 127,
                         "end": 128,
@@ -202,12 +181,10 @@ expression: actual
                   },
                   {
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution",
                     "start": 131,
                     "end": 132
                   },
                   {
-                    "type": "TagDeclarator",
                     "type": "TagDeclarator",
                     "start": 134,
                     "end": 144,
@@ -217,7 +194,6 @@ expression: actual
                 "optional": false
               },
               {
-                "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 157,
                 "end": 165,
@@ -229,7 +205,6 @@ expression: actual
                 },
                 "arguments": [
                   {
-                    "type": "PipeSubstitution",
                     "type": "PipeSubstitution",
                     "start": 163,
                     "end": 164

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ag.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ag.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 70,
       "declarations": [
@@ -24,12 +23,10 @@ expression: actual
           },
           "init": {
             "type": "PipeExpression",
-            "type": "PipeExpression",
             "start": 17,
             "end": 70,
             "body": [
               {
-                "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 17,
                 "end": 37,
@@ -42,12 +39,10 @@ expression: actual
                 "arguments": [
                   {
                     "type": "ArrayExpression",
-                    "type": "ArrayExpression",
                     "start": 31,
                     "end": 36,
                     "elements": [
                       {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 32,
                         "end": 33,
@@ -55,7 +50,6 @@ expression: actual
                         "raw": "0"
                       },
                       {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 34,
                         "end": 35,
@@ -69,7 +63,6 @@ expression: actual
               },
               {
                 "type": "CallExpression",
-                "type": "CallExpression",
                 "start": 41,
                 "end": 58,
                 "callee": {
@@ -81,12 +74,10 @@ expression: actual
                 "arguments": [
                   {
                     "type": "ArrayExpression",
-                    "type": "ArrayExpression",
                     "start": 48,
                     "end": 54,
                     "elements": [
                       {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 49,
                         "end": 50,
@@ -94,7 +85,6 @@ expression: actual
                         "raw": "1"
                       },
                       {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 52,
                         "end": 53,
@@ -105,7 +95,6 @@ expression: actual
                   },
                   {
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution",
                     "start": 56,
                     "end": 57
                   }
@@ -113,7 +102,6 @@ expression: actual
                 "optional": false
               },
               {
-                "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 62,
                 "end": 70,
@@ -125,7 +113,6 @@ expression: actual
                 },
                 "arguments": [
                   {
-                    "type": "PipeSubstitution",
                     "type": "PipeSubstitution",
                     "start": 68,
                     "end": 69

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ah.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ah.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 30,
       "declarations": [
@@ -24,7 +23,6 @@ expression: actual
           },
           "init": {
             "type": "CallExpression",
-            "type": "CallExpression",
             "start": 14,
             "end": 30,
             "callee": {
@@ -35,7 +33,6 @@ expression: actual
             },
             "arguments": [
               {
-                "type": "Identifier",
                 "type": "Identifier",
                 "start": 28,
                 "end": 29,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ai.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ai.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 29,
       "declarations": [
@@ -24,12 +23,10 @@ expression: actual
           },
           "init": {
             "type": "PipeExpression",
-            "type": "PipeExpression",
             "start": 14,
             "end": 29,
             "body": [
               {
-                "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 14,
                 "end": 18,
@@ -42,7 +39,6 @@ expression: actual
                 "arguments": [
                   {
                     "type": "Literal",
-                    "type": "Literal",
                     "start": 16,
                     "end": 17,
                     "value": 1,
@@ -52,7 +48,6 @@ expression: actual
                 "optional": false
               },
               {
-                "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 22,
                 "end": 29,
@@ -65,14 +60,12 @@ expression: actual
                 "arguments": [
                   {
                     "type": "Literal",
-                    "type": "Literal",
                     "start": 24,
                     "end": 25,
                     "value": 2,
                     "raw": "2"
                   },
                   {
-                    "type": "PipeSubstitution",
                     "type": "PipeSubstitution",
                     "start": 27,
                     "end": 28

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__aj.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__aj.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 49,
       "declarations": [
@@ -24,12 +23,10 @@ expression: actual
           },
           "init": {
             "type": "PipeExpression",
-            "type": "PipeExpression",
             "start": 14,
             "end": 49,
             "body": [
               {
-                "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 14,
                 "end": 30,
@@ -42,7 +39,6 @@ expression: actual
                 "arguments": [
                   {
                     "type": "Identifier",
-                    "type": "Identifier",
                     "start": 28,
                     "end": 29,
                     "name": "p"
@@ -51,7 +47,6 @@ expression: actual
                 "optional": false
               },
               {
-                "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 34,
                 "end": 49,
@@ -64,12 +59,10 @@ expression: actual
                 "arguments": [
                   {
                     "type": "ArrayExpression",
-                    "type": "ArrayExpression",
                     "start": 39,
                     "end": 45,
                     "elements": [
                       {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 40,
                         "end": 41,
@@ -78,7 +71,6 @@ expression: actual
                       },
                       {
                         "type": "Identifier",
-                        "type": "Identifier",
                         "start": 43,
                         "end": 44,
                         "name": "l"
@@ -86,7 +78,6 @@ expression: actual
                     ]
                   },
                   {
-                    "type": "PipeSubstitution",
                     "type": "PipeSubstitution",
                     "start": 47,
                     "end": 48

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ak.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ak.snap
@@ -8,11 +8,9 @@ expression: actual
   "body": [
     {
       "type": "ExpressionStatement",
-      "type": "ExpressionStatement",
       "start": 0,
       "end": 22,
       "expression": {
-        "type": "CallExpression",
         "type": "CallExpression",
         "start": 0,
         "end": 22,
@@ -24,7 +22,6 @@ expression: actual
         },
         "arguments": [
           {
-            "type": "ObjectExpression",
             "type": "ObjectExpression",
             "start": 7,
             "end": 21,
@@ -41,12 +38,10 @@ expression: actual
                 },
                 "value": {
                   "type": "ArrayExpression",
-                  "type": "ArrayExpression",
                   "start": 13,
                   "end": 19,
                   "elements": [
                     {
-                      "type": "Literal",
                       "type": "Literal",
                       "start": 14,
                       "end": 15,
@@ -54,7 +49,6 @@ expression: actual
                       "raw": "0"
                     },
                     {
-                      "type": "Literal",
                       "type": "Literal",
                       "start": 17,
                       "end": 18,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__al.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__al.snap
@@ -8,11 +8,9 @@ expression: actual
   "body": [
     {
       "type": "ExpressionStatement",
-      "type": "ExpressionStatement",
       "start": 0,
       "end": 36,
       "expression": {
-        "type": "CallExpression",
         "type": "CallExpression",
         "start": 0,
         "end": 36,
@@ -24,7 +22,6 @@ expression: actual
         },
         "arguments": [
           {
-            "type": "ObjectExpression",
             "type": "ObjectExpression",
             "start": 7,
             "end": 35,
@@ -41,12 +38,10 @@ expression: actual
                 },
                 "value": {
                   "type": "ArrayExpression",
-                  "type": "ArrayExpression",
                   "start": 13,
                   "end": 19,
                   "elements": [
                     {
-                      "type": "Literal",
                       "type": "Literal",
                       "start": 14,
                       "end": 15,
@@ -54,7 +49,6 @@ expression: actual
                       "raw": "0"
                     },
                     {
-                      "type": "Literal",
                       "type": "Literal",
                       "start": 17,
                       "end": 18,
@@ -76,12 +70,10 @@ expression: actual
                 },
                 "value": {
                   "type": "ArrayExpression",
-                  "type": "ArrayExpression",
                   "start": 27,
                   "end": 33,
                   "elements": [
                     {
-                      "type": "Literal",
                       "type": "Literal",
                       "start": 28,
                       "end": 29,
@@ -89,7 +81,6 @@ expression: actual
                       "raw": "3"
                     },
                     {
-                      "type": "Literal",
                       "type": "Literal",
                       "start": 31,
                       "end": 32,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__am.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__am.snap
@@ -8,11 +8,9 @@ expression: actual
   "body": [
     {
       "type": "ExpressionStatement",
-      "type": "ExpressionStatement",
       "start": 0,
       "end": 19,
       "expression": {
-        "type": "CallExpression",
         "type": "CallExpression",
         "start": 0,
         "end": 19,
@@ -24,7 +22,6 @@ expression: actual
         },
         "arguments": [
           {
-            "type": "ObjectExpression",
             "type": "ObjectExpression",
             "start": 7,
             "end": 18,
@@ -41,12 +38,10 @@ expression: actual
                 },
                 "value": {
                   "type": "ArrayExpression",
-                  "type": "ArrayExpression",
                   "start": 11,
                   "end": 17,
                   "elements": [
                     {
-                      "type": "Literal",
                       "type": "Literal",
                       "start": 12,
                       "end": 13,
@@ -54,7 +49,6 @@ expression: actual
                       "raw": "0"
                     },
                     {
-                      "type": "Literal",
                       "type": "Literal",
                       "start": 15,
                       "end": 16,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__an.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__an.snap
@@ -8,11 +8,9 @@ expression: actual
   "body": [
     {
       "type": "ExpressionStatement",
-      "type": "ExpressionStatement",
       "start": 0,
       "end": 35,
       "expression": {
-        "type": "CallExpression",
         "type": "CallExpression",
         "start": 0,
         "end": 35,
@@ -24,7 +22,6 @@ expression: actual
         },
         "arguments": [
           {
-            "type": "ObjectExpression",
             "type": "ObjectExpression",
             "start": 7,
             "end": 34,
@@ -41,12 +38,10 @@ expression: actual
                 },
                 "value": {
                   "type": "ArrayExpression",
-                  "type": "ArrayExpression",
                   "start": 13,
                   "end": 19,
                   "elements": [
                     {
-                      "type": "Literal",
                       "type": "Literal",
                       "start": 14,
                       "end": 15,
@@ -54,7 +49,6 @@ expression: actual
                       "raw": "0"
                     },
                     {
-                      "type": "Literal",
                       "type": "Literal",
                       "start": 17,
                       "end": 18,
@@ -76,12 +70,10 @@ expression: actual
                 },
                 "value": {
                   "type": "ArrayExpression",
-                  "type": "ArrayExpression",
                   "start": 27,
                   "end": 33,
                   "elements": [
                     {
-                      "type": "Literal",
                       "type": "Literal",
                       "start": 28,
                       "end": 29,
@@ -89,7 +81,6 @@ expression: actual
                       "raw": "3"
                     },
                     {
-                      "type": "Literal",
                       "type": "Literal",
                       "start": 31,
                       "end": 32,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ao.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ao.snap
@@ -8,11 +8,9 @@ expression: actual
   "body": [
     {
       "type": "ExpressionStatement",
-      "type": "ExpressionStatement",
       "start": 0,
       "end": 35,
       "expression": {
-        "type": "CallExpression",
         "type": "CallExpression",
         "start": 0,
         "end": 35,
@@ -24,7 +22,6 @@ expression: actual
         },
         "arguments": [
           {
-            "type": "ObjectExpression",
             "type": "ObjectExpression",
             "start": 7,
             "end": 34,
@@ -41,12 +38,10 @@ expression: actual
                 },
                 "value": {
                   "type": "ArrayExpression",
-                  "type": "ArrayExpression",
                   "start": 13,
                   "end": 19,
                   "elements": [
                     {
-                      "type": "Literal",
                       "type": "Literal",
                       "start": 14,
                       "end": 15,
@@ -54,7 +49,6 @@ expression: actual
                       "raw": "0"
                     },
                     {
-                      "type": "Literal",
                       "type": "Literal",
                       "start": 17,
                       "end": 18,
@@ -76,12 +70,10 @@ expression: actual
                 },
                 "value": {
                   "type": "ArrayExpression",
-                  "type": "ArrayExpression",
                   "start": 26,
                   "end": 32,
                   "elements": [
                     {
-                      "type": "Literal",
                       "type": "Literal",
                       "start": 27,
                       "end": 28,
@@ -89,7 +81,6 @@ expression: actual
                       "raw": "3"
                     },
                     {
-                      "type": "Literal",
                       "type": "Literal",
                       "start": 30,
                       "end": 31,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ap.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ap.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 37,
       "declarations": [
@@ -24,7 +23,6 @@ expression: actual
           },
           "init": {
             "type": "CallExpression",
-            "type": "CallExpression",
             "start": 17,
             "end": 37,
             "callee": {
@@ -36,12 +34,10 @@ expression: actual
             "arguments": [
               {
                 "type": "ArrayExpression",
-                "type": "ArrayExpression",
                 "start": 31,
                 "end": 36,
                 "elements": [
                   {
-                    "type": "Literal",
                     "type": "Literal",
                     "start": 32,
                     "end": 33,
@@ -49,7 +45,6 @@ expression: actual
                     "raw": "0"
                   },
                   {
-                    "type": "Literal",
                     "type": "Literal",
                     "start": 34,
                     "end": 35,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__aq.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__aq.snap
@@ -8,11 +8,9 @@ expression: actual
   "body": [
     {
       "type": "ExpressionStatement",
-      "type": "ExpressionStatement",
       "start": 0,
       "end": 28,
       "expression": {
-        "type": "CallExpression",
         "type": "CallExpression",
         "start": 0,
         "end": 28,
@@ -25,7 +23,6 @@ expression: actual
         "arguments": [
           {
             "type": "Literal",
-            "type": "Literal",
             "start": 4,
             "end": 5,
             "value": 5,
@@ -33,14 +30,12 @@ expression: actual
           },
           {
             "type": "Literal",
-            "type": "Literal",
             "start": 7,
             "end": 14,
             "value": "hello",
             "raw": "\"hello\""
           },
           {
-            "type": "Identifier",
             "type": "Identifier",
             "start": 16,
             "end": 27,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ar.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ar.snap
@@ -8,17 +8,14 @@ expression: actual
   "body": [
     {
       "type": "ExpressionStatement",
-      "type": "ExpressionStatement",
       "start": 0,
       "end": 7,
       "expression": {
-        "type": "BinaryExpression",
         "type": "BinaryExpression",
         "start": 0,
         "end": 7,
         "operator": "+",
         "left": {
-          "type": "Literal",
           "type": "Literal",
           "start": 0,
           "end": 1,
@@ -26,7 +23,6 @@ expression: actual
           "raw": "5"
         },
         "right": {
-          "type": "Literal",
           "type": "Literal",
           "start": 4,
           "end": 7,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__at.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__at.snap
@@ -8,11 +8,9 @@ expression: actual
   "body": [
     {
       "type": "ExpressionStatement",
-      "type": "ExpressionStatement",
       "start": 0,
       "end": 15,
       "expression": {
-        "type": "CallExpression",
         "type": "CallExpression",
         "start": 0,
         "end": 15,
@@ -25,12 +23,10 @@ expression: actual
         "arguments": [
           {
             "type": "ArrayExpression",
-            "type": "ArrayExpression",
             "start": 5,
             "end": 11,
             "elements": [
               {
-                "type": "Literal",
                 "type": "Literal",
                 "start": 6,
                 "end": 7,
@@ -39,7 +35,6 @@ expression: actual
               },
               {
                 "type": "Identifier",
-                "type": "Identifier",
                 "start": 9,
                 "end": 10,
                 "name": "l"
@@ -47,7 +42,6 @@ expression: actual
             ]
           },
           {
-            "type": "PipeSubstitution",
             "type": "PipeSubstitution",
             "start": 13,
             "end": 14

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__au.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__au.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 107,
       "declarations": [
@@ -24,12 +23,10 @@ expression: actual
           },
           "init": {
             "type": "PipeExpression",
-            "type": "PipeExpression",
             "start": 17,
             "end": 107,
             "body": [
               {
-                "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 17,
                 "end": 36,
@@ -42,7 +39,6 @@ expression: actual
                 "arguments": [
                   {
                     "type": "Literal",
-                    "type": "Literal",
                     "start": 31,
                     "end": 35,
                     "value": "XY",
@@ -52,7 +48,6 @@ expression: actual
                 "optional": false
               },
               {
-                "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 44,
                 "end": 85,
@@ -64,7 +59,6 @@ expression: actual
                 },
                 "arguments": [
                   {
-                    "type": "ObjectExpression",
                     "type": "ObjectExpression",
                     "start": 51,
                     "end": 81,
@@ -81,12 +75,10 @@ expression: actual
                         },
                         "value": {
                           "type": "ArrayExpression",
-                          "type": "ArrayExpression",
                           "start": 61,
                           "end": 67,
                           "elements": [
                             {
-                              "type": "Literal",
                               "type": "Literal",
                               "start": 62,
                               "end": 63,
@@ -94,7 +86,6 @@ expression: actual
                               "raw": "0"
                             },
                             {
-                              "type": "Literal",
                               "type": "Literal",
                               "start": 65,
                               "end": 66,
@@ -116,7 +107,6 @@ expression: actual
                         },
                         "value": {
                           "type": "Literal",
-                          "type": "Literal",
                           "start": 77,
                           "end": 79,
                           "value": 22,
@@ -127,7 +117,6 @@ expression: actual
                   },
                   {
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution",
                     "start": 83,
                     "end": 84
                   }
@@ -135,7 +124,6 @@ expression: actual
                 "optional": false
               },
               {
-                "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 93,
                 "end": 107,
@@ -148,14 +136,12 @@ expression: actual
                 "arguments": [
                   {
                     "type": "Literal",
-                    "type": "Literal",
                     "start": 101,
                     "end": 103,
                     "value": 14,
                     "raw": "14"
                   },
                   {
-                    "type": "PipeSubstitution",
                     "type": "PipeSubstitution",
                     "start": 105,
                     "end": 106

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__av.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__av.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 49,
       "declarations": [
@@ -23,7 +22,6 @@ expression: actual
             "name": "f"
           },
           "init": {
-            "type": "FunctionExpression",
             "type": "FunctionExpression",
             "start": 7,
             "end": 49,
@@ -45,11 +43,9 @@ expression: actual
               "body": [
                 {
                   "type": "ReturnStatement",
-                  "type": "ReturnStatement",
                   "start": 21,
                   "end": 47,
                   "argument": {
-                    "type": "CallExpression",
                     "type": "CallExpression",
                     "start": 28,
                     "end": 47,
@@ -62,13 +58,11 @@ expression: actual
                     "arguments": [
                       {
                         "type": "Identifier",
-                        "type": "Identifier",
                         "start": 36,
                         "end": 41,
                         "name": "angle"
                       },
                       {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 43,
                         "end": 46,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__aw.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__aw.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 91,
       "declarations": [
@@ -24,12 +23,10 @@ expression: actual
           },
           "init": {
             "type": "ArrayExpression",
-            "type": "ArrayExpression",
             "start": 14,
             "end": 91,
             "elements": [
               {
-                "type": "Literal",
                 "type": "Literal",
                 "start": 28,
                 "end": 29,
@@ -37,7 +34,6 @@ expression: actual
                 "raw": "1"
               },
               {
-                "type": "Literal",
                 "type": "Literal",
                 "start": 79,
                 "end": 80,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ax.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ax.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 91,
       "declarations": [
@@ -24,12 +23,10 @@ expression: actual
           },
           "init": {
             "type": "ArrayExpression",
-            "type": "ArrayExpression",
             "start": 14,
             "end": 91,
             "elements": [
               {
-                "type": "Literal",
                 "type": "Literal",
                 "start": 28,
                 "end": 29,
@@ -37,7 +34,6 @@ expression: actual
                 "raw": "1"
               },
               {
-                "type": "Literal",
                 "type": "Literal",
                 "start": 43,
                 "end": 44,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ay.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ay.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 80,
       "declarations": [
@@ -24,7 +23,6 @@ expression: actual
           },
           "init": {
             "type": "ObjectExpression",
-            "type": "ObjectExpression",
             "start": 12,
             "end": 80,
             "properties": [
@@ -39,7 +37,6 @@ expression: actual
                   "name": "a"
                 },
                 "value": {
-                  "type": "Literal",
                   "type": "Literal",
                   "start": 29,
                   "end": 30,
@@ -58,7 +55,6 @@ expression: actual
                   "name": "c"
                 },
                 "value": {
-                  "type": "Literal",
                   "type": "Literal",
                   "start": 68,
                   "end": 69,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__az.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__az.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 79,
       "declarations": [
@@ -24,7 +23,6 @@ expression: actual
           },
           "init": {
             "type": "ObjectExpression",
-            "type": "ObjectExpression",
             "start": 12,
             "end": 79,
             "properties": [
@@ -39,7 +37,6 @@ expression: actual
                   "name": "a"
                 },
                 "value": {
-                  "type": "Literal",
                   "type": "Literal",
                   "start": 29,
                   "end": 30,
@@ -58,7 +55,6 @@ expression: actual
                   "name": "c"
                 },
                 "value": {
-                  "type": "Literal",
                   "type": "Literal",
                   "start": 68,
                   "end": 69,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__b.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__b.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 36,
       "declarations": [
@@ -24,7 +23,6 @@ expression: actual
           },
           "init": {
             "type": "CallExpression",
-            "type": "CallExpression",
             "start": 14,
             "end": 36,
             "callee": {
@@ -36,7 +34,6 @@ expression: actual
             "arguments": [
               {
                 "type": "Literal",
-                "type": "Literal",
                 "start": 18,
                 "end": 19,
                 "value": 5,
@@ -44,12 +41,10 @@ expression: actual
               },
               {
                 "type": "UnaryExpression",
-                "type": "UnaryExpression",
                 "start": 22,
                 "end": 35,
                 "operator": "-",
                 "argument": {
-                  "type": "CallExpression",
                   "type": "CallExpression",
                   "start": 23,
                   "end": 35,
@@ -62,14 +57,12 @@ expression: actual
                   "arguments": [
                     {
                       "type": "Literal",
-                      "type": "Literal",
                       "start": 30,
                       "end": 31,
                       "value": 5,
                       "raw": "5"
                     },
                     {
-                      "type": "Literal",
                       "type": "Literal",
                       "start": 33,
                       "end": 34,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ba.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ba.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 1,
       "end": 132,
       "declarations": [
@@ -24,12 +23,10 @@ expression: actual
           },
           "init": {
             "type": "PipeExpression",
-            "type": "PipeExpression",
             "start": 19,
             "end": 132,
             "body": [
               {
-                "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 19,
                 "end": 38,
@@ -42,7 +39,6 @@ expression: actual
                 "arguments": [
                   {
                     "type": "Literal",
-                    "type": "Literal",
                     "start": 33,
                     "end": 37,
                     "value": "XY",
@@ -52,7 +48,6 @@ expression: actual
                 "optional": false
               },
               {
-                "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 115,
                 "end": 132,
@@ -64,7 +59,6 @@ expression: actual
                 },
                 "arguments": [
                   {
-                    "type": "PipeSubstitution",
                     "type": "PipeSubstitution",
                     "start": 130,
                     "end": 131

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bb.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bb.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 1,
       "end": 31,
       "declarations": [
@@ -24,18 +23,15 @@ expression: actual
           },
           "init": {
             "type": "BinaryExpression",
-            "type": "BinaryExpression",
             "start": 14,
             "end": 31,
             "operator": "-",
             "left": {
               "type": "BinaryExpression",
-              "type": "BinaryExpression",
               "start": 14,
               "end": 19,
               "operator": "^",
               "left": {
-                "type": "Literal",
                 "type": "Literal",
                 "start": 14,
                 "end": 15,
@@ -43,7 +39,6 @@ expression: actual
                 "raw": "4"
               },
               "right": {
-                "type": "Literal",
                 "type": "Literal",
                 "start": 18,
                 "end": 19,
@@ -53,18 +48,15 @@ expression: actual
             },
             "right": {
               "type": "BinaryExpression",
-              "type": "BinaryExpression",
               "start": 22,
               "end": 31,
               "operator": "*",
               "left": {
                 "type": "BinaryExpression",
-                "type": "BinaryExpression",
                 "start": 22,
                 "end": 27,
                 "operator": "^",
                 "left": {
-                  "type": "Literal",
                   "type": "Literal",
                   "start": 22,
                   "end": 23,
@@ -73,7 +65,6 @@ expression: actual
                 },
                 "right": {
                   "type": "Literal",
-                  "type": "Literal",
                   "start": 26,
                   "end": 27,
                   "value": 2,
@@ -81,7 +72,6 @@ expression: actual
                 }
               },
               "right": {
-                "type": "Literal",
                 "type": "Literal",
                 "start": 30,
                 "end": 31,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bc.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bc.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 74,
       "declarations": [
@@ -24,11 +23,9 @@ expression: actual
           },
           "init": {
             "type": "IfExpression",
-            "type": "IfExpression",
             "start": 10,
             "end": 74,
             "cond": {
-              "type": "Literal",
               "type": "Literal",
               "start": 13,
               "end": 17,
@@ -41,11 +38,9 @@ expression: actual
               "body": [
                 {
                   "type": "ExpressionStatement",
-                  "type": "ExpressionStatement",
                   "start": 32,
                   "end": 33,
                   "expression": {
-                    "type": "Literal",
                     "type": "Literal",
                     "start": 32,
                     "end": 33,
@@ -62,11 +57,9 @@ expression: actual
               "body": [
                 {
                   "type": "ExpressionStatement",
-                  "type": "ExpressionStatement",
                   "start": 63,
                   "end": 64,
                   "expression": {
-                    "type": "Literal",
                     "type": "Literal",
                     "start": 63,
                     "end": 64,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bd.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bd.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 121,
       "declarations": [
@@ -24,11 +23,9 @@ expression: actual
           },
           "init": {
             "type": "IfExpression",
-            "type": "IfExpression",
             "start": 10,
             "end": 121,
             "cond": {
-              "type": "Literal",
               "type": "Literal",
               "start": 13,
               "end": 17,
@@ -41,11 +38,9 @@ expression: actual
               "body": [
                 {
                   "type": "ExpressionStatement",
-                  "type": "ExpressionStatement",
                   "start": 32,
                   "end": 33,
                   "expression": {
-                    "type": "Literal",
                     "type": "Literal",
                     "start": 32,
                     "end": 33,
@@ -62,7 +57,6 @@ expression: actual
                 "end": 90,
                 "cond": {
                   "type": "CallExpression",
-                  "type": "CallExpression",
                   "start": 52,
                   "end": 64,
                   "callee": {
@@ -73,7 +67,6 @@ expression: actual
                   },
                   "arguments": [
                     {
-                      "type": "Identifier",
                       "type": "Identifier",
                       "start": 57,
                       "end": 63,
@@ -88,11 +81,9 @@ expression: actual
                   "body": [
                     {
                       "type": "ExpressionStatement",
-                      "type": "ExpressionStatement",
                       "start": 79,
                       "end": 80,
                       "expression": {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 79,
                         "end": 80,
@@ -111,11 +102,9 @@ expression: actual
               "body": [
                 {
                   "type": "ExpressionStatement",
-                  "type": "ExpressionStatement",
                   "start": 110,
                   "end": 111,
                   "expression": {
-                    "type": "Literal",
                     "type": "Literal",
                     "start": 110,
                     "end": 111,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__be.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__be.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 14,
       "declarations": [
@@ -24,12 +23,10 @@ expression: actual
           },
           "init": {
             "type": "BinaryExpression",
-            "type": "BinaryExpression",
             "start": 8,
             "end": 14,
             "operator": "==",
             "left": {
-              "type": "Literal",
               "type": "Literal",
               "start": 8,
               "end": 9,
@@ -37,7 +34,6 @@ expression: actual
               "raw": "3"
             },
             "right": {
-              "type": "Literal",
               "type": "Literal",
               "start": 13,
               "end": 14,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bf.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bf.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 14,
       "declarations": [
@@ -24,12 +23,10 @@ expression: actual
           },
           "init": {
             "type": "BinaryExpression",
-            "type": "BinaryExpression",
             "start": 8,
             "end": 14,
             "operator": "!=",
             "left": {
-              "type": "Literal",
               "type": "Literal",
               "start": 8,
               "end": 9,
@@ -37,7 +34,6 @@ expression: actual
               "raw": "3"
             },
             "right": {
-              "type": "Literal",
               "type": "Literal",
               "start": 13,
               "end": 14,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bg.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bg.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 5,
       "declarations": [
@@ -23,7 +22,6 @@ expression: actual
             "name": "x"
           },
           "init": {
-            "type": "Literal",
             "type": "Literal",
             "start": 4,
             "end": 5,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bh.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bh.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 42,
       "declarations": [
@@ -23,7 +22,6 @@ expression: actual
             "name": "obj"
           },
           "init": {
-            "type": "ObjectExpression",
             "type": "ObjectExpression",
             "start": 12,
             "end": 42,
@@ -40,12 +38,10 @@ expression: actual
                 },
                 "value": {
                   "type": "ArrayExpression",
-                  "type": "ArrayExpression",
                   "start": 22,
                   "end": 30,
                   "elements": [
                     {
-                      "type": "Literal",
                       "type": "Literal",
                       "start": 23,
                       "end": 25,
@@ -53,7 +49,6 @@ expression: actual
                       "raw": "10"
                     },
                     {
-                      "type": "Literal",
                       "type": "Literal",
                       "start": 27,
                       "end": 29,
@@ -74,7 +69,6 @@ expression: actual
                   "name": "radius"
                 },
                 "value": {
-                  "type": "Literal",
                   "type": "Literal",
                   "start": 40,
                   "end": 41,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__c.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__c.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 35,
       "declarations": [
@@ -24,7 +23,6 @@ expression: actual
           },
           "init": {
             "type": "CallExpression",
-            "type": "CallExpression",
             "start": 14,
             "end": 35,
             "callee": {
@@ -36,12 +34,10 @@ expression: actual
             "arguments": [
               {
                 "type": "UnaryExpression",
-                "type": "UnaryExpression",
                 "start": 18,
                 "end": 31,
                 "operator": "-",
                 "argument": {
-                  "type": "CallExpression",
                   "type": "CallExpression",
                   "start": 19,
                   "end": 31,
@@ -54,14 +50,12 @@ expression: actual
                   "arguments": [
                     {
                       "type": "Literal",
-                      "type": "Literal",
                       "start": 26,
                       "end": 27,
                       "value": 5,
                       "raw": "5"
                     },
                     {
-                      "type": "Literal",
                       "type": "Literal",
                       "start": 29,
                       "end": 30,
@@ -73,7 +67,6 @@ expression: actual
                 }
               },
               {
-                "type": "Literal",
                 "type": "Literal",
                 "start": 33,
                 "end": 34,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__d.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__d.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 36,
       "declarations": [
@@ -24,18 +23,15 @@ expression: actual
           },
           "init": {
             "type": "PipeExpression",
-            "type": "PipeExpression",
             "start": 14,
             "end": 36,
             "body": [
               {
                 "type": "BinaryExpression",
-                "type": "BinaryExpression",
                 "start": 14,
                 "end": 19,
                 "operator": "+",
                 "left": {
-                  "type": "Literal",
                   "type": "Literal",
                   "start": 14,
                   "end": 15,
@@ -44,7 +40,6 @@ expression: actual
                 },
                 "right": {
                   "type": "Literal",
-                  "type": "Literal",
                   "start": 18,
                   "end": 19,
                   "value": 6,
@@ -52,7 +47,6 @@ expression: actual
                 }
               },
               {
-                "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 23,
                 "end": 36,
@@ -65,14 +59,12 @@ expression: actual
                 "arguments": [
                   {
                     "type": "Literal",
-                    "type": "Literal",
                     "start": 30,
                     "end": 32,
                     "value": 45,
                     "raw": "45"
                   },
                   {
-                    "type": "PipeSubstitution",
                     "type": "PipeSubstitution",
                     "start": 34,
                     "end": 35

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__d2.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__d2.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 27,
       "declarations": [
@@ -24,18 +23,15 @@ expression: actual
           },
           "init": {
             "type": "BinaryExpression",
-            "type": "BinaryExpression",
             "start": 10,
             "end": 27,
             "operator": "+",
             "left": {
               "type": "UnaryExpression",
-              "type": "UnaryExpression",
               "start": 10,
               "end": 15,
               "operator": "-",
               "argument": {
-                "type": "Identifier",
                 "type": "Identifier",
                 "start": 11,
                 "end": 15,
@@ -43,7 +39,6 @@ expression: actual
               }
             },
             "right": {
-              "type": "Identifier",
               "type": "Identifier",
               "start": 18,
               "end": 27,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__e.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__e.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 18,
       "declarations": [
@@ -24,12 +23,10 @@ expression: actual
           },
           "init": {
             "type": "BinaryExpression",
-            "type": "BinaryExpression",
             "start": 8,
             "end": 18,
             "operator": "*",
             "left": {
-              "type": "Literal",
               "type": "Literal",
               "start": 8,
               "end": 9,
@@ -38,12 +35,10 @@ expression: actual
             },
             "right": {
               "type": "BinaryExpression",
-              "type": "BinaryExpression",
               "start": 13,
               "end": 18,
               "operator": "-",
               "left": {
-                "type": "Literal",
                 "type": "Literal",
                 "start": 13,
                 "end": 14,
@@ -51,7 +46,6 @@ expression: actual
                 "raw": "3"
               },
               "right": {
-                "type": "Literal",
                 "type": "Literal",
                 "start": 17,
                 "end": 18,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__f.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__f.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 11,
       "declarations": [
@@ -23,7 +22,6 @@ expression: actual
             "name": "x"
           },
           "init": {
-            "type": "Literal",
             "type": "Literal",
             "start": 10,
             "end": 11,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__g.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__g.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 58,
       "declarations": [
@@ -24,7 +23,6 @@ expression: actual
           },
           "init": {
             "type": "FunctionExpression",
-            "type": "FunctionExpression",
             "start": 7,
             "end": 58,
             "params": [],
@@ -34,11 +32,9 @@ expression: actual
               "body": [
                 {
                   "type": "ReturnStatement",
-                  "type": "ReturnStatement",
                   "start": 23,
                   "end": 32,
                   "argument": {
-                    "type": "Identifier",
                     "type": "Identifier",
                     "start": 30,
                     "end": 32,
@@ -47,11 +43,9 @@ expression: actual
                 },
                 {
                   "type": "ReturnStatement",
-                  "type": "ReturnStatement",
                   "start": 41,
                   "end": 50,
                   "argument": {
-                    "type": "Identifier",
                     "type": "Identifier",
                     "start": 48,
                     "end": 50,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__h.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__h.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 26,
       "declarations": [
@@ -24,7 +23,6 @@ expression: actual
           },
           "init": {
             "type": "ObjectExpression",
-            "type": "ObjectExpression",
             "start": 12,
             "end": 26,
             "properties": [
@@ -39,7 +37,6 @@ expression: actual
                   "name": "a"
                 },
                 "value": {
-                  "type": "Literal",
                   "type": "Literal",
                   "start": 17,
                   "end": 18,
@@ -59,7 +56,6 @@ expression: actual
                 },
                 "value": {
                   "type": "Literal",
-                  "type": "Literal",
                   "start": 23,
                   "end": 24,
                   "value": 2,
@@ -73,7 +69,6 @@ expression: actual
       "kind": "const"
     },
     {
-      "type": "VariableDeclaration",
       "type": "VariableDeclaration",
       "start": 31,
       "end": 55,
@@ -90,12 +85,10 @@ expression: actual
           },
           "init": {
             "type": "BinaryExpression",
-            "type": "BinaryExpression",
             "start": 46,
             "end": 55,
             "operator": "-",
             "left": {
-              "type": "Literal",
               "type": "Literal",
               "start": 46,
               "end": 47,
@@ -104,18 +97,15 @@ expression: actual
             },
             "right": {
               "type": "MemberExpression",
-              "type": "MemberExpression",
               "start": 50,
               "end": 55,
               "object": {
-                "type": "Identifier",
                 "type": "Identifier",
                 "start": 50,
                 "end": 53,
                 "name": "obj"
               },
               "property": {
-                "type": "Identifier",
                 "type": "Identifier",
                 "start": 54,
                 "end": 55,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__i.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__i.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 26,
       "declarations": [
@@ -24,7 +23,6 @@ expression: actual
           },
           "init": {
             "type": "ObjectExpression",
-            "type": "ObjectExpression",
             "start": 12,
             "end": 26,
             "properties": [
@@ -39,7 +37,6 @@ expression: actual
                   "name": "a"
                 },
                 "value": {
-                  "type": "Literal",
                   "type": "Literal",
                   "start": 17,
                   "end": 18,
@@ -59,7 +56,6 @@ expression: actual
                 },
                 "value": {
                   "type": "Literal",
-                  "type": "Literal",
                   "start": 23,
                   "end": 24,
                   "value": 2,
@@ -73,7 +69,6 @@ expression: actual
       "kind": "const"
     },
     {
-      "type": "VariableDeclaration",
       "type": "VariableDeclaration",
       "start": 32,
       "end": 59,
@@ -90,12 +85,10 @@ expression: actual
           },
           "init": {
             "type": "BinaryExpression",
-            "type": "BinaryExpression",
             "start": 47,
             "end": 59,
             "operator": "-",
             "left": {
-              "type": "Literal",
               "type": "Literal",
               "start": 47,
               "end": 48,
@@ -104,18 +97,15 @@ expression: actual
             },
             "right": {
               "type": "MemberExpression",
-              "type": "MemberExpression",
               "start": 51,
               "end": 59,
               "object": {
-                "type": "Identifier",
                 "type": "Identifier",
                 "start": 51,
                 "end": 54,
                 "name": "obj"
               },
               "property": {
-                "type": "Literal",
                 "type": "Literal",
                 "start": 55,
                 "end": 58,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__j.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__j.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 26,
       "declarations": [
@@ -24,7 +23,6 @@ expression: actual
           },
           "init": {
             "type": "ObjectExpression",
-            "type": "ObjectExpression",
             "start": 12,
             "end": 26,
             "properties": [
@@ -39,7 +37,6 @@ expression: actual
                   "name": "a"
                 },
                 "value": {
-                  "type": "Literal",
                   "type": "Literal",
                   "start": 17,
                   "end": 18,
@@ -59,7 +56,6 @@ expression: actual
                 },
                 "value": {
                   "type": "Literal",
-                  "type": "Literal",
                   "start": 23,
                   "end": 24,
                   "value": 2,
@@ -73,7 +69,6 @@ expression: actual
       "kind": "const"
     },
     {
-      "type": "VariableDeclaration",
       "type": "VariableDeclaration",
       "start": 31,
       "end": 58,
@@ -90,24 +85,20 @@ expression: actual
           },
           "init": {
             "type": "BinaryExpression",
-            "type": "BinaryExpression",
             "start": 46,
             "end": 58,
             "operator": "-",
             "left": {
               "type": "MemberExpression",
-              "type": "MemberExpression",
               "start": 46,
               "end": 54,
               "object": {
-                "type": "Identifier",
                 "type": "Identifier",
                 "start": 46,
                 "end": 49,
                 "name": "obj"
               },
               "property": {
-                "type": "Literal",
                 "type": "Literal",
                 "start": 50,
                 "end": 53,
@@ -117,7 +108,6 @@ expression: actual
               "computed": false
             },
             "right": {
-              "type": "Literal",
               "type": "Literal",
               "start": 57,
               "end": 58,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__k.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__k.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 26,
       "declarations": [
@@ -24,7 +23,6 @@ expression: actual
           },
           "init": {
             "type": "ObjectExpression",
-            "type": "ObjectExpression",
             "start": 12,
             "end": 26,
             "properties": [
@@ -39,7 +37,6 @@ expression: actual
                   "name": "a"
                 },
                 "value": {
-                  "type": "Literal",
                   "type": "Literal",
                   "start": 17,
                   "end": 18,
@@ -59,7 +56,6 @@ expression: actual
                 },
                 "value": {
                   "type": "Literal",
-                  "type": "Literal",
                   "start": 23,
                   "end": 24,
                   "value": 2,
@@ -73,7 +69,6 @@ expression: actual
       "kind": "const"
     },
     {
-      "type": "VariableDeclaration",
       "type": "VariableDeclaration",
       "start": 31,
       "end": 63,
@@ -90,18 +85,15 @@ expression: actual
           },
           "init": {
             "type": "ArrayExpression",
-            "type": "ArrayExpression",
             "start": 46,
             "end": 63,
             "elements": [
               {
                 "type": "BinaryExpression",
-                "type": "BinaryExpression",
                 "start": 47,
                 "end": 59,
                 "operator": "-",
                 "left": {
-                  "type": "Literal",
                   "type": "Literal",
                   "start": 47,
                   "end": 48,
@@ -110,18 +102,15 @@ expression: actual
                 },
                 "right": {
                   "type": "MemberExpression",
-                  "type": "MemberExpression",
                   "start": 51,
                   "end": 59,
                   "object": {
-                    "type": "Identifier",
                     "type": "Identifier",
                     "start": 51,
                     "end": 54,
                     "name": "obj"
                   },
                   "property": {
-                    "type": "Literal",
                     "type": "Literal",
                     "start": 55,
                     "end": 58,
@@ -132,7 +121,6 @@ expression: actual
                 }
               },
               {
-                "type": "Literal",
                 "type": "Literal",
                 "start": 61,
                 "end": 62,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__l.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__l.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 26,
       "declarations": [
@@ -24,7 +23,6 @@ expression: actual
           },
           "init": {
             "type": "ObjectExpression",
-            "type": "ObjectExpression",
             "start": 12,
             "end": 26,
             "properties": [
@@ -39,7 +37,6 @@ expression: actual
                   "name": "a"
                 },
                 "value": {
-                  "type": "Literal",
                   "type": "Literal",
                   "start": 17,
                   "end": 18,
@@ -59,7 +56,6 @@ expression: actual
                 },
                 "value": {
                   "type": "Literal",
-                  "type": "Literal",
                   "start": 23,
                   "end": 24,
                   "value": 2,
@@ -73,7 +69,6 @@ expression: actual
       "kind": "const"
     },
     {
-      "type": "VariableDeclaration",
       "type": "VariableDeclaration",
       "start": 31,
       "end": 63,
@@ -90,30 +85,25 @@ expression: actual
           },
           "init": {
             "type": "ArrayExpression",
-            "type": "ArrayExpression",
             "start": 46,
             "end": 63,
             "elements": [
               {
-                "type": "BinaryExpression",
                 "type": "BinaryExpression",
                 "start": 47,
                 "end": 59,
                 "operator": "-",
                 "left": {
                   "type": "MemberExpression",
-                  "type": "MemberExpression",
                   "start": 47,
                   "end": 55,
                   "object": {
-                    "type": "Identifier",
                     "type": "Identifier",
                     "start": 47,
                     "end": 50,
                     "name": "obj"
                   },
                   "property": {
-                    "type": "Literal",
                     "type": "Literal",
                     "start": 51,
                     "end": 54,
@@ -124,7 +114,6 @@ expression: actual
                 },
                 "right": {
                   "type": "Literal",
-                  "type": "Literal",
                   "start": 58,
                   "end": 59,
                   "value": 1,
@@ -132,7 +121,6 @@ expression: actual
                 }
               },
               {
-                "type": "Literal",
                 "type": "Literal",
                 "start": 61,
                 "end": 62,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__m.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__m.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 26,
       "declarations": [
@@ -24,7 +23,6 @@ expression: actual
           },
           "init": {
             "type": "ObjectExpression",
-            "type": "ObjectExpression",
             "start": 12,
             "end": 26,
             "properties": [
@@ -39,7 +37,6 @@ expression: actual
                   "name": "a"
                 },
                 "value": {
-                  "type": "Literal",
                   "type": "Literal",
                   "start": 17,
                   "end": 18,
@@ -59,7 +56,6 @@ expression: actual
                 },
                 "value": {
                   "type": "Literal",
-                  "type": "Literal",
                   "start": 23,
                   "end": 24,
                   "value": 2,
@@ -73,7 +69,6 @@ expression: actual
       "kind": "const"
     },
     {
-      "type": "VariableDeclaration",
       "type": "VariableDeclaration",
       "start": 31,
       "end": 62,
@@ -90,30 +85,25 @@ expression: actual
           },
           "init": {
             "type": "ArrayExpression",
-            "type": "ArrayExpression",
             "start": 46,
             "end": 62,
             "elements": [
               {
-                "type": "BinaryExpression",
                 "type": "BinaryExpression",
                 "start": 47,
                 "end": 58,
                 "operator": "-",
                 "left": {
                   "type": "MemberExpression",
-                  "type": "MemberExpression",
                   "start": 47,
                   "end": 55,
                   "object": {
-                    "type": "Identifier",
                     "type": "Identifier",
                     "start": 47,
                     "end": 50,
                     "name": "obj"
                   },
                   "property": {
-                    "type": "Literal",
                     "type": "Literal",
                     "start": 51,
                     "end": 54,
@@ -124,7 +114,6 @@ expression: actual
                 },
                 "right": {
                   "type": "Literal",
-                  "type": "Literal",
                   "start": 57,
                   "end": 58,
                   "value": 1,
@@ -132,7 +121,6 @@ expression: actual
                 }
               },
               {
-                "type": "Literal",
                 "type": "Literal",
                 "start": 60,
                 "end": 61,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__n.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__n.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 24,
       "declarations": [
@@ -24,12 +23,10 @@ expression: actual
           },
           "init": {
             "type": "BinaryExpression",
-            "type": "BinaryExpression",
             "start": 15,
             "end": 24,
             "operator": "-",
             "left": {
-              "type": "Literal",
               "type": "Literal",
               "start": 15,
               "end": 16,
@@ -38,18 +35,15 @@ expression: actual
             },
             "right": {
               "type": "MemberExpression",
-              "type": "MemberExpression",
               "start": 19,
               "end": 24,
               "object": {
-                "type": "Identifier",
                 "type": "Identifier",
                 "start": 19,
                 "end": 22,
                 "name": "obj"
               },
               "property": {
-                "type": "Identifier",
                 "type": "Identifier",
                 "start": 23,
                 "end": 24,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__o.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__o.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 21,
       "declarations": [
@@ -24,18 +23,15 @@ expression: actual
           },
           "init": {
             "type": "BinaryExpression",
-            "type": "BinaryExpression",
             "start": 12,
             "end": 21,
             "operator": "+",
             "left": {
               "type": "BinaryExpression",
-              "type": "BinaryExpression",
               "start": 12,
               "end": 17,
               "operator": "+",
               "left": {
-                "type": "Literal",
                 "type": "Literal",
                 "start": 12,
                 "end": 13,
@@ -44,7 +40,6 @@ expression: actual
               },
               "right": {
                 "type": "Literal",
-                "type": "Literal",
                 "start": 16,
                 "end": 17,
                 "value": 2,
@@ -52,7 +47,6 @@ expression: actual
               }
             },
             "right": {
-              "type": "Literal",
               "type": "Literal",
               "start": 20,
               "end": 21,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__p.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__p.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 22,
       "declarations": [
@@ -24,18 +23,15 @@ expression: actual
           },
           "init": {
             "type": "BinaryExpression",
-            "type": "BinaryExpression",
             "start": 13,
             "end": 22,
             "operator": "+",
             "left": {
               "type": "BinaryExpression",
-              "type": "BinaryExpression",
               "start": 13,
               "end": 18,
               "operator": "*",
               "left": {
-                "type": "Literal",
                 "type": "Literal",
                 "start": 13,
                 "end": 14,
@@ -44,7 +40,6 @@ expression: actual
               },
               "right": {
                 "type": "Literal",
-                "type": "Literal",
                 "start": 17,
                 "end": 18,
                 "value": 1,
@@ -52,7 +47,6 @@ expression: actual
               }
             },
             "right": {
-              "type": "Literal",
               "type": "Literal",
               "start": 21,
               "end": 22,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__q.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__q.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 30,
       "declarations": [
@@ -24,24 +23,20 @@ expression: actual
           },
           "init": {
             "type": "ArrayExpression",
-            "type": "ArrayExpression",
             "start": 15,
             "end": 30,
             "elements": [
               {
                 "type": "MemberExpression",
-                "type": "MemberExpression",
                 "start": 17,
                 "end": 25,
                 "object": {
-                  "type": "Identifier",
                   "type": "Identifier",
                   "start": 17,
                   "end": 20,
                   "name": "obj"
                 },
                 "property": {
-                  "type": "Literal",
                   "type": "Literal",
                   "start": 21,
                   "end": 24,
@@ -51,7 +46,6 @@ expression: actual
                 "computed": false
               },
               {
-                "type": "Literal",
                 "type": "Literal",
                 "start": 27,
                 "end": 28,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__r.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__r.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 26,
       "declarations": [
@@ -24,7 +23,6 @@ expression: actual
           },
           "init": {
             "type": "ObjectExpression",
-            "type": "ObjectExpression",
             "start": 12,
             "end": 26,
             "properties": [
@@ -39,7 +37,6 @@ expression: actual
                   "name": "a"
                 },
                 "value": {
-                  "type": "Literal",
                   "type": "Literal",
                   "start": 17,
                   "end": 18,
@@ -59,7 +56,6 @@ expression: actual
                 },
                 "value": {
                   "type": "Literal",
-                  "type": "Literal",
                   "start": 23,
                   "end": 24,
                   "value": 2,
@@ -73,7 +69,6 @@ expression: actual
       "kind": "const"
     },
     {
-      "type": "VariableDeclaration",
       "type": "VariableDeclaration",
       "start": 31,
       "end": 54,
@@ -90,18 +85,15 @@ expression: actual
           },
           "init": {
             "type": "MemberExpression",
-            "type": "MemberExpression",
             "start": 46,
             "end": 54,
             "object": {
-              "type": "Identifier",
               "type": "Identifier",
               "start": 46,
               "end": 49,
               "name": "obj"
             },
             "property": {
-              "type": "Literal",
               "type": "Literal",
               "start": 50,
               "end": 53,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__s.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__s.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 27,
       "declarations": [
@@ -24,23 +23,19 @@ expression: actual
           },
           "init": {
             "type": "MemberExpression",
-            "type": "MemberExpression",
             "start": 13,
             "end": 27,
             "object": {
               "type": "MemberExpression",
-              "type": "MemberExpression",
               "start": 13,
               "end": 22,
               "object": {
-                "type": "Identifier",
                 "type": "Identifier",
                 "start": 13,
                 "end": 15,
                 "name": "yo"
               },
               "property": {
-                "type": "Literal",
                 "type": "Literal",
                 "start": 16,
                 "end": 21,
@@ -50,7 +45,6 @@ expression: actual
               "computed": false
             },
             "property": {
-              "type": "Identifier",
               "type": "Identifier",
               "start": 23,
               "end": 26,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__t.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__t.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 17,
       "declarations": [
@@ -24,18 +23,15 @@ expression: actual
           },
           "init": {
             "type": "MemberExpression",
-            "type": "MemberExpression",
             "start": 12,
             "end": 17,
             "object": {
-              "type": "Identifier",
               "type": "Identifier",
               "start": 12,
               "end": 14,
               "name": "b1"
             },
             "property": {
-              "type": "Identifier",
               "type": "Identifier",
               "start": 15,
               "end": 16,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__u.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__u.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 34,
       "declarations": [
@@ -24,33 +23,27 @@ expression: actual
           },
           "init": {
             "type": "MemberExpression",
-            "type": "MemberExpression",
             "start": 13,
             "end": 34,
             "object": {
-              "type": "MemberExpression",
               "type": "MemberExpression",
               "start": 13,
               "end": 29,
               "object": {
                 "type": "MemberExpression",
-                "type": "MemberExpression",
                 "start": 13,
                 "end": 23,
                 "object": {
                   "type": "MemberExpression",
-                  "type": "MemberExpression",
                   "start": 13,
                   "end": 19,
                   "object": {
-                    "type": "Identifier",
                     "type": "Identifier",
                     "start": 13,
                     "end": 15,
                     "name": "yo"
                   },
                   "property": {
-                    "type": "Identifier",
                     "type": "Identifier",
                     "start": 16,
                     "end": 19,
@@ -60,7 +53,6 @@ expression: actual
                 },
                 "property": {
                   "type": "Identifier",
-                  "type": "Identifier",
                   "start": 20,
                   "end": 23,
                   "name": "two"
@@ -69,7 +61,6 @@ expression: actual
               },
               "property": {
                 "type": "Identifier",
-                "type": "Identifier",
                 "start": 24,
                 "end": 29,
                 "name": "three"
@@ -77,7 +68,6 @@ expression: actual
               "computed": false
             },
             "property": {
-              "type": "Identifier",
               "type": "Identifier",
               "start": 30,
               "end": 34,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__v.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__v.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 17,
       "declarations": [
@@ -24,18 +23,15 @@ expression: actual
           },
           "init": {
             "type": "MemberExpression",
-            "type": "MemberExpression",
             "start": 12,
             "end": 17,
             "object": {
-              "type": "Identifier",
               "type": "Identifier",
               "start": 12,
               "end": 14,
               "name": "b1"
             },
             "property": {
-              "type": "Literal",
               "type": "Literal",
               "start": 15,
               "end": 16,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__w.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__w.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 22,
       "declarations": [
@@ -24,18 +23,15 @@ expression: actual
           },
           "init": {
             "type": "MemberExpression",
-            "type": "MemberExpression",
             "start": 12,
             "end": 22,
             "object": {
-              "type": "Identifier",
               "type": "Identifier",
               "start": 12,
               "end": 14,
               "name": "b1"
             },
             "property": {
-              "type": "Literal",
               "type": "Literal",
               "start": 15,
               "end": 21,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__x.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__x.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 19,
       "declarations": [
@@ -24,18 +23,15 @@ expression: actual
           },
           "init": {
             "type": "MemberExpression",
-            "type": "MemberExpression",
             "start": 12,
             "end": 19,
             "object": {
-              "type": "Identifier",
               "type": "Identifier",
               "start": 12,
               "end": 14,
               "name": "b1"
             },
             "property": {
-              "type": "Identifier",
               "type": "Identifier",
               "start": 15,
               "end": 19,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__y.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__y.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 29,
       "declarations": [
@@ -24,7 +23,6 @@ expression: actual
           },
           "init": {
             "type": "CallExpression",
-            "type": "CallExpression",
             "start": 11,
             "end": 29,
             "callee": {
@@ -35,7 +33,6 @@ expression: actual
             },
             "arguments": [
               {
-                "type": "Identifier",
                 "type": "Identifier",
                 "start": 25,
                 "end": 28,

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__z.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__z.snap
@@ -8,7 +8,6 @@ expression: actual
   "body": [
     {
       "type": "VariableDeclaration",
-      "type": "VariableDeclaration",
       "start": 0,
       "end": 53,
       "declarations": [
@@ -24,12 +23,10 @@ expression: actual
           },
           "init": {
             "type": "PipeExpression",
-            "type": "PipeExpression",
             "start": 11,
             "end": 53,
             "body": [
               {
-                "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 11,
                 "end": 29,
@@ -42,7 +39,6 @@ expression: actual
                 "arguments": [
                   {
                     "type": "Identifier",
-                    "type": "Identifier",
                     "start": 25,
                     "end": 28,
                     "name": "pos"
@@ -51,7 +47,6 @@ expression: actual
                 "optional": false
               },
               {
-                "type": "CallExpression",
                 "type": "CallExpression",
                 "start": 33,
                 "end": 53,
@@ -64,12 +59,10 @@ expression: actual
                 "arguments": [
                   {
                     "type": "ArrayExpression",
-                    "type": "ArrayExpression",
                     "start": 38,
                     "end": 49,
                     "elements": [
                       {
-                        "type": "Literal",
                         "type": "Literal",
                         "start": 39,
                         "end": 40,
@@ -78,12 +71,10 @@ expression: actual
                       },
                       {
                         "type": "UnaryExpression",
-                        "type": "UnaryExpression",
                         "start": 42,
                         "end": 48,
                         "operator": "-",
                         "argument": {
-                          "type": "Identifier",
                           "type": "Identifier",
                           "start": 43,
                           "end": 48,
@@ -93,7 +84,6 @@ expression: actual
                     ]
                   },
                   {
-                    "type": "PipeSubstitution",
                     "type": "PipeSubstitution",
                     "start": 51,
                     "end": 52


### PR DESCRIPTION
# Background

KCL serializes its AST nodes serialize to JSON. This way they can be read by the frontend. We also serialize to JSON for the parser's snapshot tests.

# Problem

There's an unfortunate effect where we use `serde(tag = "type")` on both the `enum Expr` and on the individual AST node `struct` types stored within that enum. So the `Expr::Literal(Literal{...})` gets _two_ `type: "Literal"` tags (one from the enum wrapper, and one from the struct). This just seems weird, you get JSON like `{"type": "Literal", "type": "Literal", value: 3}`. Duplicate keys are technically OK JSON, but it's weird and adds a lot of noise to our snapshot tests.

# Solution

We can't remove the tag from the individual structs, because the frontend needs to check (at runtime) what kind of node each AST node is. So we have to remove it from the enum. But there's a problem: `#[serde(tag)]` on a struct is only used when serializing. It doesn't get checked when deserializing. So we cannot rely on that tag attribute to deserialize `enum Expr` into the correct variants.

So, we have to keep the tag on each struct, but make sure it's read during deserialization. 

Define a new tag type for `Literal` which serializes to the string `"Literal"`. It becomes part of the `struct Literal`. We do this for each kind of expression struct, then change the `serde(tag = "type")`  on `enum Expr` to `serde(untagged)`. 

# Testing

You can look at the snapshot tests and see a lot of removed JSON duplicate keys. I also added a new test in `ast/types.rs` showing that serde can now serialize then deserialize an AST. Previously this test would have panicked, complaining about duplicate keys.