### PR TITLE
KCL: Object literals like {x} as shorthand for {x: x}

### DIFF
--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bi.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bi.snap
@@ -1,0 +1,104 @@
+---
+source: kcl/src/parser/parser_impl.rs
+expression: actual
+snapshot_kind: text
+---
+{
+  "body": [
+    {
+      "declarations": [
+        {
+          "end": 5,
+          "id": {
+            "end": 1,
+            "name": "x",
+            "start": 0,
+            "type": "Identifier"
+          },
+          "init": {
+            "end": 5,
+            "raw": "3",
+            "start": 4,
+            "type": "Literal",
+            "type": "Literal",
+            "value": 3
+          },
+          "start": 0,
+          "type": "VariableDeclarator"
+        }
+      ],
+      "end": 5,
+      "kind": "const",
+      "start": 0,
+      "type": "VariableDeclaration",
+      "type": "VariableDeclaration"
+    },
+    {
+      "declarations": [
+        {
+          "end": 30,
+          "id": {
+            "end": 17,
+            "name": "obj",
+            "start": 14,
+            "type": "Identifier"
+          },
+          "init": {
+            "end": 30,
+            "properties": [
+              {
+                "end": 23,
+                "key": {
+                  "end": 23,
+                  "name": "x",
+                  "start": 22,
+                  "type": "Identifier"
+                },
+                "start": 22,
+                "type": "ObjectProperty",
+                "value": {
+                  "end": 23,
+                  "name": "x",
+                  "start": 22,
+                  "type": "Identifier",
+                  "type": "Identifier"
+                }
+              },
+              {
+                "end": 29,
+                "key": {
+                  "end": 26,
+                  "name": "y",
+                  "start": 25,
+                  "type": "Identifier"
+                },
+                "start": 25,
+                "type": "ObjectProperty",
+                "value": {
+                  "end": 29,
+                  "raw": "4",
+                  "start": 28,
+                  "type": "Literal",
+                  "type": "Literal",
+                  "value": 4
+                }
+              }
+            ],
+            "start": 20,
+            "type": "ObjectExpression",
+            "type": "ObjectExpression"
+          },
+          "start": 14,
+          "type": "VariableDeclarator"
+        }
+      ],
+      "end": 30,
+      "kind": "const",
+      "start": 14,
+      "type": "VariableDeclaration",
+      "type": "VariableDeclaration"
+    }
+  ],
+  "end": 30,
+  "start": 0
+}


### PR DESCRIPTION
If the key and value in an object literal use the same identifier, allow abbreviating it.

Basically these two are now equivalent:

```
x = 2
obj = { x: x, y: 3}
```

```diff
x = 2
- obj = { x: x, y: 3}
+ obj = { x, y: 3}
```

This syntax is used in JS, Rust and probably elsewhere too.

Here's a more realistic example. Before:

```
radius = 10

startSketchAt([0, 0])
|> circle({center: [0, 0], radius: radius}, %)
```
After:
```diff
radius = 10

startSketchAt([0, 0])
- |> circle({center: [0, 0], radius: radius}, %)
+ |> circle({center: [0, 0], radius}, %)
```