### PR TITLE
KCL: Remove unnecessary 'optional: bool' field on CallExpression

### DIFF
--- a/docs/kcl/types/BinaryPart.md
+++ b/docs/kcl/types/BinaryPart.md
@@ -85,7 +85,6 @@ layout: manual
 | `type` |enum: `CallExpression`|  | No |
 | `callee` |[`Identifier`](/docs/kcl/types/Identifier)|  | No |
 | `arguments` |`[` [`Expr`](/docs/kcl/types/Expr) `]`|  | No |
-| `optional` |`boolean`|  | No |
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |

--- a/docs/kcl/types/Expr.md
+++ b/docs/kcl/types/Expr.md
@@ -125,7 +125,6 @@ An expression can be evaluated to yield a single KCL value.
 | `type` |enum: `CallExpression`|  | No |
 | `callee` |[`Identifier`](/docs/kcl/types/Identifier)| An expression can be evaluated to yield a single KCL value. | No |
 | `arguments` |`[` [`Expr`](/docs/kcl/types/Expr) `]`|  | No |
-| `optional` |`boolean`|  | No |
 | `digest` |`[, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`, `integer`]`|  | No |
 | `start` |`integer`|  | No |
 | `end` |`integer`|  | No |

--- a/src/lang/abstractSyntaxTree.test.ts
+++ b/src/lang/abstractSyntaxTree.test.ts
@@ -384,7 +384,6 @@ const myVar = funcN(1, 2)`
                   raw: '2',
                 },
               ],
-              optional: false,
             },
           },
         ],
@@ -465,7 +464,6 @@ describe('testing pipe operator special', () => {
                       ],
                     },
                   ],
-                  optional: false,
                 },
                 {
                   type: 'CallExpression',
@@ -508,7 +506,6 @@ describe('testing pipe operator special', () => {
                       end: 60,
                     },
                   ],
-                  optional: false,
                 },
                 {
                   type: 'CallExpression',
@@ -556,7 +553,6 @@ describe('testing pipe operator special', () => {
                       value: 'myPath',
                     },
                   ],
-                  optional: false,
                 },
                 {
                   type: 'CallExpression',
@@ -598,7 +594,6 @@ describe('testing pipe operator special', () => {
                       end: 115,
                     },
                   ],
-                  optional: false,
                 },
                 {
                   type: 'CallExpression',
@@ -625,7 +620,6 @@ describe('testing pipe operator special', () => {
                       end: 130,
                     },
                   ],
-                  optional: false,
                 },
               ],
             },
@@ -711,7 +705,6 @@ describe('testing pipe operator special', () => {
                       end: 35,
                     },
                   ],
-                  optional: false,
                 },
               ],
             },
@@ -1765,7 +1758,6 @@ describe('test UnaryExpression', () => {
             raw: '100',
           },
         ],
-        optional: false,
       },
     })
   })
@@ -1837,11 +1829,9 @@ describe('testing nested call expressions', () => {
                 raw: '3',
               },
             ],
-            optional: false,
           },
         },
       ],
-      optional: false,
     })
   })
 })
@@ -1879,7 +1869,6 @@ describe('should recognise callExpresions in binaryExpressions', () => {
               name: 'seg02',
             },
           ],
-          optional: false,
         },
         right: {
           type: 'Literal',

--- a/src/lang/modifyAst.ts
+++ b/src/lang/modifyAst.ts
@@ -727,7 +727,6 @@ export function createCallExpressionStdLib(
 
       name,
     },
-    optional: false,
     arguments: args,
   }
 }
@@ -749,7 +748,6 @@ export function createCallExpression(
 
       name,
     },
-    optional: false,
     arguments: args,
   }
 }

--- a/src/wasm-lib/kcl/src/ast/types.rs
+++ b/src/wasm-lib/kcl/src/ast/types.rs
@@ -1264,7 +1264,6 @@ pub struct ExpressionStatement {
 pub struct CallExpression {
     pub callee: Node<Identifier>,
     pub arguments: Vec<Expr>,
-    pub optional: bool,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
@@ -1301,7 +1300,6 @@ impl CallExpression {
         Ok(Node::no_src(Self {
             callee: Identifier::new(name),
             arguments,
-            optional: false,
             digest: None,
         }))
     }

--- a/src/wasm-lib/kcl/src/ast/types/digest.rs
+++ b/src/wasm-lib/kcl/src/ast/types/digest.rs
@@ -369,7 +369,6 @@ impl CallExpression {
         for argument in slf.arguments.iter_mut() {
             hasher.update(argument.compute_digest());
         }
-        hasher.update(if slf.optional { [1] } else { [0] });
     });
 }
 

--- a/src/wasm-lib/kcl/src/parser/parser_impl.rs
+++ b/src/wasm-lib/kcl/src/parser/parser_impl.rs
@@ -2232,7 +2232,6 @@ fn fn_call(i: TokenSlice) -> PResult<Node<CallExpression>> {
         inner: CallExpression {
             callee: fn_name,
             arguments: args,
-            optional: false,
             digest: None,
         },
     })

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__a.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__a.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/parser/parser_impl.rs
-assertion_line: 3649
 expression: actual
 snapshot_kind: text
 ---
@@ -52,7 +51,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 39,
-                "optional": false,
                 "start": 18,
                 "type": "CallExpression",
                 "type": "CallExpression"
@@ -97,7 +95,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 63,
-                "optional": false,
                 "start": 47,
                 "type": "CallExpression",
                 "type": "CallExpression"
@@ -149,7 +146,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 96,
-                "optional": false,
                 "start": 71,
                 "type": "CallExpression",
                 "type": "CallExpression"
@@ -201,7 +197,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 121,
-                "optional": false,
                 "start": 104,
                 "type": "CallExpression",
                 "type": "CallExpression"
@@ -230,7 +225,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 143,
-                "optional": false,
                 "start": 129,
                 "type": "CallExpression",
                 "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ab.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ab.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/parser/parser_impl.rs
-assertion_line: 3720
 expression: actual
 snapshot_kind: text
 ---
@@ -68,7 +67,6 @@ snapshot_kind: text
           "type": "Identifier"
         },
         "end": 23,
-        "optional": false,
         "start": 0,
         "type": "CallExpression",
         "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ad.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ad.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/parser/parser_impl.rs
 expression: actual
+snapshot_kind: text
 ---
 {
   "body": [
@@ -62,7 +63,6 @@ expression: actual
           "type": "Identifier"
         },
         "end": 80,
-        "optional": false,
         "start": 62,
         "type": "CallExpression",
         "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ae.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ae.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/parser/parser_impl.rs
 expression: actual
+snapshot_kind: text
 ---
 {
   "body": [
@@ -82,7 +83,6 @@ expression: actual
           "type": "Identifier"
         },
         "end": 66,
-        "optional": false,
         "start": 54,
         "type": "CallExpression",
         "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__af.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__af.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/parser/parser_impl.rs
-assertion_line: 3737
 expression: actual
 snapshot_kind: text
 ---
@@ -52,7 +51,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 37,
-                "optional": false,
                 "start": 17,
                 "type": "CallExpression",
                 "type": "CallExpression"
@@ -104,7 +102,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 75,
-                "optional": false,
                 "start": 49,
                 "type": "CallExpression",
                 "type": "CallExpression"
@@ -149,7 +146,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 104,
-                "optional": false,
                 "start": 87,
                 "type": "CallExpression",
                 "type": "CallExpression"
@@ -201,7 +197,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 145,
-                "optional": false,
                 "start": 116,
                 "type": "CallExpression",
                 "type": "CallExpression"
@@ -222,7 +217,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 165,
-                "optional": false,
                 "start": 157,
                 "type": "CallExpression",
                 "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ag.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ag.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/parser/parser_impl.rs
-assertion_line: 3745
 expression: actual
 snapshot_kind: text
 ---
@@ -52,7 +51,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 37,
-                "optional": false,
                 "start": 17,
                 "type": "CallExpression",
                 "type": "CallExpression"
@@ -97,7 +95,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 58,
-                "optional": false,
                 "start": 41,
                 "type": "CallExpression",
                 "type": "CallExpression"
@@ -118,7 +115,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 70,
-                "optional": false,
                 "start": 62,
                 "type": "CallExpression",
                 "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ah.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ah.snap
@@ -32,7 +32,6 @@ snapshot_kind: text
               "type": "Identifier"
             },
             "end": 30,
-            "optional": false,
             "start": 14,
             "type": "CallExpression",
             "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ai.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ai.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/parser/parser_impl.rs
-assertion_line: 3750
 expression: actual
 snapshot_kind: text
 ---
@@ -36,7 +35,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 18,
-                "optional": false,
                 "start": 14,
                 "type": "CallExpression",
                 "type": "CallExpression"
@@ -65,7 +63,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 29,
-                "optional": false,
                 "start": 22,
                 "type": "CallExpression",
                 "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__aj.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__aj.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/parser/parser_impl.rs
-assertion_line: 3751
 expression: actual
 snapshot_kind: text
 ---
@@ -35,7 +34,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 30,
-                "optional": false,
                 "start": 14,
                 "type": "CallExpression",
                 "type": "CallExpression"
@@ -79,7 +77,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 49,
-                "optional": false,
                 "start": 34,
                 "type": "CallExpression",
                 "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ak.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ak.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/parser/parser_impl.rs
-assertion_line: 3752
 expression: actual
 snapshot_kind: text
 ---
@@ -61,7 +60,6 @@ snapshot_kind: text
           "type": "Identifier"
         },
         "end": 22,
-        "optional": false,
         "start": 0,
         "type": "CallExpression",
         "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__al.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__al.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/parser/parser_impl.rs
-assertion_line: 3753
 expression: actual
 snapshot_kind: text
 ---
@@ -96,7 +95,6 @@ snapshot_kind: text
           "type": "Identifier"
         },
         "end": 36,
-        "optional": false,
         "start": 0,
         "type": "CallExpression",
         "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__am.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__am.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/parser/parser_impl.rs
-assertion_line: 3754
 expression: actual
 snapshot_kind: text
 ---
@@ -61,7 +60,6 @@ snapshot_kind: text
           "type": "Identifier"
         },
         "end": 19,
-        "optional": false,
         "start": 0,
         "type": "CallExpression",
         "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__an.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__an.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/parser/parser_impl.rs
-assertion_line: 3755
 expression: actual
 snapshot_kind: text
 ---
@@ -96,7 +95,6 @@ snapshot_kind: text
           "type": "Identifier"
         },
         "end": 35,
-        "optional": false,
         "start": 0,
         "type": "CallExpression",
         "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ao.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ao.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/parser/parser_impl.rs
-assertion_line: 3756
 expression: actual
 snapshot_kind: text
 ---
@@ -96,7 +95,6 @@ snapshot_kind: text
           "type": "Identifier"
         },
         "end": 35,
-        "optional": false,
         "start": 0,
         "type": "CallExpression",
         "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ap.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ap.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/parser/parser_impl.rs
-assertion_line: 3757
 expression: actual
 snapshot_kind: text
 ---
@@ -50,7 +49,6 @@ snapshot_kind: text
               "type": "Identifier"
             },
             "end": 37,
-            "optional": false,
             "start": 17,
             "type": "CallExpression",
             "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__aq.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__aq.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/parser/parser_impl.rs
-assertion_line: 3758
 expression: actual
 snapshot_kind: text
 ---
@@ -41,7 +40,6 @@ snapshot_kind: text
           "type": "Identifier"
         },
         "end": 28,
-        "optional": false,
         "start": 0,
         "type": "CallExpression",
         "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__at.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__at.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/parser/parser_impl.rs
-assertion_line: 3760
 expression: actual
 snapshot_kind: text
 ---
@@ -47,7 +46,6 @@ snapshot_kind: text
           "type": "Identifier"
         },
         "end": 15,
-        "optional": false,
         "start": 0,
         "type": "CallExpression",
         "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__au.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__au.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/parser/parser_impl.rs
-assertion_line: 3761
 expression: actual
 snapshot_kind: text
 ---
@@ -36,7 +35,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 36,
-                "optional": false,
                 "start": 17,
                 "type": "CallExpression",
                 "type": "CallExpression"
@@ -119,7 +117,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 85,
-                "optional": false,
                 "start": 44,
                 "type": "CallExpression",
                 "type": "CallExpression"
@@ -148,7 +145,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 107,
-                "optional": false,
                 "start": 93,
                 "type": "CallExpression",
                 "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__av.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__av.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/parser/parser_impl.rs
 expression: actual
+snapshot_kind: text
 ---
 {
   "body": [
@@ -43,7 +44,6 @@ expression: actual
                       "type": "Identifier"
                     },
                     "end": 47,
-                    "optional": false,
                     "start": 28,
                     "type": "CallExpression",
                     "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__b.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__b.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/parser/parser_impl.rs
-assertion_line: 3658
 expression: actual
 snapshot_kind: text
 ---
@@ -53,7 +52,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 35,
-                  "optional": false,
                   "start": 23,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -72,7 +70,6 @@ snapshot_kind: text
               "type": "Identifier"
             },
             "end": 36,
-            "optional": false,
             "start": 14,
             "type": "CallExpression",
             "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ba.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__ba.snap
@@ -35,7 +35,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 38,
-                "optional": false,
                 "start": 19,
                 "type": "CallExpression",
                 "type": "CallExpression"
@@ -56,7 +55,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 132,
-                "optional": false,
                 "start": 115,
                 "type": "CallExpression",
                 "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bd.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__bd.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/parser/parser_impl.rs
-assertion_line: 3822
 expression: actual
 snapshot_kind: text
 ---
@@ -45,7 +44,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 64,
-                  "optional": false,
                   "start": 52,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__c.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__c.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/parser/parser_impl.rs
-assertion_line: 3660
 expression: actual
 snapshot_kind: text
 ---
@@ -45,7 +44,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 31,
-                  "optional": false,
                   "start": 19,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -72,7 +70,6 @@ snapshot_kind: text
               "type": "Identifier"
             },
             "end": 35,
-            "optional": false,
             "start": 14,
             "type": "CallExpression",
             "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__d.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__d.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/parser/parser_impl.rs
-assertion_line: 3661
 expression: actual
 snapshot_kind: text
 ---
@@ -65,7 +64,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 36,
-                "optional": false,
                 "start": 23,
                 "type": "CallExpression",
                 "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__y.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__y.snap
@@ -32,7 +32,6 @@ snapshot_kind: text
               "type": "Identifier"
             },
             "end": 29,
-            "optional": false,
             "start": 11,
             "type": "CallExpression",
             "type": "CallExpression"

--- a/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__z.snap
+++ b/src/wasm-lib/kcl/src/parser/snapshots/kcl_lib__parser__parser_impl__snapshot_tests__z.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/parser/parser_impl.rs
-assertion_line: 3718
 expression: actual
 snapshot_kind: text
 ---
@@ -35,7 +34,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 29,
-                "optional": false,
                 "start": 11,
                 "type": "CallExpression",
                 "type": "CallExpression"
@@ -86,7 +84,6 @@ snapshot_kind: text
                   "type": "Identifier"
                 },
                 "end": 53,
-                "optional": false,
                 "start": 33,
                 "type": "CallExpression",
                 "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/add_lots/ast.snap
+++ b/src/wasm-lib/kcl/tests/add_lots/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Result of parsing add_lots.kcl
+snapshot_kind: text
 ---
 {
   "Ok": {
@@ -305,7 +306,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                                                                         "type": "Identifier"
                                                                                                                                                                                                                       },
                                                                                                                                                                                                                       "end": 36,
-                                                                                                                                                                                                                      "optional": false,
                                                                                                                                                                                                                       "start": 32,
                                                                                                                                                                                                                       "type": "CallExpression",
                                                                                                                                                                                                                       "type": "CallExpression"
@@ -329,7 +329,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                                                                         "type": "Identifier"
                                                                                                                                                                                                                       },
                                                                                                                                                                                                                       "end": 43,
-                                                                                                                                                                                                                      "optional": false,
                                                                                                                                                                                                                       "start": 39,
                                                                                                                                                                                                                       "type": "CallExpression",
                                                                                                                                                                                                                       "type": "CallExpression"
@@ -357,7 +356,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                                                                       "type": "Identifier"
                                                                                                                                                                                                                     },
                                                                                                                                                                                                                     "end": 50,
-                                                                                                                                                                                                                    "optional": false,
                                                                                                                                                                                                                     "start": 46,
                                                                                                                                                                                                                     "type": "CallExpression",
                                                                                                                                                                                                                     "type": "CallExpression"
@@ -385,7 +383,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                                                                     "type": "Identifier"
                                                                                                                                                                                                                   },
                                                                                                                                                                                                                   "end": 57,
-                                                                                                                                                                                                                  "optional": false,
                                                                                                                                                                                                                   "start": 53,
                                                                                                                                                                                                                   "type": "CallExpression",
                                                                                                                                                                                                                   "type": "CallExpression"
@@ -413,7 +410,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                                                                   "type": "Identifier"
                                                                                                                                                                                                                 },
                                                                                                                                                                                                                 "end": 64,
-                                                                                                                                                                                                                "optional": false,
                                                                                                                                                                                                                 "start": 60,
                                                                                                                                                                                                                 "type": "CallExpression",
                                                                                                                                                                                                                 "type": "CallExpression"
@@ -441,7 +437,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                                                                 "type": "Identifier"
                                                                                                                                                                                                               },
                                                                                                                                                                                                               "end": 71,
-                                                                                                                                                                                                              "optional": false,
                                                                                                                                                                                                               "start": 67,
                                                                                                                                                                                                               "type": "CallExpression",
                                                                                                                                                                                                               "type": "CallExpression"
@@ -469,7 +464,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                                                               "type": "Identifier"
                                                                                                                                                                                                             },
                                                                                                                                                                                                             "end": 78,
-                                                                                                                                                                                                            "optional": false,
                                                                                                                                                                                                             "start": 74,
                                                                                                                                                                                                             "type": "CallExpression",
                                                                                                                                                                                                             "type": "CallExpression"
@@ -497,7 +491,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                                                             "type": "Identifier"
                                                                                                                                                                                                           },
                                                                                                                                                                                                           "end": 85,
-                                                                                                                                                                                                          "optional": false,
                                                                                                                                                                                                           "start": 81,
                                                                                                                                                                                                           "type": "CallExpression",
                                                                                                                                                                                                           "type": "CallExpression"
@@ -525,7 +518,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                                                           "type": "Identifier"
                                                                                                                                                                                                         },
                                                                                                                                                                                                         "end": 92,
-                                                                                                                                                                                                        "optional": false,
                                                                                                                                                                                                         "start": 88,
                                                                                                                                                                                                         "type": "CallExpression",
                                                                                                                                                                                                         "type": "CallExpression"
@@ -553,7 +545,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                                                         "type": "Identifier"
                                                                                                                                                                                                       },
                                                                                                                                                                                                       "end": 99,
-                                                                                                                                                                                                      "optional": false,
                                                                                                                                                                                                       "start": 95,
                                                                                                                                                                                                       "type": "CallExpression",
                                                                                                                                                                                                       "type": "CallExpression"
@@ -581,7 +572,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                                                       "type": "Identifier"
                                                                                                                                                                                                     },
                                                                                                                                                                                                     "end": 107,
-                                                                                                                                                                                                    "optional": false,
                                                                                                                                                                                                     "start": 102,
                                                                                                                                                                                                     "type": "CallExpression",
                                                                                                                                                                                                     "type": "CallExpression"
@@ -609,7 +599,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                                                     "type": "Identifier"
                                                                                                                                                                                                   },
                                                                                                                                                                                                   "end": 115,
-                                                                                                                                                                                                  "optional": false,
                                                                                                                                                                                                   "start": 110,
                                                                                                                                                                                                   "type": "CallExpression",
                                                                                                                                                                                                   "type": "CallExpression"
@@ -637,7 +626,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                                                   "type": "Identifier"
                                                                                                                                                                                                 },
                                                                                                                                                                                                 "end": 123,
-                                                                                                                                                                                                "optional": false,
                                                                                                                                                                                                 "start": 118,
                                                                                                                                                                                                 "type": "CallExpression",
                                                                                                                                                                                                 "type": "CallExpression"
@@ -665,7 +653,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                                                 "type": "Identifier"
                                                                                                                                                                                               },
                                                                                                                                                                                               "end": 131,
-                                                                                                                                                                                              "optional": false,
                                                                                                                                                                                               "start": 126,
                                                                                                                                                                                               "type": "CallExpression",
                                                                                                                                                                                               "type": "CallExpression"
@@ -693,7 +680,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                                               "type": "Identifier"
                                                                                                                                                                                             },
                                                                                                                                                                                             "end": 139,
-                                                                                                                                                                                            "optional": false,
                                                                                                                                                                                             "start": 134,
                                                                                                                                                                                             "type": "CallExpression",
                                                                                                                                                                                             "type": "CallExpression"
@@ -721,7 +707,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                                             "type": "Identifier"
                                                                                                                                                                                           },
                                                                                                                                                                                           "end": 147,
-                                                                                                                                                                                          "optional": false,
                                                                                                                                                                                           "start": 142,
                                                                                                                                                                                           "type": "CallExpression",
                                                                                                                                                                                           "type": "CallExpression"
@@ -749,7 +734,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                                           "type": "Identifier"
                                                                                                                                                                                         },
                                                                                                                                                                                         "end": 155,
-                                                                                                                                                                                        "optional": false,
                                                                                                                                                                                         "start": 150,
                                                                                                                                                                                         "type": "CallExpression",
                                                                                                                                                                                         "type": "CallExpression"
@@ -777,7 +761,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                                         "type": "Identifier"
                                                                                                                                                                                       },
                                                                                                                                                                                       "end": 163,
-                                                                                                                                                                                      "optional": false,
                                                                                                                                                                                       "start": 158,
                                                                                                                                                                                       "type": "CallExpression",
                                                                                                                                                                                       "type": "CallExpression"
@@ -805,7 +788,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                                       "type": "Identifier"
                                                                                                                                                                                     },
                                                                                                                                                                                     "end": 171,
-                                                                                                                                                                                    "optional": false,
                                                                                                                                                                                     "start": 166,
                                                                                                                                                                                     "type": "CallExpression",
                                                                                                                                                                                     "type": "CallExpression"
@@ -833,7 +815,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                                     "type": "Identifier"
                                                                                                                                                                                   },
                                                                                                                                                                                   "end": 179,
-                                                                                                                                                                                  "optional": false,
                                                                                                                                                                                   "start": 174,
                                                                                                                                                                                   "type": "CallExpression",
                                                                                                                                                                                   "type": "CallExpression"
@@ -861,7 +842,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                                   "type": "Identifier"
                                                                                                                                                                                 },
                                                                                                                                                                                 "end": 187,
-                                                                                                                                                                                "optional": false,
                                                                                                                                                                                 "start": 182,
                                                                                                                                                                                 "type": "CallExpression",
                                                                                                                                                                                 "type": "CallExpression"
@@ -889,7 +869,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                                 "type": "Identifier"
                                                                                                                                                                               },
                                                                                                                                                                               "end": 195,
-                                                                                                                                                                              "optional": false,
                                                                                                                                                                               "start": 190,
                                                                                                                                                                               "type": "CallExpression",
                                                                                                                                                                               "type": "CallExpression"
@@ -917,7 +896,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                               "type": "Identifier"
                                                                                                                                                                             },
                                                                                                                                                                             "end": 203,
-                                                                                                                                                                            "optional": false,
                                                                                                                                                                             "start": 198,
                                                                                                                                                                             "type": "CallExpression",
                                                                                                                                                                             "type": "CallExpression"
@@ -945,7 +923,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                             "type": "Identifier"
                                                                                                                                                                           },
                                                                                                                                                                           "end": 211,
-                                                                                                                                                                          "optional": false,
                                                                                                                                                                           "start": 206,
                                                                                                                                                                           "type": "CallExpression",
                                                                                                                                                                           "type": "CallExpression"
@@ -973,7 +950,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                           "type": "Identifier"
                                                                                                                                                                         },
                                                                                                                                                                         "end": 219,
-                                                                                                                                                                        "optional": false,
                                                                                                                                                                         "start": 214,
                                                                                                                                                                         "type": "CallExpression",
                                                                                                                                                                         "type": "CallExpression"
@@ -1001,7 +977,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                         "type": "Identifier"
                                                                                                                                                                       },
                                                                                                                                                                       "end": 227,
-                                                                                                                                                                      "optional": false,
                                                                                                                                                                       "start": 222,
                                                                                                                                                                       "type": "CallExpression",
                                                                                                                                                                       "type": "CallExpression"
@@ -1029,7 +1004,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                       "type": "Identifier"
                                                                                                                                                                     },
                                                                                                                                                                     "end": 235,
-                                                                                                                                                                    "optional": false,
                                                                                                                                                                     "start": 230,
                                                                                                                                                                     "type": "CallExpression",
                                                                                                                                                                     "type": "CallExpression"
@@ -1057,7 +1031,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                     "type": "Identifier"
                                                                                                                                                                   },
                                                                                                                                                                   "end": 243,
-                                                                                                                                                                  "optional": false,
                                                                                                                                                                   "start": 238,
                                                                                                                                                                   "type": "CallExpression",
                                                                                                                                                                   "type": "CallExpression"
@@ -1085,7 +1058,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                   "type": "Identifier"
                                                                                                                                                                 },
                                                                                                                                                                 "end": 251,
-                                                                                                                                                                "optional": false,
                                                                                                                                                                 "start": 246,
                                                                                                                                                                 "type": "CallExpression",
                                                                                                                                                                 "type": "CallExpression"
@@ -1113,7 +1085,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                                 "type": "Identifier"
                                                                                                                                                               },
                                                                                                                                                               "end": 259,
-                                                                                                                                                              "optional": false,
                                                                                                                                                               "start": 254,
                                                                                                                                                               "type": "CallExpression",
                                                                                                                                                               "type": "CallExpression"
@@ -1141,7 +1112,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                               "type": "Identifier"
                                                                                                                                                             },
                                                                                                                                                             "end": 267,
-                                                                                                                                                            "optional": false,
                                                                                                                                                             "start": 262,
                                                                                                                                                             "type": "CallExpression",
                                                                                                                                                             "type": "CallExpression"
@@ -1169,7 +1139,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                             "type": "Identifier"
                                                                                                                                                           },
                                                                                                                                                           "end": 275,
-                                                                                                                                                          "optional": false,
                                                                                                                                                           "start": 270,
                                                                                                                                                           "type": "CallExpression",
                                                                                                                                                           "type": "CallExpression"
@@ -1197,7 +1166,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                           "type": "Identifier"
                                                                                                                                                         },
                                                                                                                                                         "end": 283,
-                                                                                                                                                        "optional": false,
                                                                                                                                                         "start": 278,
                                                                                                                                                         "type": "CallExpression",
                                                                                                                                                         "type": "CallExpression"
@@ -1225,7 +1193,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                         "type": "Identifier"
                                                                                                                                                       },
                                                                                                                                                       "end": 291,
-                                                                                                                                                      "optional": false,
                                                                                                                                                       "start": 286,
                                                                                                                                                       "type": "CallExpression",
                                                                                                                                                       "type": "CallExpression"
@@ -1253,7 +1220,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                       "type": "Identifier"
                                                                                                                                                     },
                                                                                                                                                     "end": 299,
-                                                                                                                                                    "optional": false,
                                                                                                                                                     "start": 294,
                                                                                                                                                     "type": "CallExpression",
                                                                                                                                                     "type": "CallExpression"
@@ -1281,7 +1247,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                     "type": "Identifier"
                                                                                                                                                   },
                                                                                                                                                   "end": 307,
-                                                                                                                                                  "optional": false,
                                                                                                                                                   "start": 302,
                                                                                                                                                   "type": "CallExpression",
                                                                                                                                                   "type": "CallExpression"
@@ -1309,7 +1274,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                   "type": "Identifier"
                                                                                                                                                 },
                                                                                                                                                 "end": 315,
-                                                                                                                                                "optional": false,
                                                                                                                                                 "start": 310,
                                                                                                                                                 "type": "CallExpression",
                                                                                                                                                 "type": "CallExpression"
@@ -1337,7 +1301,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                                 "type": "Identifier"
                                                                                                                                               },
                                                                                                                                               "end": 323,
-                                                                                                                                              "optional": false,
                                                                                                                                               "start": 318,
                                                                                                                                               "type": "CallExpression",
                                                                                                                                               "type": "CallExpression"
@@ -1365,7 +1328,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                               "type": "Identifier"
                                                                                                                                             },
                                                                                                                                             "end": 331,
-                                                                                                                                            "optional": false,
                                                                                                                                             "start": 326,
                                                                                                                                             "type": "CallExpression",
                                                                                                                                             "type": "CallExpression"
@@ -1393,7 +1355,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                             "type": "Identifier"
                                                                                                                                           },
                                                                                                                                           "end": 339,
-                                                                                                                                          "optional": false,
                                                                                                                                           "start": 334,
                                                                                                                                           "type": "CallExpression",
                                                                                                                                           "type": "CallExpression"
@@ -1421,7 +1382,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                           "type": "Identifier"
                                                                                                                                         },
                                                                                                                                         "end": 347,
-                                                                                                                                        "optional": false,
                                                                                                                                         "start": 342,
                                                                                                                                         "type": "CallExpression",
                                                                                                                                         "type": "CallExpression"
@@ -1449,7 +1409,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                         "type": "Identifier"
                                                                                                                                       },
                                                                                                                                       "end": 355,
-                                                                                                                                      "optional": false,
                                                                                                                                       "start": 350,
                                                                                                                                       "type": "CallExpression",
                                                                                                                                       "type": "CallExpression"
@@ -1477,7 +1436,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                       "type": "Identifier"
                                                                                                                                     },
                                                                                                                                     "end": 363,
-                                                                                                                                    "optional": false,
                                                                                                                                     "start": 358,
                                                                                                                                     "type": "CallExpression",
                                                                                                                                     "type": "CallExpression"
@@ -1505,7 +1463,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                     "type": "Identifier"
                                                                                                                                   },
                                                                                                                                   "end": 371,
-                                                                                                                                  "optional": false,
                                                                                                                                   "start": 366,
                                                                                                                                   "type": "CallExpression",
                                                                                                                                   "type": "CallExpression"
@@ -1533,7 +1490,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                   "type": "Identifier"
                                                                                                                                 },
                                                                                                                                 "end": 379,
-                                                                                                                                "optional": false,
                                                                                                                                 "start": 374,
                                                                                                                                 "type": "CallExpression",
                                                                                                                                 "type": "CallExpression"
@@ -1561,7 +1517,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                                 "type": "Identifier"
                                                                                                                               },
                                                                                                                               "end": 387,
-                                                                                                                              "optional": false,
                                                                                                                               "start": 382,
                                                                                                                               "type": "CallExpression",
                                                                                                                               "type": "CallExpression"
@@ -1589,7 +1544,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                               "type": "Identifier"
                                                                                                                             },
                                                                                                                             "end": 395,
-                                                                                                                            "optional": false,
                                                                                                                             "start": 390,
                                                                                                                             "type": "CallExpression",
                                                                                                                             "type": "CallExpression"
@@ -1617,7 +1571,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                             "type": "Identifier"
                                                                                                                           },
                                                                                                                           "end": 403,
-                                                                                                                          "optional": false,
                                                                                                                           "start": 398,
                                                                                                                           "type": "CallExpression",
                                                                                                                           "type": "CallExpression"
@@ -1645,7 +1598,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                           "type": "Identifier"
                                                                                                                         },
                                                                                                                         "end": 411,
-                                                                                                                        "optional": false,
                                                                                                                         "start": 406,
                                                                                                                         "type": "CallExpression",
                                                                                                                         "type": "CallExpression"
@@ -1673,7 +1625,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                         "type": "Identifier"
                                                                                                                       },
                                                                                                                       "end": 419,
-                                                                                                                      "optional": false,
                                                                                                                       "start": 414,
                                                                                                                       "type": "CallExpression",
                                                                                                                       "type": "CallExpression"
@@ -1701,7 +1652,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                       "type": "Identifier"
                                                                                                                     },
                                                                                                                     "end": 427,
-                                                                                                                    "optional": false,
                                                                                                                     "start": 422,
                                                                                                                     "type": "CallExpression",
                                                                                                                     "type": "CallExpression"
@@ -1729,7 +1679,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                     "type": "Identifier"
                                                                                                                   },
                                                                                                                   "end": 435,
-                                                                                                                  "optional": false,
                                                                                                                   "start": 430,
                                                                                                                   "type": "CallExpression",
                                                                                                                   "type": "CallExpression"
@@ -1757,7 +1706,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                   "type": "Identifier"
                                                                                                                 },
                                                                                                                 "end": 443,
-                                                                                                                "optional": false,
                                                                                                                 "start": 438,
                                                                                                                 "type": "CallExpression",
                                                                                                                 "type": "CallExpression"
@@ -1785,7 +1733,6 @@ description: Result of parsing add_lots.kcl
                                                                                                                 "type": "Identifier"
                                                                                                               },
                                                                                                               "end": 451,
-                                                                                                              "optional": false,
                                                                                                               "start": 446,
                                                                                                               "type": "CallExpression",
                                                                                                               "type": "CallExpression"
@@ -1813,7 +1760,6 @@ description: Result of parsing add_lots.kcl
                                                                                                               "type": "Identifier"
                                                                                                             },
                                                                                                             "end": 459,
