### PR TITLE
Nadro/adhoc/stdlib arcTo (three point arc)

### DIFF
--- a/src/wasm-lib/kcl/src/std/args.rs
+++ b/src/wasm-lib/kcl/src/std/args.rs
@@ -656,6 +656,7 @@ impl_from_arg_via_json!(super::shapes::CircleData);
 impl_from_arg_via_json!(super::shapes::PolygonData);
 impl_from_arg_via_json!(super::sketch::ArcData);
 impl_from_arg_via_json!(super::sketch::TangentialArcData);
+impl_from_arg_via_json!(super::sketch::ArcToData);
 impl_from_arg_via_json!(super::sketch::BezierData);
 impl_from_arg_via_json!(super::chamfer::ChamferData);
 impl_from_arg_via_json!(super::patterns::LinearPattern3dData);

--- a/src/wasm-lib/kcl/src/std/mod.rs
+++ b/src/wasm-lib/kcl/src/std/mod.rs
@@ -91,6 +91,7 @@ lazy_static! {
         Box::new(crate::std::sketch::ProfileStart),
         Box::new(crate::std::sketch::Close),
         Box::new(crate::std::sketch::Arc),
+        Box::new(crate::std::sketch::ArcTo),
         Box::new(crate::std::sketch::TangentialArc),
         Box::new(crate::std::sketch::TangentialArcTo),
         Box::new(crate::std::sketch::TangentialArcToRelative),

--- a/src/wasm-lib/kcl/src/std/sketch.rs
+++ b/src/wasm-lib/kcl/src/std/sketch.rs
@@ -1486,7 +1486,7 @@ pub async fn arc(exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kcl
 ///        radius: 16
 ///      }, %)
 ///   |> close(%)
-// const example = extrude(10, exampleSketch)
+/// const example = extrude(10, exampleSketch)
 /// ```
 #[stdlib {
     name = "arc",
@@ -1573,27 +1573,17 @@ pub async fn arc_to(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
     Ok(KclValue::new_user_val(new_sketch.meta.clone(), new_sketch))
 }
 
-/// Draw a curved line segment along an imaginary circle.
-/// The arc is constructed such that the current position of the sketch is
-/// placed along an imaginary circle of the specified radius, at angleStart
-/// degrees. The resulting arc is the segment of the imaginary circle from
-/// that origin point to angleEnd, radius away from the center of the imaginary
-/// circle.
-///
-/// Unless this makes a lot of sense and feels like what you're looking
-/// for to construct your shape, you're likely looking for tangentialArc.
+/// Draw a 3 point arc.
 ///
 /// ```no_run
 /// const exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
-///   |> line([10, 0], %)
 ///   |> arcTo({
-///        angleStart: 0,
-///        angleEnd: 280,
-///        radius: 16
+///         end: [10,0],
+///         interior: [5,5]
 ///      }, %)
 ///   |> close(%)
-// const example = extrude(10, exampleSketch)
+/// const example = extrude(10, exampleSketch)
 /// ```
 #[stdlib {
     name = "arcTo",


### PR DESCRIPTION
First pass on implement the stdlib function `arcTo` which is a 3 point arc. 

Sample code
```
 const exampleSketch = startSketchOn('XZ')
   |> startProfileAt([0, 0], %)
   |> arcTo({
         end: [10,0],
         interior: [5,5]
     }, %)
  |> close(%)
const example = extrude(10, exampleSketch)
```

To visualize the three point arc (it isn't a circular arc in the photo but you get the idea)
![image](https://github.com/user-attachments/assets/884250b4-ac65-4978-8d50-ea5a01cbcef6)

- Engine API [reference](https://zoo.dev/docs/api/modeling/open-a-websocket-which-accepts-modeling-commands?lang=typescript#parameters-body-modeling_cmd_req-cmd-extend_path-segment-arc_to-relative)
