### PR TITLE
Fix lint scripts to check all targets

### DIFF
--- a/.github/workflows/cargo-check.yml
+++ b/.github/workflows/cargo-check.yml
@@ -37,4 +37,4 @@ jobs:
           # We specifically want to test the disable-println feature
           # Since it is not enabled by default, we need to specify it
           # This is used in kcl-lsp
-          cargo check --all --features disable-println --features pyo3 --features cli
+          cargo check --workspace --features disable-println --features pyo3 --features cli

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "build:both": "vite build",
     "build:both:local": "yarn build:wasm && vite build",
     "pretest": "yarn remove-importmeta",
-    "test:rust": "(cd src/wasm-lib && cargo test --all && cargo clippy --all --all-targets)",
+    "test:rust": "(cd src/wasm-lib && cargo test --workspace && cargo clippy --workspace --all-targets)",
     "simpleserver": "yarn pretest && http-server ./public --cors -p 3000",
     "simpleserver:ci": "yarn pretest && http-server ./public --cors -p 3000 &",
     "simpleserver:bg": "yarn pretest && http-server ./public --cors -p 3000 &",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "build:both": "vite build",
     "build:both:local": "yarn build:wasm && vite build",
     "pretest": "yarn remove-importmeta",
-    "test:rust": "(cd src/wasm-lib && cargo test --all && cargo clippy --all --all-targets --tests --benches)",
+    "test:rust": "(cd src/wasm-lib && cargo test --all && cargo clippy --all --all-targets)",
     "simpleserver": "yarn pretest && http-server ./public --cors -p 3000",
     "simpleserver:ci": "yarn pretest && http-server ./public --cors -p 3000 &",
     "simpleserver:bg": "yarn pretest && http-server ./public --cors -p 3000 &",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "build:both": "vite build",
     "build:both:local": "yarn build:wasm && vite build",
     "pretest": "yarn remove-importmeta",
-    "test:rust": "(cd src/wasm-lib && cargo test --all && cargo clippy --all --tests --benches)",
+    "test:rust": "(cd src/wasm-lib && cargo test --all && cargo clippy --all --all-targets --tests --benches)",
     "simpleserver": "yarn pretest && http-server ./public --cors -p 3000",
     "simpleserver:ci": "yarn pretest && http-server ./public --cors -p 3000 &",
     "simpleserver:bg": "yarn pretest && http-server ./public --cors -p 3000 &",

--- a/src/wasm-lib/justfile
+++ b/src/wasm-lib/justfile
@@ -4,7 +4,7 @@ new-test name:
     TWENTY_TWENTY=overwrite cargo nextest run --test executor -E 'test(=visuals::{{name}})'
 
 lint:
-    cargo clippy --all --tests --benches -- -D warnings
+    cargo clippy --all --all-targets --tests --benches -- -D warnings
 
 redo-kcl-stdlib-docs:
     EXPECTORATE=overwrite cargo nextest run -p kcl-lib docs::gen_std_tests::test_generate_stdlib

--- a/src/wasm-lib/justfile
+++ b/src/wasm-lib/justfile
@@ -4,7 +4,7 @@ new-test name:
     TWENTY_TWENTY=overwrite cargo nextest run --test executor -E 'test(=visuals::{{name}})'
 
 lint:
-    cargo clippy --all --all-targets --tests --benches -- -D warnings
+    cargo clippy --all --all-targets -- -D warnings
 
 redo-kcl-stdlib-docs:
     EXPECTORATE=overwrite cargo nextest run -p kcl-lib docs::gen_std_tests::test_generate_stdlib

--- a/src/wasm-lib/justfile
+++ b/src/wasm-lib/justfile
@@ -4,7 +4,7 @@ new-test name:
     TWENTY_TWENTY=overwrite cargo nextest run --test executor -E 'test(=visuals::{{name}})'
 
 lint:
-    cargo clippy --all --all-targets -- -D warnings
+    cargo clippy --workspace --all-targets -- -D warnings
 
 redo-kcl-stdlib-docs:
     EXPECTORATE=overwrite cargo nextest run -p kcl-lib docs::gen_std_tests::test_generate_stdlib

--- a/src/wasm-lib/kcl/README.md
+++ b/src/wasm-lib/kcl/README.md
@@ -16,7 +16,7 @@ We've built a lot of tooling to make contributing to KCL easier. If you are inte
 8. Add your new standard library function to [the long list of CORE_FNS in mod.rs](https://github.com/KittyCAD/modeling-app/blob/main/src/wasm-lib/kcl/src/std/mod.rs#L42)
 9. Get a production Zoo dev token and run `export KITTYCAD_API_TOKEN=your-token-here` in a terminal
 10. Run `TWENTY_TWENTY=overwrite cargo nextest run --workspace --no-fail-fast` to take snapshot tests of your example code running in the engine
-11. Run `EXPECTORATE=overwrite cargo test --workspace generate_stdlib -- --nocapture` to generate new Markdown documentation for your function that will be used [to generate docs on our website](https://zoo.dev/docs/kcl).
+11. Run `just redo-kcl-stdlib-docs` to generate new Markdown documentation for your function that will be used [to generate docs on our website](https://zoo.dev/docs/kcl).
 12. Create a PR in GitHub.
 
 ## Bumping the version

--- a/src/wasm-lib/kcl/README.md
+++ b/src/wasm-lib/kcl/README.md
@@ -16,7 +16,7 @@ We've built a lot of tooling to make contributing to KCL easier. If you are inte
 8. Add your new standard library function to [the long list of CORE_FNS in mod.rs](https://github.com/KittyCAD/modeling-app/blob/main/src/wasm-lib/kcl/src/std/mod.rs#L42)
 9. Get a production Zoo dev token and run `export KITTYCAD_API_TOKEN=your-token-here` in a terminal
 10. Run `TWENTY_TWENTY=overwrite cargo nextest run --workspace --no-fail-fast` to take snapshot tests of your example code running in the engine
-11. Run `EXPECTORATE=overwrite cargo test --all generate_stdlib -- --nocapture` to generate new Markdown documentation for your function that will be used [to generate docs on our website](https://zoo.dev/docs/kcl).
+11. Run `EXPECTORATE=overwrite cargo test --workspace generate_stdlib -- --nocapture` to generate new Markdown documentation for your function that will be used [to generate docs on our website](https://zoo.dev/docs/kcl).
 12. Create a PR in GitHub.
 
 ## Bumping the version


### PR DESCRIPTION
Prior to this change, our commands didn't actually lint everything.