### PR TITLE
yarn test:unit issues: sketchFromKclValue error with UserVal, update to He not wrapped in act(...)

### DIFF
--- a/src/components/ModelingSidebar/ModelingPanes/MemoryPane.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/MemoryPane.tsx
@@ -88,8 +88,12 @@ export const MemoryPane = () => {
 export const processMemory = (programMemory: ProgramMemory) => {
   const processedMemory: any = {}
   for (const [key, val] of programMemory?.visibleEntries()) {
-    if (typeof val.value !== 'function') {
-      const sg = sketchFromKclValue(val, null)
+    if (
+      (val.type === 'UserVal' && val.value.type === 'Sketch') ||
+      // @ts-ignore
+      (val.type !== 'Function' && val.type !== 'UserVal')
+    ) {
+      const sg = sketchFromKclValue(val, key)
       if (val.type === 'Solid') {
         processedMemory[key] = val.value.map(({ ...rest }: ExtrudeSurface) => {
           return rest
@@ -98,15 +102,16 @@ export const processMemory = (programMemory: ProgramMemory) => {
         processedMemory[key] = sg.value.map(({ __geoMeta, ...rest }: Path) => {
           return rest
         })
-      } else if ((val.type as any) === 'Function') {
-        processedMemory[key] = `__function(${(val as any)?.expression?.params
-          ?.map?.(({ identifier }: any) => identifier?.name || '')
-          .join(', ')})__`
       } else {
         processedMemory[key] = val.value
       }
-    } else if (key !== 'log') {
-      processedMemory[key] = '__function__'
+      // @ts-ignore
+    } else if (val.type === 'Function') {
+      processedMemory[key] = `__function(${(val as any)?.expression?.params
+        ?.map?.(({ identifier }: any) => identifier?.name || '')
+        .join(', ')})__`
+    } else {
+      processedMemory[key] = val.value
     }
   }
   return processedMemory

--- a/src/components/UserSidebarMenu.test.tsx
+++ b/src/components/UserSidebarMenu.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import UserSidebarMenu from './UserSidebarMenu'
 import {
   Route,
@@ -13,7 +13,7 @@ import { CommandBarProvider } from './CommandBar/CommandBarProvider'
 type User = Models['User_type']
 
 describe('UserSidebarMenu tests', () => {
-  test("Renders user's name and email if available", () => {
+  test("Renders user's name and email if available", async () => {
     const userWellFormed: User = {
       id: '8675309',
       name: 'Test User',
@@ -39,13 +39,19 @@ describe('UserSidebarMenu tests', () => {
 
     fireEvent.click(screen.getByTestId('user-sidebar-toggle'))
 
-    expect(screen.getByTestId('username')).toHaveTextContent(
-      userWellFormed.name || ''
+    await waitFor(() =>
+      expect(screen.getByTestId('username')).toHaveTextContent(
+        userWellFormed.name || ''
+      )
     )
-    expect(screen.getByTestId('email')).toHaveTextContent(userWellFormed.email)
+    await waitFor(() =>
+      expect(screen.getByTestId('email')).toHaveTextContent(
+        userWellFormed.email
+      )
+    )
   })
 
-  test("Renders just the user's email if no name is available", () => {
+  test("Renders just the user's email if no name is available", async () => {
     const userNoName: User = {
       id: '8675309',
       email: 'kittycad.sidebar.test@example.com',
@@ -71,10 +77,12 @@ describe('UserSidebarMenu tests', () => {
 
     fireEvent.click(screen.getByTestId('user-sidebar-toggle'))
 
-    expect(screen.getByTestId('username')).toHaveTextContent(userNoName.email)
+    await waitFor(() =>
+      expect(screen.getByTestId('username')).toHaveTextContent(userNoName.email)
+    )
   })
 
-  test('Renders a menu button if no user avatar is available', () => {
+  test('Renders a menu button if no user avatar is available', async () => {
     const userNoAvatar: User = {
       id: '8675309',
       name: 'Test User',
@@ -98,8 +106,10 @@ describe('UserSidebarMenu tests', () => {
       </TestWrap>
     )
 
-    expect(screen.getByTestId('user-sidebar-toggle')).toHaveTextContent(
-      'User menu'
+    await waitFor(() =>
+      expect(screen.getByTestId('user-sidebar-toggle')).toHaveTextContent(
+        'User menu'
+      )
     )
   })
 })

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -361,6 +361,7 @@ export function sketchFromKclValue(
   varName: string | null
 ): Sketch | Error {
   if (obj?.value?.type === 'Sketch') return obj.value
+  if (obj?.type === 'Sketch') return obj
   if (obj?.value?.type === 'Solid') return obj.value.sketch
   if (obj?.type === 'Solid') return obj.sketch
   if (!varName) {
@@ -368,7 +369,7 @@ export function sketchFromKclValue(
   }
   const actualType = obj?.value?.type ?? obj?.type
   if (actualType) {
-    console.log(obj)
+    console.log('THIS IS ERROR SG', obj)
     return new Error(
       `Expected ${varName} to be a sketch or solid, but it was ${actualType} instead.`
     )


### PR DESCRIPTION
Noticed some errors with `yarn test:unit`. 

In MemoryPane, there were errors when trying to call sketchFromKclValue on a UserVal wrapping a Sketch.  I saw there is discussion about overhauling KclValues in #1130, so this is likely a short-lived change, but it does seem to address the test failures that were previously happening from MemoryPane.test.tsx. 

(apologies for the @ts_ignore, the KclValue autogenerated type def does not include type union with Function, even though a Function is fair game apparently and needs to be handled.)

Also fixed a minor error where tests were not properly awaiting changes to the tests for UserSidebarMenu.