### PR TITLE
Chore: Don't let draft lines receive mouseEnter/Leave events, or create invalid overlays

### DIFF
--- a/src/clientSideScene/sceneEntities.ts
+++ b/src/clientSideScene/sceneEntities.ts
@@ -746,7 +746,6 @@ export class SceneEntities {
           },
         })
       },
-      ...this.mouseEnterLeaveCallbacks(),
     })
   }
   setupDraftRectangle = async (

--- a/src/clientSideScene/sceneInfra.ts
+++ b/src/clientSideScene/sceneInfra.ts
@@ -213,7 +213,7 @@ export class SceneInfra {
     to: Coords2d
     angle?: number
   }): SegmentOverlayPayload | null {
-    if (group.userData.pathToNode && arrowGroup) {
+    if (!group.userData.draft && group.userData.pathToNode && arrowGroup) {
       const vector = new Vector3(0, 0, 0)
 
       // Get the position of the object3D in world space

--- a/src/clientSideScene/segments.ts
+++ b/src/clientSideScene/segments.ts
@@ -147,6 +147,7 @@ class StraightSegment implements SegmentUtils {
     segmentGroup.name = STRAIGHT_SEGMENT
     segmentGroup.userData = {
       type: STRAIGHT_SEGMENT,
+      draft: isDraftSegment,
       id,
       from,
       to,
@@ -347,6 +348,7 @@ class TangentialArcToSegment implements SegmentUtils {
     mesh.name = meshName
     group.userData = {
       type: TANGENTIAL_ARC_TO_SEGMENT,
+      draft: isDraftSegment,
       id,
       from,
       to,
@@ -520,6 +522,7 @@ class CircleSegment implements SegmentUtils {
     arcMesh.name = meshType
     group.userData = {
       type: CIRCLE_SEGMENT,
+      draft: isDraftSegment,
       id,
       from,
       radius,


### PR DESCRIPTION
Currently the console gets spammed with errors when creating draft lines, making for noisy development. This was because draft segments were receiving the normal segment onMouseEnter and onMouseLeave listeners, and were being provided constraint overlays, even though they aren't yet in the AST. This marks those segments as draft so they can be excluded from receiving the listeners or the overlay components.

No new tests because this removes console.log only behavior. All the existing tests passing should verify no behavior has changed.

## Demo

https://github.com/user-attachments/assets/54ede2b0-8646-47c4-bdfd-73f7685b9fbd

