### PR TITLE
Fix CI docs generation after #4329

### DIFF
--- a/src/wasm-lib/justfile
+++ b/src/wasm-lib/justfile
@@ -5,3 +5,6 @@ new-test name:
 
 lint:
     cargo clippy --all --tests --benches -- -D warnings
+
+redo-kcl-stdlib-docs:
+    EXPECTORATE=overwrite cargo nextest run -p kcl-lib docs::gen_std_tests::test_generate_stdlib

--- a/src/wasm-lib/kcl/src/std/assert.rs
+++ b/src/wasm-lib/kcl/src/std/assert.rs
@@ -80,7 +80,7 @@ pub async fn assert_gt(_exec_state: &mut ExecState, args: Args) -> Result<KclVal
 async fn inner_assert_equal(left: f64, right: f64, epsilon: f64, message: &str, args: &Args) -> Result<(), KclError> {
     if epsilon <= 0.0 {
         Err(KclError::Type(KclErrorDetails {
-            message: format!("assertEqual epsilon must be greater than zero"),
+            message: "assertEqual epsilon must be greater than zero".to_owned(),
             source_ranges: vec![args.source_range],
         }))
     } else if (right - left).abs() < epsilon {


### PR DESCRIPTION
@franknoirot admin merged #4329 without verifying that CI was green (outside contributor PRs do not run our CI for security reasons). This fixes the clippy lint fix and docs generation issue present in that PR, causing a real red on main.