-                                                                                                            "optional": false,
                                                                                                             "start": 454,
                                                                                                             "type": "CallExpression",
                                                                                                             "type": "CallExpression"
@@ -1841,7 +1787,6 @@ description: Result of parsing add_lots.kcl
                                                                                                             "type": "Identifier"
                                                                                                           },
                                                                                                           "end": 467,
-                                                                                                          "optional": false,
                                                                                                           "start": 462,
                                                                                                           "type": "CallExpression",
                                                                                                           "type": "CallExpression"
@@ -1869,7 +1814,6 @@ description: Result of parsing add_lots.kcl
                                                                                                           "type": "Identifier"
                                                                                                         },
                                                                                                         "end": 475,
-                                                                                                        "optional": false,
                                                                                                         "start": 470,
                                                                                                         "type": "CallExpression",
                                                                                                         "type": "CallExpression"
@@ -1897,7 +1841,6 @@ description: Result of parsing add_lots.kcl
                                                                                                         "type": "Identifier"
                                                                                                       },
                                                                                                       "end": 483,
-                                                                                                      "optional": false,
                                                                                                       "start": 478,
                                                                                                       "type": "CallExpression",
                                                                                                       "type": "CallExpression"
@@ -1925,7 +1868,6 @@ description: Result of parsing add_lots.kcl
                                                                                                       "type": "Identifier"
                                                                                                     },
                                                                                                     "end": 491,
-                                                                                                    "optional": false,
                                                                                                     "start": 486,
                                                                                                     "type": "CallExpression",
                                                                                                     "type": "CallExpression"
@@ -1953,7 +1895,6 @@ description: Result of parsing add_lots.kcl
                                                                                                     "type": "Identifier"
                                                                                                   },
                                                                                                   "end": 499,
-                                                                                                  "optional": false,
                                                                                                   "start": 494,
                                                                                                   "type": "CallExpression",
                                                                                                   "type": "CallExpression"
@@ -1981,7 +1922,6 @@ description: Result of parsing add_lots.kcl
                                                                                                   "type": "Identifier"
                                                                                                 },
                                                                                                 "end": 507,
-                                                                                                "optional": false,
                                                                                                 "start": 502,
                                                                                                 "type": "CallExpression",
                                                                                                 "type": "CallExpression"
@@ -2009,7 +1949,6 @@ description: Result of parsing add_lots.kcl
                                                                                                 "type": "Identifier"
                                                                                               },
                                                                                               "end": 515,
-                                                                                              "optional": false,
                                                                                               "start": 510,
                                                                                               "type": "CallExpression",
                                                                                               "type": "CallExpression"
@@ -2037,7 +1976,6 @@ description: Result of parsing add_lots.kcl
                                                                                               "type": "Identifier"
                                                                                             },
                                                                                             "end": 523,
-                                                                                            "optional": false,
                                                                                             "start": 518,
                                                                                             "type": "CallExpression",
                                                                                             "type": "CallExpression"
@@ -2065,7 +2003,6 @@ description: Result of parsing add_lots.kcl
                                                                                             "type": "Identifier"
                                                                                           },
                                                                                           "end": 531,
-                                                                                          "optional": false,
                                                                                           "start": 526,
                                                                                           "type": "CallExpression",
                                                                                           "type": "CallExpression"
@@ -2093,7 +2030,6 @@ description: Result of parsing add_lots.kcl
                                                                                           "type": "Identifier"
                                                                                         },
                                                                                         "end": 539,
-                                                                                        "optional": false,
                                                                                         "start": 534,
                                                                                         "type": "CallExpression",
                                                                                         "type": "CallExpression"
@@ -2121,7 +2057,6 @@ description: Result of parsing add_lots.kcl
                                                                                         "type": "Identifier"
                                                                                       },
                                                                                       "end": 547,
-                                                                                      "optional": false,
                                                                                       "start": 542,
                                                                                       "type": "CallExpression",
                                                                                       "type": "CallExpression"
@@ -2149,7 +2084,6 @@ description: Result of parsing add_lots.kcl
                                                                                       "type": "Identifier"
                                                                                     },
                                                                                     "end": 555,
-                                                                                    "optional": false,
                                                                                     "start": 550,
                                                                                     "type": "CallExpression",
                                                                                     "type": "CallExpression"
@@ -2177,7 +2111,6 @@ description: Result of parsing add_lots.kcl
                                                                                     "type": "Identifier"
                                                                                   },
                                                                                   "end": 563,
-                                                                                  "optional": false,
                                                                                   "start": 558,
                                                                                   "type": "CallExpression",
                                                                                   "type": "CallExpression"
@@ -2205,7 +2138,6 @@ description: Result of parsing add_lots.kcl
                                                                                   "type": "Identifier"
                                                                                 },
                                                                                 "end": 571,
-                                                                                "optional": false,
                                                                                 "start": 566,
                                                                                 "type": "CallExpression",
                                                                                 "type": "CallExpression"
@@ -2233,7 +2165,6 @@ description: Result of parsing add_lots.kcl
                                                                                 "type": "Identifier"
                                                                               },
                                                                               "end": 579,
-                                                                              "optional": false,
                                                                               "start": 574,
                                                                               "type": "CallExpression",
                                                                               "type": "CallExpression"
@@ -2261,7 +2192,6 @@ description: Result of parsing add_lots.kcl
                                                                               "type": "Identifier"
                                                                             },
                                                                             "end": 587,
-                                                                            "optional": false,
                                                                             "start": 582,
                                                                             "type": "CallExpression",
                                                                             "type": "CallExpression"
@@ -2289,7 +2219,6 @@ description: Result of parsing add_lots.kcl
                                                                             "type": "Identifier"
                                                                           },
                                                                           "end": 595,
-                                                                          "optional": false,
                                                                           "start": 590,
                                                                           "type": "CallExpression",
                                                                           "type": "CallExpression"
@@ -2317,7 +2246,6 @@ description: Result of parsing add_lots.kcl
                                                                           "type": "Identifier"
                                                                         },
                                                                         "end": 603,
-                                                                        "optional": false,
                                                                         "start": 598,
                                                                         "type": "CallExpression",
                                                                         "type": "CallExpression"
@@ -2345,7 +2273,6 @@ description: Result of parsing add_lots.kcl
                                                                         "type": "Identifier"
                                                                       },
                                                                       "end": 611,
-                                                                      "optional": false,
                                                                       "start": 606,
                                                                       "type": "CallExpression",
                                                                       "type": "CallExpression"
@@ -2373,7 +2300,6 @@ description: Result of parsing add_lots.kcl
                                                                       "type": "Identifier"
                                                                     },
                                                                     "end": 619,
-                                                                    "optional": false,
                                                                     "start": 614,
                                                                     "type": "CallExpression",
                                                                     "type": "CallExpression"
@@ -2401,7 +2327,6 @@ description: Result of parsing add_lots.kcl
                                                                     "type": "Identifier"
                                                                   },
                                                                   "end": 627,
-                                                                  "optional": false,
                                                                   "start": 622,
                                                                   "type": "CallExpression",
                                                                   "type": "CallExpression"
@@ -2429,7 +2354,6 @@ description: Result of parsing add_lots.kcl
                                                                   "type": "Identifier"
                                                                 },
                                                                 "end": 635,
-                                                                "optional": false,
                                                                 "start": 630,
                                                                 "type": "CallExpression",
                                                                 "type": "CallExpression"
@@ -2457,7 +2381,6 @@ description: Result of parsing add_lots.kcl
                                                                 "type": "Identifier"
                                                               },
                                                               "end": 643,
-                                                              "optional": false,
                                                               "start": 638,
                                                               "type": "CallExpression",
                                                               "type": "CallExpression"
@@ -2485,7 +2408,6 @@ description: Result of parsing add_lots.kcl
                                                               "type": "Identifier"
                                                             },
                                                             "end": 651,
-                                                            "optional": false,
                                                             "start": 646,
                                                             "type": "CallExpression",
                                                             "type": "CallExpression"
@@ -2513,7 +2435,6 @@ description: Result of parsing add_lots.kcl
                                                             "type": "Identifier"
                                                           },
                                                           "end": 659,
-                                                          "optional": false,
                                                           "start": 654,
                                                           "type": "CallExpression",
                                                           "type": "CallExpression"
@@ -2541,7 +2462,6 @@ description: Result of parsing add_lots.kcl
                                                           "type": "Identifier"
                                                         },
                                                         "end": 667,
-                                                        "optional": false,
                                                         "start": 662,
                                                         "type": "CallExpression",
                                                         "type": "CallExpression"
@@ -2569,7 +2489,6 @@ description: Result of parsing add_lots.kcl
                                                         "type": "Identifier"
                                                       },
                                                       "end": 675,
-                                                      "optional": false,
                                                       "start": 670,
                                                       "type": "CallExpression",
                                                       "type": "CallExpression"
@@ -2597,7 +2516,6 @@ description: Result of parsing add_lots.kcl
                                                       "type": "Identifier"
                                                     },
                                                     "end": 683,
-                                                    "optional": false,
                                                     "start": 678,
                                                     "type": "CallExpression",
                                                     "type": "CallExpression"
@@ -2625,7 +2543,6 @@ description: Result of parsing add_lots.kcl
                                                     "type": "Identifier"
                                                   },
                                                   "end": 691,
-                                                  "optional": false,
                                                   "start": 686,
                                                   "type": "CallExpression",
                                                   "type": "CallExpression"
@@ -2653,7 +2570,6 @@ description: Result of parsing add_lots.kcl
                                                   "type": "Identifier"
                                                 },
                                                 "end": 699,
-                                                "optional": false,
                                                 "start": 694,
                                                 "type": "CallExpression",
                                                 "type": "CallExpression"
@@ -2681,7 +2597,6 @@ description: Result of parsing add_lots.kcl
                                                 "type": "Identifier"
                                               },
                                               "end": 707,
-                                              "optional": false,
                                               "start": 702,
                                               "type": "CallExpression",
                                               "type": "CallExpression"
@@ -2709,7 +2624,6 @@ description: Result of parsing add_lots.kcl
                                               "type": "Identifier"
                                             },
                                             "end": 715,
-                                            "optional": false,
                                             "start": 710,
                                             "type": "CallExpression",
                                             "type": "CallExpression"
@@ -2737,7 +2651,6 @@ description: Result of parsing add_lots.kcl
                                             "type": "Identifier"
                                           },
                                           "end": 723,
-                                          "optional": false,
                                           "start": 718,
                                           "type": "CallExpression",
                                           "type": "CallExpression"
@@ -2765,7 +2678,6 @@ description: Result of parsing add_lots.kcl
                                           "type": "Identifier"
                                         },
                                         "end": 731,
-                                        "optional": false,
                                         "start": 726,
                                         "type": "CallExpression",
                                         "type": "CallExpression"
@@ -2793,7 +2705,6 @@ description: Result of parsing add_lots.kcl
                                         "type": "Identifier"
                                       },
                                       "end": 739,
-                                      "optional": false,
                                       "start": 734,
                                       "type": "CallExpression",
                                       "type": "CallExpression"
@@ -2821,7 +2732,6 @@ description: Result of parsing add_lots.kcl
                                       "type": "Identifier"
                                     },
                                     "end": 747,
-                                    "optional": false,
                                     "start": 742,
                                     "type": "CallExpression",
                                     "type": "CallExpression"
@@ -2849,7 +2759,6 @@ description: Result of parsing add_lots.kcl
                                     "type": "Identifier"
                                   },
                                   "end": 755,
-                                  "optional": false,
                                   "start": 750,
                                   "type": "CallExpression",
                                   "type": "CallExpression"
@@ -2877,7 +2786,6 @@ description: Result of parsing add_lots.kcl
                                   "type": "Identifier"
                                 },
                                 "end": 763,
-                                "optional": false,
                                 "start": 758,
                                 "type": "CallExpression",
                                 "type": "CallExpression"
@@ -2905,7 +2813,6 @@ description: Result of parsing add_lots.kcl
                                 "type": "Identifier"
                               },
                               "end": 771,
-                              "optional": false,
                               "start": 766,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -2933,7 +2840,6 @@ description: Result of parsing add_lots.kcl
                               "type": "Identifier"
                             },
                             "end": 779,
-                            "optional": false,
                             "start": 774,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -2961,7 +2867,6 @@ description: Result of parsing add_lots.kcl
                             "type": "Identifier"
                           },
                           "end": 787,
-                          "optional": false,
                           "start": 782,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -2989,7 +2894,6 @@ description: Result of parsing add_lots.kcl
                           "type": "Identifier"
                         },
                         "end": 795,
-                        "optional": false,
                         "start": 790,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -3017,7 +2921,6 @@ description: Result of parsing add_lots.kcl
                         "type": "Identifier"
                       },
                       "end": 803,
-                      "optional": false,
                       "start": 798,
                       "type": "CallExpression",
                       "type": "CallExpression"
@@ -3045,7 +2948,6 @@ description: Result of parsing add_lots.kcl
                       "type": "Identifier"
                     },
                     "end": 811,
-                    "optional": false,
                     "start": 806,
                     "type": "CallExpression",
                     "type": "CallExpression"
@@ -3073,7 +2975,6 @@ description: Result of parsing add_lots.kcl
                     "type": "Identifier"
                   },
                   "end": 819,
-                  "optional": false,
                   "start": 814,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3101,7 +3002,6 @@ description: Result of parsing add_lots.kcl
                   "type": "Identifier"
                 },
                 "end": 828,
-                "optional": false,
                 "start": 822,
                 "type": "CallExpression",
                 "type": "CallExpression"
@@ -3163,7 +3063,6 @@ description: Result of parsing add_lots.kcl
             "type": "Identifier"
           },
           "end": 867,
-          "optional": false,
           "start": 830,
           "type": "CallExpression",
           "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/angled_line/ast.snap
+++ b/src/wasm-lib/kcl/tests/angled_line/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing angled_line.kcl
 snapshot_kind: text
 ---
@@ -37,7 +36,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29,
-                  "optional": false,
                   "start": 10,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -82,7 +80,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 67,
-                  "optional": false,
                   "start": 35,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -127,7 +124,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 94,
-                  "optional": false,
                   "start": 73,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -186,7 +182,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 130,
-                  "optional": false,
                   "start": 100,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -245,7 +240,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 159,
-                  "optional": false,
                   "start": 136,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -271,7 +265,6 @@ snapshot_kind: text
                             "type": "Identifier"
                           },
                           "end": 190,
-                          "optional": false,
                           "start": 177,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -304,7 +297,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 202,
-                  "optional": false,
                   "start": 165,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -356,7 +348,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 232,
-                  "optional": false,
                   "start": 208,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -377,7 +368,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 246,
-                  "optional": false,
                   "start": 238,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -406,7 +396,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 265,
-                  "optional": false,
                   "start": 252,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/argument_error/ast.snap
+++ b/src/wasm-lib/kcl/tests/argument_error/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Result of parsing argument_error.kcl
+snapshot_kind: text
 ---
 {
   "Ok": {
@@ -106,7 +107,6 @@ description: Result of parsing argument_error.kcl
             "type": "Identifier"
           },
           "end": 38,
-          "optional": false,
           "start": 24,
           "type": "CallExpression",
           "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/array_elem_push/ast.snap
+++ b/src/wasm-lib/kcl/tests/array_elem_push/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing array_elem_push.kcl
 snapshot_kind: text
 ---
@@ -94,7 +93,6 @@ snapshot_kind: text
                 "type": "Identifier"
               },
               "end": 39,
-              "optional": false,
               "start": 27,
               "type": "CallExpression",
               "type": "CallExpression"
@@ -144,7 +142,6 @@ snapshot_kind: text
                 "type": "Identifier"
               },
               "end": 68,
-              "optional": false,
               "start": 51,
               "type": "CallExpression",
               "type": "CallExpression"
@@ -217,7 +214,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 142,
-          "optional": false,
           "start": 69,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -284,7 +280,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 216,
-          "optional": false,
           "start": 143,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -351,7 +346,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 290,
-          "optional": false,
           "start": 217,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -418,7 +412,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 366,
-          "optional": false,
           "start": 291,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -485,7 +478,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 440,
-          "optional": false,
           "start": 367,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -552,7 +544,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 514,
-          "optional": false,
           "start": 441,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -619,7 +610,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 588,
-          "optional": false,
           "start": 515,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -686,7 +676,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 664,
-          "optional": false,
           "start": 589,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -753,7 +742,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 740,
-          "optional": false,
           "start": 665,
           "type": "CallExpression",
           "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/array_elem_push_fail/ast.snap
+++ b/src/wasm-lib/kcl/tests/array_elem_push_fail/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing array_elem_push_fail.kcl
 snapshot_kind: text
 ---
@@ -94,7 +93,6 @@ snapshot_kind: text
                 "type": "Identifier"
               },
               "end": 40,
-              "optional": false,
               "start": 28,
               "type": "CallExpression",
               "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/array_range_expr/ast.snap
+++ b/src/wasm-lib/kcl/tests/array_range_expr/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Result of parsing array_range_expr.kcl
+snapshot_kind: text
 ---
 {
   "Ok": {
@@ -106,7 +107,6 @@ description: Result of parsing array_range_expr.kcl
             "type": "Identifier"
           },
           "end": 70,
-          "optional": false,
           "start": 12,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -270,7 +270,6 @@ description: Result of parsing array_range_expr.kcl
             "type": "Identifier"
           },
           "end": 166,
-          "optional": false,
           "start": 108,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -321,7 +320,6 @@ description: Result of parsing array_range_expr.kcl
                 "type": "Identifier"
               },
               "end": 188,
-              "optional": false,
               "start": 175,
               "type": "CallExpression",
               "type": "CallExpression"
@@ -435,7 +433,6 @@ description: Result of parsing array_range_expr.kcl
             "type": "Identifier"
           },
           "end": 275,
-          "optional": false,
           "start": 207,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -502,7 +499,6 @@ description: Result of parsing array_range_expr.kcl
             "type": "Identifier"
           },
           "end": 334,
-          "optional": false,
           "start": 276,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -555,7 +551,6 @@ description: Result of parsing array_range_expr.kcl
                   "type": "Identifier"
                 },
                 "end": 372,
-                "optional": false,
                 "start": 359,
                 "type": "CallExpression",
                 "type": "CallExpression"
@@ -594,7 +589,6 @@ description: Result of parsing array_range_expr.kcl
                   "type": "Identifier"
                 },
                 "end": 355,
-                "optional": false,
                 "start": 342,
                 "type": "CallExpression",
                 "type": "CallExpression"
@@ -670,7 +664,6 @@ description: Result of parsing array_range_expr.kcl
             "type": "Identifier"
           },
           "end": 426,
-          "optional": false,
           "start": 374,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -737,7 +730,6 @@ description: Result of parsing array_range_expr.kcl
             "type": "Identifier"
           },
           "end": 488,
-          "optional": false,
           "start": 427,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -804,7 +796,6 @@ description: Result of parsing array_range_expr.kcl
             "type": "Identifier"
           },
           "end": 540,
-          "optional": false,
           "start": 489,
           "type": "CallExpression",
           "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/array_range_negative_expr/ast.snap
+++ b/src/wasm-lib/kcl/tests/array_range_negative_expr/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Result of parsing array_range_negative_expr.kcl
+snapshot_kind: text
 ---
 {
   "Ok": {
@@ -52,7 +53,6 @@ description: Result of parsing array_range_negative_expr.kcl
                   "type": "Identifier"
                 },
                 "end": 13,
-                "optional": false,
                 "start": 6,
                 "type": "CallExpression",
                 "type": "CallExpression"
@@ -135,7 +135,6 @@ description: Result of parsing array_range_negative_expr.kcl
             "type": "Identifier"
           },
           "end": 72,
-          "optional": false,
           "start": 20,
           "type": "CallExpression",
           "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/basic_fillet_cube_close_opposite/ast.snap
+++ b/src/wasm-lib/kcl/tests/basic_fillet_cube_close_opposite/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing basic_fillet_cube_close_opposite.kcl
 snapshot_kind: text
 ---
@@ -37,7 +36,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29,
-                  "optional": false,
                   "start": 10,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -82,7 +80,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 60,
-                  "optional": false,
                   "start": 35,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -134,7 +131,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 90,
-                  "optional": false,
                   "start": 66,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -179,7 +175,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 112,
-                  "optional": false,
                   "start": 96,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -238,7 +233,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 144,
-                  "optional": false,
                   "start": 118,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -266,7 +260,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 167,
-                  "optional": false,
                   "start": 150,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -295,7 +288,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 187,
-                  "optional": false,
                   "start": 173,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -360,7 +352,6 @@ snapshot_kind: text
                                   "type": "Identifier"
                                 },
                                 "end": 267,
-                                "optional": false,
                                 "start": 244,
                                 "type": "CallExpression",
                                 "type": "CallExpression"
@@ -391,7 +382,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 279,
-                  "optional": false,
                   "start": 193,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/basic_fillet_cube_end/ast.snap
+++ b/src/wasm-lib/kcl/tests/basic_fillet_cube_end/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing basic_fillet_cube_end.kcl
 snapshot_kind: text
 ---
@@ -37,7 +36,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29,
-                  "optional": false,
                   "start": 10,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -82,7 +80,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 60,
-                  "optional": false,
                   "start": 35,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -134,7 +131,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 90,
-                  "optional": false,
                   "start": 66,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -179,7 +175,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 112,
-                  "optional": false,
                   "start": 96,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -238,7 +233,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 144,
-                  "optional": false,
                   "start": 118,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -259,7 +253,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 158,
-                  "optional": false,
                   "start": 150,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -288,7 +281,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 178,
-                  "optional": false,
                   "start": 164,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -353,7 +345,6 @@ snapshot_kind: text
                                   "type": "Identifier"
                                 },
                                 "end": 256,
-                                "optional": false,
                                 "start": 234,
                                 "type": "CallExpression",
                                 "type": "CallExpression"
@@ -384,7 +375,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 268,
-                  "optional": false,
                   "start": 184,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/basic_fillet_cube_next_adjacent/ast.snap
+++ b/src/wasm-lib/kcl/tests/basic_fillet_cube_next_adjacent/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing basic_fillet_cube_next_adjacent.kcl
 snapshot_kind: text
 ---
@@ -37,7 +36,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29,
-                  "optional": false,
                   "start": 10,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -82,7 +80,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 60,
-                  "optional": false,
                   "start": 35,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -134,7 +131,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 90,
-                  "optional": false,
                   "start": 66,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -186,7 +182,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 121,
-                  "optional": false,
                   "start": 96,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -245,7 +240,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 153,
-                  "optional": false,
                   "start": 127,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -273,7 +267,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 176,
-                  "optional": false,
                   "start": 159,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -302,7 +295,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 196,
-                  "optional": false,
                   "start": 182,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -360,7 +352,6 @@ snapshot_kind: text
                                   "type": "Identifier"
                                 },
                                 "end": 272,
-                                "optional": false,
                                 "start": 245,
                                 "type": "CallExpression",
                                 "type": "CallExpression"
@@ -391,7 +382,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 284,
-                  "optional": false,
                   "start": 202,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/basic_fillet_cube_previous_adjacent/ast.snap
+++ b/src/wasm-lib/kcl/tests/basic_fillet_cube_previous_adjacent/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing basic_fillet_cube_previous_adjacent.kcl
 snapshot_kind: text
 ---
@@ -37,7 +36,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29,
-                  "optional": false,
                   "start": 10,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -82,7 +80,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 60,
-                  "optional": false,
                   "start": 35,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -134,7 +131,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 90,
-                  "optional": false,
                   "start": 66,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -186,7 +182,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 121,
-                  "optional": false,
                   "start": 96,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -245,7 +240,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 153,
-                  "optional": false,
                   "start": 127,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -273,7 +267,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 176,
-                  "optional": false,
                   "start": 159,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -302,7 +295,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 196,
-                  "optional": false,
                   "start": 182,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -360,7 +352,6 @@ snapshot_kind: text
                                   "type": "Identifier"
                                 },
                                 "end": 276,
-                                "optional": false,
                                 "start": 245,
                                 "type": "CallExpression",
                                 "type": "CallExpression"
@@ -391,7 +382,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 288,
-                  "optional": false,
                   "start": 202,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/basic_fillet_cube_start/ast.snap
+++ b/src/wasm-lib/kcl/tests/basic_fillet_cube_start/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing basic_fillet_cube_start.kcl
 snapshot_kind: text
 ---
@@ -37,7 +36,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29,
-                  "optional": false,
                   "start": 10,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -82,7 +80,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 60,
-                  "optional": false,
                   "start": 35,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -134,7 +131,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 90,
-                  "optional": false,
                   "start": 66,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -179,7 +175,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 112,
-                  "optional": false,
                   "start": 96,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -238,7 +233,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 144,
-                  "optional": false,
                   "start": 118,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -259,7 +253,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 158,
-                  "optional": false,
                   "start": 150,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -288,7 +281,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 178,
-                  "optional": false,
                   "start": 164,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -369,7 +361,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 233,
-                  "optional": false,
                   "start": 184,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/big_number_angle_to_match_length_x/ast.snap
+++ b/src/wasm-lib/kcl/tests/big_number_angle_to_match_length_x/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing big_number_angle_to_match_length_x.kcl
 snapshot_kind: text
 ---
@@ -37,7 +36,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29,
-                  "optional": false,
                   "start": 10,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -82,7 +80,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 60,
-                  "optional": false,
                   "start": 35,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -134,7 +131,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 92,
-                  "optional": false,
                   "start": 66,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -175,7 +171,6 @@ snapshot_kind: text
                               "type": "Identifier"
                             },
                             "end": 146,
-                            "optional": false,
                             "start": 114,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -214,7 +209,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 154,
-                  "optional": false,
                   "start": 98,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -235,7 +229,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 168,
-                  "optional": false,
                   "start": 160,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -264,7 +257,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 188,
-                  "optional": false,
                   "start": 174,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/big_number_angle_to_match_length_y/ast.snap
+++ b/src/wasm-lib/kcl/tests/big_number_angle_to_match_length_y/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing big_number_angle_to_match_length_y.kcl
 snapshot_kind: text
 ---
@@ -37,7 +36,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29,
-                  "optional": false,
                   "start": 10,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -82,7 +80,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 60,
-                  "optional": false,
                   "start": 35,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -134,7 +131,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 92,
-                  "optional": false,
                   "start": 66,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -175,7 +171,6 @@ snapshot_kind: text
                               "type": "Identifier"
                             },
                             "end": 146,
-                            "optional": false,
                             "start": 114,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -214,7 +209,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 154,
-                  "optional": false,
                   "start": 98,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -235,7 +229,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 168,
-                  "optional": false,
                   "start": 160,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -264,7 +257,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 188,
-                  "optional": false,
                   "start": 174,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/circular_pattern3d_a_pattern/ast.snap
+++ b/src/wasm-lib/kcl/tests/circular_pattern3d_a_pattern/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing circular_pattern3d_a_pattern.kcl
 snapshot_kind: text
 ---
@@ -37,7 +36,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 35,
-                  "optional": false,
                   "start": 16,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -82,7 +80,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 66,
-                  "optional": false,
                   "start": 41,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -127,7 +124,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 87,
-                  "optional": false,
                   "start": 72,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -172,7 +168,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 108,
-                  "optional": false,
                   "start": 93,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -224,7 +219,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 130,
-                  "optional": false,
                   "start": 114,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -245,7 +239,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 144,
-                  "optional": false,
                   "start": 136,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -274,7 +267,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 163,
-                  "optional": false,
                   "start": 150,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -411,7 +403,6 @@ snapshot_kind: text
                 "type": "Identifier"
               },
               "end": 261,
-              "optional": false,
               "start": 174,
               "type": "CallExpression",
               "type": "CallExpression"
@@ -625,7 +616,6 @@ snapshot_kind: text
                 "type": "Identifier"
               },
               "end": 415,
-              "optional": false,
               "start": 272,
               "type": "CallExpression",
               "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/comparisons/ast.snap
+++ b/src/wasm-lib/kcl/tests/comparisons/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing comparisons.kcl
 snapshot_kind: text
 ---
@@ -50,7 +49,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 26,
-          "optional": false,
           "start": 0,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -102,7 +100,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 67,
-          "optional": false,
           "start": 27,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -154,7 +151,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 98,
-          "optional": false,
           "start": 68,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -206,7 +202,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 143,
-          "optional": false,
           "start": 99,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -258,7 +253,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 163,
-          "optional": false,
           "start": 144,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -310,7 +304,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 201,
-          "optional": false,
           "start": 164,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -362,7 +355,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 239,
-          "optional": false,
           "start": 202,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -414,7 +406,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 259,
-          "optional": false,
           "start": 240,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -466,7 +457,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 297,
-          "optional": false,
           "start": 260,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -518,7 +508,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 335,
-          "optional": false,
           "start": 298,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -570,7 +559,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 375,
-          "optional": false,
           "start": 337,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -629,7 +617,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 428,
-          "optional": false,
           "start": 376,
           "type": "CallExpression",
           "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/comparisons_multiple/ast.snap
+++ b/src/wasm-lib/kcl/tests/comparisons_multiple/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing comparisons_multiple.kcl
 snapshot_kind: text
 ---
@@ -65,7 +64,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 46,
-          "optional": false,
           "start": 0,
           "type": "CallExpression",
           "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/computed_var/ast.snap
+++ b/src/wasm-lib/kcl/tests/computed_var/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing computed_var.kcl
 snapshot_kind: text
 ---
@@ -179,7 +178,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 115,
-          "optional": false,
           "start": 77,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -366,7 +364,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 206,
-          "optional": false,
           "start": 168,
           "type": "CallExpression",
           "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/cube/ast.snap
+++ b/src/wasm-lib/kcl/tests/cube/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Result of parsing cube.kcl
+snapshot_kind: text
 ---
 {
   "Ok": {
@@ -472,7 +473,6 @@ description: Result of parsing cube.kcl
                             "type": "Identifier"
                           },
                           "end": 194,
-                          "optional": false,
                           "start": 177,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -500,7 +500,6 @@ description: Result of parsing cube.kcl
                             "type": "Identifier"
                           },
                           "end": 215,
-                          "optional": false,
                           "start": 202,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -528,7 +527,6 @@ description: Result of parsing cube.kcl
                             "type": "Identifier"
                           },
                           "end": 236,
-                          "optional": false,
                           "start": 223,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -556,7 +554,6 @@ description: Result of parsing cube.kcl
                             "type": "Identifier"
                           },
                           "end": 257,
-                          "optional": false,
                           "start": 244,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -584,7 +581,6 @@ description: Result of parsing cube.kcl
                             "type": "Identifier"
                           },
                           "end": 278,
-                          "optional": false,
                           "start": 265,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -605,7 +601,6 @@ description: Result of parsing cube.kcl
                             "type": "Identifier"
                           },
                           "end": 294,
-                          "optional": false,
                           "start": 286,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -633,7 +628,6 @@ description: Result of parsing cube.kcl
                             "type": "Identifier"
                           },
                           "end": 320,
-                          "optional": false,
                           "start": 302,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -757,7 +751,6 @@ description: Result of parsing cube.kcl
                 "type": "Identifier"
               },
               "end": 349,
-              "optional": false,
               "start": 333,
               "type": "CallExpression",
               "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/cube/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/cube/program_memory.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Program memory after executing cube.kcl
+snapshot_kind: text
 ---
 {
   "environments": [
@@ -485,7 +486,6 @@ description: Program memory after executing cube.kcl
                           "type": "Identifier"
                         },
                         "end": 194,
-                        "optional": false,
                         "start": 177,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -513,7 +513,6 @@ description: Program memory after executing cube.kcl
                           "type": "Identifier"
                         },
                         "end": 215,
-                        "optional": false,
                         "start": 202,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -541,7 +540,6 @@ description: Program memory after executing cube.kcl
                           "type": "Identifier"
                         },
                         "end": 236,
-                        "optional": false,
                         "start": 223,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -569,7 +567,6 @@ description: Program memory after executing cube.kcl
                           "type": "Identifier"
                         },
                         "end": 257,
-                        "optional": false,
                         "start": 244,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -597,7 +594,6 @@ description: Program memory after executing cube.kcl
                           "type": "Identifier"
                         },
                         "end": 278,
-                        "optional": false,
                         "start": 265,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -618,7 +614,6 @@ description: Program memory after executing cube.kcl
                           "type": "Identifier"
                         },
                         "end": 294,
-                        "optional": false,
                         "start": 286,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -646,7 +641,6 @@ description: Program memory after executing cube.kcl
                           "type": "Identifier"
                         },
                         "end": 320,
-                        "optional": false,
                         "start": 302,
                         "type": "CallExpression",
                         "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/double_map_fn/ast.snap
+++ b/src/wasm-lib/kcl/tests/double_map_fn/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Result of parsing double_map_fn.kcl
+snapshot_kind: text
 ---
 {
   "Ok": {
@@ -162,7 +163,6 @@ description: Result of parsing double_map_fn.kcl
                     "type": "Identifier"
                   },
                   "end": 78,
-                  "optional": false,
                   "start": 61,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -190,7 +190,6 @@ description: Result of parsing double_map_fn.kcl
                     "type": "Identifier"
                   },
                   "end": 101,
-                  "optional": false,
                   "start": 84,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/fillet-and-shell/ast.snap
