### PR TITLE
Remove references to wasm-dev build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ $(XSTATE_TYPEGENS): $(TS_SRC)
 	yarn xstate typegen 'src/**/*.ts?(x)'
 
 public/wasm_lib_bg.wasm: $(WASM_LIB_FILES)
-	yarn build:wasm-dev
+	yarn build:wasm
 
 node_modules: package.json yarn.lock
 	yarn install

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Which commands from setup are one off vs need to be run every time?
 The following will need to be run when checking out a new commit and guarantees the build is not stale:
 ```bash
 yarn install
-yarn build:wasm-dev # or yarn build:wasm for slower but more production-like build
+yarn build:wasm
 yarn start # or yarn build:local && yarn serve for slower but more production-like build
 ```
 


### PR DESCRIPTION
WASM dev builds are so slow that they trigger race conditions, and the UI breaks. We've accidentally released dev builds before. No one should be using dev builds, unless you absolutely know what you're doing. Many of us have stopped using this for dev a long time ago.