### PR TITLE
KCL: No more BasePath 

### DIFF
--- a/docs/kcl/types/Path.md
+++ b/docs/kcl/types/Path.md
@@ -142,26 +142,6 @@ An angled line to.
 
 
 ----
-A base path.
-
-**Type:** `object`
-
-
-
-
-
-## Properties
-
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `type` |enum: `Base`|  | No |
-| `from` |`[number, number]`| The from point. | No |
-| `to` |`[number, number]`| The to point. | No |
-| `tag` |[`TagDeclarator`](/docs/kcl/types#tag-declaration)| The tag of the path. | No |
-| `__geoMeta` |[`GeoMeta`](/docs/kcl/types/GeoMeta)| Metadata. | No |
-
-
-----
 A circular arc, not necessarily tangential to the current point.
 
 **Type:** `object`

--- a/docs/kcl/types/Sketch.md
+++ b/docs/kcl/types/Sketch.md
@@ -19,7 +19,7 @@ A sketch is a collection of paths.
 | `id` |`string`| The id of the sketch (this will change when the engine's reference to it changes). | No |
 | `paths` |`[` [`Path`](/docs/kcl/types/Path) `]`| The paths in the sketch. | No |
 | `on` |[`SketchSurface`](/docs/kcl/types/SketchSurface)| What the sketch is on (can be a plane or a face). | No |
-| `start` |[`BasePath`](/docs/kcl/types/BasePath)| The starting path. | No |
+| `start` |[`SketchStart`](/docs/kcl/types/SketchStart)| The starting path. | No |
 | `tags` |`object`| Tag identifiers that have been declared in this sketch. | No |
 | `__meta` |`[` [`Metadata`](/docs/kcl/types/Metadata) `]`| Metadata. | No |
 

--- a/docs/kcl/types/SketchSet.md
+++ b/docs/kcl/types/SketchSet.md
@@ -28,7 +28,7 @@ A sketch is a collection of paths.
 | `id` |`string`| The id of the sketch (this will change when the engine's reference to it changes). | No |
 | `paths` |`[` [`Path`](/docs/kcl/types/Path) `]`| The paths in the sketch. | No |
 | `on` |[`SketchSurface`](/docs/kcl/types/SketchSurface)| What the sketch is on (can be a plane or a face). | No |
-| `start` |[`BasePath`](/docs/kcl/types/BasePath)| The starting path. | No |
+| `start` |[`SketchStart`](/docs/kcl/types/SketchStart)| The starting path. | No |
 | `tags` |`object`| Tag identifiers that have been declared in this sketch. | No |
 | `__meta` |`[` [`Metadata`](/docs/kcl/types/Metadata) `]`| Metadata. | No |
 

--- a/docs/kcl/types/SketchStart.md
+++ b/docs/kcl/types/SketchStart.md
@@ -1,0 +1,23 @@
+---
+title: "SketchStart"
+excerpt: "Where the sketch starts."
+layout: manual
+---
+
+Where the sketch starts.
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `at` |`[number, number]`| Start point. | No |
+| `tag` |[`TagDeclarator`](/docs/kcl/types#tag-declaration)| Tag of the start point. | No |
+| `__geoMeta` |[`GeoMeta`](/docs/kcl/types/GeoMeta)| Metadata. | No |
+
+

--- a/docs/kcl/types/TagEngineInfo.md
+++ b/docs/kcl/types/TagEngineInfo.md
@@ -44,6 +44,22 @@ The surface information for the tag.
 
 
 ----
+The point being tagged.
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `point` |`[number, number]`|  | No |
+
+
+----
 
 
 ## Properties

--- a/src/wasm-lib/kcl/src/std/extrude.rs
+++ b/src/wasm-lib/kcl/src/std/extrude.rs
@@ -238,7 +238,7 @@ pub(crate) async fn do_post_extrude(
                         });
                         Some(extrude_surface)
                     }
-                    Path::Base { .. } | Path::ToPoint { .. } | Path::Horizontal { .. } | Path::AngledLineTo { .. } => {
+                    Path::ToPoint { .. } | Path::Horizontal { .. } | Path::AngledLineTo { .. } => {
                         let extrude_surface = ExtrudeSurface::ExtrudePlane(crate::executor::ExtrudePlane {
                             face_id: *actual_face_id,
                             tag: path.get_base().tag.clone(),


### PR DESCRIPTION
Path enum no longer includes BasePath

BasePath is a pair of points and geometry metadata.

Previously BasePath was used for:

 - The start of a sketch
 - The data which all path types have in common

It wasn't a good fit for the start of a sketch, because there was a lot
of duplicated information, and a sketch starts at a point, not a line
(two points).

This adds a separate SketchStart struct which replaces the first use
of BasePath. This means BasePath no longer needs to be a variant of
Path, simplifying it.

Solves problem 4 of https://github.com/KittyCAD/modeling-app/issues/4297