+++ b/src/wasm-lib/kcl/tests/fillet-and-shell/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Result of parsing fillet-and-shell.kcl
+snapshot_kind: text
 ---
 {
   "Ok": {
@@ -612,7 +613,6 @@ description: Result of parsing fillet-and-shell.kcl
                     "type": "Identifier"
                   },
                   "end": 461,
-                  "optional": false,
                   "start": 373,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -699,7 +699,6 @@ description: Result of parsing fillet-and-shell.kcl
                     "type": "Identifier"
                   },
                   "end": 549,
-                  "optional": false,
                   "start": 467,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -786,7 +785,6 @@ description: Result of parsing fillet-and-shell.kcl
                     "type": "Identifier"
                   },
                   "end": 637,
-                  "optional": false,
                   "start": 555,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -873,7 +871,6 @@ description: Result of parsing fillet-and-shell.kcl
                     "type": "Identifier"
                   },
                   "end": 727,
-                  "optional": false,
                   "start": 643,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -894,7 +891,6 @@ description: Result of parsing fillet-and-shell.kcl
                     "type": "Identifier"
                   },
                   "end": 741,
-                  "optional": false,
                   "start": 733,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -945,7 +941,6 @@ description: Result of parsing fillet-and-shell.kcl
                     "type": "Identifier"
                   },
                   "end": 769,
-                  "optional": false,
                   "start": 750,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -990,7 +985,6 @@ description: Result of parsing fillet-and-shell.kcl
                     "type": "Identifier"
                   },
                   "end": 800,
-                  "optional": false,
                   "start": 775,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1041,7 +1035,6 @@ description: Result of parsing fillet-and-shell.kcl
                     "type": "Identifier"
                   },
                   "end": 839,
-                  "optional": false,
                   "start": 806,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1091,7 +1084,6 @@ description: Result of parsing fillet-and-shell.kcl
                     "type": "Identifier"
                   },
                   "end": 887,
-                  "optional": false,
                   "start": 845,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1142,7 +1134,6 @@ description: Result of parsing fillet-and-shell.kcl
                     "type": "Identifier"
                   },
                   "end": 927,
-                  "optional": false,
                   "start": 893,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1170,7 +1161,6 @@ description: Result of parsing fillet-and-shell.kcl
                     "type": "Identifier"
                   },
                   "end": 949,
-                  "optional": false,
                   "start": 933,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1198,7 +1188,6 @@ description: Result of parsing fillet-and-shell.kcl
                     "type": "Identifier"
                   },
                   "end": 977,
-                  "optional": false,
                   "start": 955,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1256,7 +1245,6 @@ description: Result of parsing fillet-and-shell.kcl
                                   "type": "Identifier"
                                 },
                                 "end": 1062,
-                                "optional": false,
                                 "start": 1036,
                                 "type": "CallExpression",
                                 "type": "CallExpression"
@@ -1278,7 +1266,6 @@ description: Result of parsing fillet-and-shell.kcl
                                   "type": "Identifier"
                                 },
                                 "end": 1099,
-                                "optional": false,
                                 "start": 1073,
                                 "type": "CallExpression",
                                 "type": "CallExpression"
@@ -1300,7 +1287,6 @@ description: Result of parsing fillet-and-shell.kcl
                                   "type": "Identifier"
                                 },
                                 "end": 1136,
-                                "optional": false,
                                 "start": 1110,
                                 "type": "CallExpression",
                                 "type": "CallExpression"
@@ -1322,7 +1308,6 @@ description: Result of parsing fillet-and-shell.kcl
                                   "type": "Identifier"
                                 },
                                 "end": 1173,
-                                "optional": false,
                                 "start": 1147,
                                 "type": "CallExpression",
                                 "type": "CallExpression"
@@ -1353,7 +1338,6 @@ description: Result of parsing fillet-and-shell.kcl
                     "type": "Identifier"
                   },
                   "end": 1193,
-                  "optional": false,
                   "start": 983,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1417,7 +1401,6 @@ description: Result of parsing fillet-and-shell.kcl
                                 "type": "Identifier"
                               },
                               "end": 1252,
-                              "optional": false,
                               "start": 1233,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -1462,7 +1445,6 @@ description: Result of parsing fillet-and-shell.kcl
                                 "type": "Identifier"
                               },
                               "end": 1285,
-                              "optional": false,
                               "start": 1260,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -1543,7 +1525,6 @@ description: Result of parsing fillet-and-shell.kcl
                                 "type": "Identifier"
                               },
                               "end": 1337,
-                              "optional": false,
                               "start": 1293,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -1626,7 +1607,6 @@ description: Result of parsing fillet-and-shell.kcl
                                     "type": "Identifier"
                                   },
                                   "end": 1395,
-                                  "optional": false,
                                   "start": 1350,
                                   "type": "CallExpression",
                                   "type": "CallExpression"
@@ -1645,7 +1625,6 @@ description: Result of parsing fillet-and-shell.kcl
                                 "type": "Identifier"
                               },
                               "end": 1399,
-                              "optional": false,
                               "start": 1345,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -1673,7 +1652,6 @@ description: Result of parsing fillet-and-shell.kcl
                                 "type": "Identifier"
                               },
                               "end": 1425,
-                              "optional": false,
                               "start": 1407,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -1922,7 +1900,6 @@ description: Result of parsing fillet-and-shell.kcl
             "type": "Identifier"
           },
           "end": 1573,
-          "optional": false,
           "start": 1444,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -2095,7 +2072,6 @@ description: Result of parsing fillet-and-shell.kcl
             "type": "Identifier"
           },
           "end": 1702,
-          "optional": false,
           "start": 1575,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -2268,7 +2244,6 @@ description: Result of parsing fillet-and-shell.kcl
             "type": "Identifier"
           },
           "end": 1829,
-          "optional": false,
           "start": 1704,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -2441,7 +2416,6 @@ description: Result of parsing fillet-and-shell.kcl
             "type": "Identifier"
           },
           "end": 1958,
-          "optional": false,
           "start": 1831,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -2522,7 +2496,6 @@ description: Result of parsing fillet-and-shell.kcl
             "type": "Identifier"
           },
           "end": 2023,
-          "optional": false,
           "start": 1960,
           "type": "CallExpression",
           "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/fillet-and-shell/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/fillet-and-shell/program_memory.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Program memory after executing fillet-and-shell.kcl
+snapshot_kind: text
 ---
 {
   "environments": [
@@ -938,7 +939,6 @@ description: Program memory after executing fillet-and-shell.kcl
                               "type": "Identifier"
                             },
                             "end": 1252,
-                            "optional": false,
                             "start": 1233,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -983,7 +983,6 @@ description: Program memory after executing fillet-and-shell.kcl
                               "type": "Identifier"
                             },
                             "end": 1285,
-                            "optional": false,
                             "start": 1260,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -1064,7 +1063,6 @@ description: Program memory after executing fillet-and-shell.kcl
                               "type": "Identifier"
                             },
                             "end": 1337,
-                            "optional": false,
                             "start": 1293,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -1147,7 +1145,6 @@ description: Program memory after executing fillet-and-shell.kcl
                                   "type": "Identifier"
                                 },
                                 "end": 1395,
-                                "optional": false,
                                 "start": 1350,
                                 "type": "CallExpression",
                                 "type": "CallExpression"
@@ -1166,7 +1163,6 @@ description: Program memory after executing fillet-and-shell.kcl
                               "type": "Identifier"
                             },
                             "end": 1399,
-                            "optional": false,
                             "start": 1345,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -1194,7 +1190,6 @@ description: Program memory after executing fillet-and-shell.kcl
                               "type": "Identifier"
                             },
                             "end": 1425,
-                            "optional": false,
                             "start": 1407,
                             "type": "CallExpression",
                             "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/function_sketch/ast.snap
+++ b/src/wasm-lib/kcl/tests/function_sketch/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Result of parsing function_sketch.kcl
+snapshot_kind: text
 ---
 {
   "Ok": {
@@ -48,7 +49,6 @@ description: Result of parsing function_sketch.kcl
                                 "type": "Identifier"
                               },
                               "end": 47,
-                              "optional": false,
                               "start": 28,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -93,7 +93,6 @@ description: Result of parsing function_sketch.kcl
                                 "type": "Identifier"
                               },
                               "end": 80,
-                              "optional": false,
                               "start": 55,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -137,7 +136,6 @@ description: Result of parsing function_sketch.kcl
                                 "type": "Identifier"
                               },
                               "end": 103,
-                              "optional": false,
                               "start": 88,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -181,7 +179,6 @@ description: Result of parsing function_sketch.kcl
                                 "type": "Identifier"
                               },
                               "end": 126,
-                              "optional": false,
                               "start": 111,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -232,7 +229,6 @@ description: Result of parsing function_sketch.kcl
                                 "type": "Identifier"
                               },
                               "end": 150,
-                              "optional": false,
                               "start": 134,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -253,7 +249,6 @@ description: Result of parsing function_sketch.kcl
                                 "type": "Identifier"
                               },
                               "end": 166,
-                              "optional": false,
                               "start": 158,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -281,7 +276,6 @@ description: Result of parsing function_sketch.kcl
                                 "type": "Identifier"
                               },
                               "end": 187,
-                              "optional": false,
                               "start": 174,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -425,7 +419,6 @@ description: Result of parsing function_sketch.kcl
                 "type": "Identifier"
               },
               "end": 228,
-              "optional": false,
               "start": 215,
               "type": "CallExpression",
               "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/function_sketch/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/function_sketch/program_memory.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Program memory after executing function_sketch.kcl
+snapshot_kind: text
 ---
 {
   "environments": [
@@ -61,7 +62,6 @@ description: Program memory after executing function_sketch.kcl
                               "type": "Identifier"
                             },
                             "end": 47,
-                            "optional": false,
                             "start": 28,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -106,7 +106,6 @@ description: Program memory after executing function_sketch.kcl
                               "type": "Identifier"
                             },
                             "end": 80,
-                            "optional": false,
                             "start": 55,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -150,7 +149,6 @@ description: Program memory after executing function_sketch.kcl
                               "type": "Identifier"
                             },
                             "end": 103,
-                            "optional": false,
                             "start": 88,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -194,7 +192,6 @@ description: Program memory after executing function_sketch.kcl
                               "type": "Identifier"
                             },
                             "end": 126,
-                            "optional": false,
                             "start": 111,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -245,7 +242,6 @@ description: Program memory after executing function_sketch.kcl
                               "type": "Identifier"
                             },
                             "end": 150,
-                            "optional": false,
                             "start": 134,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -266,7 +262,6 @@ description: Program memory after executing function_sketch.kcl
                               "type": "Identifier"
                             },
                             "end": 166,
-                            "optional": false,
                             "start": 158,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -294,7 +289,6 @@ description: Program memory after executing function_sketch.kcl
                               "type": "Identifier"
                             },
                             "end": 187,
-                            "optional": false,
                             "start": 174,
                             "type": "CallExpression",
                             "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/function_sketch_with_position/ast.snap
+++ b/src/wasm-lib/kcl/tests/function_sketch_with_position/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Result of parsing function_sketch_with_position.kcl
+snapshot_kind: text
 ---
 {
   "Ok": {
@@ -48,7 +49,6 @@ description: Result of parsing function_sketch_with_position.kcl
                                 "type": "Identifier"
                               },
                               "end": 50,
-                              "optional": false,
                               "start": 31,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -76,7 +76,6 @@ description: Result of parsing function_sketch_with_position.kcl
                                 "type": "Identifier"
                               },
                               "end": 78,
-                              "optional": false,
                               "start": 58,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -120,7 +119,6 @@ description: Result of parsing function_sketch_with_position.kcl
                                 "type": "Identifier"
                               },
                               "end": 101,
-                              "optional": false,
                               "start": 86,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -164,7 +162,6 @@ description: Result of parsing function_sketch_with_position.kcl
                                 "type": "Identifier"
                               },
                               "end": 124,
-                              "optional": false,
                               "start": 109,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -215,7 +212,6 @@ description: Result of parsing function_sketch_with_position.kcl
                                 "type": "Identifier"
                               },
                               "end": 148,
-                              "optional": false,
                               "start": 132,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -236,7 +232,6 @@ description: Result of parsing function_sketch_with_position.kcl
                                 "type": "Identifier"
                               },
                               "end": 164,
-                              "optional": false,
                               "start": 156,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -264,7 +259,6 @@ description: Result of parsing function_sketch_with_position.kcl
                                 "type": "Identifier"
                               },
                               "end": 185,
-                              "optional": false,
                               "start": 172,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -442,7 +436,6 @@ description: Result of parsing function_sketch_with_position.kcl
                 "type": "Identifier"
               },
               "end": 234,
-              "optional": false,
               "start": 213,
               "type": "CallExpression",
               "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/function_sketch_with_position/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/function_sketch_with_position/program_memory.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Program memory after executing function_sketch_with_position.kcl
+snapshot_kind: text
 ---
 {
   "environments": [
@@ -61,7 +62,6 @@ description: Program memory after executing function_sketch_with_position.kcl
                               "type": "Identifier"
                             },
                             "end": 50,
-                            "optional": false,
                             "start": 31,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -89,7 +89,6 @@ description: Program memory after executing function_sketch_with_position.kcl
                               "type": "Identifier"
                             },
                             "end": 78,
-                            "optional": false,
                             "start": 58,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -133,7 +132,6 @@ description: Program memory after executing function_sketch_with_position.kcl
                               "type": "Identifier"
                             },
                             "end": 101,
-                            "optional": false,
                             "start": 86,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -177,7 +175,6 @@ description: Program memory after executing function_sketch_with_position.kcl
                               "type": "Identifier"
                             },
                             "end": 124,
-                            "optional": false,
                             "start": 109,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -228,7 +225,6 @@ description: Program memory after executing function_sketch_with_position.kcl
                               "type": "Identifier"
                             },
                             "end": 148,
-                            "optional": false,
                             "start": 132,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -249,7 +245,6 @@ description: Program memory after executing function_sketch_with_position.kcl
                               "type": "Identifier"
                             },
                             "end": 164,
-                            "optional": false,
                             "start": 156,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -277,7 +272,6 @@ description: Program memory after executing function_sketch_with_position.kcl
                               "type": "Identifier"
                             },
                             "end": 185,
-                            "optional": false,
                             "start": 172,
                             "type": "CallExpression",
                             "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/helix_ccw/ast.snap
+++ b/src/wasm-lib/kcl/tests/helix_ccw/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing helix_ccw.kcl
 snapshot_kind: text
 ---
@@ -37,7 +36,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29,
-                  "optional": false,
                   "start": 10,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -120,7 +118,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 78,
-                  "optional": false,
                   "start": 35,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -149,7 +146,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 98,
-                  "optional": false,
                   "start": 84,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -235,7 +231,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 188,
-                  "optional": false,
                   "start": 104,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/i_shape/ast.snap
+++ b/src/wasm-lib/kcl/tests/i_shape/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing i_shape.kcl
 snapshot_kind: text
 ---
@@ -325,7 +324,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 432,
-                  "optional": false,
                   "start": 399,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -383,7 +381,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 475,
-                  "optional": false,
                   "start": 438,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -426,7 +423,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 539,
-                  "optional": false,
                   "start": 481,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -469,7 +465,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 575,
-                  "optional": false,
                   "start": 545,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -519,7 +514,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 640,
-                  "optional": false,
                   "start": 581,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -598,7 +592,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 705,
-                  "optional": false,
                   "start": 646,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -648,7 +641,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 770,
-                  "optional": false,
                   "start": 711,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -735,7 +727,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 828,
-                  "optional": false,
                   "start": 776,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -778,7 +769,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 892,
-                  "optional": false,
                   "start": 834,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -836,7 +826,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 934,
-                  "optional": false,
                   "start": 898,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -879,7 +868,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 998,
-                  "optional": false,
                   "start": 940,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -922,7 +910,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1034,
-                  "optional": false,
                   "start": 1004,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -972,7 +959,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1099,
-                  "optional": false,
                   "start": 1040,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1066,7 +1052,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1168,
-                  "optional": false,
                   "start": 1105,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1123,7 +1108,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1234,
-                  "optional": false,
                   "start": 1174,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1173,7 +1157,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1273,
-                  "optional": false,
                   "start": 1240,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1223,7 +1206,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1338,
-                  "optional": false,
                   "start": 1279,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1281,7 +1263,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1380,
-                  "optional": false,
                   "start": 1344,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1331,7 +1312,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1445,
-                  "optional": false,
                   "start": 1386,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1425,7 +1405,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1506,
-                  "optional": false,
                   "start": 1451,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1482,7 +1461,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1572,
-                  "optional": false,
                   "start": 1512,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1618,7 +1596,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1702,
-                  "optional": false,
                   "start": 1578,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1675,7 +1652,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1768,
-                  "optional": false,
                   "start": 1708,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1725,7 +1701,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1807,
-                  "optional": false,
                   "start": 1774,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1775,7 +1750,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1872,
-                  "optional": false,
                   "start": 1813,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1796,7 +1770,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1886,
-                  "optional": false,
                   "start": 1878,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1863,7 +1836,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1917,
-                  "optional": false,
                   "start": 1896,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1892,7 +1864,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1936,
-                  "optional": false,
                   "start": 1923,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1935,7 +1906,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2000,
-                  "optional": false,
                   "start": 1942,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1993,7 +1963,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2042,
-                  "optional": false,
                   "start": 2006,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2043,7 +2012,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2107,
-                  "optional": false,
                   "start": 2048,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2079,7 +2047,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2127,
-                  "optional": false,
                   "start": 2113,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2136,7 +2103,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2193,
-                  "optional": false,
                   "start": 2133,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2201,7 +2167,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2238,
-                  "optional": false,
                   "start": 2199,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2251,7 +2216,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2303,
-                  "optional": false,
                   "start": 2244,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2272,7 +2236,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2317,
-                  "optional": false,
                   "start": 2309,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2335,7 +2298,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2357,
-                  "optional": false,
                   "start": 2343,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2364,7 +2326,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2378,
-                  "optional": false,
                   "start": 2363,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/if_else/ast.snap
+++ b/src/wasm-lib/kcl/tests/if_else/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing if_else.kcl
 snapshot_kind: text
 ---
@@ -161,7 +160,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 159,
-          "optional": false,
           "start": 102,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -324,7 +322,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 278,
-          "optional": false,
           "start": 216,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -487,7 +484,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 395,
-          "optional": false,
           "start": 336,
           "type": "CallExpression",
           "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/import_cycle1/ast.snap
+++ b/src/wasm-lib/kcl/tests/import_cycle1/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Result of parsing import_cycle1.kcl
+snapshot_kind: text
 ---
 {
   "Ok": {
@@ -52,7 +53,6 @@ description: Result of parsing import_cycle1.kcl
                           "type": "Identifier"
                         },
                         "end": 69,
-                        "optional": false,
                         "start": 64,
                         "type": "CallExpression",
                         "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/index_of_array/ast.snap
+++ b/src/wasm-lib/kcl/tests/index_of_array/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Result of parsing index_of_array.kcl
+snapshot_kind: text
 ---
 {
   "Ok": {
@@ -134,7 +135,6 @@ description: Result of parsing index_of_array.kcl
             "type": "Identifier"
           },
           "end": 157,
-          "optional": false,
           "start": 99,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -178,7 +178,6 @@ description: Result of parsing index_of_array.kcl
             "type": "Identifier"
           },
           "end": 219,
-          "optional": false,
           "start": 158,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -230,7 +229,6 @@ description: Result of parsing index_of_array.kcl
                 "type": "Identifier"
               },
               "end": 262,
-              "optional": false,
               "start": 252,
               "type": "CallExpression",
               "type": "CallExpression"
@@ -321,7 +319,6 @@ description: Result of parsing index_of_array.kcl
             "type": "Identifier"
           },
           "end": 340,
-          "optional": false,
           "start": 281,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -365,7 +362,6 @@ description: Result of parsing index_of_array.kcl
             "type": "Identifier"
           },
           "end": 403,
-          "optional": false,
           "start": 341,
           "type": "CallExpression",
           "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/kittycad_svg/ast.snap
+++ b/src/wasm-lib/kcl/tests/kittycad_svg/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing kittycad_svg.kcl
 snapshot_kind: text
 ---
@@ -37,7 +36,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 25,
-                  "optional": false,
                   "start": 6,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -82,7 +80,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 56,
-                  "optional": false,
                   "start": 31,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -134,7 +131,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 87,
-                  "optional": false,
                   "start": 62,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -186,7 +182,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 133,
-                  "optional": false,
                   "start": 109,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -238,7 +233,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 187,
-                  "optional": false,
                   "start": 163,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -290,7 +284,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 244,
-                  "optional": false,
                   "start": 219,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -342,7 +335,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 296,
-                  "optional": false,
                   "start": 274,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -394,7 +386,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 349,
-                  "optional": false,
                   "start": 328,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -446,7 +437,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 403,
-                  "optional": false,
                   "start": 379,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -498,7 +488,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 459,
-                  "optional": false,
                   "start": 435,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -550,7 +539,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 513,
-                  "optional": false,
                   "start": 489,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -602,7 +590,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 569,
-                  "optional": false,
                   "start": 545,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -654,7 +641,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 623,
-                  "optional": false,
                   "start": 599,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -706,7 +692,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 678,
-                  "optional": false,
                   "start": 655,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -758,7 +743,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 731,
-                  "optional": false,
                   "start": 708,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -810,7 +794,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 787,
-                  "optional": false,
                   "start": 763,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -862,7 +845,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 842,
-                  "optional": false,
                   "start": 817,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -914,7 +896,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 898,
-                  "optional": false,
                   "start": 874,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -966,7 +947,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 952,
-                  "optional": false,
                   "start": 928,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1018,7 +998,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1009,
-                  "optional": false,
                   "start": 984,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1070,7 +1049,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1065,
-                  "optional": false,
                   "start": 1040,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1122,7 +1100,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1122,
-                  "optional": false,
                   "start": 1097,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1174,7 +1151,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1178,
-                  "optional": false,
                   "start": 1153,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1226,7 +1202,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1235,
-                  "optional": false,
                   "start": 1210,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1278,7 +1253,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1287,
-                  "optional": false,
                   "start": 1265,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1330,7 +1304,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1342,
-                  "optional": false,
                   "start": 1319,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1382,7 +1355,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1399,
-                  "optional": false,
                   "start": 1373,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1434,7 +1406,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1456,
-                  "optional": false,
                   "start": 1431,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1486,7 +1457,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1512,
-                  "optional": false,
                   "start": 1487,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1538,7 +1508,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1570,
-                  "optional": false,
                   "start": 1544,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1590,7 +1559,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1627,
-                  "optional": false,
                   "start": 1601,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1642,7 +1610,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1685,
-                  "optional": false,
                   "start": 1659,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1694,7 +1661,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1741,
-                  "optional": false,
                   "start": 1716,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1746,7 +1712,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1798,
-                  "optional": false,
                   "start": 1773,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1798,7 +1763,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1855,
-                  "optional": false,
                   "start": 1829,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1850,7 +1814,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1913,
-                  "optional": false,
                   "start": 1887,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1902,7 +1865,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1968,
-                  "optional": false,
                   "start": 1943,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1954,7 +1916,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2025,
-                  "optional": false,
                   "start": 2000,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2006,7 +1967,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2079,
-                  "optional": false,
                   "start": 2055,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2058,7 +2018,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2135,
-                  "optional": false,
                   "start": 2111,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2110,7 +2069,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2191,
-                  "optional": false,
                   "start": 2166,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2162,7 +2120,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2248,
-                  "optional": false,
                   "start": 2223,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2214,7 +2171,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2303,
-                  "optional": false,
                   "start": 2279,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2266,7 +2222,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2359,
-                  "optional": false,
                   "start": 2335,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2318,7 +2273,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2415,
-                  "optional": false,
                   "start": 2390,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2370,7 +2324,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2472,
-                  "optional": false,
                   "start": 2447,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2422,7 +2375,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2532,
-                  "optional": false,
                   "start": 2503,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2474,7 +2426,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2583,
-                  "optional": false,
                   "start": 2554,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2526,7 +2477,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2639,
-                  "optional": false,
                   "start": 2614,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2578,7 +2528,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2695,
-                  "optional": false,
                   "start": 2671,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2630,7 +2579,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2751,
-                  "optional": false,
                   "start": 2726,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2682,7 +2630,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2809,
-                  "optional": false,
                   "start": 2783,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2734,7 +2681,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2866,
-                  "optional": false,
                   "start": 2840,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2786,7 +2732,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2924,
-                  "optional": false,
                   "start": 2898,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2838,7 +2783,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2997,
-                  "optional": false,
                   "start": 2972,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2890,7 +2834,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3044,
-                  "optional": false,
                   "start": 3019,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2942,7 +2885,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3101,
-                  "optional": false,
                   "start": 3075,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2994,7 +2936,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3159,
-                  "optional": false,
                   "start": 3133,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3046,7 +2987,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3215,
-                  "optional": false,
                   "start": 3190,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3098,7 +3038,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3262,
-                  "optional": false,
                   "start": 3237,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3150,7 +3089,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3318,
-                  "optional": false,
                   "start": 3293,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3202,7 +3140,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3375,
-                  "optional": false,
                   "start": 3350,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3254,7 +3191,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3431,
-                  "optional": false,
                   "start": 3406,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3306,7 +3242,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3478,
-                  "optional": false,
                   "start": 3453,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3358,7 +3293,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3534,
-                  "optional": false,
                   "start": 3509,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3410,7 +3344,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3591,
-                  "optional": false,
                   "start": 3566,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3462,7 +3395,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3648,
-                  "optional": false,
                   "start": 3622,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3514,7 +3446,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3696,
-                  "optional": false,
                   "start": 3670,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3566,7 +3497,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3766,
-                  "optional": false,
                   "start": 3727,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3618,7 +3548,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3837,
-                  "optional": false,
                   "start": 3798,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3670,7 +3599,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3893,
-                  "optional": false,
                   "start": 3868,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3722,7 +3650,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3940,
-                  "optional": false,
                   "start": 3915,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3774,7 +3701,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3997,
-                  "optional": false,
                   "start": 3971,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3826,7 +3752,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4055,
-                  "optional": false,
                   "start": 4029,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3878,7 +3803,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4112,
-                  "optional": false,
                   "start": 4086,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3930,7 +3854,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4160,
-                  "optional": false,
                   "start": 4134,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3982,7 +3905,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4217,
-                  "optional": false,
                   "start": 4191,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4034,7 +3956,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4275,
-                  "optional": false,
                   "start": 4249,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4086,7 +4007,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4332,
-                  "optional": false,
                   "start": 4306,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4138,7 +4058,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4380,
-                  "optional": false,
                   "start": 4354,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4190,7 +4109,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4437,
-                  "optional": false,
                   "start": 4411,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4242,7 +4160,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4495,
-                  "optional": false,
                   "start": 4469,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4294,7 +4211,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4551,
-                  "optional": false,
                   "start": 4526,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4346,7 +4262,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4598,
-                  "optional": false,
                   "start": 4573,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4398,7 +4313,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4653,
-                  "optional": false,
                   "start": 4628,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4450,7 +4364,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4709,
-                  "optional": false,
                   "start": 4685,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4502,7 +4415,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4762,
-                  "optional": false,
                   "start": 4739,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4554,7 +4466,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4818,
-                  "optional": false,
                   "start": 4794,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4606,7 +4517,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4872,
-                  "optional": false,
                   "start": 4848,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4658,7 +4568,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4928,
-                  "optional": false,
                   "start": 4904,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4710,7 +4619,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4982,
-                  "optional": false,
                   "start": 4958,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4762,7 +4670,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5038,
-                  "optional": false,
                   "start": 5014,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4814,7 +4721,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5096,
-                  "optional": false,
                   "start": 5068,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4866,7 +4772,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5155,
-                  "optional": false,
                   "start": 5128,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4918,7 +4823,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5209,
-                  "optional": false,
                   "start": 5185,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4970,7 +4874,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5266,
-                  "optional": false,
                   "start": 5241,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5022,7 +4925,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5321,
-                  "optional": false,
                   "start": 5296,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5074,7 +4976,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5378,
-                  "optional": false,
                   "start": 5353,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5126,7 +5027,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5433,
-                  "optional": false,
                   "start": 5408,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5178,7 +5078,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5483,
-                  "optional": false,
                   "start": 5455,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5230,7 +5129,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5544,
-                  "optional": false,
                   "start": 5515,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5282,7 +5180,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5600,
-                  "optional": false,
                   "start": 5574,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5334,7 +5231,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5657,
-                  "optional": false,
                   "start": 5632,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5386,7 +5282,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5706,
-                  "optional": false,
                   "start": 5679,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5438,7 +5333,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5764,
-                  "optional": false,
                   "start": 5736,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5490,7 +5384,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5822,
-                  "optional": false,
                   "start": 5796,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5542,7 +5435,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5878,
-                  "optional": false,
                   "start": 5852,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5594,7 +5486,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5935,
-                  "optional": false,
                   "start": 5910,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5646,7 +5537,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5991,
-                  "optional": false,
                   "start": 5966,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5698,7 +5588,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6049,
-                  "optional": false,
                   "start": 6023,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5750,7 +5639,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6105,
-                  "optional": false,
                   "start": 6080,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5802,7 +5690,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6161,
-                  "optional": false,
                   "start": 6137,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5854,7 +5741,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6215,
-                  "optional": false,
                   "start": 6191,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5906,7 +5792,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6285,
-                  "optional": false,
                   "start": 6247,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5958,7 +5843,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6342,
-                  "optional": false,
                   "start": 6316,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6010,7 +5894,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6390,
-                  "optional": false,
                   "start": 6364,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6062,7 +5945,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6447,
-                  "optional": false,
                   "start": 6421,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6114,7 +5996,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6505,
-                  "optional": false,
                   "start": 6479,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6166,7 +6047,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6562,
-                  "optional": false,
                   "start": 6536,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6218,7 +6098,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6619,
-                  "optional": false,
                   "start": 6594,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6270,7 +6149,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6667,
-                  "optional": false,
                   "start": 6641,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6322,7 +6200,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6725,
-                  "optional": false,
                   "start": 6699,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6374,7 +6251,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6782,
-                  "optional": false,
                   "start": 6756,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6426,7 +6302,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6858,
-                  "optional": false,
                   "start": 6819,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6478,7 +6353,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6928,
-                  "optional": false,
                   "start": 6889,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6530,7 +6404,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6986,
-                  "optional": false,
                   "start": 6960,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6582,7 +6455,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7043,
-                  "optional": false,
                   "start": 7017,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6634,7 +6506,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7114,
-                  "optional": false,
                   "start": 7075,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6686,7 +6557,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7184,
-                  "optional": false,
                   "start": 7145,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6738,7 +6608,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7241,
-                  "optional": false,
                   "start": 7216,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6790,7 +6659,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7295,
-                  "optional": false,
                   "start": 7271,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6842,7 +6710,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7352,
-                  "optional": false,
                   "start": 7327,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6894,7 +6761,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7407,
-                  "optional": false,
                   "start": 7382,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6946,7 +6812,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7477,
-                  "optional": false,
                   "start": 7439,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6998,7 +6863,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7546,
-                  "optional": false,
                   "start": 7508,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7050,7 +6914,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7603,
-                  "optional": false,
                   "start": 7578,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7102,7 +6965,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7660,
-                  "optional": false,
                   "start": 7634,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7154,7 +7016,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7718,
-                  "optional": false,
                   "start": 7692,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7206,7 +7067,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7773,
-                  "optional": false,
                   "start": 7748,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7258,7 +7118,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7829,
-                  "optional": false,
                   "start": 7805,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7310,7 +7169,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7876,
-                  "optional": false,
                   "start": 7851,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7362,7 +7220,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7931,
-                  "optional": false,
                   "start": 7906,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7414,7 +7271,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7987,
-                  "optional": false,
                   "start": 7963,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7466,7 +7322,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8040,
-                  "optional": false,
                   "start": 8017,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7518,7 +7373,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8096,
-                  "optional": false,
                   "start": 8072,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7570,7 +7424,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8152,
-                  "optional": false,
                   "start": 8127,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7622,7 +7475,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8209,
-                  "optional": false,
                   "start": 8184,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7674,7 +7526,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8279,
-                  "optional": false,
                   "start": 8240,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7726,7 +7577,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8350,
-                  "optional": false,
                   "start": 8311,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7778,7 +7628,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8405,
-                  "optional": false,
                   "start": 8381,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7830,7 +7679,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8460,
-                  "optional": false,
                   "start": 8437,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7882,7 +7730,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8515,
-                  "optional": false,
                   "start": 8491,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7934,7 +7781,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8561,
-                  "optional": false,
                   "start": 8537,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7986,7 +7832,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8614,
-                  "optional": false,
                   "start": 8591,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8038,7 +7883,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8669,
-                  "optional": false,
                   "start": 8646,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8090,7 +7934,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8723,
-                  "optional": false,
                   "start": 8699,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8142,7 +7985,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8779,
-                  "optional": false,
                   "start": 8755,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8194,7 +8036,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8833,
-                  "optional": false,
                   "start": 8809,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8246,7 +8087,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8895,
-                  "optional": false,
                   "start": 8865,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8298,7 +8138,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8955,
-                  "optional": false,
                   "start": 8925,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8350,7 +8189,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9011,
