### PR TITLE
Error if assertEqual's epsilon value is invalid

### DIFF
--- a/src/wasm-lib/kcl/src/std/assert.rs
+++ b/src/wasm-lib/kcl/src/std/assert.rs
@@ -78,7 +78,12 @@ pub async fn assert_gt(_exec_state: &mut ExecState, args: Args) -> Result<KclVal
     name = "assertEqual",
 }]
 async fn inner_assert_equal(left: f64, right: f64, epsilon: f64, message: &str, args: &Args) -> Result<(), KclError> {
-    if (right - left).abs() < epsilon {
+    if epsilon <= 0.0 {
+        Err(KclError::Type(KclErrorDetails {
+            message: format!("assertEqual epsilon must be greater than zero"),
+            source_ranges: vec![args.source_range],
+        }))
+    } else if (right - left).abs() < epsilon {
         Ok(())
     } else {
         Err(KclError::Type(KclErrorDetails {


### PR DESCRIPTION
Without this, you can get a funny error message, such as:

    assert failed because 42 != 42: number is not 42

I'm assuming an epsilon of zero is never useful because we're dealing with floating point.