### PR TITLE
Bug fix: fix autocompletion regression

### DIFF
--- a/e2e/playwright/editor-tests.spec.ts
+++ b/e2e/playwright/editor-tests.spec.ts
@@ -694,6 +694,9 @@ test.describe('Editor tests', () => {
         .toHaveText(`sketch001 = startSketchOn('XZ')
     |> startProfileAt([3.14, 12], %)
     |> xLine(5, %) // lin`)
+
+      // expect there to be no KCL errors
+      await expect(page.locator('.cm-lint-marker-error')).toHaveCount(0)
     })
 
     test('with tab to accept the completion', async ({ page }) => {

--- a/src/editor/manager.ts
+++ b/src/editor/manager.ts
@@ -61,9 +61,7 @@ export default class EditorManager {
 
   setEditorView(editorView: EditorView) {
     this._editorView = editorView
-    // TODO: There is a bug with this override that is causing
-    // the editor to lock-up after an autocompletion is selected.
-    // this.overrideTreeHighlighterUpdateForPerformanceTracking()
+    this.overrideTreeHighlighterUpdateForPerformanceTracking()
   }
 
   overrideTreeHighlighterUpdateForPerformanceTracking() {
@@ -74,9 +72,10 @@ export default class EditorManager {
       // we cannot use <>.constructor.name since it will get destroyed
       // when packaging the application.
       const isTreeHighlightPlugin =
-        e.value.hasOwnProperty('tree') &&
-        e.value.hasOwnProperty('decoratedTo') &&
-        e.value.hasOwnProperty('decorations')
+        e?.value &&
+        e.value?.hasOwnProperty('tree') &&
+        e.value?.hasOwnProperty('decoratedTo') &&
+        e.value?.hasOwnProperty('decorations')
 
       if (isTreeHighlightPlugin) {
         let originalUpdate = e.value.update

--- a/src/editor/manager.ts
+++ b/src/editor/manager.ts
@@ -61,7 +61,9 @@ export default class EditorManager {
 
   setEditorView(editorView: EditorView) {
     this._editorView = editorView
-    this.overrideTreeHighlighterUpdateForPerformanceTracking()
+    // TODO: There is a bug with this override that is causing
+    // the editor to lock-up after an autocompletion is selected.
+    // this.overrideTreeHighlighterUpdateForPerformanceTracking()
   }
 
   overrideTreeHighlighterUpdateForPerformanceTracking() {


### PR DESCRIPTION
The function `overrideTreeHighlighterUpdateForPerformanceTracking` is somehow causing an editor lock-up if a user applies an autocompletion suggestion.

This removes the only call to it, and adds an E2E test expectation which ensures that using autocomplete does not result in any diagnostic errors.