### PR TITLE
fix: make variable declaration errors Cut instead of Backtrack

### DIFF
--- a/e2e/playwright/editor-tests.spec.ts
+++ b/e2e/playwright/editor-tests.spec.ts
@@ -458,8 +458,8 @@ test.describe('Editor tests', () => {
 
     /* add the following code to the editor ($ error is not a valid line)
       $ error
-      const topAng = 30
-      const bottomAng = 25
+      topAng = 30
+      bottomAng = 25
      */
     await u.codeLocator.click()
     await page.keyboard.type('$ error')
@@ -474,12 +474,14 @@ test.describe('Editor tests', () => {
     await page.keyboard.type('bottomAng = 25')
     await page.keyboard.press('Enter')
 
-    // error in guter
+    // error in gutter
     await expect(page.locator('.cm-lint-marker-error')).toBeVisible()
 
     // error text on hover
     await page.hover('.cm-lint-marker-error')
-    await expect(page.getByText('Unexpected token: $').first()).toBeVisible()
+    await expect(
+      page.getByText('Tag names must not be empty').first()
+    ).toBeVisible()
 
     // select the line that's causing the error and delete it
     await page.getByText('$ error').click()

--- a/src/wasm-lib/kcl/src/parsing/parser.rs
+++ b/src/wasm-lib/kcl/src/parsing/parser.rs
@@ -12,7 +12,6 @@ use winnow::{
     token::{any, one_of, take_till},
 };
 
-use super::ast::types::LabeledArg;
 use crate::{
     docs::StdLibFn,
     errors::{CompilationError, Severity, Tag},
@@ -1802,7 +1801,7 @@ impl TryFrom<Token> for Node<TagDeclarator> {
                 ))
             }
             TokenType::Number => Err(CompilationError::fatal(
-                token.as_source_ranges(),
+                token.as_source_range(),
                 format!(
                     "Tag names must not start with a number. Tag starts with `{}`",
                     token.value.as_str()
@@ -1811,7 +1810,7 @@ impl TryFrom<Token> for Node<TagDeclarator> {
 
             // e.g. `line(%, $)` or `line(%, $ , 5)`
             TokenType::Brace | TokenType::Whitespace | TokenType::Comma => Err(CompilationError::fatal(
-                token.as_source_ranges(),
+                token.as_source_range(),
                 format!("Tag names must not be empty",),
             )),
 
@@ -1835,7 +1834,7 @@ impl TryFrom<Token> for Node<TagDeclarator> {
             | TokenType::Keyword
             | TokenType::Unknown
             | TokenType::LineComment => Err(CompilationError::fatal(
-                token.as_source_ranges(),
+                token.as_source_range(),
                 // this is `start with` because if most of these cases are in the middle, it ends
                 // up hitting a different error path(e.g. including a bang) or being valid(e.g. including a comment) since it will get broken up into
                 // multiple tokens
@@ -4057,7 +4056,7 @@ let myBox = box([0,0], -3, -16, -10)
     "#;
         assert_err(
             some_program_string,
-            "Tag names must not be a reserved keyword. Invalid tag name is `sketch`",
+            "Cannot assign a tag to a reserved keyword: sketch",
             [41, 47],
         );
     }

--- a/src/wasm-lib/kcl/src/parsing/parser.rs
+++ b/src/wasm-lib/kcl/src/parsing/parser.rs
@@ -12,6 +12,7 @@ use winnow::{
     token::{any, one_of, take_till},
 };
 
+use super::ast::types::LabeledArg;
 use crate::{
     docs::StdLibFn,
     errors::{CompilationError, Severity, Tag},
@@ -1820,6 +1821,7 @@ impl TryFrom<Token> for Node<TagDeclarator> {
             )),
 
             TokenType::Bang
+            | TokenType::At
             | TokenType::Hash
             | TokenType::Colon
             | TokenType::Period

--- a/src/wasm-lib/kcl/src/parsing/parser.rs
+++ b/src/wasm-lib/kcl/src/parsing/parser.rs
@@ -1808,7 +1808,8 @@ impl TryFrom<Token> for Node<TagDeclarator> {
                 ),
             )),
 
-            TokenType::Brace | TokenType::Whitespace => Err(CompilationError::fatal(
+            // e.g. `line(%, $)` or `line(%, $ , 5)`
+            TokenType::Brace | TokenType::Whitespace | TokenType::Comma => Err(CompilationError::fatal(
                 token.as_source_ranges(),
                 format!("Tag names must not be empty",),
             )),
@@ -1820,7 +1821,6 @@ impl TryFrom<Token> for Node<TagDeclarator> {
 
             TokenType::Bang
             | TokenType::Hash
-            | TokenType::Comma
             | TokenType::Colon
             | TokenType::Period
             | TokenType::Operator
@@ -3977,6 +3977,15 @@ let myBox = box([0,0], -3, -16, -10)
         let some_program_string = r#"startSketchOn('XY')
     |> startProfileAt([0, 0], %)
     |> line(%, $ ,01)
+    "#;
+        assert_err(some_program_string, "Tag names must not be empty", [69, 70]);
+    }
+
+    #[test]
+    fn test_parse_empty_tag_comma() {
+        let some_program_string = r#"startSketchOn('XY')
+    |> startProfileAt([0, 0], %)
+    |> line(%, $,)
     "#;
         assert_err(some_program_string, "Tag names must not be empty", [69, 70]);
     }

--- a/src/wasm-lib/kcl/src/parsing/parser.rs
+++ b/src/wasm-lib/kcl/src/parsing/parser.rs
@@ -1811,7 +1811,7 @@ impl TryFrom<Token> for Node<TagDeclarator> {
             // e.g. `line(%, $)` or `line(%, $ , 5)`
             TokenType::Brace | TokenType::Whitespace | TokenType::Comma => Err(CompilationError::fatal(
                 token.as_source_range(),
-                format!("Tag names must not be empty",),
+                "Tag names must not be empty".to_string(),
             )),
 
             TokenType::Type => Err(CompilationError::fatal(


### PR DESCRIPTION
closes #4340
The main issue was that the tag declaration errors weren't being marked as `ErrorMode::Cut`, which meant that the `alt` expression a couple layers up ended up running another branch that would end up failing and returning the unhelpful errors described in the parent issue.
I also added some more descriptive error messages for some of the more common(i'm assuming) cases and tests for some of them. 