### PR TITLE
Reduce Python API surface area to what is necessary for kcl.py

### DIFF
--- a/src/wasm-lib/kcl/src/ast/modify.rs
+++ b/src/wasm-lib/kcl/src/ast/modify.rs
@@ -6,11 +6,10 @@ use kcmc::{
 };
 use kittycad_modeling_cmds as kcmc;
 
-use super::types::Node;
 use crate::{
     ast::types::{
-        ArrayExpression, CallExpression, ConstraintLevel, FormatOptions, Literal, PipeExpression, PipeSubstitution,
-        VariableDeclarator,
+        ArrayExpression, CallExpression, ConstraintLevel, FormatOptions, Literal, Node, PipeExpression,
+        PipeSubstitution, VariableDeclarator,
     },
     engine::EngineManager,
     errors::{KclError, KclErrorDetails},

--- a/src/wasm-lib/kcl/src/ast/types.rs
+++ b/src/wasm-lib/kcl/src/ast/types.rs
@@ -541,7 +541,6 @@ impl Program {
 /// #!/usr/bin/env python
 /// ```
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Deserialize, Serialize, ts_rs::TS, JsonSchema, Bake)]
-#[cfg_attr(feature = "pyo3", pyo3::pyclass)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
 pub struct Shebang {
@@ -2936,7 +2935,6 @@ pub enum Hover {
 
 /// Format options.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
-#[cfg_attr(feature = "pyo3", pyo3::pyclass)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct FormatOptions {

--- a/src/wasm-lib/kcl/src/executor.rs
+++ b/src/wasm-lib/kcl/src/executor.rs
@@ -991,7 +991,6 @@ pub enum BodyType {
 /// Info about a module.  Right now, this is pretty minimal.  We hope to cache
 /// modules here in the future.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize, Serialize, ts_rs::TS, JsonSchema)]
-#[cfg_attr(feature = "pyo3", pyo3::pyclass)]
 #[ts(export)]
 pub struct ModuleInfo {
     /// The ID of the module.

--- a/src/wasm-lib/kcl/src/lint/rule.rs
+++ b/src/wasm-lib/kcl/src/lint/rule.rs
@@ -30,16 +30,16 @@ where
 #[serde(rename_all = "camelCase")]
 pub struct Discovered {
     /// Zoo Lint Finding information.
-    pub finding: Finding,
+    pub(super) finding: Finding,
 
     /// Further information about the specific finding.
-    pub description: String,
+    pub(super) description: String,
 
     /// Source code location.
-    pub pos: SourceRange,
+    pub(super) pos: SourceRange,
 
     /// Is this discovered issue overridden by the programmer?
-    pub overridden: bool,
+    pub(super) overridden: bool,
 }
 
 #[cfg(feature = "pyo3")]
@@ -56,8 +56,8 @@ impl Discovered {
     }
 
     #[getter]
-    pub fn pos(&self) -> SourceRange {
-        self.pos
+    pub fn pos(&self) -> (usize, usize) {
+        (self.pos.start(), self.pos.end())
     }
 
     #[getter]

--- a/src/wasm-lib/kcl/src/source_range.rs
+++ b/src/wasm-lib/kcl/src/source_range.rs
@@ -5,7 +5,6 @@ use tower_lsp::lsp_types::{Position as LspPosition, Range as LspRange};
 
 /// Identifier of a source file.  Uses a u32 to keep the size small.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize, ts_rs::TS, JsonSchema, Bake)]
-#[cfg_attr(feature = "pyo3", pyo3::pyclass)]
 #[databake(path = kcl_lib::ast::types)]
 #[ts(export)]
 pub struct ModuleId(u32);
@@ -26,9 +25,7 @@ impl ModuleId {
     }
 }
 
-// TODO Serialization and Python bindings expose the implementation of source ranges.
 #[derive(Debug, Default, Deserialize, Serialize, PartialEq, Copy, Clone, ts_rs::TS, JsonSchema, Hash, Eq)]
-#[cfg_attr(feature = "pyo3", pyo3::pyclass)]
 #[ts(export, as = "TsSourceRange")]
 pub struct SourceRange([usize; 3]);
 

--- a/src/wasm-lib/kcl/src/token.rs
+++ b/src/wasm-lib/kcl/src/token.rs
@@ -22,7 +22,6 @@ pub(crate) use tokeniser::RESERVED_WORDS;
 
 /// The types of tokens.
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Deserialize, Serialize, JsonSchema, FromStr, Display)]
-#[cfg_attr(feature = "pyo3", pyo3::pyclass(eq, eq_int))]
 #[serde(rename_all = "camelCase")]
 #[display(style = "camelCase")]
 pub enum TokenType {
@@ -159,7 +158,6 @@ impl TokenType {
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone)]
-#[cfg_attr(feature = "pyo3", pyo3::pyclass)]
 pub struct Token {
     #[serde(rename = "type")]
     pub token_type: TokenType,


### PR DESCRIPTION
I've tested locally that kcl.py still builds (annoyingly I ran nightly rustfmt, so there is some reordering of imports included here too, sorry).