### PR TITLE
Fix yarn tsc in codemirror-lsp-client

### DIFF
--- a/packages/codemirror-lsp-client/package.json
+++ b/packages/codemirror-lsp-client/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@codemirror/autocomplete": "^6.16.3",
+    "@codemirror/autocomplete": "6.17.0",
     "@codemirror/language": "^6.10.2",
     "@codemirror/state": "^6.4.1",
     "@lezer/highlight": "^1.2.0",

--- a/packages/codemirror-lsp-client/yarn.lock
+++ b/packages/codemirror-lsp-client/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@codemirror/autocomplete@^6.16.3":
-  version "6.16.3"
-  resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-6.16.3.tgz#04d5a4e4e44ccae1ba525d47db53a5479bf46338"
-  integrity sha512-Vl/tIeRVVUCRDuOG48lttBasNQu8usGgXQawBXI7WJAiUDSFOfzflmEsZFZo48mAvAaa4FZ/4/yLLxFtdJaKYA==
+"@codemirror/autocomplete@6.17.0":
+  version "6.17.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-6.17.0.tgz#24ff5fc37fd91f6439df6f4ff9c8e910cde1b053"
+  integrity sha512-fdfj6e6ZxZf8yrkMHUSJJir7OJkHkZKaOZGzLWIYp2PZ3jd+d+UjG8zVPqJF6d3bKxkhvXTPan/UZ1t7Bqm0gA==
   dependencies:
     "@codemirror/language" "^6.0.0"
     "@codemirror/state" "^6.0.0"


### PR DESCRIPTION
This makes `@codemirror/autocomplete` match the version in the root directory.