-                  "optional": false,
                   "start": 8987,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8402,7 +8240,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9065,
-                  "optional": false,
                   "start": 9041,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8454,7 +8291,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9121,
-                  "optional": false,
                   "start": 9097,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8506,7 +8342,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9174,
-                  "optional": false,
                   "start": 9151,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8558,7 +8393,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9229,
-                  "optional": false,
                   "start": 9206,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8610,7 +8444,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9284,
-                  "optional": false,
                   "start": 9260,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8662,7 +8495,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9340,
-                  "optional": false,
                   "start": 9316,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8714,7 +8546,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9396,
-                  "optional": false,
                   "start": 9371,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8766,7 +8597,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9443,
-                  "optional": false,
                   "start": 9418,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8818,7 +8648,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9498,
-                  "optional": false,
                   "start": 9473,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8870,7 +8699,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9555,
-                  "optional": false,
                   "start": 9530,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8922,7 +8750,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9609,
-                  "optional": false,
                   "start": 9585,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8974,7 +8801,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9665,
-                  "optional": false,
                   "start": 9641,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9026,7 +8852,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9720,
-                  "optional": false,
                   "start": 9695,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9078,7 +8903,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9777,
-                  "optional": false,
                   "start": 9752,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9130,7 +8954,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9832,
-                  "optional": false,
                   "start": 9807,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9182,7 +9005,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9895,
-                  "optional": false,
                   "start": 9864,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9234,7 +9056,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9956,
-                  "optional": false,
                   "start": 9925,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9286,7 +9107,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10013,
-                  "optional": false,
                   "start": 9988,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9338,7 +9158,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10081,
-                  "optional": false,
                   "start": 10043,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9390,7 +9209,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10151,
-                  "optional": false,
                   "start": 10113,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9442,7 +9260,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10206,
-                  "optional": false,
                   "start": 10182,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9494,7 +9311,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10262,
-                  "optional": false,
                   "start": 10238,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9546,7 +9362,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10318,
-                  "optional": false,
                   "start": 10293,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9598,7 +9413,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10362,
-                  "optional": false,
                   "start": 10340,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9650,7 +9464,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10427,
-                  "optional": false,
                   "start": 10392,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9702,7 +9515,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10497,
-                  "optional": false,
                   "start": 10459,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9754,7 +9566,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10552,
-                  "optional": false,
                   "start": 10528,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9806,7 +9617,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10608,
-                  "optional": false,
                   "start": 10584,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9858,7 +9668,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10664,
-                  "optional": false,
                   "start": 10639,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9910,7 +9719,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10721,
-                  "optional": false,
                   "start": 10696,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9962,7 +9770,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10775,
-                  "optional": false,
                   "start": 10751,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10014,7 +9821,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10831,
-                  "optional": false,
                   "start": 10807,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10066,7 +9872,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10886,
-                  "optional": false,
                   "start": 10861,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10118,7 +9923,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10943,
-                  "optional": false,
                   "start": 10918,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10170,7 +9974,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10998,
-                  "optional": false,
                   "start": 10973,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10222,7 +10025,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11061,
-                  "optional": false,
                   "start": 11030,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10274,7 +10076,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11122,
-                  "optional": false,
                   "start": 11091,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10326,7 +10127,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11179,
-                  "optional": false,
                   "start": 11154,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10378,7 +10178,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11234,
-                  "optional": false,
                   "start": 11209,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10430,7 +10229,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11291,
-                  "optional": false,
                   "start": 11266,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10482,7 +10280,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11345,
-                  "optional": false,
                   "start": 11321,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10534,7 +10331,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11401,
-                  "optional": false,
                   "start": 11377,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10586,7 +10382,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11456,
-                  "optional": false,
                   "start": 11431,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10638,7 +10433,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11513,
-                  "optional": false,
                   "start": 11488,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10690,7 +10484,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11567,
-                  "optional": false,
                   "start": 11543,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10742,7 +10535,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11623,
-                  "optional": false,
                   "start": 11599,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10794,7 +10586,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11677,
-                  "optional": false,
                   "start": 11653,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10846,7 +10637,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11720,
-                  "optional": false,
                   "start": 11699,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10898,7 +10688,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11771,
-                  "optional": false,
                   "start": 11750,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10950,7 +10739,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11827,
-                  "optional": false,
                   "start": 11803,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11002,7 +10790,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11880,
-                  "optional": false,
                   "start": 11857,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11054,7 +10841,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11935,
-                  "optional": false,
                   "start": 11912,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11106,7 +10892,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11989,
-                  "optional": false,
                   "start": 11965,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11158,7 +10943,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12045,
-                  "optional": false,
                   "start": 12021,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11210,7 +10994,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12098,
-                  "optional": false,
                   "start": 12075,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11262,7 +11045,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12153,
-                  "optional": false,
                   "start": 12130,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11314,7 +11096,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12207,
-                  "optional": false,
                   "start": 12183,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11366,7 +11147,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12263,
-                  "optional": false,
                   "start": 12239,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11418,7 +11198,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12317,
-                  "optional": false,
                   "start": 12293,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11470,7 +11249,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12379,
-                  "optional": false,
                   "start": 12349,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11522,7 +11300,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12439,
-                  "optional": false,
                   "start": 12409,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11574,7 +11351,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12495,
-                  "optional": false,
                   "start": 12471,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11626,7 +11402,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12549,
-                  "optional": false,
                   "start": 12525,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11678,7 +11453,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12605,
-                  "optional": false,
                   "start": 12581,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11730,7 +11504,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12658,
-                  "optional": false,
                   "start": 12635,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11782,7 +11555,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12713,
-                  "optional": false,
                   "start": 12690,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11834,7 +11606,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12767,
-                  "optional": false,
                   "start": 12743,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11886,7 +11657,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12823,
-                  "optional": false,
                   "start": 12799,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11938,7 +11708,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12876,
-                  "optional": false,
                   "start": 12853,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11990,7 +11759,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12931,
-                  "optional": false,
                   "start": 12908,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12042,7 +11810,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12986,
-                  "optional": false,
                   "start": 12961,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12094,7 +11861,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13033,
-                  "optional": false,
                   "start": 13008,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12146,7 +11912,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13088,
-                  "optional": false,
                   "start": 13063,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12198,7 +11963,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13144,
-                  "optional": false,
                   "start": 13120,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12250,7 +12014,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13198,
-                  "optional": false,
                   "start": 13174,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12302,7 +12065,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13255,
-                  "optional": false,
                   "start": 13230,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12354,7 +12116,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13324,
-                  "optional": false,
                   "start": 13286,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12406,7 +12167,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13394,
-                  "optional": false,
                   "start": 13356,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12458,7 +12218,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13449,
-                  "optional": false,
                   "start": 13425,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12510,7 +12269,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13494,
-                  "optional": false,
                   "start": 13471,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12562,7 +12320,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13547,
-                  "optional": false,
                   "start": 13524,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12614,7 +12371,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13603,
-                  "optional": false,
                   "start": 13579,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12666,7 +12422,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13657,
-                  "optional": false,
                   "start": 13633,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12718,7 +12473,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13713,
-                  "optional": false,
                   "start": 13689,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12770,7 +12524,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13767,
-                  "optional": false,
                   "start": 13743,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12822,7 +12575,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13823,
-                  "optional": false,
                   "start": 13799,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12874,7 +12626,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13878,
-                  "optional": false,
                   "start": 13853,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12926,7 +12677,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13925,
-                  "optional": false,
                   "start": 13900,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12978,7 +12728,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13979,
-                  "optional": false,
                   "start": 13955,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13030,7 +12779,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14034,
-                  "optional": false,
                   "start": 14011,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13082,7 +12830,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14088,
-                  "optional": false,
                   "start": 14064,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13134,7 +12881,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14145,
-                  "optional": false,
                   "start": 14120,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13186,7 +12932,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14201,
-                  "optional": false,
                   "start": 14176,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13238,7 +12983,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14258,
-                  "optional": false,
                   "start": 14233,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13290,7 +13034,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14313,
-                  "optional": false,
                   "start": 14289,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13342,7 +13085,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14359,
-                  "optional": false,
                   "start": 14335,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13394,7 +13136,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14413,
-                  "optional": false,
                   "start": 14389,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13446,7 +13187,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14469,
-                  "optional": false,
                   "start": 14445,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13498,7 +13238,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14523,
-                  "optional": false,
                   "start": 14499,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13550,7 +13289,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14578,
-                  "optional": false,
                   "start": 14555,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13602,7 +13340,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14630,
-                  "optional": false,
                   "start": 14608,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13654,7 +13391,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14685,
-                  "optional": false,
                   "start": 14662,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13706,7 +13442,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14738,
-                  "optional": false,
                   "start": 14716,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13758,7 +13493,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14783,
-                  "optional": false,
                   "start": 14760,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13810,7 +13544,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14839,
-                  "optional": false,
                   "start": 14815,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13862,7 +13595,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14895,
-                  "optional": false,
                   "start": 14870,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13914,7 +13646,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14952,
-                  "optional": false,
                   "start": 14927,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13966,7 +13697,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15006,
-                  "optional": false,
                   "start": 14982,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14018,7 +13748,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15062,
-                  "optional": false,
                   "start": 15038,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14070,7 +13799,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15115,
-                  "optional": false,
                   "start": 15092,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14122,7 +13850,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15171,
-                  "optional": false,
                   "start": 15147,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14174,7 +13901,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15216,
-                  "optional": false,
                   "start": 15193,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14226,7 +13952,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15272,
-                  "optional": false,
                   "start": 15248,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14278,7 +14003,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15327,
-                  "optional": false,
                   "start": 15302,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14330,7 +14054,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15384,
-                  "optional": false,
                   "start": 15359,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14382,7 +14105,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15439,
-                  "optional": false,
                   "start": 15414,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14434,7 +14156,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15496,
-                  "optional": false,
                   "start": 15471,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14486,7 +14207,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15551,
-                  "optional": false,
                   "start": 15526,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14538,7 +14258,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15609,
-                  "optional": false,
                   "start": 15583,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14590,7 +14309,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15657,
-                  "optional": false,
                   "start": 15631,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14642,7 +14360,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15715,
-                  "optional": false,
                   "start": 15689,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14694,7 +14411,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15772,
-                  "optional": false,
                   "start": 15746,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14715,7 +14431,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15812,
-                  "optional": false,
                   "start": 15804,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14744,7 +14459,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15831,
-                  "optional": false,
                   "start": 15818,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/linear_pattern3d_a_pattern/ast.snap
+++ b/src/wasm-lib/kcl/tests/linear_pattern3d_a_pattern/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing linear_pattern3d_a_pattern.kcl
 snapshot_kind: text
 ---
@@ -37,7 +36,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 35,
-                  "optional": false,
                   "start": 16,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -82,7 +80,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 66,
-                  "optional": false,
                   "start": 41,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -127,7 +124,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 87,
-                  "optional": false,
                   "start": 72,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -172,7 +168,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 108,
-                  "optional": false,
                   "start": 93,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -224,7 +219,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 130,
-                  "optional": false,
                   "start": 114,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -245,7 +239,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 144,
-                  "optional": false,
                   "start": 136,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -274,7 +267,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 163,
-                  "optional": false,
                   "start": 150,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -411,7 +403,6 @@ snapshot_kind: text
                 "type": "Identifier"
               },
               "end": 261,
-              "optional": false,
               "start": 174,
               "type": "CallExpression",
               "type": "CallExpression"
@@ -542,7 +533,6 @@ snapshot_kind: text
                 "type": "Identifier"
               },
               "end": 352,
-              "optional": false,
               "start": 272,
               "type": "CallExpression",
               "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/mike_stress_test/ast.snap
+++ b/src/wasm-lib/kcl/tests/mike_stress_test/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing mike_stress_test.kcl
 snapshot_kind: text
 ---
@@ -37,7 +36,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29,
-                  "optional": false,
                   "start": 10,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -82,7 +80,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 64,
-                  "optional": false,
                   "start": 35,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -134,7 +131,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 142,
-                  "optional": false,
                   "start": 70,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -186,7 +182,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 219,
-                  "optional": false,
                   "start": 148,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -238,7 +233,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 296,
-                  "optional": false,
                   "start": 225,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -297,7 +291,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 375,
-                  "optional": false,
                   "start": 302,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -342,7 +335,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 453,
-                  "optional": false,
                   "start": 381,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -387,7 +379,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 531,
-                  "optional": false,
                   "start": 459,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -439,7 +430,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 609,
-                  "optional": false,
                   "start": 537,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -498,7 +488,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 689,
-                  "optional": false,
                   "start": 615,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -550,7 +539,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 767,
-                  "optional": false,
                   "start": 695,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -602,7 +590,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 847,
-                  "optional": false,
                   "start": 773,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -654,7 +641,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 924,
-                  "optional": false,
                   "start": 853,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -706,7 +692,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1001,
-                  "optional": false,
                   "start": 930,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -751,7 +736,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1056,
-                  "optional": false,
                   "start": 1007,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -803,7 +787,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1136,
-                  "optional": false,
                   "start": 1062,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -862,7 +845,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1215,
-                  "optional": false,
                   "start": 1142,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -921,7 +903,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1294,
-                  "optional": false,
                   "start": 1221,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -966,7 +947,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1348,
-                  "optional": false,
                   "start": 1300,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1018,7 +998,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1427,
-                  "optional": false,
                   "start": 1354,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1063,7 +1042,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1481,
-                  "optional": false,
                   "start": 1433,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1115,7 +1093,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1559,
-                  "optional": false,
                   "start": 1487,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1160,7 +1137,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1614,
-                  "optional": false,
                   "start": 1565,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1205,7 +1181,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1691,
-                  "optional": false,
                   "start": 1620,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1250,7 +1225,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1746,
-                  "optional": false,
                   "start": 1697,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1309,7 +1283,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1825,
-                  "optional": false,
                   "start": 1752,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1361,7 +1334,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1902,
-                  "optional": false,
                   "start": 1831,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1420,7 +1392,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1980,
-                  "optional": false,
                   "start": 1908,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1472,7 +1443,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2060,
-                  "optional": false,
                   "start": 1986,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1524,7 +1494,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2139,
-                  "optional": false,
                   "start": 2066,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1576,7 +1545,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2217,
-                  "optional": false,
                   "start": 2145,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1635,7 +1603,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2295,
-                  "optional": false,
                   "start": 2223,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1680,7 +1647,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2350,
-                  "optional": false,
                   "start": 2301,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1725,7 +1691,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2427,
-                  "optional": false,
                   "start": 2356,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1777,7 +1742,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2505,
-                  "optional": false,
                   "start": 2433,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1836,7 +1800,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2585,
-                  "optional": false,
                   "start": 2511,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1888,7 +1851,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2663,
-                  "optional": false,
                   "start": 2591,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1940,7 +1902,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2741,
-                  "optional": false,
                   "start": 2669,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1985,7 +1946,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2796,
-                  "optional": false,
                   "start": 2747,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2044,7 +2004,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2875,
-                  "optional": false,
                   "start": 2802,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2096,7 +2055,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 2952,
-                  "optional": false,
                   "start": 2881,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2148,7 +2106,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3029,
-                  "optional": false,
                   "start": 2958,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2193,7 +2150,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3084,
-                  "optional": false,
                   "start": 3035,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2245,7 +2201,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3161,
-                  "optional": false,
                   "start": 3090,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2290,7 +2245,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3216,
-                  "optional": false,
                   "start": 3167,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2335,7 +2289,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3293,
-                  "optional": false,
                   "start": 3222,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2394,7 +2347,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3370,
-                  "optional": false,
                   "start": 3299,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2446,7 +2398,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3448,
-                  "optional": false,
                   "start": 3376,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2505,7 +2456,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3528,
-                  "optional": false,
                   "start": 3454,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2564,7 +2514,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3607,
-                  "optional": false,
                   "start": 3534,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2616,7 +2565,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3685,
-                  "optional": false,
                   "start": 3613,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2675,7 +2623,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3764,
-                  "optional": false,
                   "start": 3691,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2727,7 +2674,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3841,
-                  "optional": false,
                   "start": 3770,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2779,7 +2725,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3918,
-                  "optional": false,
                   "start": 3847,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2831,7 +2776,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 3995,
-                  "optional": false,
                   "start": 3924,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2890,7 +2834,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4074,
-                  "optional": false,
                   "start": 4001,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2935,7 +2878,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4152,
-                  "optional": false,
                   "start": 4080,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2980,7 +2922,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4230,
-                  "optional": false,
                   "start": 4158,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3032,7 +2973,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4308,
-                  "optional": false,
                   "start": 4236,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3091,7 +3031,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4388,
-                  "optional": false,
                   "start": 4314,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3143,7 +3082,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4466,
-                  "optional": false,
                   "start": 4394,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3195,7 +3133,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4546,
-                  "optional": false,
                   "start": 4472,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3247,7 +3184,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4623,
-                  "optional": false,
                   "start": 4552,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3299,7 +3235,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4700,
-                  "optional": false,
                   "start": 4629,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3344,7 +3279,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4755,
-                  "optional": false,
                   "start": 4706,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3396,7 +3330,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4835,
-                  "optional": false,
                   "start": 4761,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3455,7 +3388,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4914,
-                  "optional": false,
                   "start": 4841,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3514,7 +3446,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 4993,
-                  "optional": false,
                   "start": 4920,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3559,7 +3490,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5047,
-                  "optional": false,
                   "start": 4999,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3611,7 +3541,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5126,
-                  "optional": false,
                   "start": 5053,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3656,7 +3585,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5180,
-                  "optional": false,
                   "start": 5132,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3708,7 +3636,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5258,
-                  "optional": false,
                   "start": 5186,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3753,7 +3680,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5313,
-                  "optional": false,
                   "start": 5264,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3798,7 +3724,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5390,
-                  "optional": false,
                   "start": 5319,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3843,7 +3768,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5445,
-                  "optional": false,
                   "start": 5396,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3902,7 +3826,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5524,
-                  "optional": false,
                   "start": 5451,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -3954,7 +3877,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5601,
-                  "optional": false,
                   "start": 5530,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4006,7 +3928,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5678,
-                  "optional": false,
                   "start": 5607,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4058,7 +3979,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5755,
-                  "optional": false,
                   "start": 5684,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4110,7 +4030,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5832,
-                  "optional": false,
                   "start": 5761,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4155,7 +4074,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5887,
-                  "optional": false,
                   "start": 5838,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4214,7 +4132,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 5966,
-                  "optional": false,
                   "start": 5893,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4273,7 +4190,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6044,
-                  "optional": false,
                   "start": 5972,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4332,7 +4248,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6123,
-                  "optional": false,
                   "start": 6050,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4384,7 +4299,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6200,
-                  "optional": false,
                   "start": 6129,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4436,7 +4350,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6277,
-                  "optional": false,
                   "start": 6206,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4495,7 +4408,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6354,
-                  "optional": false,
                   "start": 6283,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4540,7 +4452,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6431,
-                  "optional": false,
                   "start": 6360,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4592,7 +4503,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6508,
-                  "optional": false,
                   "start": 6437,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4644,7 +4554,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6587,
-                  "optional": false,
                   "start": 6514,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4689,7 +4598,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6642,
-                  "optional": false,
                   "start": 6593,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4734,7 +4642,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6720,
-                  "optional": false,
                   "start": 6648,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4779,7 +4686,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6797,
-                  "optional": false,
                   "start": 6726,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4831,7 +4737,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6874,
-                  "optional": false,
                   "start": 6803,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4876,7 +4781,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 6951,
-                  "optional": false,
                   "start": 6880,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4928,7 +4832,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7028,
-                  "optional": false,
                   "start": 6957,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -4980,7 +4883,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7106,
-                  "optional": false,
                   "start": 7034,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5032,7 +4934,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7184,
-                  "optional": false,
                   "start": 7112,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5091,7 +4992,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7263,
-                  "optional": false,
                   "start": 7190,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5150,7 +5050,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7342,
-                  "optional": false,
                   "start": 7269,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5209,7 +5108,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7421,
-                  "optional": false,
                   "start": 7348,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5254,7 +5152,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7476,
-                  "optional": false,
                   "start": 7427,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5306,7 +5203,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7554,
-                  "optional": false,
                   "start": 7482,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5358,7 +5254,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7631,
-                  "optional": false,
                   "start": 7560,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5410,7 +5305,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7708,
-                  "optional": false,
                   "start": 7637,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5469,7 +5363,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7787,
-                  "optional": false,
                   "start": 7714,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5514,7 +5407,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7865,
-                  "optional": false,
                   "start": 7793,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5559,7 +5451,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 7943,
-                  "optional": false,
                   "start": 7871,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5611,7 +5502,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8021,
-                  "optional": false,
                   "start": 7949,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5670,7 +5560,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8101,
-                  "optional": false,
                   "start": 8027,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5722,7 +5611,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8179,
-                  "optional": false,
                   "start": 8107,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5774,7 +5662,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8259,
-                  "optional": false,
                   "start": 8185,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5826,7 +5713,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8336,
-                  "optional": false,
                   "start": 8265,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5878,7 +5764,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8413,
-                  "optional": false,
                   "start": 8342,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5923,7 +5808,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8468,
-                  "optional": false,
                   "start": 8419,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -5975,7 +5859,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8548,
-                  "optional": false,
                   "start": 8474,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6034,7 +5917,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8627,
-                  "optional": false,
                   "start": 8554,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6093,7 +5975,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8706,
-                  "optional": false,
                   "start": 8633,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6138,7 +6019,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8760,
-                  "optional": false,
                   "start": 8712,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6190,7 +6070,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8839,
-                  "optional": false,
                   "start": 8766,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6235,7 +6114,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8893,
-                  "optional": false,
                   "start": 8845,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6287,7 +6165,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 8971,
-                  "optional": false,
                   "start": 8899,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6332,7 +6209,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9026,
-                  "optional": false,
                   "start": 8977,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6377,7 +6253,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9103,
-                  "optional": false,
                   "start": 9032,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6422,7 +6297,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9158,
-                  "optional": false,
                   "start": 9109,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6481,7 +6355,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9237,
-                  "optional": false,
                   "start": 9164,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6533,7 +6406,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9314,
-                  "optional": false,
                   "start": 9243,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6592,7 +6464,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9392,
-                  "optional": false,
                   "start": 9320,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6644,7 +6515,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9472,
-                  "optional": false,
                   "start": 9398,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6696,7 +6566,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9551,
-                  "optional": false,
                   "start": 9478,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6748,7 +6617,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9629,
-                  "optional": false,
                   "start": 9557,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6807,7 +6675,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9707,
-                  "optional": false,
                   "start": 9635,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6852,7 +6719,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9762,
-                  "optional": false,
                   "start": 9713,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6897,7 +6763,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9839,
-                  "optional": false,
                   "start": 9768,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -6949,7 +6814,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9917,
-                  "optional": false,
                   "start": 9845,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7008,7 +6872,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 9997,
-                  "optional": false,
                   "start": 9923,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7060,7 +6923,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10075,
-                  "optional": false,
                   "start": 10003,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7112,7 +6974,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10153,
-                  "optional": false,
                   "start": 10081,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7157,7 +7018,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10208,
-                  "optional": false,
                   "start": 10159,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7216,7 +7076,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10287,
-                  "optional": false,
                   "start": 10214,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7268,7 +7127,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10364,
-                  "optional": false,
                   "start": 10293,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7320,7 +7178,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10441,
-                  "optional": false,
                   "start": 10370,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7365,7 +7222,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10496,
-                  "optional": false,
                   "start": 10447,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7417,7 +7273,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10573,
-                  "optional": false,
                   "start": 10502,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7462,7 +7317,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10628,
-                  "optional": false,
                   "start": 10579,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7507,7 +7361,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10705,
-                  "optional": false,
                   "start": 10634,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7566,7 +7419,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10782,
-                  "optional": false,
                   "start": 10711,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7618,7 +7470,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10860,
-                  "optional": false,
                   "start": 10788,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7677,7 +7528,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 10940,
-                  "optional": false,
                   "start": 10866,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7736,7 +7586,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11019,
-                  "optional": false,
                   "start": 10946,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7788,7 +7637,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11097,
-                  "optional": false,
                   "start": 11025,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7847,7 +7695,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11176,
-                  "optional": false,
                   "start": 11103,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7899,7 +7746,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11253,
-                  "optional": false,
                   "start": 11182,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -7951,7 +7797,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11330,
-                  "optional": false,
                   "start": 11259,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8003,7 +7848,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11407,
-                  "optional": false,
                   "start": 11336,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8062,7 +7906,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11486,
-                  "optional": false,
                   "start": 11413,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8107,7 +7950,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11564,
-                  "optional": false,
                   "start": 11492,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8152,7 +7994,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11642,
-                  "optional": false,
                   "start": 11570,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8204,7 +8045,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11720,
-                  "optional": false,
                   "start": 11648,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8263,7 +8103,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11800,
-                  "optional": false,
                   "start": 11726,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8315,7 +8154,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11878,
-                  "optional": false,
                   "start": 11806,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8367,7 +8205,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 11958,
-                  "optional": false,
                   "start": 11884,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8419,7 +8256,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12035,
-                  "optional": false,
                   "start": 11964,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8471,7 +8307,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12112,
-                  "optional": false,
                   "start": 12041,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8516,7 +8351,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12167,
-                  "optional": false,
                   "start": 12118,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8568,7 +8402,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12247,
-                  "optional": false,
                   "start": 12173,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8627,7 +8460,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12326,
-                  "optional": false,
                   "start": 12253,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8686,7 +8518,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12405,
-                  "optional": false,
                   "start": 12332,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8731,7 +8562,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12459,
-                  "optional": false,
                   "start": 12411,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8783,7 +8613,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12538,
-                  "optional": false,
                   "start": 12465,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8828,7 +8657,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12592,
-                  "optional": false,
                   "start": 12544,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8880,7 +8708,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12670,
-                  "optional": false,
                   "start": 12598,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8925,7 +8752,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12725,
-                  "optional": false,
                   "start": 12676,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -8970,7 +8796,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12802,
-                  "optional": false,
                   "start": 12731,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9015,7 +8840,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12857,
-                  "optional": false,
                   "start": 12808,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9067,7 +8891,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 12935,
-                  "optional": false,
                   "start": 12863,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9119,7 +8942,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13012,
-                  "optional": false,
                   "start": 12941,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9171,7 +8993,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13089,
-                  "optional": false,
                   "start": 13018,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9230,7 +9051,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13168,
-                  "optional": false,
                   "start": 13095,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9275,7 +9095,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13246,
-                  "optional": false,
                   "start": 13174,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9320,7 +9139,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13324,
-                  "optional": false,
                   "start": 13252,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9372,7 +9190,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13402,
-                  "optional": false,
                   "start": 13330,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9431,7 +9248,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13482,
-                  "optional": false,
                   "start": 13408,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9483,7 +9299,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13560,
-                  "optional": false,
                   "start": 13488,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9535,7 +9350,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13640,
-                  "optional": false,
                   "start": 13566,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9587,7 +9401,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13717,
-                  "optional": false,
                   "start": 13646,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9639,7 +9452,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13794,
-                  "optional": false,
                   "start": 13723,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9684,7 +9496,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13849,
-                  "optional": false,
                   "start": 13800,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9736,7 +9547,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 13929,
-                  "optional": false,
                   "start": 13855,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9795,7 +9605,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14008,
-                  "optional": false,
                   "start": 13935,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9854,7 +9663,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14087,
-                  "optional": false,
                   "start": 14014,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9899,7 +9707,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14141,
-                  "optional": false,
                   "start": 14093,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9951,7 +9758,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14220,
-                  "optional": false,
                   "start": 14147,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -9996,7 +9802,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14274,
-                  "optional": false,
                   "start": 14226,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10048,7 +9853,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14352,
-                  "optional": false,
                   "start": 14280,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10093,7 +9897,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14407,
-                  "optional": false,
                   "start": 14358,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10138,7 +9941,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14484,
-                  "optional": false,
                   "start": 14413,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10183,7 +9985,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14539,
-                  "optional": false,
                   "start": 14490,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10242,7 +10043,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14618,
-                  "optional": false,
                   "start": 14545,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10294,7 +10094,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14695,
-                  "optional": false,
                   "start": 14624,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10353,7 +10152,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14773,
-                  "optional": false,
                   "start": 14701,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10405,7 +10203,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14853,
-                  "optional": false,
                   "start": 14779,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10457,7 +10254,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 14931,
-                  "optional": false,
                   "start": 14859,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10509,7 +10305,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15008,
-                  "optional": false,
                   "start": 14937,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10561,7 +10356,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15085,
-                  "optional": false,
                   "start": 15014,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10620,7 +10414,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15164,
-                  "optional": false,
                   "start": 15091,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10665,7 +10458,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15242,
-                  "optional": false,
                   "start": 15170,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10710,7 +10502,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15320,
-                  "optional": false,
                   "start": 15248,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10762,7 +10553,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15398,
-                  "optional": false,
                   "start": 15326,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10821,7 +10611,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15478,
-                  "optional": false,
                   "start": 15404,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10873,7 +10662,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15556,
-                  "optional": false,
                   "start": 15484,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10925,7 +10713,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15636,
-                  "optional": false,
                   "start": 15562,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -10977,7 +10764,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15713,
-                  "optional": false,
                   "start": 15642,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11029,7 +10815,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15790,
-                  "optional": false,
                   "start": 15719,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11074,7 +10859,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15845,
-                  "optional": false,
                   "start": 15796,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11126,7 +10910,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 15925,
-                  "optional": false,
                   "start": 15851,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11185,7 +10968,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 16004,
-                  "optional": false,
                   "start": 15931,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11244,7 +11026,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 16083,
-                  "optional": false,
                   "start": 16010,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11289,7 +11070,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 16137,
-                  "optional": false,
                   "start": 16089,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11341,7 +11121,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 16216,
-                  "optional": false,
                   "start": 16143,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11386,7 +11165,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 16270,
-                  "optional": false,
                   "start": 16222,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11438,7 +11216,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 16348,
-                  "optional": false,
                   "start": 16276,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11483,7 +11260,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 16403,
-                  "optional": false,
                   "start": 16354,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11528,7 +11304,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 16480,
-                  "optional": false,
                   "start": 16409,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11573,7 +11348,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 16535,
-                  "optional": false,
                   "start": 16486,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11632,7 +11406,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 16614,
-                  "optional": false,
                   "start": 16541,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11684,7 +11457,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 16691,
-                  "optional": false,
                   "start": 16620,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11743,7 +11515,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 16769,
-                  "optional": false,
                   "start": 16697,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11795,7 +11566,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 16849,
-                  "optional": false,
                   "start": 16775,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11847,7 +11617,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 16928,
-                  "optional": false,
                   "start": 16855,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11899,7 +11668,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 17006,
-                  "optional": false,
                   "start": 16934,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -11958,7 +11726,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 17084,
-                  "optional": false,
                   "start": 17012,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12003,7 +11770,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 17139,
-                  "optional": false,
                   "start": 17090,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12048,7 +11814,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 17216,
-                  "optional": false,
                   "start": 17145,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12100,7 +11865,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 17294,
-                  "optional": false,
                   "start": 17222,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12159,7 +11923,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 17374,
-                  "optional": false,
                   "start": 17300,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12211,7 +11974,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 17452,
-                  "optional": false,
                   "start": 17380,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12263,7 +12025,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 17530,
-                  "optional": false,
                   "start": 17458,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12308,7 +12069,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 17585,
-                  "optional": false,
                   "start": 17536,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12367,7 +12127,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 17664,
-                  "optional": false,
                   "start": 17591,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12419,7 +12178,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 17741,
-                  "optional": false,
                   "start": 17670,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12471,7 +12229,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 17818,
-                  "optional": false,
                   "start": 17747,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12516,7 +12273,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 17873,
-                  "optional": false,
                   "start": 17824,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12568,7 +12324,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 17950,
-                  "optional": false,
                   "start": 17879,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12613,7 +12368,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 18005,
-                  "optional": false,
                   "start": 17956,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12658,7 +12412,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 18082,
-                  "optional": false,
                   "start": 18011,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12717,7 +12470,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 18159,
-                  "optional": false,
                   "start": 18088,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12769,7 +12521,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 18237,
-                  "optional": false,
                   "start": 18165,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12828,7 +12579,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 18317,
-                  "optional": false,
                   "start": 18243,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12887,7 +12637,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 18396,
-                  "optional": false,
                   "start": 18323,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12939,7 +12688,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 18474,
-                  "optional": false,
                   "start": 18402,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -12998,7 +12746,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 18553,
-                  "optional": false,
                   "start": 18480,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13050,7 +12797,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 18630,
-                  "optional": false,
                   "start": 18559,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13102,7 +12848,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 18707,
-                  "optional": false,
                   "start": 18636,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13154,7 +12899,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 18784,
-                  "optional": false,
                   "start": 18713,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13213,7 +12957,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 18863,
-                  "optional": false,
                   "start": 18790,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13258,7 +13001,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 18941,
-                  "optional": false,
                   "start": 18869,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13303,7 +13045,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 19019,
-                  "optional": false,
                   "start": 18947,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13355,7 +13096,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 19097,
-                  "optional": false,
                   "start": 19025,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13414,7 +13154,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 19177,
-                  "optional": false,
                   "start": 19103,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13466,7 +13205,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 19255,
