### PR TITLE
KCL refactor: Fix argument names

### DIFF
--- a/src/wasm-lib/src/wasm.rs
+++ b/src/wasm-lib/src/wasm.rs
@@ -25,7 +25,7 @@ async fn read_old_ast_memory() -> Option<OldAstState> {
 // wasm_bindgen wrapper for execute
 #[wasm_bindgen]
 pub async fn execute_wasm(
-    program_str: &str,
+    program_ast_json: &str,
     program_memory_override_str: &str,
     units: &str,
     engine_manager: kcl_lib::wasm_engine::EngineCommandManager,
@@ -33,7 +33,7 @@ pub async fn execute_wasm(
 ) -> Result<JsValue, String> {
     console_error_panic_hook::set_once();
 
-    let program: Program = serde_json::from_str(program_str).map_err(|e| e.to_string())?;
+    let program: Program = serde_json::from_str(program_ast_json).map_err(|e| e.to_string())?;
     let program_memory_override: Option<kcl_lib::exec::ProgramMemory> =
         serde_json::from_str(program_memory_override_str).map_err(|e| e.to_string())?;
 
@@ -106,10 +106,10 @@ pub async fn execute_wasm(
 
 // wasm_bindgen wrapper for execute
 #[wasm_bindgen]
-pub async fn kcl_lint(program_str: &str) -> Result<JsValue, JsValue> {
+pub async fn kcl_lint(program_ast_json: &str) -> Result<JsValue, JsValue> {
     console_error_panic_hook::set_once();
 
-    let program: Program = serde_json::from_str(program_str).map_err(|e| e.to_string())?;
+    let program: Program = serde_json::from_str(program_ast_json).map_err(|e| e.to_string())?;
     let mut findings = vec![];
     for discovered_finding in program.lint_all().into_iter().flatten() {
         findings.push(discovered_finding);
@@ -160,14 +160,14 @@ pub async fn modify_grid(
 #[wasm_bindgen]
 pub async fn modify_ast_for_sketch_wasm(
     manager: kcl_lib::wasm_engine::EngineCommandManager,
-    program_str: &str,
+    program_ast_json: &str,
     sketch_name: &str,
     plane_type: &str,
     sketch_id: &str,
 ) -> Result<JsValue, String> {
     console_error_panic_hook::set_once();
 
-    let mut program: Program = serde_json::from_str(program_str).map_err(|e| e.to_string())?;
+    let mut program: Program = serde_json::from_str(program_ast_json).map_err(|e| e.to_string())?;
 
     let plane: kcl_lib::exec::PlaneType = serde_json::from_str(plane_type).map_err(|e| e.to_string())?;
 
@@ -214,10 +214,10 @@ pub fn deserialize_files(data: &[u8]) -> Result<JsValue, JsError> {
 }
 
 #[wasm_bindgen]
-pub fn parse_wasm(js: &str) -> Result<JsValue, String> {
+pub fn parse_wasm(kcl_program_source: &str) -> Result<JsValue, String> {
     console_error_panic_hook::set_once();
 
-    let (program, errs) = Program::parse(js).map_err(String::from)?;
+    let (program, errs) = Program::parse(kcl_program_source).map_err(String::from)?;
     // The serde-wasm-bindgen does not work here because of weird HashMap issues so we use the
     // gloo-serialize crate instead.
     JsValue::from_serde(&(program, errs)).map_err(|e| e.to_string())


### PR DESCRIPTION
Does not change behaviour. It just clarifies whether JS is passing a string containing KCL source code, or containing a JSON-stringified KCL AST.