### PR TITLE
fix: center rectangle code writing bug

### DIFF
--- a/src/clientSideScene/sceneEntities.ts
+++ b/src/clientSideScene/sceneEntities.ts
@@ -1178,6 +1178,11 @@ export class SceneEntities {
           await kclManager.executeAstMock(_ast)
           sceneInfra.modelingSend({ type: 'Finish center rectangle' })
 
+          // lee: I had this at the bottom of the function, but it's
+          // possible sketchFromKclValue "fails" when sketching on a face,
+          // and this couldn't wouldn't run.
+          await codeManager.updateEditorWithAstAndWriteToFile(_ast)
+
           const { execState } = await executeAst({
             ast: _ast,
             useFakeExecutor: true,


### PR DESCRIPTION
# Bug

When using the center rectangle tool it would not write code to the editor when the workflow finished.

# Fix

Added the explicit line to update the AST and Code Mirror since this is a new pattern. Similar to the corner rectangle tool. 


