### PR TITLE
AST: Allow unlabeled kw args

### DIFF
--- a/src/wasm-lib/justfile
+++ b/src/wasm-lib/justfile
@@ -15,7 +15,6 @@ redo-kcl-stdlib-docs:
     TWENTY_TWENTY=overwrite {{cnr}} -p kcl-lib kcl_test_example
     EXPECTORATE=overwrite {{cnr}} -p kcl-lib docs::gen_std_tests::test_generate_stdlib
 
-
 # Copy a test KCL file from executor tests into a new simulation test.
 copy-exec-test-into-sim-test test_name:
     mkdir -p kcl/tests/{{test_name}}

--- a/src/wasm-lib/kcl/src/parsing/ast/types/mod.rs
+++ b/src/wasm-lib/kcl/src/parsing/ast/types/mod.rs
@@ -2834,6 +2834,18 @@ impl Parameter {
     }
 }
 
+impl From<&Parameter> for SourceRange {
+    fn from(p: &Parameter) -> Self {
+        let sr = Self::from(&p.identifier);
+        // If it's unlabelled, the span should start 1 char earlier than the identifier,
+        // to include the '@' symbol.
+        if !p.labeled {
+            return Self::new(sr.start() - 1, sr.end(), sr.module_id());
+        }
+        sr
+    }
+}
+
 fn is_true(b: &bool) -> bool {
     *b
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__kw_function_decl_all_labeled.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__kw_function_decl_all_labeled.snap
@@ -1,0 +1,75 @@
+---
+source: kcl/src/parsing/parser.rs
+expression: actual
+snapshot_kind: text
+---
+{
+  "body": [
+    {
+      "declaration": {
+        "end": 25,
+        "id": {
+          "end": 6,
+          "name": "foo",
+          "start": 3,
+          "type": "Identifier"
+        },
+        "init": {
+          "body": {
+            "body": [
+              {
+                "argument": {
+                  "end": 23,
+                  "raw": "1",
+                  "start": 22,
+                  "type": "Literal",
+                  "type": "Literal",
+                  "value": 1.0
+                },
+                "end": 23,
+                "start": 15,
+                "type": "ReturnStatement",
+                "type": "ReturnStatement"
+              }
+            ],
+            "end": 25,
+            "start": 13
+          },
+          "end": 25,
+          "params": [
+            {
+              "type": "Parameter",
+              "identifier": {
+                "end": 8,
+                "name": "x",
+                "start": 7,
+                "type": "Identifier"
+              }
+            },
+            {
+              "type": "Parameter",
+              "identifier": {
+                "end": 11,
+                "name": "y",
+                "start": 10,
+                "type": "Identifier"
+              }
+            }
+          ],
+          "start": 6,
+          "type": "FunctionExpression",
+          "type": "FunctionExpression"
+        },
+        "start": 3,
+        "type": "VariableDeclarator"
+      },
+      "end": 25,
+      "kind": "fn",
+      "start": 0,
+      "type": "VariableDeclaration",
+      "type": "VariableDeclaration"
+    }
+  ],
+  "end": 25,
+  "start": 0
+}

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__kw_function_decl_first_unlabeled.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__kw_function_decl_first_unlabeled.snap
@@ -1,0 +1,76 @@
+---
+source: kcl/src/parsing/parser.rs
+expression: actual
+snapshot_kind: text
+---
+{
+  "body": [
+    {
+      "declaration": {
+        "end": 26,
+        "id": {
+          "end": 6,
+          "name": "foo",
+          "start": 3,
+          "type": "Identifier"
+        },
+        "init": {
+          "body": {
+            "body": [
+              {
+                "argument": {
+                  "end": 24,
+                  "raw": "1",
+                  "start": 23,
+                  "type": "Literal",
+                  "type": "Literal",
+                  "value": 1.0
+                },
+                "end": 24,
+                "start": 16,
+                "type": "ReturnStatement",
+                "type": "ReturnStatement"
+              }
+            ],
+            "end": 26,
+            "start": 14
+          },
+          "end": 26,
+          "params": [
+            {
+              "type": "Parameter",
+              "identifier": {
+                "end": 9,
+                "name": "x",
+                "start": 8,
+                "type": "Identifier"
+              },
+              "labeled": false
+            },
+            {
+              "type": "Parameter",
+              "identifier": {
+                "end": 12,
+                "name": "y",
+                "start": 11,
+                "type": "Identifier"
+              }
+            }
+          ],
+          "start": 6,
+          "type": "FunctionExpression",
+          "type": "FunctionExpression"
+        },
+        "start": 3,
+        "type": "VariableDeclarator"
+      },
+      "end": 26,
+      "kind": "fn",
+      "start": 0,
+      "type": "VariableDeclaration",
+      "type": "VariableDeclaration"
+    }
+  ],
+  "end": 26,
+  "start": 0
+}

--- a/src/wasm-lib/kcl/src/simulation_tests.rs
+++ b/src/wasm-lib/kcl/src/simulation_tests.rs
@@ -1481,3 +1481,24 @@ mod kittycad_svg {
         super::execute(TEST_NAME, true).await
     }
 }
