### PR TITLE
Remove auto creation of the draft release

### DIFF
--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -382,13 +382,3 @@ jobs:
           glob: '*'
           parent: false
           destination: 'dl.kittycad.io/releases/modeling-app/nightly'
-
-      - name: Create draft release
-        uses: softprops/action-gh-release@v2
-        if: ${{ env.IS_RELEASE == 'true' }}
-        with:
-          name: ${{ env.VERSION }}
-          tag_name: ${{ env.VERSION }}
-          draft: true
-          generate_release_notes: true
-          files: 'out/Zoo*'

--- a/.github/workflows/publish-apps-release.yml
+++ b/.github/workflows/publish-apps-release.yml
@@ -132,6 +132,12 @@ jobs:
           gcloud compute url-maps invalidate-cdn-cache dl-url-map --path="/releases/modeling-app/latest-mac.yml" --async
           gcloud compute url-maps invalidate-cdn-cache dl-url-map --path="/releases/modeling-app/latest.yml" --async
 
+      - name: Upload release files to Github
+        if: ${{ github.event_name == 'release' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          files: 'out/Zoo*'
+
 
   announce_release:
     needs: [publish-apps-release]

--- a/README.md
+++ b/README.md
@@ -148,13 +148,11 @@ This will trigger the `build-apps` workflow, set the version, build & sign the a
 
 Once the workflow succeeds, a draft release will be created at https://github.com/KittyCAD/modeling-app/releases.
 
-#### 3. Manually test artifacts from the Cut Release PR
+#### 3. Manually test artifacts
 
 ##### Release builds
 
 The release builds can be found under the `out-{arch}-{platform}` zip files, at the very bottom of the `build-apps` summary page for the workflow (triggered by the tag in 2.).
-
-Alternatively, the draft release will also include these builds.
 
 Manually test against this [list](https://github.com/KittyCAD/modeling-app/issues/3588) across Windows, MacOS, Linux and posting results as comments in the issue.
 
@@ -178,7 +176,9 @@ If the prompt doesn't show up, start the app in command line to grab the electro
 
 #### 4. Publish the release
 
-Head over to https://github.com/KittyCAD/modeling-app/releases, paste in the changelog discussed in the issue, and publish the draft release created by the `build-apps` workflow from step 2.
+Head over to https://github.com/KittyCAD/modeling-app/releases/new, pick the newly created tag and type it in the _Release title_ field as well.
+
+Hit _Generate release notes_ as a starting point to discuss the changelog in the issue. Once done, make sure _Set as the latest release_ is checked, and hit _Publish release_. 
 
 A new Action kicks in at https://github.com/KittyCAD/modeling-app/actions, which can be found under `release` event filter. On success, the files will be uploaded to the public bucket and the announcement on Discord will be sent. 
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ https://github.com/KittyCAD/modeling-app/issues/new
 
 #### 2. Push a new tag
 
-Create a new tag and push it to the repo (eg. `v0.28.0` for `$VERSION`)
+Create a new tag and push it to the repo. The `semantic-release.sh` script will automatically bump the minor part, which we use the most. For instance going from `v0.27.0` to `v0.28.0`.
 
 ```
 VERSION=$(./scripts/semantic-release.sh)
@@ -146,7 +146,7 @@ git push origin --tags
 
 This will trigger the `build-apps` workflow, set the version, build & sign the apps, and generate release files as well as updater-test artifacts.
 
-Once the workflow succeeds, a draft release will be created at https://github.com/KittyCAD/modeling-app/releases.
+The workflow should be listed right away [in this list](https://github.com/KittyCAD/modeling-app/actions/workflows/build-apps.yml?query=event%3Apush)).
 
 #### 3. Manually test artifacts
 
@@ -180,7 +180,7 @@ Head over to https://github.com/KittyCAD/modeling-app/releases/new, pick the new
 
 Hit _Generate release notes_ as a starting point to discuss the changelog in the issue. Once done, make sure _Set as the latest release_ is checked, and hit _Publish release_. 
 
-A new Action kicks in at https://github.com/KittyCAD/modeling-app/actions, which can be found under `release` event filter. On success, the files will be uploaded to the public bucket and the announcement on Discord will be sent. 
+A new `publish-apps-release` will kick in and you should be able to find it [here](https://github.com/KittyCAD/modeling-app/actions?query=event%3Arelease). On success, the files will be uploaded to the public bucket as well as to the GitHub release, and the announcement on Discord will be sent. 
 
 #### 5. Close the issue
 


### PR DESCRIPTION
Fixes #4586

Not sure how else to work around the limit we hit during #4581 with the publish-apps-release workflow not triggered as the draft release had originally been created by github-actions and not a user. This should get us going for now with minimal user input still. README process updated too.