### PR TITLE
fix: upon entering sketch mode, axis do not rotate.

### DIFF
--- a/src/clientSideScene/CameraControls.ts
+++ b/src/clientSideScene/CameraControls.ts
@@ -273,14 +273,19 @@ export class CameraControls {
         camSettings.center.y,
         camSettings.center.z
       )
-      const quat = new Quaternion(
+      const orientation = new Quaternion(
         camSettings.orientation.x,
         camSettings.orientation.y,
         camSettings.orientation.z,
         camSettings.orientation.w
       ).invert()
 
-      this.camera.up.copy(new Vector3(0, 1, 0).applyQuaternion(quat))
+      this.camera.quaternion.set(
+        orientation.x,
+        orientation.y,
+        orientation.z,
+        orientation.w
+      )
       if (this.camera instanceof PerspectiveCamera && camSettings.ortho) {
         this.useOrthographicCamera()
       }
@@ -1164,7 +1169,7 @@ export class CameraControls {
       this.camera.updateProjectionMatrix()
     }
 
-    if (this.syncDirection === 'clientToEngine' || forceUpdate)
+    if (this.syncDirection === 'clientToEngine' || forceUpdate) {
       this.throttledUpdateEngineCamera({
         quaternion: this.camera.quaternion,
         position: this.camera.position,
@@ -1172,6 +1177,7 @@ export class CameraControls {
         isPerspective: this.isPerspective,
         target: this.target,
       })
+    }
     this.deferReactUpdate(this.reactCameraProperties)
     Object.values(this._camChangeCallbacks).forEach((cb) => cb())
   }

--- a/src/clientSideScene/CameraControls.ts
+++ b/src/clientSideScene/CameraControls.ts
@@ -280,12 +280,19 @@ export class CameraControls {
         camSettings.orientation.w
       ).invert()
 
+      const newUp = new Vector3(
+        camSettings.up.x,
+        camSettings.up.y,
+        camSettings.up.z
+      )
       this.camera.quaternion.set(
         orientation.x,
         orientation.y,
         orientation.z,
         orientation.w
       )
+      this.camera.up.copy(newUp)
+      this.camera.updateProjectionMatrix()
       if (this.camera instanceof PerspectiveCamera && camSettings.ortho) {
         this.useOrthographicCamera()
       }


### PR DESCRIPTION
# Issue

The axis for sketch mode can have a rotation applied when entering the sketch mode which is wrong.

# How to recreate the bug

Do not look perpendicular to your sketch plane then enter the sketch mode on that plane. Some rotation will be applied 

# Fix
Set the orientation from the cam settings directly to the camera instead of recomputing a new up vector.
Turns out we can use the up vector from the camera settings that is returned instead of hard coding it to `<0,1,0>`. 

# Video description
https://github.com/user-attachments/assets/6bc8725d-42bb-45e4-bc40-07991b5575c7

