### PR TITLE
KCL refactor: Type alias for KCL object fields

### DIFF
--- a/src/wasm-lib/kcl/src/kcl_value.rs
+++ b/src/wasm-lib/kcl/src/kcl_value.rs
@@ -13,6 +13,8 @@ use crate::{
     ExecState, ExecutorContext, KclError, SourceRange,
 };
 
+pub type KclObjectFields = HashMap<String, KclValue>;
+
 /// Any KCL value.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
@@ -49,7 +51,7 @@ pub enum KclValue {
         meta: Vec<Metadata>,
     },
     Object {
-        value: HashMap<String, KclValue>,
+        value: KclObjectFields,
         #[serde(rename = "__meta")]
         meta: Vec<Metadata>,
     },
@@ -287,7 +289,7 @@ impl KclValue {
         }
     }
 
-    pub fn as_object(&self) -> Option<&HashMap<String, KclValue>> {
+    pub fn as_object(&self) -> Option<&KclObjectFields> {
         if let KclValue::Object { value, meta: _ } = &self {
             Some(value)
         } else {
@@ -295,7 +297,7 @@ impl KclValue {
         }
     }
 
-    pub fn into_object(self) -> Option<HashMap<String, KclValue>> {
+    pub fn into_object(self) -> Option<KclObjectFields> {
         if let KclValue::Object { value, meta: _ } = self {
             Some(value)
         } else {

--- a/src/wasm-lib/kcl/src/std/args.rs
+++ b/src/wasm-lib/kcl/src/std/args.rs
@@ -1,4 +1,4 @@
-use std::{any::type_name, collections::HashMap, num::NonZeroU32};
+use std::{any::type_name, num::NonZeroU32};
 
 use anyhow::Result;
 use kcmc::{websocket::OkWebSocketResponseData, ModelingCmd};
@@ -11,6 +11,7 @@ use crate::{
         ExecState, ExecutorContext, ExtrudeSurface, KclValue, Metadata, Sketch, SketchSet, SketchSurface, Solid,
         SolidSet, SourceRange, TagIdentifier,
     },
+    kcl_value::KclObjectFields,
     std::{shapes::SketchOrSurface, sketch::FaceTag, FnAsArg},
 };
 
@@ -1169,7 +1170,7 @@ impl<'a> FromKclValue<'a> for super::sketch::PlaneData {
         }
         // Case 2: custom plane
         let obj = arg.as_object()?;
-        let_field_of!(obj, plane, &std::collections::HashMap<String, KclValue>);
+        let_field_of!(obj, plane, &KclObjectFields);
         let origin = plane.get("origin").and_then(FromKclValue::from_kcl_val).map(Box::new)?;
         let x_axis = plane
             .get("xAxis")
@@ -1359,7 +1360,7 @@ impl<'a> FromKclValue<'a> for super::revolve::AxisAndOrigin {
         }
         // Case 2: custom planes.
         let obj = arg.as_object()?;
-        let_field_of!(obj, custom, &HashMap<String, KclValue>);
+        let_field_of!(obj, custom, &KclObjectFields);
         let_field_of!(custom, origin);
         let_field_of!(custom, axis);
         Some(Self::Custom { axis, origin })
@@ -1419,7 +1420,7 @@ impl<'a> FromKclValue<'a> for i64 {
 }
 
 impl<'a> FromKclValue<'a> for &'a str {
-    fn from_kcl_val(arg: &'a KclValue) -> Option<&'a str> {
+    fn from_kcl_val(arg: &'a KclValue) -> Option<Self> {
         let KclValue::String { value, meta: _ } = arg else {
             return None;
         };
@@ -1427,8 +1428,8 @@ impl<'a> FromKclValue<'a> for &'a str {
     }
 }
 
-impl<'a> FromKclValue<'a> for &'a HashMap<String, KclValue> {
-    fn from_kcl_val(arg: &'a KclValue) -> Option<&'a HashMap<String, KclValue>> {
+impl<'a> FromKclValue<'a> for &'a KclObjectFields {
+    fn from_kcl_val(arg: &'a KclValue) -> Option<Self> {
         let KclValue::Object { value, meta: _ } = arg else {
             return None;
         };

--- a/src/wasm-lib/kcl/src/std/patterns.rs
+++ b/src/wasm-lib/kcl/src/std/patterns.rs
@@ -1,6 +1,6 @@
 //! Standard library patterns.
 
-use std::{cmp::Ordering, collections::HashMap};
+use std::cmp::Ordering;
 
 use anyhow::Result;
 use derive_docs::stdlib;
@@ -22,6 +22,7 @@ use crate::{
         ExecState, Geometries, Geometry, KclValue, Point2d, Point3d, Sketch, SketchSet, Solid, SolidSet, SourceRange,
     },
     function_param::FunctionParam,
+    kcl_value::KclObjectFields,
     std::Args,
 };
 
@@ -461,7 +462,7 @@ async fn make_transform<'a, T: GeometryTrait>(
 }
 
 fn transform_from_obj_fields<T: GeometryTrait>(
-    transform: HashMap<String, KclValue>,
+    transform: KclObjectFields,
     source_ranges: Vec<SourceRange>,
 ) -> Result<Transform, KclError> {
     // Apply defaults to the transform.


### PR DESCRIPTION
This way, if we want to change our key-value representation later (e.g. using a tree map instead of a hash map) we can, easily, in just one place.