### PR TITLE
Remove duplicate JSON "type" tags

### DIFF
--- a/docs/kcl/types/ArrayExpression.md
+++ b/docs/kcl/types/ArrayExpression.md
@@ -1,0 +1,25 @@
+---
+title: "ArrayExpression"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`ArrayExpressionTag`](/docs/kcl/types/ArrayExpressionTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `elements` |`[` [`Expr`](/docs/kcl/types/Expr) `]`|  | No |
+| `nonCodeMeta` |[`NonCodeMeta`](/docs/kcl/types/NonCodeMeta)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/ArrayExpressionTag.md
+++ b/docs/kcl/types/ArrayExpressionTag.md
@@ -1,0 +1,16 @@
+---
+title: "ArrayExpressionTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`ArrayExpression`](/docs/kcl/types/ArrayExpression)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/ArrayRangeExpression.md
+++ b/docs/kcl/types/ArrayRangeExpression.md
@@ -1,0 +1,26 @@
+---
+title: "ArrayRangeExpression"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`ArrayRangeExpressionTag`](/docs/kcl/types/ArrayRangeExpressionTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `startElement` |[`Expr`](/docs/kcl/types/Expr)|  | No |
+| `endElement` |[`Expr`](/docs/kcl/types/Expr)|  | No |
+| `endInclusive` |`boolean`| Is the `end_element` included in the range? | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/ArrayRangeExpressionTag.md
+++ b/docs/kcl/types/ArrayRangeExpressionTag.md
@@ -1,0 +1,16 @@
+---
+title: "ArrayRangeExpressionTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`ArrayRangeExpression`](/docs/kcl/types/ArrayRangeExpression)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/BinaryExpression.md
+++ b/docs/kcl/types/BinaryExpression.md
@@ -1,0 +1,26 @@
+---
+title: "BinaryExpression"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`BinaryExpressionTag`](/docs/kcl/types/BinaryExpressionTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `operator` |[`BinaryOperator`](/docs/kcl/types/BinaryOperator)|  | No |
+| `left` |[`BinaryPart`](/docs/kcl/types/BinaryPart)|  | No |
+| `right` |[`BinaryPart`](/docs/kcl/types/BinaryPart)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/BinaryExpressionTag.md
+++ b/docs/kcl/types/BinaryExpressionTag.md
@@ -1,0 +1,16 @@
+---
+title: "BinaryExpressionTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`BinaryExpression`](/docs/kcl/types/BinaryExpression)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/BinaryPart.md
+++ b/docs/kcl/types/BinaryPart.md
@@ -8,18 +8,17 @@ layout: manual
 
 
 
+**This schema accepts any of the following:**
 
-**This schema accepts exactly one of the following:**
 
-
-**Type:** `object`
-
+[`Literal`](/docs/kcl/types/Literal)
 
 
 
 
-## Properties
 
+
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `Literal`|  | No |
@@ -28,18 +27,29 @@ layout: manual
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Literal`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `value` |[`LiteralValue`](/docs/kcl/types/LiteralValue)|  | No |
+| `raw` |`string`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
 
-**Type:** `object`
+[`Identifier`](/docs/kcl/types/Identifier)
 
 
 
 
 
-## Properties
 
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: [`Identifier`](/docs/kcl/types/Identifier)|  | No |
@@ -47,18 +57,28 @@ layout: manual
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: [`Identifier`](/docs/kcl/types/Identifier)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `name` |`string`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
 
-**Type:** `object`
+[`BinaryExpression`](/docs/kcl/types/BinaryExpression)
 
 
 
 
 
-## Properties
 
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `BinaryExpression`|  | No |
@@ -68,18 +88,30 @@ layout: manual
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `BinaryExpression`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `operator` |[`BinaryOperator`](/docs/kcl/types/BinaryOperator)|  | No |
+| `left` |[`BinaryPart`](/docs/kcl/types/BinaryPart)|  | No |
+| `right` |[`BinaryPart`](/docs/kcl/types/BinaryPart)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
 
-**Type:** `object`
+[`CallExpression`](/docs/kcl/types/CallExpression)
 
 
 
 
 
-## Properties
 
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `CallExpression`|  | No |
@@ -89,18 +121,30 @@ layout: manual
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `CallExpression`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `callee` |[`Identifier`](/docs/kcl/types/Identifier)|  | No |
+| `arguments` |`[` [`Expr`](/docs/kcl/types/Expr) `]`|  | No |
+| `optional` |`boolean`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
 
-**Type:** `object`
+[`UnaryExpression`](/docs/kcl/types/UnaryExpression)
 
 
 
 
 
-## Properties
 
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `UnaryExpression`|  | No |
@@ -109,18 +153,29 @@ layout: manual
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `UnaryExpression`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `operator` |[`UnaryOperator`](/docs/kcl/types/UnaryOperator)|  | No |
+| `argument` |[`BinaryPart`](/docs/kcl/types/BinaryPart)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
 
-**Type:** `object`
+[`MemberExpression`](/docs/kcl/types/MemberExpression)
 
 
 
 
 
-## Properties
 
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `MemberExpression`|  | No |
@@ -130,18 +185,30 @@ layout: manual
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `MemberExpression`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `object` |[`MemberObject`](/docs/kcl/types/MemberObject)|  | No |
+| `property` |[`LiteralIdentifier`](/docs/kcl/types/LiteralIdentifier)|  | No |
+| `computed` |`boolean`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
 
-**Type:** `object`
+[`IfExpression`](/docs/kcl/types/IfExpression)
 
 
 
 
 
-## Properties
 
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `IfExpression`|  | No |
@@ -152,9 +219,23 @@ layout: manual
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `IfExpression`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `cond` |[`Expr`](/docs/kcl/types/Expr)|  | No |
+| `then_val` |[`Program`](/docs/kcl/types/Program)|  | No |
+| `else_ifs` |`[` [`ElseIf`](/docs/kcl/types/ElseIf) `]`|  | No |
+| `final_else` |[`Program`](/docs/kcl/types/Program)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
+
 
 
 

--- a/docs/kcl/types/BodyItem.md
+++ b/docs/kcl/types/BodyItem.md
@@ -8,18 +8,17 @@ layout: manual
 
 
 
+**This schema accepts any of the following:**
 
-**This schema accepts exactly one of the following:**
 
-
-**Type:** `object`
-
+[`ImportStatement`](/docs/kcl/types/ImportStatement)
 
 
 
 
-## Properties
 
+
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `ImportStatement`|  | No |
@@ -29,18 +28,30 @@ layout: manual
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `ImportStatement`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `items` |`[` [`ImportItem`](/docs/kcl/types/ImportItem) `]`|  | No |
+| `path` |`string`|  | No |
+| `raw_path` |`string`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
 
-**Type:** `object`
+[`ExpressionStatement`](/docs/kcl/types/ExpressionStatement)
 
 
 
 
 
-## Properties
 
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `ExpressionStatement`|  | No |
@@ -48,18 +59,28 @@ layout: manual
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `ExpressionStatement`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `expression` |[`Expr`](/docs/kcl/types/Expr)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
 
-**Type:** `object`
+[`VariableDeclaration`](/docs/kcl/types/VariableDeclaration)
 
 
 
 
 
-## Properties
 
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `VariableDeclaration`|  | No |
@@ -69,18 +90,30 @@ layout: manual
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `VariableDeclaration`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `declarations` |`[` [`VariableDeclarator`](/docs/kcl/types/VariableDeclarator) `]`|  | No |
+| `visibility` |[`ItemVisibility`](/docs/kcl/types/ItemVisibility)|  | No |
+| `kind` |[`VariableKind`](/docs/kcl/types/VariableKind)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
 
-**Type:** `object`
+[`ReturnStatement`](/docs/kcl/types/ReturnStatement)
 
 
 
 
 
-## Properties
 
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `ReturnStatement`|  | No |
@@ -88,9 +121,20 @@ layout: manual
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `ReturnStatement`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `argument` |[`Expr`](/docs/kcl/types/Expr)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
+
 
 
 

--- a/docs/kcl/types/CallExpression.md
+++ b/docs/kcl/types/CallExpression.md
@@ -1,0 +1,26 @@
+---
+title: "CallExpression"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`CallExpressionTag`](/docs/kcl/types/CallExpressionTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `callee` |[`Identifier`](/docs/kcl/types/Identifier)|  | No |
+| `arguments` |`[` [`Expr`](/docs/kcl/types/Expr) `]`|  | No |
+| `optional` |`boolean`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/CallExpressionTag.md
+++ b/docs/kcl/types/CallExpressionTag.md
@@ -1,0 +1,16 @@
+---
+title: "CallExpressionTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`CallExpression`](/docs/kcl/types/CallExpression)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/Expr.md
+++ b/docs/kcl/types/Expr.md
@@ -9,18 +9,18 @@ An expression can be evaluated to yield a single KCL value.
 
 
 
+**This schema accepts any of the following:**
 
-**This schema accepts exactly one of the following:**
+An expression can be evaluated to yield a single KCL value.
 
-
-**Type:** `object`
-
-
+[`Literal`](/docs/kcl/types/Literal)
 
 
 
-## Properties
 
+
+
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `Literal`|  | No |
@@ -29,18 +29,30 @@ An expression can be evaluated to yield a single KCL value.
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Literal`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `value` |[`LiteralValue`](/docs/kcl/types/LiteralValue)| An expression can be evaluated to yield a single KCL value. | No |
+| `raw` |`string`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
+An expression can be evaluated to yield a single KCL value.
 
-**Type:** `object`
-
-
-
+[`Identifier`](/docs/kcl/types/Identifier)
 
 
-## Properties
 
+
+
+
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: [`Identifier`](/docs/kcl/types/Identifier)|  | No |
@@ -48,18 +60,29 @@ An expression can be evaluated to yield a single KCL value.
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: [`Identifier`](/docs/kcl/types/Identifier)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `name` |`string`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
+An expression can be evaluated to yield a single KCL value.
 
-**Type:** `object`
-
-
-
+[`TagDeclarator`](/docs/kcl/types#tag-declaration)
 
 
-## Properties
 
+
+
+
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: [`TagDeclarator`](/docs/kcl/types#tag-declaration)|  | No |
@@ -67,18 +90,29 @@ An expression can be evaluated to yield a single KCL value.
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: [`TagDeclarator`](/docs/kcl/types#tag-declaration)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `value` |`string`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
+An expression can be evaluated to yield a single KCL value.
 
-**Type:** `object`
-
-
-
+[`BinaryExpression`](/docs/kcl/types/BinaryExpression)
 
 
-## Properties
 
+
+
+
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `BinaryExpression`|  | No |
@@ -88,18 +122,31 @@ An expression can be evaluated to yield a single KCL value.
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `BinaryExpression`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `operator` |[`BinaryOperator`](/docs/kcl/types/BinaryOperator)| An expression can be evaluated to yield a single KCL value. | No |
+| `left` |[`BinaryPart`](/docs/kcl/types/BinaryPart)| An expression can be evaluated to yield a single KCL value. | No |
+| `right` |[`BinaryPart`](/docs/kcl/types/BinaryPart)| An expression can be evaluated to yield a single KCL value. | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
+An expression can be evaluated to yield a single KCL value.
 
-**Type:** `object`
-
-
-
+[`FunctionExpression`](/docs/kcl/types/FunctionExpression)
 
 
-## Properties
 
+
+
+
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: [`FunctionExpression`](/docs/kcl/types/FunctionExpression)|  | No |
@@ -108,18 +155,30 @@ An expression can be evaluated to yield a single KCL value.
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: [`FunctionExpression`](/docs/kcl/types/FunctionExpression)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `params` |`[` [`Parameter`](/docs/kcl/types/Parameter) `]`|  | No |
+| `body` |[`Program`](/docs/kcl/types/Program)| An expression can be evaluated to yield a single KCL value. | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
+An expression can be evaluated to yield a single KCL value.
 
-**Type:** `object`
-
-
-
+[`CallExpression`](/docs/kcl/types/CallExpression)
 
 
-## Properties
 
+
+
+
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `CallExpression`|  | No |
@@ -129,18 +188,31 @@ An expression can be evaluated to yield a single KCL value.
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `CallExpression`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `callee` |[`Identifier`](/docs/kcl/types/Identifier)| An expression can be evaluated to yield a single KCL value. | No |
+| `arguments` |`[` [`Expr`](/docs/kcl/types/Expr) `]`|  | No |
+| `optional` |`boolean`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
+An expression can be evaluated to yield a single KCL value.
 
-**Type:** `object`
-
-
-
+[`PipeExpression`](/docs/kcl/types/PipeExpression)
 
 
-## Properties
 
+
+
+
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `PipeExpression`|  | No |
@@ -149,36 +221,58 @@ An expression can be evaluated to yield a single KCL value.
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `PipeExpression`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `body` |`[` [`Expr`](/docs/kcl/types/Expr) `]`|  | No |
+| `nonCodeMeta` |[`NonCodeMeta`](/docs/kcl/types/NonCodeMeta)| An expression can be evaluated to yield a single KCL value. | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
+An expression can be evaluated to yield a single KCL value.
 
-**Type:** `object`
-
-
-
+[`PipeSubstitution`](/docs/kcl/types/PipeSubstitution)
 
 
-## Properties
 
+
+
+
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `PipeSubstitution`|  | No |
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `PipeSubstitution`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
+An expression can be evaluated to yield a single KCL value.
 
-**Type:** `object`
-
-
-
+[`ArrayExpression`](/docs/kcl/types/ArrayExpression)
 
 
-## Properties
 
+
+
+
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `ArrayExpression`|  | No |
@@ -187,18 +281,30 @@ An expression can be evaluated to yield a single KCL value.
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `ArrayExpression`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `elements` |`[` [`Expr`](/docs/kcl/types/Expr) `]`|  | No |
+| `nonCodeMeta` |[`NonCodeMeta`](/docs/kcl/types/NonCodeMeta)| An expression can be evaluated to yield a single KCL value. | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
+An expression can be evaluated to yield a single KCL value.
 
-**Type:** `object`
-
-
-
+[`ArrayRangeExpression`](/docs/kcl/types/ArrayRangeExpression)
 
 
-## Properties
 
+
+
+
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `ArrayRangeExpression`|  | No |
@@ -208,18 +314,31 @@ An expression can be evaluated to yield a single KCL value.
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `ArrayRangeExpression`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `startElement` |[`Expr`](/docs/kcl/types/Expr)| An expression can be evaluated to yield a single KCL value. | No |
+| `endElement` |[`Expr`](/docs/kcl/types/Expr)| An expression can be evaluated to yield a single KCL value. | No |
+| `endInclusive` |`boolean`| Is the `end_element` included in the range? | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
+An expression can be evaluated to yield a single KCL value.
 
-**Type:** `object`
-
-
-
+[`ObjectExpression`](/docs/kcl/types/ObjectExpression)
 
 
-## Properties
 
+
+
+
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `ObjectExpression`|  | No |
@@ -228,18 +347,30 @@ An expression can be evaluated to yield a single KCL value.
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `ObjectExpression`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `properties` |`[` [`ObjectProperty`](/docs/kcl/types/ObjectProperty) `]`|  | No |
+| `nonCodeMeta` |[`NonCodeMeta`](/docs/kcl/types/NonCodeMeta)| An expression can be evaluated to yield a single KCL value. | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
+An expression can be evaluated to yield a single KCL value.
 
-**Type:** `object`
-
-
-
+[`MemberExpression`](/docs/kcl/types/MemberExpression)
 
 
-## Properties
 
+
+
+
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `MemberExpression`|  | No |
@@ -249,18 +380,31 @@ An expression can be evaluated to yield a single KCL value.
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `MemberExpression`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `object` |[`MemberObject`](/docs/kcl/types/MemberObject)| An expression can be evaluated to yield a single KCL value. | No |
+| `property` |[`LiteralIdentifier`](/docs/kcl/types/LiteralIdentifier)| An expression can be evaluated to yield a single KCL value. | No |
+| `computed` |`boolean`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
+An expression can be evaluated to yield a single KCL value.
 
-**Type:** `object`
-
-
-
+[`UnaryExpression`](/docs/kcl/types/UnaryExpression)
 
 
-## Properties
 
+
+
+
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `UnaryExpression`|  | No |
@@ -269,18 +413,30 @@ An expression can be evaluated to yield a single KCL value.
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `UnaryExpression`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `operator` |[`UnaryOperator`](/docs/kcl/types/UnaryOperator)| An expression can be evaluated to yield a single KCL value. | No |
+| `argument` |[`BinaryPart`](/docs/kcl/types/BinaryPart)| An expression can be evaluated to yield a single KCL value. | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
+An expression can be evaluated to yield a single KCL value.
 
-**Type:** `object`
-
-
-
+[`IfExpression`](/docs/kcl/types/IfExpression)
 
 
-## Properties
 
+
+
+
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `IfExpression`|  | No |
@@ -291,27 +447,49 @@ An expression can be evaluated to yield a single KCL value.
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `IfExpression`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `cond` |[`Expr`](/docs/kcl/types/Expr)| An expression can be evaluated to yield a single KCL value. | No |
+| `then_val` |[`Program`](/docs/kcl/types/Program)| An expression can be evaluated to yield a single KCL value. | No |
+| `else_ifs` |`[` [`ElseIf`](/docs/kcl/types/ElseIf) `]`|  | No |
+| `final_else` |[`Program`](/docs/kcl/types/Program)| An expression can be evaluated to yield a single KCL value. | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
-KCL value for an optional parameter which was not given an argument. (remember, parameters are in the function declaration, arguments are in the function call/application).
+An expression can be evaluated to yield a single KCL value.
 
-**Type:** `object`
-
-
+[`KclNone`](/docs/kcl/types/KclNone)
 
 
 
-## Properties
 
+
+
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `None`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `None`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
+
 
 
 

--- a/docs/kcl/types/ExpressionStatement.md
+++ b/docs/kcl/types/ExpressionStatement.md
@@ -1,0 +1,23 @@
+---
+title: "ExpressionStatement"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `expression` |[`Expr`](/docs/kcl/types/Expr)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/FunctionExpression.md
+++ b/docs/kcl/types/FunctionExpression.md
@@ -15,6 +15,15 @@ layout: manual
 
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
+<<<<<<< HEAD
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+=======
+| `type` |[`FunctionExpressionTag`](/docs/kcl/types/FunctionExpressionTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 | `params` |`[` [`Parameter`](/docs/kcl/types/Parameter) `]`|  | No |
 | `body` |[`Program`](/docs/kcl/types/Program)|  | No |
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |

--- a/docs/kcl/types/FunctionExpressionTag.md
+++ b/docs/kcl/types/FunctionExpressionTag.md
@@ -1,0 +1,16 @@
+---
+title: "FunctionExpressionTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`FunctionExpression`](/docs/kcl/types/FunctionExpression)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/Identifier.md
+++ b/docs/kcl/types/Identifier.md
@@ -15,6 +15,15 @@ layout: manual
 
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
+<<<<<<< HEAD
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+=======
+| `type` |[`IdentifierTag`](/docs/kcl/types/IdentifierTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 | `name` |`string`|  | No |
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |

--- a/docs/kcl/types/IdentifierTag.md
+++ b/docs/kcl/types/IdentifierTag.md
@@ -1,0 +1,16 @@
+---
+title: "IdentifierTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`Identifier`](/docs/kcl/types/Identifier)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/IfExpression.md
+++ b/docs/kcl/types/IfExpression.md
@@ -1,0 +1,26 @@
+---
+title: "IfExpression"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `cond` |[`Expr`](/docs/kcl/types/Expr)|  | No |
+| `then_val` |[`Program`](/docs/kcl/types/Program)|  | No |
+| `else_ifs` |`[` [`ElseIf`](/docs/kcl/types/ElseIf) `]`|  | No |
+| `final_else` |[`Program`](/docs/kcl/types/Program)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/ImportStatement.md
+++ b/docs/kcl/types/ImportStatement.md
@@ -1,0 +1,26 @@
+---
+title: "ImportStatement"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`ImportStatementTag`](/docs/kcl/types/ImportStatementTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `items` |`[` [`ImportItem`](/docs/kcl/types/ImportItem) `]`|  | No |
+| `path` |`string`|  | No |
+| `raw_path` |`string`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/ImportStatementTag.md
+++ b/docs/kcl/types/ImportStatementTag.md
@@ -1,0 +1,16 @@
+---
+title: "ImportStatementTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`ImportStatement`](/docs/kcl/types/ImportStatement)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/KclNone.md
+++ b/docs/kcl/types/KclNone.md
@@ -1,0 +1,23 @@
+---
+title: "KclNone"
+excerpt: "KCL value for an optional parameter which was not given an argument. (remember, parameters are in the function declaration, arguments are in the function call/application)."
+layout: manual
+---
+
+KCL value for an optional parameter which was not given an argument. (remember, parameters are in the function declaration, arguments are in the function call/application).
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`KclNoneTag`](/docs/kcl/types/KclNoneTag)| KCL value for an optional parameter which was not given an argument. (remember, parameters are in the function declaration, arguments are in the function call/application). | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+
+

--- a/docs/kcl/types/KclNoneTag.md
+++ b/docs/kcl/types/KclNoneTag.md
@@ -1,0 +1,16 @@
+---
+title: "KclNoneTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`KclNone`](/docs/kcl/types/KclNone)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/KclValue.md
+++ b/docs/kcl/types/KclValue.md
@@ -48,14 +48,14 @@ Any KCL value.
 
 ----
 
-**Type:** `object`
+[`TagDeclarator`](/docs/kcl/types#tag-declaration)
 
 
 
 
 
-## Properties
 
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: [`TagDeclarator`](/docs/kcl/types#tag-declaration)|  | No |
@@ -63,6 +63,16 @@ Any KCL value.
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: [`TagDeclarator`](/docs/kcl/types#tag-declaration)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `value` |`string`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----

--- a/docs/kcl/types/Literal.md
+++ b/docs/kcl/types/Literal.md
@@ -1,0 +1,25 @@
+---
+title: "Literal"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`LiteralTag`](/docs/kcl/types/LiteralTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `value` |[`LiteralValue`](/docs/kcl/types/LiteralValue)|  | No |
+| `raw` |`string`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/LiteralIdentifier.md
+++ b/docs/kcl/types/LiteralIdentifier.md
@@ -8,18 +8,17 @@ layout: manual
 
 
 
+**This schema accepts any of the following:**
 
-**This schema accepts exactly one of the following:**
 
-
-**Type:** `object`
-
+[`Identifier`](/docs/kcl/types/Identifier)
 
 
 
 
-## Properties
 
+
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: [`Identifier`](/docs/kcl/types/Identifier)|  | No |
@@ -27,18 +26,28 @@ layout: manual
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: [`Identifier`](/docs/kcl/types/Identifier)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `name` |`string`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
 
-**Type:** `object`
+[`Literal`](/docs/kcl/types/Literal)
 
 
 
 
 
-## Properties
 
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `Literal`|  | No |
@@ -47,9 +56,21 @@ layout: manual
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Literal`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `value` |[`LiteralValue`](/docs/kcl/types/LiteralValue)|  | No |
+| `raw` |`string`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
+
 
 
 

--- a/docs/kcl/types/LiteralTag.md
+++ b/docs/kcl/types/LiteralTag.md
@@ -1,0 +1,16 @@
+---
+title: "LiteralTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`Literal`](/docs/kcl/types/Literal)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/MemberExpression.md
+++ b/docs/kcl/types/MemberExpression.md
@@ -1,0 +1,26 @@
+---
+title: "MemberExpression"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`MemberExpressionTag`](/docs/kcl/types/MemberExpressionTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `object` |[`MemberObject`](/docs/kcl/types/MemberObject)|  | No |
+| `property` |[`LiteralIdentifier`](/docs/kcl/types/LiteralIdentifier)|  | No |
+| `computed` |`boolean`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/MemberExpressionTag.md
+++ b/docs/kcl/types/MemberExpressionTag.md
@@ -1,0 +1,16 @@
+---
+title: "MemberExpressionTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`MemberExpression`](/docs/kcl/types/MemberExpression)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/MemberObject.md
+++ b/docs/kcl/types/MemberObject.md
@@ -8,18 +8,17 @@ layout: manual
 
 
 
+**This schema accepts any of the following:**
 
-**This schema accepts exactly one of the following:**
 
-
-**Type:** `object`
-
+[`MemberExpression`](/docs/kcl/types/MemberExpression)
 
 
 
 
-## Properties
 
+
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: `MemberExpression`|  | No |
@@ -29,18 +28,30 @@ layout: manual
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `MemberExpression`|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `object` |[`MemberObject`](/docs/kcl/types/MemberObject)|  | No |
+| `property` |[`LiteralIdentifier`](/docs/kcl/types/LiteralIdentifier)|  | No |
+| `computed` |`boolean`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
 
-**Type:** `object`
+[`Identifier`](/docs/kcl/types/Identifier)
 
 
 
 
 
-## Properties
 
+<<<<<<< HEAD
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `type` |enum: [`Identifier`](/docs/kcl/types/Identifier)|  | No |
@@ -48,9 +59,20 @@ layout: manual
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: [`Identifier`](/docs/kcl/types/Identifier)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `name` |`string`|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+=======
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 
 
 ----
+
 
 
 

--- a/docs/kcl/types/ObjectExpression.md
+++ b/docs/kcl/types/ObjectExpression.md
@@ -1,0 +1,25 @@
+---
+title: "ObjectExpression"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`ObjectExpressionTag`](/docs/kcl/types/ObjectExpressionTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `properties` |`[` [`ObjectProperty`](/docs/kcl/types/ObjectProperty) `]`|  | No |
+| `nonCodeMeta` |[`NonCodeMeta`](/docs/kcl/types/NonCodeMeta)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/ObjectExpressionTag.md
+++ b/docs/kcl/types/ObjectExpressionTag.md
@@ -1,0 +1,16 @@
+---
+title: "ObjectExpressionTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`ObjectExpression`](/docs/kcl/types/ObjectExpression)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/PipeExpression.md
+++ b/docs/kcl/types/PipeExpression.md
@@ -1,0 +1,25 @@
+---
+title: "PipeExpression"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`PipeExpressionTag`](/docs/kcl/types/PipeExpressionTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `body` |`[` [`Expr`](/docs/kcl/types/Expr) `]`|  | No |
+| `nonCodeMeta` |[`NonCodeMeta`](/docs/kcl/types/NonCodeMeta)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/PipeExpressionTag.md
+++ b/docs/kcl/types/PipeExpressionTag.md
@@ -1,0 +1,16 @@
+---
+title: "PipeExpressionTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`PipeExpression`](/docs/kcl/types/PipeExpression)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/PipeSubstitution.md
+++ b/docs/kcl/types/PipeSubstitution.md
@@ -1,0 +1,23 @@
+---
+title: "PipeSubstitution"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`PipeSubstitutionTag`](/docs/kcl/types/PipeSubstitutionTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/PipeSubstitutionTag.md
+++ b/docs/kcl/types/PipeSubstitutionTag.md
@@ -1,0 +1,16 @@
+---
+title: "PipeSubstitutionTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`PipeSubstitution`](/docs/kcl/types/PipeSubstitution)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/ReturnStatement.md
+++ b/docs/kcl/types/ReturnStatement.md
@@ -1,0 +1,24 @@
+---
+title: "ReturnStatement"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`ReturnStatementTag`](/docs/kcl/types/ReturnStatementTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `argument` |[`Expr`](/docs/kcl/types/Expr)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/ReturnStatementTag.md
+++ b/docs/kcl/types/ReturnStatementTag.md
@@ -1,0 +1,16 @@
+---
+title: "ReturnStatementTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`ReturnStatement`](/docs/kcl/types/ReturnStatement)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/TagDeclaratorTag.md
+++ b/docs/kcl/types/TagDeclaratorTag.md
@@ -1,0 +1,16 @@
+---
+title: "TagDeclaratorTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`TagDeclarator`](/docs/kcl/types#tag-declaration)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/UnaryExpression.md
+++ b/docs/kcl/types/UnaryExpression.md
@@ -1,0 +1,25 @@
+---
+title: "UnaryExpression"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`UnaryExpressionTag`](/docs/kcl/types/UnaryExpressionTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `operator` |[`UnaryOperator`](/docs/kcl/types/UnaryOperator)|  | No |
+| `argument` |[`BinaryPart`](/docs/kcl/types/BinaryPart)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/UnaryExpressionTag.md
+++ b/docs/kcl/types/UnaryExpressionTag.md
@@ -1,0 +1,16 @@
+---
+title: "UnaryExpressionTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`UnaryExpression`](/docs/kcl/types/UnaryExpression)
+
+
+
+
+
+
+
+

--- a/docs/kcl/types/VariableDeclaration.md
+++ b/docs/kcl/types/VariableDeclaration.md
@@ -1,0 +1,26 @@
+---
+title: "VariableDeclaration"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |[`VariableDeclarationTag`](/docs/kcl/types/VariableDeclarationTag)|  | No |
+| `start` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `end` |[`EnvironmentRef`](/docs/kcl/types/EnvironmentRef)|  | No |
+| `declarations` |`[` [`VariableDeclarator`](/docs/kcl/types/VariableDeclarator) `]`|  | No |
+| `visibility` |[`ItemVisibility`](/docs/kcl/types/ItemVisibility)|  | No |
+| `kind` |[`VariableKind`](/docs/kcl/types/VariableKind)|  | No |
+| `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
+
+

--- a/docs/kcl/types/VariableDeclarationTag.md
+++ b/docs/kcl/types/VariableDeclarationTag.md
@@ -1,0 +1,16 @@
+---
+title: "VariableDeclarationTag"
+excerpt: ""
+layout: manual
+---
+
+
+**enum:** [`VariableDeclaration`](/docs/kcl/types/VariableDeclaration)
+
+
+
+
+
+
+
+

--- a/src/wasm-lib/kcl-macros/tests/macro_test.rs
+++ b/src/wasm-lib/kcl-macros/tests/macro_test.rs
@@ -9,6 +9,7 @@ use pretty_assertions::assert_eq;
 #[test]
 fn basic() {
     let actual = parse!("const y = 4");
+<<<<<<< HEAD
     let expected = Node {
         inner: Program {
             body: vec![BodyItem::VariableDeclaration(Box::new(Node::new(
@@ -39,12 +40,70 @@ fn basic() {
                     )],
                     visibility: ItemVisibility::Default,
                     kind: VariableKind::Const,
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    let expected = Program {
+        start: 0,
+        end: 11,
+        body: vec![BodyItem::VariableDeclaration(VariableDeclaration {
+            start: 0,
+            end: 11,
+            declarations: vec![VariableDeclarator {
+                start: 6,
+                end: 11,
+                id: Identifier {
+                    start: 6,
+                    end: 7,
+                    name: "y".to_owned(),
+=======
+    let expected = Program {
+        start: 0,
+        end: 11,
+        body: vec![BodyItem::VariableDeclaration(VariableDeclaration {
+            r#type: Default::default(),
+            start: 0,
+            end: 11,
+            declarations: vec![VariableDeclarator {
+                start: 6,
+                end: 11,
+                id: Identifier {
+                    r#type: Default::default(),
+                    start: 6,
+                    end: 7,
+                    name: "y".to_owned(),
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                     digest: None,
                 },
+<<<<<<< HEAD
                 0,
                 11,
             )))],
             non_code_meta: Default::default(),
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                init: Expr::Literal(Box::new(Literal {
+                    start: 10,
+                    end: 11,
+                    value: LiteralValue::IInteger(4),
+                    raw: "4".to_owned(),
+                    digest: None,
+                })),
+                digest: None,
+            }],
+            visibility: ItemVisibility::Default,
+            kind: VariableKind::Const,
+=======
+                init: Expr::Literal(Box::new(Literal {
+                    r#type: Default::default(),
+                    start: 10,
+                    end: 11,
+                    value: LiteralValue::IInteger(4),
+                    raw: "4".to_owned(),
+                    digest: None,
+                })),
+                digest: None,
+            }],
+            visibility: ItemVisibility::Default,
+            kind: VariableKind::Const,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
             digest: None,
         },
         start: 0,

--- a/src/wasm-lib/kcl/src/ast/types.rs
+++ b/src/wasm-lib/kcl/src/ast/types.rs
@@ -507,7 +507,7 @@ impl Program {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(tag = "type")]
+#[serde(untagged)]
 pub enum BodyItem {
     ImportStatement(BoxNode<ImportStatement>),
     ExpressionStatement(Node<ExpressionStatement>),
@@ -551,7 +551,7 @@ impl From<&BodyItem> for SourceRange {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(tag = "type")]
+#[serde(untagged)]
 pub enum Expr {
     Literal(BoxNode<Literal>),
     Identifier(BoxNode<Identifier>),
@@ -770,7 +770,7 @@ impl From<&Expr> for SourceRange {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(tag = "type")]
+#[serde(untagged)]
 pub enum BinaryPart {
     Literal(BoxNode<Literal>),
     Identifier(BoxNode<Identifier>),
@@ -1148,9 +1148,19 @@ impl ImportItem {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(tag = "type")]
 pub struct ImportStatement {
+<<<<<<< HEAD
     pub items: NodeList<ImportItem>,
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    pub start: usize,
+    pub end: usize,
+    pub items: Vec<ImportItem>,
+=======
+    pub r#type: ImportStatementTag,
+    pub start: usize,
+    pub end: usize,
+    pub items: Vec<ImportItem>,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     pub path: String,
     pub raw_path: String,
 
@@ -1203,9 +1213,19 @@ pub struct ExpressionStatement {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(tag = "type")]
 pub struct CallExpression {
+<<<<<<< HEAD
     pub callee: Node<Identifier>,
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    pub start: usize,
+    pub end: usize,
+    pub callee: Identifier,
+=======
+    pub r#type: CallExpressionTag,
+    pub start: usize,
+    pub end: usize,
+    pub callee: Identifier,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     pub arguments: Vec<Expr>,
     pub optional: bool,
 
@@ -1240,8 +1260,21 @@ impl Node<CallExpression> {
 }
 
 impl CallExpression {
+<<<<<<< HEAD
     pub fn new(name: &str, arguments: Vec<Expr>) -> Result<Node<Self>, KclError> {
         Ok(Node::no_src(Self {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    pub fn new(name: &str, arguments: Vec<Expr>) -> Result<Self, KclError> {
+        Ok(Self {
+            start: 0,
+            end: 0,
+=======
+    pub fn new(name: &str, arguments: Vec<Expr>) -> Result<Self, KclError> {
+        Ok(Self {
+            r#type: Default::default(),
+            start: 0,
+            end: 0,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
             callee: Identifier::new(name),
             arguments,
             optional: false,
@@ -1355,9 +1388,19 @@ impl ItemVisibility {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(tag = "type")]
 pub struct VariableDeclaration {
+<<<<<<< HEAD
     pub declarations: NodeList<VariableDeclarator>,
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    pub start: usize,
+    pub end: usize,
+    pub declarations: Vec<VariableDeclarator>,
+=======
+    pub r#type: VariableDeclarationTag,
+    pub start: usize,
+    pub end: usize,
+    pub declarations: Vec<VariableDeclarator>,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     #[serde(default, skip_serializing_if = "ItemVisibility::is_default")]
     pub visibility: ItemVisibility,
     pub kind: VariableKind, // Change to enum if there are specific values
@@ -1399,7 +1442,38 @@ impl From<&Node<VariableDeclaration>> for Vec<CompletionItem> {
     }
 }
 
+<<<<<<< HEAD
 impl Node<VariableDeclaration> {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+impl_value_meta!(VariableDeclaration);
+
+impl VariableDeclaration {
+    pub fn new(declarations: Vec<VariableDeclarator>, visibility: ItemVisibility, kind: VariableKind) -> Self {
+        Self {
+            start: 0,
+            end: 0,
+            declarations,
+            visibility,
+            kind,
+            digest: None,
+        }
+    }
+=======
+impl_value_meta!(VariableDeclaration);
+
+impl VariableDeclaration {
+    pub fn new(declarations: Vec<VariableDeclarator>, visibility: ItemVisibility, kind: VariableKind) -> Self {
+        Self {
+            r#type: Default::default(),
+            start: 0,
+            end: 0,
+            declarations,
+            visibility,
+            kind,
+            digest: None,
+        }
+    }
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     pub fn get_lsp_folding_range(&self) -> Option<FoldingRange> {
         let recasted = self.recast(&FormatOptions::default(), 0);
         // If the recasted value only has one line, don't fold it.
@@ -1634,11 +1708,53 @@ impl VariableDeclarator {
     }
 }
 
+// This is a simple macro named `say_hello`.
+macro_rules! gen_tag {
+    ($name:ident, $name_tag:ident) => {
+        #[derive(
+            Debug, Default, serde::Serialize, serde::Deserialize, Clone, PartialEq, ts_rs::TS, JsonSchema, Bake, Eq,
+        )]
+        #[databake(path = kcl_lib::ast::types)]
+        #[serde(rename_all = "PascalCase")]
+        pub enum $name_tag {
+            #[default]
+            $name,
+        }
+    };
+}
+
+gen_tag!(Literal, LiteralTag);
+gen_tag!(Identifier, IdentifierTag);
+gen_tag!(TagDeclarator, TagDeclaratorTag);
+gen_tag!(BinaryExpression, BinaryExpressionTag);
+gen_tag!(FunctionExpression, FunctionExpressionTag);
+gen_tag!(CallExpression, CallExpressionTag);
+gen_tag!(PipeExpression, PipeExpressionTag);
+gen_tag!(PipeSubstitution, PipeSubstitutionTag);
+gen_tag!(ArrayExpression, ArrayExpressionTag);
+gen_tag!(ArrayRangeExpression, ArrayRangeExpressionTag);
+gen_tag!(ObjectExpression, ObjectExpressionTag);
+gen_tag!(MemberExpression, MemberExpressionTag);
+gen_tag!(UnaryExpression, UnaryExpressionTag);
+gen_tag!(IfExpression, IfExpressionTag);
+gen_tag!(KclNone, KclNoneTag);
+gen_tag!(VariableDeclaration, VariableDeclarationTag);
+gen_tag!(ImportStatement, ImportStatementTag);
+gen_tag!(ReturnStatement, ReturnStatementTag);
+
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(tag = "type")]
 pub struct Literal {
+<<<<<<< HEAD
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    pub start: usize,
+    pub end: usize,
+=======
+    pub r#type: LiteralTag,
+    pub start: usize,
+    pub end: usize,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     pub value: LiteralValue,
     pub raw: String,
 
@@ -1647,7 +1763,38 @@ pub struct Literal {
     pub digest: Option<Digest>,
 }
 
+<<<<<<< HEAD
 impl Node<Literal> {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+impl_value_meta!(Literal);
+
+impl Literal {
+    pub fn new(value: LiteralValue) -> Self {
+        Self {
+            start: 0,
+            end: 0,
+            raw: JValue::from(value.clone()).to_string(),
+            value,
+            digest: None,
+        }
+    }
+
+=======
+impl_value_meta!(Literal);
+
+impl Literal {
+    pub fn new(value: LiteralValue) -> Self {
+        Self {
+            r#type: Default::default(),
+            start: 0,
+            end: 0,
+            raw: JValue::from(value.clone()).to_string(),
+            value,
+            digest: None,
+        }
+    }
+
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     /// Get the constraint level for this literal.
     /// Literals are always not constrained.
     pub fn get_constraint_level(&self) -> ConstraintLevel {
@@ -1703,8 +1850,16 @@ impl From<&BoxNode<Literal>> for KclValue {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake, Eq)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(tag = "type")]
 pub struct Identifier {
+<<<<<<< HEAD
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    pub start: usize,
+    pub end: usize,
+=======
+    pub r#type: IdentifierTag,
+    pub start: usize,
+    pub end: usize,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     pub name: String,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1712,7 +1867,36 @@ pub struct Identifier {
     pub digest: Option<Digest>,
 }
 
+<<<<<<< HEAD
 impl Node<Identifier> {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+impl_value_meta!(Identifier);
+
+impl Identifier {
+    pub fn new(name: &str) -> Self {
+        Self {
+            start: 0,
+            end: 0,
+            name: name.to_string(),
+            digest: None,
+        }
+    }
+
+=======
+impl_value_meta!(Identifier);
+
+impl Identifier {
+    pub fn new(name: &str) -> Self {
+        Self {
+            r#type: Default::default(),
+            start: 0,
+            end: 0,
+            name: name.to_string(),
+            digest: None,
+        }
+    }
+
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     /// Get the constraint level for this identifier.
     /// Identifier are always fully constrained.
     pub fn get_constraint_level(&self) -> ConstraintLevel {
@@ -1741,8 +1925,16 @@ impl Identifier {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake, Eq)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(tag = "type")]
 pub struct TagDeclarator {
+<<<<<<< HEAD
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    pub start: usize,
+    pub end: usize,
+=======
+    pub r#type: TagDeclaratorTag,
+    pub start: usize,
+    pub end: usize,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     #[serde(rename = "value")]
     pub name: String,
 
@@ -1802,7 +1994,32 @@ impl From<&Node<TagDeclarator>> for CompletionItem {
     }
 }
 
+<<<<<<< HEAD
 impl Node<TagDeclarator> {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+impl TagDeclarator {
+    pub fn new(name: &str) -> Self {
+        Self {
+            start: 0,
+            end: 0,
+            name: name.to_string(),
+            digest: None,
+        }
+    }
+
+=======
+impl TagDeclarator {
+    pub fn new(name: &str) -> Self {
+        Self {
+            r#type: Default::default(),
+            start: 0,
+            end: 0,
+            name: name.to_string(),
+            digest: None,
+        }
+    }
+
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     /// Get the constraint level for this identifier.
     /// TagDeclarator are always fully constrained.
     pub fn get_constraint_level(&self) -> ConstraintLevel {
@@ -1849,16 +2066,43 @@ impl TagDeclarator {
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(tag = "type")]
 pub struct PipeSubstitution {
+<<<<<<< HEAD
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    pub start: usize,
+    pub end: usize,
+
+=======
+    pub r#type: PipeSubstitutionTag,
+    pub start: usize,
+    pub end: usize,
+
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub digest: Option<Digest>,
 }
 
 impl PipeSubstitution {
+<<<<<<< HEAD
     pub fn new() -> Node<Self> {
         Node::no_src(Self { digest: None })
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    pub fn new() -> Self {
+        Self {
+            start: 0,
+            end: 0,
+            digest: None,
+        }
+=======
+    pub fn new() -> Self {
+        Self {
+            r#type: Default::default(),
+            start: 0,
+            end: 0,
+            digest: None,
+        }
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     }
 }
 
@@ -1871,8 +2115,17 @@ impl From<Node<PipeSubstitution>> for Expr {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(rename_all = "camelCase", tag = "type")]
+#[serde(rename_all = "camelCase")]
 pub struct ArrayExpression {
+<<<<<<< HEAD
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    pub start: usize,
+    pub end: usize,
+=======
+    pub r#type: ArrayExpressionTag,
+    pub start: usize,
+    pub end: usize,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     pub elements: Vec<Expr>,
     #[serde(default, skip_serializing_if = "NonCodeMeta::is_empty")]
     pub non_code_meta: NonCodeMeta,
@@ -1888,7 +2141,46 @@ impl From<Node<ArrayExpression>> for Expr {
     }
 }
 
+<<<<<<< HEAD
 impl Node<ArrayExpression> {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+impl ArrayExpression {
+    pub fn new(elements: Vec<Expr>) -> Self {
+        Self {
+            start: 0,
+            end: 0,
+            elements,
+            non_code_meta: Default::default(),
+            digest: None,
+        }
+    }
+
+    pub fn replace_value(&mut self, source_range: SourceRange, new_value: Expr) {
+        for element in &mut self.elements {
+            element.replace_value(source_range, new_value.clone());
+        }
+    }
+
+=======
+impl ArrayExpression {
+    pub fn new(elements: Vec<Expr>) -> Self {
+        Self {
+            r#type: Default::default(),
+            start: 0,
+            end: 0,
+            elements,
+            non_code_meta: Default::default(),
+            digest: None,
+        }
+    }
+
+    pub fn replace_value(&mut self, source_range: SourceRange, new_value: Expr) {
+        for element in &mut self.elements {
+            element.replace_value(source_range, new_value.clone());
+        }
+    }
+
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     pub fn get_constraint_level(&self) -> ConstraintLevel {
         if self.elements.is_empty() {
             return ConstraintLevel::Ignore {
@@ -1943,10 +2235,23 @@ impl ArrayExpression {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(rename_all = "camelCase", tag = "type")]
+#[serde(rename_all = "camelCase")]
 pub struct ArrayRangeExpression {
+<<<<<<< HEAD
     pub start_element: Expr,
     pub end_element: Expr,
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    pub start: usize,
+    pub end: usize,
+    pub start_element: Box<Expr>,
+    pub end_element: Box<Expr>,
+=======
+    pub r#type: ArrayRangeExpressionTag,
+    pub start: usize,
+    pub end: usize,
+    pub start_element: Box<Expr>,
+    pub end_element: Box<Expr>,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     /// Is the `end_element` included in the range?
     pub end_inclusive: bool,
     // TODO (maybe) comments on range components?
@@ -1961,7 +2266,46 @@ impl From<Node<ArrayRangeExpression>> for Expr {
     }
 }
 
+<<<<<<< HEAD
 impl Node<ArrayRangeExpression> {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+impl ArrayRangeExpression {
+    pub fn new(start_element: Box<Expr>, end_element: Box<Expr>) -> Self {
+        Self {
+            start: 0,
+            end: 0,
+            start_element,
+            end_element,
+            end_inclusive: true,
+            digest: None,
+        }
+    }
+
+    pub fn replace_value(&mut self, source_range: SourceRange, new_value: Expr) {
+        self.start_element.replace_value(source_range, new_value.clone());
+        self.end_element.replace_value(source_range, new_value.clone());
+    }
+
+=======
+impl ArrayRangeExpression {
+    pub fn new(start_element: Box<Expr>, end_element: Box<Expr>) -> Self {
+        Self {
+            r#type: Default::default(),
+            start: 0,
+            end: 0,
+            start_element,
+            end_element,
+            end_inclusive: true,
+            digest: None,
+        }
+    }
+
+    pub fn replace_value(&mut self, source_range: SourceRange, new_value: Expr) {
+        self.start_element.replace_value(source_range, new_value.clone());
+        self.end_element.replace_value(source_range, new_value.clone());
+    }
+
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     pub fn get_constraint_level(&self) -> ConstraintLevel {
         let mut constraint_levels = ConstraintLevels::new();
         constraint_levels.push(self.start_element.get_constraint_level());
@@ -2008,9 +2352,20 @@ impl ArrayRangeExpression {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(rename_all = "camelCase", tag = "type")]
+#[serde(rename_all = "camelCase")]
 pub struct ObjectExpression {
+<<<<<<< HEAD
     pub properties: NodeList<ObjectProperty>,
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    pub start: usize,
+    pub end: usize,
+    pub properties: Vec<ObjectProperty>,
+=======
+    pub r#type: ObjectExpressionTag,
+    pub start: usize,
+    pub end: usize,
+    pub properties: Vec<ObjectProperty>,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     #[serde(default, skip_serializing_if = "NonCodeMeta::is_empty")]
     pub non_code_meta: NonCodeMeta,
 
@@ -2019,7 +2374,46 @@ pub struct ObjectExpression {
     pub digest: Option<Digest>,
 }
 
+<<<<<<< HEAD
 impl Node<ObjectExpression> {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+impl ObjectExpression {
+    pub fn new(properties: Vec<ObjectProperty>) -> Self {
+        Self {
+            start: 0,
+            end: 0,
+            properties,
+            non_code_meta: Default::default(),
+            digest: None,
+        }
+    }
+
+    pub fn replace_value(&mut self, source_range: SourceRange, new_value: Expr) {
+        for property in &mut self.properties {
+            property.value.replace_value(source_range, new_value.clone());
+        }
+    }
+
+=======
+impl ObjectExpression {
+    pub fn new(properties: Vec<ObjectProperty>) -> Self {
+        Self {
+            r#type: Default::default(),
+            start: 0,
+            end: 0,
+            properties,
+            non_code_meta: Default::default(),
+            digest: None,
+        }
+    }
+
+    pub fn replace_value(&mut self, source_range: SourceRange, new_value: Expr) {
+        for property in &mut self.properties {
+            property.value.replace_value(source_range, new_value.clone());
+        }
+    }
+
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     pub fn get_constraint_level(&self) -> ConstraintLevel {
         if self.properties.is_empty() {
             return ConstraintLevel::Ignore {
@@ -2073,8 +2467,8 @@ impl ObjectExpression {
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake)]
 #[databake(path = kcl_lib::ast::types)]
-#[ts(export)]
 #[serde(tag = "type")]
+#[ts(export)]
 pub struct ObjectProperty {
     pub key: Node<Identifier>,
     pub value: Expr,
@@ -2119,7 +2513,7 @@ impl ObjectProperty {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(tag = "type")]
+#[serde(untagged)]
 pub enum MemberObject {
     MemberExpression(BoxNode<MemberExpression>),
     Identifier(BoxNode<Identifier>),
@@ -2166,7 +2560,7 @@ impl From<&MemberObject> for SourceRange {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(tag = "type")]
+#[serde(untagged)]
 pub enum LiteralIdentifier {
     Identifier(BoxNode<Identifier>),
     Literal(BoxNode<Literal>),
@@ -2203,8 +2597,16 @@ impl From<&LiteralIdentifier> for SourceRange {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(tag = "type")]
 pub struct MemberExpression {
+<<<<<<< HEAD
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    pub start: usize,
+    pub end: usize,
+=======
+    pub r#type: MemberExpressionTag,
+    pub start: usize,
+    pub end: usize,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     pub object: MemberObject,
     pub property: LiteralIdentifier,
     pub computed: bool,
@@ -2262,8 +2664,16 @@ pub struct ObjectKeyInfo {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(tag = "type")]
 pub struct BinaryExpression {
+<<<<<<< HEAD
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    pub start: usize,
+    pub end: usize,
+=======
+    pub r#type: BinaryExpressionTag,
+    pub start: usize,
+    pub end: usize,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     pub operator: BinaryOperator,
     pub left: BinaryPart,
     pub right: BinaryPart,
@@ -2273,7 +2683,50 @@ pub struct BinaryExpression {
     pub digest: Option<Digest>,
 }
 
+<<<<<<< HEAD
 impl Node<BinaryExpression> {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+impl_value_meta!(BinaryExpression);
+
+impl BinaryExpression {
+    pub fn new(operator: BinaryOperator, left: BinaryPart, right: BinaryPart) -> Self {
+        Self {
+            start: left.start(),
+            end: right.end(),
+            operator,
+            left,
+            right,
+            digest: None,
+        }
+    }
+
+    pub fn replace_value(&mut self, source_range: SourceRange, new_value: Expr) {
+        self.left.replace_value(source_range, new_value.clone());
+        self.right.replace_value(source_range, new_value);
+    }
+
+=======
+impl_value_meta!(BinaryExpression);
+
+impl BinaryExpression {
+    pub fn new(operator: BinaryOperator, left: BinaryPart, right: BinaryPart) -> Self {
+        Self {
+            r#type: Default::default(),
+            start: left.start(),
+            end: right.end(),
+            operator,
+            left,
+            right,
+            digest: None,
+        }
+    }
+
+    pub fn replace_value(&mut self, source_range: SourceRange, new_value: Expr) {
+        self.left.replace_value(source_range, new_value.clone());
+        self.right.replace_value(source_range, new_value);
+    }
+
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     pub fn get_constraint_level(&self) -> ConstraintLevel {
         let left_constraint_level = self.left.get_constraint_level();
         let right_constraint_level = self.right.get_constraint_level();
@@ -2443,8 +2896,16 @@ impl BinaryOperator {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(tag = "type")]
 pub struct UnaryExpression {
+<<<<<<< HEAD
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    pub start: usize,
+    pub end: usize,
+=======
+    pub r#type: UnaryExpressionTag,
+    pub start: usize,
+    pub end: usize,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     pub operator: UnaryOperator,
     pub argument: BinaryPart,
 
@@ -2454,8 +2915,21 @@ pub struct UnaryExpression {
 }
 
 impl UnaryExpression {
+<<<<<<< HEAD
     pub fn new(operator: UnaryOperator, argument: BinaryPart) -> Node<Self> {
         Node::no_src(Self {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    pub fn new(operator: UnaryOperator, argument: BinaryPart) -> Self {
+        Self {
+            start: 0,
+            end: argument.end(),
+=======
+    pub fn new(operator: UnaryOperator, argument: BinaryPart) -> Self {
+        Self {
+            r#type: Default::default(),
+            start: 0,
+            end: argument.end(),
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
             operator,
             argument,
             digest: None,
@@ -2514,8 +2988,17 @@ impl UnaryOperator {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(rename_all = "camelCase", tag = "type")]
+#[serde(rename_all = "camelCase")]
 pub struct PipeExpression {
+<<<<<<< HEAD
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    pub start: usize,
+    pub end: usize,
+=======
+    pub r#type: PipeExpressionTag,
+    pub start: usize,
+    pub end: usize,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     // TODO: Only the first body expression can be any Value.
     // The rest will be CallExpression, and the AST type should reflect this.
     pub body: Vec<Expr>,
@@ -2533,7 +3016,46 @@ impl From<Node<PipeExpression>> for Expr {
     }
 }
 
+<<<<<<< HEAD
 impl Node<PipeExpression> {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+impl PipeExpression {
+    pub fn new(body: Vec<Expr>) -> Self {
+        Self {
+            start: 0,
+            end: 0,
+            body,
+            non_code_meta: Default::default(),
+            digest: None,
+        }
+    }
+
+    pub fn replace_value(&mut self, source_range: SourceRange, new_value: Expr) {
+        for value in &mut self.body {
+            value.replace_value(source_range, new_value.clone());
+        }
+    }
+
+=======
+impl PipeExpression {
+    pub fn new(body: Vec<Expr>) -> Self {
+        Self {
+            r#type: Default::default(),
+            start: 0,
+            end: 0,
+            body,
+            non_code_meta: Default::default(),
+            digest: None,
+        }
+    }
+
+    pub fn replace_value(&mut self, source_range: SourceRange, new_value: Expr) {
+        for value in &mut self.body {
+            value.replace_value(source_range, new_value.clone());
+        }
+    }
+
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     pub fn get_constraint_level(&self) -> ConstraintLevel {
         if self.body.is_empty() {
             return ConstraintLevel::Ignore {
@@ -2665,8 +3187,16 @@ pub struct Parameter {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(tag = "type")]
 pub struct FunctionExpression {
+<<<<<<< HEAD
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    pub start: usize,
+    pub end: usize,
+=======
+    pub r#type: FunctionExpressionTag,
+    pub start: usize,
+    pub end: usize,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     pub params: Vec<Parameter>,
     pub body: Node<Program>,
     #[serde(skip)]
@@ -2700,6 +3230,15 @@ impl FunctionExpression {
         &self,
     ) -> Result<(&[Parameter], &[Parameter]), RequiredParamAfterOptionalParam> {
         let Self {
+<<<<<<< HEAD
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+            start: _,
+            end: _,
+=======
+            start: _,
+            end: _,
+            r#type: _,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
             params,
             body: _,
             digest: _,
@@ -2752,8 +3291,16 @@ impl FunctionExpression {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(tag = "type")]
 pub struct ReturnStatement {
+<<<<<<< HEAD
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    pub start: usize,
+    pub end: usize,
+=======
+    pub r#type: ReturnStatementTag,
+    pub start: usize,
+    pub end: usize,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     pub argument: Expr,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -3199,6 +3746,7 @@ const cylinder = startSketchOn('-XZ')
             Some(FnArgType::Object {
                 properties: vec![
                     Parameter {
+<<<<<<< HEAD
                         identifier: Node::new(
                             Identifier {
                                 name: "thing".to_owned(),
@@ -3207,11 +3755,28 @@ const cylinder = startSketchOn('-XZ')
                             35,
                             40,
                         ),
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                        identifier: Identifier {
+                            start: 35,
+                            end: 40,
+                            name: "thing".to_owned(),
+                            digest: None,
+                        },
+=======
+                        identifier: Identifier {
+                            r#type: Default::default(),
+                            start: 35,
+                            end: 40,
+                            name: "thing".to_owned(),
+                            digest: None,
+                        },
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                         type_: Some(FnArgType::Primitive(FnArgPrimitive::Number)),
                         optional: false,
                         digest: None
                     },
                     Parameter {
+<<<<<<< HEAD
                         identifier: Node::new(
                             Identifier {
                                 name: "things".to_owned(),
@@ -3220,11 +3785,28 @@ const cylinder = startSketchOn('-XZ')
                             50,
                             56,
                         ),
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                        identifier: Identifier {
+                            start: 50,
+                            end: 56,
+                            name: "things".to_owned(),
+                            digest: None,
+                        },
+=======
+                        identifier: Identifier {
+                            r#type: Default::default(),
+                            start: 50,
+                            end: 56,
+                            name: "things".to_owned(),
+                            digest: None,
+                        },
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                         type_: Some(FnArgType::Array(FnArgPrimitive::String)),
                         optional: false,
                         digest: None
                     },
                     Parameter {
+<<<<<<< HEAD
                         identifier: Node::new(
                             Identifier {
                                 name: "more".to_owned(),
@@ -3233,6 +3815,22 @@ const cylinder = startSketchOn('-XZ')
                             68,
                             72,
                         ),
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                        identifier: Identifier {
+                            start: 68,
+                            end: 72,
+                            name: "more".to_owned(),
+                            digest: None
+                        },
+=======
+                        identifier: Identifier {
+                            r#type: Default::default(),
+                            start: 68,
+                            end: 72,
+                            name: "more".to_owned(),
+                            digest: None
+                        },
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                         type_: Some(FnArgType::Primitive(FnArgPrimitive::String)),
                         optional: true,
                         digest: None
@@ -3267,6 +3865,7 @@ const cylinder = startSketchOn('-XZ')
             Some(FnArgType::Object {
                 properties: vec![
                     Parameter {
+<<<<<<< HEAD
                         identifier: Node::new(
                             Identifier {
                                 name: "thing".to_owned(),
@@ -3275,11 +3874,28 @@ const cylinder = startSketchOn('-XZ')
                             18,
                             23,
                         ),
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                        identifier: Identifier {
+                            start: 18,
+                            end: 23,
+                            name: "thing".to_owned(),
+                            digest: None
+                        },
+=======
+                        identifier: Identifier {
+                            r#type: Default::default(),
+                            start: 18,
+                            end: 23,
+                            name: "thing".to_owned(),
+                            digest: None
+                        },
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                         type_: Some(FnArgType::Primitive(FnArgPrimitive::Number)),
                         optional: false,
                         digest: None
                     },
                     Parameter {
+<<<<<<< HEAD
                         identifier: Node::new(
                             Identifier {
                                 name: "things".to_owned(),
@@ -3288,11 +3904,28 @@ const cylinder = startSketchOn('-XZ')
                             33,
                             39,
                         ),
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                        identifier: Identifier {
+                            start: 33,
+                            end: 39,
+                            name: "things".to_owned(),
+                            digest: None
+                        },
+=======
+                        identifier: Identifier {
+                            r#type: Default::default(),
+                            start: 33,
+                            end: 39,
+                            name: "things".to_owned(),
+                            digest: None
+                        },
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                         type_: Some(FnArgType::Array(FnArgPrimitive::String)),
                         optional: false,
                         digest: None
                     },
                     Parameter {
+<<<<<<< HEAD
                         identifier: Node::new(
                             Identifier {
                                 name: "more".to_owned(),
@@ -3301,6 +3934,22 @@ const cylinder = startSketchOn('-XZ')
                             51,
                             55,
                         ),
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                        identifier: Identifier {
+                            start: 51,
+                            end: 55,
+                            name: "more".to_owned(),
+                            digest: None
+                        },
+=======
+                        identifier: Identifier {
+                            r#type: Default::default(),
+                            start: 51,
+                            end: 55,
+                            name: "more".to_owned(),
+                            digest: None
+                        },
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                         type_: Some(FnArgType::Primitive(FnArgPrimitive::String)),
                         optional: true,
                         digest: None
@@ -3316,7 +3965,18 @@ const cylinder = startSketchOn('-XZ')
             (
                 "no params",
                 (0..=0),
+<<<<<<< HEAD
                 Node::no_src(FunctionExpression {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                FunctionExpression {
+                    start: 0,
+                    end: 0,
+=======
+                FunctionExpression {
+                    r#type: Default::default(),
+                    start: 0,
+                    end: 0,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                     params: vec![],
                     body: Node::no_src(Program {
                         body: Vec::new(),
@@ -3330,9 +3990,31 @@ const cylinder = startSketchOn('-XZ')
             (
                 "all required params",
                 (1..=1),
+<<<<<<< HEAD
                 Node::no_src(FunctionExpression {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                FunctionExpression {
+                    start: 0,
+                    end: 0,
+=======
+                FunctionExpression {
+                    r#type: Default::default(),
+                    start: 0,
+                    end: 0,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                     params: vec![Parameter {
+<<<<<<< HEAD
                         identifier: Node::no_src(Identifier {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                        identifier: Identifier {
+                            start: 0,
+                            end: 0,
+=======
+                        identifier: Identifier {
+                            r#type: Default::default(),
+                            start: 0,
+                            end: 0,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                             name: "foo".to_owned(),
                             digest: None,
                         }),
@@ -3356,9 +4038,31 @@ const cylinder = startSketchOn('-XZ')
             (
                 "all optional params",
                 (0..=1),
+<<<<<<< HEAD
                 Node::no_src(FunctionExpression {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                FunctionExpression {
+                    start: 0,
+                    end: 0,
+=======
+                FunctionExpression {
+                    r#type: Default::default(),
+                    start: 0,
+                    end: 0,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                     params: vec![Parameter {
+<<<<<<< HEAD
                         identifier: Node::no_src(Identifier {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                        identifier: Identifier {
+                            start: 0,
+                            end: 0,
+=======
+                        identifier: Identifier {
+                            r#type: Default::default(),
+                            start: 0,
+                            end: 0,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                             name: "foo".to_owned(),
                             digest: None,
                         }),
@@ -3382,10 +4086,32 @@ const cylinder = startSketchOn('-XZ')
             (
                 "mixed params",
                 (1..=2),
+<<<<<<< HEAD
                 Node::no_src(FunctionExpression {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                FunctionExpression {
+                    start: 0,
+                    end: 0,
+=======
+                FunctionExpression {
+                    r#type: Default::default(),
+                    start: 0,
+                    end: 0,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                     params: vec![
                         Parameter {
+<<<<<<< HEAD
                             identifier: Node::no_src(Identifier {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                            identifier: Identifier {
+                                start: 0,
+                                end: 0,
+=======
+                            identifier: Identifier {
+                                r#type: Default::default(),
+                                start: 0,
+                                end: 0,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                                 name: "foo".to_owned(),
                                 digest: None,
                             }),
@@ -3394,7 +4120,18 @@ const cylinder = startSketchOn('-XZ')
                             digest: None,
                         },
                         Parameter {
+<<<<<<< HEAD
                             identifier: Node::no_src(Identifier {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                            identifier: Identifier {
+                                start: 0,
+                                end: 0,
+=======
+                            identifier: Identifier {
+                                r#type: Default::default(),
+                                start: 0,
+                                end: 0,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                                 name: "bar".to_owned(),
                                 digest: None,
                             }),
@@ -3535,5 +4272,40 @@ const cylinder = startSketchOn('-XZ')
         let prog3_digest = prog3_parser.ast().unwrap().compute_digest();
 
         assert_eq!(prog1_digest, prog3_digest);
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let program = include_str!("../../../tests/executor/inputs/focusrite_scarlett_mounting_braket.kcl");
+        let ast_in = crate::parser::parse(program).unwrap();
+        let ast_serialized = serde_json::to_string_pretty(&ast_in).unwrap();
+        let ast_out: Program = serde_json::from_str(&ast_serialized).unwrap();
+        assert_eq!(ast_in, ast_out);
+    }
+
+    #[test]
+    fn weird_untagged() {
+        let json_str = r#"
+        {
+              "type": "MemberExpression",
+              "start": 41,
+              "end": 45,
+              "object": {
+                "type": "Identifier",
+                "start": 41,
+                "end": 43,
+                "name": "yo"
+              },
+              "property": {
+                "type": "Identifier",
+                "start": 44,
+                "end": 45,
+                "name": "a"
+              },
+              "computed": false
+            }
+
+        "#;
+        let _: MemberExpression = serde_json::from_str(json_str).unwrap();
     }
 }

--- a/src/wasm-lib/kcl/src/ast/types/none.rs
+++ b/src/wasm-lib/kcl/src/ast/types/none.rs
@@ -17,8 +17,8 @@ const KCL_NONE_ID: &str = "KCL_NONE_ID";
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake, Default)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
-#[serde(tag = "type")]
 pub struct KclNone {
+    pub r#type: super::KclNoneTag,
     // TODO: Convert this to be an Option<SourceRange>.
     pub start: usize,
     pub end: usize,
@@ -31,6 +31,7 @@ pub struct KclNone {
 impl KclNone {
     pub fn new(start: usize, end: usize) -> Self {
         Self {
+            r#type: Default::default(),
             start,
             end,
             __private: Private {},

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -3555,8 +3555,21 @@ let w = f() + f()
                 meta: Default::default(),
             })
         }
+<<<<<<< HEAD
         fn ident(s: &'static str) -> Node<Identifier> {
             Node::no_src(Identifier {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+        fn ident(s: &'static str) -> Identifier {
+            Identifier {
+                start: 0,
+                end: 0,
+=======
+        fn ident(s: &'static str) -> Identifier {
+            Identifier {
+                r#type: Default::default(),
+                start: 0,
+                end: 0,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                 name: s.to_owned(),
                 digest: None,
             })
@@ -3651,7 +3664,18 @@ let w = f() + f()
             ),
         ] {
             // Run each test.
+<<<<<<< HEAD
             let func_expr = &Node::no_src(FunctionExpression {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+            let func_expr = &FunctionExpression {
+                start: 0,
+                end: 0,
+=======
+            let func_expr = &FunctionExpression {
+                r#type: Default::default(),
+                start: 0,
+                end: 0,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                 params,
                 body: Node {
                     inner: crate::ast::types::Program {

--- a/src/wasm-lib/kcl/src/parser/math.rs
+++ b/src/wasm-lib/kcl/src/parser/math.rs
@@ -28,6 +28,7 @@ fn evaluate(rpn: Vec<BinaryExpressionToken>) -> Result<Node<BinaryExpression>, K
                 let Some(left) = operand_stack.pop() else {
                     return Err(e);
                 };
+<<<<<<< HEAD
                 let start = left.start();
                 let end = right.end();
 
@@ -41,6 +42,26 @@ fn evaluate(rpn: Vec<BinaryExpressionToken>) -> Result<Node<BinaryExpression>, K
                     start,
                     end,
                 ))
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                BinaryPart::BinaryExpression(Box::new(BinaryExpression {
+                    start: left.start(),
+                    end: right.end(),
+                    operator,
+                    left,
+                    right,
+                    digest: None,
+                }))
+=======
+                BinaryPart::BinaryExpression(Box::new(BinaryExpression {
+                    r#type: Default::default(),
+                    start: left.start(),
+                    end: right.end(),
+                    operator,
+                    left,
+                    right,
+                    digest: None,
+                }))
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
             }
             BinaryExpressionToken::Operand(o) => o,
         };
@@ -130,6 +151,7 @@ mod tests {
     fn parse_and_evaluate() {
         /// Make a literal
         fn lit(n: u8) -> BinaryPart {
+<<<<<<< HEAD
             BinaryPart::Literal(Box::new(Node::new(
                 Literal {
                     value: n.into(),
@@ -139,6 +161,24 @@ mod tests {
                 0,
                 0,
             )))
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+            BinaryPart::Literal(Box::new(Literal {
+                start: 0,
+                end: 0,
+                value: n.into(),
+                raw: n.to_string(),
+                digest: None,
+            }))
+=======
+            BinaryPart::Literal(Box::new(Literal {
+                r#type: Default::default(),
+                start: 0,
+                end: 0,
+                value: n.into(),
+                raw: n.to_string(),
+                digest: None,
+            }))
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
         }
         let tests: Vec<Vec<BinaryExpressionToken>> = vec![
             // 3 + 4 × 2 ÷ ( 1 − 5 ) ^ 2 ^ 3
@@ -149,6 +189,7 @@ mod tests {
                 BinaryOperator::Mul.into(),
                 lit(2).into(),
                 BinaryOperator::Div.into(),
+<<<<<<< HEAD
                 BinaryPart::BinaryExpression(Node::boxed(
                     BinaryExpression {
                         operator: BinaryOperator::Sub,
@@ -159,6 +200,26 @@ mod tests {
                     0,
                     0,
                 ))
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                BinaryPart::BinaryExpression(Box::new(BinaryExpression {
+                    start: 0,
+                    end: 0,
+                    operator: BinaryOperator::Sub,
+                    left: lit(1),
+                    right: lit(5),
+                    digest: None,
+                }))
+=======
+                BinaryPart::BinaryExpression(Box::new(BinaryExpression {
+                    r#type: Default::default(),
+                    start: 0,
+                    end: 0,
+                    operator: BinaryOperator::Sub,
+                    left: lit(1),
+                    right: lit(5),
+                    digest: None,
+                }))
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                 .into(),
                 BinaryOperator::Pow.into(),
                 lit(2).into(),

--- a/src/wasm-lib/kcl/src/parser/parser_impl.rs
+++ b/src/wasm-lib/kcl/src/parser/parser_impl.rs
@@ -191,7 +191,14 @@ fn pipe_expression(i: TokenSlice) -> PResult<Node<PipeExpression>> {
             non_code_meta.insert(code_count, nc);
         }
     }
+<<<<<<< HEAD
     Ok(Node {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    Ok(PipeExpression {
+=======
+    Ok(PipeExpression {
+        r#type: Default::default(),
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
         start: values.first().unwrap().start(),
         end: values.last().unwrap().end().max(max_noncode_end),
         inner: PipeExpression {
@@ -214,6 +221,7 @@ fn bool_value(i: TokenSlice) -> PResult<BoxNode<Literal>> {
         })
         .context(expected("a boolean literal (either true or false)"))
         .parse_next(i)?;
+<<<<<<< HEAD
     Ok(Box::new(Node::new(
         Literal {
             value: LiteralValue::Bool(value),
@@ -223,6 +231,24 @@ fn bool_value(i: TokenSlice) -> PResult<BoxNode<Literal>> {
         token.start,
         token.end,
     )))
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    Ok(Literal {
+        start: token.start,
+        end: token.end,
+        value: LiteralValue::Bool(value),
+        raw: value.to_string(),
+        digest: None,
+    })
+=======
+    Ok(Literal {
+        r#type: Default::default(),
+        start: token.start,
+        end: token.end,
+        value: LiteralValue::Bool(value),
+        raw: value.to_string(),
+        digest: None,
+    })
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 }
 
 pub fn literal(i: TokenSlice) -> PResult<BoxNode<Literal>> {
@@ -247,6 +273,7 @@ pub fn string_literal(i: TokenSlice) -> PResult<Node<Literal>> {
         })
         .context(expected("string literal (like \"myPart\""))
         .parse_next(i)?;
+<<<<<<< HEAD
     Ok(Node::new(
         Literal {
             value,
@@ -256,6 +283,24 @@ pub fn string_literal(i: TokenSlice) -> PResult<Node<Literal>> {
         token.start,
         token.end,
     ))
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    Ok(Literal {
+        start: token.start,
+        end: token.end,
+        value,
+        raw: token.value.clone(),
+        digest: None,
+    })
+=======
+    Ok(Literal {
+        r#type: Default::default(),
+        start: token.start,
+        end: token.end,
+        value,
+        raw: token.value.clone(),
+        digest: None,
+    })
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 }
 
 /// Parse a KCL literal number, with no - sign.
@@ -282,6 +327,7 @@ pub(crate) fn unsigned_number_literal(i: TokenSlice) -> PResult<Node<Literal>> {
         })
         .context(expected("an unsigned number literal (e.g. 3 or 12.5)"))
         .parse_next(i)?;
+<<<<<<< HEAD
     Ok(Node::new(
         Literal {
             value,
@@ -291,6 +337,24 @@ pub(crate) fn unsigned_number_literal(i: TokenSlice) -> PResult<Node<Literal>> {
         token.start,
         token.end,
     ))
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    Ok(Literal {
+        start: token.start,
+        end: token.end,
+        value,
+        raw: token.value.clone(),
+        digest: None,
+    })
+=======
+    Ok(Literal {
+        start: token.start,
+        r#type: Default::default(),
+        end: token.end,
+        value,
+        raw: token.value.clone(),
+        digest: None,
+    })
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
 }
 
 /// Parse a KCL operator that takes a left- and right-hand side argument.
@@ -489,12 +553,19 @@ fn array_empty(i: TokenSlice) -> PResult<Node<ArrayExpression>> {
     let start = open_bracket(i)?.start;
     ignore_whitespace(i);
     let end = close_bracket(i)?.end;
+<<<<<<< HEAD
     Ok(Node::new(
         ArrayExpression {
             elements: Default::default(),
             non_code_meta: Default::default(),
             digest: None,
         },
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    Ok(ArrayExpression {
+=======
+    Ok(ArrayExpression {
+        r#type: Default::default(),
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
         start,
         end,
     ))
@@ -546,12 +617,19 @@ pub(crate) fn array_elem_by_elem(i: TokenSlice) -> PResult<Node<ArrayExpression>
         start_nodes: Vec::new(),
         digest: None,
     };
+<<<<<<< HEAD
     Ok(Node::new(
         ArrayExpression {
             elements,
             non_code_meta,
             digest: None,
         },
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    Ok(ArrayExpression {
+=======
+    Ok(ArrayExpression {
+        r#type: Default::default(),
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
         start,
         end,
     ))
@@ -567,6 +645,7 @@ fn array_end_start(i: TokenSlice) -> PResult<Node<ArrayRangeExpression>> {
     let end_element = expression.parse_next(i)?;
     ignore_whitespace(i);
     let end = close_bracket(i)?.end;
+<<<<<<< HEAD
     Ok(Node::new(
         ArrayRangeExpression {
             start_element,
@@ -574,6 +653,12 @@ fn array_end_start(i: TokenSlice) -> PResult<Node<ArrayRangeExpression>> {
             end_inclusive: true,
             digest: None,
         },
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    Ok(ArrayRangeExpression {
+=======
+    Ok(ArrayRangeExpression {
+        r#type: Default::default(),
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
         start,
         end,
     ))
@@ -653,12 +738,19 @@ pub(crate) fn object(i: TokenSlice) -> PResult<Node<ObjectExpression>> {
         non_code_nodes,
         ..Default::default()
     };
+<<<<<<< HEAD
     Ok(Node::new(
         ObjectExpression {
             properties,
             non_code_meta,
             digest: None,
         },
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    Ok(ObjectExpression {
+=======
+    Ok(ObjectExpression {
+        r#type: Default::default(),
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
         start,
         end,
     ))
@@ -668,7 +760,22 @@ pub(crate) fn object(i: TokenSlice) -> PResult<Node<ObjectExpression>> {
 fn pipe_sub(i: TokenSlice) -> PResult<Node<PipeSubstitution>> {
     any.try_map(|token: Token| {
         if matches!(token.token_type, TokenType::Operator) && token.value == PIPE_SUBSTITUTION_OPERATOR {
+<<<<<<< HEAD
             Ok(Node::new(PipeSubstitution { digest: None }, token.start, token.end))
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+            Ok(PipeSubstitution {
+                start: token.start,
+                end: token.end,
+                digest: None,
+            })
+=======
+            Ok(PipeSubstitution {
+                r#type: Default::default(),
+                start: token.start,
+                end: token.end,
+                digest: None,
+            })
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
         } else {
             Err(KclError::Syntax(KclErrorDetails {
                 source_ranges: token.as_source_ranges(),
@@ -818,6 +925,7 @@ fn function_expression(i: TokenSlice) -> PResult<Node<FunctionExpression>> {
     open_brace(i)?;
     let body = function_body(i)?;
     let end = close_brace(i)?.end;
+<<<<<<< HEAD
     Ok(Node::new(
         FunctionExpression {
             params,
@@ -825,6 +933,12 @@ fn function_expression(i: TokenSlice) -> PResult<Node<FunctionExpression>> {
             return_type,
             digest: None,
         },
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    Ok(FunctionExpression {
+=======
+    Ok(FunctionExpression {
+        r#type: Default::default(),
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
         start,
         end,
     ))
@@ -874,6 +988,7 @@ fn member_expression(i: TokenSlice) -> PResult<Node<MemberExpression>> {
     // which is guaranteed to have >=1 elements.
     let (property, end, computed) = members.remove(0);
     let start = id.start;
+<<<<<<< HEAD
     let initial_member_expression = Node::new(
         MemberExpression {
             object: MemberObject::Identifier(Box::new(id)),
@@ -881,6 +996,12 @@ fn member_expression(i: TokenSlice) -> PResult<Node<MemberExpression>> {
             property,
             digest: None,
         },
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    let initial_member_expression = MemberExpression {
+=======
+    let initial_member_expression = MemberExpression {
+        r#type: Default::default(),
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
         start,
         end,
     );
@@ -891,6 +1012,7 @@ fn member_expression(i: TokenSlice) -> PResult<Node<MemberExpression>> {
         // Take the accumulated member expression from the previous iteration,
         // and use it as the `object` of a new, bigger member expression.
         .fold(initial_member_expression, |accumulated, (property, end, computed)| {
+<<<<<<< HEAD
             Node::new(
                 MemberExpression {
                     object: MemberObject::MemberExpression(Box::new(accumulated)),
@@ -898,6 +1020,12 @@ fn member_expression(i: TokenSlice) -> PResult<Node<MemberExpression>> {
                     property,
                     digest: None,
                 },
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+            MemberExpression {
+=======
+            MemberExpression {
+                r#type: Default::default(),
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                 start,
                 end,
             )
@@ -1206,6 +1334,7 @@ fn import_stmt(i: TokenSlice) -> PResult<BoxNode<ImportStatement>> {
             .into(),
         ));
     }
+<<<<<<< HEAD
     Ok(Node::boxed(
         ImportStatement {
             items,
@@ -1213,6 +1342,18 @@ fn import_stmt(i: TokenSlice) -> PResult<BoxNode<ImportStatement>> {
             raw_path: path.inner.raw,
             digest: None,
         },
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    Ok(Box::new(ImportStatement {
+        items,
+        path: path_string,
+        raw_path: path.raw,
+=======
+    Ok(Box::new(ImportStatement {
+        r#type: Default::default(),
+        items,
+        path: path_string,
+        raw_path: path.raw,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
         start,
         end,
     ))
@@ -1276,7 +1417,14 @@ pub fn return_stmt(i: TokenSlice) -> PResult<Node<ReturnStatement>> {
         .parse_next(i)?;
     require_whitespace(i)?;
     let argument = expression(i)?;
+<<<<<<< HEAD
     Ok(Node {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    Ok(ReturnStatement {
+=======
+    Ok(ReturnStatement {
+        r#type: Default::default(),
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
         start,
         end: argument.end(),
         inner: ReturnStatement { argument, digest: None },
@@ -1431,6 +1579,7 @@ fn declaration(i: TokenSlice) -> PResult<BoxNode<VariableDeclaration>> {
     .map_err(|e| e.cut())?;
 
     let end = val.end();
+<<<<<<< HEAD
     Ok(Box::new(Node {
         inner: VariableDeclaration {
             declarations: vec![Node {
@@ -1446,6 +1595,12 @@ fn declaration(i: TokenSlice) -> PResult<BoxNode<VariableDeclaration>> {
             kind,
             digest: None,
         },
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    Ok(VariableDeclaration {
+=======
+    Ok(VariableDeclaration {
+        r#type: Default::default(),
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
         start,
         end,
     }))
@@ -1456,6 +1611,7 @@ impl TryFrom<Token> for Node<Identifier> {
 
     fn try_from(token: Token) -> Result<Self, Self::Error> {
         if token.token_type == TokenType::Word {
+<<<<<<< HEAD
             Ok(Node::new(
                 Identifier {
                     name: token.value,
@@ -1464,6 +1620,22 @@ impl TryFrom<Token> for Node<Identifier> {
                 token.start,
                 token.end,
             ))
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+            Ok(Identifier {
+                start: token.start,
+                end: token.end,
+                name: token.value,
+                digest: None,
+            })
+=======
+            Ok(Identifier {
+                r#type: Default::default(),
+                start: token.start,
+                end: token.end,
+                name: token.value,
+                digest: None,
+            })
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
         } else {
             Err(KclError::Syntax(KclErrorDetails {
                 source_ranges: token.as_source_ranges(),
@@ -1486,6 +1658,7 @@ fn identifier(i: TokenSlice) -> PResult<Node<Identifier>> {
 fn sketch_keyword(i: TokenSlice) -> PResult<Node<Identifier>> {
     any.try_map(|token: Token| {
         if token.token_type == TokenType::Type && token.value == "sketch" {
+<<<<<<< HEAD
             Ok(Node::new(
                 Identifier {
                     name: token.value,
@@ -1494,6 +1667,22 @@ fn sketch_keyword(i: TokenSlice) -> PResult<Node<Identifier>> {
                 token.start,
                 token.end,
             ))
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+            Ok(Identifier {
+                start: token.start,
+                end: token.end,
+                name: token.value,
+                digest: None,
+            })
+=======
+            Ok(Identifier {
+                r#type: Default::default(),
+                start: token.start,
+                end: token.end,
+                name: token.value,
+                digest: None,
+            })
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
         } else {
             Err(KclError::Syntax(KclErrorDetails {
                 source_ranges: token.as_source_ranges(),
@@ -1510,6 +1699,7 @@ impl TryFrom<Token> for Node<TagDeclarator> {
 
     fn try_from(token: Token) -> Result<Self, Self::Error> {
         if token.token_type == TokenType::Word {
+<<<<<<< HEAD
             Ok(Node::new(
                 TagDeclarator {
                     // We subtract 1 from the start because the tag starts with a `$`.
@@ -1519,6 +1709,24 @@ impl TryFrom<Token> for Node<TagDeclarator> {
                 token.start - 1,
                 token.end,
             ))
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+            Ok(TagDeclarator {
+                // We subtract 1 from the start because the tag starts with a `$`.
+                start: token.start - 1,
+                end: token.end,
+                name: token.value,
+                digest: None,
+            })
+=======
+            Ok(TagDeclarator {
+                r#type: Default::default(),
+                // We subtract 1 from the start because the tag starts with a `$`.
+                start: token.start - 1,
+                end: token.end,
+                name: token.value,
+                digest: None,
+            })
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
         } else {
             Err(KclError::Syntax(KclErrorDetails {
                 source_ranges: token.as_source_ranges(),
@@ -1585,7 +1793,14 @@ fn unary_expression(i: TokenSlice) -> PResult<Node<UnaryExpression>> {
         .context(expected("a unary expression, e.g. -x or -3"))
         .parse_next(i)?;
     let argument = operand.parse_next(i)?;
+<<<<<<< HEAD
     Ok(Node {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    Ok(UnaryExpression {
+=======
+    Ok(UnaryExpression {
+        r#type: Default::default(),
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
         start: op_token.start,
         end: argument.end(),
         inner: UnaryExpression {
@@ -1975,7 +2190,14 @@ fn fn_call(i: TokenSlice) -> PResult<Node<CallExpression>> {
         }
     }
     let end = preceded(opt(whitespace), close_paren).parse_next(i)?.end;
+<<<<<<< HEAD
     Ok(Node {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+    Ok(CallExpression {
+=======
+    Ok(CallExpression {
+        r#type: Default::default(),
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
         start: fn_name.start,
         end,
         inner: CallExpression {
@@ -2158,6 +2380,7 @@ const mySk1 = startSketchAt([0, 0])"#;
         let expr = function_expression.parse_next(&mut slice).unwrap();
         assert_eq!(
             expr,
+<<<<<<< HEAD
             Node::new(
                 FunctionExpression {
                     params: Default::default(),
@@ -2191,6 +2414,42 @@ const mySk1 = startSketchAt([0, 0])"#;
                                 )],
                                 digest: None,
                             },
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+            FunctionExpression {
+                start: 0,
+                end: 47,
+                params: Default::default(),
+                body: Program {
+                    start: 7,
+                    end: 47,
+                    body: vec![BodyItem::ReturnStatement(ReturnStatement {
+                        start: 25,
+                        end: 33,
+                        argument: Expr::Literal(Box::new(Literal {
+                            start: 32,
+                            end: 33,
+                            value: 2u32.into(),
+                            raw: "2".to_owned(),
+=======
+            FunctionExpression {
+                r#type: Default::default(),
+                start: 0,
+                end: 47,
+                params: Default::default(),
+                body: Program {
+                    start: 7,
+                    end: 47,
+                    body: vec![BodyItem::ReturnStatement(ReturnStatement {
+                        r#type: Default::default(),
+                        start: 25,
+                        end: 33,
+                        argument: Expr::Literal(Box::new(Literal {
+                            r#type: Default::default(),
+                            start: 32,
+                            end: 33,
+                            value: 2u32.into(),
+                            raw: "2".to_owned(),
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                             digest: None,
                         },
                         7,
@@ -2355,6 +2614,7 @@ const mySk1 = startSketchAt([0, 0])"#;
             panic!("Expected RHS to be another binary expression");
         };
         assert_eq!(rhs.operator, BinaryOperator::Sub);
+<<<<<<< HEAD
         match &rhs.right {
             BinaryPart::Literal(lit) => {
                 assert!(lit.start == 9 && lit.end == 10);
@@ -2362,6 +2622,30 @@ const mySk1 = startSketchAt([0, 0])"#;
             }
             _ => panic!(),
         }
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+        assert_eq!(
+            rhs.right,
+            BinaryPart::Literal(Box::new(Literal {
+                start: 9,
+                end: 10,
+                value: 3u32.into(),
+                raw: "3".to_owned(),
+                digest: None,
+            }))
+        );
+=======
+        assert_eq!(
+            rhs.right,
+            BinaryPart::Literal(Box::new(Literal {
+                r#type: Default::default(),
+                start: 9,
+                end: 10,
+                value: 3u32.into(),
+                raw: "3".to_owned(),
+                digest: None,
+            }))
+        );
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
     }
 
     #[test]
@@ -2735,6 +3019,7 @@ const mySk1 = startSketchAt([0, 0])"#;
     #[test]
     fn test_math_parse() {
         let tokens = crate::token::lexer(r#"5 + "a""#).unwrap();
+<<<<<<< HEAD
         let actual = crate::parser::Parser::new(tokens).ast().unwrap().inner.body;
         let expr = Node::boxed(
             BinaryExpression {
@@ -2757,7 +3042,33 @@ const mySk1 = startSketchAt([0, 0])"#;
                     4,
                     7,
                 ))),
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+        let actual = crate::parser::Parser::new(tokens).ast().unwrap().body;
+        let expr = BinaryExpression {
+            start: 0,
+            end: 7,
+            operator: BinaryOperator::Add,
+            left: BinaryPart::Literal(Box::new(Literal {
+                start: 0,
+                end: 1,
+                value: 5u32.into(),
+                raw: "5".to_owned(),
+=======
+        let actual = crate::parser::Parser::new(tokens).ast().unwrap().body;
+        let expr = BinaryExpression {
+            r#type: Default::default(),
+            start: 0,
+            end: 7,
+            operator: BinaryOperator::Add,
+            left: BinaryPart::Literal(Box::new(Literal {
+                r#type: Default::default(),
+                start: 0,
+                end: 1,
+                value: 5u32.into(),
+                raw: "5".to_owned(),
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                 digest: None,
+<<<<<<< HEAD
             },
             0,
             7,
@@ -2765,6 +3076,22 @@ const mySk1 = startSketchAt([0, 0])"#;
         let expected = vec![BodyItem::ExpressionStatement(Node::new(
             ExpressionStatement {
                 expression: Expr::BinaryExpression(expr),
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+            })),
+            right: BinaryPart::Literal(Box::new(Literal {
+                start: 4,
+                end: 7,
+                value: "a".into(),
+                raw: r#""a""#.to_owned(),
+=======
+            })),
+            right: BinaryPart::Literal(Box::new(Literal {
+                r#type: Default::default(),
+                start: 4,
+                end: 7,
+                value: "a".into(),
+                raw: r#""a""#.to_owned(),
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                 digest: None,
             },
             0,
@@ -2856,6 +3183,7 @@ const mySk1 = startSketchAt([0, 0])"#;
         let code = "5 +6";
         let parser = crate::parser::Parser::new(crate::token::lexer(code).unwrap());
         let result = parser.ast().unwrap();
+<<<<<<< HEAD
         let expected_result = Node::new(
             Program {
                 body: vec![BodyItem::ExpressionStatement(Node::new(
@@ -2886,12 +3214,72 @@ const mySk1 = startSketchAt([0, 0])"#;
                             0,
                             4,
                         )),
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+        let expected_result = Program {
+            start: 0,
+            end: 4,
+            body: vec![BodyItem::ExpressionStatement(ExpressionStatement {
+                start: 0,
+                end: 4,
+                expression: Expr::BinaryExpression(Box::new(BinaryExpression {
+                    start: 0,
+                    end: 4,
+                    left: BinaryPart::Literal(Box::new(Literal {
+                        start: 0,
+                        end: 1,
+                        value: 5u32.into(),
+                        raw: "5".to_string(),
+=======
+        let expected_result = Program {
+            start: 0,
+            end: 4,
+            body: vec![BodyItem::ExpressionStatement(ExpressionStatement {
+                start: 0,
+                end: 4,
+                expression: Expr::BinaryExpression(Box::new(BinaryExpression {
+                    r#type: Default::default(),
+                    start: 0,
+                    end: 4,
+                    left: BinaryPart::Literal(Box::new(Literal {
+                        r#type: Default::default(),
+                        start: 0,
+                        end: 1,
+                        value: 5u32.into(),
+                        raw: "5".to_string(),
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                         digest: None,
+<<<<<<< HEAD
                     },
                     0,
                     4,
                 ))],
                 non_code_meta: NonCodeMeta::default(),
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                    })),
+                    operator: BinaryOperator::Add,
+                    right: BinaryPart::Literal(Box::new(Literal {
+                        start: 3,
+                        end: 4,
+                        value: 6u32.into(),
+                        raw: "6".to_string(),
+                        digest: None,
+                    })),
+                    digest: None,
+                })),
+=======
+                    })),
+                    operator: BinaryOperator::Add,
+                    right: BinaryPart::Literal(Box::new(Literal {
+                        r#type: Default::default(),
+                        start: 3,
+                        end: 4,
+                        value: 6u32.into(),
+                        raw: "6".to_string(),
+                        digest: None,
+                    })),
+                    digest: None,
+                })),
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                 digest: None,
             },
             0,
@@ -3174,7 +3562,18 @@ e
         for (i, (params, expect_ok)) in [
             (
                 vec![Parameter {
+<<<<<<< HEAD
                     identifier: Node::no_src(Identifier {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                    identifier: Identifier {
+                        start: 0,
+                        end: 0,
+=======
+                    identifier: Identifier {
+                        r#type: Default::default(),
+                        start: 0,
+                        end: 0,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                         name: "a".to_owned(),
                         digest: None,
                     }),
@@ -3186,7 +3585,18 @@ e
             ),
             (
                 vec![Parameter {
+<<<<<<< HEAD
                     identifier: Node::no_src(Identifier {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                    identifier: Identifier {
+                        start: 0,
+                        end: 0,
+=======
+                    identifier: Identifier {
+                        r#type: Default::default(),
+                        start: 0,
+                        end: 0,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                         name: "a".to_owned(),
                         digest: None,
                     }),
@@ -3199,7 +3609,18 @@ e
             (
                 vec![
                     Parameter {
+<<<<<<< HEAD
                         identifier: Node::no_src(Identifier {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                        identifier: Identifier {
+                            start: 0,
+                            end: 0,
+=======
+                        identifier: Identifier {
+                            r#type: Default::default(),
+                            start: 0,
+                            end: 0,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                             name: "a".to_owned(),
                             digest: None,
                         }),
@@ -3208,7 +3629,18 @@ e
                         digest: None,
                     },
                     Parameter {
+<<<<<<< HEAD
                         identifier: Node::no_src(Identifier {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                        identifier: Identifier {
+                            start: 0,
+                            end: 0,
+=======
+                        identifier: Identifier {
+                            r#type: Default::default(),
+                            start: 0,
+                            end: 0,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                             name: "b".to_owned(),
                             digest: None,
                         }),
@@ -3222,7 +3654,18 @@ e
             (
                 vec![
                     Parameter {
+<<<<<<< HEAD
                         identifier: Node::no_src(Identifier {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                        identifier: Identifier {
+                            start: 0,
+                            end: 0,
+=======
+                        identifier: Identifier {
+                            r#type: Default::default(),
+                            start: 0,
+                            end: 0,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                             name: "a".to_owned(),
                             digest: None,
                         }),
@@ -3231,7 +3674,18 @@ e
                         digest: None,
                     },
                     Parameter {
+<<<<<<< HEAD
                         identifier: Node::no_src(Identifier {
+||||||| parent of 611085fe1 (Remove duplicate JSON "type" tags)
+                        identifier: Identifier {
+                            start: 0,
+                            end: 0,
+=======
+                        identifier: Identifier {
+                            r#type: Default::default(),
+                            start: 0,
+                            end: 0,
+>>>>>>> 611085fe1 (Remove duplicate JSON "type" tags)
                             name: "b".to_owned(),
                             digest: None,
                         }),

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__a.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__a.snap
@@ -4,23 +4,21 @@ expression: actual
 ---
 {
   "type": "BinaryExpression",
+  "start": 0,
+  "end": 5,
   "operator": "+",
   "left": {
     "type": "Literal",
-    "type": "Literal",
-    "value": 1,
-    "raw": "1",
     "start": 0,
-    "end": 1
+    "end": 1,
+    "value": 1,
+    "raw": "1"
   },
   "right": {
     "type": "Literal",
-    "type": "Literal",
-    "value": 2,
-    "raw": "2",
     "start": 4,
-    "end": 5
-  },
-  "start": 0,
-  "end": 5
+    "end": 5,
+    "value": 2,
+    "raw": "2"
+  }
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__b.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__b.snap
@@ -4,23 +4,21 @@ expression: actual
 ---
 {
   "type": "BinaryExpression",
+  "start": 0,
+  "end": 3,
   "operator": "+",
   "left": {
     "type": "Literal",
-    "type": "Literal",
-    "value": 1,
-    "raw": "1",
     "start": 0,
-    "end": 1
+    "end": 1,
+    "value": 1,
+    "raw": "1"
   },
   "right": {
     "type": "Literal",
-    "type": "Literal",
-    "value": 2,
-    "raw": "2",
     "start": 2,
-    "end": 3
-  },
-  "start": 0,
-  "end": 3
+    "end": 3,
+    "value": 2,
+    "raw": "2"
+  }
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__c.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__c.snap
@@ -4,23 +4,21 @@ expression: actual
 ---
 {
   "type": "BinaryExpression",
+  "start": 0,
+  "end": 4,
   "operator": "-",
   "left": {
     "type": "Literal",
-    "type": "Literal",
-    "value": 1,
-    "raw": "1",
     "start": 0,
-    "end": 1
+    "end": 1,
+    "value": 1,
+    "raw": "1"
   },
   "right": {
     "type": "Literal",
-    "type": "Literal",
-    "value": 2,
-    "raw": "2",
     "start": 3,
-    "end": 4
-  },
-  "start": 0,
-  "end": 4
+    "end": 4,
+    "value": 2,
+    "raw": "2"
+  }
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__d.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__d.snap
@@ -4,38 +4,34 @@ expression: actual
 ---
 {
   "type": "BinaryExpression",
+  "start": 0,
+  "end": 9,
   "operator": "+",
   "left": {
     "type": "Literal",
-    "type": "Literal",
-    "value": 1,
-    "raw": "1",
     "start": 0,
-    "end": 1
+    "end": 1,
+    "value": 1,
+    "raw": "1"
   },
   "right": {
     "type": "BinaryExpression",
-    "type": "BinaryExpression",
+    "start": 4,
+    "end": 9,
     "operator": "*",
     "left": {
       "type": "Literal",
-      "type": "Literal",
-      "value": 2,
-      "raw": "2",
       "start": 4,
-      "end": 5
+      "end": 5,
+      "value": 2,
+      "raw": "2"
     },
     "right": {
       "type": "Literal",
-      "type": "Literal",
-      "value": 3,
-      "raw": "3",
       "start": 8,
-      "end": 9
-    },
-    "start": 4,
-    "end": 9
-  },
-  "start": 0,
-  "end": 9
+      "end": 9,
+      "value": 3,
+      "raw": "3"
+    }
+  }
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__e.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__e.snap
@@ -4,38 +4,34 @@ expression: actual
 ---
 {
   "type": "BinaryExpression",
+  "start": 0,
+  "end": 11,
   "operator": "*",
   "left": {
     "type": "Literal",
-    "type": "Literal",
-    "value": 1,
-    "raw": "1",
     "start": 0,
-    "end": 1
+    "end": 1,
+    "value": 1,
+    "raw": "1"
   },
   "right": {
     "type": "BinaryExpression",
-    "type": "BinaryExpression",
+    "start": 6,
+    "end": 11,
     "operator": "+",
     "left": {
       "type": "Literal",
-      "type": "Literal",
-      "value": 2,
-      "raw": "2",
       "start": 6,
-      "end": 7
+      "end": 7,
+      "value": 2,
+      "raw": "2"
     },
     "right": {
       "type": "Literal",
-      "type": "Literal",
-      "value": 3,
-      "raw": "3",
       "start": 10,
-      "end": 11
-    },
-    "start": 6,
-    "end": 11
-  },
-  "start": 0,
-  "end": 11
+      "end": 11,
+      "value": 3,
+      "raw": "3"
+    }
+  }
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__f.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__f.snap
@@ -4,53 +4,47 @@ expression: actual
 ---
 {
   "type": "BinaryExpression",
+  "start": 0,
+  "end": 17,
   "operator": "/",
   "left": {
     "type": "BinaryExpression",
-    "type": "BinaryExpression",
+    "start": 0,
+    "end": 11,
     "operator": "*",
     "left": {
       "type": "Literal",
-      "type": "Literal",
-      "value": 1,
-      "raw": "1",
       "start": 0,
-      "end": 1
+      "end": 1,
+      "value": 1,
+      "raw": "1"
     },
     "right": {
       "type": "BinaryExpression",
-      "type": "BinaryExpression",
+      "start": 6,
+      "end": 11,
       "operator": "+",
       "left": {
         "type": "Literal",
-        "type": "Literal",
-        "value": 2,
-        "raw": "2",
         "start": 6,
-        "end": 7
+        "end": 7,
+        "value": 2,
+        "raw": "2"
       },
       "right": {
         "type": "Literal",
-        "type": "Literal",
-        "value": 3,
-        "raw": "3",
         "start": 10,
-        "end": 11
-      },
-      "start": 6,
-      "end": 11
-    },
-    "start": 0,
-    "end": 11
+        "end": 11,
+        "value": 3,
+        "raw": "3"
+      }
+    }
   },
   "right": {
     "type": "Literal",
-    "type": "Literal",
-    "value": 4,
-    "raw": "4",
     "start": 16,
-    "end": 17
-  },
-  "start": 0,
-  "end": 17
+    "end": 17,
+    "value": 4,
+    "raw": "4"
+  }
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__g.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__g.snap
@@ -4,53 +4,47 @@ expression: actual
 ---
 {
   "type": "BinaryExpression",
+  "start": 0,
+  "end": 17,
   "operator": "+",
   "left": {
     "type": "Literal",
-    "type": "Literal",
-    "value": 1,
-    "raw": "1",
     "start": 0,
-    "end": 1
+    "end": 1,
+    "value": 1,
+    "raw": "1"
   },
   "right": {
     "type": "BinaryExpression",
-    "type": "BinaryExpression",
+    "start": 6,
+    "end": 17,
     "operator": "/",
     "left": {
       "type": "BinaryExpression",
-      "type": "BinaryExpression",
+      "start": 6,
+      "end": 11,
       "operator": "+",
       "left": {
         "type": "Literal",
-        "type": "Literal",
-        "value": 2,
-        "raw": "2",
         "start": 6,
-        "end": 7
+        "end": 7,
+        "value": 2,
+        "raw": "2"
       },
       "right": {
         "type": "Literal",
-        "type": "Literal",
-        "value": 3,
-        "raw": "3",
         "start": 10,
-        "end": 11
-      },
-      "start": 6,
-      "end": 11
+        "end": 11,
+        "value": 3,
+        "raw": "3"
+      }
     },
     "right": {
       "type": "Literal",
-      "type": "Literal",
-      "value": 4,
-      "raw": "4",
       "start": 16,
-      "end": 17
-    },
-    "start": 6,
-    "end": 17
-  },
-  "start": 0,
-  "end": 17
+      "end": 17,
+      "value": 4,
+      "raw": "4"
+    }
+  }
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__h.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__h.snap
@@ -4,68 +4,60 @@ expression: actual
 ---
 {
   "type": "BinaryExpression",
+  "start": 0,
+  "end": 22,
   "operator": "*",
   "left": {
     "type": "Literal",
-    "type": "Literal",
-    "value": 1,
-    "raw": "1",
     "start": 0,
-    "end": 1
+    "end": 1,
+    "value": 1,
+    "raw": "1"
   },
   "right": {
     "type": "BinaryExpression",
-    "type": "BinaryExpression",
+    "start": 7,
+    "end": 22,
     "operator": "+",
     "left": {
       "type": "BinaryExpression",
-      "type": "BinaryExpression",
+      "start": 7,
+      "end": 18,
       "operator": "/",
       "left": {
         "type": "BinaryExpression",
-        "type": "BinaryExpression",
+        "start": 7,
+        "end": 12,
         "operator": "+",
         "left": {
           "type": "Literal",
-          "type": "Literal",
-          "value": 2,
-          "raw": "2",
           "start": 7,
-          "end": 8
+          "end": 8,
+          "value": 2,
+          "raw": "2"
         },
         "right": {
           "type": "Literal",
-          "type": "Literal",
-          "value": 3,
-          "raw": "3",
           "start": 11,
-          "end": 12
-        },
-        "start": 7,
-        "end": 12
+          "end": 12,
+          "value": 3,
+          "raw": "3"
+        }
       },
       "right": {
         "type": "Literal",
-        "type": "Literal",
-        "value": 4,
-        "raw": "4",
         "start": 17,
-        "end": 18
-      },
-      "start": 7,
-      "end": 18
+        "end": 18,
+        "value": 4,
+        "raw": "4"
+      }
     },
     "right": {
       "type": "Literal",
-      "type": "Literal",
-      "value": 5,
-      "raw": "5",
       "start": 21,
-      "end": 22
-    },
-    "start": 7,
-    "end": 22
-  },
-  "start": 0,
-  "end": 22
+      "end": 22,
+      "value": 5,
+      "raw": "5"
+    }
+  }
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__i.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__i.snap
@@ -4,38 +4,34 @@ expression: actual
 ---
 {
   "type": "BinaryExpression",
+  "start": 0,
+  "end": 13,
   "operator": "*",
   "left": {
     "type": "Literal",
-    "type": "Literal",
-    "value": 1,
-    "raw": "1",
     "start": 0,
-    "end": 1
+    "end": 1,
+    "value": 1,
+    "raw": "1"
   },
   "right": {
     "type": "BinaryExpression",
-    "type": "BinaryExpression",
+    "start": 8,
+    "end": 13,
     "operator": "+",
     "left": {
       "type": "Literal",
-      "type": "Literal",
-      "value": 2,
-      "raw": "2",
       "start": 8,
-      "end": 9
+      "end": 9,
+      "value": 2,
+      "raw": "2"
     },
     "right": {
       "type": "Literal",
-      "type": "Literal",
-      "value": 3,
-      "raw": "3",
       "start": 12,
-      "end": 13
-    },
-    "start": 8,
-    "end": 13
-  },
-  "start": 0,
-  "end": 13
+      "end": 13,
+      "value": 3,
+      "raw": "3"
+    }
+  }
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__j.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__j.snap
@@ -4,78 +4,68 @@ expression: actual
 ---
 {
   "type": "BinaryExpression",
+  "start": 0,
+  "end": 44,
   "operator": "/",
   "left": {
     "type": "BinaryExpression",
-    "type": "BinaryExpression",
+    "start": 0,
+    "end": 22,
     "operator": "*",
     "left": {
       "type": "BinaryExpression",
-      "type": "BinaryExpression",
+      "start": 0,
+      "end": 18,
       "operator": "*",
       "left": {
         "type": "BinaryExpression",
-        "type": "BinaryExpression",
+        "start": 0,
+        "end": 12,
         "operator": "*",
         "left": {
           "type": "Identifier",
-          "type": "Identifier",
-          "name": "distance",
           "start": 0,
-          "end": 8
+          "end": 8,
+          "name": "distance"
         },
         "right": {
           "type": "Identifier",
-          "type": "Identifier",
-          "name": "p",
           "start": 11,
-          "end": 12
-        },
-        "start": 0,
-        "end": 12
+          "end": 12,
+          "name": "p"
+        }
       },
       "right": {
         "type": "Identifier",
-        "type": "Identifier",
-        "name": "FOS",
         "start": 15,
-        "end": 18
-      },
-      "start": 0,
-      "end": 18
+        "end": 18,
+        "name": "FOS"
+      }
     },
     "right": {
       "type": "Literal",
-      "type": "Literal",
-      "value": 6,
-      "raw": "6",
       "start": 21,
-      "end": 22
-    },
-    "start": 0,
-    "end": 22
+      "end": 22,
+      "value": 6,
+      "raw": "6"
+    }
   },
   "right": {
     "type": "BinaryExpression",
-    "type": "BinaryExpression",
+    "start": 26,
+    "end": 44,
     "operator": "*",
     "left": {
       "type": "Identifier",
-      "type": "Identifier",
-      "name": "sigmaAllow",
       "start": 26,
-      "end": 36
+      "end": 36,
+      "name": "sigmaAllow"
     },
     "right": {
       "type": "Identifier",
-      "type": "Identifier",
-      "name": "width",
       "start": 39,
-      "end": 44
-    },
-    "start": 26,
-    "end": 44
-  },
-  "start": 0,
-  "end": 44
+      "end": 44,
+      "name": "width"
+    }
+  }
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__k.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_math_tests__k.snap
@@ -4,23 +4,21 @@ expression: actual
 ---
 {
   "type": "BinaryExpression",
+  "start": 0,
+  "end": 8,
   "operator": "+",
   "left": {
     "type": "Literal",
-    "type": "Literal",
-    "value": 2,
-    "raw": "2",
     "start": 0,
-    "end": 1
+    "end": 1,
+    "value": 2,
+    "raw": "2"
   },
   "right": {
     "type": "Literal",
-    "type": "Literal",
-    "value": 3,
-    "raw": "3",
     "start": 7,
-    "end": 8
-  },
-  "start": 0,
-  "end": 8
+    "end": 8,
+    "value": 3,
+    "raw": "3"
+  }
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__a.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__a.snap
@@ -3,253 +3,227 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 144,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 143,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 143,
           "id": {
-            "end": 15,
-            "name": "boxSketch",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 15,
+            "name": "boxSketch"
           },
           "init": {
+            "type": "PipeExpression",
+            "start": 18,
+            "end": 143,
             "body": [
               {
+                "type": "CallExpression",
+                "start": 18,
+                "end": 39,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 18,
+                  "end": 31,
+                  "name": "startSketchAt"
+                },
                 "arguments": [
                   {
+                    "type": "ArrayExpression",
+                    "start": 32,
+                    "end": 38,
                     "elements": [
                       {
-                        "end": 34,
-                        "raw": "0",
+                        "type": "Literal",
                         "start": 33,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 0
+                        "end": 34,
+                        "value": 0,
+                        "raw": "0"
                       },
                       {
-                        "end": 37,
-                        "raw": "0",
+                        "type": "Literal",
                         "start": 36,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 0
+                        "end": 37,
+                        "value": 0,
+                        "raw": "0"
                       }
-                    ],
-                    "end": 38,
-                    "start": 32,
-                    "type": "ArrayExpression",
-                    "type": "ArrayExpression"
+                    ]
                   }
                 ],
-                "callee": {
-                  "end": 31,
-                  "name": "startSketchAt",
-                  "start": 18,
-                  "type": "Identifier"
-                },
-                "end": 39,
-                "optional": false,
-                "start": 18,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               },
               {
+                "type": "CallExpression",
+                "start": 47,
+                "end": 63,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 47,
+                  "end": 51,
+                  "name": "line"
+                },
                 "arguments": [
                   {
+                    "type": "ArrayExpression",
+                    "start": 52,
+                    "end": 59,
                     "elements": [
                       {
-                        "end": 54,
-                        "raw": "0",
+                        "type": "Literal",
                         "start": 53,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 0
+                        "end": 54,
+                        "value": 0,
+                        "raw": "0"
                       },
                       {
-                        "end": 58,
-                        "raw": "10",
+                        "type": "Literal",
                         "start": 56,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 10
+                        "end": 58,
+                        "value": 10,
+                        "raw": "10"
                       }
-                    ],
-                    "end": 59,
-                    "start": 52,
-                    "type": "ArrayExpression",
-                    "type": "ArrayExpression"
+                    ]
                   },
                   {
-                    "end": 62,
-                    "start": 61,
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution"
+                    "start": 61,
+                    "end": 62
                   }
                 ],
-                "callee": {
-                  "end": 51,
-                  "name": "line",
-                  "start": 47,
-                  "type": "Identifier"
-                },
-                "end": 63,
-                "optional": false,
-                "start": 47,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               },
               {
+                "type": "CallExpression",
+                "start": 71,
+                "end": 96,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 71,
+                  "end": 84,
+                  "name": "tangentialArc"
+                },
                 "arguments": [
                   {
+                    "type": "ArrayExpression",
+                    "start": 85,
+                    "end": 92,
                     "elements": [
                       {
-                        "argument": {
-                          "end": 88,
-                          "raw": "5",
-                          "start": 87,
-                          "type": "Literal",
-                          "type": "Literal",
-                          "value": 5
-                        },
+                        "type": "UnaryExpression",
+                        "start": 86,
                         "end": 88,
                         "operator": "-",
-                        "start": 86,
-                        "type": "UnaryExpression",
-                        "type": "UnaryExpression"
+                        "argument": {
+                          "type": "Literal",
+                          "start": 87,
+                          "end": 88,
+                          "value": 5,
+                          "raw": "5"
+                        }
                       },
                       {
-                        "end": 91,
-                        "raw": "5",
+                        "type": "Literal",
                         "start": 90,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 5
+                        "end": 91,
+                        "value": 5,
+                        "raw": "5"
                       }
-                    ],
-                    "end": 92,
-                    "start": 85,
-                    "type": "ArrayExpression",
-                    "type": "ArrayExpression"
+                    ]
                   },
                   {
-                    "end": 95,
-                    "start": 94,
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution"
+                    "start": 94,
+                    "end": 95
                   }
                 ],
-                "callee": {
-                  "end": 84,
-                  "name": "tangentialArc",
-                  "start": 71,
-                  "type": "Identifier"
-                },
-                "end": 96,
-                "optional": false,
-                "start": 71,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               },
               {
+                "type": "CallExpression",
+                "start": 104,
+                "end": 121,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 104,
+                  "end": 108,
+                  "name": "line"
+                },
                 "arguments": [
                   {
+                    "type": "ArrayExpression",
+                    "start": 109,
+                    "end": 117,
                     "elements": [
                       {
-                        "end": 111,
-                        "raw": "5",
+                        "type": "Literal",
                         "start": 110,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 5
+                        "end": 111,
+                        "value": 5,
+                        "raw": "5"
                       },
                       {
-                        "argument": {
-                          "end": 116,
-                          "raw": "15",
-                          "start": 114,
-                          "type": "Literal",
-                          "type": "Literal",
-                          "value": 15
-                        },
+                        "type": "UnaryExpression",
+                        "start": 113,
                         "end": 116,
                         "operator": "-",
-                        "start": 113,
-                        "type": "UnaryExpression",
-                        "type": "UnaryExpression"
+                        "argument": {
+                          "type": "Literal",
+                          "start": 114,
+                          "end": 116,
+                          "value": 15,
+                          "raw": "15"
+                        }
                       }
-                    ],
-                    "end": 117,
-                    "start": 109,
-                    "type": "ArrayExpression",
-                    "type": "ArrayExpression"
+                    ]
                   },
                   {
-                    "end": 120,
-                    "start": 119,
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution"
+                    "start": 119,
+                    "end": 120
                   }
                 ],
-                "callee": {
-                  "end": 108,
-                  "name": "line",
-                  "start": 104,
-                  "type": "Identifier"
-                },
-                "end": 121,
-                "optional": false,
-                "start": 104,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               },
               {
+                "type": "CallExpression",
+                "start": 129,
+                "end": 143,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 129,
+                  "end": 136,
+                  "name": "extrude"
+                },
                 "arguments": [
                   {
-                    "end": 139,
-                    "raw": "10",
+                    "type": "Literal",
                     "start": 137,
-                    "type": "Literal",
-                    "type": "Literal",
-                    "value": 10
+                    "end": 139,
+                    "value": 10,
+                    "raw": "10"
                   },
                   {
-                    "end": 142,
-                    "start": 141,
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution"
+                    "start": 141,
+                    "end": 142
                   }
                 ],
-                "callee": {
-                  "end": 136,
-                  "name": "extrude",
-                  "start": 129,
-                  "type": "Identifier"
-                },
-                "end": 143,
-                "optional": false,
-                "start": 129,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               }
-            ],
-            "end": 143,
-            "start": 18,
-            "type": "PipeExpression",
-            "type": "PipeExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            ]
+          }
         }
       ],
-      "end": 143,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 144,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__aa.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__aa.snap
@@ -3,42 +3,39 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 17,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 17,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 17,
           "id": {
-            "end": 8,
-            "name": "sg",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 8,
+            "name": "sg"
           },
           "init": {
-            "argument": {
-              "end": 17,
-              "name": "scale",
-              "start": 12,
-              "type": "Identifier",
-              "type": "Identifier"
-            },
+            "type": "UnaryExpression",
+            "start": 11,
             "end": 17,
             "operator": "-",
-            "start": 11,
-            "type": "UnaryExpression",
-            "type": "UnaryExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            "argument": {
+              "type": "Identifier",
+              "start": 12,
+              "end": 17,
+              "name": "scale"
+            }
+          }
         }
       ],
-      "end": 17,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 17,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ab.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ab.snap
@@ -3,79 +3,72 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 23,
   "body": [
     {
+      "type": "ExpressionStatement",
+      "start": 0,
       "end": 23,
       "expression": {
+        "type": "CallExpression",
+        "start": 0,
+        "end": 23,
+        "callee": {
+          "type": "Identifier",
+          "start": 0,
+          "end": 6,
+          "name": "lineTo"
+        },
         "arguments": [
           {
+            "type": "ObjectExpression",
+            "start": 7,
             "end": 22,
             "properties": [
               {
+                "type": "ObjectProperty",
+                "start": 9,
                 "end": 20,
                 "key": {
-                  "end": 11,
-                  "name": "to",
+                  "type": "Identifier",
                   "start": 9,
-                  "type": "Identifier"
+                  "end": 11,
+                  "name": "to"
                 },
-                "start": 9,
-                "type": "ObjectProperty",
                 "value": {
+                  "type": "ArrayExpression",
+                  "start": 13,
+                  "end": 20,
                   "elements": [
                     {
-                      "end": 15,
-                      "raw": "0",
+                      "type": "Literal",
                       "start": 14,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 0
+                      "end": 15,
+                      "value": 0,
+                      "raw": "0"
                     },
                     {
-                      "argument": {
-                        "end": 19,
-                        "raw": "1",
-                        "start": 18,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 1
-                      },
+                      "type": "UnaryExpression",
+                      "start": 17,
                       "end": 19,
                       "operator": "-",
-                      "start": 17,
-                      "type": "UnaryExpression",
-                      "type": "UnaryExpression"
+                      "argument": {
+                        "type": "Literal",
+                        "start": 18,
+                        "end": 19,
+                        "value": 1,
+                        "raw": "1"
+                      }
                     }
-                  ],
-                  "end": 20,
-                  "start": 13,
-                  "type": "ArrayExpression",
-                  "type": "ArrayExpression"
+                  ]
                 }
               }
-            ],
-            "start": 7,
-            "type": "ObjectExpression",
-            "type": "ObjectExpression"
+            ]
           }
         ],
-        "callee": {
-          "end": 6,
-          "name": "lineTo",
-          "start": 0,
-          "type": "Identifier"
-        },
-        "end": 23,
-        "optional": false,
-        "start": 0,
-        "type": "CallExpression",
-        "type": "CallExpression"
-      },
-      "start": 0,
-      "type": "ExpressionStatement",
-      "type": "ExpressionStatement"
+        "optional": false
+      }
     }
-  ],
-  "end": 23,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ac.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ac.snap
@@ -3,51 +3,47 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 23,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 23,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 23,
           "id": {
-            "end": 13,
-            "name": "myArray",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 13,
+            "name": "myArray"
           },
           "init": {
-            "end": 23,
-            "endElement": {
-              "end": 22,
-              "raw": "10",
-              "start": 20,
-              "type": "Literal",
-              "type": "Literal",
-              "value": 10
-            },
-            "endInclusive": true,
-            "start": 16,
-            "startElement": {
-              "end": 18,
-              "raw": "0",
-              "start": 17,
-              "type": "Literal",
-              "type": "Literal",
-              "value": 0
-            },
             "type": "ArrayRangeExpression",
-            "type": "ArrayRangeExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            "start": 16,
+            "end": 23,
+            "startElement": {
+              "type": "Literal",
+              "start": 17,
+              "end": 18,
+              "value": 0,
+              "raw": "0"
+            },
+            "endElement": {
+              "type": "Literal",
+              "start": 20,
+              "end": 22,
+              "value": 10,
+              "raw": "10"
+            },
+            "endInclusive": true
+          }
         }
       ],
-      "end": 23,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 23,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ad.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ad.snap
@@ -3,75 +3,69 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 80,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 5,
+      "end": 57,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 8,
           "end": 57,
           "id": {
-            "end": 24,
-            "name": "firstPrimeNumber",
+            "type": "Identifier",
             "start": 8,
-            "type": "Identifier"
+            "end": 24,
+            "name": "firstPrimeNumber"
           },
           "init": {
-            "body": {
-              "body": [
-                {
-                  "argument": {
-                    "end": 51,
-                    "raw": "2",
-                    "start": 50,
-                    "type": "Literal",
-                    "type": "Literal",
-                    "value": 2
-                  },
-                  "end": 51,
-                  "start": 43,
-                  "type": "ReturnStatement",
-                  "type": "ReturnStatement"
-                }
-              ],
-              "end": 57,
-              "start": 33
-            },
+            "type": "FunctionExpression",
+            "start": 27,
             "end": 57,
             "params": [],
-            "start": 27,
-            "type": "FunctionExpression",
-            "type": "FunctionExpression"
-          },
-          "start": 8,
-          "type": "VariableDeclarator"
+            "body": {
+              "start": 33,
+              "end": 57,
+              "body": [
+                {
+                  "type": "ReturnStatement",
+                  "start": 43,
+                  "end": 51,
+                  "argument": {
+                    "type": "Literal",
+                    "start": 50,
+                    "end": 51,
+                    "value": 2,
+                    "raw": "2"
+                  }
+                }
+              ]
+            }
+          }
         }
       ],
-      "end": 57,
-      "kind": "fn",
-      "start": 5,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "fn"
     },
     {
+      "type": "ExpressionStatement",
+      "start": 62,
       "end": 80,
       "expression": {
-        "arguments": [],
-        "callee": {
-          "end": 78,
-          "name": "firstPrimeNumber",
-          "start": 62,
-          "type": "Identifier"
-        },
-        "end": 80,
-        "optional": false,
-        "start": 62,
         "type": "CallExpression",
-        "type": "CallExpression"
-      },
-      "start": 62,
-      "type": "ExpressionStatement",
-      "type": "ExpressionStatement"
+        "start": 62,
+        "end": 80,
+        "callee": {
+          "type": "Identifier",
+          "start": 62,
+          "end": 78,
+          "name": "firstPrimeNumber"
+        },
+        "arguments": [],
+        "optional": false
+      }
     }
-  ],
-  "end": 80,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ae.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ae.snap
@@ -3,95 +3,88 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 66,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 49,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 3,
           "end": 49,
           "id": {
-            "end": 8,
-            "name": "thing",
+            "type": "Identifier",
             "start": 3,
-            "type": "Identifier"
+            "end": 8,
+            "name": "thing"
           },
           "init": {
-            "body": {
-              "body": [
-                {
-                  "argument": {
-                    "end": 43,
-                    "raw": "true",
-                    "start": 39,
-                    "type": "Literal",
-                    "type": "Literal",
-                    "value": true
-                  },
-                  "end": 43,
-                  "start": 32,
-                  "type": "ReturnStatement",
-                  "type": "ReturnStatement"
-                }
-              ],
-              "end": 49,
-              "start": 22
-            },
+            "type": "FunctionExpression",
+            "start": 11,
             "end": 49,
             "params": [
               {
                 "type": "Parameter",
                 "identifier": {
-                  "end": 17,
-                  "name": "param",
+                  "type": "Identifier",
                   "start": 12,
-                  "type": "Identifier"
+                  "end": 17,
+                  "name": "param"
                 },
                 "optional": false
               }
             ],
-            "start": 11,
-            "type": "FunctionExpression",
-            "type": "FunctionExpression"
-          },
-          "start": 3,
-          "type": "VariableDeclarator"
+            "body": {
+              "start": 22,
+              "end": 49,
+              "body": [
+                {
+                  "type": "ReturnStatement",
+                  "start": 32,
+                  "end": 43,
+                  "argument": {
+                    "type": "Literal",
+                    "start": 39,
+                    "end": 43,
+                    "value": true,
+                    "raw": "true"
+                  }
+                }
+              ]
+            }
+          }
         }
       ],
-      "end": 49,
-      "kind": "fn",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "fn"
     },
     {
+      "type": "ExpressionStatement",
+      "start": 54,
       "end": 66,
       "expression": {
+        "type": "CallExpression",
+        "start": 54,
+        "end": 66,
+        "callee": {
+          "type": "Identifier",
+          "start": 54,
+          "end": 59,
+          "name": "thing"
+        },
         "arguments": [
           {
-            "end": 65,
-            "raw": "false",
+            "type": "Literal",
             "start": 60,
-            "type": "Literal",
-            "type": "Literal",
-            "value": false
+            "end": 65,
+            "value": false,
+            "raw": "false"
           }
         ],
-        "callee": {
-          "end": 59,
-          "name": "thing",
-          "start": 54,
-          "type": "Identifier"
-        },
-        "end": 66,
-        "optional": false,
-        "start": 54,
-        "type": "CallExpression",
-        "type": "CallExpression"
-      },
-      "start": 54,
-      "type": "ExpressionStatement",
-      "type": "ExpressionStatement"
+        "optional": false
+      }
     }
-  ],
-  "end": 66,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__af.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__af.snap
@@ -3,245 +3,220 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 165,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 165,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 165,
           "id": {
-            "end": 14,
-            "name": "mySketch",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 14,
+            "name": "mySketch"
           },
           "init": {
+            "type": "PipeExpression",
+            "start": 17,
+            "end": 165,
             "body": [
               {
+                "type": "CallExpression",
+                "start": 17,
+                "end": 37,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 17,
+                  "end": 30,
+                  "name": "startSketchAt"
+                },
                 "arguments": [
                   {
+                    "type": "ArrayExpression",
+                    "start": 31,
+                    "end": 36,
                     "elements": [
                       {
-                        "end": 33,
-                        "raw": "0",
+                        "type": "Literal",
                         "start": 32,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 0
+                        "end": 33,
+                        "value": 0,
+                        "raw": "0"
                       },
                       {
-                        "end": 35,
-                        "raw": "0",
+                        "type": "Literal",
                         "start": 34,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 0
+                        "end": 35,
+                        "value": 0,
+                        "raw": "0"
                       }
-                    ],
-                    "end": 36,
-                    "start": 31,
-                    "type": "ArrayExpression",
-                    "type": "ArrayExpression"
+                    ]
                   }
                 ],
-                "callee": {
-                  "end": 30,
-                  "name": "startSketchAt",
-                  "start": 17,
-                  "type": "Identifier"
-                },
-                "end": 37,
-                "optional": false,
-                "start": 17,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               },
               {
+                "type": "CallExpression",
+                "start": 49,
+                "end": 75,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 49,
+                  "end": 55,
+                  "name": "lineTo"
+                },
                 "arguments": [
                   {
+                    "type": "ArrayExpression",
+                    "start": 56,
+                    "end": 62,
                     "elements": [
                       {
-                        "end": 58,
-                        "raw": "0",
+                        "type": "Literal",
                         "start": 57,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 0
+                        "end": 58,
+                        "value": 0,
+                        "raw": "0"
                       },
                       {
-                        "end": 61,
-                        "raw": "1",
+                        "type": "Literal",
                         "start": 60,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 1
+                        "end": 61,
+                        "value": 1,
+                        "raw": "1"
                       }
-                    ],
-                    "end": 62,
-                    "start": 56,
-                    "type": "ArrayExpression",
-                    "type": "ArrayExpression"
+                    ]
                   },
                   {
-                    "end": 65,
-                    "start": 64,
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution"
+                    "start": 64,
+                    "end": 65
                   },
                   {
-                    "end": 74,
+                    "type": "TagDeclarator",
                     "start": 67,
-                    "type": "TagDeclarator",
-                    "type": "TagDeclarator",
+                    "end": 74,
                     "value": "myPath"
                   }
                 ],
-                "callee": {
-                  "end": 55,
-                  "name": "lineTo",
-                  "start": 49,
-                  "type": "Identifier"
-                },
-                "end": 75,
-                "optional": false,
-                "start": 49,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               },
               {
+                "type": "CallExpression",
+                "start": 87,
+                "end": 104,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 87,
+                  "end": 93,
+                  "name": "lineTo"
+                },
                 "arguments": [
                   {
+                    "type": "ArrayExpression",
+                    "start": 94,
+                    "end": 100,
                     "elements": [
                       {
-                        "end": 96,
-                        "raw": "1",
+                        "type": "Literal",
                         "start": 95,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 1
+                        "end": 96,
+                        "value": 1,
+                        "raw": "1"
                       },
                       {
-                        "end": 99,
-                        "raw": "1",
+                        "type": "Literal",
                         "start": 98,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 1
+                        "end": 99,
+                        "value": 1,
+                        "raw": "1"
                       }
-                    ],
-                    "end": 100,
-                    "start": 94,
-                    "type": "ArrayExpression",
-                    "type": "ArrayExpression"
+                    ]
                   },
                   {
-                    "end": 103,
-                    "start": 102,
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution"
+                    "start": 102,
+                    "end": 103
                   }
                 ],
-                "callee": {
-                  "end": 93,
-                  "name": "lineTo",
-                  "start": 87,
-                  "type": "Identifier"
-                },
-                "end": 104,
-                "optional": false,
-                "start": 87,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               },
               {
+                "type": "CallExpression",
+                "start": 116,
+                "end": 145,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 116,
+                  "end": 122,
+                  "name": "lineTo"
+                },
                 "arguments": [
                   {
+                    "type": "ArrayExpression",
+                    "start": 123,
+                    "end": 129,
                     "elements": [
                       {
-                        "end": 125,
-                        "raw": "1",
+                        "type": "Literal",
                         "start": 124,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 1
+                        "end": 125,
+                        "value": 1,
+                        "raw": "1"
                       },
                       {
-                        "end": 128,
-                        "raw": "0",
+                        "type": "Literal",
                         "start": 127,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 0
+                        "end": 128,
+                        "value": 0,
+                        "raw": "0"
                       }
-                    ],
-                    "end": 129,
-                    "start": 123,
-                    "type": "ArrayExpression",
-                    "type": "ArrayExpression"
+                    ]
                   },
                   {
-                    "end": 132,
-                    "start": 131,
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution"
+                    "start": 131,
+                    "end": 132
                   },
                   {
-                    "end": 144,
+                    "type": "TagDeclarator",
                     "start": 134,
-                    "type": "TagDeclarator",
-                    "type": "TagDeclarator",
+                    "end": 144,
                     "value": "rightPath"
                   }
                 ],
-                "callee": {
-                  "end": 122,
-                  "name": "lineTo",
-                  "start": 116,
-                  "type": "Identifier"
-                },
-                "end": 145,
-                "optional": false,
-                "start": 116,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               },
               {
+                "type": "CallExpression",
+                "start": 157,
+                "end": 165,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 157,
+                  "end": 162,
+                  "name": "close"
+                },
                 "arguments": [
                   {
-                    "end": 164,
-                    "start": 163,
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution"
+                    "start": 163,
+                    "end": 164
                   }
                 ],
-                "callee": {
-                  "end": 162,
-                  "name": "close",
-                  "start": 157,
-                  "type": "Identifier"
-                },
-                "end": 165,
-                "optional": false,
-                "start": 157,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               }
-            ],
-            "end": 165,
-            "start": 17,
-            "type": "PipeExpression",
-            "type": "PipeExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            ]
+          }
         }
       ],
-      "end": 165,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 165,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ag.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ag.snap
@@ -3,141 +3,128 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 70,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 70,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 70,
           "id": {
-            "end": 14,
-            "name": "mySketch",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 14,
+            "name": "mySketch"
           },
           "init": {
+            "type": "PipeExpression",
+            "start": 17,
+            "end": 70,
             "body": [
               {
+                "type": "CallExpression",
+                "start": 17,
+                "end": 37,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 17,
+                  "end": 30,
+                  "name": "startSketchAt"
+                },
                 "arguments": [
                   {
+                    "type": "ArrayExpression",
+                    "start": 31,
+                    "end": 36,
                     "elements": [
                       {
-                        "end": 33,
-                        "raw": "0",
+                        "type": "Literal",
                         "start": 32,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 0
+                        "end": 33,
+                        "value": 0,
+                        "raw": "0"
                       },
                       {
-                        "end": 35,
-                        "raw": "0",
+                        "type": "Literal",
                         "start": 34,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 0
+                        "end": 35,
+                        "value": 0,
+                        "raw": "0"
                       }
-                    ],
-                    "end": 36,
-                    "start": 31,
-                    "type": "ArrayExpression",
-                    "type": "ArrayExpression"
+                    ]
                   }
                 ],
-                "callee": {
-                  "end": 30,
-                  "name": "startSketchAt",
-                  "start": 17,
-                  "type": "Identifier"
-                },
-                "end": 37,
-                "optional": false,
-                "start": 17,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               },
               {
+                "type": "CallExpression",
+                "start": 41,
+                "end": 58,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 41,
+                  "end": 47,
+                  "name": "lineTo"
+                },
                 "arguments": [
                   {
+                    "type": "ArrayExpression",
+                    "start": 48,
+                    "end": 54,
                     "elements": [
                       {
-                        "end": 50,
-                        "raw": "1",
+                        "type": "Literal",
                         "start": 49,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 1
+                        "end": 50,
+                        "value": 1,
+                        "raw": "1"
                       },
                       {
-                        "end": 53,
-                        "raw": "1",
+                        "type": "Literal",
                         "start": 52,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 1
+                        "end": 53,
+                        "value": 1,
+                        "raw": "1"
                       }
-                    ],
-                    "end": 54,
-                    "start": 48,
-                    "type": "ArrayExpression",
-                    "type": "ArrayExpression"
+                    ]
                   },
                   {
-                    "end": 57,
-                    "start": 56,
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution"
+                    "start": 56,
+                    "end": 57
                   }
                 ],
-                "callee": {
-                  "end": 47,
-                  "name": "lineTo",
-                  "start": 41,
-                  "type": "Identifier"
-                },
-                "end": 58,
-                "optional": false,
-                "start": 41,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               },
               {
+                "type": "CallExpression",
+                "start": 62,
+                "end": 70,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 62,
+                  "end": 67,
+                  "name": "close"
+                },
                 "arguments": [
                   {
-                    "end": 69,
-                    "start": 68,
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution"
+                    "start": 68,
+                    "end": 69
                   }
                 ],
-                "callee": {
-                  "end": 67,
-                  "name": "close",
-                  "start": 62,
-                  "type": "Identifier"
-                },
-                "end": 70,
-                "optional": false,
-                "start": 62,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               }
-            ],
-            "end": 70,
-            "start": 17,
-            "type": "PipeExpression",
-            "type": "PipeExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            ]
+          }
         }
       ],
-      "end": 70,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 70,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ah.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ah.snap
@@ -3,50 +3,47 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 30,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 30,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 30,
           "id": {
-            "end": 11,
-            "name": "myBox",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 11,
+            "name": "myBox"
           },
           "init": {
+            "type": "CallExpression",
+            "start": 14,
+            "end": 30,
+            "callee": {
+              "type": "Identifier",
+              "start": 14,
+              "end": 27,
+              "name": "startSketchAt"
+            },
             "arguments": [
               {
-                "end": 29,
-                "name": "p",
-                "start": 28,
                 "type": "Identifier",
-                "type": "Identifier"
+                "start": 28,
+                "end": 29,
+                "name": "p"
               }
             ],
-            "callee": {
-              "end": 27,
-              "name": "startSketchAt",
-              "start": 14,
-              "type": "Identifier"
-            },
-            "end": 30,
-            "optional": false,
-            "start": 14,
-            "type": "CallExpression",
-            "type": "CallExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            "optional": false
+          }
         }
       ],
-      "end": 30,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 30,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ai.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ai.snap
@@ -3,88 +3,81 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 29,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 29,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 29,
           "id": {
-            "end": 11,
-            "name": "myBox",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 11,
+            "name": "myBox"
           },
           "init": {
+            "type": "PipeExpression",
+            "start": 14,
+            "end": 29,
             "body": [
               {
+                "type": "CallExpression",
+                "start": 14,
+                "end": 18,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 14,
+                  "end": 15,
+                  "name": "f"
+                },
                 "arguments": [
                   {
-                    "end": 17,
-                    "raw": "1",
+                    "type": "Literal",
                     "start": 16,
-                    "type": "Literal",
-                    "type": "Literal",
-                    "value": 1
+                    "end": 17,
+                    "value": 1,
+                    "raw": "1"
                   }
                 ],
-                "callee": {
-                  "end": 15,
-                  "name": "f",
-                  "start": 14,
-                  "type": "Identifier"
-                },
-                "end": 18,
-                "optional": false,
-                "start": 14,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               },
               {
+                "type": "CallExpression",
+                "start": 22,
+                "end": 29,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 22,
+                  "end": 23,
+                  "name": "g"
+                },
                 "arguments": [
                   {
-                    "end": 25,
-                    "raw": "2",
+                    "type": "Literal",
                     "start": 24,
-                    "type": "Literal",
-                    "type": "Literal",
-                    "value": 2
+                    "end": 25,
+                    "value": 2,
+                    "raw": "2"
                   },
                   {
-                    "end": 28,
-                    "start": 27,
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution"
+                    "start": 27,
+                    "end": 28
                   }
                 ],
-                "callee": {
-                  "end": 23,
-                  "name": "g",
-                  "start": 22,
-                  "type": "Identifier"
-                },
-                "end": 29,
-                "optional": false,
-                "start": 22,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               }
-            ],
-            "end": 29,
-            "start": 14,
-            "type": "PipeExpression",
-            "type": "PipeExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            ]
+          }
         }
       ],
-      "end": 29,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 29,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__aj.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__aj.snap
@@ -3,102 +3,93 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 49,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 49,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 49,
           "id": {
-            "end": 11,
-            "name": "myBox",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 11,
+            "name": "myBox"
           },
           "init": {
+            "type": "PipeExpression",
+            "start": 14,
+            "end": 49,
             "body": [
               {
+                "type": "CallExpression",
+                "start": 14,
+                "end": 30,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 14,
+                  "end": 27,
+                  "name": "startSketchAt"
+                },
                 "arguments": [
                   {
-                    "end": 29,
-                    "name": "p",
-                    "start": 28,
                     "type": "Identifier",
-                    "type": "Identifier"
+                    "start": 28,
+                    "end": 29,
+                    "name": "p"
                   }
                 ],
-                "callee": {
-                  "end": 27,
-                  "name": "startSketchAt",
-                  "start": 14,
-                  "type": "Identifier"
-                },
-                "end": 30,
-                "optional": false,
-                "start": 14,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               },
               {
+                "type": "CallExpression",
+                "start": 34,
+                "end": 49,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 34,
+                  "end": 38,
+                  "name": "line"
+                },
                 "arguments": [
                   {
+                    "type": "ArrayExpression",
+                    "start": 39,
+                    "end": 45,
                     "elements": [
                       {
-                        "end": 41,
-                        "raw": "0",
+                        "type": "Literal",
                         "start": 40,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 0
+                        "end": 41,
+                        "value": 0,
+                        "raw": "0"
                       },
                       {
-                        "end": 44,
-                        "name": "l",
-                        "start": 43,
                         "type": "Identifier",
-                        "type": "Identifier"
+                        "start": 43,
+                        "end": 44,
+                        "name": "l"
                       }
-                    ],
-                    "end": 45,
-                    "start": 39,
-                    "type": "ArrayExpression",
-                    "type": "ArrayExpression"
+                    ]
                   },
                   {
-                    "end": 48,
-                    "start": 47,
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution"
+                    "start": 47,
+                    "end": 48
                   }
                 ],
-                "callee": {
-                  "end": 38,
-                  "name": "line",
-                  "start": 34,
-                  "type": "Identifier"
-                },
-                "end": 49,
-                "optional": false,
-                "start": 34,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               }
-            ],
-            "end": 49,
-            "start": 14,
-            "type": "PipeExpression",
-            "type": "PipeExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            ]
+          }
         }
       ],
-      "end": 49,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 49,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ak.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ak.snap
@@ -3,72 +3,66 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 22,
   "body": [
     {
+      "type": "ExpressionStatement",
+      "start": 0,
       "end": 22,
       "expression": {
+        "type": "CallExpression",
+        "start": 0,
+        "end": 22,
+        "callee": {
+          "type": "Identifier",
+          "start": 0,
+          "end": 6,
+          "name": "lineTo"
+        },
         "arguments": [
           {
+            "type": "ObjectExpression",
+            "start": 7,
             "end": 21,
             "properties": [
               {
+                "type": "ObjectProperty",
+                "start": 9,
                 "end": 19,
                 "key": {
-                  "end": 11,
-                  "name": "to",
+                  "type": "Identifier",
                   "start": 9,
-                  "type": "Identifier"
+                  "end": 11,
+                  "name": "to"
                 },
-                "start": 9,
-                "type": "ObjectProperty",
                 "value": {
+                  "type": "ArrayExpression",
+                  "start": 13,
+                  "end": 19,
                   "elements": [
                     {
-                      "end": 15,
-                      "raw": "0",
+                      "type": "Literal",
                       "start": 14,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 0
+                      "end": 15,
+                      "value": 0,
+                      "raw": "0"
                     },
                     {
-                      "end": 18,
-                      "raw": "1",
+                      "type": "Literal",
                       "start": 17,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 1
+                      "end": 18,
+                      "value": 1,
+                      "raw": "1"
                     }
-                  ],
-                  "end": 19,
-                  "start": 13,
-                  "type": "ArrayExpression",
-                  "type": "ArrayExpression"
+                  ]
                 }
               }
-            ],
-            "start": 7,
-            "type": "ObjectExpression",
-            "type": "ObjectExpression"
+            ]
           }
         ],
-        "callee": {
-          "end": 6,
-          "name": "lineTo",
-          "start": 0,
-          "type": "Identifier"
-        },
-        "end": 22,
-        "optional": false,
-        "start": 0,
-        "type": "CallExpression",
-        "type": "CallExpression"
-      },
-      "start": 0,
-      "type": "ExpressionStatement",
-      "type": "ExpressionStatement"
+        "optional": false
+      }
     }
-  ],
-  "end": 22,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__al.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__al.snap
@@ -3,107 +3,98 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 36,
   "body": [
     {
+      "type": "ExpressionStatement",
+      "start": 0,
       "end": 36,
       "expression": {
+        "type": "CallExpression",
+        "start": 0,
+        "end": 36,
+        "callee": {
+          "type": "Identifier",
+          "start": 0,
+          "end": 6,
+          "name": "lineTo"
+        },
         "arguments": [
           {
+            "type": "ObjectExpression",
+            "start": 7,
             "end": 35,
             "properties": [
               {
+                "type": "ObjectProperty",
+                "start": 9,
                 "end": 19,
                 "key": {
-                  "end": 11,
-                  "name": "to",
+                  "type": "Identifier",
                   "start": 9,
-                  "type": "Identifier"
+                  "end": 11,
+                  "name": "to"
                 },
-                "start": 9,
-                "type": "ObjectProperty",
                 "value": {
+                  "type": "ArrayExpression",
+                  "start": 13,
+                  "end": 19,
                   "elements": [
                     {
-                      "end": 15,
-                      "raw": "0",
+                      "type": "Literal",
                       "start": 14,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 0
+                      "end": 15,
+                      "value": 0,
+                      "raw": "0"
                     },
                     {
-                      "end": 18,
-                      "raw": "1",
+                      "type": "Literal",
                       "start": 17,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 1
+                      "end": 18,
+                      "value": 1,
+                      "raw": "1"
                     }
-                  ],
-                  "end": 19,
-                  "start": 13,
-                  "type": "ArrayExpression",
-                  "type": "ArrayExpression"
+                  ]
                 }
               },
               {
+                "type": "ObjectProperty",
+                "start": 21,
                 "end": 33,
                 "key": {
-                  "end": 25,
-                  "name": "from",
+                  "type": "Identifier",
                   "start": 21,
-                  "type": "Identifier"
+                  "end": 25,
+                  "name": "from"
                 },
-                "start": 21,
-                "type": "ObjectProperty",
                 "value": {
+                  "type": "ArrayExpression",
+                  "start": 27,
+                  "end": 33,
                   "elements": [
                     {
-                      "end": 29,
-                      "raw": "3",
+                      "type": "Literal",
                       "start": 28,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 3
+                      "end": 29,
+                      "value": 3,
+                      "raw": "3"
                     },
                     {
-                      "end": 32,
-                      "raw": "3",
+                      "type": "Literal",
                       "start": 31,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 3
+                      "end": 32,
+                      "value": 3,
+                      "raw": "3"
                     }
-                  ],
-                  "end": 33,
-                  "start": 27,
-                  "type": "ArrayExpression",
-                  "type": "ArrayExpression"
+                  ]
                 }
               }
-            ],
-            "start": 7,
-            "type": "ObjectExpression",
-            "type": "ObjectExpression"
+            ]
           }
         ],
-        "callee": {
-          "end": 6,
-          "name": "lineTo",
-          "start": 0,
-          "type": "Identifier"
-        },
-        "end": 36,
-        "optional": false,
-        "start": 0,
-        "type": "CallExpression",
-        "type": "CallExpression"
-      },
-      "start": 0,
-      "type": "ExpressionStatement",
-      "type": "ExpressionStatement"
+        "optional": false
+      }
     }
-  ],
-  "end": 36,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__am.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__am.snap
@@ -3,72 +3,66 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 19,
   "body": [
     {
+      "type": "ExpressionStatement",
+      "start": 0,
       "end": 19,
       "expression": {
+        "type": "CallExpression",
+        "start": 0,
+        "end": 19,
+        "callee": {
+          "type": "Identifier",
+          "start": 0,
+          "end": 6,
+          "name": "lineTo"
+        },
         "arguments": [
           {
+            "type": "ObjectExpression",
+            "start": 7,
             "end": 18,
             "properties": [
               {
+                "type": "ObjectProperty",
+                "start": 8,
                 "end": 17,
                 "key": {
-                  "end": 10,
-                  "name": "to",
+                  "type": "Identifier",
                   "start": 8,
-                  "type": "Identifier"
+                  "end": 10,
+                  "name": "to"
                 },
-                "start": 8,
-                "type": "ObjectProperty",
                 "value": {
+                  "type": "ArrayExpression",
+                  "start": 11,
+                  "end": 17,
                   "elements": [
                     {
-                      "end": 13,
-                      "raw": "0",
+                      "type": "Literal",
                       "start": 12,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 0
+                      "end": 13,
+                      "value": 0,
+                      "raw": "0"
                     },
                     {
-                      "end": 16,
-                      "raw": "1",
+                      "type": "Literal",
                       "start": 15,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 1
+                      "end": 16,
+                      "value": 1,
+                      "raw": "1"
                     }
-                  ],
-                  "end": 17,
-                  "start": 11,
-                  "type": "ArrayExpression",
-                  "type": "ArrayExpression"
+                  ]
                 }
               }
-            ],
-            "start": 7,
-            "type": "ObjectExpression",
-            "type": "ObjectExpression"
+            ]
           }
         ],
-        "callee": {
-          "end": 6,
-          "name": "lineTo",
-          "start": 0,
-          "type": "Identifier"
-        },
-        "end": 19,
-        "optional": false,
-        "start": 0,
-        "type": "CallExpression",
-        "type": "CallExpression"
-      },
-      "start": 0,
-      "type": "ExpressionStatement",
-      "type": "ExpressionStatement"
+        "optional": false
+      }
     }
-  ],
-  "end": 19,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__an.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__an.snap
@@ -3,107 +3,98 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 35,
   "body": [
     {
+      "type": "ExpressionStatement",
+      "start": 0,
       "end": 35,
       "expression": {
+        "type": "CallExpression",
+        "start": 0,
+        "end": 35,
+        "callee": {
+          "type": "Identifier",
+          "start": 0,
+          "end": 6,
+          "name": "lineTo"
+        },
         "arguments": [
           {
+            "type": "ObjectExpression",
+            "start": 7,
             "end": 34,
             "properties": [
               {
+                "type": "ObjectProperty",
+                "start": 9,
                 "end": 19,
                 "key": {
-                  "end": 11,
-                  "name": "to",
+                  "type": "Identifier",
                   "start": 9,
-                  "type": "Identifier"
+                  "end": 11,
+                  "name": "to"
                 },
-                "start": 9,
-                "type": "ObjectProperty",
                 "value": {
+                  "type": "ArrayExpression",
+                  "start": 13,
+                  "end": 19,
                   "elements": [
                     {
-                      "end": 15,
-                      "raw": "0",
+                      "type": "Literal",
                       "start": 14,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 0
+                      "end": 15,
+                      "value": 0,
+                      "raw": "0"
                     },
                     {
-                      "end": 18,
-                      "raw": "1",
+                      "type": "Literal",
                       "start": 17,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 1
+                      "end": 18,
+                      "value": 1,
+                      "raw": "1"
                     }
-                  ],
-                  "end": 19,
-                  "start": 13,
-                  "type": "ArrayExpression",
-                  "type": "ArrayExpression"
+                  ]
                 }
               },
               {
+                "type": "ObjectProperty",
+                "start": 21,
                 "end": 33,
                 "key": {
-                  "end": 25,
-                  "name": "from",
+                  "type": "Identifier",
                   "start": 21,
-                  "type": "Identifier"
+                  "end": 25,
+                  "name": "from"
                 },
-                "start": 21,
-                "type": "ObjectProperty",
                 "value": {
+                  "type": "ArrayExpression",
+                  "start": 27,
+                  "end": 33,
                   "elements": [
                     {
-                      "end": 29,
-                      "raw": "3",
+                      "type": "Literal",
                       "start": 28,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 3
+                      "end": 29,
+                      "value": 3,
+                      "raw": "3"
                     },
                     {
-                      "end": 32,
-                      "raw": "3",
+                      "type": "Literal",
                       "start": 31,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 3
+                      "end": 32,
+                      "value": 3,
+                      "raw": "3"
                     }
-                  ],
-                  "end": 33,
-                  "start": 27,
-                  "type": "ArrayExpression",
-                  "type": "ArrayExpression"
+                  ]
                 }
               }
-            ],
-            "start": 7,
-            "type": "ObjectExpression",
-            "type": "ObjectExpression"
+            ]
           }
         ],
-        "callee": {
-          "end": 6,
-          "name": "lineTo",
-          "start": 0,
-          "type": "Identifier"
-        },
-        "end": 35,
-        "optional": false,
-        "start": 0,
-        "type": "CallExpression",
-        "type": "CallExpression"
-      },
-      "start": 0,
-      "type": "ExpressionStatement",
-      "type": "ExpressionStatement"
+        "optional": false
+      }
     }
-  ],
-  "end": 35,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ao.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ao.snap
@@ -3,107 +3,98 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 35,
   "body": [
     {
+      "type": "ExpressionStatement",
+      "start": 0,
       "end": 35,
       "expression": {
+        "type": "CallExpression",
+        "start": 0,
+        "end": 35,
+        "callee": {
+          "type": "Identifier",
+          "start": 0,
+          "end": 6,
+          "name": "lineTo"
+        },
         "arguments": [
           {
+            "type": "ObjectExpression",
+            "start": 7,
             "end": 34,
             "properties": [
               {
+                "type": "ObjectProperty",
+                "start": 9,
                 "end": 19,
                 "key": {
-                  "end": 11,
-                  "name": "to",
+                  "type": "Identifier",
                   "start": 9,
-                  "type": "Identifier"
+                  "end": 11,
+                  "name": "to"
                 },
-                "start": 9,
-                "type": "ObjectProperty",
                 "value": {
+                  "type": "ArrayExpression",
+                  "start": 13,
+                  "end": 19,
                   "elements": [
                     {
-                      "end": 15,
-                      "raw": "0",
+                      "type": "Literal",
                       "start": 14,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 0
+                      "end": 15,
+                      "value": 0,
+                      "raw": "0"
                     },
                     {
-                      "end": 18,
-                      "raw": "1",
+                      "type": "Literal",
                       "start": 17,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 1
+                      "end": 18,
+                      "value": 1,
+                      "raw": "1"
                     }
-                  ],
-                  "end": 19,
-                  "start": 13,
-                  "type": "ArrayExpression",
-                  "type": "ArrayExpression"
+                  ]
                 }
               },
               {
+                "type": "ObjectProperty",
+                "start": 20,
                 "end": 32,
                 "key": {
-                  "end": 24,
-                  "name": "from",
+                  "type": "Identifier",
                   "start": 20,
-                  "type": "Identifier"
+                  "end": 24,
+                  "name": "from"
                 },
-                "start": 20,
-                "type": "ObjectProperty",
                 "value": {
+                  "type": "ArrayExpression",
+                  "start": 26,
+                  "end": 32,
                   "elements": [
                     {
-                      "end": 28,
-                      "raw": "3",
+                      "type": "Literal",
                       "start": 27,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 3
+                      "end": 28,
+                      "value": 3,
+                      "raw": "3"
                     },
                     {
-                      "end": 31,
-                      "raw": "3",
+                      "type": "Literal",
                       "start": 30,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 3
+                      "end": 31,
+                      "value": 3,
+                      "raw": "3"
                     }
-                  ],
-                  "end": 32,
-                  "start": 26,
-                  "type": "ArrayExpression",
-                  "type": "ArrayExpression"
+                  ]
                 }
               }
-            ],
-            "start": 7,
-            "type": "ObjectExpression",
-            "type": "ObjectExpression"
+            ]
           }
         ],
-        "callee": {
-          "end": 6,
-          "name": "lineTo",
-          "start": 0,
-          "type": "Identifier"
-        },
-        "end": 35,
-        "optional": false,
-        "start": 0,
-        "type": "CallExpression",
-        "type": "CallExpression"
-      },
-      "start": 0,
-      "type": "ExpressionStatement",
-      "type": "ExpressionStatement"
+        "optional": false
+      }
     }
-  ],
-  "end": 35,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ap.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ap.snap
@@ -3,67 +3,62 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 37,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 37,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 37,
           "id": {
-            "end": 14,
-            "name": "mySketch",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 14,
+            "name": "mySketch"
           },
           "init": {
+            "type": "CallExpression",
+            "start": 17,
+            "end": 37,
+            "callee": {
+              "type": "Identifier",
+              "start": 17,
+              "end": 30,
+              "name": "startSketchAt"
+            },
             "arguments": [
               {
+                "type": "ArrayExpression",
+                "start": 31,
+                "end": 36,
                 "elements": [
                   {
-                    "end": 33,
-                    "raw": "0",
+                    "type": "Literal",
                     "start": 32,
-                    "type": "Literal",
-                    "type": "Literal",
-                    "value": 0
+                    "end": 33,
+                    "value": 0,
+                    "raw": "0"
                   },
                   {
-                    "end": 35,
-                    "raw": "0",
+                    "type": "Literal",
                     "start": 34,
-                    "type": "Literal",
-                    "type": "Literal",
-                    "value": 0
+                    "end": 35,
+                    "value": 0,
+                    "raw": "0"
                   }
-                ],
-                "end": 36,
-                "start": 31,
-                "type": "ArrayExpression",
-                "type": "ArrayExpression"
+                ]
               }
             ],
-            "callee": {
-              "end": 30,
-              "name": "startSketchAt",
-              "start": 17,
-              "type": "Identifier"
-            },
-            "end": 37,
-            "optional": false,
-            "start": 17,
-            "type": "CallExpression",
-            "type": "CallExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            "optional": false
+          }
         }
       ],
-      "end": 37,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 37,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__aq.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__aq.snap
@@ -3,52 +3,47 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 28,
   "body": [
     {
+      "type": "ExpressionStatement",
+      "start": 0,
       "end": 28,
       "expression": {
+        "type": "CallExpression",
+        "start": 0,
+        "end": 28,
+        "callee": {
+          "type": "Identifier",
+          "start": 0,
+          "end": 3,
+          "name": "log"
+        },
         "arguments": [
           {
-            "end": 5,
-            "raw": "5",
+            "type": "Literal",
             "start": 4,
-            "type": "Literal",
-            "type": "Literal",
-            "value": 5
+            "end": 5,
+            "value": 5,
+            "raw": "5"
           },
           {
-            "end": 14,
-            "raw": "\"hello\"",
+            "type": "Literal",
             "start": 7,
-            "type": "Literal",
-            "type": "Literal",
-            "value": "hello"
+            "end": 14,
+            "value": "hello",
+            "raw": "\"hello\""
           },
           {
-            "end": 27,
-            "name": "aIdentifier",
-            "start": 16,
             "type": "Identifier",
-            "type": "Identifier"
+            "start": 16,
+            "end": 27,
+            "name": "aIdentifier"
           }
         ],
-        "callee": {
-          "end": 3,
-          "name": "log",
-          "start": 0,
-          "type": "Identifier"
-        },
-        "end": 28,
-        "optional": false,
-        "start": 0,
-        "type": "CallExpression",
-        "type": "CallExpression"
-      },
-      "start": 0,
-      "type": "ExpressionStatement",
-      "type": "ExpressionStatement"
+        "optional": false
+      }
     }
-  ],
-  "end": 28,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ar.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ar.snap
@@ -3,37 +3,33 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 7,
   "body": [
     {
+      "type": "ExpressionStatement",
+      "start": 0,
       "end": 7,
       "expression": {
-        "end": 7,
-        "left": {
-          "end": 1,
-          "raw": "5",
-          "start": 0,
-          "type": "Literal",
-          "type": "Literal",
-          "value": 5
-        },
-        "operator": "+",
-        "right": {
-          "end": 7,
-          "raw": "\"a\"",
-          "start": 4,
-          "type": "Literal",
-          "type": "Literal",
-          "value": "a"
-        },
-        "start": 0,
         "type": "BinaryExpression",
-        "type": "BinaryExpression"
-      },
-      "start": 0,
-      "type": "ExpressionStatement",
-      "type": "ExpressionStatement"
+        "start": 0,
+        "end": 7,
+        "operator": "+",
+        "left": {
+          "type": "Literal",
+          "start": 0,
+          "end": 1,
+          "value": 5,
+          "raw": "5"
+        },
+        "right": {
+          "type": "Literal",
+          "start": 4,
+          "end": 7,
+          "value": "a",
+          "raw": "\"a\""
+        }
+      }
     }
-  ],
-  "end": 7,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__at.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__at.snap
@@ -3,58 +3,52 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 15,
   "body": [
     {
+      "type": "ExpressionStatement",
+      "start": 0,
       "end": 15,
       "expression": {
+        "type": "CallExpression",
+        "start": 0,
+        "end": 15,
+        "callee": {
+          "type": "Identifier",
+          "start": 0,
+          "end": 4,
+          "name": "line"
+        },
         "arguments": [
           {
+            "type": "ArrayExpression",
+            "start": 5,
+            "end": 11,
             "elements": [
               {
-                "end": 7,
-                "raw": "0",
+                "type": "Literal",
                 "start": 6,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 0
+                "end": 7,
+                "value": 0,
+                "raw": "0"
               },
               {
-                "end": 10,
-                "name": "l",
-                "start": 9,
                 "type": "Identifier",
-                "type": "Identifier"
+                "start": 9,
+                "end": 10,
+                "name": "l"
               }
-            ],
-            "end": 11,
-            "start": 5,
-            "type": "ArrayExpression",
-            "type": "ArrayExpression"
+            ]
           },
           {
-            "end": 14,
-            "start": 13,
             "type": "PipeSubstitution",
-            "type": "PipeSubstitution"
+            "start": 13,
+            "end": 14
           }
         ],
-        "callee": {
-          "end": 4,
-          "name": "line",
-          "start": 0,
-          "type": "Identifier"
-        },
-        "end": 15,
-        "optional": false,
-        "start": 0,
-        "type": "CallExpression",
-        "type": "CallExpression"
-      },
-      "start": 0,
-      "type": "ExpressionStatement",
-      "type": "ExpressionStatement"
+        "optional": false
+      }
     }
-  ],
-  "end": 15,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__au.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__au.snap
@@ -3,171 +3,157 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 108,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 107,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 107,
           "id": {
-            "end": 14,
-            "name": "cylinder",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 14,
+            "name": "cylinder"
           },
           "init": {
+            "type": "PipeExpression",
+            "start": 17,
+            "end": 107,
             "body": [
               {
+                "type": "CallExpression",
+                "start": 17,
+                "end": 36,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 17,
+                  "end": 30,
+                  "name": "startSketchOn"
+                },
                 "arguments": [
                   {
-                    "end": 35,
-                    "raw": "'XY'",
+                    "type": "Literal",
                     "start": 31,
-                    "type": "Literal",
-                    "type": "Literal",
-                    "value": "XY"
+                    "end": 35,
+                    "value": "XY",
+                    "raw": "'XY'"
                   }
                 ],
-                "callee": {
-                  "end": 30,
-                  "name": "startSketchOn",
-                  "start": 17,
-                  "type": "Identifier"
-                },
-                "end": 36,
-                "optional": false,
-                "start": 17,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               },
               {
+                "type": "CallExpression",
+                "start": 44,
+                "end": 85,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 44,
+                  "end": 50,
+                  "name": "circle"
+                },
                 "arguments": [
                   {
+                    "type": "ObjectExpression",
+                    "start": 51,
                     "end": 81,
                     "properties": [
                       {
+                        "type": "ObjectProperty",
+                        "start": 53,
                         "end": 67,
                         "key": {
-                          "end": 59,
-                          "name": "center",
+                          "type": "Identifier",
                           "start": 53,
-                          "type": "Identifier"
+                          "end": 59,
+                          "name": "center"
                         },
-                        "start": 53,
-                        "type": "ObjectProperty",
                         "value": {
+                          "type": "ArrayExpression",
+                          "start": 61,
+                          "end": 67,
                           "elements": [
                             {
-                              "end": 63,
-                              "raw": "0",
+                              "type": "Literal",
                               "start": 62,
-                              "type": "Literal",
-                              "type": "Literal",
-                              "value": 0
+                              "end": 63,
+                              "value": 0,
+                              "raw": "0"
                             },
                             {
-                              "end": 66,
-                              "raw": "0",
+                              "type": "Literal",
                               "start": 65,
-                              "type": "Literal",
-                              "type": "Literal",
-                              "value": 0
+                              "end": 66,
+                              "value": 0,
+                              "raw": "0"
                             }
-                          ],
-                          "end": 67,
-                          "start": 61,
-                          "type": "ArrayExpression",
-                          "type": "ArrayExpression"
+                          ]
                         }
                       },
                       {
+                        "type": "ObjectProperty",
+                        "start": 69,
                         "end": 79,
                         "key": {
-                          "end": 75,
-                          "name": "radius",
+                          "type": "Identifier",
                           "start": 69,
-                          "type": "Identifier"
+                          "end": 75,
+                          "name": "radius"
                         },
-                        "start": 69,
-                        "type": "ObjectProperty",
                         "value": {
-                          "end": 79,
-                          "raw": "22",
+                          "type": "Literal",
                           "start": 77,
-                          "type": "Literal",
-                          "type": "Literal",
-                          "value": 22
+                          "end": 79,
+                          "value": 22,
+                          "raw": "22"
                         }
                       }
-                    ],
-                    "start": 51,
-                    "type": "ObjectExpression",
-                    "type": "ObjectExpression"
+                    ]
                   },
                   {
-                    "end": 84,
-                    "start": 83,
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution"
+                    "start": 83,
+                    "end": 84
                   }
                 ],
-                "callee": {
-                  "end": 50,
-                  "name": "circle",
-                  "start": 44,
-                  "type": "Identifier"
-                },
-                "end": 85,
-                "optional": false,
-                "start": 44,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               },
               {
+                "type": "CallExpression",
+                "start": 93,
+                "end": 107,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 93,
+                  "end": 100,
+                  "name": "extrude"
+                },
                 "arguments": [
                   {
-                    "end": 103,
-                    "raw": "14",
+                    "type": "Literal",
                     "start": 101,
-                    "type": "Literal",
-                    "type": "Literal",
-                    "value": 14
+                    "end": 103,
+                    "value": 14,
+                    "raw": "14"
                   },
                   {
-                    "end": 106,
-                    "start": 105,
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution"
+                    "start": 105,
+                    "end": 106
                   }
                 ],
-                "callee": {
-                  "end": 100,
-                  "name": "extrude",
-                  "start": 93,
-                  "type": "Identifier"
-                },
-                "end": 107,
-                "optional": false,
-                "start": 93,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               }
-            ],
-            "end": 107,
-            "start": 17,
-            "type": "PipeExpression",
-            "type": "PipeExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            ]
+          }
         }
       ],
-      "end": 107,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 108,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__av.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__av.snap
@@ -3,88 +3,82 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 49,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 49,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 3,
           "end": 49,
           "id": {
-            "end": 4,
-            "name": "f",
+            "type": "Identifier",
             "start": 3,
-            "type": "Identifier"
+            "end": 4,
+            "name": "f"
           },
           "init": {
-            "body": {
-              "body": [
-                {
-                  "argument": {
-                    "arguments": [
-                      {
-                        "end": 41,
-                        "name": "angle",
-                        "start": 36,
-                        "type": "Identifier",
-                        "type": "Identifier"
-                      },
-                      {
-                        "end": 46,
-                        "raw": "360",
-                        "start": 43,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 360
-                      }
-                    ],
-                    "callee": {
-                      "end": 35,
-                      "name": "default",
-                      "start": 28,
-                      "type": "Identifier"
-                    },
-                    "end": 47,
-                    "optional": false,
-                    "start": 28,
-                    "type": "CallExpression",
-                    "type": "CallExpression"
-                  },
-                  "end": 47,
-                  "start": 21,
-                  "type": "ReturnStatement",
-                  "type": "ReturnStatement"
-                }
-              ],
-              "end": 49,
-              "start": 19
-            },
+            "type": "FunctionExpression",
+            "start": 7,
             "end": 49,
             "params": [
               {
                 "type": "Parameter",
                 "identifier": {
-                  "end": 13,
-                  "name": "angle",
+                  "type": "Identifier",
                   "start": 8,
-                  "type": "Identifier"
+                  "end": 13,
+                  "name": "angle"
                 },
                 "optional": true
               }
             ],
-            "start": 7,
-            "type": "FunctionExpression",
-            "type": "FunctionExpression"
-          },
-          "start": 3,
-          "type": "VariableDeclarator"
+            "body": {
+              "start": 19,
+              "end": 49,
+              "body": [
+                {
+                  "type": "ReturnStatement",
+                  "start": 21,
+                  "end": 47,
+                  "argument": {
+                    "type": "CallExpression",
+                    "start": 28,
+                    "end": 47,
+                    "callee": {
+                      "type": "Identifier",
+                      "start": 28,
+                      "end": 35,
+                      "name": "default"
+                    },
+                    "arguments": [
+                      {
+                        "type": "Identifier",
+                        "start": 36,
+                        "end": 41,
+                        "name": "angle"
+                      },
+                      {
+                        "type": "Literal",
+                        "start": 43,
+                        "end": 46,
+                        "value": 360,
+                        "raw": "360"
+                      }
+                    ],
+                    "optional": false
+                  }
+                }
+              ]
+            }
+          }
         }
       ],
-      "end": 49,
-      "kind": "fn",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "fn"
     }
-  ],
-  "end": 49,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__aw.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__aw.snap
@@ -3,44 +3,51 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 91,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 91,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 4,
           "end": 91,
           "id": {
-            "end": 11,
-            "name": "numbers",
+            "type": "Identifier",
             "start": 4,
-            "type": "Identifier"
+            "end": 11,
+            "name": "numbers"
           },
           "init": {
+            "type": "ArrayExpression",
+            "start": 14,
+            "end": 91,
             "elements": [
               {
-                "end": 29,
-                "raw": "1",
+                "type": "Literal",
                 "start": 28,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 1
+                "end": 29,
+                "value": 1,
+                "raw": "1"
               },
               {
-                "end": 80,
-                "raw": "3",
+                "type": "Literal",
                 "start": 79,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 3
+                "end": 80,
+                "value": 3,
+                "raw": "3"
               }
             ],
-            "end": 91,
             "nonCodeMeta": {
               "nonCodeNodes": {
                 "1": [
                   {
-                    "end": 48,
-                    "start": 43,
                     "type": "NonCodeNode",
+                    "start": 43,
+                    "end": 48,
                     "value": {
                       "type": "blockComment",
                       "value": "A,",
@@ -50,9 +57,9 @@ expression: actual
                 ],
                 "2": [
                   {
-                    "end": 66,
-                    "start": 61,
                     "type": "NonCodeNode",
+                    "start": 61,
+                    "end": 66,
                     "value": {
                       "type": "blockComment",
                       "value": "B,",
@@ -61,23 +68,12 @@ expression: actual
                   }
                 ]
               },
-              "startNodes": []
-            },
-            "start": 14,
-            "type": "ArrayExpression",
-            "type": "ArrayExpression"
-          },
-          "start": 4,
-          "type": "VariableDeclarator"
+              "start": []
+            }
+          }
         }
       ],
-      "end": 91,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 91,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ax.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ax.snap
@@ -3,44 +3,51 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 91,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 91,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 4,
           "end": 91,
           "id": {
-            "end": 11,
-            "name": "numbers",
+            "type": "Identifier",
             "start": 4,
-            "type": "Identifier"
+            "end": 11,
+            "name": "numbers"
           },
           "init": {
+            "type": "ArrayExpression",
+            "start": 14,
+            "end": 91,
             "elements": [
               {
-                "end": 29,
-                "raw": "1",
+                "type": "Literal",
                 "start": 28,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 1
+                "end": 29,
+                "value": 1,
+                "raw": "1"
               },
               {
-                "end": 44,
-                "raw": "2",
+                "type": "Literal",
                 "start": 43,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 2
+                "end": 44,
+                "value": 2,
+                "raw": "2"
               }
             ],
-            "end": 91,
             "nonCodeMeta": {
               "nonCodeNodes": {
                 "2": [
                   {
-                    "end": 63,
-                    "start": 58,
                     "type": "NonCodeNode",
+                    "start": 58,
+                    "end": 63,
                     "value": {
                       "type": "blockComment",
                       "value": "A,",
@@ -50,9 +57,9 @@ expression: actual
                 ],
                 "3": [
                   {
-                    "end": 81,
-                    "start": 76,
                     "type": "NonCodeNode",
+                    "start": 76,
+                    "end": 81,
                     "value": {
                       "type": "blockComment",
                       "value": "B,",
@@ -61,23 +68,12 @@ expression: actual
                   }
                 ]
               },
-              "startNodes": []
-            },
-            "start": 14,
-            "type": "ArrayExpression",
-            "type": "ArrayExpression"
-          },
-          "start": 4,
-          "type": "VariableDeclarator"
+              "start": []
+            }
+          }
         }
       ],
-      "end": 91,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 91,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ay.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ay.snap
@@ -3,26 +3,73 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 80,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 80,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 4,
           "end": 80,
           "id": {
-            "end": 9,
-            "name": "props",
+            "type": "Identifier",
             "start": 4,
-            "type": "Identifier"
+            "end": 9,
+            "name": "props"
           },
           "init": {
+            "type": "ObjectExpression",
+            "start": 12,
             "end": 80,
+            "properties": [
+              {
+                "type": "ObjectProperty",
+                "start": 26,
+                "end": 30,
+                "key": {
+                  "type": "Identifier",
+                  "start": 26,
+                  "end": 27,
+                  "name": "a"
+                },
+                "value": {
+                  "type": "Literal",
+                  "start": 29,
+                  "end": 30,
+                  "value": 1,
+                  "raw": "1"
+                }
+              },
+              {
+                "type": "ObjectProperty",
+                "start": 65,
+                "end": 69,
+                "key": {
+                  "type": "Identifier",
+                  "start": 65,
+                  "end": 66,
+                  "name": "c"
+                },
+                "value": {
+                  "type": "Literal",
+                  "start": 68,
+                  "end": 69,
+                  "value": 3,
+                  "raw": "3"
+                }
+              }
+            ],
             "nonCodeMeta": {
               "nonCodeNodes": {
                 "1": [
                   {
-                    "end": 52,
-                    "start": 44,
                     "type": "NonCodeNode",
+                    "start": 44,
+                    "end": 52,
                     "value": {
                       "type": "blockComment",
                       "value": "b: 2,",
@@ -31,63 +78,12 @@ expression: actual
                   }
                 ]
               },
-              "startNodes": []
-            },
-            "properties": [
-              {
-                "end": 30,
-                "key": {
-                  "end": 27,
-                  "name": "a",
-                  "start": 26,
-                  "type": "Identifier"
-                },
-                "start": 26,
-                "type": "ObjectProperty",
-                "value": {
-                  "end": 30,
-                  "raw": "1",
-                  "start": 29,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 1
-                }
-              },
-              {
-                "end": 69,
-                "key": {
-                  "end": 66,
-                  "name": "c",
-                  "start": 65,
-                  "type": "Identifier"
-                },
-                "start": 65,
-                "type": "ObjectProperty",
-                "value": {
-                  "end": 69,
-                  "raw": "3",
-                  "start": 68,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 3
-                }
-              }
-            ],
-            "start": 12,
-            "type": "ObjectExpression",
-            "type": "ObjectExpression"
-          },
-          "start": 4,
-          "type": "VariableDeclarator"
+              "start": []
+            }
+          }
         }
       ],
-      "end": 80,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 80,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__az.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__az.snap
@@ -3,26 +3,73 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 79,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 79,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 4,
           "end": 79,
           "id": {
-            "end": 9,
-            "name": "props",
+            "type": "Identifier",
             "start": 4,
-            "type": "Identifier"
+            "end": 9,
+            "name": "props"
           },
           "init": {
+            "type": "ObjectExpression",
+            "start": 12,
             "end": 79,
+            "properties": [
+              {
+                "type": "ObjectProperty",
+                "start": 26,
+                "end": 30,
+                "key": {
+                  "type": "Identifier",
+                  "start": 26,
+                  "end": 27,
+                  "name": "a"
+                },
+                "value": {
+                  "type": "Literal",
+                  "start": 29,
+                  "end": 30,
+                  "value": 1,
+                  "raw": "1"
+                }
+              },
+              {
+                "type": "ObjectProperty",
+                "start": 65,
+                "end": 69,
+                "key": {
+                  "type": "Identifier",
+                  "start": 65,
+                  "end": 66,
+                  "name": "c"
+                },
+                "value": {
+                  "type": "Literal",
+                  "start": 68,
+                  "end": 69,
+                  "value": 3,
+                  "raw": "3"
+                }
+              }
+            ],
             "nonCodeMeta": {
               "nonCodeNodes": {
                 "1": [
                   {
-                    "end": 52,
-                    "start": 44,
                     "type": "NonCodeNode",
+                    "start": 44,
+                    "end": 52,
                     "value": {
                       "type": "blockComment",
                       "value": "b: 2,",
@@ -31,63 +78,12 @@ expression: actual
                   }
                 ]
               },
-              "startNodes": []
-            },
-            "properties": [
-              {
-                "end": 30,
-                "key": {
-                  "end": 27,
-                  "name": "a",
-                  "start": 26,
-                  "type": "Identifier"
-                },
-                "start": 26,
-                "type": "ObjectProperty",
-                "value": {
-                  "end": 30,
-                  "raw": "1",
-                  "start": 29,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 1
-                }
-              },
-              {
-                "end": 69,
-                "key": {
-                  "end": 66,
-                  "name": "c",
-                  "start": 65,
-                  "type": "Identifier"
-                },
-                "start": 65,
-                "type": "ObjectProperty",
-                "value": {
-                  "end": 69,
-                  "raw": "3",
-                  "start": 68,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 3
-                }
-              }
-            ],
-            "start": 12,
-            "type": "ObjectExpression",
-            "type": "ObjectExpression"
-          },
-          "start": 4,
-          "type": "VariableDeclarator"
+              "start": []
+            }
+          }
         }
       ],
-      "end": 79,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 79,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__b.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__b.snap
@@ -3,89 +3,82 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 36,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 36,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 36,
           "id": {
-            "end": 11,
-            "name": "myVar",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 11,
+            "name": "myVar"
           },
           "init": {
+            "type": "CallExpression",
+            "start": 14,
+            "end": 36,
+            "callee": {
+              "type": "Identifier",
+              "start": 14,
+              "end": 17,
+              "name": "min"
+            },
             "arguments": [
               {
-                "end": 19,
-                "raw": "5",
+                "type": "Literal",
                 "start": 18,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 5
+                "end": 19,
+                "value": 5,
+                "raw": "5"
               },
               {
-                "argument": {
-                  "arguments": [
-                    {
-                      "end": 31,
-                      "raw": "5",
-                      "start": 30,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 5
-                    },
-                    {
-                      "end": 34,
-                      "raw": "4",
-                      "start": 33,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 4
-                    }
-                  ],
-                  "callee": {
-                    "end": 29,
-                    "name": "legLen",
-                    "start": 23,
-                    "type": "Identifier"
-                  },
-                  "end": 35,
-                  "optional": false,
-                  "start": 23,
-                  "type": "CallExpression",
-                  "type": "CallExpression"
-                },
+                "type": "UnaryExpression",
+                "start": 22,
                 "end": 35,
                 "operator": "-",
-                "start": 22,
-                "type": "UnaryExpression",
-                "type": "UnaryExpression"
+                "argument": {
+                  "type": "CallExpression",
+                  "start": 23,
+                  "end": 35,
+                  "callee": {
+                    "type": "Identifier",
+                    "start": 23,
+                    "end": 29,
+                    "name": "legLen"
+                  },
+                  "arguments": [
+                    {
+                      "type": "Literal",
+                      "start": 30,
+                      "end": 31,
+                      "value": 5,
+                      "raw": "5"
+                    },
+                    {
+                      "type": "Literal",
+                      "start": 33,
+                      "end": 34,
+                      "value": 4,
+                      "raw": "4"
+                    }
+                  ],
+                  "optional": false
+                }
               }
             ],
-            "callee": {
-              "end": 17,
-              "name": "min",
-              "start": 14,
-              "type": "Identifier"
-            },
-            "end": 36,
-            "optional": false,
-            "start": 14,
-            "type": "CallExpression",
-            "type": "CallExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            "optional": false
+          }
         }
       ],
-      "end": 36,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 36,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ba.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ba.snap
@@ -3,72 +3,77 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 133,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 1,
+      "end": 132,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 7,
           "end": 132,
           "id": {
-            "end": 16,
-            "name": "sketch001",
+            "type": "Identifier",
             "start": 7,
-            "type": "Identifier"
+            "end": 16,
+            "name": "sketch001"
           },
           "init": {
+            "type": "PipeExpression",
+            "start": 19,
+            "end": 132,
             "body": [
               {
+                "type": "CallExpression",
+                "start": 19,
+                "end": 38,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 19,
+                  "end": 32,
+                  "name": "startSketchOn"
+                },
                 "arguments": [
                   {
-                    "end": 37,
-                    "raw": "'XY'",
+                    "type": "Literal",
                     "start": 33,
-                    "type": "Literal",
-                    "type": "Literal",
-                    "value": "XY"
+                    "end": 37,
+                    "value": "XY",
+                    "raw": "'XY'"
                   }
                 ],
-                "callee": {
-                  "end": 32,
-                  "name": "startSketchOn",
-                  "start": 19,
-                  "type": "Identifier"
-                },
-                "end": 38,
-                "optional": false,
-                "start": 19,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               },
               {
+                "type": "CallExpression",
+                "start": 115,
+                "end": 132,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 115,
+                  "end": 129,
+                  "name": "startProfileAt"
+                },
                 "arguments": [
                   {
-                    "end": 131,
-                    "start": 130,
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution"
+                    "start": 130,
+                    "end": 131
                   }
                 ],
-                "callee": {
-                  "end": 129,
-                  "name": "startProfileAt",
-                  "start": 115,
-                  "type": "Identifier"
-                },
-                "end": 132,
-                "optional": false,
-                "start": 115,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               }
             ],
-            "end": 132,
             "nonCodeMeta": {
               "nonCodeNodes": {
                 "0": [
                   {
-                    "end": 52,
-                    "start": 41,
                     "type": "NonCodeNode",
+                    "start": 41,
+                    "end": 52,
                     "value": {
                       "type": "blockComment",
                       "value": "|> arc({",
@@ -76,9 +81,9 @@ expression: actual
                     }
                   },
                   {
-                    "end": 74,
-                    "start": 55,
                     "type": "NonCodeNode",
+                    "start": 55,
+                    "end": 74,
                     "value": {
                       "type": "blockComment",
                       "value": "angleEnd: 270,",
@@ -86,9 +91,9 @@ expression: actual
                     }
                   },
                   {
-                    "end": 98,
-                    "start": 77,
                     "type": "NonCodeNode",
+                    "start": 77,
+                    "end": 98,
                     "value": {
                       "type": "blockComment",
                       "value": "angleStart: 450,",
@@ -96,9 +101,9 @@ expression: actual
                     }
                   },
                   {
-                    "end": 109,
-                    "start": 101,
                     "type": "NonCodeNode",
+                    "start": 101,
+                    "end": 109,
                     "value": {
                       "type": "blockComment",
                       "value": "}, %)",
@@ -107,23 +112,12 @@ expression: actual
                   }
                 ]
               },
-              "startNodes": []
-            },
-            "start": 19,
-            "type": "PipeExpression",
-            "type": "PipeExpression"
-          },
-          "start": 7,
-          "type": "VariableDeclarator"
+              "start": []
+            }
+          }
         }
       ],
-      "end": 132,
-      "kind": "const",
-      "start": 1,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 133,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bb.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bb.snap
@@ -3,96 +3,86 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 32,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 1,
+      "end": 31,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 7,
           "end": 31,
           "id": {
-            "end": 11,
-            "name": "my14",
+            "type": "Identifier",
             "start": 7,
-            "type": "Identifier"
+            "end": 11,
+            "name": "my14"
           },
           "init": {
-            "end": 31,
-            "left": {
-              "end": 19,
-              "left": {
-                "end": 15,
-                "raw": "4",
-                "start": 14,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 4
-              },
-              "operator": "^",
-              "right": {
-                "end": 19,
-                "raw": "2",
-                "start": 18,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 2
-              },
-              "start": 14,
-              "type": "BinaryExpression",
-              "type": "BinaryExpression"
-            },
-            "operator": "-",
-            "right": {
-              "end": 31,
-              "left": {
-                "end": 27,
-                "left": {
-                  "end": 23,
-                  "raw": "3",
-                  "start": 22,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 3
-                },
-                "operator": "^",
-                "right": {
-                  "end": 27,
-                  "raw": "2",
-                  "start": 26,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 2
-                },
-                "start": 22,
-                "type": "BinaryExpression",
-                "type": "BinaryExpression"
-              },
-              "operator": "*",
-              "right": {
-                "end": 31,
-                "raw": "2",
-                "start": 30,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 2
-              },
-              "start": 22,
-              "type": "BinaryExpression",
-              "type": "BinaryExpression"
-            },
-            "start": 14,
             "type": "BinaryExpression",
-            "type": "BinaryExpression"
-          },
-          "start": 7,
-          "type": "VariableDeclarator"
+            "start": 14,
+            "end": 31,
+            "operator": "-",
+            "left": {
+              "type": "BinaryExpression",
+              "start": 14,
+              "end": 19,
+              "operator": "^",
+              "left": {
+                "type": "Literal",
+                "start": 14,
+                "end": 15,
+                "value": 4,
+                "raw": "4"
+              },
+              "right": {
+                "type": "Literal",
+                "start": 18,
+                "end": 19,
+                "value": 2,
+                "raw": "2"
+              }
+            },
+            "right": {
+              "type": "BinaryExpression",
+              "start": 22,
+              "end": 31,
+              "operator": "*",
+              "left": {
+                "type": "BinaryExpression",
+                "start": 22,
+                "end": 27,
+                "operator": "^",
+                "left": {
+                  "type": "Literal",
+                  "start": 22,
+                  "end": 23,
+                  "value": 3,
+                  "raw": "3"
+                },
+                "right": {
+                  "type": "Literal",
+                  "start": 26,
+                  "end": 27,
+                  "value": 2,
+                  "raw": "2"
+                }
+              },
+              "right": {
+                "type": "Literal",
+                "start": 30,
+                "end": 31,
+                "value": 2,
+                "raw": "2"
+              }
+            }
+          }
         }
       ],
-      "end": 31,
-      "kind": "const",
-      "start": 1,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 32,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bc.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bc.snap
@@ -3,84 +3,77 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 74,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 74,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 74,
           "id": {
-            "end": 7,
-            "name": "x",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 7,
+            "name": "x"
           },
           "init": {
-            "cond": {
-              "end": 17,
-              "raw": "true",
-              "start": 13,
-              "type": "Literal",
-              "type": "Literal",
-              "value": true
-            },
-            "digest": null,
-            "else_ifs": [],
-            "end": 74,
-            "final_else": {
-              "body": [
-                {
-                  "end": 64,
-                  "expression": {
-                    "end": 64,
-                    "raw": "4",
-                    "start": 63,
-                    "type": "Literal",
-                    "type": "Literal",
-                    "value": 4
-                  },
-                  "start": 63,
-                  "type": "ExpressionStatement",
-                  "type": "ExpressionStatement"
-                }
-              ],
-              "end": 73,
-              "start": 63
-            },
+            "type": "IfExpression",
             "start": 10,
+            "end": 74,
+            "cond": {
+              "type": "Literal",
+              "start": 13,
+              "end": 17,
+              "value": true,
+              "raw": "true"
+            },
             "then_val": {
+              "start": 32,
+              "end": 42,
               "body": [
                 {
+                  "type": "ExpressionStatement",
+                  "start": 32,
                   "end": 33,
                   "expression": {
-                    "end": 33,
-                    "raw": "3",
+                    "type": "Literal",
                     "start": 32,
-                    "type": "Literal",
-                    "type": "Literal",
-                    "value": 3
-                  },
-                  "start": 32,
-                  "type": "ExpressionStatement",
-                  "type": "ExpressionStatement"
+                    "end": 33,
+                    "value": 3,
+                    "raw": "3"
+                  }
                 }
-              ],
-              "end": 42,
-              "start": 32
+              ]
             },
-            "type": "IfExpression",
-            "type": "IfExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            "else_ifs": [],
+            "final_else": {
+              "start": 63,
+              "end": 73,
+              "body": [
+                {
+                  "type": "ExpressionStatement",
+                  "start": 63,
+                  "end": 64,
+                  "expression": {
+                    "type": "Literal",
+                    "start": 63,
+                    "end": 64,
+                    "value": 4,
+                    "raw": "4"
+                  }
+                }
+              ]
+            },
+            "digest": null
+          }
         }
       ],
-      "end": 74,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 74,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bd.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bd.snap
@@ -3,133 +3,122 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 121,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 121,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 121,
           "id": {
-            "end": 7,
-            "name": "x",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 7,
+            "name": "x"
           },
           "init": {
-            "cond": {
-              "end": 17,
-              "raw": "true",
-              "start": 13,
-              "type": "Literal",
-              "type": "Literal",
-              "value": true
-            },
-            "digest": null,
-            "else_ifs": [
-              {
-                "cond": {
-                  "arguments": [
-                    {
-                      "end": 63,
-                      "name": "radius",
-                      "start": 57,
-                      "type": "Identifier",
-                      "type": "Identifier"
-                    }
-                  ],
-                  "callee": {
-                    "end": 56,
-                    "name": "func",
-                    "start": 52,
-                    "type": "Identifier"
-                  },
-                  "end": 64,
-                  "optional": false,
-                  "start": 52,
-                  "type": "CallExpression",
-                  "type": "CallExpression"
-                },
-                "digest": null,
-                "end": 90,
-                "start": 44,
-                "then_val": {
-                  "body": [
-                    {
-                      "end": 80,
-                      "expression": {
-                        "end": 80,
-                        "raw": "4",
-                        "start": 79,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 4
-                      },
-                      "start": 79,
-                      "type": "ExpressionStatement",
-                      "type": "ExpressionStatement"
-                    }
-                  ],
-                  "end": 89,
-                  "start": 65
-                },
-                "type": "ElseIf"
-              }
-            ],
-            "end": 121,
-            "final_else": {
-              "body": [
-                {
-                  "end": 111,
-                  "expression": {
-                    "end": 111,
-                    "raw": "5",
-                    "start": 110,
-                    "type": "Literal",
-                    "type": "Literal",
-                    "value": 5
-                  },
-                  "start": 110,
-                  "type": "ExpressionStatement",
-                  "type": "ExpressionStatement"
-                }
-              ],
-              "end": 120,
-              "start": 110
-            },
+            "type": "IfExpression",
             "start": 10,
+            "end": 121,
+            "cond": {
+              "type": "Literal",
+              "start": 13,
+              "end": 17,
+              "value": true,
+              "raw": "true"
+            },
             "then_val": {
+              "start": 32,
+              "end": 42,
               "body": [
                 {
+                  "type": "ExpressionStatement",
+                  "start": 32,
                   "end": 33,
                   "expression": {
-                    "end": 33,
-                    "raw": "3",
+                    "type": "Literal",
                     "start": 32,
-                    "type": "Literal",
-                    "type": "Literal",
-                    "value": 3
-                  },
-                  "start": 32,
-                  "type": "ExpressionStatement",
-                  "type": "ExpressionStatement"
+                    "end": 33,
+                    "value": 3,
+                    "raw": "3"
+                  }
                 }
-              ],
-              "end": 42,
-              "start": 32
+              ]
             },
-            "type": "IfExpression",
-            "type": "IfExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            "else_ifs": [
+              {
+                "type": "ElseIf",
+                "start": 44,
+                "end": 90,
+                "cond": {
+                  "type": "CallExpression",
+                  "start": 52,
+                  "end": 64,
+                  "callee": {
+                    "type": "Identifier",
+                    "start": 52,
+                    "end": 56,
+                    "name": "func"
+                  },
+                  "arguments": [
+                    {
+                      "type": "Identifier",
+                      "start": 57,
+                      "end": 63,
+                      "name": "radius"
+                    }
+                  ],
+                  "optional": false
+                },
+                "then_val": {
+                  "start": 65,
+                  "end": 89,
+                  "body": [
+                    {
+                      "type": "ExpressionStatement",
+                      "start": 79,
+                      "end": 80,
+                      "expression": {
+                        "type": "Literal",
+                        "start": 79,
+                        "end": 80,
+                        "value": 4,
+                        "raw": "4"
+                      }
+                    }
+                  ]
+                },
+                "digest": null
+              }
+            ],
+            "final_else": {
+              "start": 110,
+              "end": 120,
+              "body": [
+                {
+                  "type": "ExpressionStatement",
+                  "start": 110,
+                  "end": 111,
+                  "expression": {
+                    "type": "Literal",
+                    "start": 110,
+                    "end": 111,
+                    "value": 5,
+                    "raw": "5"
+                  }
+                }
+              ]
+            },
+            "digest": null
+          }
         }
       ],
-      "end": 121,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 121,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__be.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__be.snap
@@ -3,51 +3,47 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 14,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 14,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 4,
           "end": 14,
           "id": {
-            "end": 5,
-            "name": "x",
+            "type": "Identifier",
             "start": 4,
-            "type": "Identifier"
+            "end": 5,
+            "name": "x"
           },
           "init": {
-            "end": 14,
-            "left": {
-              "end": 9,
-              "raw": "3",
-              "start": 8,
-              "type": "Literal",
-              "type": "Literal",
-              "value": 3
-            },
-            "operator": "==",
-            "right": {
-              "end": 14,
-              "raw": "3",
-              "start": 13,
-              "type": "Literal",
-              "type": "Literal",
-              "value": 3
-            },
-            "start": 8,
             "type": "BinaryExpression",
-            "type": "BinaryExpression"
-          },
-          "start": 4,
-          "type": "VariableDeclarator"
+            "start": 8,
+            "end": 14,
+            "operator": "==",
+            "left": {
+              "type": "Literal",
+              "start": 8,
+              "end": 9,
+              "value": 3,
+              "raw": "3"
+            },
+            "right": {
+              "type": "Literal",
+              "start": 13,
+              "end": 14,
+              "value": 3,
+              "raw": "3"
+            }
+          }
         }
       ],
-      "end": 14,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 14,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bf.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bf.snap
@@ -3,51 +3,47 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 14,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 14,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 4,
           "end": 14,
           "id": {
-            "end": 5,
-            "name": "x",
+            "type": "Identifier",
             "start": 4,
-            "type": "Identifier"
+            "end": 5,
+            "name": "x"
           },
           "init": {
-            "end": 14,
-            "left": {
-              "end": 9,
-              "raw": "3",
-              "start": 8,
-              "type": "Literal",
-              "type": "Literal",
-              "value": 3
-            },
-            "operator": "!=",
-            "right": {
-              "end": 14,
-              "raw": "3",
-              "start": 13,
-              "type": "Literal",
-              "type": "Literal",
-              "value": 3
-            },
-            "start": 8,
             "type": "BinaryExpression",
-            "type": "BinaryExpression"
-          },
-          "start": 4,
-          "type": "VariableDeclarator"
+            "start": 8,
+            "end": 14,
+            "operator": "!=",
+            "left": {
+              "type": "Literal",
+              "start": 8,
+              "end": 9,
+              "value": 3,
+              "raw": "3"
+            },
+            "right": {
+              "type": "Literal",
+              "start": 13,
+              "end": 14,
+              "value": 3,
+              "raw": "3"
+            }
+          }
         }
       ],
-      "end": 14,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 14,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bg.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bg.snap
@@ -3,36 +3,34 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 5,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 5,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 0,
           "end": 5,
           "id": {
-            "end": 1,
-            "name": "x",
+            "type": "Identifier",
             "start": 0,
-            "type": "Identifier"
+            "end": 1,
+            "name": "x"
           },
           "init": {
-            "end": 5,
-            "raw": "4",
+            "type": "Literal",
             "start": 4,
-            "type": "Literal",
-            "type": "Literal",
-            "value": 4
-          },
-          "start": 0,
-          "type": "VariableDeclarator"
+            "end": 5,
+            "value": 4,
+            "raw": "4"
+          }
         }
       ],
-      "end": 5,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 5,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bh.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bh.snap
@@ -3,90 +3,84 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 42,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 42,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 42,
           "id": {
-            "end": 9,
-            "name": "obj",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 9,
+            "name": "obj"
           },
           "init": {
+            "type": "ObjectExpression",
+            "start": 12,
             "end": 42,
             "properties": [
               {
+                "type": "ObjectProperty",
+                "start": 13,
                 "end": 30,
                 "key": {
-                  "end": 19,
-                  "name": "center",
+                  "type": "Identifier",
                   "start": 13,
-                  "type": "Identifier"
+                  "end": 19,
+                  "name": "center"
                 },
-                "start": 13,
-                "type": "ObjectProperty",
                 "value": {
+                  "type": "ArrayExpression",
+                  "start": 22,
+                  "end": 30,
                   "elements": [
                     {
-                      "end": 25,
-                      "raw": "10",
+                      "type": "Literal",
                       "start": 23,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 10
+                      "end": 25,
+                      "value": 10,
+                      "raw": "10"
                     },
                     {
-                      "end": 29,
-                      "raw": "10",
+                      "type": "Literal",
                       "start": 27,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 10
+                      "end": 29,
+                      "value": 10,
+                      "raw": "10"
                     }
-                  ],
-                  "end": 30,
-                  "start": 22,
-                  "type": "ArrayExpression",
-                  "type": "ArrayExpression"
+                  ]
                 }
               },
               {
+                "type": "ObjectProperty",
+                "start": 32,
                 "end": 41,
                 "key": {
-                  "end": 38,
-                  "name": "radius",
+                  "type": "Identifier",
                   "start": 32,
-                  "type": "Identifier"
+                  "end": 38,
+                  "name": "radius"
                 },
-                "start": 32,
-                "type": "ObjectProperty",
                 "value": {
-                  "end": 41,
-                  "raw": "5",
+                  "type": "Literal",
                   "start": 40,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 5
+                  "end": 41,
+                  "value": 5,
+                  "raw": "5"
                 }
               }
-            ],
-            "start": 12,
-            "type": "ObjectExpression",
-            "type": "ObjectExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            ]
+          }
         }
       ],
-      "end": 42,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 42,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__c.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__c.snap
@@ -3,89 +3,82 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 35,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 35,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 35,
           "id": {
-            "end": 11,
-            "name": "myVar",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 11,
+            "name": "myVar"
           },
           "init": {
+            "type": "CallExpression",
+            "start": 14,
+            "end": 35,
+            "callee": {
+              "type": "Identifier",
+              "start": 14,
+              "end": 17,
+              "name": "min"
+            },
             "arguments": [
               {
-                "argument": {
-                  "arguments": [
-                    {
-                      "end": 27,
-                      "raw": "5",
-                      "start": 26,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 5
-                    },
-                    {
-                      "end": 30,
-                      "raw": "4",
-                      "start": 29,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": 4
-                    }
-                  ],
-                  "callee": {
-                    "end": 25,
-                    "name": "legLen",
-                    "start": 19,
-                    "type": "Identifier"
-                  },
-                  "end": 31,
-                  "optional": false,
-                  "start": 19,
-                  "type": "CallExpression",
-                  "type": "CallExpression"
-                },
+                "type": "UnaryExpression",
+                "start": 18,
                 "end": 31,
                 "operator": "-",
-                "start": 18,
-                "type": "UnaryExpression",
-                "type": "UnaryExpression"
+                "argument": {
+                  "type": "CallExpression",
+                  "start": 19,
+                  "end": 31,
+                  "callee": {
+                    "type": "Identifier",
+                    "start": 19,
+                    "end": 25,
+                    "name": "legLen"
+                  },
+                  "arguments": [
+                    {
+                      "type": "Literal",
+                      "start": 26,
+                      "end": 27,
+                      "value": 5,
+                      "raw": "5"
+                    },
+                    {
+                      "type": "Literal",
+                      "start": 29,
+                      "end": 30,
+                      "value": 4,
+                      "raw": "4"
+                    }
+                  ],
+                  "optional": false
+                }
               },
               {
-                "end": 34,
-                "raw": "5",
+                "type": "Literal",
                 "start": 33,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 5
+                "end": 34,
+                "value": 5,
+                "raw": "5"
               }
             ],
-            "callee": {
-              "end": 17,
-              "name": "min",
-              "start": 14,
-              "type": "Identifier"
-            },
-            "end": 35,
-            "optional": false,
-            "start": 14,
-            "type": "CallExpression",
-            "type": "CallExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            "optional": false
+          }
         }
       ],
-      "end": 35,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 35,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__d.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__d.snap
@@ -3,88 +3,80 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 36,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 36,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 36,
           "id": {
-            "end": 11,
-            "name": "myVar",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 11,
+            "name": "myVar"
           },
           "init": {
+            "type": "PipeExpression",
+            "start": 14,
+            "end": 36,
             "body": [
               {
-                "end": 19,
-                "left": {
-                  "end": 15,
-                  "raw": "5",
-                  "start": 14,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 5
-                },
-                "operator": "+",
-                "right": {
-                  "end": 19,
-                  "raw": "6",
-                  "start": 18,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 6
-                },
-                "start": 14,
                 "type": "BinaryExpression",
-                "type": "BinaryExpression"
+                "start": 14,
+                "end": 19,
+                "operator": "+",
+                "left": {
+                  "type": "Literal",
+                  "start": 14,
+                  "end": 15,
+                  "value": 5,
+                  "raw": "5"
+                },
+                "right": {
+                  "type": "Literal",
+                  "start": 18,
+                  "end": 19,
+                  "value": 6,
+                  "raw": "6"
+                }
               },
               {
+                "type": "CallExpression",
+                "start": 23,
+                "end": 36,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 23,
+                  "end": 29,
+                  "name": "myFunc"
+                },
                 "arguments": [
                   {
-                    "end": 32,
-                    "raw": "45",
+                    "type": "Literal",
                     "start": 30,
-                    "type": "Literal",
-                    "type": "Literal",
-                    "value": 45
+                    "end": 32,
+                    "value": 45,
+                    "raw": "45"
                   },
                   {
-                    "end": 35,
-                    "start": 34,
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution"
+                    "start": 34,
+                    "end": 35
                   }
                 ],
-                "callee": {
-                  "end": 29,
-                  "name": "myFunc",
-                  "start": 23,
-                  "type": "Identifier"
-                },
-                "end": 36,
-                "optional": false,
-                "start": 23,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               }
-            ],
-            "end": 36,
-            "start": 14,
-            "type": "PipeExpression",
-            "type": "PipeExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            ]
+          }
         }
       ],
-      "end": 36,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 36,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__d2.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__d2.snap
@@ -3,56 +3,51 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 27,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 27,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 27,
           "id": {
-            "end": 7,
-            "name": "x",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 7,
+            "name": "x"
           },
           "init": {
+            "type": "BinaryExpression",
+            "start": 10,
             "end": 27,
+            "operator": "+",
             "left": {
-              "argument": {
-                "end": 15,
-                "name": "leg2",
-                "start": 11,
-                "type": "Identifier",
-                "type": "Identifier"
-              },
+              "type": "UnaryExpression",
+              "start": 10,
               "end": 15,
               "operator": "-",
-              "start": 10,
-              "type": "UnaryExpression",
-              "type": "UnaryExpression"
+              "argument": {
+                "type": "Identifier",
+                "start": 11,
+                "end": 15,
+                "name": "leg2"
+              }
             },
-            "operator": "+",
             "right": {
-              "end": 27,
-              "name": "thickness",
-              "start": 18,
               "type": "Identifier",
-              "type": "Identifier"
-            },
-            "start": 10,
-            "type": "BinaryExpression",
-            "type": "BinaryExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+              "start": 18,
+              "end": 27,
+              "name": "thickness"
+            }
+          }
         }
       ],
-      "end": 27,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 27,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__e.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__e.snap
@@ -3,66 +3,60 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 18,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 18,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 4,
           "end": 18,
           "id": {
-            "end": 5,
-            "name": "x",
+            "type": "Identifier",
             "start": 4,
-            "type": "Identifier"
+            "end": 5,
+            "name": "x"
           },
           "init": {
-            "end": 18,
-            "left": {
-              "end": 9,
-              "raw": "1",
-              "start": 8,
-              "type": "Literal",
-              "type": "Literal",
-              "value": 1
-            },
-            "operator": "*",
-            "right": {
-              "end": 18,
-              "left": {
-                "end": 14,
-                "raw": "3",
-                "start": 13,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 3
-              },
-              "operator": "-",
-              "right": {
-                "end": 18,
-                "raw": "4",
-                "start": 17,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 4
-              },
-              "start": 13,
-              "type": "BinaryExpression",
-              "type": "BinaryExpression"
-            },
-            "start": 8,
             "type": "BinaryExpression",
-            "type": "BinaryExpression"
-          },
-          "start": 4,
-          "type": "VariableDeclarator"
+            "start": 8,
+            "end": 18,
+            "operator": "*",
+            "left": {
+              "type": "Literal",
+              "start": 8,
+              "end": 9,
+              "value": 1,
+              "raw": "1"
+            },
+            "right": {
+              "type": "BinaryExpression",
+              "start": 13,
+              "end": 18,
+              "operator": "-",
+              "left": {
+                "type": "Literal",
+                "start": 13,
+                "end": 14,
+                "value": 3,
+                "raw": "3"
+              },
+              "right": {
+                "type": "Literal",
+                "start": 17,
+                "end": 18,
+                "value": 4,
+                "raw": "4"
+              }
+            }
+          }
         }
       ],
-      "end": 18,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 18,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__f.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__f.snap
@@ -3,44 +3,43 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 40,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 11,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 11,
           "id": {
-            "end": 7,
-            "name": "x",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 7,
+            "name": "x"
           },
           "init": {
-            "end": 11,
-            "raw": "1",
+            "type": "Literal",
             "start": 10,
-            "type": "Literal",
-            "type": "Literal",
-            "value": 1
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            "end": 11,
+            "value": 1,
+            "raw": "1"
+          }
         }
       ],
-      "end": 11,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
   ],
-  "end": 40,
   "nonCodeMeta": {
     "nonCodeNodes": {
       "0": [
         {
-          "end": 40,
-          "start": 11,
           "type": "NonCodeNode",
+          "start": 11,
+          "end": 40,
           "value": {
             "type": "inlineComment",
             "value": "this is an inline comment",
@@ -49,7 +48,6 @@ expression: actual
         }
       ]
     },
-    "startNodes": []
-  },
-  "start": 0
+    "start": []
+  }
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__g.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__g.snap
@@ -3,67 +3,61 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 58,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 58,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 3,
           "end": 58,
           "id": {
-            "end": 4,
-            "name": "x",
+            "type": "Identifier",
             "start": 3,
-            "type": "Identifier"
+            "end": 4,
+            "name": "x"
           },
           "init": {
-            "body": {
-              "body": [
-                {
-                  "argument": {
-                    "end": 32,
-                    "name": "sg",
-                    "start": 30,
-                    "type": "Identifier",
-                    "type": "Identifier"
-                  },
-                  "end": 32,
-                  "start": 23,
-                  "type": "ReturnStatement",
-                  "type": "ReturnStatement"
-                },
-                {
-                  "argument": {
-                    "end": 50,
-                    "name": "sg",
-                    "start": 48,
-                    "type": "Identifier",
-                    "type": "Identifier"
-                  },
-                  "end": 50,
-                  "start": 41,
-                  "type": "ReturnStatement",
-                  "type": "ReturnStatement"
-                }
-              ],
-              "end": 58,
-              "start": 13
-            },
+            "type": "FunctionExpression",
+            "start": 7,
             "end": 58,
             "params": [],
-            "start": 7,
-            "type": "FunctionExpression",
-            "type": "FunctionExpression"
-          },
-          "start": 3,
-          "type": "VariableDeclarator"
+            "body": {
+              "start": 13,
+              "end": 58,
+              "body": [
+                {
+                  "type": "ReturnStatement",
+                  "start": 23,
+                  "end": 32,
+                  "argument": {
+                    "type": "Identifier",
+                    "start": 30,
+                    "end": 32,
+                    "name": "sg"
+                  }
+                },
+                {
+                  "type": "ReturnStatement",
+                  "start": 41,
+                  "end": 50,
+                  "argument": {
+                    "type": "Identifier",
+                    "start": 48,
+                    "end": 50,
+                    "name": "sg"
+                  }
+                }
+              ]
+            }
+          }
         }
       ],
-      "end": 58,
-      "kind": "fn",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "fn"
     }
-  ],
-  "end": 58,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__h.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__h.snap
@@ -3,130 +3,120 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 55,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 26,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 26,
           "id": {
-            "end": 9,
-            "name": "obj",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 9,
+            "name": "obj"
           },
           "init": {
+            "type": "ObjectExpression",
+            "start": 12,
             "end": 26,
             "properties": [
               {
+                "type": "ObjectProperty",
+                "start": 14,
                 "end": 18,
                 "key": {
-                  "end": 15,
-                  "name": "a",
+                  "type": "Identifier",
                   "start": 14,
-                  "type": "Identifier"
+                  "end": 15,
+                  "name": "a"
                 },
-                "start": 14,
-                "type": "ObjectProperty",
                 "value": {
-                  "end": 18,
-                  "raw": "1",
+                  "type": "Literal",
                   "start": 17,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 1
+                  "end": 18,
+                  "value": 1,
+                  "raw": "1"
                 }
               },
               {
+                "type": "ObjectProperty",
+                "start": 20,
                 "end": 24,
                 "key": {
-                  "end": 21,
-                  "name": "b",
+                  "type": "Identifier",
                   "start": 20,
-                  "type": "Identifier"
+                  "end": 21,
+                  "name": "b"
                 },
-                "start": 20,
-                "type": "ObjectProperty",
                 "value": {
-                  "end": 24,
-                  "raw": "2",
+                  "type": "Literal",
                   "start": 23,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 2
+                  "end": 24,
+                  "value": 2,
+                  "raw": "2"
                 }
               }
-            ],
-            "start": 12,
-            "type": "ObjectExpression",
-            "type": "ObjectExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            ]
+          }
         }
       ],
-      "end": 26,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     },
     {
+      "type": "VariableDeclaration",
+      "start": 31,
+      "end": 55,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 37,
           "end": 55,
           "id": {
-            "end": 43,
-            "name": "height",
+            "type": "Identifier",
             "start": 37,
-            "type": "Identifier"
+            "end": 43,
+            "name": "height"
           },
           "init": {
+            "type": "BinaryExpression",
+            "start": 46,
             "end": 55,
-            "left": {
-              "end": 47,
-              "raw": "1",
-              "start": 46,
-              "type": "Literal",
-              "type": "Literal",
-              "value": 1
-            },
             "operator": "-",
+            "left": {
+              "type": "Literal",
+              "start": 46,
+              "end": 47,
+              "value": 1,
+              "raw": "1"
+            },
             "right": {
-              "computed": false,
+              "type": "MemberExpression",
+              "start": 50,
               "end": 55,
               "object": {
-                "end": 53,
-                "name": "obj",
-                "start": 50,
                 "type": "Identifier",
-                "type": "Identifier"
+                "start": 50,
+                "end": 53,
+                "name": "obj"
               },
               "property": {
-                "end": 55,
-                "name": "a",
-                "start": 54,
                 "type": "Identifier",
-                "type": "Identifier"
+                "start": 54,
+                "end": 55,
+                "name": "a"
               },
-              "start": 50,
-              "type": "MemberExpression",
-              "type": "MemberExpression"
-            },
-            "start": 46,
-            "type": "BinaryExpression",
-            "type": "BinaryExpression"
-          },
-          "start": 37,
-          "type": "VariableDeclarator"
+              "computed": false
+            }
+          }
         }
       ],
-      "end": 55,
-      "kind": "const",
-      "start": 31,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 55,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__i.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__i.snap
@@ -3,131 +3,121 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 59,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 26,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 26,
           "id": {
-            "end": 9,
-            "name": "obj",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 9,
+            "name": "obj"
           },
           "init": {
+            "type": "ObjectExpression",
+            "start": 12,
             "end": 26,
             "properties": [
               {
+                "type": "ObjectProperty",
+                "start": 14,
                 "end": 18,
                 "key": {
-                  "end": 15,
-                  "name": "a",
+                  "type": "Identifier",
                   "start": 14,
-                  "type": "Identifier"
+                  "end": 15,
+                  "name": "a"
                 },
-                "start": 14,
-                "type": "ObjectProperty",
                 "value": {
-                  "end": 18,
-                  "raw": "1",
+                  "type": "Literal",
                   "start": 17,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 1
+                  "end": 18,
+                  "value": 1,
+                  "raw": "1"
                 }
               },
               {
+                "type": "ObjectProperty",
+                "start": 20,
                 "end": 24,
                 "key": {
-                  "end": 21,
-                  "name": "b",
+                  "type": "Identifier",
                   "start": 20,
-                  "type": "Identifier"
+                  "end": 21,
+                  "name": "b"
                 },
-                "start": 20,
-                "type": "ObjectProperty",
                 "value": {
-                  "end": 24,
-                  "raw": "2",
+                  "type": "Literal",
                   "start": 23,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 2
+                  "end": 24,
+                  "value": 2,
+                  "raw": "2"
                 }
               }
-            ],
-            "start": 12,
-            "type": "ObjectExpression",
-            "type": "ObjectExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            ]
+          }
         }
       ],
-      "end": 26,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     },
     {
+      "type": "VariableDeclaration",
+      "start": 32,
+      "end": 59,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 38,
           "end": 59,
           "id": {
-            "end": 44,
-            "name": "height",
+            "type": "Identifier",
             "start": 38,
-            "type": "Identifier"
+            "end": 44,
+            "name": "height"
           },
           "init": {
+            "type": "BinaryExpression",
+            "start": 47,
             "end": 59,
-            "left": {
-              "end": 48,
-              "raw": "1",
-              "start": 47,
-              "type": "Literal",
-              "type": "Literal",
-              "value": 1
-            },
             "operator": "-",
+            "left": {
+              "type": "Literal",
+              "start": 47,
+              "end": 48,
+              "value": 1,
+              "raw": "1"
+            },
             "right": {
-              "computed": false,
+              "type": "MemberExpression",
+              "start": 51,
               "end": 59,
               "object": {
-                "end": 54,
-                "name": "obj",
-                "start": 51,
                 "type": "Identifier",
-                "type": "Identifier"
+                "start": 51,
+                "end": 54,
+                "name": "obj"
               },
               "property": {
-                "end": 58,
-                "raw": "\"a\"",
+                "type": "Literal",
                 "start": 55,
-                "type": "Literal",
-                "type": "Literal",
-                "value": "a"
+                "end": 58,
+                "value": "a",
+                "raw": "\"a\""
               },
-              "start": 51,
-              "type": "MemberExpression",
-              "type": "MemberExpression"
-            },
-            "start": 47,
-            "type": "BinaryExpression",
-            "type": "BinaryExpression"
-          },
-          "start": 38,
-          "type": "VariableDeclarator"
+              "computed": false
+            }
+          }
         }
       ],
-      "end": 59,
-      "kind": "const",
-      "start": 32,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 59,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__j.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__j.snap
@@ -3,131 +3,121 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 58,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 26,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 26,
           "id": {
-            "end": 9,
-            "name": "obj",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 9,
+            "name": "obj"
           },
           "init": {
+            "type": "ObjectExpression",
+            "start": 12,
             "end": 26,
             "properties": [
               {
+                "type": "ObjectProperty",
+                "start": 14,
                 "end": 18,
                 "key": {
-                  "end": 15,
-                  "name": "a",
+                  "type": "Identifier",
                   "start": 14,
-                  "type": "Identifier"
+                  "end": 15,
+                  "name": "a"
                 },
-                "start": 14,
-                "type": "ObjectProperty",
                 "value": {
-                  "end": 18,
-                  "raw": "1",
+                  "type": "Literal",
                   "start": 17,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 1
+                  "end": 18,
+                  "value": 1,
+                  "raw": "1"
                 }
               },
               {
+                "type": "ObjectProperty",
+                "start": 20,
                 "end": 24,
                 "key": {
-                  "end": 21,
-                  "name": "b",
+                  "type": "Identifier",
                   "start": 20,
-                  "type": "Identifier"
+                  "end": 21,
+                  "name": "b"
                 },
-                "start": 20,
-                "type": "ObjectProperty",
                 "value": {
-                  "end": 24,
-                  "raw": "2",
+                  "type": "Literal",
                   "start": 23,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 2
+                  "end": 24,
+                  "value": 2,
+                  "raw": "2"
                 }
               }
-            ],
-            "start": 12,
-            "type": "ObjectExpression",
-            "type": "ObjectExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            ]
+          }
         }
       ],
-      "end": 26,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     },
     {
+      "type": "VariableDeclaration",
+      "start": 31,
+      "end": 58,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 37,
           "end": 58,
           "id": {
-            "end": 43,
-            "name": "height",
+            "type": "Identifier",
             "start": 37,
-            "type": "Identifier"
+            "end": 43,
+            "name": "height"
           },
           "init": {
+            "type": "BinaryExpression",
+            "start": 46,
             "end": 58,
+            "operator": "-",
             "left": {
-              "computed": false,
+              "type": "MemberExpression",
+              "start": 46,
               "end": 54,
               "object": {
-                "end": 49,
-                "name": "obj",
-                "start": 46,
                 "type": "Identifier",
-                "type": "Identifier"
+                "start": 46,
+                "end": 49,
+                "name": "obj"
               },
               "property": {
-                "end": 53,
-                "raw": "\"a\"",
+                "type": "Literal",
                 "start": 50,
-                "type": "Literal",
-                "type": "Literal",
-                "value": "a"
+                "end": 53,
+                "value": "a",
+                "raw": "\"a\""
               },
-              "start": 46,
-              "type": "MemberExpression",
-              "type": "MemberExpression"
+              "computed": false
             },
-            "operator": "-",
             "right": {
-              "end": 58,
-              "raw": "1",
+              "type": "Literal",
               "start": 57,
-              "type": "Literal",
-              "type": "Literal",
-              "value": 1
-            },
-            "start": 46,
-            "type": "BinaryExpression",
-            "type": "BinaryExpression"
-          },
-          "start": 37,
-          "type": "VariableDeclarator"
+              "end": 58,
+              "value": 1,
+              "raw": "1"
+            }
+          }
         }
       ],
-      "end": 58,
-      "kind": "const",
-      "start": 31,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 58,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__k.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__k.snap
@@ -3,147 +3,135 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 63,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 26,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 26,
           "id": {
-            "end": 9,
-            "name": "obj",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 9,
+            "name": "obj"
           },
           "init": {
+            "type": "ObjectExpression",
+            "start": 12,
             "end": 26,
             "properties": [
               {
+                "type": "ObjectProperty",
+                "start": 14,
                 "end": 18,
                 "key": {
-                  "end": 15,
-                  "name": "a",
+                  "type": "Identifier",
                   "start": 14,
-                  "type": "Identifier"
+                  "end": 15,
+                  "name": "a"
                 },
-                "start": 14,
-                "type": "ObjectProperty",
                 "value": {
-                  "end": 18,
-                  "raw": "1",
+                  "type": "Literal",
                   "start": 17,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 1
+                  "end": 18,
+                  "value": 1,
+                  "raw": "1"
                 }
               },
               {
+                "type": "ObjectProperty",
+                "start": 20,
                 "end": 24,
                 "key": {
-                  "end": 21,
-                  "name": "b",
+                  "type": "Identifier",
                   "start": 20,
-                  "type": "Identifier"
+                  "end": 21,
+                  "name": "b"
                 },
-                "start": 20,
-                "type": "ObjectProperty",
                 "value": {
-                  "end": 24,
-                  "raw": "2",
+                  "type": "Literal",
                   "start": 23,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 2
+                  "end": 24,
+                  "value": 2,
+                  "raw": "2"
                 }
               }
-            ],
-            "start": 12,
-            "type": "ObjectExpression",
-            "type": "ObjectExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            ]
+          }
         }
       ],
-      "end": 26,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     },
     {
+      "type": "VariableDeclaration",
+      "start": 31,
+      "end": 63,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 37,
           "end": 63,
           "id": {
-            "end": 43,
-            "name": "height",
+            "type": "Identifier",
             "start": 37,
-            "type": "Identifier"
+            "end": 43,
+            "name": "height"
           },
           "init": {
+            "type": "ArrayExpression",
+            "start": 46,
+            "end": 63,
             "elements": [
               {
+                "type": "BinaryExpression",
+                "start": 47,
                 "end": 59,
-                "left": {
-                  "end": 48,
-                  "raw": "1",
-                  "start": 47,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 1
-                },
                 "operator": "-",
+                "left": {
+                  "type": "Literal",
+                  "start": 47,
+                  "end": 48,
+                  "value": 1,
+                  "raw": "1"
+                },
                 "right": {
-                  "computed": false,
+                  "type": "MemberExpression",
+                  "start": 51,
                   "end": 59,
                   "object": {
-                    "end": 54,
-                    "name": "obj",
-                    "start": 51,
                     "type": "Identifier",
-                    "type": "Identifier"
+                    "start": 51,
+                    "end": 54,
+                    "name": "obj"
                   },
                   "property": {
-                    "end": 58,
-                    "raw": "\"a\"",
+                    "type": "Literal",
                     "start": 55,
-                    "type": "Literal",
-                    "type": "Literal",
-                    "value": "a"
+                    "end": 58,
+                    "value": "a",
+                    "raw": "\"a\""
                   },
-                  "start": 51,
-                  "type": "MemberExpression",
-                  "type": "MemberExpression"
-                },
-                "start": 47,
-                "type": "BinaryExpression",
-                "type": "BinaryExpression"
+                  "computed": false
+                }
               },
               {
-                "end": 62,
-                "raw": "0",
+                "type": "Literal",
                 "start": 61,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 0
+                "end": 62,
+                "value": 0,
+                "raw": "0"
               }
-            ],
-            "end": 63,
-            "start": 46,
-            "type": "ArrayExpression",
-            "type": "ArrayExpression"
-          },
-          "start": 37,
-          "type": "VariableDeclarator"
+            ]
+          }
         }
       ],
-      "end": 63,
-      "kind": "const",
-      "start": 31,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 63,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__l.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__l.snap
@@ -3,147 +3,135 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 63,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 26,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 26,
           "id": {
-            "end": 9,
-            "name": "obj",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 9,
+            "name": "obj"
           },
           "init": {
+            "type": "ObjectExpression",
+            "start": 12,
             "end": 26,
             "properties": [
               {
+                "type": "ObjectProperty",
+                "start": 14,
                 "end": 18,
                 "key": {
-                  "end": 15,
-                  "name": "a",
+                  "type": "Identifier",
                   "start": 14,
-                  "type": "Identifier"
+                  "end": 15,
+                  "name": "a"
                 },
-                "start": 14,
-                "type": "ObjectProperty",
                 "value": {
-                  "end": 18,
-                  "raw": "1",
+                  "type": "Literal",
                   "start": 17,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 1
+                  "end": 18,
+                  "value": 1,
+                  "raw": "1"
                 }
               },
               {
+                "type": "ObjectProperty",
+                "start": 20,
                 "end": 24,
                 "key": {
-                  "end": 21,
-                  "name": "b",
+                  "type": "Identifier",
                   "start": 20,
-                  "type": "Identifier"
+                  "end": 21,
+                  "name": "b"
                 },
-                "start": 20,
-                "type": "ObjectProperty",
                 "value": {
-                  "end": 24,
-                  "raw": "2",
+                  "type": "Literal",
                   "start": 23,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 2
+                  "end": 24,
+                  "value": 2,
+                  "raw": "2"
                 }
               }
-            ],
-            "start": 12,
-            "type": "ObjectExpression",
-            "type": "ObjectExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            ]
+          }
         }
       ],
-      "end": 26,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     },
     {
+      "type": "VariableDeclaration",
+      "start": 31,
+      "end": 63,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 37,
           "end": 63,
           "id": {
-            "end": 43,
-            "name": "height",
+            "type": "Identifier",
             "start": 37,
-            "type": "Identifier"
+            "end": 43,
+            "name": "height"
           },
           "init": {
+            "type": "ArrayExpression",
+            "start": 46,
+            "end": 63,
             "elements": [
               {
+                "type": "BinaryExpression",
+                "start": 47,
                 "end": 59,
+                "operator": "-",
                 "left": {
-                  "computed": false,
+                  "type": "MemberExpression",
+                  "start": 47,
                   "end": 55,
                   "object": {
-                    "end": 50,
-                    "name": "obj",
-                    "start": 47,
                     "type": "Identifier",
-                    "type": "Identifier"
+                    "start": 47,
+                    "end": 50,
+                    "name": "obj"
                   },
                   "property": {
-                    "end": 54,
-                    "raw": "\"a\"",
+                    "type": "Literal",
                     "start": 51,
-                    "type": "Literal",
-                    "type": "Literal",
-                    "value": "a"
+                    "end": 54,
+                    "value": "a",
+                    "raw": "\"a\""
                   },
-                  "start": 47,
-                  "type": "MemberExpression",
-                  "type": "MemberExpression"
+                  "computed": false
                 },
-                "operator": "-",
                 "right": {
-                  "end": 59,
-                  "raw": "1",
+                  "type": "Literal",
                   "start": 58,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 1
-                },
-                "start": 47,
-                "type": "BinaryExpression",
-                "type": "BinaryExpression"
+                  "end": 59,
+                  "value": 1,
+                  "raw": "1"
+                }
               },
               {
-                "end": 62,
-                "raw": "0",
+                "type": "Literal",
                 "start": 61,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 0
+                "end": 62,
+                "value": 0,
+                "raw": "0"
               }
-            ],
-            "end": 63,
-            "start": 46,
-            "type": "ArrayExpression",
-            "type": "ArrayExpression"
-          },
-          "start": 37,
-          "type": "VariableDeclarator"
+            ]
+          }
         }
       ],
-      "end": 63,
-      "kind": "const",
-      "start": 31,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 63,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__m.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__m.snap
@@ -3,147 +3,135 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 62,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 26,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 26,
           "id": {
-            "end": 9,
-            "name": "obj",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 9,
+            "name": "obj"
           },
           "init": {
+            "type": "ObjectExpression",
+            "start": 12,
             "end": 26,
             "properties": [
               {
+                "type": "ObjectProperty",
+                "start": 14,
                 "end": 18,
                 "key": {
-                  "end": 15,
-                  "name": "a",
+                  "type": "Identifier",
                   "start": 14,
-                  "type": "Identifier"
+                  "end": 15,
+                  "name": "a"
                 },
-                "start": 14,
-                "type": "ObjectProperty",
                 "value": {
-                  "end": 18,
-                  "raw": "1",
+                  "type": "Literal",
                   "start": 17,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 1
+                  "end": 18,
+                  "value": 1,
+                  "raw": "1"
                 }
               },
               {
+                "type": "ObjectProperty",
+                "start": 20,
                 "end": 24,
                 "key": {
-                  "end": 21,
-                  "name": "b",
+                  "type": "Identifier",
                   "start": 20,
-                  "type": "Identifier"
+                  "end": 21,
+                  "name": "b"
                 },
-                "start": 20,
-                "type": "ObjectProperty",
                 "value": {
-                  "end": 24,
-                  "raw": "2",
+                  "type": "Literal",
                   "start": 23,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 2
+                  "end": 24,
+                  "value": 2,
+                  "raw": "2"
                 }
               }
-            ],
-            "start": 12,
-            "type": "ObjectExpression",
-            "type": "ObjectExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            ]
+          }
         }
       ],
-      "end": 26,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     },
     {
+      "type": "VariableDeclaration",
+      "start": 31,
+      "end": 62,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 37,
           "end": 62,
           "id": {
-            "end": 43,
-            "name": "height",
+            "type": "Identifier",
             "start": 37,
-            "type": "Identifier"
+            "end": 43,
+            "name": "height"
           },
           "init": {
+            "type": "ArrayExpression",
+            "start": 46,
+            "end": 62,
             "elements": [
               {
+                "type": "BinaryExpression",
+                "start": 47,
                 "end": 58,
+                "operator": "-",
                 "left": {
-                  "computed": false,
+                  "type": "MemberExpression",
+                  "start": 47,
                   "end": 55,
                   "object": {
-                    "end": 50,
-                    "name": "obj",
-                    "start": 47,
                     "type": "Identifier",
-                    "type": "Identifier"
+                    "start": 47,
+                    "end": 50,
+                    "name": "obj"
                   },
                   "property": {
-                    "end": 54,
-                    "raw": "\"a\"",
+                    "type": "Literal",
                     "start": 51,
-                    "type": "Literal",
-                    "type": "Literal",
-                    "value": "a"
+                    "end": 54,
+                    "value": "a",
+                    "raw": "\"a\""
                   },
-                  "start": 47,
-                  "type": "MemberExpression",
-                  "type": "MemberExpression"
+                  "computed": false
                 },
-                "operator": "-",
                 "right": {
-                  "end": 58,
-                  "raw": "1",
+                  "type": "Literal",
                   "start": 57,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 1
-                },
-                "start": 47,
-                "type": "BinaryExpression",
-                "type": "BinaryExpression"
+                  "end": 58,
+                  "value": 1,
+                  "raw": "1"
+                }
               },
               {
-                "end": 61,
-                "raw": "0",
+                "type": "Literal",
                 "start": 60,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 0
+                "end": 61,
+                "value": 0,
+                "raw": "0"
               }
-            ],
-            "end": 62,
-            "start": 46,
-            "type": "ArrayExpression",
-            "type": "ArrayExpression"
-          },
-          "start": 37,
-          "type": "VariableDeclarator"
+            ]
+          }
         }
       ],
-      "end": 62,
-      "kind": "const",
-      "start": 31,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 62,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__n.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__n.snap
@@ -3,64 +3,58 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 24,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 24,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 24,
           "id": {
-            "end": 12,
-            "name": "height",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 12,
+            "name": "height"
           },
           "init": {
+            "type": "BinaryExpression",
+            "start": 15,
             "end": 24,
-            "left": {
-              "end": 16,
-              "raw": "1",
-              "start": 15,
-              "type": "Literal",
-              "type": "Literal",
-              "value": 1
-            },
             "operator": "-",
+            "left": {
+              "type": "Literal",
+              "start": 15,
+              "end": 16,
+              "value": 1,
+              "raw": "1"
+            },
             "right": {
-              "computed": false,
+              "type": "MemberExpression",
+              "start": 19,
               "end": 24,
               "object": {
-                "end": 22,
-                "name": "obj",
-                "start": 19,
                 "type": "Identifier",
-                "type": "Identifier"
+                "start": 19,
+                "end": 22,
+                "name": "obj"
               },
               "property": {
-                "end": 24,
-                "name": "a",
-                "start": 23,
                 "type": "Identifier",
-                "type": "Identifier"
+                "start": 23,
+                "end": 24,
+                "name": "a"
               },
-              "start": 19,
-              "type": "MemberExpression",
-              "type": "MemberExpression"
-            },
-            "start": 15,
-            "type": "BinaryExpression",
-            "type": "BinaryExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+              "computed": false
+            }
+          }
         }
       ],
-      "end": 24,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 24,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__o.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__o.snap
@@ -3,66 +3,60 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 21,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 21,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 21,
           "id": {
-            "end": 9,
-            "name": "six",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 9,
+            "name": "six"
           },
           "init": {
-            "end": 21,
-            "left": {
-              "end": 17,
-              "left": {
-                "end": 13,
-                "raw": "1",
-                "start": 12,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 1
-              },
-              "operator": "+",
-              "right": {
-                "end": 17,
-                "raw": "2",
-                "start": 16,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 2
-              },
-              "start": 12,
-              "type": "BinaryExpression",
-              "type": "BinaryExpression"
-            },
-            "operator": "+",
-            "right": {
-              "end": 21,
-              "raw": "3",
-              "start": 20,
-              "type": "Literal",
-              "type": "Literal",
-              "value": 3
-            },
-            "start": 12,
             "type": "BinaryExpression",
-            "type": "BinaryExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            "start": 12,
+            "end": 21,
+            "operator": "+",
+            "left": {
+              "type": "BinaryExpression",
+              "start": 12,
+              "end": 17,
+              "operator": "+",
+              "left": {
+                "type": "Literal",
+                "start": 12,
+                "end": 13,
+                "value": 1,
+                "raw": "1"
+              },
+              "right": {
+                "type": "Literal",
+                "start": 16,
+                "end": 17,
+                "value": 2,
+                "raw": "2"
+              }
+            },
+            "right": {
+              "type": "Literal",
+              "start": 20,
+              "end": 21,
+              "value": 3,
+              "raw": "3"
+            }
+          }
         }
       ],
-      "end": 21,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 21,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__p.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__p.snap
@@ -3,66 +3,60 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 22,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 22,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 22,
           "id": {
-            "end": 10,
-            "name": "five",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 10,
+            "name": "five"
           },
           "init": {
-            "end": 22,
-            "left": {
-              "end": 18,
-              "left": {
-                "end": 14,
-                "raw": "3",
-                "start": 13,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 3
-              },
-              "operator": "*",
-              "right": {
-                "end": 18,
-                "raw": "1",
-                "start": 17,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 1
-              },
-              "start": 13,
-              "type": "BinaryExpression",
-              "type": "BinaryExpression"
-            },
-            "operator": "+",
-            "right": {
-              "end": 22,
-              "raw": "2",
-              "start": 21,
-              "type": "Literal",
-              "type": "Literal",
-              "value": 2
-            },
-            "start": 13,
             "type": "BinaryExpression",
-            "type": "BinaryExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            "start": 13,
+            "end": 22,
+            "operator": "+",
+            "left": {
+              "type": "BinaryExpression",
+              "start": 13,
+              "end": 18,
+              "operator": "*",
+              "left": {
+                "type": "Literal",
+                "start": 13,
+                "end": 14,
+                "value": 3,
+                "raw": "3"
+              },
+              "right": {
+                "type": "Literal",
+                "start": 17,
+                "end": 18,
+                "value": 1,
+                "raw": "1"
+              }
+            },
+            "right": {
+              "type": "Literal",
+              "start": 21,
+              "end": 22,
+              "value": 2,
+              "raw": "2"
+            }
+          }
         }
       ],
-      "end": 22,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 22,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__q.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__q.snap
@@ -3,66 +3,60 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 30,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 30,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 30,
           "id": {
-            "end": 12,
-            "name": "height",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 12,
+            "name": "height"
           },
           "init": {
+            "type": "ArrayExpression",
+            "start": 15,
+            "end": 30,
             "elements": [
               {
-                "computed": false,
+                "type": "MemberExpression",
+                "start": 17,
                 "end": 25,
                 "object": {
-                  "end": 20,
-                  "name": "obj",
-                  "start": 17,
                   "type": "Identifier",
-                  "type": "Identifier"
+                  "start": 17,
+                  "end": 20,
+                  "name": "obj"
                 },
                 "property": {
-                  "end": 24,
-                  "raw": "\"a\"",
+                  "type": "Literal",
                   "start": 21,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": "a"
+                  "end": 24,
+                  "value": "a",
+                  "raw": "\"a\""
                 },
-                "start": 17,
-                "type": "MemberExpression",
-                "type": "MemberExpression"
+                "computed": false
               },
               {
-                "end": 28,
-                "raw": "0",
+                "type": "Literal",
                 "start": 27,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 0
+                "end": 28,
+                "value": 0,
+                "raw": "0"
               }
-            ],
-            "end": 30,
-            "start": 15,
-            "type": "ArrayExpression",
-            "type": "ArrayExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            ]
+          }
         }
       ],
-      "end": 30,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 30,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__r.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__r.snap
@@ -3,116 +3,108 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 54,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 26,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 26,
           "id": {
-            "end": 9,
-            "name": "obj",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 9,
+            "name": "obj"
           },
           "init": {
+            "type": "ObjectExpression",
+            "start": 12,
             "end": 26,
             "properties": [
               {
+                "type": "ObjectProperty",
+                "start": 14,
                 "end": 18,
                 "key": {
-                  "end": 15,
-                  "name": "a",
+                  "type": "Identifier",
                   "start": 14,
-                  "type": "Identifier"
+                  "end": 15,
+                  "name": "a"
                 },
-                "start": 14,
-                "type": "ObjectProperty",
                 "value": {
-                  "end": 18,
-                  "raw": "1",
+                  "type": "Literal",
                   "start": 17,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 1
+                  "end": 18,
+                  "value": 1,
+                  "raw": "1"
                 }
               },
               {
+                "type": "ObjectProperty",
+                "start": 20,
                 "end": 24,
                 "key": {
-                  "end": 21,
-                  "name": "b",
+                  "type": "Identifier",
                   "start": 20,
-                  "type": "Identifier"
+                  "end": 21,
+                  "name": "b"
                 },
-                "start": 20,
-                "type": "ObjectProperty",
                 "value": {
-                  "end": 24,
-                  "raw": "2",
+                  "type": "Literal",
                   "start": 23,
-                  "type": "Literal",
-                  "type": "Literal",
-                  "value": 2
+                  "end": 24,
+                  "value": 2,
+                  "raw": "2"
                 }
               }
-            ],
-            "start": 12,
-            "type": "ObjectExpression",
-            "type": "ObjectExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            ]
+          }
         }
       ],
-      "end": 26,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     },
     {
+      "type": "VariableDeclaration",
+      "start": 31,
+      "end": 54,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 37,
           "end": 54,
           "id": {
-            "end": 43,
-            "name": "height",
+            "type": "Identifier",
             "start": 37,
-            "type": "Identifier"
+            "end": 43,
+            "name": "height"
           },
           "init": {
-            "computed": false,
+            "type": "MemberExpression",
+            "start": 46,
             "end": 54,
             "object": {
-              "end": 49,
-              "name": "obj",
-              "start": 46,
               "type": "Identifier",
-              "type": "Identifier"
+              "start": 46,
+              "end": 49,
+              "name": "obj"
             },
             "property": {
-              "end": 53,
-              "raw": "\"a\"",
+              "type": "Literal",
               "start": 50,
-              "type": "Literal",
-              "type": "Literal",
-              "value": "a"
+              "end": 53,
+              "value": "a",
+              "raw": "\"a\""
             },
-            "start": 46,
-            "type": "MemberExpression",
-            "type": "MemberExpression"
-          },
-          "start": 37,
-          "type": "VariableDeclarator"
+            "computed": false
+          }
         }
       ],
-      "end": 54,
-      "kind": "const",
-      "start": 31,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 54,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__s.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__s.snap
@@ -3,64 +3,58 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 27,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 27,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 27,
           "id": {
-            "end": 10,
-            "name": "prop",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 10,
+            "name": "prop"
           },
           "init": {
-            "computed": true,
+            "type": "MemberExpression",
+            "start": 13,
             "end": 27,
             "object": {
-              "computed": false,
+              "type": "MemberExpression",
+              "start": 13,
               "end": 22,
               "object": {
-                "end": 15,
-                "name": "yo",
-                "start": 13,
                 "type": "Identifier",
-                "type": "Identifier"
+                "start": 13,
+                "end": 15,
+                "name": "yo"
               },
               "property": {
-                "end": 21,
-                "raw": "\"one\"",
+                "type": "Literal",
                 "start": 16,
-                "type": "Literal",
-                "type": "Literal",
-                "value": "one"
+                "end": 21,
+                "value": "one",
+                "raw": "\"one\""
               },
-              "start": 13,
-              "type": "MemberExpression",
-              "type": "MemberExpression"
+              "computed": false
             },
             "property": {
-              "end": 26,
-              "name": "two",
-              "start": 23,
               "type": "Identifier",
-              "type": "Identifier"
+              "start": 23,
+              "end": 26,
+              "name": "two"
             },
-            "start": 13,
-            "type": "MemberExpression",
-            "type": "MemberExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            "computed": true
+          }
         }
       ],
-      "end": 27,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 27,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__t.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__t.snap
@@ -3,49 +3,45 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 17,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 17,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 17,
           "id": {
-            "end": 9,
-            "name": "pt1",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 9,
+            "name": "pt1"
           },
           "init": {
-            "computed": true,
+            "type": "MemberExpression",
+            "start": 12,
             "end": 17,
             "object": {
-              "end": 14,
-              "name": "b1",
-              "start": 12,
               "type": "Identifier",
-              "type": "Identifier"
+              "start": 12,
+              "end": 14,
+              "name": "b1"
             },
             "property": {
-              "end": 16,
-              "name": "x",
-              "start": 15,
               "type": "Identifier",
-              "type": "Identifier"
+              "start": 15,
+              "end": 16,
+              "name": "x"
             },
-            "start": 12,
-            "type": "MemberExpression",
-            "type": "MemberExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            "computed": true
+          }
         }
       ],
-      "end": 17,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 17,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__u.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__u.snap
@@ -3,91 +3,81 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 34,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 34,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 34,
           "id": {
-            "end": 10,
-            "name": "prop",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 10,
+            "name": "prop"
           },
           "init": {
-            "computed": false,
+            "type": "MemberExpression",
+            "start": 13,
             "end": 34,
             "object": {
-              "computed": false,
+              "type": "MemberExpression",
+              "start": 13,
               "end": 29,
               "object": {
-                "computed": false,
+                "type": "MemberExpression",
+                "start": 13,
                 "end": 23,
                 "object": {
-                  "computed": false,
+                  "type": "MemberExpression",
+                  "start": 13,
                   "end": 19,
                   "object": {
-                    "end": 15,
-                    "name": "yo",
-                    "start": 13,
                     "type": "Identifier",
-                    "type": "Identifier"
+                    "start": 13,
+                    "end": 15,
+                    "name": "yo"
                   },
                   "property": {
-                    "end": 19,
-                    "name": "one",
-                    "start": 16,
                     "type": "Identifier",
-                    "type": "Identifier"
+                    "start": 16,
+                    "end": 19,
+                    "name": "one"
                   },
-                  "start": 13,
-                  "type": "MemberExpression",
-                  "type": "MemberExpression"
+                  "computed": false
                 },
                 "property": {
-                  "end": 23,
-                  "name": "two",
-                  "start": 20,
                   "type": "Identifier",
-                  "type": "Identifier"
+                  "start": 20,
+                  "end": 23,
+                  "name": "two"
                 },
-                "start": 13,
-                "type": "MemberExpression",
-                "type": "MemberExpression"
+                "computed": false
               },
               "property": {
-                "end": 29,
-                "name": "three",
-                "start": 24,
                 "type": "Identifier",
-                "type": "Identifier"
+                "start": 24,
+                "end": 29,
+                "name": "three"
               },
-              "start": 13,
-              "type": "MemberExpression",
-              "type": "MemberExpression"
+              "computed": false
             },
             "property": {
-              "end": 34,
-              "name": "four",
-              "start": 30,
               "type": "Identifier",
-              "type": "Identifier"
+              "start": 30,
+              "end": 34,
+              "name": "four"
             },
-            "start": 13,
-            "type": "MemberExpression",
-            "type": "MemberExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            "computed": false
+          }
         }
       ],
-      "end": 34,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 34,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__v.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__v.snap
@@ -3,50 +3,46 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 17,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 17,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 17,
           "id": {
-            "end": 9,
-            "name": "pt1",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 9,
+            "name": "pt1"
           },
           "init": {
-            "computed": false,
+            "type": "MemberExpression",
+            "start": 12,
             "end": 17,
             "object": {
-              "end": 14,
-              "name": "b1",
-              "start": 12,
               "type": "Identifier",
-              "type": "Identifier"
+              "start": 12,
+              "end": 14,
+              "name": "b1"
             },
             "property": {
-              "end": 16,
-              "raw": "0",
+              "type": "Literal",
               "start": 15,
-              "type": "Literal",
-              "type": "Literal",
-              "value": 0
+              "end": 16,
+              "value": 0,
+              "raw": "0"
             },
-            "start": 12,
-            "type": "MemberExpression",
-            "type": "MemberExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            "computed": false
+          }
         }
       ],
-      "end": 17,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 17,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__w.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__w.snap
@@ -3,50 +3,46 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 22,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 22,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 22,
           "id": {
-            "end": 9,
-            "name": "pt1",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 9,
+            "name": "pt1"
           },
           "init": {
-            "computed": false,
+            "type": "MemberExpression",
+            "start": 12,
             "end": 22,
             "object": {
-              "end": 14,
-              "name": "b1",
-              "start": 12,
               "type": "Identifier",
-              "type": "Identifier"
+              "start": 12,
+              "end": 14,
+              "name": "b1"
             },
             "property": {
-              "end": 21,
-              "raw": "'zero'",
+              "type": "Literal",
               "start": 15,
-              "type": "Literal",
-              "type": "Literal",
-              "value": "zero"
+              "end": 21,
+              "value": "zero",
+              "raw": "'zero'"
             },
-            "start": 12,
-            "type": "MemberExpression",
-            "type": "MemberExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            "computed": false
+          }
         }
       ],
-      "end": 22,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 22,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__x.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__x.snap
@@ -3,49 +3,45 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 19,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 19,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 19,
           "id": {
-            "end": 9,
-            "name": "pt1",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 9,
+            "name": "pt1"
           },
           "init": {
-            "computed": false,
+            "type": "MemberExpression",
+            "start": 12,
             "end": 19,
             "object": {
-              "end": 14,
-              "name": "b1",
-              "start": 12,
               "type": "Identifier",
-              "type": "Identifier"
+              "start": 12,
+              "end": 14,
+              "name": "b1"
             },
             "property": {
-              "end": 19,
-              "name": "zero",
-              "start": 15,
               "type": "Identifier",
-              "type": "Identifier"
+              "start": 15,
+              "end": 19,
+              "name": "zero"
             },
-            "start": 12,
-            "type": "MemberExpression",
-            "type": "MemberExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            "computed": false
+          }
         }
       ],
-      "end": 19,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 19,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__y.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__y.snap
@@ -3,50 +3,47 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 29,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 29,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 29,
           "id": {
-            "end": 8,
-            "name": "sg",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 8,
+            "name": "sg"
           },
           "init": {
+            "type": "CallExpression",
+            "start": 11,
+            "end": 29,
+            "callee": {
+              "type": "Identifier",
+              "start": 11,
+              "end": 24,
+              "name": "startSketchAt"
+            },
             "arguments": [
               {
-                "end": 28,
-                "name": "pos",
-                "start": 25,
                 "type": "Identifier",
-                "type": "Identifier"
+                "start": 25,
+                "end": 28,
+                "name": "pos"
               }
             ],
-            "callee": {
-              "end": 24,
-              "name": "startSketchAt",
-              "start": 11,
-              "type": "Identifier"
-            },
-            "end": 29,
-            "optional": false,
-            "start": 11,
-            "type": "CallExpression",
-            "type": "CallExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            "optional": false
+          }
         }
       ],
-      "end": 29,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 29,
-  "start": 0
+  ]
 }

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__z.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__z.snap
@@ -3,109 +3,99 @@ source: kcl/src/parser/parser_impl.rs
 expression: actual
 ---
 {
+  "start": 0,
+  "end": 53,
   "body": [
     {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 53,
       "declarations": [
         {
+          "type": "VariableDeclarator",
+          "start": 6,
           "end": 53,
           "id": {
-            "end": 8,
-            "name": "sg",
+            "type": "Identifier",
             "start": 6,
-            "type": "Identifier"
+            "end": 8,
+            "name": "sg"
           },
           "init": {
+            "type": "PipeExpression",
+            "start": 11,
+            "end": 53,
             "body": [
               {
+                "type": "CallExpression",
+                "start": 11,
+                "end": 29,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 11,
+                  "end": 24,
+                  "name": "startSketchAt"
+                },
                 "arguments": [
                   {
-                    "end": 28,
-                    "name": "pos",
-                    "start": 25,
                     "type": "Identifier",
-                    "type": "Identifier"
+                    "start": 25,
+                    "end": 28,
+                    "name": "pos"
                   }
                 ],
-                "callee": {
-                  "end": 24,
-                  "name": "startSketchAt",
-                  "start": 11,
-                  "type": "Identifier"
-                },
-                "end": 29,
-                "optional": false,
-                "start": 11,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               },
               {
+                "type": "CallExpression",
+                "start": 33,
+                "end": 53,
+                "callee": {
+                  "type": "Identifier",
+                  "start": 33,
+                  "end": 37,
+                  "name": "line"
+                },
                 "arguments": [
                   {
+                    "type": "ArrayExpression",
+                    "start": 38,
+                    "end": 49,
                     "elements": [
                       {
-                        "end": 40,
-                        "raw": "0",
+                        "type": "Literal",
                         "start": 39,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": 0
+                        "end": 40,
+                        "value": 0,
+                        "raw": "0"
                       },
                       {
-                        "argument": {
-                          "end": 48,
-                          "name": "scale",
-                          "start": 43,
-                          "type": "Identifier",
-                          "type": "Identifier"
-                        },
+                        "type": "UnaryExpression",
+                        "start": 42,
                         "end": 48,
                         "operator": "-",
-                        "start": 42,
-                        "type": "UnaryExpression",
-                        "type": "UnaryExpression"
+                        "argument": {
+                          "type": "Identifier",
+                          "start": 43,
+                          "end": 48,
+                          "name": "scale"
+                        }
                       }
-                    ],
-                    "end": 49,
-                    "start": 38,
-                    "type": "ArrayExpression",
-                    "type": "ArrayExpression"
+                    ]
                   },
                   {
-                    "end": 52,
-                    "start": 51,
                     "type": "PipeSubstitution",
-                    "type": "PipeSubstitution"
+                    "start": 51,
+                    "end": 52
                   }
                 ],
-                "callee": {
-                  "end": 37,
-                  "name": "line",
-                  "start": 33,
-                  "type": "Identifier"
-                },
-                "end": 53,
-                "optional": false,
-                "start": 33,
-                "type": "CallExpression",
-                "type": "CallExpression"
+                "optional": false
               }
-            ],
-            "end": 53,
-            "start": 11,
-            "type": "PipeExpression",
-            "type": "PipeExpression"
-          },
-          "start": 6,
-          "type": "VariableDeclarator"
+            ]
+          }
         }
       ],
-      "end": 53,
-      "kind": "const",
-      "start": 0,
-      "type": "VariableDeclaration",
-      "type": "VariableDeclaration"
+      "kind": "const"
     }
-  ],
-  "end": 53,
-  "start": 0
+  ]
 }


### PR DESCRIPTION
KCL serializes its AST nodes serialize to JSON. This way they can be read by the frontend. We also serialize to JSON for the parser's snapshot tests.

There's an unfortunate effect where we use `serde(tag = "type")` on both the `enum Expr` and on the individual AST node `struct` types stored within that enum. So the `Expr::Literal(Literal{...})` gets _two_ `type: "Literal"` tags (one from the enum wrapper, and one from the struct). This just seems weird, you get JSON like `{"type": "Literal", "type": "Literal", value: 3}`. Duplicate keys are technically OK JSON, but it's weird and adds a lot of noise to our snapshot tests.

We can't remove the tag from the individual structs, because the frontend needs to check (at runtime) what kind of node each AST node is. So we have to remove it from the enum. But there's a problem: `#[serde(tag)]` on a struct is only used when serializing. It doesn't get checked when deserializing. So we cannot rely on that tag attribute to deserialize `enum Expr` into the correct variants.

So, we have to keep the tag on each struct, but make sure it's read during deserialization.

Define a new tag type for `Literal` which serializes to the string `"Literal"`. It becomes part of the `struct Literal`. We do this for each kind of expression struct, then change the `serde(tag = "type")`  on `enum Expr` to `serde(untagged)`.

You can look at the snapshot tests and see a lot of removed JSON duplicate keys. I also added a new test in `ast/types.rs` showing that serde can now serialize then deserialize an AST. Previously this test would have panicked, complaining about duplicate keys.