-                  "optional": false,
                   "start": 19183,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13518,7 +13256,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 19335,
-                  "optional": false,
                   "start": 19261,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13570,7 +13307,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 19412,
-                  "optional": false,
                   "start": 19341,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13622,7 +13358,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 19489,
-                  "optional": false,
                   "start": 19418,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13667,7 +13402,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 19544,
-                  "optional": false,
                   "start": 19495,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13719,7 +13453,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 19624,
-                  "optional": false,
                   "start": 19550,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13778,7 +13511,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 19703,
-                  "optional": false,
                   "start": 19630,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13837,7 +13569,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 19782,
-                  "optional": false,
                   "start": 19709,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13882,7 +13613,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 19836,
-                  "optional": false,
                   "start": 19788,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13934,7 +13664,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 19915,
-                  "optional": false,
                   "start": 19842,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -13979,7 +13708,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 19969,
-                  "optional": false,
                   "start": 19921,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14031,7 +13759,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 20047,
-                  "optional": false,
                   "start": 19975,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14076,7 +13803,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 20102,
-                  "optional": false,
                   "start": 20053,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14121,7 +13847,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 20179,
-                  "optional": false,
                   "start": 20108,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14166,7 +13891,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 20234,
-                  "optional": false,
                   "start": 20185,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14225,7 +13949,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 20313,
-                  "optional": false,
                   "start": 20240,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14277,7 +14000,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 20390,
-                  "optional": false,
                   "start": 20319,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14329,7 +14051,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 20467,
-                  "optional": false,
                   "start": 20396,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14381,7 +14102,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 20544,
-                  "optional": false,
                   "start": 20473,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14433,7 +14153,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 20621,
-                  "optional": false,
                   "start": 20550,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14478,7 +14197,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 20676,
-                  "optional": false,
                   "start": 20627,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14537,7 +14255,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 20755,
-                  "optional": false,
                   "start": 20682,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14596,7 +14313,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 20833,
-                  "optional": false,
                   "start": 20761,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14655,7 +14371,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 20912,
-                  "optional": false,
                   "start": 20839,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14707,7 +14422,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 20989,
-                  "optional": false,
                   "start": 20918,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14759,7 +14473,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 21066,
-                  "optional": false,
                   "start": 20995,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14818,7 +14531,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 21143,
-                  "optional": false,
                   "start": 21072,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14863,7 +14575,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 21220,
-                  "optional": false,
                   "start": 21149,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14915,7 +14626,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 21297,
-                  "optional": false,
                   "start": 21226,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -14967,7 +14677,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 21376,
-                  "optional": false,
                   "start": 21303,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -15012,7 +14721,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 21431,
-                  "optional": false,
                   "start": 21382,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -15057,7 +14765,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 21509,
-                  "optional": false,
                   "start": 21437,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -15102,7 +14809,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 21586,
-                  "optional": false,
                   "start": 21515,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -15154,7 +14860,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 21663,
-                  "optional": false,
                   "start": 21592,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -15199,7 +14904,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 21740,
-                  "optional": false,
                   "start": 21669,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -15251,7 +14955,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 21817,
-                  "optional": false,
                   "start": 21746,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -15303,7 +15006,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 21895,
-                  "optional": false,
                   "start": 21823,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -15355,7 +15057,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 21973,
-                  "optional": false,
                   "start": 21901,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -15414,7 +15115,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 22052,
-                  "optional": false,
                   "start": 21979,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -15473,7 +15173,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 22131,
-                  "optional": false,
                   "start": 22058,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -15532,7 +15231,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 22210,
-                  "optional": false,
                   "start": 22137,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -15577,7 +15275,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 22265,
-                  "optional": false,
                   "start": 22216,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -15629,7 +15326,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 22343,
-                  "optional": false,
                   "start": 22271,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -15681,7 +15377,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 22420,
-                  "optional": false,
                   "start": 22349,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -15733,7 +15428,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 22497,
-                  "optional": false,
                   "start": 22426,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -15792,7 +15486,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 22576,
-                  "optional": false,
                   "start": 22503,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -15837,7 +15530,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 22654,
-                  "optional": false,
                   "start": 22582,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -15882,7 +15574,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 22732,
-                  "optional": false,
                   "start": 22660,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -15934,7 +15625,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 22810,
-                  "optional": false,
                   "start": 22738,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -15993,7 +15683,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 22890,
-                  "optional": false,
                   "start": 22816,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -16045,7 +15734,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 22968,
-                  "optional": false,
                   "start": 22896,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -16097,7 +15785,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 23048,
-                  "optional": false,
                   "start": 22974,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -16149,7 +15836,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 23125,
-                  "optional": false,
                   "start": 23054,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -16201,7 +15887,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 23202,
-                  "optional": false,
                   "start": 23131,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -16246,7 +15931,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 23257,
-                  "optional": false,
                   "start": 23208,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -16298,7 +15982,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 23337,
-                  "optional": false,
                   "start": 23263,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -16357,7 +16040,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 23416,
-                  "optional": false,
                   "start": 23343,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -16416,7 +16098,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 23495,
-                  "optional": false,
                   "start": 23422,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -16461,7 +16142,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 23549,
-                  "optional": false,
                   "start": 23501,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -16513,7 +16193,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 23628,
-                  "optional": false,
                   "start": 23555,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -16558,7 +16237,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 23682,
-                  "optional": false,
                   "start": 23634,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -16610,7 +16288,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 23760,
-                  "optional": false,
                   "start": 23688,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -16655,7 +16332,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 23815,
-                  "optional": false,
                   "start": 23766,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -16700,7 +16376,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 23892,
-                  "optional": false,
                   "start": 23821,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -16745,7 +16420,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 23947,
-                  "optional": false,
                   "start": 23898,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -16804,7 +16478,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 24026,
-                  "optional": false,
                   "start": 23953,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -16856,7 +16529,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 24103,
-                  "optional": false,
                   "start": 24032,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -16915,7 +16587,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 24181,
-                  "optional": false,
                   "start": 24109,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -16967,7 +16638,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 24261,
-                  "optional": false,
                   "start": 24187,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -17019,7 +16689,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 24340,
-                  "optional": false,
                   "start": 24267,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -17071,7 +16740,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 24418,
-                  "optional": false,
                   "start": 24346,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -17130,7 +16798,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 24496,
-                  "optional": false,
                   "start": 24424,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -17175,7 +16842,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 24551,
-                  "optional": false,
                   "start": 24502,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -17220,7 +16886,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 24628,
-                  "optional": false,
                   "start": 24557,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -17272,7 +16937,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 24706,
-                  "optional": false,
                   "start": 24634,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -17331,7 +16995,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 24786,
-                  "optional": false,
                   "start": 24712,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -17383,7 +17046,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 24864,
-                  "optional": false,
                   "start": 24792,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -17435,7 +17097,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 24942,
-                  "optional": false,
                   "start": 24870,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -17480,7 +17141,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 24997,
-                  "optional": false,
                   "start": 24948,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -17539,7 +17199,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 25076,
-                  "optional": false,
                   "start": 25003,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -17591,7 +17250,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 25153,
-                  "optional": false,
                   "start": 25082,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -17643,7 +17301,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 25230,
-                  "optional": false,
                   "start": 25159,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -17688,7 +17345,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 25285,
-                  "optional": false,
                   "start": 25236,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -17740,7 +17396,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 25362,
-                  "optional": false,
                   "start": 25291,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -17785,7 +17440,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 25417,
-                  "optional": false,
                   "start": 25368,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -17830,7 +17484,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 25494,
-                  "optional": false,
                   "start": 25423,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -17889,7 +17542,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 25571,
-                  "optional": false,
                   "start": 25500,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -17941,7 +17593,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 25649,
-                  "optional": false,
                   "start": 25577,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -18000,7 +17651,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 25729,
-                  "optional": false,
                   "start": 25655,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -18059,7 +17709,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 25808,
-                  "optional": false,
                   "start": 25735,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -18111,7 +17760,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 25886,
-                  "optional": false,
                   "start": 25814,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -18170,7 +17818,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 25965,
-                  "optional": false,
                   "start": 25892,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -18222,7 +17869,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 26042,
-                  "optional": false,
                   "start": 25971,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -18274,7 +17920,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 26119,
-                  "optional": false,
                   "start": 26048,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -18326,7 +17971,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 26196,
-                  "optional": false,
                   "start": 26125,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -18385,7 +18029,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 26275,
-                  "optional": false,
                   "start": 26202,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -18430,7 +18073,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 26353,
-                  "optional": false,
                   "start": 26281,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -18475,7 +18117,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 26431,
-                  "optional": false,
                   "start": 26359,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -18527,7 +18168,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 26509,
-                  "optional": false,
                   "start": 26437,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -18586,7 +18226,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 26589,
-                  "optional": false,
                   "start": 26515,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -18638,7 +18277,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 26667,
-                  "optional": false,
                   "start": 26595,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -18690,7 +18328,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 26747,
-                  "optional": false,
                   "start": 26673,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -18742,7 +18379,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 26824,
-                  "optional": false,
                   "start": 26753,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -18794,7 +18430,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 26901,
-                  "optional": false,
                   "start": 26830,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -18839,7 +18474,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 26956,
-                  "optional": false,
                   "start": 26907,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -18891,7 +18525,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 27036,
-                  "optional": false,
                   "start": 26962,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -18950,7 +18583,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 27115,
-                  "optional": false,
                   "start": 27042,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -19009,7 +18641,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 27194,
-                  "optional": false,
                   "start": 27121,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -19054,7 +18685,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 27248,
-                  "optional": false,
                   "start": 27200,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -19106,7 +18736,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 27327,
-                  "optional": false,
                   "start": 27254,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -19151,7 +18780,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 27381,
-                  "optional": false,
                   "start": 27333,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -19203,7 +18831,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 27459,
-                  "optional": false,
                   "start": 27387,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -19248,7 +18875,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 27514,
-                  "optional": false,
                   "start": 27465,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -19293,7 +18919,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 27591,
-                  "optional": false,
                   "start": 27520,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -19338,7 +18963,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 27646,
-                  "optional": false,
                   "start": 27597,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -19390,7 +19014,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 27724,
-                  "optional": false,
                   "start": 27652,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -19442,7 +19065,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 27801,
-                  "optional": false,
                   "start": 27730,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -19494,7 +19116,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 27878,
-                  "optional": false,
                   "start": 27807,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -19553,7 +19174,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 27957,
-                  "optional": false,
                   "start": 27884,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -19598,7 +19218,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 28035,
-                  "optional": false,
                   "start": 27963,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -19643,7 +19262,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 28113,
-                  "optional": false,
                   "start": 28041,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -19695,7 +19313,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 28191,
-                  "optional": false,
                   "start": 28119,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -19754,7 +19371,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 28271,
-                  "optional": false,
                   "start": 28197,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -19806,7 +19422,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 28349,
-                  "optional": false,
                   "start": 28277,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -19858,7 +19473,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 28429,
-                  "optional": false,
                   "start": 28355,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -19910,7 +19524,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 28506,
-                  "optional": false,
                   "start": 28435,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -19962,7 +19575,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 28583,
-                  "optional": false,
                   "start": 28512,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -20007,7 +19619,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 28638,
-                  "optional": false,
                   "start": 28589,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -20059,7 +19670,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 28718,
-                  "optional": false,
                   "start": 28644,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -20118,7 +19728,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 28797,
-                  "optional": false,
                   "start": 28724,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -20177,7 +19786,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 28876,
-                  "optional": false,
                   "start": 28803,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -20222,7 +19830,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 28930,
-                  "optional": false,
                   "start": 28882,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -20274,7 +19881,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29009,
-                  "optional": false,
                   "start": 28936,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -20319,7 +19925,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29063,
-                  "optional": false,
                   "start": 29015,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -20371,7 +19976,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29141,
-                  "optional": false,
                   "start": 29069,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -20416,7 +20020,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29196,
-                  "optional": false,
                   "start": 29147,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -20461,7 +20064,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29273,
-                  "optional": false,
                   "start": 29202,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -20506,7 +20108,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29328,
-                  "optional": false,
                   "start": 29279,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -20565,7 +20166,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29407,
-                  "optional": false,
                   "start": 29334,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -20617,7 +20217,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29484,
-                  "optional": false,
                   "start": 29413,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -20676,7 +20275,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29562,
-                  "optional": false,
                   "start": 29490,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -20728,7 +20326,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29642,
-                  "optional": false,
                   "start": 29568,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -20780,7 +20377,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29721,
-                  "optional": false,
                   "start": 29648,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -20832,7 +20428,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29799,
-                  "optional": false,
                   "start": 29727,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -20891,7 +20486,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29877,
-                  "optional": false,
                   "start": 29805,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -20936,7 +20530,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29932,
-                  "optional": false,
                   "start": 29883,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -20981,7 +20574,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 30009,
-                  "optional": false,
                   "start": 29938,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -21033,7 +20625,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 30087,
-                  "optional": false,
                   "start": 30015,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -21092,7 +20683,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 30167,
-                  "optional": false,
                   "start": 30093,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -21144,7 +20734,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 30245,
-                  "optional": false,
                   "start": 30173,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -21196,7 +20785,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 30323,
-                  "optional": false,
                   "start": 30251,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -21241,7 +20829,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 30378,
-                  "optional": false,
                   "start": 30329,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -21300,7 +20887,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 30457,
-                  "optional": false,
                   "start": 30384,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -21352,7 +20938,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 30534,
-                  "optional": false,
                   "start": 30463,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -21404,7 +20989,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 30611,
-                  "optional": false,
                   "start": 30540,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -21449,7 +21033,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 30666,
-                  "optional": false,
                   "start": 30617,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -21501,7 +21084,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 30743,
-                  "optional": false,
                   "start": 30672,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -21546,7 +21128,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 30798,
-                  "optional": false,
                   "start": 30749,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -21591,7 +21172,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 30875,
-                  "optional": false,
                   "start": 30804,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -21650,7 +21230,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 30952,
-                  "optional": false,
                   "start": 30881,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -21702,7 +21281,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 31030,
-                  "optional": false,
                   "start": 30958,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -21761,7 +21339,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 31110,
-                  "optional": false,
                   "start": 31036,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -21820,7 +21397,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 31189,
-                  "optional": false,
                   "start": 31116,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -21872,7 +21448,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 31267,
-                  "optional": false,
                   "start": 31195,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -21931,7 +21506,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 31346,
-                  "optional": false,
                   "start": 31273,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -21983,7 +21557,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 31423,
-                  "optional": false,
                   "start": 31352,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -22035,7 +21608,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 31500,
-                  "optional": false,
                   "start": 31429,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -22087,7 +21659,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 31577,
-                  "optional": false,
                   "start": 31506,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -22146,7 +21717,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 31656,
-                  "optional": false,
                   "start": 31583,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -22191,7 +21761,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 31734,
-                  "optional": false,
                   "start": 31662,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -22236,7 +21805,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 31812,
-                  "optional": false,
                   "start": 31740,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -22288,7 +21856,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 31890,
-                  "optional": false,
                   "start": 31818,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -22347,7 +21914,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 31970,
-                  "optional": false,
                   "start": 31896,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -22399,7 +21965,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 32048,
-                  "optional": false,
                   "start": 31976,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -22451,7 +22016,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 32128,
-                  "optional": false,
                   "start": 32054,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -22503,7 +22067,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 32205,
-                  "optional": false,
                   "start": 32134,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -22555,7 +22118,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 32282,
-                  "optional": false,
                   "start": 32211,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -22600,7 +22162,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 32337,
-                  "optional": false,
                   "start": 32288,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -22652,7 +22213,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 32417,
-                  "optional": false,
                   "start": 32343,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -22711,7 +22271,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 32496,
-                  "optional": false,
                   "start": 32423,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -22770,7 +22329,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 32575,
-                  "optional": false,
                   "start": 32502,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -22815,7 +22373,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 32629,
-                  "optional": false,
                   "start": 32581,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -22867,7 +22424,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 32708,
-                  "optional": false,
                   "start": 32635,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -22912,7 +22468,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 32762,
-                  "optional": false,
                   "start": 32714,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -22964,7 +22519,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 32840,
-                  "optional": false,
                   "start": 32768,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -23009,7 +22563,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 32895,
-                  "optional": false,
                   "start": 32846,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -23054,7 +22607,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 32972,
-                  "optional": false,
                   "start": 32901,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -23113,7 +22665,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 33051,
-                  "optional": false,
                   "start": 32978,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -23172,7 +22723,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 33130,
-                  "optional": false,
                   "start": 33057,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -23217,7 +22767,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 33185,
-                  "optional": false,
                   "start": 33136,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -23276,7 +22825,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 33264,
-                  "optional": false,
                   "start": 33191,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -23328,7 +22876,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 33341,
-                  "optional": false,
                   "start": 33270,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -23380,7 +22927,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 33418,
-                  "optional": false,
                   "start": 33347,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -23432,7 +22978,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 33495,
-                  "optional": false,
                   "start": 33424,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -23484,7 +23029,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 33572,
-                  "optional": false,
                   "start": 33501,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -23529,7 +23073,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 33627,
-                  "optional": false,
                   "start": 33578,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -23588,7 +23131,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 33706,
-                  "optional": false,
                   "start": 33633,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -23647,7 +23189,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 33784,
-                  "optional": false,
                   "start": 33712,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -23706,7 +23247,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 33863,
-                  "optional": false,
                   "start": 33790,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -23758,7 +23298,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 33940,
-                  "optional": false,
                   "start": 33869,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -23810,7 +23349,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 34017,
-                  "optional": false,
                   "start": 33946,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -23869,7 +23407,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 34094,
-                  "optional": false,
                   "start": 34023,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -23914,7 +23451,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 34171,
-                  "optional": false,
                   "start": 34100,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -23966,7 +23502,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 34248,
-                  "optional": false,
                   "start": 34177,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -24018,7 +23553,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 34327,
-                  "optional": false,
                   "start": 34254,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -24063,7 +23597,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 34382,
-                  "optional": false,
                   "start": 34333,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -24108,7 +23641,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 34460,
-                  "optional": false,
                   "start": 34388,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -24153,7 +23685,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 34537,
-                  "optional": false,
                   "start": 34466,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -24205,7 +23736,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 34614,
-                  "optional": false,
                   "start": 34543,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -24250,7 +23780,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 34691,
-                  "optional": false,
                   "start": 34620,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -24302,7 +23831,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 34768,
-                  "optional": false,
                   "start": 34697,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -24354,7 +23882,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 34846,
-                  "optional": false,
                   "start": 34774,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -24406,7 +23933,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 34924,
-                  "optional": false,
                   "start": 34852,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -24465,7 +23991,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 35003,
-                  "optional": false,
                   "start": 34930,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -24524,7 +24049,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 35082,
-                  "optional": false,
                   "start": 35009,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -24583,7 +24107,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 35161,
-                  "optional": false,
                   "start": 35088,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -24628,7 +24151,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 35216,
-                  "optional": false,
                   "start": 35167,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -24680,7 +24202,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 35293,
-                  "optional": false,
                   "start": 35222,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -24732,7 +24253,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 35371,
-                  "optional": false,
                   "start": 35299,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -24784,7 +24304,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 35448,
-                  "optional": false,
                   "start": 35377,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -24829,7 +24348,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 35503,
-                  "optional": false,
                   "start": 35454,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -24881,7 +24399,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 35582,
-                  "optional": false,
                   "start": 35509,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -24933,7 +24450,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 35660,
-                  "optional": false,
                   "start": 35588,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -24992,7 +24508,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 35739,
-                  "optional": false,
                   "start": 35666,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -25051,7 +24566,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 35819,
-                  "optional": false,
                   "start": 35745,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -25103,7 +24617,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 35896,
-                  "optional": false,
                   "start": 35825,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -25155,7 +24668,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 35951,
-                  "optional": false,
                   "start": 35902,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -25207,7 +24719,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 36028,
-                  "optional": false,
                   "start": 35957,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -25266,7 +24777,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 36109,
-                  "optional": false,
                   "start": 36034,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -25318,7 +24828,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 36188,
-                  "optional": false,
                   "start": 36115,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -25363,7 +24872,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 36242,
-                  "optional": false,
                   "start": 36194,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -25415,7 +24923,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 36319,
-                  "optional": false,
                   "start": 36248,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -25467,7 +24974,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 36397,
-                  "optional": false,
                   "start": 36325,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -25526,7 +25032,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 36475,
-                  "optional": false,
                   "start": 36403,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -25571,7 +25076,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 36552,
-                  "optional": false,
                   "start": 36481,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -25630,7 +25134,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 36607,
-                  "optional": false,
                   "start": 36558,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -25689,7 +25192,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 36685,
-                  "optional": false,
                   "start": 36613,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -25741,7 +25243,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 36762,
-                  "optional": false,
                   "start": 36691,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -25786,7 +25287,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 36839,
-                  "optional": false,
                   "start": 36768,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -25838,7 +25338,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 36917,
-                  "optional": false,
                   "start": 36845,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -25890,7 +25389,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 36996,
-                  "optional": false,
                   "start": 36923,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -25942,7 +25440,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 37073,
-                  "optional": false,
                   "start": 37002,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -25994,7 +25491,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 37151,
-                  "optional": false,
                   "start": 37079,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -26046,7 +25542,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 37228,
-                  "optional": false,
                   "start": 37157,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -26098,7 +25593,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 37305,
-                  "optional": false,
                   "start": 37234,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -26157,7 +25651,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 37384,
-                  "optional": false,
                   "start": 37311,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -26202,7 +25695,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 37462,
-                  "optional": false,
                   "start": 37390,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -26247,7 +25739,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 37540,
-                  "optional": false,
                   "start": 37468,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -26299,7 +25790,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 37618,
-                  "optional": false,
                   "start": 37546,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -26358,7 +25848,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 37698,
-                  "optional": false,
                   "start": 37624,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -26410,7 +25899,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 37776,
-                  "optional": false,
                   "start": 37704,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -26462,7 +25950,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 37856,
-                  "optional": false,
                   "start": 37782,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -26514,7 +26001,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 37933,
-                  "optional": false,
                   "start": 37862,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -26566,7 +26052,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 38010,
-                  "optional": false,
                   "start": 37939,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -26611,7 +26096,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 38065,
-                  "optional": false,
                   "start": 38016,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -26663,7 +26147,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 38145,
-                  "optional": false,
                   "start": 38071,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -26722,7 +26205,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 38224,
-                  "optional": false,
                   "start": 38151,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -26781,7 +26263,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 38303,
-                  "optional": false,
                   "start": 38230,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -26826,7 +26307,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 38357,
-                  "optional": false,
                   "start": 38309,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -26878,7 +26358,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 38436,
-                  "optional": false,
                   "start": 38363,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -26923,7 +26402,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 38490,
-                  "optional": false,
                   "start": 38442,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -26975,7 +26453,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 38568,
-                  "optional": false,
                   "start": 38496,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -27020,7 +26497,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 38623,
-                  "optional": false,
                   "start": 38574,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -27065,7 +26541,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 38700,
-                  "optional": false,
                   "start": 38629,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -27110,7 +26585,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 38755,
-                  "optional": false,
                   "start": 38706,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -27169,7 +26643,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 38834,
-                  "optional": false,
                   "start": 38761,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -27221,7 +26694,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 38911,
-                  "optional": false,
                   "start": 38840,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -27280,7 +26752,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 38989,
-                  "optional": false,
                   "start": 38917,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -27332,7 +26803,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 39069,
-                  "optional": false,
                   "start": 38995,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -27384,7 +26854,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 39148,
-                  "optional": false,
                   "start": 39075,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -27436,7 +26905,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 39226,
-                  "optional": false,
                   "start": 39154,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -27495,7 +26963,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 39304,
-                  "optional": false,
                   "start": 39232,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -27540,7 +27007,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 39359,
-                  "optional": false,
                   "start": 39310,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -27585,7 +27051,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 39436,
-                  "optional": false,
                   "start": 39365,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -27637,7 +27102,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 39514,
-                  "optional": false,
                   "start": 39442,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -27696,7 +27160,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 39594,
-                  "optional": false,
                   "start": 39520,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -27748,7 +27211,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 39672,
-                  "optional": false,
                   "start": 39600,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -27800,7 +27262,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 39750,
-                  "optional": false,
                   "start": 39678,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -27845,7 +27306,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 39805,
-                  "optional": false,
                   "start": 39756,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -27904,7 +27364,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 39884,
-                  "optional": false,
                   "start": 39811,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -27956,7 +27415,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 39961,
-                  "optional": false,
                   "start": 39890,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -28008,7 +27466,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 40038,
-                  "optional": false,
                   "start": 39967,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -28053,7 +27510,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 40093,
-                  "optional": false,
                   "start": 40044,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -28105,7 +27561,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 40170,
-                  "optional": false,
                   "start": 40099,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -28150,7 +27605,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 40225,
-                  "optional": false,
                   "start": 40176,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -28195,7 +27649,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 40302,
-                  "optional": false,
                   "start": 40231,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -28254,7 +27707,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 40379,
-                  "optional": false,
                   "start": 40308,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -28306,7 +27758,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 40457,
-                  "optional": false,
                   "start": 40385,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -28365,7 +27816,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 40537,
-                  "optional": false,
                   "start": 40463,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -28424,7 +27874,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 40616,
-                  "optional": false,
                   "start": 40543,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -28476,7 +27925,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 40694,
-                  "optional": false,
                   "start": 40622,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -28535,7 +27983,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 40773,
-                  "optional": false,
                   "start": 40700,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -28587,7 +28034,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 40850,
-                  "optional": false,
                   "start": 40779,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -28639,7 +28085,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 40927,
-                  "optional": false,
                   "start": 40856,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -28691,7 +28136,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 41004,
-                  "optional": false,
                   "start": 40933,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -28750,7 +28194,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 41083,
-                  "optional": false,
                   "start": 41010,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -28795,7 +28238,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 41161,
-                  "optional": false,
                   "start": 41089,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -28840,7 +28282,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 41239,
-                  "optional": false,
                   "start": 41167,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -28892,7 +28333,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 41317,
-                  "optional": false,
                   "start": 41245,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -28951,7 +28391,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 41397,
-                  "optional": false,
                   "start": 41323,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -29003,7 +28442,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 41475,
-                  "optional": false,
                   "start": 41403,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -29055,7 +28493,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 41555,
-                  "optional": false,
                   "start": 41481,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -29107,7 +28544,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 41632,
-                  "optional": false,
                   "start": 41561,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -29159,7 +28595,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 41709,
-                  "optional": false,
                   "start": 41638,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -29204,7 +28639,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 41764,
-                  "optional": false,
                   "start": 41715,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -29256,7 +28690,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 41844,
-                  "optional": false,
                   "start": 41770,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -29315,7 +28748,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 41923,
-                  "optional": false,
                   "start": 41850,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -29374,7 +28806,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 42002,
-                  "optional": false,
                   "start": 41929,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -29419,7 +28850,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 42056,
-                  "optional": false,
                   "start": 42008,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -29471,7 +28901,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 42135,
-                  "optional": false,
                   "start": 42062,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -29516,7 +28945,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 42189,
-                  "optional": false,
                   "start": 42141,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -29568,7 +28996,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 42267,
-                  "optional": false,
                   "start": 42195,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -29613,7 +29040,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 42322,
-                  "optional": false,
                   "start": 42273,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -29658,7 +29084,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 42399,
-                  "optional": false,
                   "start": 42328,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -29703,7 +29128,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 42454,
-                  "optional": false,
                   "start": 42405,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -29762,7 +29186,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 42533,
-                  "optional": false,
                   "start": 42460,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -29814,7 +29237,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 42610,
-                  "optional": false,
                   "start": 42539,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -29866,7 +29288,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 42687,
-                  "optional": false,
                   "start": 42616,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -29918,7 +29339,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 42764,
-                  "optional": false,
                   "start": 42693,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -29970,7 +29390,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 42841,
-                  "optional": false,
                   "start": 42770,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -30015,7 +29434,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 42896,
-                  "optional": false,
                   "start": 42847,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -30074,7 +29492,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 42975,
-                  "optional": false,
                   "start": 42902,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -30133,7 +29550,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 43053,
-                  "optional": false,
                   "start": 42981,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -30192,7 +29608,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 43132,
-                  "optional": false,
                   "start": 43059,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -30244,7 +29659,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 43209,
-                  "optional": false,
                   "start": 43138,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -30296,7 +29710,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 43286,
-                  "optional": false,
                   "start": 43215,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -30355,7 +29768,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 43363,
-                  "optional": false,
                   "start": 43292,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -30400,7 +29812,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 43440,
-                  "optional": false,
                   "start": 43369,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -30452,7 +29863,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 43517,
-                  "optional": false,
                   "start": 43446,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -30504,7 +29914,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 43596,
-                  "optional": false,
                   "start": 43523,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -30549,7 +29958,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 43651,
-                  "optional": false,
                   "start": 43602,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -30594,7 +30002,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 43729,
-                  "optional": false,
                   "start": 43657,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -30639,7 +30046,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 43806,
-                  "optional": false,
                   "start": 43735,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -30691,7 +30097,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 43883,
-                  "optional": false,
                   "start": 43812,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -30736,7 +30141,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 43960,
-                  "optional": false,
                   "start": 43889,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -30788,7 +30192,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 44037,
-                  "optional": false,
                   "start": 43966,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -30840,7 +30243,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 44115,
-                  "optional": false,
                   "start": 44043,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -30892,7 +30294,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 44193,
-                  "optional": false,
                   "start": 44121,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -30951,7 +30352,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 44272,
-                  "optional": false,
                   "start": 44199,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -31010,7 +30410,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 44351,
-                  "optional": false,
                   "start": 44278,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -31069,7 +30468,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 44430,
-                  "optional": false,
                   "start": 44357,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -31114,7 +30512,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 44485,
-                  "optional": false,
                   "start": 44436,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -31166,7 +30563,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 44563,
-                  "optional": false,
                   "start": 44491,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -31218,7 +30614,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 44640,
-                  "optional": false,
                   "start": 44569,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -31270,7 +30665,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 44717,
-                  "optional": false,
                   "start": 44646,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -31329,7 +30723,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 44796,
-                  "optional": false,
                   "start": 44723,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -31374,7 +30767,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 44874,
-                  "optional": false,
                   "start": 44802,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -31419,7 +30811,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 44952,
-                  "optional": false,
                   "start": 44880,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -31471,7 +30862,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 45030,
-                  "optional": false,
                   "start": 44958,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -31530,7 +30920,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 45110,
-                  "optional": false,
                   "start": 45036,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -31582,7 +30971,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 45188,
-                  "optional": false,
                   "start": 45116,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -31634,7 +31022,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 45268,
-                  "optional": false,
                   "start": 45194,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -31686,7 +31073,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 45345,
-                  "optional": false,
                   "start": 45274,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -31738,7 +31124,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 45422,
-                  "optional": false,
                   "start": 45351,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -31783,7 +31168,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 45477,
-                  "optional": false,
                   "start": 45428,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -31835,7 +31219,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 45557,
-                  "optional": false,
                   "start": 45483,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -31894,7 +31277,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 45636,
-                  "optional": false,
                   "start": 45563,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -31953,7 +31335,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 45715,
-                  "optional": false,
                   "start": 45642,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -31998,7 +31379,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 45769,
-                  "optional": false,
                   "start": 45721,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -32050,7 +31430,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 45848,
-                  "optional": false,
                   "start": 45775,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -32095,7 +31474,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 45902,
-                  "optional": false,
                   "start": 45854,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -32147,7 +31525,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 45980,
-                  "optional": false,
                   "start": 45908,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -32192,7 +31569,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 46035,
-                  "optional": false,
                   "start": 45986,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -32237,7 +31613,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 46112,
-                  "optional": false,
                   "start": 46041,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -32282,7 +31657,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 46167,
-                  "optional": false,
                   "start": 46118,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -32341,7 +31715,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 46246,
-                  "optional": false,
                   "start": 46173,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -32393,7 +31766,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 46323,
-                  "optional": false,
                   "start": 46252,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -32452,7 +31824,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 46401,
-                  "optional": false,
                   "start": 46329,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -32504,7 +31875,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 46481,
-                  "optional": false,
                   "start": 46407,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -32556,7 +31926,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 46560,
-                  "optional": false,
                   "start": 46487,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -32608,7 +31977,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 46638,
-                  "optional": false,
                   "start": 46566,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -32667,7 +32035,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 46716,
-                  "optional": false,
                   "start": 46644,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -32712,7 +32079,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 46771,
-                  "optional": false,
                   "start": 46722,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -32757,7 +32123,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 46848,
-                  "optional": false,
                   "start": 46777,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -32809,7 +32174,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 46926,
-                  "optional": false,
                   "start": 46854,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -32868,7 +32232,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 47006,
-                  "optional": false,
                   "start": 46932,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -32920,7 +32283,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 47084,
-                  "optional": false,
                   "start": 47012,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -32972,7 +32334,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 47162,
-                  "optional": false,
                   "start": 47090,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -33017,7 +32378,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 47217,
-                  "optional": false,
                   "start": 47168,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -33076,7 +32436,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 47296,
-                  "optional": false,
                   "start": 47223,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -33128,7 +32487,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 47373,
-                  "optional": false,
                   "start": 47302,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -33180,7 +32538,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 47450,
-                  "optional": false,
                   "start": 47379,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -33225,7 +32582,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 47505,
