### PR TITLE
KCL: Executor returns specific errors, not anyhow

### DIFF
--- a/src/wasm-lib/kcl-test-server/src/lib.rs
+++ b/src/wasm-lib/kcl-test-server/src/lib.rs
@@ -203,7 +203,7 @@ fn bad_gateway(msg: String) -> Response<Body> {
     resp
 }
 
-fn kcl_err(err: anyhow::Error) -> Response<Body> {
+fn kcl_err(err: impl std::fmt::Display) -> Response<Body> {
     eprintln!("\tBad KCL");
     bad_gateway(format!("{err}"))
 }

--- a/src/wasm-lib/kcl/src/errors.rs
+++ b/src/wasm-lib/kcl/src/errors.rs
@@ -4,6 +4,26 @@ use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
 
 use crate::{ast::types::ModuleId, executor::SourceRange, lsp::IntoDiagnostic};
 
+/// How did the KCL execution fail
+#[derive(thiserror::Error, Debug)]
+pub enum ExecError {
+    #[error("{0}")]
+    Kcl(#[from] crate::KclError),
+    #[error("Could not connect to engine: {0}")]
+    Connection(#[from] ConnectionError),
+    #[error("PNG snapshot could not be decoded: {0}")]
+    BadPng(String),
+}
+
+/// How did KCL client fail to connect to the engine
+#[derive(thiserror::Error, Debug)]
+pub enum ConnectionError {
+    #[error("Could not create a Zoo client: {0}")]
+    CouldNotMakeClient(anyhow::Error),
+    #[error("Could not establish connection to engine: {0}")]
+    Establishing(anyhow::Error),
+}
+
 #[derive(Error, Debug, Serialize, Deserialize, ts_rs::TS, Clone, PartialEq, Eq)]
 #[ts(export)]
 #[serde(tag = "kind", rename_all = "snake_case")]

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -34,7 +34,7 @@ use crate::{
     fs::{FileManager, FileSystem},
     settings::types::UnitLength,
     std::{args::Arg, StdLib},
-    Program,
+    ExecError, Program,
 };
 
 /// State for executing a program.
@@ -2161,12 +2161,16 @@ impl ExecutorContext {
         &self,
         program: &Program,
         exec_state: &mut ExecState,
-    ) -> Result<TakeSnapshot> {
+    ) -> std::result::Result<TakeSnapshot, ExecError> {
         self.execute_and_prepare(program, exec_state).await
     }
 
     /// Execute the program, return the interpreter and outputs.
-    pub async fn execute_and_prepare(&self, program: &Program, exec_state: &mut ExecState) -> Result<TakeSnapshot> {
+    pub async fn execute_and_prepare(
+        &self,
+        program: &Program,
+        exec_state: &mut ExecState,
+    ) -> std::result::Result<TakeSnapshot, ExecError> {
         self.run(program, exec_state).await?;
 
         // Zoom to fit.
@@ -2198,7 +2202,9 @@ impl ExecutorContext {
             modeling_response: OkModelingCmdResponse::TakeSnapshot(contents),
         } = resp
         else {
-            anyhow::bail!("Unexpected response from engine: {:?}", resp);
+            return Err(ExecError::BadPng(format!(
+                "Instead of a TakeSnapshot response, the engine returned {resp:?}"
+            )));
         };
         Ok(contents)
     }

--- a/src/wasm-lib/kcl/src/lib.rs
+++ b/src/wasm-lib/kcl/src/lib.rs
@@ -42,7 +42,7 @@ pub use ast::modify::modify_ast_for_sketch;
 pub use ast::types::{FormatOptions, ModuleId};
 pub use coredump::CoreDump;
 pub use engine::{EngineManager, ExecutionKind};
-pub use errors::KclError;
+pub use errors::{ConnectionError, ExecError, KclError};
 pub use executor::{ExecState, ExecutorContext, ExecutorSettings, SourceRange};
 pub use lsp::copilot::Backend as CopilotLspBackend;
 pub use lsp::kcl::Backend as KclLspBackend;


### PR DESCRIPTION
Some clients (e.g. the simulation tests) want to know why a KCL program failed. Was it because of a network error? Or because the client wasn't authorized properly? Or was it a KCL runtime type error?

It's difficult for clients to ask these questions, because the interpreter just returns Anyhow error, basically just a string.

Instead, we should return different variants of an Error enum for different kinds of errors.

This lets us render nice Cargo-style error messages that show the exact KCL line where an error occurred, instead of just printing off a source range. We have that in the CLI, but I'd like it for running normal KCL unit tests.

# Testing

This is a pure refactor, it doesn't change any behaviour, it just stops hiding the specific error types via anyhow. No testing needed. If it compiles, it works.