### PR TITLE
Refactor SourceRange and ModuleId to make them better encapsualated

### DIFF
--- a/src/wasm-lib/kcl/src/ast/modify.rs
+++ b/src/wasm-lib/kcl/src/ast/modify.rs
@@ -6,6 +6,7 @@ use kcmc::{
 };
 use kittycad_modeling_cmds as kcmc;
 
+use super::types::Node;
 use crate::{
     ast::types::{
         ArrayExpression, CallExpression, ConstraintLevel, FormatOptions, Literal, PipeExpression, PipeSubstitution,
@@ -13,11 +14,10 @@ use crate::{
     },
     engine::EngineManager,
     errors::{KclError, KclErrorDetails},
-    executor::{Point2d, SourceRange},
+    executor::Point2d,
+    source_range::{ModuleId, SourceRange},
     Program,
 };
-
-use super::types::{ModuleId, Node};
 
 type Point3d = kcmc::shared::Point3d<f64>;
 

--- a/src/wasm-lib/kcl/src/ast/types/condition.rs
+++ b/src/wasm-lib/kcl/src/ast/types/condition.rs
@@ -1,14 +1,9 @@
-use crate::executor::SourceRange;
-
-use super::BoxNode;
-use super::ConstraintLevel;
-use super::Hover;
-use super::Node;
-use super::NodeList;
-use super::{Digest, Expr};
 use databake::*;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+use super::{BoxNode, ConstraintLevel, Digest, Expr, Hover, Node, NodeList};
+use crate::SourceRange;
 
 // TODO: This should be its own type, similar to Program,
 // but guaranteed to have an Expression as its final item.
@@ -50,7 +45,7 @@ impl Node<IfExpression> {
 impl Node<ElseIf> {
     #[allow(dead_code)]
     fn source_ranges(&self) -> Vec<SourceRange> {
-        vec![SourceRange([self.start, self.end, self.module_id.as_usize()])]
+        vec![SourceRange::new(self.start, self.end, self.module_id)]
     }
 }
 

--- a/src/wasm-lib/kcl/src/ast/types/execute.rs
+++ b/src/wasm-lib/kcl/src/ast/types/execute.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use async_recursion::async_recursion;
+
 use super::{
     ArrayExpression, ArrayRangeExpression, BinaryExpression, BinaryOperator, BinaryPart, CallExpression,
     CallExpressionKw, Expr, IfExpression, KclNone, LiteralIdentifier, LiteralValue, MemberExpression, MemberObject,
@@ -7,13 +9,10 @@ use super::{
 };
 use crate::{
     errors::{KclError, KclErrorDetails},
-    executor::{
-        BodyType, ExecState, ExecutorContext, KclValue, Metadata, SourceRange, StatementKind, TagEngineInfo,
-        TagIdentifier,
-    },
+    executor::{BodyType, ExecState, ExecutorContext, KclValue, Metadata, StatementKind, TagEngineInfo, TagIdentifier},
+    source_range::SourceRange,
     std::{args::Arg, FunctionKind},
 };
-use async_recursion::async_recursion;
 
 const FLOAT_TO_INT_MAX_DELTA: f64 = 0.01;
 

--- a/src/wasm-lib/kcl/src/ast/types/literal_value.rs
+++ b/src/wasm-lib/kcl/src/ast/types/literal_value.rs
@@ -3,9 +3,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JValue;
 
-use crate::ast::types::{Expr, Literal};
-
 use super::Node;
+use crate::ast::types::{Expr, Literal};
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Bake)]
 #[databake(path = kcl_lib::ast::types)]

--- a/src/wasm-lib/kcl/src/ast/types/none.rs
+++ b/src/wasm-lib/kcl/src/ast/types/none.rs
@@ -4,9 +4,8 @@ use databake::*;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{ast::types::ConstraintLevel, executor::KclValue};
-
 use super::Node;
+use crate::{ast::types::ConstraintLevel, executor::KclValue};
 
 const KCL_NONE_ID: &str = "KCL_NONE_ID";
 

--- a/src/wasm-lib/kcl/src/ast/types/source_range.rs
+++ b/src/wasm-lib/kcl/src/ast/types/source_range.rs
@@ -1,4 +1,5 @@
-use super::{BinaryPart, BodyItem, Expr, LiteralIdentifier, MemberObject, ModuleId};
+use super::{BinaryPart, BodyItem, Expr, LiteralIdentifier, MemberObject};
+use crate::source_range::ModuleId;
 
 impl BodyItem {
     pub fn module_id(&self) -> ModuleId {

--- a/src/wasm-lib/kcl/src/engine/conn.rs
+++ b/src/wasm-lib/kcl/src/engine/conn.rs
@@ -18,13 +18,13 @@ use kittycad_modeling_cmds as kcmc;
 use tokio::sync::{mpsc, oneshot, RwLock};
 use tokio_tungstenite::tungstenite::Message as WsMsg;
 
+use super::ExecutionKind;
 use crate::{
     engine::EngineManager,
     errors::{KclError, KclErrorDetails},
     executor::{DefaultPlanes, IdGenerator},
+    SourceRange,
 };
-
-use super::ExecutionKind;
 
 #[derive(Debug, PartialEq)]
 enum SocketHealth {
@@ -41,8 +41,8 @@ pub struct EngineConnection {
     #[allow(dead_code)]
     tcp_read_handle: Arc<TcpReadHandle>,
     socket_health: Arc<Mutex<SocketHealth>>,
-    batch: Arc<Mutex<Vec<(WebSocketRequest, crate::executor::SourceRange)>>>,
-    batch_end: Arc<Mutex<IndexMap<uuid::Uuid, (WebSocketRequest, crate::executor::SourceRange)>>>,
+    batch: Arc<Mutex<Vec<(WebSocketRequest, SourceRange)>>>,
+    batch_end: Arc<Mutex<IndexMap<uuid::Uuid, (WebSocketRequest, SourceRange)>>>,
 
     /// The default planes for the scene.
     default_planes: Arc<RwLock<Option<DefaultPlanes>>>,
@@ -311,11 +311,11 @@ impl EngineConnection {
 
 #[async_trait::async_trait]
 impl EngineManager for EngineConnection {
-    fn batch(&self) -> Arc<Mutex<Vec<(WebSocketRequest, crate::executor::SourceRange)>>> {
+    fn batch(&self) -> Arc<Mutex<Vec<(WebSocketRequest, SourceRange)>>> {
         self.batch.clone()
     }
 
-    fn batch_end(&self) -> Arc<Mutex<IndexMap<uuid::Uuid, (WebSocketRequest, crate::executor::SourceRange)>>> {
+    fn batch_end(&self) -> Arc<Mutex<IndexMap<uuid::Uuid, (WebSocketRequest, SourceRange)>>> {
         self.batch_end.clone()
     }
 
@@ -334,7 +334,7 @@ impl EngineManager for EngineConnection {
     async fn default_planes(
         &self,
         id_generator: &mut IdGenerator,
-        source_range: crate::executor::SourceRange,
+        source_range: SourceRange,
     ) -> Result<DefaultPlanes, KclError> {
         {
             let opt = self.default_planes.read().await.as_ref().cloned();
@@ -352,7 +352,7 @@ impl EngineManager for EngineConnection {
     async fn clear_scene_post_hook(
         &self,
         id_generator: &mut IdGenerator,
-        source_range: crate::executor::SourceRange,
+        source_range: SourceRange,
     ) -> Result<(), KclError> {
         // Remake the default planes, since they would have been removed after the scene was cleared.
         let new_planes = self.new_default_planes(id_generator, source_range).await?;
@@ -364,9 +364,9 @@ impl EngineManager for EngineConnection {
     async fn inner_send_modeling_cmd(
         &self,
         id: uuid::Uuid,
-        source_range: crate::executor::SourceRange,
+        source_range: SourceRange,
         cmd: WebSocketRequest,
-        _id_to_source_range: std::collections::HashMap<uuid::Uuid, crate::executor::SourceRange>,
+        _id_to_source_range: std::collections::HashMap<uuid::Uuid, SourceRange>,
     ) -> Result<WebSocketResponse, KclError> {
         let (tx, rx) = oneshot::channel();
 

--- a/src/wasm-lib/kcl/src/engine/conn_mock.rs
+++ b/src/wasm-lib/kcl/src/engine/conn_mock.rs
@@ -17,17 +17,17 @@ use kcmc::{
 };
 use kittycad_modeling_cmds::{self as kcmc};
 
+use super::ExecutionKind;
 use crate::{
     errors::KclError,
     executor::{DefaultPlanes, IdGenerator},
+    SourceRange,
 };
-
-use super::ExecutionKind;
 
 #[derive(Debug, Clone)]
 pub struct EngineConnection {
-    batch: Arc<Mutex<Vec<(WebSocketRequest, crate::executor::SourceRange)>>>,
-    batch_end: Arc<Mutex<IndexMap<uuid::Uuid, (WebSocketRequest, crate::executor::SourceRange)>>>,
+    batch: Arc<Mutex<Vec<(WebSocketRequest, SourceRange)>>>,
+    batch_end: Arc<Mutex<IndexMap<uuid::Uuid, (WebSocketRequest, SourceRange)>>>,
     execution_kind: Arc<Mutex<ExecutionKind>>,
 }
 
@@ -43,11 +43,11 @@ impl EngineConnection {
 
 #[async_trait::async_trait]
 impl crate::engine::EngineManager for EngineConnection {
-    fn batch(&self) -> Arc<Mutex<Vec<(WebSocketRequest, crate::executor::SourceRange)>>> {
+    fn batch(&self) -> Arc<Mutex<Vec<(WebSocketRequest, SourceRange)>>> {
         self.batch.clone()
     }
 
-    fn batch_end(&self) -> Arc<Mutex<IndexMap<uuid::Uuid, (WebSocketRequest, crate::executor::SourceRange)>>> {
+    fn batch_end(&self) -> Arc<Mutex<IndexMap<uuid::Uuid, (WebSocketRequest, SourceRange)>>> {
         self.batch_end.clone()
     }
 
@@ -66,7 +66,7 @@ impl crate::engine::EngineManager for EngineConnection {
     async fn default_planes(
         &self,
         _id_generator: &mut IdGenerator,
-        _source_range: crate::executor::SourceRange,
+        _source_range: SourceRange,
     ) -> Result<DefaultPlanes, KclError> {
         Ok(DefaultPlanes::default())
     }
@@ -74,7 +74,7 @@ impl crate::engine::EngineManager for EngineConnection {
     async fn clear_scene_post_hook(
         &self,
         _id_generator: &mut IdGenerator,
-        _source_range: crate::executor::SourceRange,
+        _source_range: SourceRange,
     ) -> Result<(), KclError> {
         Ok(())
     }
@@ -82,9 +82,9 @@ impl crate::engine::EngineManager for EngineConnection {
     async fn inner_send_modeling_cmd(
         &self,
         id: uuid::Uuid,
-        _source_range: crate::executor::SourceRange,
+        _source_range: SourceRange,
         cmd: WebSocketRequest,
-        _id_to_source_range: std::collections::HashMap<uuid::Uuid, crate::executor::SourceRange>,
+        _id_to_source_range: std::collections::HashMap<uuid::Uuid, SourceRange>,
     ) -> Result<WebSocketResponse, KclError> {
         match cmd {
             WebSocketRequest::ModelingCmdBatchReq(ModelingBatch {

--- a/src/wasm-lib/kcl/src/engine/conn_wasm.rs
+++ b/src/wasm-lib/kcl/src/engine/conn_wasm.rs
@@ -12,6 +12,7 @@ use crate::{
     engine::ExecutionKind,
     errors::{KclError, KclErrorDetails},
     executor::{DefaultPlanes, IdGenerator},
+    SourceRange,
 };
 
 #[wasm_bindgen(module = "/../../lang/std/engineConnection.ts")]
@@ -41,8 +42,8 @@ extern "C" {
 #[derive(Debug, Clone)]
 pub struct EngineConnection {
     manager: Arc<EngineCommandManager>,
-    batch: Arc<Mutex<Vec<(WebSocketRequest, crate::executor::SourceRange)>>>,
-    batch_end: Arc<Mutex<IndexMap<uuid::Uuid, (WebSocketRequest, crate::executor::SourceRange)>>>,
+    batch: Arc<Mutex<Vec<(WebSocketRequest, SourceRange)>>>,
+    batch_end: Arc<Mutex<IndexMap<uuid::Uuid, (WebSocketRequest, SourceRange)>>>,
     execution_kind: Arc<Mutex<ExecutionKind>>,
 }
 
@@ -63,11 +64,11 @@ impl EngineConnection {
 
 #[async_trait::async_trait]
 impl crate::engine::EngineManager for EngineConnection {
-    fn batch(&self) -> Arc<Mutex<Vec<(WebSocketRequest, crate::executor::SourceRange)>>> {
+    fn batch(&self) -> Arc<Mutex<Vec<(WebSocketRequest, SourceRange)>>> {
         self.batch.clone()
     }
 
-    fn batch_end(&self) -> Arc<Mutex<IndexMap<uuid::Uuid, (WebSocketRequest, crate::executor::SourceRange)>>> {
+    fn batch_end(&self) -> Arc<Mutex<IndexMap<uuid::Uuid, (WebSocketRequest, SourceRange)>>> {
         self.batch_end.clone()
     }
 
@@ -86,7 +87,7 @@ impl crate::engine::EngineManager for EngineConnection {
     async fn default_planes(
         &self,
         _id_generator: &mut IdGenerator,
-        source_range: crate::executor::SourceRange,
+        source_range: SourceRange,
     ) -> Result<DefaultPlanes, KclError> {
         // Get the default planes.
         let promise = self.manager.get_default_planes().map_err(|e| {
@@ -128,7 +129,7 @@ impl crate::engine::EngineManager for EngineConnection {
     async fn clear_scene_post_hook(
         &self,
         _id_generator: &mut IdGenerator,
-        source_range: crate::executor::SourceRange,
+        source_range: SourceRange,
     ) -> Result<(), KclError> {
         self.manager.clear_default_planes().map_err(|e| {
             KclError::Engine(KclErrorDetails {
@@ -158,9 +159,9 @@ impl crate::engine::EngineManager for EngineConnection {
     async fn inner_send_modeling_cmd(
         &self,
         id: uuid::Uuid,
-        source_range: crate::executor::SourceRange,
+        source_range: SourceRange,
         cmd: WebSocketRequest,
-        id_to_source_range: std::collections::HashMap<uuid::Uuid, crate::executor::SourceRange>,
+        id_to_source_range: std::collections::HashMap<uuid::Uuid, SourceRange>,
     ) -> Result<WebSocketResponse, KclError> {
         let source_range_str = serde_json::to_string(&source_range).map_err(|e| {
             KclError::Engine(KclErrorDetails {

--- a/src/wasm-lib/kcl/src/errors.rs
+++ b/src/wasm-lib/kcl/src/errors.rs
@@ -2,7 +2,10 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
 
-use crate::{ast::types::ModuleId, executor::SourceRange, lsp::IntoDiagnostic};
+use crate::{
+    lsp::IntoDiagnostic,
+    source_range::{ModuleId, SourceRange},
+};
 
 /// How did the KCL execution fail
 #[derive(thiserror::Error, Debug)]

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -19,20 +19,18 @@ use kittycad_modeling_cmds::length_unit::LengthUnit;
 use parse_display::{Display, FromStr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use tower_lsp::lsp_types::{Position as LspPosition, Range as LspRange};
 
 type Point2D = kcmc::shared::Point2d<f64>;
 type Point3D = kcmc::shared::Point3d<f64>;
 
 pub use crate::kcl_value::KclValue;
 use crate::{
-    ast::types::{
-        BodyItem, Expr, FunctionExpression, ItemVisibility, KclNone, ModuleId, Node, NodeRef, TagDeclarator, TagNode,
-    },
+    ast::types::{BodyItem, Expr, FunctionExpression, ItemVisibility, KclNone, Node, NodeRef, TagDeclarator, TagNode},
     engine::{EngineManager, ExecutionKind},
     errors::{KclError, KclErrorDetails},
     fs::{FileManager, FileSystem},
     settings::types::UnitLength,
+    source_range::{ModuleId, SourceRange},
     std::{args::Arg, StdLib},
     ExecError, Program,
 };
@@ -1000,101 +998,6 @@ pub struct ModuleInfo {
     id: ModuleId,
     /// Absolute path of the module's source file.
     path: std::path::PathBuf,
-}
-
-#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Copy, Clone, ts_rs::TS, JsonSchema, Hash, Eq)]
-#[cfg_attr(feature = "pyo3", pyo3::pyclass)]
-#[ts(export)]
-pub struct SourceRange(#[ts(type = "[number, number]")] pub [usize; 3]);
-
-impl From<[usize; 3]> for SourceRange {
-    fn from(value: [usize; 3]) -> Self {
-        Self(value)
-    }
-}
-
-impl From<&SourceRange> for miette::SourceSpan {
-    fn from(source_range: &SourceRange) -> Self {
-        let length = source_range.end() - source_range.start();
-        let start = miette::SourceOffset::from(source_range.start());
-        Self::new(start, length)
-    }
-}
-
-impl From<SourceRange> for miette::SourceSpan {
-    fn from(source_range: SourceRange) -> Self {
-        Self::from(&source_range)
-    }
-}
-
-impl SourceRange {
-    /// Create a new source range.
-    pub fn new(start: usize, end: usize, module_id: ModuleId) -> Self {
-        Self([start, end, module_id.as_usize()])
-    }
-
-    /// A source range that doesn't correspond to any source code.
-    pub fn synthetic() -> Self {
-        Self::default()
-    }
-
-    /// Get the start of the range.
-    pub fn start(&self) -> usize {
-        self.0[0]
-    }
-
-    /// Get the end of the range.
-    pub fn end(&self) -> usize {
-        self.0[1]
-    }
-
-    /// Get the module ID of the range.
-    pub fn module_id(&self) -> ModuleId {
-        ModuleId::from_usize(self.0[2])
-    }
-
-    /// Check if the range contains a position.
-    pub fn contains(&self, pos: usize) -> bool {
-        pos >= self.start() && pos <= self.end()
-    }
-
-    pub fn start_to_lsp_position(&self, code: &str) -> LspPosition {
-        // Calculate the line and column of the error from the source range.
-        // Lines are zero indexed in vscode so we need to subtract 1.
-        let mut line = code.get(..self.start()).unwrap_or_default().lines().count();
-        if line > 0 {
-            line = line.saturating_sub(1);
-        }
-        let column = code[..self.start()].lines().last().map(|l| l.len()).unwrap_or_default();
-
-        LspPosition {
-            line: line as u32,
-            character: column as u32,
-        }
-    }
-
-    pub fn end_to_lsp_position(&self, code: &str) -> LspPosition {
-        let lines = code.get(..self.end()).unwrap_or_default().lines();
-        if lines.clone().count() == 0 {
-            return LspPosition { line: 0, character: 0 };
-        }
-
-        // Calculate the line and column of the error from the source range.
-        // Lines are zero indexed in vscode so we need to subtract 1.
-        let line = lines.clone().count() - 1;
-        let column = lines.last().map(|l| l.len()).unwrap_or_default();
-
-        LspPosition {
-            line: line as u32,
-            character: column as u32,
-        }
-    }
-
-    pub fn to_lsp_range(&self, code: &str) -> LspRange {
-        let start = self.start_to_lsp_position(code);
-        let end = self.end_to_lsp_position(code);
-        LspRange { start, end }
-    }
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Clone, Copy, ts_rs::TS, JsonSchema)]
@@ -2109,7 +2012,7 @@ impl ExecutorContext {
                     // True here tells the engine to flush all the end commands as well like fillets
                     // and chamfers where the engine would otherwise eat the ID of the segments.
                     true,
-                    SourceRange([program.end, program.end, program.module_id.as_usize()]),
+                    SourceRange::new(program.end, program.end, program.module_id),
                 )
                 .await?;
         }
@@ -2715,7 +2618,10 @@ const answer = returnX()"#;
             err,
             KclError::UndefinedValue(KclErrorDetails {
                 message: "memory item key `x` is not defined".to_owned(),
-                source_ranges: vec![SourceRange([64, 65, 0]), SourceRange([97, 106, 0])],
+                source_ranges: vec![
+                    SourceRange::new(64, 65, ModuleId::default()),
+                    SourceRange::new(97, 106, ModuleId::default())
+                ],
             }),
         );
     }
@@ -2750,7 +2656,7 @@ let shape = layer() |> patternTransform(10, transform, %)
             err,
             KclError::UndefinedValue(KclErrorDetails {
                 message: "memory item key `x` is not defined".to_owned(),
-                source_ranges: vec![SourceRange([80, 81, 0])],
+                source_ranges: vec![SourceRange::new(80, 81, ModuleId::default())],
             }),
         );
     }
@@ -2846,7 +2752,7 @@ let notNull = !myNull
             parse_execute(code1).await.unwrap_err().downcast::<KclError>().unwrap(),
             KclError::Semantic(KclErrorDetails {
                 message: "Cannot apply unary operator ! to non-boolean value: number".to_owned(),
-                source_ranges: vec![SourceRange([56, 63, 0])],
+                source_ranges: vec![SourceRange::new(56, 63, ModuleId::default())],
             })
         );
 
@@ -2855,7 +2761,7 @@ let notNull = !myNull
             parse_execute(code2).await.unwrap_err().downcast::<KclError>().unwrap(),
             KclError::Semantic(KclErrorDetails {
                 message: "Cannot apply unary operator ! to non-boolean value: number".to_owned(),
-                source_ranges: vec![SourceRange([14, 16, 0])],
+                source_ranges: vec![SourceRange::new(14, 16, ModuleId::default())],
             })
         );
 
@@ -2866,7 +2772,7 @@ let notEmptyString = !""
             parse_execute(code3).await.unwrap_err().downcast::<KclError>().unwrap(),
             KclError::Semantic(KclErrorDetails {
                 message: "Cannot apply unary operator ! to non-boolean value: string (text)".to_owned(),
-                source_ranges: vec![SourceRange([22, 25, 0])],
+                source_ranges: vec![SourceRange::new(22, 25, ModuleId::default())],
             })
         );
 
@@ -2878,7 +2784,7 @@ let notMember = !obj.a
             parse_execute(code4).await.unwrap_err().downcast::<KclError>().unwrap(),
             KclError::Semantic(KclErrorDetails {
                 message: "Cannot apply unary operator ! to non-boolean value: number".to_owned(),
-                source_ranges: vec![SourceRange([36, 42, 0])],
+                source_ranges: vec![SourceRange::new(36, 42, ModuleId::default())],
             })
         );
 
@@ -2889,7 +2795,7 @@ let notArray = !a";
             parse_execute(code5).await.unwrap_err().downcast::<KclError>().unwrap(),
             KclError::Semantic(KclErrorDetails {
                 message: "Cannot apply unary operator ! to non-boolean value: array (list)".to_owned(),
-                source_ranges: vec![SourceRange([27, 29, 0])],
+                source_ranges: vec![SourceRange::new(27, 29, ModuleId::default())],
             })
         );
 
@@ -2900,7 +2806,7 @@ let notObject = !x";
             parse_execute(code6).await.unwrap_err().downcast::<KclError>().unwrap(),
             KclError::Semantic(KclErrorDetails {
                 message: "Cannot apply unary operator ! to non-boolean value: object".to_owned(),
-                source_ranges: vec![SourceRange([28, 30, 0])],
+                source_ranges: vec![SourceRange::new(28, 30, ModuleId::default())],
             })
         );
 
@@ -2953,7 +2859,7 @@ let notTagIdentifier = !myTag";
             parse_execute(code10).await.unwrap_err().downcast::<KclError>().unwrap(),
             KclError::Syntax(KclErrorDetails {
                 message: "Unexpected token: !".to_owned(),
-                source_ranges: vec![SourceRange([14, 15, 0])],
+                source_ranges: vec![SourceRange::new(14, 15, ModuleId::default())],
             })
         );
 
@@ -2966,7 +2872,7 @@ let notPipeSub = 1 |> identity(!%))";
             parse_execute(code11).await.unwrap_err().downcast::<KclError>().unwrap(),
             KclError::Syntax(KclErrorDetails {
                 message: "Unexpected token: |>".to_owned(),
-                source_ranges: vec![SourceRange([54, 56, 0])],
+                source_ranges: vec![SourceRange::new(54, 56, ModuleId::default())],
             })
         );
 
@@ -3010,10 +2916,10 @@ test([0, 0])
 "#;
         let result = parse_execute(ast).await;
         assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            r#"undefined value: KclErrorDetails { source_ranges: [SourceRange([10, 34, 0])], message: "Result of user-defined function test is undefined" }"#.to_owned()
-        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Result of user-defined function test is undefined"),);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -3129,7 +3035,7 @@ let w = f() + f()
                 vec![req_param("x")],
                 vec![],
                 Err(KclError::Semantic(KclErrorDetails {
-                    source_ranges: vec![SourceRange([0, 0, 0])],
+                    source_ranges: vec![SourceRange::default()],
                     message: "Expected 1 arguments, got 0".to_owned(),
                 })),
             ),
@@ -3147,7 +3053,7 @@ let w = f() + f()
                 vec![req_param("x"), opt_param("y")],
                 vec![],
                 Err(KclError::Semantic(KclErrorDetails {
-                    source_ranges: vec![SourceRange([0, 0, 0])],
+                    source_ranges: vec![SourceRange::default()],
                     message: "Expected 1-2 arguments, got 0".to_owned(),
                 })),
             ),
@@ -3174,7 +3080,7 @@ let w = f() + f()
                 vec![req_param("x"), opt_param("y")],
                 vec![mem(1), mem(2), mem(3)],
                 Err(KclError::Semantic(KclErrorDetails {
-                    source_ranges: vec![SourceRange([0, 0, 0])],
+                    source_ranges: vec![SourceRange::default()],
                     message: "Expected 1-2 arguments, got 3".to_owned(),
                 })),
             ),

--- a/src/wasm-lib/kcl/src/fs/local.rs
+++ b/src/wasm-lib/kcl/src/fs/local.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use crate::{
     errors::{KclError, KclErrorDetails},
     fs::FileSystem,
+    SourceRange,
 };
 
 #[derive(Debug, Clone)]
@@ -27,7 +28,7 @@ impl FileSystem for FileManager {
     async fn read<P: AsRef<std::path::Path> + std::marker::Send + std::marker::Sync>(
         &self,
         path: P,
-        source_range: crate::executor::SourceRange,
+        source_range: SourceRange,
     ) -> Result<Vec<u8>, KclError> {
         tokio::fs::read(&path).await.map_err(|e| {
             KclError::Engine(KclErrorDetails {
@@ -40,7 +41,7 @@ impl FileSystem for FileManager {
     async fn read_to_string<P: AsRef<std::path::Path> + std::marker::Send + std::marker::Sync>(
         &self,
         path: P,
-        source_range: crate::executor::SourceRange,
+        source_range: SourceRange,
     ) -> Result<String, KclError> {
         tokio::fs::read_to_string(&path).await.map_err(|e| {
             KclError::Engine(KclErrorDetails {
@@ -53,7 +54,7 @@ impl FileSystem for FileManager {
     async fn exists<P: AsRef<std::path::Path> + std::marker::Send + std::marker::Sync>(
         &self,
         path: P,
-        source_range: crate::executor::SourceRange,
+        source_range: SourceRange,
     ) -> Result<bool, crate::errors::KclError> {
         tokio::fs::metadata(&path).await.map(|_| true).or_else(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
@@ -70,7 +71,7 @@ impl FileSystem for FileManager {
     async fn get_all_files<P: AsRef<std::path::Path> + std::marker::Send + std::marker::Sync>(
         &self,
         path: P,
-        source_range: crate::executor::SourceRange,
+        source_range: SourceRange,
     ) -> Result<Vec<std::path::PathBuf>, crate::errors::KclError> {
         let mut files = vec![];
         let mut stack = vec![path.as_ref().to_path_buf()];

--- a/src/wasm-lib/kcl/src/fs/mod.rs
+++ b/src/wasm-lib/kcl/src/fs/mod.rs
@@ -1,5 +1,9 @@
 //! Functions for interacting with files on a machine.
 
+use anyhow::Result;
+
+use crate::SourceRange;
+
 #[cfg(not(target_arch = "wasm32"))]
 pub mod local;
 #[cfg(not(target_arch = "wasm32"))]
@@ -9,7 +13,6 @@ pub use local::FileManager;
 #[cfg(not(test))]
 pub mod wasm;
 
-use anyhow::Result;
 #[cfg(target_arch = "wasm32")]
 #[cfg(not(test))]
 pub use wasm::FileManager;
@@ -20,27 +23,27 @@ pub trait FileSystem: Clone {
     async fn read<P: AsRef<std::path::Path> + std::marker::Send + std::marker::Sync>(
         &self,
         path: P,
-        source_range: crate::executor::SourceRange,
+        source_range: SourceRange,
     ) -> Result<Vec<u8>, crate::errors::KclError>;
 
     /// Read a file from the local file system.
     async fn read_to_string<P: AsRef<std::path::Path> + std::marker::Send + std::marker::Sync>(
         &self,
         path: P,
-        source_range: crate::executor::SourceRange,
+        source_range: SourceRange,
     ) -> Result<String, crate::errors::KclError>;
 
     /// Check if a file exists on the local file system.
     async fn exists<P: AsRef<std::path::Path> + std::marker::Send + std::marker::Sync>(
         &self,
         path: P,
-        source_range: crate::executor::SourceRange,
+        source_range: SourceRange,
     ) -> Result<bool, crate::errors::KclError>;
 
     /// Get all the files in a directory recursively.
     async fn get_all_files<P: AsRef<std::path::Path> + std::marker::Send + std::marker::Sync>(
         &self,
         path: P,
-        source_range: crate::executor::SourceRange,
+        source_range: SourceRange,
     ) -> Result<Vec<std::path::PathBuf>, crate::errors::KclError>;
 }

--- a/src/wasm-lib/kcl/src/fs/wasm.rs
+++ b/src/wasm-lib/kcl/src/fs/wasm.rs
@@ -7,6 +7,7 @@ use crate::{
     errors::{KclError, KclErrorDetails},
     fs::FileSystem,
     wasm::JsFuture,
+    SourceRange,
 };
 
 #[wasm_bindgen(module = "/../../lang/std/fileSystemManager.ts")]
@@ -43,7 +44,7 @@ impl FileSystem for FileManager {
     async fn read<P: AsRef<std::path::Path> + std::marker::Send + std::marker::Sync>(
         &self,
         path: P,
-        source_range: crate::executor::SourceRange,
+        source_range: SourceRange,
     ) -> Result<Vec<u8>, KclError> {
         let promise = self
             .manager
@@ -81,7 +82,7 @@ impl FileSystem for FileManager {
     async fn read_to_string<P: AsRef<std::path::Path> + std::marker::Send + std::marker::Sync>(
         &self,
         path: P,
-        source_range: crate::executor::SourceRange,
+        source_range: SourceRange,
     ) -> Result<String, KclError> {
         let bytes = self.read(path, source_range).await?;
         let string = String::from_utf8(bytes).map_err(|e| {
@@ -97,7 +98,7 @@ impl FileSystem for FileManager {
     async fn exists<P: AsRef<std::path::Path> + std::marker::Send + std::marker::Sync>(
         &self,
         path: P,
-        source_range: crate::executor::SourceRange,
+        source_range: SourceRange,
     ) -> Result<bool, crate::errors::KclError> {
         let promise = self
             .manager
@@ -139,7 +140,7 @@ impl FileSystem for FileManager {
     async fn get_all_files<P: AsRef<std::path::Path> + std::marker::Send + std::marker::Sync>(
         &self,
         path: P,
-        source_range: crate::executor::SourceRange,
+        source_range: SourceRange,
     ) -> Result<Vec<std::path::PathBuf>, crate::errors::KclError> {
         let promise = self
             .manager

--- a/src/wasm-lib/kcl/src/kcl_value.rs
+++ b/src/wasm-lib/kcl/src/kcl_value.rs
@@ -123,7 +123,7 @@ impl From<Vec<Box<Solid>>> for KclValue {
 impl From<KclValue> for Vec<SourceRange> {
     fn from(item: KclValue) -> Self {
         match item {
-            KclValue::TagDeclarator(t) => vec![SourceRange([t.start, t.end, t.module_id.0 as usize])],
+            KclValue::TagDeclarator(t) => vec![SourceRange::new(t.start, t.end, t.module_id)],
             KclValue::TagIdentifier(t) => to_vec_sr(&t.meta),
             KclValue::Solid(e) => to_vec_sr(&e.meta),
             KclValue::Solids { value } => value.iter().flat_map(|eg| to_vec_sr(&eg.meta)).collect(),
@@ -152,7 +152,7 @@ fn to_vec_sr(meta: &[Metadata]) -> Vec<SourceRange> {
 impl From<&KclValue> for Vec<SourceRange> {
     fn from(item: &KclValue) -> Self {
         match item {
-            KclValue::TagDeclarator(t) => vec![SourceRange([t.start, t.end, t.module_id.0 as usize])],
+            KclValue::TagDeclarator(t) => vec![SourceRange::new(t.start, t.end, t.module_id)],
             KclValue::TagIdentifier(t) => to_vec_sr(&t.meta),
             KclValue::Solid(e) => to_vec_sr(&e.meta),
             KclValue::Solids { value } => value.iter().flat_map(|eg| to_vec_sr(&eg.meta)).collect(),

--- a/src/wasm-lib/kcl/src/lib.rs
+++ b/src/wasm-lib/kcl/src/lib.rs
@@ -72,6 +72,7 @@ mod parser;
 mod settings;
 #[cfg(test)]
 mod simulation_tests;
+mod source_range;
 mod std;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod test_server;
@@ -82,16 +83,17 @@ mod walk;
 #[cfg(target_arch = "wasm32")]
 mod wasm;
 
-pub use ast::modify::modify_ast_for_sketch;
-pub use ast::types::{FormatOptions, ModuleId};
+pub use ast::{modify::modify_ast_for_sketch, types::FormatOptions};
 pub use coredump::CoreDump;
 pub use engine::{EngineManager, ExecutionKind};
 pub use errors::{ConnectionError, ExecError, KclError};
-pub use executor::{ExecState, ExecutorContext, ExecutorSettings, SourceRange};
-pub use lsp::copilot::Backend as CopilotLspBackend;
-pub use lsp::kcl::Backend as KclLspBackend;
-pub use lsp::kcl::Server as KclLspServerSubCommand;
+pub use executor::{ExecState, ExecutorContext, ExecutorSettings};
+pub use lsp::{
+    copilot::Backend as CopilotLspBackend,
+    kcl::{Backend as KclLspBackend, Server as KclLspServerSubCommand},
+};
 pub use settings::types::{project::ProjectConfiguration, Configuration, UnitLength};
+pub use source_range::{ModuleId, SourceRange};
 
 // Rather than make executor public and make lots of it pub(crate), just re-export into a new module.
 // Ideally we wouldn't export these things at all, they should only be used for testing.
@@ -101,9 +103,11 @@ pub mod exec {
 
 #[cfg(target_arch = "wasm32")]
 pub mod wasm_engine {
-    pub use crate::coredump::wasm::{CoreDumpManager, CoreDumper};
-    pub use crate::engine::conn_wasm::{EngineCommandManager, EngineConnection};
-    pub use crate::fs::wasm::FileSystemManager;
+    pub use crate::{
+        coredump::wasm::{CoreDumpManager, CoreDumper},
+        engine::conn_wasm::{EngineCommandManager, EngineConnection},
+        fs::wasm::FileSystemManager,
+    };
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -115,9 +119,10 @@ pub mod std_utils {
     pub use crate::std::utils::{get_tangential_arc_to_info, is_points_ccw_wasm, TangentialArcInfoInput};
 }
 
+use serde::{Deserialize, Serialize};
+
 #[allow(unused_imports)]
 use crate::log::{log, logln};
-use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Program {

--- a/src/wasm-lib/kcl/src/lint/checks/camel_case.rs
+++ b/src/wasm-lib/kcl/src/lint/checks/camel_case.rs
@@ -3,9 +3,9 @@ use convert_case::Casing;
 
 use crate::{
     ast::types::{ObjectProperty, VariableDeclarator},
-    executor::SourceRange,
     lint::rule::{def_finding, Discovered, Finding},
     walk::Node,
+    SourceRange,
 };
 
 def_finding!(

--- a/src/wasm-lib/kcl/src/lint/checks/offset_plane.rs
+++ b/src/wasm-lib/kcl/src/lint/checks/offset_plane.rs
@@ -1,11 +1,13 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+
 use crate::{
     ast::types::{BinaryPart, Expr, LiteralValue, ObjectExpression, UnaryOperator},
-    executor::SourceRange,
     lint::rule::{def_finding, Discovered, Finding},
     walk::Node,
+    SourceRange,
 };
-use anyhow::Result;
-use std::collections::HashMap;
 
 def_finding!(
     Z0003,

--- a/src/wasm-lib/kcl/src/lint/checks/std_lib_args.rs
+++ b/src/wasm-lib/kcl/src/lint/checks/std_lib_args.rs
@@ -5,10 +5,10 @@ use anyhow::Result;
 use crate::{
     ast::types::{CallExpression, NodeRef},
     docs::StdLibFn,
-    executor::SourceRange,
     lint::rule::{def_finding, Discovered, Finding},
     std::{FunctionKind, StdLib},
     walk::Node,
+    SourceRange,
 };
 
 def_finding!(

--- a/src/wasm-lib/kcl/src/lint/rule.rs
+++ b/src/wasm-lib/kcl/src/lint/rule.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 use serde::Serialize;
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
 
-use crate::{executor::SourceRange, lsp::IntoDiagnostic, walk::Node};
+use crate::{lsp::IntoDiagnostic, walk::Node, SourceRange};
 
 /// Check the provided AST for any found rule violations.
 ///

--- a/src/wasm-lib/kcl/src/log.rs
+++ b/src/wasm-lib/kcl/src/log.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
+use std::env;
+
 #[cfg(feature = "dhat-heap")]
 use dhat::{HeapStats, Profiler};
-use std::env;
 use web_time::Instant;
 
 const LOG_ENV_VAR: &str = "ZOO_LOG";

--- a/src/wasm-lib/kcl/src/lsp/copilot/mod.rs
+++ b/src/wasm-lib/kcl/src/lsp/copilot/mod.rs
@@ -27,10 +27,12 @@ use tower_lsp::{
 
 use crate::lsp::{
     backend::Backend as _,
-    copilot::cache::CopilotCache,
-    copilot::types::{
-        CopilotAcceptCompletionParams, CopilotCompletionResponse, CopilotCompletionTelemetry, CopilotEditorInfo,
-        CopilotLspCompletionParams, CopilotRejectCompletionParams, DocParams,
+    copilot::{
+        cache::CopilotCache,
+        types::{
+            CopilotAcceptCompletionParams, CopilotCompletionResponse, CopilotCompletionTelemetry, CopilotEditorInfo,
+            CopilotLspCompletionParams, CopilotRejectCompletionParams, DocParams,
+        },
     },
 };
 

--- a/src/wasm-lib/kcl/src/lsp/kcl/mod.rs
+++ b/src/wasm-lib/kcl/src/lsp/kcl/mod.rs
@@ -41,11 +41,11 @@ use tower_lsp::{
 };
 
 use crate::{
-    ast::types::{Expr, ModuleId, Node, VariableKind},
+    ast::types::{Expr, Node, VariableKind},
     lsp::{backend::Backend as _, util::IntoDiagnostic},
     parser::PIPE_OPERATOR,
     token::TokenType,
-    ExecState, Program, SourceRange,
+    ExecState, ModuleId, Program, SourceRange,
 };
 
 lazy_static::lazy_static! {

--- a/src/wasm-lib/kcl/src/parser.rs
+++ b/src/wasm-lib/kcl/src/parser.rs
@@ -1,9 +1,9 @@
 use parser_impl::ParseContext;
 
 use crate::{
-    ast::types::{ModuleId, Node, Program},
+    ast::types::{Node, Program},
     errors::{KclError, KclErrorDetails},
-    executor::SourceRange,
+    source_range::{ModuleId, SourceRange},
     token::{Token, TokenType},
 };
 

--- a/src/wasm-lib/kcl/src/parser/math.rs
+++ b/src/wasm-lib/kcl/src/parser/math.rs
@@ -1,7 +1,7 @@
 use crate::{
     ast::types::{BinaryExpression, BinaryOperator, BinaryPart, Node},
     errors::{KclError, KclErrorDetails},
-    executor::SourceRange,
+    SourceRange,
 };
 
 /// Parses a list of tokens (in infix order, i.e. as the user typed them)
@@ -66,7 +66,7 @@ fn source_range(tokens: &[BinaryExpressionToken]) -> Vec<SourceRange> {
         })
         .collect();
     match (sources.first(), sources.last()) {
-        (Some((start, _, module_id)), Some((_, end, _))) => vec![SourceRange([*start, *end, module_id.as_usize()])],
+        (Some((start, _, module_id)), Some((_, end, _))) => vec![SourceRange::new(*start, *end, *module_id)],
         _ => Vec::new(),
     }
 }
@@ -126,7 +126,7 @@ impl From<BinaryOperator> for BinaryExpressionToken {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::types::{Literal, ModuleId};
+    use crate::{ast::types::Literal, source_range::ModuleId};
 
     #[test]
     fn parse_and_evaluate() {

--- a/src/wasm-lib/kcl/src/parser/parser_impl/error.rs
+++ b/src/wasm-lib/kcl/src/parser/parser_impl/error.rs
@@ -2,8 +2,8 @@ use winnow::{error::StrContext, stream::Stream};
 
 use crate::{
     errors::{KclError, KclErrorDetails},
-    executor::SourceRange,
     token::Token,
+    SourceRange,
 };
 
 /// Accumulate context while backtracking errors

--- a/src/wasm-lib/kcl/src/simulation_tests.rs
+++ b/src/wasm-lib/kcl/src/simulation_tests.rs
@@ -1,8 +1,9 @@
 use insta::rounded_redaction;
 
 use crate::{
-    ast::types::{ModuleId, Node, Program},
+    ast::types::{Node, Program},
     errors::KclError,
+    source_range::ModuleId,
 };
 
 /// Deserialize the data from a snapshot.

--- a/src/wasm-lib/kcl/src/source_range.rs
+++ b/src/wasm-lib/kcl/src/source_range.rs
@@ -1,0 +1,132 @@
+use databake::*;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tower_lsp::lsp_types::{Position as LspPosition, Range as LspRange};
+
+/// Identifier of a source file.  Uses a u32 to keep the size small.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize, ts_rs::TS, JsonSchema, Bake)]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass)]
+#[databake(path = kcl_lib::ast::types)]
+#[ts(export)]
+pub struct ModuleId(u32);
+
+impl ModuleId {
+    pub fn from_usize(id: usize) -> Self {
+        Self(u32::try_from(id).expect("module ID should fit in a u32"))
+    }
+
+    pub fn as_usize(&self) -> usize {
+        usize::try_from(self.0).expect("module ID should fit in a usize")
+    }
+
+    /// Top-level file is the one being executed.
+    /// Represented by module ID of 0, i.e. the default value.
+    pub fn is_top_level(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+// TODO Serialization and Python bindings expose the implementation of source ranges.
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Copy, Clone, ts_rs::TS, JsonSchema, Hash, Eq)]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass)]
+#[ts(export, as = "TsSourceRange")]
+pub struct SourceRange([usize; 3]);
+
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Copy, Clone, ts_rs::TS, JsonSchema, Hash, Eq)]
+struct TsSourceRange(#[ts(type = "[number, number]")] [usize; 2]);
+
+impl From<[usize; 3]> for SourceRange {
+    fn from(value: [usize; 3]) -> Self {
+        Self(value)
+    }
+}
+
+impl From<SourceRange> for TsSourceRange {
+    fn from(value: SourceRange) -> Self {
+        Self([value.start(), value.end()])
+    }
+}
+
+impl From<&SourceRange> for miette::SourceSpan {
+    fn from(source_range: &SourceRange) -> Self {
+        let length = source_range.end() - source_range.start();
+        let start = miette::SourceOffset::from(source_range.start());
+        Self::new(start, length)
+    }
+}
+
+impl From<SourceRange> for miette::SourceSpan {
+    fn from(source_range: SourceRange) -> Self {
+        Self::from(&source_range)
+    }
+}
+
+impl SourceRange {
+    /// Create a new source range.
+    pub fn new(start: usize, end: usize, module_id: ModuleId) -> Self {
+        Self([start, end, module_id.as_usize()])
+    }
+
+    /// A source range that doesn't correspond to any source code.
+    pub fn synthetic() -> Self {
+        Self::default()
+    }
+
+    /// Get the start of the range.
+    pub fn start(&self) -> usize {
+        self.0[0]
+    }
+
+    /// Get the end of the range.
+    pub fn end(&self) -> usize {
+        self.0[1]
+    }
+
+    /// Get the module ID of the range.
+    pub fn module_id(&self) -> ModuleId {
+        ModuleId::from_usize(self.0[2])
+    }
+
+    /// Check if the range contains a position.
+    pub fn contains(&self, pos: usize) -> bool {
+        pos >= self.start() && pos <= self.end()
+    }
+
+    pub fn start_to_lsp_position(&self, code: &str) -> LspPosition {
+        // Calculate the line and column of the error from the source range.
+        // Lines are zero indexed in vscode so we need to subtract 1.
+        let mut line = code.get(..self.start()).unwrap_or_default().lines().count();
+        if line > 0 {
+            line = line.saturating_sub(1);
+        }
+        let column = code[..self.start()].lines().last().map(|l| l.len()).unwrap_or_default();
+
+        LspPosition {
+            line: line as u32,
+            character: column as u32,
+        }
+    }
+
+    pub fn end_to_lsp_position(&self, code: &str) -> LspPosition {
+        let lines = code.get(..self.end()).unwrap_or_default().lines();
+        if lines.clone().count() == 0 {
+            return LspPosition { line: 0, character: 0 };
+        }
+
+        // Calculate the line and column of the error from the source range.
+        // Lines are zero indexed in vscode so we need to subtract 1.
+        let line = lines.clone().count() - 1;
+        let column = lines.last().map(|l| l.len()).unwrap_or_default();
+
+        LspPosition {
+            line: line as u32,
+            character: column as u32,
+        }
+    }
+
+    pub fn to_lsp_range(&self, code: &str) -> LspRange {
+        let start = self.start_to_lsp_position(code);
+        let end = self.end_to_lsp_position(code);
+        LspRange { start, end }
+    }
+}

--- a/src/wasm-lib/kcl/src/std/array.rs
+++ b/src/wasm-lib/kcl/src/std/array.rs
@@ -6,8 +6,9 @@ use super::{
 };
 use crate::{
     errors::{KclError, KclErrorDetails},
-    executor::{ExecState, KclValue, SourceRange},
+    executor::{ExecState, KclValue},
     function_param::FunctionParam,
+    source_range::SourceRange,
 };
 
 /// Apply a function to each element of an array.

--- a/src/wasm-lib/kcl/src/std/patterns.rs
+++ b/src/wasm-lib/kcl/src/std/patterns.rs
@@ -16,17 +16,15 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use super::args::Arg;
 use crate::{
     errors::{KclError, KclErrorDetails},
-    executor::{
-        ExecState, Geometries, Geometry, KclValue, Point2d, Point3d, Sketch, SketchSet, Solid, SolidSet, SourceRange,
-    },
+    executor::{ExecState, Geometries, Geometry, KclValue, Point2d, Point3d, Sketch, SketchSet, Solid, SolidSet},
     function_param::FunctionParam,
     kcl_value::KclObjectFields,
     std::Args,
+    SourceRange,
 };
-
-use super::args::Arg;
 
 const MUST_HAVE_ONE_INSTANCE: &str = "There must be at least 1 instance of your geometry";
 

--- a/src/wasm-lib/kcl/src/std/sketch.rs
+++ b/src/wasm-lib/kcl/src/std/sketch.rs
@@ -12,8 +12,8 @@ use parse_display::{Display, FromStr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::ast::types::TagNode;
 use crate::{
+    ast::types::TagNode,
     errors::{KclError, KclErrorDetails},
     executor::{
         BasePath, ExecState, Face, GeoMeta, KclValue, Path, Plane, Point2d, Point3d, Sketch, SketchSet, SketchSurface,
@@ -2250,7 +2250,10 @@ mod tests {
 
     use pretty_assertions::assert_eq;
 
-    use crate::{executor::TagIdentifier, std::sketch::calculate_circle_center, std::sketch::PlaneData};
+    use crate::{
+        executor::TagIdentifier,
+        std::sketch::{calculate_circle_center, PlaneData},
+    };
 
     #[test]
     fn test_deserialize_plane_data() {

--- a/src/wasm-lib/kcl/src/std/utils.rs
+++ b/src/wasm-lib/kcl/src/std/utils.rs
@@ -4,7 +4,8 @@ use kittycad_modeling_cmds::shared::Angle;
 
 use crate::{
     errors::{KclError, KclErrorDetails},
-    executor::{Point2d, SourceRange},
+    executor::Point2d,
+    source_range::SourceRange,
 };
 
 /// Get the angle between these points
@@ -234,7 +235,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::{get_x_component, get_y_component, Angle};
-    use crate::executor::SourceRange;
+    use crate::SourceRange;
 
     static EACH_QUAD: [(i32, [i32; 2]); 12] = [
         (-315, [1, 1]),
@@ -354,7 +355,7 @@ mod tests {
             super::Point2d { x: -1.0, y: 1.0 },
             super::Point2d { x: -1.0, y: 0.0 },
             1.0,
-            SourceRange(Default::default()),
+            SourceRange::default(),
         )
         .unwrap();
         assert_eq!(angle_start.to_degrees().round(), 0.0);
@@ -365,7 +366,7 @@ mod tests {
             super::Point2d { x: -2.0, y: 0.0 },
             super::Point2d { x: -1.0, y: 0.0 },
             1.0,
-            SourceRange(Default::default()),
+            SourceRange::default(),
         )
         .unwrap();
         assert_eq!(angle_start.to_degrees().round(), 0.0);
@@ -376,7 +377,7 @@ mod tests {
             super::Point2d { x: -20.0, y: 0.0 },
             super::Point2d { x: -10.0, y: 0.0 },
             10.0,
-            SourceRange(Default::default()),
+            SourceRange::default(),
         )
         .unwrap();
         assert_eq!(angle_start.to_degrees().round(), 0.0);
@@ -387,7 +388,7 @@ mod tests {
             super::Point2d { x: 5.0, y: 5.0 },
             super::Point2d { x: 10.0, y: -10.0 },
             10.0,
-            SourceRange(Default::default()),
+            SourceRange::default(),
         );
 
         if let Err(err) = result {

--- a/src/wasm-lib/kcl/src/token/tokeniser.rs
+++ b/src/wasm-lib/kcl/src/token/tokeniser.rs
@@ -11,7 +11,7 @@ use winnow::{
 };
 
 use crate::{
-    ast::types::ModuleId,
+    source_range::ModuleId,
     token::{Token, TokenType},
 };
 

--- a/src/wasm-lib/kcl/src/unparser.rs
+++ b/src/wasm-lib/kcl/src/unparser.rs
@@ -683,7 +683,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
-    use crate::ast::types::{FormatOptions, ModuleId};
+    use crate::{ast::types::FormatOptions, source_range::ModuleId};
 
     #[test]
     fn test_recast_if_else_if_same() {

--- a/src/wasm-lib/kcl/src/walk/ast_node.rs
+++ b/src/wasm-lib/kcl/src/walk/ast_node.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast::types::{self, NodeRef},
-    executor::SourceRange,
+    source_range::SourceRange,
 };
 
 /// The "Node" type wraps all the AST elements we're able to find in a KCL
@@ -65,9 +65,9 @@ impl From<&Node<'_>> for SourceRange {
             Node::UnaryExpression(n) => SourceRange::from(*n),
             Node::Parameter(p) => SourceRange::from(&p.identifier),
             Node::ObjectProperty(n) => SourceRange::from(*n),
-            Node::MemberObject(m) => SourceRange([m.start(), m.end(), m.module_id().as_usize()]),
+            Node::MemberObject(m) => SourceRange::new(m.start(), m.end(), m.module_id()),
             Node::IfExpression(n) => SourceRange::from(*n),
-            Node::LiteralIdentifier(l) => SourceRange([l.start(), l.end(), l.module_id().as_usize()]),
+            Node::LiteralIdentifier(l) => SourceRange::new(l.start(), l.end(), l.module_id()),
         }
     }
 }


### PR DESCRIPTION
This is some initial refactoring of `SourceRange`. This PR just makes it better encapsulated, unfortunately it is leaked everywhere anyway due to the TypeScript and Python bindings, but we'll get there. Then we can optimise `SourceRange` and `Node` a bit.