### PR TITLE
Revert "Track tagged geometry with an enum, not options (#4333)"

### DIFF
--- a/docs/kcl/types/TagEngineInfo.md
+++ b/docs/kcl/types/TagEngineInfo.md
@@ -10,40 +10,6 @@ Engine information for a tag.
 
 
 
-**This schema accepts exactly one of the following:**
-
-The path the tag is on.
-
-**Type:** `object`
-
-
-
-
-
-## Properties
-
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `path` |[`Path`](/docs/kcl/types/Path)| Engine information for a tag. | No |
-
-
-----
-The surface information for the tag.
-
-**Type:** `object`
-
-
-
-
-
-## Properties
-
-| Property | Type | Description | Required |
-|----------|------|-------------|----------|
-| `surface` |[`ExtrudeSurface`](/docs/kcl/types/ExtrudeSurface)| Engine information for a tag. | No |
-
-
-----
 
 
 ## Properties
@@ -52,5 +18,7 @@ The surface information for the tag.
 |----------|------|-------------|----------|
 | `id` |`string`| The id of the tagged object. | No |
 | `sketch` |`string`| The sketch the tag is on. | No |
+| `path` |[`Path`](/docs/kcl/types/Path)| The path the tag is on. | No |
+| `surface` |[`ExtrudeSurface`](/docs/kcl/types/ExtrudeSurface)| The surface information for the tag. | No |
 
 

--- a/src/wasm-lib/kcl/src/ast/types/execute.rs
+++ b/src/wasm-lib/kcl/src/ast/types/execute.rs
@@ -7,7 +7,7 @@ use crate::{
     errors::{KclError, KclErrorDetails},
     executor::{
         BodyType, ExecState, ExecutorContext, KclValue, Metadata, Sketch, SourceRange, StatementKind, TagEngineInfo,
-        TagIdentifier, Tagged, UserVal,
+        TagIdentifier, UserVal,
     },
     std::FunctionKind,
 };