-                  "optional": false,
                   "start": 47456,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -33277,7 +32633,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 47582,
-                  "optional": false,
                   "start": 47511,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -33322,7 +32677,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 47637,
-                  "optional": false,
                   "start": 47588,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -33367,7 +32721,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 47714,
-                  "optional": false,
                   "start": 47643,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -33426,7 +32779,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 47791,
-                  "optional": false,
                   "start": 47720,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -33478,7 +32830,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 47869,
-                  "optional": false,
                   "start": 47797,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -33537,7 +32888,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 47949,
-                  "optional": false,
                   "start": 47875,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -33596,7 +32946,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 48028,
-                  "optional": false,
                   "start": 47955,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -33648,7 +32997,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 48106,
-                  "optional": false,
                   "start": 48034,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -33707,7 +33055,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 48185,
-                  "optional": false,
                   "start": 48112,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -33759,7 +33106,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 48262,
-                  "optional": false,
                   "start": 48191,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -33811,7 +33157,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 48339,
-                  "optional": false,
                   "start": 48268,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -33863,7 +33208,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 48416,
-                  "optional": false,
                   "start": 48345,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -33922,7 +33266,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 48495,
-                  "optional": false,
                   "start": 48422,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -33967,7 +33310,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 48573,
-                  "optional": false,
                   "start": 48501,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -34012,7 +33354,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 48651,
-                  "optional": false,
                   "start": 48579,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -34064,7 +33405,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 48729,
-                  "optional": false,
                   "start": 48657,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -34123,7 +33463,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 48809,
-                  "optional": false,
                   "start": 48735,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -34175,7 +33514,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 48887,
-                  "optional": false,
                   "start": 48815,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -34227,7 +33565,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 48967,
-                  "optional": false,
                   "start": 48893,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -34279,7 +33616,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 49044,
-                  "optional": false,
                   "start": 48973,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -34331,7 +33667,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 49121,
-                  "optional": false,
                   "start": 49050,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -34376,7 +33711,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 49176,
-                  "optional": false,
                   "start": 49127,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -34428,7 +33762,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 49256,
-                  "optional": false,
                   "start": 49182,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -34487,7 +33820,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 49335,
-                  "optional": false,
                   "start": 49262,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -34546,7 +33878,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 49414,
-                  "optional": false,
                   "start": 49341,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -34591,7 +33922,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 49468,
-                  "optional": false,
                   "start": 49420,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -34643,7 +33973,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 49547,
-                  "optional": false,
                   "start": 49474,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -34688,7 +34017,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 49601,
-                  "optional": false,
                   "start": 49553,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -34740,7 +34068,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 49679,
-                  "optional": false,
                   "start": 49607,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -34785,7 +34112,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 49734,
-                  "optional": false,
                   "start": 49685,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -34830,7 +34156,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 49811,
-                  "optional": false,
                   "start": 49740,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -34875,7 +34200,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 49866,
-                  "optional": false,
                   "start": 49817,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -34927,7 +34251,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 49944,
-                  "optional": false,
                   "start": 49872,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -34979,7 +34302,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 50021,
-                  "optional": false,
                   "start": 49950,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -35031,7 +34353,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 50098,
-                  "optional": false,
                   "start": 50027,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -35090,7 +34411,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 50177,
-                  "optional": false,
                   "start": 50104,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -35135,7 +34455,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 50255,
-                  "optional": false,
                   "start": 50183,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -35180,7 +34499,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 50333,
-                  "optional": false,
                   "start": 50261,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -35232,7 +34550,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 50411,
-                  "optional": false,
                   "start": 50339,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -35291,7 +34608,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 50491,
-                  "optional": false,
                   "start": 50417,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -35343,7 +34659,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 50569,
-                  "optional": false,
                   "start": 50497,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -35395,7 +34710,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 50649,
-                  "optional": false,
                   "start": 50575,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -35447,7 +34761,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 50726,
-                  "optional": false,
                   "start": 50655,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -35499,7 +34812,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 50803,
-                  "optional": false,
                   "start": 50732,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -35544,7 +34856,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 50858,
-                  "optional": false,
                   "start": 50809,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -35596,7 +34907,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 50938,
-                  "optional": false,
                   "start": 50864,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -35655,7 +34965,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 51017,
-                  "optional": false,
                   "start": 50944,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -35714,7 +35023,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 51096,
-                  "optional": false,
                   "start": 51023,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -35759,7 +35067,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 51150,
-                  "optional": false,
                   "start": 51102,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -35811,7 +35118,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 51229,
-                  "optional": false,
                   "start": 51156,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -35856,7 +35162,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 51283,
-                  "optional": false,
                   "start": 51235,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -35908,7 +35213,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 51361,
-                  "optional": false,
                   "start": 51289,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -35953,7 +35257,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 51416,
-                  "optional": false,
                   "start": 51367,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -35998,7 +35301,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 51493,
-                  "optional": false,
                   "start": 51422,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -36043,7 +35345,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 51548,
-                  "optional": false,
                   "start": 51499,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -36102,7 +35403,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 51627,
-                  "optional": false,
                   "start": 51554,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -36154,7 +35454,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 51704,
-                  "optional": false,
                   "start": 51633,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -36213,7 +35512,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 51782,
-                  "optional": false,
                   "start": 51710,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -36265,7 +35563,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 51862,
-                  "optional": false,
                   "start": 51788,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -36317,7 +35614,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 51940,
-                  "optional": false,
                   "start": 51868,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -36369,7 +35665,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 52017,
-                  "optional": false,
                   "start": 51946,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -36421,7 +35716,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 52094,
-                  "optional": false,
                   "start": 52023,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -36480,7 +35774,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 52173,
-                  "optional": false,
                   "start": 52100,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -36525,7 +35818,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 52251,
-                  "optional": false,
                   "start": 52179,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -36570,7 +35862,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 52329,
-                  "optional": false,
                   "start": 52257,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -36622,7 +35913,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 52407,
-                  "optional": false,
                   "start": 52335,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -36681,7 +35971,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 52487,
-                  "optional": false,
                   "start": 52413,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -36733,7 +36022,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 52565,
-                  "optional": false,
                   "start": 52493,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -36785,7 +36073,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 52645,
-                  "optional": false,
                   "start": 52571,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -36837,7 +36124,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 52722,
-                  "optional": false,
                   "start": 52651,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -36889,7 +36175,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 52799,
-                  "optional": false,
                   "start": 52728,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -36934,7 +36219,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 52854,
-                  "optional": false,
                   "start": 52805,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -36986,7 +36270,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 52934,
-                  "optional": false,
                   "start": 52860,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -37045,7 +36328,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 53013,
-                  "optional": false,
                   "start": 52940,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -37104,7 +36386,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 53092,
-                  "optional": false,
                   "start": 53019,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -37149,7 +36430,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 53146,
-                  "optional": false,
                   "start": 53098,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -37201,7 +36481,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 53225,
-                  "optional": false,
                   "start": 53152,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -37246,7 +36525,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 53279,
-                  "optional": false,
                   "start": 53231,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -37298,7 +36576,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 53357,
-                  "optional": false,
                   "start": 53285,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -37343,7 +36620,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 53412,
-                  "optional": false,
                   "start": 53363,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -37388,7 +36664,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 53489,
-                  "optional": false,
                   "start": 53418,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -37433,7 +36708,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 53544,
-                  "optional": false,
                   "start": 53495,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -37492,7 +36766,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 53623,
-                  "optional": false,
                   "start": 53550,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -37544,7 +36817,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 53700,
-                  "optional": false,
                   "start": 53629,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -37603,7 +36875,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 53778,
-                  "optional": false,
                   "start": 53706,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -37655,7 +36926,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 53858,
-                  "optional": false,
                   "start": 53784,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -37707,7 +36977,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 53937,
-                  "optional": false,
                   "start": 53864,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -37759,7 +37028,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 54015,
-                  "optional": false,
                   "start": 53943,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -37818,7 +37086,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 54093,
-                  "optional": false,
                   "start": 54021,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -37863,7 +37130,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 54148,
-                  "optional": false,
                   "start": 54099,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -37908,7 +37174,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 54225,
-                  "optional": false,
                   "start": 54154,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -37960,7 +37225,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 54303,
-                  "optional": false,
                   "start": 54231,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -38019,7 +37283,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 54383,
-                  "optional": false,
                   "start": 54309,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -38071,7 +37334,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 54461,
-                  "optional": false,
                   "start": 54389,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -38123,7 +37385,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 54539,
-                  "optional": false,
                   "start": 54467,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -38168,7 +37429,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 54594,
-                  "optional": false,
                   "start": 54545,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -38227,7 +37487,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 54673,
-                  "optional": false,
                   "start": 54600,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -38279,7 +37538,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 54750,
-                  "optional": false,
                   "start": 54679,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -38331,7 +37589,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 54827,
-                  "optional": false,
                   "start": 54756,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -38376,7 +37633,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 54882,
-                  "optional": false,
                   "start": 54833,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -38428,7 +37684,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 54959,
-                  "optional": false,
                   "start": 54888,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -38473,7 +37728,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 55014,
-                  "optional": false,
                   "start": 54965,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -38518,7 +37772,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 55091,
-                  "optional": false,
                   "start": 55020,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -38577,7 +37830,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 55168,
-                  "optional": false,
                   "start": 55097,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -38629,7 +37881,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 55246,
-                  "optional": false,
                   "start": 55174,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -38688,7 +37939,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 55326,
-                  "optional": false,
                   "start": 55252,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -38747,7 +37997,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 55405,
-                  "optional": false,
                   "start": 55332,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -38799,7 +38048,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 55483,
-                  "optional": false,
                   "start": 55411,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -38858,7 +38106,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 55562,
-                  "optional": false,
                   "start": 55489,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -38910,7 +38157,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 55639,
-                  "optional": false,
                   "start": 55568,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -38962,7 +38208,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 55716,
-                  "optional": false,
                   "start": 55645,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -39014,7 +38259,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 55793,
-                  "optional": false,
                   "start": 55722,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -39073,7 +38317,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 55872,
-                  "optional": false,
                   "start": 55799,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -39118,7 +38361,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 55950,
-                  "optional": false,
                   "start": 55878,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -39163,7 +38405,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 56028,
-                  "optional": false,
                   "start": 55956,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -39215,7 +38456,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 56106,
-                  "optional": false,
                   "start": 56034,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -39274,7 +38514,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 56186,
-                  "optional": false,
                   "start": 56112,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -39326,7 +38565,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 56264,
-                  "optional": false,
                   "start": 56192,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -39378,7 +38616,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 56344,
-                  "optional": false,
                   "start": 56270,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -39430,7 +38667,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 56421,
-                  "optional": false,
                   "start": 56350,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -39482,7 +38718,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 56498,
-                  "optional": false,
                   "start": 56427,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -39527,7 +38762,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 56553,
-                  "optional": false,
                   "start": 56504,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -39579,7 +38813,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 56633,
-                  "optional": false,
                   "start": 56559,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -39638,7 +38871,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 56712,
-                  "optional": false,
                   "start": 56639,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -39697,7 +38929,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 56791,
-                  "optional": false,
                   "start": 56718,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -39742,7 +38973,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 56845,
-                  "optional": false,
                   "start": 56797,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -39794,7 +39024,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 56924,
-                  "optional": false,
                   "start": 56851,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -39839,7 +39068,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 56978,
-                  "optional": false,
                   "start": 56930,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -39891,7 +39119,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 57056,
-                  "optional": false,
                   "start": 56984,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -39936,7 +39163,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 57111,
-                  "optional": false,
                   "start": 57062,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -39981,7 +39207,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 57188,
-                  "optional": false,
                   "start": 57117,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -40026,7 +39251,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 57243,
-                  "optional": false,
                   "start": 57194,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -40085,7 +39309,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 57322,
-                  "optional": false,
                   "start": 57249,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -40137,7 +39360,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 57399,
-                  "optional": false,
                   "start": 57328,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -40189,7 +39411,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 57476,
-                  "optional": false,
                   "start": 57405,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -40241,7 +39462,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 57553,
-                  "optional": false,
                   "start": 57482,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -40293,7 +39513,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 57630,
-                  "optional": false,
                   "start": 57559,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -40338,7 +39557,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 57685,
-                  "optional": false,
                   "start": 57636,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -40397,7 +39615,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 57764,
-                  "optional": false,
                   "start": 57691,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -40456,7 +39673,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 57842,
-                  "optional": false,
                   "start": 57770,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -40515,7 +39731,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 57921,
-                  "optional": false,
                   "start": 57848,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -40567,7 +39782,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 57998,
-                  "optional": false,
                   "start": 57927,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -40619,7 +39833,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 58075,
-                  "optional": false,
                   "start": 58004,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -40678,7 +39891,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 58152,
-                  "optional": false,
                   "start": 58081,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -40723,7 +39935,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 58229,
-                  "optional": false,
                   "start": 58158,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -40775,7 +39986,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 58306,
-                  "optional": false,
                   "start": 58235,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -40827,7 +40037,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 58385,
-                  "optional": false,
                   "start": 58312,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -40872,7 +40081,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 58440,
-                  "optional": false,
                   "start": 58391,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -40917,7 +40125,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 58518,
-                  "optional": false,
                   "start": 58446,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -40962,7 +40169,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 58595,
-                  "optional": false,
                   "start": 58524,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -41014,7 +40220,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 58672,
-                  "optional": false,
                   "start": 58601,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -41059,7 +40264,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 58749,
-                  "optional": false,
                   "start": 58678,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -41111,7 +40315,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 58826,
-                  "optional": false,
                   "start": 58755,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -41163,7 +40366,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 58904,
-                  "optional": false,
                   "start": 58832,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -41215,7 +40417,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 58982,
-                  "optional": false,
                   "start": 58910,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -41274,7 +40475,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 59061,
-                  "optional": false,
                   "start": 58988,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -41333,7 +40533,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 59140,
-                  "optional": false,
                   "start": 59067,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -41392,7 +40591,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 59219,
-                  "optional": false,
                   "start": 59146,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -41437,7 +40635,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 59274,
-                  "optional": false,
                   "start": 59225,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -41489,7 +40686,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 59352,
-                  "optional": false,
                   "start": 59280,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -41541,7 +40737,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 59429,
-                  "optional": false,
                   "start": 59358,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -41593,7 +40788,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 59506,
-                  "optional": false,
                   "start": 59435,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -41652,7 +40846,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 59585,
-                  "optional": false,
                   "start": 59512,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -41697,7 +40890,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 59663,
-                  "optional": false,
                   "start": 59591,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -41742,7 +40934,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 59741,
-                  "optional": false,
                   "start": 59669,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -41794,7 +40985,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 59819,
-                  "optional": false,
                   "start": 59747,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -41853,7 +41043,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 59899,
-                  "optional": false,
                   "start": 59825,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -41905,7 +41094,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 59977,
-                  "optional": false,
                   "start": 59905,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -41957,7 +41145,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 60057,
-                  "optional": false,
                   "start": 59983,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -42009,7 +41196,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 60134,
-                  "optional": false,
                   "start": 60063,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -42061,7 +41247,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 60211,
-                  "optional": false,
                   "start": 60140,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -42106,7 +41291,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 60266,
-                  "optional": false,
                   "start": 60217,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -42158,7 +41342,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 60346,
-                  "optional": false,
                   "start": 60272,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -42217,7 +41400,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 60425,
-                  "optional": false,
                   "start": 60352,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -42276,7 +41458,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 60504,
-                  "optional": false,
                   "start": 60431,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -42321,7 +41502,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 60558,
-                  "optional": false,
                   "start": 60510,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -42373,7 +41553,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 60637,
-                  "optional": false,
                   "start": 60564,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -42418,7 +41597,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 60691,
-                  "optional": false,
                   "start": 60643,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -42470,7 +41648,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 60769,
-                  "optional": false,
                   "start": 60697,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -42515,7 +41692,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 60824,
-                  "optional": false,
                   "start": 60775,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -42560,7 +41736,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 60901,
-                  "optional": false,
                   "start": 60830,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -42605,7 +41780,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 60956,
-                  "optional": false,
                   "start": 60907,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -42664,7 +41838,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 61035,
-                  "optional": false,
                   "start": 60962,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -42716,7 +41889,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 61112,
-                  "optional": false,
                   "start": 61041,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -42775,7 +41947,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 61190,
-                  "optional": false,
                   "start": 61118,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -42827,7 +41998,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 61270,
-                  "optional": false,
                   "start": 61196,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -42879,7 +42049,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 61349,
-                  "optional": false,
                   "start": 61276,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -42931,7 +42100,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 61427,
-                  "optional": false,
                   "start": 61355,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -42990,7 +42158,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 61505,
-                  "optional": false,
                   "start": 61433,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -43035,7 +42202,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 61560,
-                  "optional": false,
                   "start": 61511,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -43080,7 +42246,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 61637,
-                  "optional": false,
                   "start": 61566,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -43132,7 +42297,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 61715,
-                  "optional": false,
                   "start": 61643,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -43191,7 +42355,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 61795,
-                  "optional": false,
                   "start": 61721,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -43243,7 +42406,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 61873,
-                  "optional": false,
                   "start": 61801,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -43295,7 +42457,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 61951,
-                  "optional": false,
                   "start": 61879,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -43340,7 +42501,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 62006,
-                  "optional": false,
                   "start": 61957,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -43399,7 +42559,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 62085,
-                  "optional": false,
                   "start": 62012,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -43451,7 +42610,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 62162,
-                  "optional": false,
                   "start": 62091,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -43503,7 +42661,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 62239,
-                  "optional": false,
                   "start": 62168,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -43548,7 +42705,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 62294,
-                  "optional": false,
                   "start": 62245,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -43600,7 +42756,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 62371,
-                  "optional": false,
                   "start": 62300,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -43645,7 +42800,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 62426,
-                  "optional": false,
                   "start": 62377,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -43690,7 +42844,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 62503,
-                  "optional": false,
                   "start": 62432,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -43749,7 +42902,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 62580,
-                  "optional": false,
                   "start": 62509,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -43801,7 +42953,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 62658,
-                  "optional": false,
                   "start": 62586,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -43860,7 +43011,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 62738,
-                  "optional": false,
                   "start": 62664,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -43919,7 +43069,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 62817,
-                  "optional": false,
                   "start": 62744,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -43971,7 +43120,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 62895,
-                  "optional": false,
                   "start": 62823,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -44030,7 +43178,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 62974,
-                  "optional": false,
                   "start": 62901,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -44082,7 +43229,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 63051,
-                  "optional": false,
                   "start": 62980,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -44134,7 +43280,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 63128,
-                  "optional": false,
                   "start": 63057,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -44186,7 +43331,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 63205,
-                  "optional": false,
                   "start": 63134,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -44245,7 +43389,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 63284,
-                  "optional": false,
                   "start": 63211,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -44290,7 +43433,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 63362,
-                  "optional": false,
                   "start": 63290,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -44335,7 +43477,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 63440,
-                  "optional": false,
                   "start": 63368,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -44387,7 +43528,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 63518,
-                  "optional": false,
                   "start": 63446,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -44446,7 +43586,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 63598,
-                  "optional": false,
                   "start": 63524,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -44498,7 +43637,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 63676,
-                  "optional": false,
                   "start": 63604,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -44550,7 +43688,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 63756,
-                  "optional": false,
                   "start": 63682,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -44602,7 +43739,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 63833,
-                  "optional": false,
                   "start": 63762,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -44654,7 +43790,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 63910,
-                  "optional": false,
                   "start": 63839,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -44699,7 +43834,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 63965,
-                  "optional": false,
                   "start": 63916,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -44751,7 +43885,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 64045,
-                  "optional": false,
                   "start": 63971,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -44810,7 +43943,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 64124,
-                  "optional": false,
                   "start": 64051,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -44869,7 +44001,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 64203,
-                  "optional": false,
                   "start": 64130,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -44914,7 +44045,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 64257,
-                  "optional": false,
                   "start": 64209,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -44966,7 +44096,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 64336,
-                  "optional": false,
                   "start": 64263,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -45011,7 +44140,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 64390,
-                  "optional": false,
                   "start": 64342,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -45063,7 +44191,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 64468,
-                  "optional": false,
                   "start": 64396,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -45108,7 +44235,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 64523,
-                  "optional": false,
                   "start": 64474,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -45153,7 +44279,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 64600,
-                  "optional": false,
                   "start": 64529,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -45198,7 +44323,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 64655,
-                  "optional": false,
                   "start": 64606,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -45250,7 +44374,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 64733,
-                  "optional": false,
                   "start": 64661,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -45302,7 +44425,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 64810,
-                  "optional": false,
                   "start": 64739,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -45354,7 +44476,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 64887,
-                  "optional": false,
                   "start": 64816,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -45413,7 +44534,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 64966,
-                  "optional": false,
                   "start": 64893,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -45458,7 +44578,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 65044,
-                  "optional": false,
                   "start": 64972,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -45503,7 +44622,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 65122,
-                  "optional": false,
                   "start": 65050,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -45555,7 +44673,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 65200,
-                  "optional": false,
                   "start": 65128,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -45614,7 +44731,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 65280,
-                  "optional": false,
                   "start": 65206,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -45666,7 +44782,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 65358,
-                  "optional": false,
                   "start": 65286,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -45718,7 +44833,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 65438,
-                  "optional": false,
                   "start": 65364,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -45770,7 +44884,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 65515,
-                  "optional": false,
                   "start": 65444,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -45822,7 +44935,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 65592,
-                  "optional": false,
                   "start": 65521,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -45867,7 +44979,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 65647,
-                  "optional": false,
                   "start": 65598,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -45919,7 +45030,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 65727,
-                  "optional": false,
                   "start": 65653,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -45978,7 +45088,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 65806,
-                  "optional": false,
                   "start": 65733,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -46037,7 +45146,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 65885,
-                  "optional": false,
                   "start": 65812,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -46082,7 +45190,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 65939,
-                  "optional": false,
                   "start": 65891,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -46134,7 +45241,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 66018,
-                  "optional": false,
                   "start": 65945,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -46179,7 +45285,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 66072,
-                  "optional": false,
                   "start": 66024,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -46231,7 +45336,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 66150,
-                  "optional": false,
                   "start": 66078,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -46276,7 +45380,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 66205,
-                  "optional": false,
                   "start": 66156,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -46321,7 +45424,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 66282,
-                  "optional": false,
                   "start": 66211,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -46366,7 +45468,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 66337,
-                  "optional": false,
                   "start": 66288,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -46425,7 +45526,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 66416,
-                  "optional": false,
                   "start": 66343,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -46477,7 +45577,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 66493,
-                  "optional": false,
                   "start": 66422,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -46536,7 +45635,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 66571,
-                  "optional": false,
                   "start": 66499,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -46588,7 +45686,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 66651,
-                  "optional": false,
                   "start": 66577,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -46640,7 +45737,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 66730,
-                  "optional": false,
                   "start": 66657,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -46692,7 +45788,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 66808,
-                  "optional": false,
                   "start": 66736,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -46751,7 +45846,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 66886,
-                  "optional": false,
                   "start": 66814,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -46796,7 +45890,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 66941,
-                  "optional": false,
                   "start": 66892,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -46841,7 +45934,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 67018,
-                  "optional": false,
                   "start": 66947,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -46893,7 +45985,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 67096,
-                  "optional": false,
                   "start": 67024,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -46952,7 +46043,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 67176,
-                  "optional": false,
                   "start": 67102,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -47004,7 +46094,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 67254,
-                  "optional": false,
                   "start": 67182,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -47056,7 +46145,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 67332,
-                  "optional": false,
                   "start": 67260,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -47101,7 +46189,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 67387,
-                  "optional": false,
                   "start": 67338,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -47160,7 +46247,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 67466,
-                  "optional": false,
                   "start": 67393,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -47212,7 +46298,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 67543,
-                  "optional": false,
                   "start": 67472,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -47264,7 +46349,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 67620,
-                  "optional": false,
                   "start": 67549,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -47309,7 +46393,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 67675,
-                  "optional": false,
                   "start": 67626,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -47361,7 +46444,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 67752,
-                  "optional": false,
                   "start": 67681,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -47406,7 +46488,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 67807,
-                  "optional": false,
                   "start": 67758,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -47451,7 +46532,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 67884,
-                  "optional": false,
                   "start": 67813,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -47510,7 +46590,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 67961,
-                  "optional": false,
                   "start": 67890,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -47562,7 +46641,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 68039,
-                  "optional": false,
                   "start": 67967,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -47621,7 +46699,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 68119,
-                  "optional": false,
                   "start": 68045,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -47680,7 +46757,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 68198,
-                  "optional": false,
                   "start": 68125,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -47732,7 +46808,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 68276,
-                  "optional": false,
                   "start": 68204,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -47791,7 +46866,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 68355,
-                  "optional": false,
                   "start": 68282,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -47843,7 +46917,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 68432,
-                  "optional": false,
                   "start": 68361,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -47895,7 +46968,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 68509,
-                  "optional": false,
                   "start": 68438,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -47947,7 +47019,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 68586,
-                  "optional": false,
                   "start": 68515,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -48006,7 +47077,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 68665,
-                  "optional": false,
                   "start": 68592,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -48051,7 +47121,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 68743,
-                  "optional": false,
                   "start": 68671,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -48096,7 +47165,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 68821,
-                  "optional": false,
                   "start": 68749,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -48148,7 +47216,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 68899,
-                  "optional": false,
                   "start": 68827,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -48207,7 +47274,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 68979,
-                  "optional": false,
                   "start": 68905,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -48259,7 +47325,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 69057,
-                  "optional": false,
                   "start": 68985,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -48311,7 +47376,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 69137,
-                  "optional": false,
                   "start": 69063,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -48363,7 +47427,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 69214,
-                  "optional": false,
                   "start": 69143,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -48415,7 +47478,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 69291,
-                  "optional": false,
                   "start": 69220,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -48460,7 +47522,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 69346,
-                  "optional": false,
                   "start": 69297,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -48512,7 +47573,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 69426,
-                  "optional": false,
                   "start": 69352,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -48571,7 +47631,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 69505,
-                  "optional": false,
                   "start": 69432,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -48630,7 +47689,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 69584,
-                  "optional": false,
                   "start": 69511,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -48675,7 +47733,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 69638,
-                  "optional": false,
                   "start": 69590,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -48727,7 +47784,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 69717,
-                  "optional": false,
                   "start": 69644,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -48772,7 +47828,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 69771,
-                  "optional": false,
                   "start": 69723,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -48824,7 +47879,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 69849,
-                  "optional": false,
                   "start": 69777,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -48869,7 +47923,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 69904,
-                  "optional": false,
                   "start": 69855,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -48914,7 +47967,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 69981,
-                  "optional": false,
                   "start": 69910,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -48973,7 +48025,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 70060,
-                  "optional": false,
                   "start": 69987,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -49032,7 +48083,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 70139,
-                  "optional": false,
                   "start": 70066,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -49077,7 +48127,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 70194,
-                  "optional": false,
                   "start": 70145,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -49136,7 +48185,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 70273,
-                  "optional": false,
                   "start": 70200,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -49188,7 +48236,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 70350,
-                  "optional": false,
                   "start": 70279,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -49240,7 +48287,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 70427,
-                  "optional": false,
                   "start": 70356,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -49292,7 +48338,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 70504,
-                  "optional": false,
                   "start": 70433,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -49344,7 +48389,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 70581,
-                  "optional": false,
                   "start": 70510,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -49389,7 +48433,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 70636,
-                  "optional": false,
                   "start": 70587,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -49448,7 +48491,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 70715,
-                  "optional": false,
                   "start": 70642,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -49507,7 +48549,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 70793,
-                  "optional": false,
                   "start": 70721,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -49566,7 +48607,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 70872,
-                  "optional": false,
                   "start": 70799,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -49618,7 +48658,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 70949,
-                  "optional": false,
                   "start": 70878,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -49670,7 +48709,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 71026,
-                  "optional": false,
                   "start": 70955,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -49729,7 +48767,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 71103,
-                  "optional": false,
                   "start": 71032,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -49774,7 +48811,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 71180,
-                  "optional": false,
                   "start": 71109,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -49826,7 +48862,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 71257,
-                  "optional": false,
                   "start": 71186,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -49878,7 +48913,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 71336,
-                  "optional": false,
                   "start": 71263,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -49923,7 +48957,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 71391,
-                  "optional": false,
                   "start": 71342,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -49968,7 +49001,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 71469,
-                  "optional": false,
                   "start": 71397,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -50013,7 +49045,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 71546,
-                  "optional": false,
                   "start": 71475,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -50065,7 +49096,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 71623,
-                  "optional": false,
                   "start": 71552,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -50110,7 +49140,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 71700,
-                  "optional": false,
                   "start": 71629,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -50162,7 +49191,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 71777,
-                  "optional": false,
                   "start": 71706,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -50214,7 +49242,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 71855,
-                  "optional": false,
                   "start": 71783,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -50266,7 +49293,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 71933,
-                  "optional": false,
                   "start": 71861,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -50325,7 +49351,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 72012,
-                  "optional": false,
                   "start": 71939,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -50384,7 +49409,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 72091,
-                  "optional": false,
                   "start": 72018,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -50443,7 +49467,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 72170,
-                  "optional": false,
                   "start": 72097,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -50488,7 +49511,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 72225,
-                  "optional": false,
                   "start": 72176,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -50540,7 +49562,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 72302,
-                  "optional": false,
                   "start": 72231,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -50592,7 +49613,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 72380,
-                  "optional": false,
                   "start": 72308,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -50644,7 +49664,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 72457,
-                  "optional": false,
                   "start": 72386,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -50689,7 +49708,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 72512,
-                  "optional": false,
                   "start": 72463,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -50741,7 +49759,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 72591,
-                  "optional": false,
                   "start": 72518,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -50793,7 +49810,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 72669,
-                  "optional": false,
                   "start": 72597,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -50852,7 +49868,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 72748,
-                  "optional": false,
                   "start": 72675,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -50911,7 +49926,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 72828,
-                  "optional": false,
                   "start": 72754,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -50963,7 +49977,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 72905,
-                  "optional": false,
                   "start": 72834,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -51015,7 +50028,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 72960,
-                  "optional": false,
                   "start": 72911,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -51067,7 +50079,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 73037,
-                  "optional": false,
                   "start": 72966,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -51126,7 +50137,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 73118,
-                  "optional": false,
                   "start": 73043,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -51178,7 +50188,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 73197,
-                  "optional": false,
                   "start": 73124,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -51223,7 +50232,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 73251,
-                  "optional": false,
                   "start": 73203,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -51275,7 +50283,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 73328,
-                  "optional": false,
                   "start": 73257,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -51327,7 +50334,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 73406,
-                  "optional": false,
                   "start": 73334,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -51386,7 +50392,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 73484,
-                  "optional": false,
                   "start": 73412,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -51431,7 +50436,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 73561,
-                  "optional": false,
                   "start": 73490,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -51490,7 +50494,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 73616,
-                  "optional": false,
                   "start": 73567,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -51549,7 +50552,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 73694,
-                  "optional": false,
                   "start": 73622,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -51601,7 +50603,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 73771,
-                  "optional": false,
                   "start": 73700,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -51646,7 +50647,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 73848,
-                  "optional": false,
                   "start": 73777,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -51698,7 +50698,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 73926,
-                  "optional": false,
                   "start": 73854,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -51750,7 +50749,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 74005,
-                  "optional": false,
                   "start": 73932,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -51802,7 +50800,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 74082,
-                  "optional": false,
                   "start": 74011,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -51823,7 +50820,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 74096,
-                  "optional": false,
                   "start": 74088,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -51852,7 +50848,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 74115,
-                  "optional": false,
                   "start": 74102,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/neg_xz_plane/ast.snap
+++ b/src/wasm-lib/kcl/tests/neg_xz_plane/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing neg_xz_plane.kcl
 snapshot_kind: text
 ---
@@ -37,7 +36,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 30,
-                  "optional": false,
                   "start": 10,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -82,7 +80,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 61,
-                  "optional": false,
                   "start": 36,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -127,7 +124,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 88,
-                  "optional": false,
                   "start": 67,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -172,7 +168,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 113,
-                  "optional": false,
                   "start": 94,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -193,7 +188,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 127,
-                  "optional": false,
                   "start": 119,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -237,7 +231,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 150,
-                  "optional": false,
                   "start": 133,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/parametric/ast.snap
+++ b/src/wasm-lib/kcl/tests/parametric/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing parametric.kcl
 snapshot_kind: text
 ---
@@ -301,7 +300,6 @@ snapshot_kind: text
                 "type": "Identifier"
               },
               "end": 207,
-              "optional": false,
               "start": 158,
               "type": "CallExpression",
               "type": "CallExpression"
@@ -346,7 +344,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 247,
-                  "optional": false,
                   "start": 228,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -391,7 +388,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 278,
-                  "optional": false,
                   "start": 253,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -435,7 +431,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 302,
-                  "optional": false,
                   "start": 284,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -479,7 +474,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 326,
-                  "optional": false,
                   "start": 308,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -530,7 +524,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 356,
-                  "optional": false,
                   "start": 332,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -595,7 +588,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 393,
-                  "optional": false,
                   "start": 362,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -660,7 +652,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 430,
-                  "optional": false,
                   "start": 399,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -681,7 +672,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 444,
