### PR TITLE
Buffer file writes, because writing to file after every keypress has bad consequences

### DIFF
--- a/e2e/playwright/file-tree.spec.ts
+++ b/e2e/playwright/file-tree.spec.ts
@@ -136,6 +136,9 @@ test.describe('when using the file tree to', () => {
       )
       await pasteCodeInEditor(kclCube)
 
+      // TODO: We have a timeout of 1s between edits to write to disk. If you reload the page too quickly it won't write to disk.
+      await tronApp.page.waitForTimeout(2000)
+
       await renameFile(fromFile, toFile)
       await tronApp.page.reload()
 
@@ -222,15 +225,20 @@ test.describe('when using the file tree to', () => {
       )
       await pasteCodeInEditor(kclCube)
 
+      // TODO: We have a timeout of 1s between edits to write to disk. If you reload the page too quickly it won't write to disk.
+      await tronApp.page.waitForTimeout(2000)
+
       const kcl1 = 'main.kcl'
       const kcl2 = '2.kcl'
-
       await createNewFileAndSelect(kcl2)
       const kclCylinder = await fsp.readFile(
         'src/wasm-lib/tests/executor/inputs/cylinder.kcl',
         'utf-8'
       )
       await pasteCodeInEditor(kclCylinder)
+
+      // TODO: We have a timeout of 1s between edits to write to disk. If you reload the page too quickly it won't write to disk.
+      await tronApp.page.waitForTimeout(2000)
 
       await renameFile(kcl2, kcl1)
 

--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -488,6 +488,12 @@ export const FileTreeInner = ({
   // Refresh the file tree when there are changes.
   useFileSystemWatcher(
     async (eventType, path) => {
+      // Our other watcher races with this watcher on the current file changes,
+      // so we need to stop this one from reacting at all, otherwise Bad Things
+      // Happen™.
+      const isCurrentFile = loaderData.file?.path === path
+      const hasChanged = eventType === 'change'
+      if (isCurrentFile && hasChanged) return
       fileSend({ type: 'Refresh' })
     },
     [loaderData?.project?.path, fileContext.selectedDirectory.path].filter(


### PR DESCRIPTION
Writing to kcl files on per-key press (very old behavior that has existed even when the app was in Tauri) is causing the file system reload routines to "thrash" hard when users are (rightfully) mashing their keyboards. This fixes that, and fixes the issues coreypdx was talking about on Discord, losing their focused file.

I'm taking Monday, Tuesday off but I'd like to push this over the line and release as soon as we're able to because losing work = trust melting