### PR TITLE
Revert "Separate debug/release electron-builder to help mac job (#4270)"

### DIFF
--- a/.github/workflows/build-test-publish-apps.yml
+++ b/.github/workflows/build-test-publish-apps.yml
@@ -114,8 +114,17 @@ jobs:
             platform: linux
     runs-on: ${{ matrix.os }}
     env:
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      CSC_LINK: ${{ secrets.APPLE_CERTIFICATE }}
+      CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      CSC_KEYCHAIN: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+      CSC_FOR_PULL_REQUEST: true
       VERSION: ${{ github.event_name == 'schedule' && needs.prepare-files.outputs.version || format('v{0}', needs.prepare-files.outputs.version) }}
       VERSION_NO_V: ${{ needs.prepare-files.outputs.version }}
+      WINDOWS_CERTIFICATE_THUMBPRINT: F4C9A52FF7BC26EE5E054946F6B11DEEA94C748D
     steps:
       - uses: actions/checkout@v4
 
@@ -177,25 +186,8 @@ jobs:
           smksp_cert_sync.exe
         shell: cmd
 
-      - name: Build the app (debug)
-        if: ${{ env.BUILD_RELEASE == 'false' }}
-        # electron-builder doesn't have a concept of release vs debug,
-        # this is just not doing any codesign or release yml generation
-        run: yarn electron-builder --config
-
-      - name: Build the app (release)
-        if: ${{ env.BUILD_RELEASE == 'true' }}
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          CSC_LINK: ${{ secrets.APPLE_CERTIFICATE }}
-          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          CSC_KEYCHAIN: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          CSC_FOR_PULL_REQUEST: true
-          WINDOWS_CERTIFICATE_THUMBPRINT: F4C9A52FF7BC26EE5E054946F6B11DEEA94C748D
-        run: yarn electron-builder --config --publish always
+      - name: Build the app
+        run: yarn electron-builder --config ${{ env.BUILD_RELEASE && '--publish always' || '' }}
 
       - name: List artifacts in out/
         run: ls -R out


### PR DESCRIPTION
This reverts commit 19d01c563e28de1c5300c5b481068836f8372d2b.

There appears to be a knock-on effect of this PR that caused MacOS arm64 updater test build assets to be corrupted in some manner. Linux updater tests worked fine.