### PR TITLE
Tags should refer to full paths, not just base paths.

### DIFF
--- a/docs/kcl/types/TagEngineInfo.md
+++ b/docs/kcl/types/TagEngineInfo.md
@@ -18,7 +18,7 @@ Engine information for a tag.
 |----------|------|-------------|----------|
 | `id` |`string`| The id of the tagged object. | No |
 | `sketch` |`string`| The sketch the tag is on. | No |
-| `path` |[`BasePath`](/docs/kcl/types/BasePath)| The path the tag is on. | No |
+| `path` |[`Path`](/docs/kcl/types/Path)| The path the tag is on. | No |
 | `surface` |[`ExtrudeSurface`](/docs/kcl/types/ExtrudeSurface)| The surface information for the tag. | No |
 
 

--- a/src/wasm-lib/kcl/src/std/segment.rs
+++ b/src/wasm-lib/kcl/src/std/segment.rs
@@ -42,7 +42,7 @@ fn inner_segment_end_x(tag: &TagIdentifier, exec_state: &mut ExecState, args: Ar
         })
     })?;
 
-    Ok(path.to[0])
+    Ok(path.get_base().to[0])
 }
 
 /// Returns the segment end of y.
@@ -79,7 +79,7 @@ fn inner_segment_end_y(tag: &TagIdentifier, exec_state: &mut ExecState, args: Ar
         })
     })?;
 
-    Ok(path.to[1])
+    Ok(path.get_to()[1])
 }
 
 /// Returns the last segment of x.
@@ -202,7 +202,7 @@ fn inner_segment_length(tag: &TagIdentifier, exec_state: &mut ExecState, args: A
         })
     })?;
 
-    let result = ((path.from[1] - path.to[1]).powi(2) + (path.from[0] - path.to[0]).powi(2)).sqrt();
+    let result = path.length();
 
     Ok(result)
 }
@@ -242,7 +242,7 @@ fn inner_segment_angle(tag: &TagIdentifier, exec_state: &mut ExecState, args: Ar
         })
     })?;
 
-    let result = between(path.from.into(), path.to.into());
+    let result = between(path.get_from().into(), path.get_to().into());
 
     Ok(result.to_degrees())
 }
@@ -286,7 +286,7 @@ fn inner_angle_to_match_length_x(
         })
     })?;
 
-    let length = ((path.from[1] - path.to[1]).powi(2) + (path.from[0] - path.to[0]).powi(2)).sqrt();
+    let length = path.length();
 
     let last_line = sketch
         .paths
@@ -350,7 +350,7 @@ fn inner_angle_to_match_length_y(
         })
     })?;
 
-    let length = ((path.from[1] - path.to[1]).powi(2) + (path.from[0] - path.to[0]).powi(2)).sqrt();
+    let length = path.length();
 
     let last_line = sketch
         .paths

--- a/src/wasm-lib/kcl/src/std/sketch.rs
+++ b/src/wasm-lib/kcl/src/std/sketch.rs
@@ -813,7 +813,7 @@ async fn inner_angled_line_that_intersects(
 
     let from = sketch.current_pen_position()?;
     let to = intersection_with_parallel_line(
-        &[path.from.into(), path.to.into()],
+        &[path.get_from().into(), path.get_to().into()],
         data.offset.unwrap_or_default(),
         data.angle,
         from,
@@ -1244,7 +1244,9 @@ pub(crate) async fn inner_start_profile_at(
             tag_identifier.info = Some(TagEngineInfo {
                 id: current_path.geo_meta.id,
                 sketch: path_id,
-                path: Some(current_path.clone()),
+                path: Some(Path::Base {
+                    base: current_path.clone(),
+                }),
                 surface: None,
             });
             HashMap::from([(tag.name.to_string(), tag_identifier)])


### PR DESCRIPTION
See "Problem 2" in https://github.com/KittyCAD/modeling-app/issues/4297

This is a pure refactor, it should not change any behaviour at all.
It adds more information into the tag system, but nothing reads that
extra information yet. It will be used to address problem 3 of the above
issue.