+mod kw_fn {
+    const TEST_NAME: &str = "kw_fn";
+
+    /// Test parsing KCL.
+    #[test]
+    fn parse() {
+        super::parse(TEST_NAME)
+    }
+
+    /// Test that parsing and unparsing KCL produces the original KCL input.
+    #[test]
+    fn unparse() {
+        super::unparse(TEST_NAME)
+    }
+
+    /// Test that KCL is executed correctly.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn kcl_test_execute() {
+        super::execute(TEST_NAME, true).await
+    }
+}

--- a/src/wasm-lib/kcl/src/unparser.rs
+++ b/src/wasm-lib/kcl/src/unparser.rs
@@ -659,7 +659,11 @@ impl FunctionExpression {
 
 impl Parameter {
     pub fn recast(&self, options: &FormatOptions, indentation_level: usize) -> String {
-        let mut result = self.identifier.name.clone();
+        let mut result = format!(
+            "{}{}",
+            if self.labeled { "" } else { "@" },
+            self.identifier.name.clone()
+        );
         if let Some(ty) = &self.type_ {
             result += ": ";
             result += &ty.recast(options, indentation_level);

--- a/src/wasm-lib/kcl/tests/kw_fn/ast.snap
+++ b/src/wasm-lib/kcl/tests/kw_fn/ast.snap
@@ -1,0 +1,138 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Result of parsing kw_fn.kcl
+snapshot_kind: text
+---
+{
+  "Ok": {
+    "body": [
+      {
+        "declaration": {
+          "end": 35,
+          "id": {
+            "end": 12,
+            "name": "increment",
+            "start": 3,
+            "type": "Identifier"
+          },
+          "init": {
+            "body": {
+              "body": [
+                {
+                  "argument": {
+                    "end": 33,
+                    "left": {
+                      "end": 29,
+                      "name": "x",
+                      "start": 28,
+                      "type": "Identifier",
+                      "type": "Identifier"
+                    },
+                    "operator": "+",
+                    "right": {
+                      "end": 33,
+                      "raw": "1",
+                      "start": 32,
+                      "type": "Literal",
+                      "type": "Literal",
+                      "value": 1.0
+                    },
+                    "start": 28,
+                    "type": "BinaryExpression",
+                    "type": "BinaryExpression"
+                  },
+                  "end": 33,
+                  "start": 21,
+                  "type": "ReturnStatement",
+                  "type": "ReturnStatement"
+                }
+              ],
+              "end": 35,
+              "start": 17
+            },
+            "end": 35,
+            "params": [
+              {
+                "type": "Parameter",
+                "identifier": {
+                  "end": 15,
+                  "name": "x",
+                  "start": 14,
+                  "type": "Identifier"
+                },
+                "labeled": false
+              }
+            ],
+            "start": 12,
+            "type": "FunctionExpression",
+            "type": "FunctionExpression"
+          },
+          "start": 3,
+          "type": "VariableDeclarator"
+        },
+        "end": 35,
+        "kind": "fn",
+        "start": 0,
+        "type": "VariableDeclaration",
+        "type": "VariableDeclaration"
+      },
+      {
+        "declaration": {
+          "end": 55,
+          "id": {
+            "end": 40,
+            "name": "two",
+            "start": 37,
+            "type": "Identifier"
+          },
+          "init": {
+            "arguments": [
+              {
+                "end": 54,
+                "raw": "1",
+                "start": 53,
+                "type": "Literal",
+                "type": "Literal",
+                "value": 1.0
+              }
+            ],
+            "callee": {
+              "end": 52,
+              "name": "increment",
+              "start": 43,
+              "type": "Identifier"
+            },
+            "end": 55,
+            "start": 43,
+            "type": "CallExpression",
+            "type": "CallExpression"
+          },
+          "start": 37,
+          "type": "VariableDeclarator"
+        },
+        "end": 55,
+        "kind": "const",
+        "start": 37,
+        "type": "VariableDeclaration",
+        "type": "VariableDeclaration"
+      }
+    ],
+    "end": 56,
+    "nonCodeMeta": {
+      "nonCodeNodes": {
+        "0": [
+          {
+            "end": 37,
+            "start": 35,
+            "type": "NonCodeNode",
+            "value": {
+              "type": "newLine"
+            }
+          }
+        ]
+      },
+      "startNodes": []
+    },
+    "start": 0
+  }
+}

--- a/src/wasm-lib/kcl/tests/kw_fn/input.kcl
+++ b/src/wasm-lib/kcl/tests/kw_fn/input.kcl
@@ -1,0 +1,5 @@
+fn increment(@x) {
+  return x + 1
+}
+
+two = increment(1)

--- a/src/wasm-lib/kcl/tests/kw_fn/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/kw_fn/program_memory.snap
@@ -1,0 +1,150 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Program memory after executing kw_fn.kcl
+snapshot_kind: text
+---
+{
+  "environments": [
+    {
+      "bindings": {
+        "HALF_TURN": {
+          "type": "Number",
+          "value": 180.0,
+          "__meta": []
+        },
+        "QUARTER_TURN": {
+          "type": "Number",
+          "value": 90.0,
+          "__meta": []
+        },
+        "THREE_QUARTER_TURN": {
+          "type": "Number",
+          "value": 270.0,
+          "__meta": []
+        },
+        "ZERO": {
+          "type": "Number",
+          "value": 0.0,
+          "__meta": []
+        },
+        "increment": {
+          "type": "Function",
+          "expression": {
+            "body": {
+              "body": [
+                {
+                  "argument": {
+                    "end": 33,
+                    "left": {
+                      "end": 29,
+                      "name": "x",
+                      "start": 28,
+                      "type": "Identifier",
+                      "type": "Identifier"
+                    },
+                    "operator": "+",
+                    "right": {
+                      "end": 33,
+                      "raw": "1",
+                      "start": 32,
+                      "type": "Literal",
+                      "type": "Literal",
+                      "value": 1.0
+                    },
+                    "start": 28,
+                    "type": "BinaryExpression",
+                    "type": "BinaryExpression"
+                  },
+                  "end": 33,
+                  "start": 21,
+                  "type": "ReturnStatement",
+                  "type": "ReturnStatement"
+                }
+              ],
+              "end": 35,
+              "start": 17
+            },
+            "end": 35,
+            "params": [
+              {
+                "type": "Parameter",
+                "identifier": {
+                  "end": 15,
+                  "name": "x",
+                  "start": 14,
+                  "type": "Identifier"
+                },
+                "labeled": false
+              }
+            ],
+            "start": 12,
+            "type": "FunctionExpression"
+          },
+          "memory": {
+            "environments": [
+              {
+                "bindings": {
+                  "HALF_TURN": {
+                    "type": "Number",
+                    "value": 180.0,
+                    "__meta": []
+                  },
+                  "QUARTER_TURN": {
+                    "type": "Number",
+                    "value": 90.0,
+                    "__meta": []
+                  },
+                  "THREE_QUARTER_TURN": {
+                    "type": "Number",
+                    "value": 270.0,
+                    "__meta": []
+                  },
+                  "ZERO": {
+                    "type": "Number",
+                    "value": 0.0,
+                    "__meta": []
+                  }
+                },
+                "parent": null
+              }
+            ],
+            "currentEnv": 0,
+            "return": null
+          },
+          "__meta": [
+            {
+              "sourceRange": [
+                12,
+                35,
+                0
+              ]
+            }
+          ]
+        },
+        "two": {
+          "type": "Number",
+          "value": 2.0,
+          "__meta": [
+            {
+              "sourceRange": [
+                53,
+                54,
+                0
+              ]
+            },
+            {
+              "sourceRange": [
+                32,
+                33,
+                0
+              ]
+            }
+          ]
+        }
+      },
+      "parent": null
+    }
+  ],
+  "currentEnv": 0,
+  "return": null
+}


### PR DESCRIPTION
When declaring a function, its first parameter is allowed to be prefixed with `@`. This means that when users call this function, they don't have to label this argument.

Only the first parameter is allowed this prefix, no others.