### PR TITLE
Added test to ensure array push is immutable

### DIFF
--- a/src/wasm-lib/tests/executor/inputs/no_visuals/array_elem_push_fail.kcl
+++ b/src/wasm-lib/tests/executor/inputs/no_visuals/array_elem_push_fail.kcl
@@ -1,0 +1,3 @@
+arr = [1, 2, 3]
+pushedArr = push(arr, 4)
+fail = arr[3]

--- a/src/wasm-lib/tests/executor/no_visuals.rs
+++ b/src/wasm-lib/tests/executor/no_visuals.rs
@@ -174,3 +174,7 @@ gen_test_parse_fail!(
 gen_test!(add_lots);
 gen_test!(double_map);
 gen_test!(array_elem_push);
+gen_test_fail!(
+    array_elem_push_fail,
+    "undefined value: The array doesn't have any item at index 3"
+);


### PR DESCRIPTION
Adding test requested by @jtran in https://github.com/KittyCAD/modeling-app/pull/4232#discussion_r1819885258

Ensures that when an element is pushed to an array, that element is not available on the original array.