-                  "optional": false,
                   "start": 436,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -709,7 +699,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 467,
-                  "optional": false,
                   "start": 450,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/parametric_with_tan_arc/ast.snap
+++ b/src/wasm-lib/kcl/tests/parametric_with_tan_arc/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing parametric_with_tan_arc.kcl
 snapshot_kind: text
 ---
@@ -245,7 +244,6 @@ snapshot_kind: text
                 "type": "Identifier"
               },
               "end": 172,
-              "optional": false,
               "start": 121,
               "type": "CallExpression",
               "type": "CallExpression"
@@ -404,7 +402,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 260,
-                  "optional": false,
                   "start": 239,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -448,7 +445,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 290,
-                  "optional": false,
                   "start": 266,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -514,7 +510,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 347,
-                  "optional": false,
                   "start": 296,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -565,7 +560,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 379,
-                  "optional": false,
                   "start": 353,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -616,7 +610,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 409,
-                  "optional": false,
                   "start": 385,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -660,7 +653,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 440,
-                  "optional": false,
                   "start": 415,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -747,7 +739,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 529,
-                  "optional": false,
                   "start": 446,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -798,7 +789,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 560,
-                  "optional": false,
                   "start": 535,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -819,7 +809,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 574,
-                  "optional": false,
                   "start": 566,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -847,7 +836,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 597,
-                  "optional": false,
                   "start": 580,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/pentagon_fillet_sugar/ast.snap
+++ b/src/wasm-lib/kcl/tests/pentagon_fillet_sugar/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Result of parsing pentagon_fillet_sugar.kcl
+snapshot_kind: text
 ---
 {
   "Ok": {
@@ -231,7 +232,6 @@ description: Result of parsing pentagon_fillet_sugar.kcl
                     "type": "Identifier"
                   },
                   "end": 159,
-                  "optional": false,
                   "start": 140,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -276,7 +276,6 @@ description: Result of parsing pentagon_fillet_sugar.kcl
                     "type": "Identifier"
                   },
                   "end": 190,
-                  "optional": false,
                   "start": 165,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -349,7 +348,6 @@ description: Result of parsing pentagon_fillet_sugar.kcl
                     "type": "Identifier"
                   },
                   "end": 251,
-                  "optional": false,
                   "start": 196,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -422,7 +420,6 @@ description: Result of parsing pentagon_fillet_sugar.kcl
                     "type": "Identifier"
                   },
                   "end": 313,
-                  "optional": false,
                   "start": 257,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -495,7 +492,6 @@ description: Result of parsing pentagon_fillet_sugar.kcl
                     "type": "Identifier"
                   },
                   "end": 375,
-                  "optional": false,
                   "start": 319,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -523,7 +519,6 @@ description: Result of parsing pentagon_fillet_sugar.kcl
                     "type": "Identifier"
                   },
                   "end": 407,
-                  "optional": false,
                   "start": 381,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -584,7 +579,6 @@ description: Result of parsing pentagon_fillet_sugar.kcl
                             "type": "Identifier"
                           },
                           "end": 460,
-                          "optional": false,
                           "start": 438,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -656,7 +650,6 @@ description: Result of parsing pentagon_fillet_sugar.kcl
                             "type": "Identifier"
                           },
                           "end": 519,
-                          "optional": false,
                           "start": 468,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -691,7 +684,6 @@ description: Result of parsing pentagon_fillet_sugar.kcl
                             "type": "Identifier"
                           },
                           "end": 549,
-                          "optional": false,
                           "start": 527,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -712,7 +704,6 @@ description: Result of parsing pentagon_fillet_sugar.kcl
                             "type": "Identifier"
                           },
                           "end": 565,
-                          "optional": false,
                           "start": 557,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -811,7 +802,6 @@ description: Result of parsing pentagon_fillet_sugar.kcl
                 "type": "Identifier"
               },
               "end": 588,
-              "optional": false,
               "start": 574,
               "type": "CallExpression",
               "type": "CallExpression"
@@ -868,7 +858,6 @@ description: Result of parsing pentagon_fillet_sugar.kcl
                     "type": "Identifier"
                   },
                   "end": 630,
-                  "optional": false,
                   "start": 608,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -989,7 +978,6 @@ description: Result of parsing pentagon_fillet_sugar.kcl
                                   "type": "Identifier"
                                 },
                                 "end": 747,
-                                "optional": false,
                                 "start": 715,
                                 "type": "CallExpression",
                                 "type": "CallExpression"
@@ -1020,7 +1008,6 @@ description: Result of parsing pentagon_fillet_sugar.kcl
                     "type": "Identifier"
                   },
                   "end": 767,
-                  "optional": false,
                   "start": 636,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1076,7 +1063,6 @@ description: Result of parsing pentagon_fillet_sugar.kcl
                 "type": "Identifier"
               },
               "end": 786,
-              "optional": false,
               "start": 773,
               "type": "CallExpression",
               "type": "CallExpression"
@@ -1133,7 +1119,6 @@ description: Result of parsing pentagon_fillet_sugar.kcl
                     "type": "Identifier"
                   },
                   "end": 828,
-                  "optional": false,
                   "start": 806,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1254,7 +1239,6 @@ description: Result of parsing pentagon_fillet_sugar.kcl
                                   "type": "Identifier"
                                 },
                                 "end": 945,
-                                "optional": false,
                                 "start": 913,
                                 "type": "CallExpression",
                                 "type": "CallExpression"
@@ -1285,7 +1269,6 @@ description: Result of parsing pentagon_fillet_sugar.kcl
                     "type": "Identifier"
                   },
                   "end": 965,
-                  "optional": false,
                   "start": 834,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/pentagon_fillet_sugar/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/pentagon_fillet_sugar/program_memory.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Program memory after executing pentagon_fillet_sugar.kcl
+snapshot_kind: text
 ---
 {
   "environments": [
@@ -1485,7 +1486,6 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
                           "type": "Identifier"
                         },
                         "end": 460,
-                        "optional": false,
                         "start": 438,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -1557,7 +1557,6 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
                           "type": "Identifier"
                         },
                         "end": 519,
-                        "optional": false,
                         "start": 468,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -1592,7 +1591,6 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
                           "type": "Identifier"
                         },
                         "end": 549,
-                        "optional": false,
                         "start": 527,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -1613,7 +1611,6 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
                           "type": "Identifier"
                         },
                         "end": 565,
-                        "optional": false,
                         "start": 557,
                         "type": "CallExpression",
                         "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/pipe_as_arg/ast.snap
+++ b/src/wasm-lib/kcl/tests/pipe_as_arg/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Result of parsing pipe_as_arg.kcl
+snapshot_kind: text
 ---
 {
   "Ok": {
@@ -472,7 +473,6 @@ description: Result of parsing pipe_as_arg.kcl
                             "type": "Identifier"
                           },
                           "end": 194,
-                          "optional": false,
                           "start": 177,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -500,7 +500,6 @@ description: Result of parsing pipe_as_arg.kcl
                             "type": "Identifier"
                           },
                           "end": 215,
-                          "optional": false,
                           "start": 202,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -528,7 +527,6 @@ description: Result of parsing pipe_as_arg.kcl
                             "type": "Identifier"
                           },
                           "end": 236,
-                          "optional": false,
                           "start": 223,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -556,7 +554,6 @@ description: Result of parsing pipe_as_arg.kcl
                             "type": "Identifier"
                           },
                           "end": 257,
-                          "optional": false,
                           "start": 244,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -584,7 +581,6 @@ description: Result of parsing pipe_as_arg.kcl
                             "type": "Identifier"
                           },
                           "end": 278,
-                          "optional": false,
                           "start": 265,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -605,7 +601,6 @@ description: Result of parsing pipe_as_arg.kcl
                             "type": "Identifier"
                           },
                           "end": 294,
-                          "optional": false,
                           "start": 286,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -633,7 +628,6 @@ description: Result of parsing pipe_as_arg.kcl
                             "type": "Identifier"
                           },
                           "end": 320,
-                          "optional": false,
                           "start": 302,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -862,7 +856,6 @@ description: Result of parsing pipe_as_arg.kcl
                         "type": "Identifier"
                       },
                       "end": 417,
-                      "optional": false,
                       "start": 408,
                       "type": "CallExpression",
                       "type": "CallExpression"
@@ -905,7 +898,6 @@ description: Result of parsing pipe_as_arg.kcl
                 "type": "Identifier"
               },
               "end": 426,
-              "optional": false,
               "start": 394,
               "type": "CallExpression",
               "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/pipe_as_arg/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/pipe_as_arg/program_memory.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Program memory after executing pipe_as_arg.kcl
+snapshot_kind: text
 ---
 {
   "environments": [
@@ -485,7 +486,6 @@ description: Program memory after executing pipe_as_arg.kcl
                           "type": "Identifier"
                         },
                         "end": 194,
-                        "optional": false,
                         "start": 177,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -513,7 +513,6 @@ description: Program memory after executing pipe_as_arg.kcl
                           "type": "Identifier"
                         },
                         "end": 215,
-                        "optional": false,
                         "start": 202,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -541,7 +540,6 @@ description: Program memory after executing pipe_as_arg.kcl
                           "type": "Identifier"
                         },
                         "end": 236,
-                        "optional": false,
                         "start": 223,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -569,7 +567,6 @@ description: Program memory after executing pipe_as_arg.kcl
                           "type": "Identifier"
                         },
                         "end": 257,
-                        "optional": false,
                         "start": 244,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -597,7 +594,6 @@ description: Program memory after executing pipe_as_arg.kcl
                           "type": "Identifier"
                         },
                         "end": 278,
-                        "optional": false,
                         "start": 265,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -618,7 +614,6 @@ description: Program memory after executing pipe_as_arg.kcl
                           "type": "Identifier"
                         },
                         "end": 294,
-                        "optional": false,
                         "start": 286,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -646,7 +641,6 @@ description: Program memory after executing pipe_as_arg.kcl
                           "type": "Identifier"
                         },
                         "end": 320,
-                        "optional": false,
                         "start": 302,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -1284,7 +1278,6 @@ description: Program memory after executing pipe_as_arg.kcl
                                     "type": "Identifier"
                                   },
                                   "end": 194,
-                                  "optional": false,
                                   "start": 177,
                                   "type": "CallExpression",
                                   "type": "CallExpression"
@@ -1312,7 +1305,6 @@ description: Program memory after executing pipe_as_arg.kcl
                                     "type": "Identifier"
                                   },
                                   "end": 215,
-                                  "optional": false,
                                   "start": 202,
                                   "type": "CallExpression",
                                   "type": "CallExpression"
@@ -1340,7 +1332,6 @@ description: Program memory after executing pipe_as_arg.kcl
                                     "type": "Identifier"
                                   },
                                   "end": 236,
-                                  "optional": false,
                                   "start": 223,
                                   "type": "CallExpression",
                                   "type": "CallExpression"
@@ -1368,7 +1359,6 @@ description: Program memory after executing pipe_as_arg.kcl
                                     "type": "Identifier"
                                   },
                                   "end": 257,
-                                  "optional": false,
                                   "start": 244,
                                   "type": "CallExpression",
                                   "type": "CallExpression"
@@ -1396,7 +1386,6 @@ description: Program memory after executing pipe_as_arg.kcl
                                     "type": "Identifier"
                                   },
                                   "end": 278,
-                                  "optional": false,
                                   "start": 265,
                                   "type": "CallExpression",
                                   "type": "CallExpression"
@@ -1417,7 +1406,6 @@ description: Program memory after executing pipe_as_arg.kcl
                                     "type": "Identifier"
                                   },
                                   "end": 294,
-                                  "optional": false,
                                   "start": 286,
                                   "type": "CallExpression",
                                   "type": "CallExpression"
@@ -1445,7 +1433,6 @@ description: Program memory after executing pipe_as_arg.kcl
                                     "type": "Identifier"
                                   },
                                   "end": 320,
-                                  "optional": false,
                                   "start": 302,
                                   "type": "CallExpression",
                                   "type": "CallExpression"
@@ -2298,7 +2285,6 @@ description: Program memory after executing pipe_as_arg.kcl
                                     "type": "Identifier"
                                   },
                                   "end": 194,
-                                  "optional": false,
                                   "start": 177,
                                   "type": "CallExpression",
                                   "type": "CallExpression"
@@ -2326,7 +2312,6 @@ description: Program memory after executing pipe_as_arg.kcl
                                     "type": "Identifier"
                                   },
                                   "end": 215,
-                                  "optional": false,
                                   "start": 202,
                                   "type": "CallExpression",
                                   "type": "CallExpression"
@@ -2354,7 +2339,6 @@ description: Program memory after executing pipe_as_arg.kcl
                                     "type": "Identifier"
                                   },
                                   "end": 236,
-                                  "optional": false,
                                   "start": 223,
                                   "type": "CallExpression",
                                   "type": "CallExpression"
@@ -2382,7 +2366,6 @@ description: Program memory after executing pipe_as_arg.kcl
                                     "type": "Identifier"
                                   },
                                   "end": 257,
-                                  "optional": false,
                                   "start": 244,
                                   "type": "CallExpression",
                                   "type": "CallExpression"
@@ -2410,7 +2393,6 @@ description: Program memory after executing pipe_as_arg.kcl
                                     "type": "Identifier"
                                   },
                                   "end": 278,
-                                  "optional": false,
                                   "start": 265,
                                   "type": "CallExpression",
                                   "type": "CallExpression"
@@ -2431,7 +2413,6 @@ description: Program memory after executing pipe_as_arg.kcl
                                     "type": "Identifier"
                                   },
                                   "end": 294,
-                                  "optional": false,
                                   "start": 286,
                                   "type": "CallExpression",
                                   "type": "CallExpression"
@@ -2459,7 +2440,6 @@ description: Program memory after executing pipe_as_arg.kcl
                                     "type": "Identifier"
                                   },
                                   "end": 320,
-                                  "optional": false,
                                   "start": 302,
                                   "type": "CallExpression",
                                   "type": "CallExpression"
@@ -3097,7 +3077,6 @@ description: Program memory after executing pipe_as_arg.kcl
                                               "type": "Identifier"
                                             },
                                             "end": 194,
-                                            "optional": false,
                                             "start": 177,
                                             "type": "CallExpression",
                                             "type": "CallExpression"
@@ -3125,7 +3104,6 @@ description: Program memory after executing pipe_as_arg.kcl
                                               "type": "Identifier"
                                             },
                                             "end": 215,
-                                            "optional": false,
                                             "start": 202,
                                             "type": "CallExpression",
                                             "type": "CallExpression"
@@ -3153,7 +3131,6 @@ description: Program memory after executing pipe_as_arg.kcl
                                               "type": "Identifier"
                                             },
                                             "end": 236,
-                                            "optional": false,
                                             "start": 223,
                                             "type": "CallExpression",
                                             "type": "CallExpression"
@@ -3181,7 +3158,6 @@ description: Program memory after executing pipe_as_arg.kcl
                                               "type": "Identifier"
                                             },
                                             "end": 257,
-                                            "optional": false,
                                             "start": 244,
                                             "type": "CallExpression",
                                             "type": "CallExpression"
@@ -3209,7 +3185,6 @@ description: Program memory after executing pipe_as_arg.kcl
                                               "type": "Identifier"
                                             },
                                             "end": 278,
-                                            "optional": false,
                                             "start": 265,
                                             "type": "CallExpression",
                                             "type": "CallExpression"
@@ -3230,7 +3205,6 @@ description: Program memory after executing pipe_as_arg.kcl
                                               "type": "Identifier"
                                             },
                                             "end": 294,
-                                            "optional": false,
                                             "start": 286,
                                             "type": "CallExpression",
                                             "type": "CallExpression"
@@ -3258,7 +3232,6 @@ description: Program memory after executing pipe_as_arg.kcl
                                               "type": "Identifier"
                                             },
                                             "end": 320,
-                                            "optional": false,
                                             "start": 302,
                                             "type": "CallExpression",
                                             "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/pipe_substitution_inside_function_called_from_pipeline/ast.snap
+++ b/src/wasm-lib/kcl/tests/pipe_substitution_inside_function_called_from_pipeline/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Result of parsing pipe_substitution_inside_function_called_from_pipeline.kcl
+snapshot_kind: text
 ---
 {
   "Ok": {
@@ -95,7 +96,6 @@ description: Result of parsing pipe_substitution_inside_function_called_from_pip
                     "type": "Identifier"
                   },
                   "end": 111,
-                  "optional": false,
                   "start": 107,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/poop_chute/ast.snap
+++ b/src/wasm-lib/kcl/tests/poop_chute/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing poop_chute.kcl
 snapshot_kind: text
 ---
@@ -317,7 +316,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 202,
-                  "optional": false,
                   "start": 182,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -376,7 +374,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 252,
-                  "optional": false,
                   "start": 208,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -419,7 +416,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 286,
-                  "optional": false,
                   "start": 258,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -492,7 +488,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 355,
-                  "optional": false,
                   "start": 292,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -520,7 +515,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 379,
-                  "optional": false,
                   "start": 361,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -555,7 +549,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 410,
-                  "optional": false,
                   "start": 385,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -579,7 +572,6 @@ snapshot_kind: text
                         "type": "Identifier"
                       },
                       "end": 438,
-                      "optional": false,
                       "start": 424,
                       "type": "CallExpression",
                       "type": "CallExpression"
@@ -598,7 +590,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 442,
-                  "optional": false,
                   "start": 416,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -708,7 +699,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 547,
-                  "optional": false,
                   "start": 448,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -743,7 +733,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 578,
-                  "optional": false,
                   "start": 553,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -824,7 +813,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 662,
-                  "optional": false,
                   "start": 584,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -852,7 +840,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 686,
-                  "optional": false,
                   "start": 668,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -881,7 +868,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 705,
-                  "optional": false,
                   "start": 692,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -905,7 +891,6 @@ snapshot_kind: text
                         "type": "Identifier"
                       },
                       "end": 733,
-                      "optional": false,
                       "start": 719,
                       "type": "CallExpression",
                       "type": "CallExpression"
@@ -924,7 +909,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 737,
-                  "optional": false,
                   "start": 711,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1006,7 +990,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 789,
-                  "optional": false,
                   "start": 743,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1027,7 +1010,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 803,
-                  "optional": false,
                   "start": 795,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1224,7 +1206,6 @@ snapshot_kind: text
                 "type": "Identifier"
               },
               "end": 952,
-              "optional": false,
               "start": 814,
               "type": "CallExpression",
               "type": "CallExpression"
@@ -1269,7 +1250,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 986,
-                  "optional": false,
                   "start": 966,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1328,7 +1308,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1036,
-                  "optional": false,
                   "start": 992,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1371,7 +1350,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1070,
-                  "optional": false,
                   "start": 1042,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1444,7 +1422,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1139,
-                  "optional": false,
                   "start": 1076,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1472,7 +1449,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1163,
-                  "optional": false,
                   "start": 1145,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1507,7 +1483,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1194,
-                  "optional": false,
                   "start": 1169,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1531,7 +1506,6 @@ snapshot_kind: text
                         "type": "Identifier"
                       },
                       "end": 1222,
-                      "optional": false,
                       "start": 1208,
                       "type": "CallExpression",
                       "type": "CallExpression"
@@ -1550,7 +1524,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1226,
-                  "optional": false,
                   "start": 1200,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1660,7 +1633,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1331,
-                  "optional": false,
                   "start": 1232,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1695,7 +1667,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1362,
-                  "optional": false,
                   "start": 1337,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1776,7 +1747,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1446,
-                  "optional": false,
                   "start": 1368,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1804,7 +1774,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1470,
-                  "optional": false,
                   "start": 1452,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1833,7 +1802,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1489,
-                  "optional": false,
                   "start": 1476,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1857,7 +1825,6 @@ snapshot_kind: text
                         "type": "Identifier"
                       },
                       "end": 1517,
-                      "optional": false,
                       "start": 1503,
                       "type": "CallExpression",
                       "type": "CallExpression"
@@ -1876,7 +1843,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1521,
-                  "optional": false,
                   "start": 1495,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1958,7 +1924,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1573,
-                  "optional": false,
                   "start": 1527,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1979,7 +1944,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1587,
-                  "optional": false,
                   "start": 1579,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -2021,7 +1985,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1625,
-                  "optional": false,
                   "start": 1593,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/property_of_object/ast.snap
+++ b/src/wasm-lib/kcl/tests/property_of_object/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing property_of_object.kcl
 snapshot_kind: text
 ---
@@ -150,7 +149,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 191,
-          "optional": false,
           "start": 136,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -194,7 +192,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 250,
-          "optional": false,
           "start": 192,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -307,7 +304,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 422,
-          "optional": false,
           "start": 366,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -351,7 +347,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 482,
-          "optional": false,
           "start": 423,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -497,7 +492,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 630,
-          "optional": false,
           "start": 575,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -541,7 +535,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 689,
-          "optional": false,
           "start": 631,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -640,7 +633,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 831,
-          "optional": false,
           "start": 775,
           "type": "CallExpression",
           "type": "CallExpression"
@@ -684,7 +676,6 @@ snapshot_kind: text
             "type": "Identifier"
           },
           "end": 891,
-          "optional": false,
           "start": 832,
           "type": "CallExpression",
           "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/riddle_small/ast.snap
+++ b/src/wasm-lib/kcl/tests/riddle_small/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Result of parsing riddle_small.kcl
+snapshot_kind: text
 ---
 {
   "Ok": {
@@ -230,7 +231,6 @@ description: Result of parsing riddle_small.kcl
                     "type": "Identifier"
                   },
                   "end": 107,
-                  "optional": false,
                   "start": 102,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -302,7 +302,6 @@ description: Result of parsing riddle_small.kcl
                     "type": "Identifier"
                   },
                   "end": 130,
-                  "optional": false,
                   "start": 125,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -364,7 +363,6 @@ description: Result of parsing riddle_small.kcl
                     "type": "Identifier"
                   },
                   "end": 160,
-                  "optional": false,
                   "start": 141,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -407,7 +405,6 @@ description: Result of parsing riddle_small.kcl
                     "type": "Identifier"
                   },
                   "end": 193,
-                  "optional": false,
                   "start": 166,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -452,7 +449,6 @@ description: Result of parsing riddle_small.kcl
                     "type": "Identifier"
                   },
                   "end": 214,
-                  "optional": false,
                   "start": 199,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -504,7 +500,6 @@ description: Result of parsing riddle_small.kcl
                     "type": "Identifier"
                   },
                   "end": 236,
-                  "optional": false,
                   "start": 220,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -556,7 +551,6 @@ description: Result of parsing riddle_small.kcl
                     "type": "Identifier"
                   },
                   "end": 258,
-                  "optional": false,
                   "start": 242,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -577,7 +571,6 @@ description: Result of parsing riddle_small.kcl
                     "type": "Identifier"
                   },
                   "end": 272,
-                  "optional": false,
                   "start": 264,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -606,7 +599,6 @@ description: Result of parsing riddle_small.kcl
                     "type": "Identifier"
                   },
                   "end": 291,
-                  "optional": false,
                   "start": 278,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/sketch-on-chamfer-two-times-different-order/ast.snap
+++ b/src/wasm-lib/kcl/tests/sketch-on-chamfer-two-times-different-order/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing sketch-on-chamfer-two-times-different-order.kcl
 snapshot_kind: text
 ---
@@ -37,7 +36,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 31,
-                  "optional": false,
                   "start": 12,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -82,7 +80,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 69,
-                  "optional": false,
                   "start": 37,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -134,7 +131,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 154,
-                  "optional": false,
                   "start": 105,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -162,7 +158,6 @@ snapshot_kind: text
                               "type": "Identifier"
                             },
                             "end": 208,
-                            "optional": false,
                             "start": 180,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -215,7 +210,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 247,
-                  "optional": false,
                   "start": 160,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -241,7 +235,6 @@ snapshot_kind: text
                             "type": "Identifier"
                           },
                           "end": 301,
-                          "optional": false,
                           "start": 273,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -264,7 +257,6 @@ snapshot_kind: text
                               "type": "Identifier"
                             },
                             "end": 339,
-                            "optional": false,
                             "start": 311,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -295,7 +287,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 350,
-                  "optional": false,
                   "start": 253,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -320,7 +311,6 @@ snapshot_kind: text
                             "type": "Identifier"
                           },
                           "end": 380,
-                          "optional": false,
                           "start": 364,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -341,7 +331,6 @@ snapshot_kind: text
                             "type": "Identifier"
                           },
                           "end": 398,
-                          "optional": false,
                           "start": 382,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -373,7 +362,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 411,
-                  "optional": false,
                   "start": 356,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -394,7 +382,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 425,
-                  "optional": false,
                   "start": 417,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -469,7 +456,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 462,
-                  "optional": false,
                   "start": 439,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -543,7 +529,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 510,
-                  "optional": false,
                   "start": 468,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -601,7 +586,6 @@ snapshot_kind: text
                                   "type": "Identifier"
                                 },
                                 "end": 583,
-                                "optional": false,
                                 "start": 561,
                                 "type": "CallExpression",
                                 "type": "CallExpression"
@@ -639,7 +623,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 603,
-                  "optional": false,
                   "start": 516,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -720,7 +703,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 660,
-                  "optional": false,
                   "start": 609,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -777,7 +759,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 706,
-                  "optional": false,
                   "start": 674,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -829,7 +810,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 746,
-                  "optional": false,
                   "start": 712,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -881,7 +861,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 800,
-                  "optional": false,
                   "start": 752,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -909,7 +888,6 @@ snapshot_kind: text
                               "type": "Identifier"
                             },
                             "end": 854,
-                            "optional": false,
                             "start": 826,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -962,7 +940,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 907,
-                  "optional": false,
                   "start": 806,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -988,7 +965,6 @@ snapshot_kind: text
                             "type": "Identifier"
                           },
                           "end": 961,
-                          "optional": false,
                           "start": 933,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -1011,7 +987,6 @@ snapshot_kind: text
                               "type": "Identifier"
                             },
                             "end": 999,
-                            "optional": false,
                             "start": 971,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -1049,7 +1024,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1033,
-                  "optional": false,
                   "start": 913,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1074,7 +1048,6 @@ snapshot_kind: text
                             "type": "Identifier"
                           },
                           "end": 1063,
-                          "optional": false,
                           "start": 1047,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -1095,7 +1068,6 @@ snapshot_kind: text
                             "type": "Identifier"
                           },
                           "end": 1081,
-                          "optional": false,
                           "start": 1065,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -1120,7 +1092,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1086,
-                  "optional": false,
                   "start": 1039,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1141,7 +1112,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1100,
-                  "optional": false,
                   "start": 1092,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1198,7 +1168,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1145,
-                  "optional": false,
                   "start": 1113,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1243,7 +1212,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1186,
-                  "optional": false,
                   "start": 1151,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1295,7 +1263,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1240,
-                  "optional": false,
                   "start": 1192,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1323,7 +1290,6 @@ snapshot_kind: text
                               "type": "Identifier"
                             },
                             "end": 1294,
-                            "optional": false,
                             "start": 1266,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -1376,7 +1342,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1348,
-                  "optional": false,
                   "start": 1246,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1402,7 +1367,6 @@ snapshot_kind: text
                             "type": "Identifier"
                           },
                           "end": 1402,
-                          "optional": false,
                           "start": 1374,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -1425,7 +1389,6 @@ snapshot_kind: text
                               "type": "Identifier"
                             },
                             "end": 1440,
-                            "optional": false,
                             "start": 1412,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -1463,7 +1426,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1474,
-                  "optional": false,
                   "start": 1354,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1488,7 +1450,6 @@ snapshot_kind: text
                             "type": "Identifier"
                           },
                           "end": 1504,
-                          "optional": false,
                           "start": 1488,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -1509,7 +1470,6 @@ snapshot_kind: text
                             "type": "Identifier"
                           },
                           "end": 1522,
-                          "optional": false,
                           "start": 1506,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -1534,7 +1494,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1527,
-                  "optional": false,
                   "start": 1480,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1555,7 +1514,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1541,
-                  "optional": false,
                   "start": 1533,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1611,7 +1569,6 @@ snapshot_kind: text
                 "type": "Identifier"
               },
               "end": 1577,
-              "optional": false,
               "start": 1555,
               "type": "CallExpression",
               "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/sketch-on-chamfer-two-times/ast.snap
+++ b/src/wasm-lib/kcl/tests/sketch-on-chamfer-two-times/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing sketch-on-chamfer-two-times.kcl
 snapshot_kind: text
 ---
@@ -37,7 +36,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 31,
-                  "optional": false,
                   "start": 12,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -82,7 +80,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 69,
-                  "optional": false,
                   "start": 37,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -134,7 +131,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 154,
-                  "optional": false,
                   "start": 105,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -162,7 +158,6 @@ snapshot_kind: text
                               "type": "Identifier"
                             },
                             "end": 208,
-                            "optional": false,
                             "start": 180,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -215,7 +210,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 247,
-                  "optional": false,
                   "start": 160,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -241,7 +235,6 @@ snapshot_kind: text
                             "type": "Identifier"
                           },
                           "end": 301,
-                          "optional": false,
                           "start": 273,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -264,7 +257,6 @@ snapshot_kind: text
                               "type": "Identifier"
                             },
                             "end": 339,
-                            "optional": false,
                             "start": 311,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -295,7 +287,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 350,
-                  "optional": false,
                   "start": 253,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -320,7 +311,6 @@ snapshot_kind: text
                             "type": "Identifier"
                           },
                           "end": 380,
-                          "optional": false,
                           "start": 364,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -341,7 +331,6 @@ snapshot_kind: text
                             "type": "Identifier"
                           },
                           "end": 398,
-                          "optional": false,
                           "start": 382,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -373,7 +362,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 411,
-                  "optional": false,
                   "start": 356,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -394,7 +382,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 425,
-                  "optional": false,
                   "start": 417,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -469,7 +456,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 462,
-                  "optional": false,
                   "start": 439,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -543,7 +529,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 510,
-                  "optional": false,
                   "start": 468,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -624,7 +609,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 567,
-                  "optional": false,
                   "start": 516,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -682,7 +666,6 @@ snapshot_kind: text
                                   "type": "Identifier"
                                 },
                                 "end": 640,
-                                "optional": false,
                                 "start": 618,
                                 "type": "CallExpression",
                                 "type": "CallExpression"
@@ -720,7 +703,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 660,
-                  "optional": false,
                   "start": 573,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -777,7 +759,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 706,
-                  "optional": false,
                   "start": 674,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -829,7 +810,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 746,
-                  "optional": false,
                   "start": 712,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -881,7 +861,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 800,
-                  "optional": false,
                   "start": 752,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -909,7 +888,6 @@ snapshot_kind: text
                               "type": "Identifier"
                             },
                             "end": 854,
-                            "optional": false,
                             "start": 826,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -962,7 +940,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 907,
-                  "optional": false,
                   "start": 806,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -988,7 +965,6 @@ snapshot_kind: text
                             "type": "Identifier"
                           },
                           "end": 961,
-                          "optional": false,
                           "start": 933,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -1011,7 +987,6 @@ snapshot_kind: text
                               "type": "Identifier"
                             },
                             "end": 999,
-                            "optional": false,
                             "start": 971,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -1049,7 +1024,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1033,
-                  "optional": false,
                   "start": 913,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1074,7 +1048,6 @@ snapshot_kind: text
                             "type": "Identifier"
                           },
                           "end": 1063,
-                          "optional": false,
                           "start": 1047,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -1095,7 +1068,6 @@ snapshot_kind: text
                             "type": "Identifier"
                           },
                           "end": 1081,
-                          "optional": false,
                           "start": 1065,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -1120,7 +1092,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1086,
-                  "optional": false,
                   "start": 1039,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1141,7 +1112,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1100,
-                  "optional": false,
                   "start": 1092,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1198,7 +1168,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1145,
-                  "optional": false,
                   "start": 1113,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1243,7 +1212,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1186,
-                  "optional": false,
                   "start": 1151,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1295,7 +1263,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1240,
-                  "optional": false,
                   "start": 1192,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1323,7 +1290,6 @@ snapshot_kind: text
                               "type": "Identifier"
                             },
                             "end": 1294,
-                            "optional": false,
                             "start": 1266,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -1376,7 +1342,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1348,
-                  "optional": false,
                   "start": 1246,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1402,7 +1367,6 @@ snapshot_kind: text
                             "type": "Identifier"
                           },
                           "end": 1402,
-                          "optional": false,
                           "start": 1374,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -1425,7 +1389,6 @@ snapshot_kind: text
                               "type": "Identifier"
                             },
                             "end": 1440,
-                            "optional": false,
                             "start": 1412,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -1463,7 +1426,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1474,
-                  "optional": false,
                   "start": 1354,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1488,7 +1450,6 @@ snapshot_kind: text
                             "type": "Identifier"
                           },
                           "end": 1504,
-                          "optional": false,
                           "start": 1488,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -1509,7 +1470,6 @@ snapshot_kind: text
                             "type": "Identifier"
                           },
                           "end": 1522,
-                          "optional": false,
                           "start": 1506,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -1534,7 +1494,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1527,
-                  "optional": false,
                   "start": 1480,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1555,7 +1514,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1541,
-                  "optional": false,
                   "start": 1533,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1611,7 +1569,6 @@ snapshot_kind: text
                 "type": "Identifier"
               },
               "end": 1577,