@@ -346,7 +346,8 @@ impl CallExpression {
                                         value: tag.name.clone(),
                                         info: Some(TagEngineInfo {
                                             id: value.get_id(),
-                                            tagged: Tagged::Surface(value.clone()),
+                                            surface: Some(value.clone()),
+                                            path: None,
                                             sketch: solid.id,
                                         }),
                                         meta: vec![Metadata {
@@ -363,7 +364,7 @@ impl CallExpression {
                                 };
 
                                 let mut info = info.clone();
-                                info.tagged = Tagged::Surface(value.clone());
+                                info.surface = Some(value.clone());
                                 info.sketch = solid.id;
                                 t.info = Some(info);
 

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -1126,49 +1126,10 @@ pub struct TagEngineInfo {
     pub id: uuid::Uuid,
     /// The sketch the tag is on.
     pub sketch: uuid::Uuid,
-    /// The thing which was tagged.
-    #[serde(flatten)]
-    pub tagged: Tagged,
-}
-
-impl TagEngineInfo {
-    /// If this is tagging a path, get it.
-    pub fn path(&self) -> Option<&Path> {
-        self.tagged.path()
-    }
-
-    /// If this is tagging a surface, get it.
-    pub fn surface(&self) -> Option<&ExtrudeSurface> {
-        self.tagged.surface()
-    }
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
-#[ts(export)]
-#[serde(rename_all = "camelCase")]
-pub enum Tagged {
     /// The path the tag is on.
-    Path(Path),
+    pub path: Option<Path>,
     /// The surface information for the tag.
-    Surface(ExtrudeSurface),
-}
-
-impl Tagged {
-    /// If this is a path, get it.
-    fn path(&self) -> Option<&Path> {
-        let Self::Path(x) = &self else {
-            return None;
-        };
-        Some(x)
-    }
-
-    /// If this is a path, get it.
-    fn surface(&self) -> Option<&ExtrudeSurface> {
-        let Self::Surface(x) = &self else {
-            return None;
-        };
-        Some(x)
-    }
+    pub surface: Option<ExtrudeSurface>,
 }
 
 /// A sketch is a collection of paths.
@@ -1245,7 +1206,8 @@ impl Sketch {
         tag_identifier.info = Some(TagEngineInfo {
             id: base.geo_meta.id,
             sketch: self.id,
-            tagged: Tagged::Path(current_path.clone()),
+            path: Some(current_path.clone()),
+            surface: None,
         });
 
         self.tags.insert(tag.name.to_string(), tag_identifier);

--- a/src/wasm-lib/kcl/src/std/args.rs
+++ b/src/wasm-lib/kcl/src/std/args.rs
@@ -118,7 +118,7 @@ impl Args {
         'e: 'a,
     {
         if let Some(info) = &tag.info {
-            if info.surface().is_some() {
+            if info.surface.is_some() {
                 return Ok(info);
             }
         }
@@ -387,7 +387,7 @@ impl Args {
 
         let engine_info = self.get_tag_engine_info_check_surface(exec_state, tag)?;
 
-        let surface = engine_info.surface().ok_or_else(|| {
+        let surface = engine_info.surface.as_ref().ok_or_else(|| {
             KclError::Type(KclErrorDetails {
                 message: format!("Tag `{}` does not have a surface", tag.value),
                 source_ranges: vec![self.source_range],

--- a/src/wasm-lib/kcl/src/std/segment.rs
+++ b/src/wasm-lib/kcl/src/std/segment.rs
@@ -35,7 +35,7 @@ pub async fn segment_end_x(exec_state: &mut ExecState, args: Args) -> Result<Kcl
 }]
 fn inner_segment_end_x(tag: &TagIdentifier, exec_state: &mut ExecState, args: Args) -> Result<f64, KclError> {
     let line = args.get_tag_engine_info(exec_state, tag)?;
-    let path = line.path().ok_or_else(|| {
+    let path = line.path.clone().ok_or_else(|| {
         KclError::Type(KclErrorDetails {
             message: format!("Expected a line segment with a path, found `{:?}`", line),
             source_ranges: vec![args.source_range],
@@ -72,7 +72,7 @@ pub async fn segment_end_y(exec_state: &mut ExecState, args: Args) -> Result<Kcl
 }]
 fn inner_segment_end_y(tag: &TagIdentifier, exec_state: &mut ExecState, args: Args) -> Result<f64, KclError> {
     let line = args.get_tag_engine_info(exec_state, tag)?;
-    let path = line.path().ok_or_else(|| {
+    let path = line.path.clone().ok_or_else(|| {
         KclError::Type(KclErrorDetails {
             message: format!("Expected a line segment with a path, found `{:?}`", line),
             source_ranges: vec![args.source_range],
@@ -195,7 +195,7 @@ pub async fn segment_length(exec_state: &mut ExecState, args: Args) -> Result<Kc
 }]
 fn inner_segment_length(tag: &TagIdentifier, exec_state: &mut ExecState, args: Args) -> Result<f64, KclError> {
     let line = args.get_tag_engine_info(exec_state, tag)?;
-    let path = line.path().ok_or_else(|| {
+    let path = line.path.clone().ok_or_else(|| {
         KclError::Type(KclErrorDetails {
             message: format!("Expected a line segment with a path, found `{:?}`", line),
             source_ranges: vec![args.source_range],
@@ -235,7 +235,7 @@ pub async fn segment_angle(exec_state: &mut ExecState, args: Args) -> Result<Kcl
 }]
 fn inner_segment_angle(tag: &TagIdentifier, exec_state: &mut ExecState, args: Args) -> Result<f64, KclError> {
     let line = args.get_tag_engine_info(exec_state, tag)?;
-    let path = line.path().ok_or_else(|| {
+    let path = line.path.clone().ok_or_else(|| {
         KclError::Type(KclErrorDetails {
             message: format!("Expected a line segment with a path, found `{:?}`", line),
             source_ranges: vec![args.source_range],
@@ -279,7 +279,7 @@ fn inner_angle_to_match_length_x(
     args: Args,
 ) -> Result<f64, KclError> {
     let line = args.get_tag_engine_info(exec_state, tag)?;
-    let path = line.path().ok_or_else(|| {
+    let path = line.path.clone().ok_or_else(|| {
         KclError::Type(KclErrorDetails {
             message: format!("Expected a line segment with a path, found `{:?}`", line),
             source_ranges: vec![args.source_range],
@@ -343,7 +343,7 @@ fn inner_angle_to_match_length_y(
     args: Args,
 ) -> Result<f64, KclError> {
     let line = args.get_tag_engine_info(exec_state, tag)?;
-    let path = line.path().ok_or_else(|| {
+    let path = line.path.clone().ok_or_else(|| {
         KclError::Type(KclErrorDetails {
             message: format!("Expected a line segment with a path, found `{:?}`", line),
             source_ranges: vec![args.source_range],

--- a/src/wasm-lib/kcl/src/std/sketch.rs
+++ b/src/wasm-lib/kcl/src/std/sketch.rs
@@ -12,7 +12,6 @@ use parse_display::{Display, FromStr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::executor::Tagged;
 use crate::{
     ast::types::TagDeclarator,
     errors::{KclError, KclErrorDetails},
@@ -805,7 +804,7 @@ async fn inner_angled_line_that_intersects(
     args: Args,
 ) -> Result<Sketch, KclError> {
     let intersect_path = args.get_tag_engine_info(exec_state, &data.intersect_tag)?;
-    let path = intersect_path.path().ok_or_else(|| {
+    let path = intersect_path.path.clone().ok_or_else(|| {
         KclError::Type(KclErrorDetails {
             message: format!("Expected an intersect path with a path, found `{:?}`", intersect_path),
             source_ranges: vec![args.source_range],
@@ -1245,9 +1244,10 @@ pub(crate) async fn inner_start_profile_at(
             tag_identifier.info = Some(TagEngineInfo {
                 id: current_path.geo_meta.id,
                 sketch: path_id,
-                tagged: Tagged::Path(Path::Base {
+                path: Some(Path::Base {
                     base: current_path.clone(),
                 }),
+                surface: None,
             });
             HashMap::from([(tag.name.to_string(), tag_identifier)])
         } else {


### PR DESCRIPTION
This reverts commit 4a62862ca002d705d95b18eda94586346473ab58.

It had a false assumption: that a tag could refer to a path XOR surface. In reality, when a sketch is extruded into a solid, its tags which pointed to paths now also point to the new surface made from that path. 

Perhaps tags _shouldn't_ be able to refer to both, but that'll be a breaking change for weird models like the poop chute. While we think about the desired behaviour, let's revert this.