### PR TITLE
Cleaner nightly release notes

### DIFF
--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - pierremtb/cleaner-nightly-release-notes
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   schedule:
@@ -15,8 +14,7 @@ on:
 
 env:
   IS_RELEASE: ${{ github.ref_type == 'tag' }}
-  # IS_NIGHTLY: ${{ github.event_name == 'schedule' }}
-  IS_NIGHTLY: true
+  IS_NIGHTLY: ${{ github.event_name == 'schedule' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -258,7 +256,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: write
-    # if: ${{ github.ref_type == 'tag' || github.event_name == 'schedule' }}
+    if: ${{ github.ref_type == 'tag' || github.event_name == 'schedule' }}
     env:
       VERSION_NO_V: ${{ needs.prepare-files.outputs.version }}
       VERSION: ${{ format('v{0}', needs.prepare-files.outputs.version) }}
@@ -315,10 +313,8 @@ jobs:
         env:
           NOTES: ${{ needs.prepare-files.outputs.notes }}
           PUB_DATE: ${{ github.event.repository.updated_at }}
-          # WEBSITE_DIR: ${{ github.event_name == 'schedule' && 'dl.zoo.dev/releases/modeling-app/nightly' || 'dl.zoo.dev/releases/modeling-app' }}
-          WEBSITE_DIR: ${{ 'dl.zoo.dev/releases/modeling-app/nightly' }}
-          # URL_CODED_NAME: ${{ github.event_name == 'schedule' && 'Zoo%20Modeling%20App%20%28Nightly%29' || 'Zoo%20Modeling%20App' }}
-          URL_CODED_NAME: ${{ 'Zoo%20Modeling%20App%20%28Nightly%29' }}
+          WEBSITE_DIR: ${{ github.event_name == 'schedule' && 'dl.zoo.dev/releases/modeling-app/nightly' || 'dl.zoo.dev/releases/modeling-app' }}
+          URL_CODED_NAME: ${{ github.event_name == 'schedule' && 'Zoo%20Modeling%20App%20%28Nightly%29' || 'Zoo%20Modeling%20App' }}
         run: |
           RELEASE_DIR=https://${WEBSITE_DIR}
           jq --null-input \
@@ -372,7 +368,7 @@ jobs:
           # Note: prefered going this way instead of a full clone in the checkout step,
           # see https://github.com/actions/checkout/issues/1471
           git fetch --prune --unshallow --tags
-          export TAG="nightly-v$VERSION"
+          export TAG="nightly-$VERSION"
           export PREVIOUS_TAG=$(git describe --tags --match="nightly-v[0-9]*" --abbrev=0)
           export NOTES=$(./scripts/get-nightly-changelog.sh)
           yarn files:set-notes

--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -368,7 +368,7 @@ jobs:
           # Note: prefered going this way instead of a full clone in the checkout step,
           # see https://github.com/actions/checkout/issues/1471
           git fetch --prune --unshallow --tags
-          export TAG="nightly-$VERSION"
+          export TAG="nightly-${VERSION}"
           export PREVIOUS_TAG=$(git describe --tags --match="nightly-v[0-9]*" --abbrev=0)
           export NOTES=$(./scripts/get-nightly-changelog.sh)
           yarn files:set-notes

--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - pierremtb/cleaner-nightly-release-notes
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   schedule:
@@ -14,7 +15,8 @@ on:
 
 env:
   IS_RELEASE: ${{ github.ref_type == 'tag' }}
-  IS_NIGHTLY: ${{ github.event_name == 'schedule' }}
+  # IS_NIGHTLY: ${{ github.event_name == 'schedule' }}
+  IS_NIGHTLY: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -256,7 +258,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: write
-    if: ${{ github.ref_type == 'tag' || github.event_name == 'schedule' }}
+    # if: ${{ github.ref_type == 'tag' || github.event_name == 'schedule' }}
     env:
       VERSION_NO_V: ${{ needs.prepare-files.outputs.version }}
       VERSION: ${{ format('v{0}', needs.prepare-files.outputs.version) }}
@@ -313,8 +315,10 @@ jobs:
         env:
           NOTES: ${{ needs.prepare-files.outputs.notes }}
           PUB_DATE: ${{ github.event.repository.updated_at }}
-          WEBSITE_DIR: ${{ github.event_name == 'schedule' && 'dl.zoo.dev/releases/modeling-app/nightly' || 'dl.zoo.dev/releases/modeling-app' }}
-          URL_CODED_NAME: ${{ github.event_name == 'schedule' && 'Zoo%20Modeling%20App%20%28Nightly%29' || 'Zoo%20Modeling%20App' }}
+          # WEBSITE_DIR: ${{ github.event_name == 'schedule' && 'dl.zoo.dev/releases/modeling-app/nightly' || 'dl.zoo.dev/releases/modeling-app' }}
+          WEBSITE_DIR: ${{ 'dl.zoo.dev/releases/modeling-app/nightly' }}
+          # URL_CODED_NAME: ${{ github.event_name == 'schedule' && 'Zoo%20Modeling%20App%20%28Nightly%29' || 'Zoo%20Modeling%20App' }}
+          URL_CODED_NAME: ${{ 'Zoo%20Modeling%20App%20%28Nightly%29' }}
         run: |
           RELEASE_DIR=https://${WEBSITE_DIR}
           jq --null-input \
@@ -361,6 +365,17 @@ jobs:
 
       - name: List artifacts
         run: "ls -R out"
+
+      - name: Set more complete nightly release notes
+        if: ${{ env.IS_NIGHTLY == 'true' }}
+        run: |
+          # Note: prefered going this way instead of a full clone in the checkout step,
+          # see https://github.com/actions/checkout/issues/1471
+          git fetch --prune --unshallow --tags
+          export TAG="nightly-v$VERSION"
+          export PREVIOUS_TAG=$(git describe --tags --match="nightly-v[0-9]*" --abbrev=0)
+          export NOTES=$(./scripts/get-nightly-changelog.sh)
+          yarn files:set-notes
 
       - name: Authenticate to Google Cloud
         if: ${{ env.IS_NIGHTLY == 'true' }}

--- a/scripts/flip-files-to-nightly.sh
+++ b/scripts/flip-files-to-nightly.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 export VERSION=$(date +'%-y.%-m.%-d')
-export TAG="nightly-v$VERSION"
-export PREVIOUS_TAG=$(git describe --tags --match="nightly-v[0-9]*" --abbrev=0)
 export COMMIT=$(git rev-parse --short HEAD)
 
 # package.json
@@ -15,7 +13,7 @@ yq -i '.publish[0].url = "https://dl.zoo.dev/releases/modeling-app/nightly"' ele
 yq -i '.appId = "dev.zoo.modeling-app-nightly"' electron-builder.yml
 
 # Release notes
-./scripts/get-nightly-changelog.sh > release-notes.md
+echo "Nightly build $VERSION (commit $COMMIT)" > release-notes.md
 
 # icons
 cp assets/icon-nightly.png assets/icon.png


### PR DESCRIPTION
Follow up to #4654. 
- Fixing the lack of pulling tags that caused the original bump https://github.com/KittyCAD/modeling-app/actions/runs/12173028479/job/33968763493
- Make things more consistent with the way we do things for release, changing the notes at publish times, reusing the `yarn files:set-notes` script. Successful in the manual push of 24.12.5 I did at https://github.com/KittyCAD/modeling-app/actions/runs/12179515583