### PR TITLE
Support negative start and end in ranges

### DIFF
--- a/src/wasm-lib/kcl/src/ast/types/execute.rs
+++ b/src/wasm-lib/kcl/src/ast/types/execute.rs
@@ -551,13 +551,13 @@ impl ArrayRangeExpression {
             .execute_expr(&self.start_element, exec_state, &metadata, StatementKind::Expression)
             .await?
             .get_json_value()?;
-        let start = parse_json_number_as_u64(&start, (&*self.start_element).into())?;
+        let start = parse_json_number_as_i64(&start, (&*self.start_element).into())?;
         let metadata = Metadata::from(&*self.end_element);
         let end = ctx
             .execute_expr(&self.end_element, exec_state, &metadata, StatementKind::Expression)
             .await?
             .get_json_value()?;
-        let end = parse_json_number_as_u64(&end, (&*self.end_element).into())?;
+        let end = parse_json_number_as_i64(&end, (&*self.end_element).into())?;
 
         if end < start {
             return Err(KclError::Semantic(KclErrorDetails {
@@ -603,9 +603,9 @@ impl ObjectExpression {
     }
 }
 
-pub fn parse_json_number_as_u64(j: &serde_json::Value, source_range: SourceRange) -> Result<u64, KclError> {
+fn parse_json_number_as_i64(j: &serde_json::Value, source_range: SourceRange) -> Result<i64, KclError> {
     if let serde_json::Value::Number(n) = &j {
-        n.as_u64().ok_or_else(|| {
+        n.as_i64().ok_or_else(|| {
             KclError::Syntax(KclErrorDetails {
                 source_ranges: vec![source_range],
                 message: format!("Invalid integer: {}", j),

--- a/src/wasm-lib/tests/executor/inputs/no_visuals/array_range_negative_expr.kcl
+++ b/src/wasm-lib/tests/executor/inputs/no_visuals/array_range_negative_expr.kcl
@@ -1,3 +1,2 @@
-xs = [-5..5]
+xs = [int(-5)..5]
 assertEqual(xs[0], -5, 0.001, "first element is -5")
-assert(false)

--- a/src/wasm-lib/tests/executor/no_visuals.rs
+++ b/src/wasm-lib/tests/executor/no_visuals.rs
@@ -101,7 +101,7 @@ gen_test!(property_of_object);
 gen_test!(index_of_array);
 gen_test!(comparisons);
 gen_test!(array_range_expr);
-gen_test_fail!(array_range_negative_expr, "syntax: Invalid integer: -5.0");
+gen_test!(array_range_negative_expr);
 gen_test_fail!(
     invalid_index_str,
     "semantic: Only integers >= 0 can be used as the index of an array, but you're using a string"


### PR DESCRIPTION
Follow-up to https://github.com/KittyCAD/modeling-app/pull/4151. Allows negative start and end in range expressions.