-              "optional": false,
               "start": 1555,
               "type": "CallExpression",
               "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/sketch_in_object/ast.snap
+++ b/src/wasm-lib/kcl/tests/sketch_in_object/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Result of parsing sketch_in_object.kcl
+snapshot_kind: text
 ---
 {
   "Ok": {
@@ -39,7 +40,6 @@ description: Result of parsing sketch_in_object.kcl
                             "type": "Identifier"
                           },
                           "end": 40,
-                          "optional": false,
                           "start": 21,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -84,7 +84,6 @@ description: Result of parsing sketch_in_object.kcl
                             "type": "Identifier"
                           },
                           "end": 73,
-                          "optional": false,
                           "start": 48,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -129,7 +128,6 @@ description: Result of parsing sketch_in_object.kcl
                             "type": "Identifier"
                           },
                           "end": 96,
-                          "optional": false,
                           "start": 81,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -174,7 +172,6 @@ description: Result of parsing sketch_in_object.kcl
                             "type": "Identifier"
                           },
                           "end": 119,
-                          "optional": false,
                           "start": 104,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -226,7 +223,6 @@ description: Result of parsing sketch_in_object.kcl
                             "type": "Identifier"
                           },
                           "end": 143,
-                          "optional": false,
                           "start": 127,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -247,7 +243,6 @@ description: Result of parsing sketch_in_object.kcl
                             "type": "Identifier"
                           },
                           "end": 159,
-                          "optional": false,
                           "start": 151,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -343,7 +338,6 @@ description: Result of parsing sketch_in_object.kcl
                                         "type": "Identifier"
                                       },
                                       "end": 236,
-                                      "optional": false,
                                       "start": 217,
                                       "type": "CallExpression",
                                       "type": "CallExpression"
@@ -388,7 +382,6 @@ description: Result of parsing sketch_in_object.kcl
                                         "type": "Identifier"
                                       },
                                       "end": 273,
-                                      "optional": false,
                                       "start": 248,
                                       "type": "CallExpression",
                                       "type": "CallExpression"
@@ -433,7 +426,6 @@ description: Result of parsing sketch_in_object.kcl
                                         "type": "Identifier"
                                       },
                                       "end": 300,
-                                      "optional": false,
                                       "start": 285,
                                       "type": "CallExpression",
                                       "type": "CallExpression"
@@ -478,7 +470,6 @@ description: Result of parsing sketch_in_object.kcl
                                         "type": "Identifier"
                                       },
                                       "end": 327,
-                                      "optional": false,
                                       "start": 312,
                                       "type": "CallExpression",
                                       "type": "CallExpression"
@@ -530,7 +521,6 @@ description: Result of parsing sketch_in_object.kcl
                                         "type": "Identifier"
                                       },
                                       "end": 355,
-                                      "optional": false,
                                       "start": 339,
                                       "type": "CallExpression",
                                       "type": "CallExpression"
@@ -551,7 +541,6 @@ description: Result of parsing sketch_in_object.kcl
                                         "type": "Identifier"
                                       },
                                       "end": 375,
-                                      "optional": false,
                                       "start": 367,
                                       "type": "CallExpression",
                                       "type": "CallExpression"
@@ -618,7 +607,6 @@ description: Result of parsing sketch_in_object.kcl
                 "type": "Identifier"
               },
               "end": 399,
-              "optional": false,
               "start": 393,
               "type": "CallExpression",
               "type": "CallExpression"
@@ -675,7 +663,6 @@ description: Result of parsing sketch_in_object.kcl
                 "type": "Identifier"
               },
               "end": 422,
-              "optional": false,
               "start": 407,
               "type": "CallExpression",
               "type": "CallExpression"
@@ -709,7 +696,6 @@ description: Result of parsing sketch_in_object.kcl
                 "type": "Identifier"
               },
               "end": 436,
-              "optional": false,
               "start": 429,
               "type": "CallExpression",
               "type": "CallExpression"
@@ -787,7 +773,6 @@ description: Result of parsing sketch_in_object.kcl
                 "type": "Identifier"
               },
               "end": 473,
-              "optional": false,
               "start": 459,
               "type": "CallExpression",
               "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/sketch_in_object/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch_in_object/program_memory.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Program memory after executing sketch_in_object.kcl
+snapshot_kind: text
 ---
 {
   "environments": [
@@ -52,7 +53,6 @@ description: Program memory after executing sketch_in_object.kcl
                           "type": "Identifier"
                         },
                         "end": 40,
-                        "optional": false,
                         "start": 21,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -97,7 +97,6 @@ description: Program memory after executing sketch_in_object.kcl
                           "type": "Identifier"
                         },
                         "end": 73,
-                        "optional": false,
                         "start": 48,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -142,7 +141,6 @@ description: Program memory after executing sketch_in_object.kcl
                           "type": "Identifier"
                         },
                         "end": 96,
-                        "optional": false,
                         "start": 81,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -187,7 +185,6 @@ description: Program memory after executing sketch_in_object.kcl
                           "type": "Identifier"
                         },
                         "end": 119,
-                        "optional": false,
                         "start": 104,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -239,7 +236,6 @@ description: Program memory after executing sketch_in_object.kcl
                           "type": "Identifier"
                         },
                         "end": 143,
-                        "optional": false,
                         "start": 127,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -260,7 +256,6 @@ description: Program memory after executing sketch_in_object.kcl
                           "type": "Identifier"
                         },
                         "end": 159,
-                        "optional": false,
                         "start": 151,
                         "type": "CallExpression",
                         "type": "CallExpression"
@@ -378,7 +373,6 @@ description: Program memory after executing sketch_in_object.kcl
                                       "type": "Identifier"
                                     },
                                     "end": 236,
-                                    "optional": false,
                                     "start": 217,
                                     "type": "CallExpression",
                                     "type": "CallExpression"
@@ -423,7 +417,6 @@ description: Program memory after executing sketch_in_object.kcl
                                       "type": "Identifier"
                                     },
                                     "end": 273,
-                                    "optional": false,
                                     "start": 248,
                                     "type": "CallExpression",
                                     "type": "CallExpression"
@@ -468,7 +461,6 @@ description: Program memory after executing sketch_in_object.kcl
                                       "type": "Identifier"
                                     },
                                     "end": 300,
-                                    "optional": false,
                                     "start": 285,
                                     "type": "CallExpression",
                                     "type": "CallExpression"
@@ -513,7 +505,6 @@ description: Program memory after executing sketch_in_object.kcl
                                       "type": "Identifier"
                                     },
                                     "end": 327,
-                                    "optional": false,
                                     "start": 312,
                                     "type": "CallExpression",
                                     "type": "CallExpression"
@@ -565,7 +556,6 @@ description: Program memory after executing sketch_in_object.kcl
                                       "type": "Identifier"
                                     },
                                     "end": 355,
-                                    "optional": false,
                                     "start": 339,
                                     "type": "CallExpression",
                                     "type": "CallExpression"
@@ -586,7 +576,6 @@ description: Program memory after executing sketch_in_object.kcl
                                       "type": "Identifier"
                                     },
                                     "end": 375,
-                                    "optional": false,
                                     "start": 367,
                                     "type": "CallExpression",
                                     "type": "CallExpression"
@@ -673,7 +662,6 @@ description: Program memory after executing sketch_in_object.kcl
                                     "type": "Identifier"
                                   },
                                   "end": 40,
-                                  "optional": false,
                                   "start": 21,
                                   "type": "CallExpression",
                                   "type": "CallExpression"
@@ -718,7 +706,6 @@ description: Program memory after executing sketch_in_object.kcl
                                     "type": "Identifier"
                                   },
                                   "end": 73,
-                                  "optional": false,
                                   "start": 48,
                                   "type": "CallExpression",
                                   "type": "CallExpression"
@@ -763,7 +750,6 @@ description: Program memory after executing sketch_in_object.kcl
                                     "type": "Identifier"
                                   },
                                   "end": 96,
-                                  "optional": false,
                                   "start": 81,
                                   "type": "CallExpression",
                                   "type": "CallExpression"
@@ -808,7 +794,6 @@ description: Program memory after executing sketch_in_object.kcl
                                     "type": "Identifier"
                                   },
                                   "end": 119,
-                                  "optional": false,
                                   "start": 104,
                                   "type": "CallExpression",
                                   "type": "CallExpression"
@@ -860,7 +845,6 @@ description: Program memory after executing sketch_in_object.kcl
                                     "type": "Identifier"
                                   },
                                   "end": 143,
-                                  "optional": false,
                                   "start": 127,
                                   "type": "CallExpression",
                                   "type": "CallExpression"
@@ -881,7 +865,6 @@ description: Program memory after executing sketch_in_object.kcl
                                     "type": "Identifier"
                                   },
                                   "end": 159,
-                                  "optional": false,
                                   "start": 151,
                                   "type": "CallExpression",
                                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/sketch_on_face/ast.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing sketch_on_face.kcl
 snapshot_kind: text
 ---
@@ -37,7 +36,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29,
-                  "optional": false,
                   "start": 10,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -82,7 +80,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 68,
-                  "optional": false,
                   "start": 35,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -141,7 +138,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 105,
-                  "optional": false,
                   "start": 74,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -200,7 +196,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 135,
-                  "optional": false,
                   "start": 111,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -252,7 +247,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 165,
-                  "optional": false,
                   "start": 141,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -273,7 +267,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 179,
-                  "optional": false,
                   "start": 171,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -302,7 +295,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 198,
-                  "optional": false,
                   "start": 185,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -359,7 +351,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 238,
-                  "optional": false,
                   "start": 210,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -404,7 +395,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 269,
-                  "optional": false,
                   "start": 244,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -449,7 +439,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 291,
-                  "optional": false,
                   "start": 275,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -494,7 +483,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 313,
-                  "optional": false,
                   "start": 297,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -546,7 +534,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 336,
-                  "optional": false,
                   "start": 319,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -567,7 +554,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 350,
-                  "optional": false,
                   "start": 342,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -596,7 +582,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 369,
-                  "optional": false,
                   "start": 356,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/sketch_on_face_after_fillets_referencing_face/ast.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face_after_fillets_referencing_face/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing sketch_on_face_after_fillets_referencing_face.kcl
 snapshot_kind: text
 ---
@@ -343,7 +342,6 @@ snapshot_kind: text
                 "type": "Identifier"
               },
               "end": 890,
-              "optional": false,
               "start": 850,
               "type": "CallExpression",
               "type": "CallExpression"
@@ -416,7 +414,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1011,
-                  "optional": false,
                   "start": 992,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -461,7 +458,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1042,
-                  "optional": false,
                   "start": 1017,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -512,7 +508,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1084,
-                  "optional": false,
                   "start": 1048,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -570,7 +565,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1124,
-                  "optional": false,
                   "start": 1090,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -621,7 +615,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1154,
-                  "optional": false,
                   "start": 1130,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -686,7 +679,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1209,
-                  "optional": false,
                   "start": 1160,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -751,7 +743,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1252,
-                  "optional": false,
                   "start": 1215,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -772,7 +763,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1266,
-                  "optional": false,
                   "start": 1258,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -800,7 +790,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1289,
-                  "optional": false,
                   "start": 1272,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -857,7 +846,6 @@ snapshot_kind: text
                                   "type": "Identifier"
                                 },
                                 "end": 1374,
-                                "optional": false,
                                 "start": 1344,
                                 "type": "CallExpression",
                                 "type": "CallExpression"
@@ -888,7 +876,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1386,
-                  "optional": false,
                   "start": 1295,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -959,7 +946,6 @@ snapshot_kind: text
                                   "type": "Identifier"
                                 },
                                 "end": 1483,
-                                "optional": false,
                                 "start": 1453,
                                 "type": "CallExpression",
                                 "type": "CallExpression"
@@ -990,7 +976,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1495,
-                  "optional": false,
                   "start": 1392,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1047,7 +1032,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1538,
-                  "optional": false,
                   "start": 1509,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1092,7 +1076,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1575,
-                  "optional": false,
                   "start": 1544,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1144,7 +1127,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1603,
-                  "optional": false,
                   "start": 1581,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1203,7 +1185,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1631,
-                  "optional": false,
                   "start": 1609,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1255,7 +1236,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1659,
-                  "optional": false,
                   "start": 1637,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1280,7 +1260,6 @@ snapshot_kind: text
                             "type": "Identifier"
                           },
                           "end": 1689,
-                          "optional": false,
                           "start": 1673,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -1301,7 +1280,6 @@ snapshot_kind: text
                             "type": "Identifier"
                           },
                           "end": 1707,
-                          "optional": false,
                           "start": 1691,
                           "type": "CallExpression",
                           "type": "CallExpression"
@@ -1326,7 +1304,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1712,
-                  "optional": false,
                   "start": 1665,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1347,7 +1324,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1726,
-                  "optional": false,
                   "start": 1718,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -1376,7 +1352,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 1746,
-                  "optional": false,
                   "start": 1732,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/sketch_on_face_circle_tagged/ast.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face_circle_tagged/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Result of parsing sketch_on_face_circle_tagged.kcl
+snapshot_kind: text
 ---
 {
   "Ok": {
@@ -48,7 +49,6 @@ description: Result of parsing sketch_on_face_circle_tagged.kcl
                                 "type": "Identifier"
                               },
                               "end": 48,
-                              "optional": false,
                               "start": 29,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -76,7 +76,6 @@ description: Result of parsing sketch_on_face_circle_tagged.kcl
                                 "type": "Identifier"
                               },
                               "end": 78,
-                              "optional": false,
                               "start": 56,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -120,7 +119,6 @@ description: Result of parsing sketch_on_face_circle_tagged.kcl
                                 "type": "Identifier"
                               },
                               "end": 105,
-                              "optional": false,
                               "start": 86,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -164,7 +162,6 @@ description: Result of parsing sketch_on_face_circle_tagged.kcl
                                 "type": "Identifier"
                               },
                               "end": 132,
-                              "optional": false,
                               "start": 113,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -215,7 +212,6 @@ description: Result of parsing sketch_on_face_circle_tagged.kcl
                                 "type": "Identifier"
                               },
                               "end": 160,
-                              "optional": false,
                               "start": 140,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -359,7 +355,6 @@ description: Result of parsing sketch_on_face_circle_tagged.kcl
                     "type": "Identifier"
                   },
                   "end": 202,
-                  "optional": false,
                   "start": 186,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -380,7 +375,6 @@ description: Result of parsing sketch_on_face_circle_tagged.kcl
                     "type": "Identifier"
                   },
                   "end": 216,
-                  "optional": false,
                   "start": 208,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -409,7 +403,6 @@ description: Result of parsing sketch_on_face_circle_tagged.kcl
                     "type": "Identifier"
                   },
                   "end": 236,
-                  "optional": false,
                   "start": 222,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -467,7 +460,6 @@ description: Result of parsing sketch_on_face_circle_tagged.kcl
                     "type": "Identifier"
                   },
                   "end": 277,
-                  "optional": false,
                   "start": 248,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -557,7 +549,6 @@ description: Result of parsing sketch_on_face_circle_tagged.kcl
                     "type": "Identifier"
                   },
                   "end": 336,
-                  "optional": false,
                   "start": 283,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -586,7 +577,6 @@ description: Result of parsing sketch_on_face_circle_tagged.kcl
                     "type": "Identifier"
                   },
                   "end": 355,
-                  "optional": false,
                   "start": 342,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/sketch_on_face_circle_tagged/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face_circle_tagged/program_memory.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Program memory after executing sketch_on_face_circle_tagged.kcl
+snapshot_kind: text
 ---
 {
   "environments": [
@@ -61,7 +62,6 @@ description: Program memory after executing sketch_on_face_circle_tagged.kcl
                               "type": "Identifier"
                             },
                             "end": 48,
-                            "optional": false,
                             "start": 29,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -89,7 +89,6 @@ description: Program memory after executing sketch_on_face_circle_tagged.kcl
                               "type": "Identifier"
                             },
                             "end": 78,
-                            "optional": false,
                             "start": 56,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -133,7 +132,6 @@ description: Program memory after executing sketch_on_face_circle_tagged.kcl
                               "type": "Identifier"
                             },
                             "end": 105,
-                            "optional": false,
                             "start": 86,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -177,7 +175,6 @@ description: Program memory after executing sketch_on_face_circle_tagged.kcl
                               "type": "Identifier"
                             },
                             "end": 132,
-                            "optional": false,
                             "start": 113,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -228,7 +225,6 @@ description: Program memory after executing sketch_on_face_circle_tagged.kcl
                               "type": "Identifier"
                             },
                             "end": 160,
-                            "optional": false,
                             "start": 140,
                             "type": "CallExpression",
                             "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/sketch_on_face_end/ast.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face_end/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Result of parsing sketch_on_face_end.kcl
+snapshot_kind: text
 ---
 {
   "Ok": {
@@ -48,7 +49,6 @@ description: Result of parsing sketch_on_face_end.kcl
                                 "type": "Identifier"
                               },
                               "end": 48,
-                              "optional": false,
                               "start": 29,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -76,7 +76,6 @@ description: Result of parsing sketch_on_face_end.kcl
                                 "type": "Identifier"
                               },
                               "end": 78,
-                              "optional": false,
                               "start": 56,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -120,7 +119,6 @@ description: Result of parsing sketch_on_face_end.kcl
                                 "type": "Identifier"
                               },
                               "end": 105,
-                              "optional": false,
                               "start": 86,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -164,7 +162,6 @@ description: Result of parsing sketch_on_face_end.kcl
                                 "type": "Identifier"
                               },
                               "end": 132,
-                              "optional": false,
                               "start": 113,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -215,7 +212,6 @@ description: Result of parsing sketch_on_face_end.kcl
                                 "type": "Identifier"
                               },
                               "end": 160,
-                              "optional": false,
                               "start": 140,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -359,7 +355,6 @@ description: Result of parsing sketch_on_face_end.kcl
                     "type": "Identifier"
                   },
                   "end": 202,
-                  "optional": false,
                   "start": 186,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -380,7 +375,6 @@ description: Result of parsing sketch_on_face_end.kcl
                     "type": "Identifier"
                   },
                   "end": 216,
-                  "optional": false,
                   "start": 208,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -409,7 +403,6 @@ description: Result of parsing sketch_on_face_end.kcl
                     "type": "Identifier"
                   },
                   "end": 236,
-                  "optional": false,
                   "start": 222,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -467,7 +460,6 @@ description: Result of parsing sketch_on_face_end.kcl
                     "type": "Identifier"
                   },
                   "end": 277,
-                  "optional": false,
                   "start": 248,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -512,7 +504,6 @@ description: Result of parsing sketch_on_face_end.kcl
                     "type": "Identifier"
                   },
                   "end": 308,
-                  "optional": false,
                   "start": 283,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -557,7 +548,6 @@ description: Result of parsing sketch_on_face_end.kcl
                     "type": "Identifier"
                   },
                   "end": 330,
-                  "optional": false,
                   "start": 314,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -602,7 +592,6 @@ description: Result of parsing sketch_on_face_end.kcl
                     "type": "Identifier"
                   },
                   "end": 352,
-                  "optional": false,
                   "start": 336,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -654,7 +643,6 @@ description: Result of parsing sketch_on_face_end.kcl
                     "type": "Identifier"
                   },
                   "end": 375,
-                  "optional": false,
                   "start": 358,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -675,7 +663,6 @@ description: Result of parsing sketch_on_face_end.kcl
                     "type": "Identifier"
                   },
                   "end": 389,
-                  "optional": false,
                   "start": 381,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -704,7 +691,6 @@ description: Result of parsing sketch_on_face_end.kcl
                     "type": "Identifier"
                   },
                   "end": 408,
-                  "optional": false,
                   "start": 395,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/sketch_on_face_end/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face_end/program_memory.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Program memory after executing sketch_on_face_end.kcl
+snapshot_kind: text
 ---
 {
   "environments": [
@@ -61,7 +62,6 @@ description: Program memory after executing sketch_on_face_end.kcl
                               "type": "Identifier"
                             },
                             "end": 48,
-                            "optional": false,
                             "start": 29,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -89,7 +89,6 @@ description: Program memory after executing sketch_on_face_end.kcl
                               "type": "Identifier"
                             },
                             "end": 78,
-                            "optional": false,
                             "start": 56,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -133,7 +132,6 @@ description: Program memory after executing sketch_on_face_end.kcl
                               "type": "Identifier"
                             },
                             "end": 105,
-                            "optional": false,
                             "start": 86,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -177,7 +175,6 @@ description: Program memory after executing sketch_on_face_end.kcl
                               "type": "Identifier"
                             },
                             "end": 132,
-                            "optional": false,
                             "start": 113,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -228,7 +225,6 @@ description: Program memory after executing sketch_on_face_end.kcl
                               "type": "Identifier"
                             },
                             "end": 160,
-                            "optional": false,
                             "start": 140,
                             "type": "CallExpression",
                             "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/sketch_on_face_end_negative_extrude/ast.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face_end_negative_extrude/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Result of parsing sketch_on_face_end_negative_extrude.kcl
+snapshot_kind: text
 ---
 {
   "Ok": {
@@ -48,7 +49,6 @@ description: Result of parsing sketch_on_face_end_negative_extrude.kcl
                                 "type": "Identifier"
                               },
                               "end": 48,
-                              "optional": false,
                               "start": 29,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -76,7 +76,6 @@ description: Result of parsing sketch_on_face_end_negative_extrude.kcl
                                 "type": "Identifier"
                               },
                               "end": 78,
-                              "optional": false,
                               "start": 56,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -120,7 +119,6 @@ description: Result of parsing sketch_on_face_end_negative_extrude.kcl
                                 "type": "Identifier"
                               },
                               "end": 105,
-                              "optional": false,
                               "start": 86,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -164,7 +162,6 @@ description: Result of parsing sketch_on_face_end_negative_extrude.kcl
                                 "type": "Identifier"
                               },
                               "end": 132,
-                              "optional": false,
                               "start": 113,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -215,7 +212,6 @@ description: Result of parsing sketch_on_face_end_negative_extrude.kcl
                                 "type": "Identifier"
                               },
                               "end": 160,
-                              "optional": false,
                               "start": 140,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -359,7 +355,6 @@ description: Result of parsing sketch_on_face_end_negative_extrude.kcl
                     "type": "Identifier"
                   },
                   "end": 202,
-                  "optional": false,
                   "start": 186,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -380,7 +375,6 @@ description: Result of parsing sketch_on_face_end_negative_extrude.kcl
                     "type": "Identifier"
                   },
                   "end": 216,
-                  "optional": false,
                   "start": 208,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -409,7 +403,6 @@ description: Result of parsing sketch_on_face_end_negative_extrude.kcl
                     "type": "Identifier"
                   },
                   "end": 236,
-                  "optional": false,
                   "start": 222,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -467,7 +460,6 @@ description: Result of parsing sketch_on_face_end_negative_extrude.kcl
                     "type": "Identifier"
                   },
                   "end": 277,
-                  "optional": false,
                   "start": 248,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -512,7 +504,6 @@ description: Result of parsing sketch_on_face_end_negative_extrude.kcl
                     "type": "Identifier"
                   },
                   "end": 308,
-                  "optional": false,
                   "start": 283,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -557,7 +548,6 @@ description: Result of parsing sketch_on_face_end_negative_extrude.kcl
                     "type": "Identifier"
                   },
                   "end": 330,
-                  "optional": false,
                   "start": 314,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -602,7 +592,6 @@ description: Result of parsing sketch_on_face_end_negative_extrude.kcl
                     "type": "Identifier"
                   },
                   "end": 352,
-                  "optional": false,
                   "start": 336,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -654,7 +643,6 @@ description: Result of parsing sketch_on_face_end_negative_extrude.kcl
                     "type": "Identifier"
                   },
                   "end": 375,
-                  "optional": false,
                   "start": 358,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -675,7 +663,6 @@ description: Result of parsing sketch_on_face_end_negative_extrude.kcl
                     "type": "Identifier"
                   },
                   "end": 389,
-                  "optional": false,
                   "start": 381,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -711,7 +698,6 @@ description: Result of parsing sketch_on_face_end_negative_extrude.kcl
                     "type": "Identifier"
                   },
                   "end": 409,
-                  "optional": false,
                   "start": 395,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/sketch_on_face_end_negative_extrude/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face_end_negative_extrude/program_memory.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Program memory after executing sketch_on_face_end_negative_extrude.kcl
+snapshot_kind: text
 ---
 {
   "environments": [
@@ -61,7 +62,6 @@ description: Program memory after executing sketch_on_face_end_negative_extrude.
                               "type": "Identifier"
                             },
                             "end": 48,
-                            "optional": false,
                             "start": 29,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -89,7 +89,6 @@ description: Program memory after executing sketch_on_face_end_negative_extrude.
                               "type": "Identifier"
                             },
                             "end": 78,
-                            "optional": false,
                             "start": 56,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -133,7 +132,6 @@ description: Program memory after executing sketch_on_face_end_negative_extrude.
                               "type": "Identifier"
                             },
                             "end": 105,
-                            "optional": false,
                             "start": 86,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -177,7 +175,6 @@ description: Program memory after executing sketch_on_face_end_negative_extrude.
                               "type": "Identifier"
                             },
                             "end": 132,
-                            "optional": false,
                             "start": 113,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -228,7 +225,6 @@ description: Program memory after executing sketch_on_face_end_negative_extrude.
                               "type": "Identifier"
                             },
                             "end": 160,
-                            "optional": false,
                             "start": 140,
                             "type": "CallExpression",
                             "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/sketch_on_face_start/ast.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face_start/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Result of parsing sketch_on_face_start.kcl
+snapshot_kind: text
 ---
 {
   "Ok": {
@@ -48,7 +49,6 @@ description: Result of parsing sketch_on_face_start.kcl
                                 "type": "Identifier"
                               },
                               "end": 48,
-                              "optional": false,
                               "start": 29,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -76,7 +76,6 @@ description: Result of parsing sketch_on_face_start.kcl
                                 "type": "Identifier"
                               },
                               "end": 78,
-                              "optional": false,
                               "start": 56,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -120,7 +119,6 @@ description: Result of parsing sketch_on_face_start.kcl
                                 "type": "Identifier"
                               },
                               "end": 105,
-                              "optional": false,
                               "start": 86,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -164,7 +162,6 @@ description: Result of parsing sketch_on_face_start.kcl
                                 "type": "Identifier"
                               },
                               "end": 132,
-                              "optional": false,
                               "start": 113,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -215,7 +212,6 @@ description: Result of parsing sketch_on_face_start.kcl
                                 "type": "Identifier"
                               },
                               "end": 160,
-                              "optional": false,
                               "start": 140,
                               "type": "CallExpression",
                               "type": "CallExpression"
@@ -359,7 +355,6 @@ description: Result of parsing sketch_on_face_start.kcl
                     "type": "Identifier"
                   },
                   "end": 202,
-                  "optional": false,
                   "start": 186,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -380,7 +375,6 @@ description: Result of parsing sketch_on_face_start.kcl
                     "type": "Identifier"
                   },
                   "end": 216,
-                  "optional": false,
                   "start": 208,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -409,7 +403,6 @@ description: Result of parsing sketch_on_face_start.kcl
                     "type": "Identifier"
                   },
                   "end": 236,
-                  "optional": false,
                   "start": 222,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -467,7 +460,6 @@ description: Result of parsing sketch_on_face_start.kcl
                     "type": "Identifier"
                   },
                   "end": 279,
-                  "optional": false,
                   "start": 248,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -512,7 +504,6 @@ description: Result of parsing sketch_on_face_start.kcl
                     "type": "Identifier"
                   },
                   "end": 310,
-                  "optional": false,
                   "start": 285,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -557,7 +548,6 @@ description: Result of parsing sketch_on_face_start.kcl
                     "type": "Identifier"
                   },
                   "end": 332,
-                  "optional": false,
                   "start": 316,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -602,7 +592,6 @@ description: Result of parsing sketch_on_face_start.kcl
                     "type": "Identifier"
                   },
                   "end": 354,
-                  "optional": false,
                   "start": 338,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -654,7 +643,6 @@ description: Result of parsing sketch_on_face_start.kcl
                     "type": "Identifier"
                   },
                   "end": 377,
-                  "optional": false,
                   "start": 360,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -675,7 +663,6 @@ description: Result of parsing sketch_on_face_start.kcl
                     "type": "Identifier"
                   },
                   "end": 391,
-                  "optional": false,
                   "start": 383,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -704,7 +691,6 @@ description: Result of parsing sketch_on_face_start.kcl
                     "type": "Identifier"
                   },
                   "end": 410,
-                  "optional": false,
                   "start": 397,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/sketch_on_face_start/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face_start/program_memory.snap
@@ -1,6 +1,7 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Program memory after executing sketch_on_face_start.kcl
+snapshot_kind: text
 ---
 {
   "environments": [
@@ -61,7 +62,6 @@ description: Program memory after executing sketch_on_face_start.kcl
                               "type": "Identifier"
                             },
                             "end": 48,
-                            "optional": false,
                             "start": 29,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -89,7 +89,6 @@ description: Program memory after executing sketch_on_face_start.kcl
                               "type": "Identifier"
                             },
                             "end": 78,
-                            "optional": false,
                             "start": 56,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -133,7 +132,6 @@ description: Program memory after executing sketch_on_face_start.kcl
                               "type": "Identifier"
                             },
                             "end": 105,
-                            "optional": false,
                             "start": 86,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -177,7 +175,6 @@ description: Program memory after executing sketch_on_face_start.kcl
                               "type": "Identifier"
                             },
                             "end": 132,
-                            "optional": false,
                             "start": 113,
                             "type": "CallExpression",
                             "type": "CallExpression"
@@ -228,7 +225,6 @@ description: Program memory after executing sketch_on_face_start.kcl
                               "type": "Identifier"
                             },
                             "end": 160,
-                            "optional": false,
                             "start": 140,
                             "type": "CallExpression",
                             "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/tan_arc_x_line/ast.snap
+++ b/src/wasm-lib/kcl/tests/tan_arc_x_line/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing tan_arc_x_line.kcl
 snapshot_kind: text
 ---
@@ -169,7 +168,6 @@ snapshot_kind: text
                 "type": "Identifier"
               },
               "end": 83,
-              "optional": false,
               "start": 64,
               "type": "CallExpression",
               "type": "CallExpression"
@@ -212,7 +210,6 @@ snapshot_kind: text
                 "type": "Identifier"
               },
               "end": 124,
-              "optional": false,
               "start": 89,
               "type": "CallExpression",
               "type": "CallExpression"
@@ -278,7 +275,6 @@ snapshot_kind: text
                 "type": "Identifier"
               },
               "end": 185,
-              "optional": false,
               "start": 130,
               "type": "CallExpression",
               "type": "CallExpression"
@@ -350,7 +346,6 @@ snapshot_kind: text
                 "type": "Identifier"
               },
               "end": 252,
-              "optional": false,
               "start": 191,
               "type": "CallExpression",
               "type": "CallExpression"
@@ -437,7 +432,6 @@ snapshot_kind: text
                 "type": "Identifier"
               },
               "end": 344,
-              "optional": false,
               "start": 258,
               "type": "CallExpression",
               "type": "CallExpression"
@@ -531,7 +525,6 @@ snapshot_kind: text
                 "type": "Identifier"
               },
               "end": 437,
-              "optional": false,
               "start": 350,
               "type": "CallExpression",
               "type": "CallExpression"
@@ -560,7 +553,6 @@ snapshot_kind: text
                 "type": "Identifier"
               },
               "end": 456,
-              "optional": false,
               "start": 443,
               "type": "CallExpression",
               "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/tangential_arc/ast.snap
+++ b/src/wasm-lib/kcl/tests/tangential_arc/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing tangential_arc.kcl
 snapshot_kind: text
 ---
@@ -53,7 +52,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 33,
-                  "optional": false,
                   "start": 12,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -98,7 +96,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 55,
-                  "optional": false,
                   "start": 39,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -165,7 +162,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 106,
-                  "optional": false,
                   "start": 61,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -217,7 +213,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 129,
-                  "optional": false,
                   "start": 112,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -246,7 +241,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 149,
-                  "optional": false,
                   "start": 135,
                   "type": "CallExpression",
                   "type": "CallExpression"

--- a/src/wasm-lib/kcl/tests/xz_plane/ast.snap
+++ b/src/wasm-lib/kcl/tests/xz_plane/ast.snap
@@ -1,6 +1,5 @@
 ---
 source: kcl/src/simulation_tests.rs
-assertion_line: 52
 description: Result of parsing xz_plane.kcl
 snapshot_kind: text
 ---
@@ -37,7 +36,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 29,
-                  "optional": false,
                   "start": 10,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -82,7 +80,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 60,
-                  "optional": false,
                   "start": 35,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -127,7 +124,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 87,
-                  "optional": false,
                   "start": 66,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -172,7 +168,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 112,
-                  "optional": false,
                   "start": 93,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -193,7 +188,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 126,
-                  "optional": false,
                   "start": 118,
                   "type": "CallExpression",
                   "type": "CallExpression"
@@ -237,7 +231,6 @@ snapshot_kind: text
                     "type": "Identifier"
                   },
                   "end": 149,
-                  "optional": false,
                   "start": 132,
                   "type": "CallExpression",
                   "type": "CallExpression"


### PR DESCRIPTION
It was put there in the original KCL JS-to-Rust rewrite, and I don't think it's used at all.