### PR TITLE
Add some more warnings

### DIFF
--- a/src/wasm-lib/kcl/src/lsp/tests.rs
+++ b/src/wasm-lib/kcl/src/lsp/tests.rs
@@ -645,7 +645,7 @@ async fn test_kcl_lsp_completions() {
                 uri: "file:///test.kcl".try_into().unwrap(),
                 language_id: "kcl".to_string(),
                 version: 1,
-                text: r#"const thing= 1
+                text: r#"thing= 1
 st"#
                 .to_string(),
             },
@@ -688,7 +688,7 @@ async fn test_kcl_lsp_completions_empty_in_comment() {
                 uri: "file:///test.kcl".try_into().unwrap(),
                 language_id: "kcl".to_string(),
                 version: 1,
-                text: r#"const thing= 1 // st"#.to_string(),
+                text: r#"thing= 1 // st"#.to_string(),
             },
         })
         .await;
@@ -700,7 +700,7 @@ async fn test_kcl_lsp_completions_empty_in_comment() {
                 text_document: tower_lsp::lsp_types::TextDocumentIdentifier {
                     uri: "file:///test.kcl".try_into().unwrap(),
                 },
-                position: tower_lsp::lsp_types::Position { line: 0, character: 19 },
+                position: tower_lsp::lsp_types::Position { line: 0, character: 13 },
             },
             context: None,
             partial_result_params: Default::default(),
@@ -723,7 +723,7 @@ async fn test_kcl_lsp_completions_tags() {
                 uri: "file:///test.kcl".try_into().unwrap(),
                 language_id: "kcl".to_string(),
                 version: 1,
-                text: r#"const part001 = startSketchOn('XY')
+                text: r#"part001 = startSketchOn('XY')
   |> startProfileAt([11.19, 28.35], %)
   |> line([28.67, -13.25], %, $here)
   |> line([-4.12, -22.81], %)
@@ -1058,7 +1058,7 @@ async fn test_kcl_lsp_semantic_tokens_with_modifiers() {
                 uri: "file:///test.kcl".try_into().unwrap(),
                 language_id: "kcl".to_string(),
                 version: 1,
-                text: r#"const part001 = startSketchOn('XY')
+                text: r#"part001 = startSketchOn('XY')
   |> startProfileAt([-10, -10], %)
   |> line([20, 0], %)
   |> line([0, 20], %, $seg01)
@@ -1066,8 +1066,8 @@ async fn test_kcl_lsp_semantic_tokens_with_modifiers() {
   |> close(%)
   |> extrude(3.14, %)
 
-const thing = {blah: "foo"}
-const bar = thing.blah
+thing = {blah: "foo"}
+bar = thing.blah
 
 fn myFn = (param1) => {
     return param1
@@ -1230,7 +1230,7 @@ async fn test_kcl_lsp_semantic_tokens_multiple_comments() {
 // A ball bearing is a type of rolling-element bearing that uses balls to maintain the separation between the bearing races. The primary purpose of a ball bearing is to reduce rotational friction and support radial and axial loads. 
 
 // Define constants like ball diameter, inside diameter, overhange length, and thickness
-const sphereDia = 0.5"#
+sphereDia = 0.5"#
                     .to_string(),
             },
         })
@@ -1251,7 +1251,7 @@ const sphereDia = 0.5"#
 
     // Check the semantic tokens.
     if let tower_lsp::lsp_types::SemanticTokensResult::Tokens(semantic_tokens) = semantic_tokens {
-        assert_eq!(semantic_tokens.data.len(), 7);
+        assert_eq!(semantic_tokens.data.len(), 6);
         assert_eq!(semantic_tokens.data[0].length, 15);
         assert_eq!(semantic_tokens.data[0].delta_start, 0);
         assert_eq!(semantic_tokens.data[0].delta_line, 0);
@@ -1279,36 +1279,27 @@ const sphereDia = 0.5"#
                 .get_semantic_token_type_index(&SemanticTokenType::COMMENT)
                 .unwrap()
         );
-        assert_eq!(semantic_tokens.data[3].length, 5);
+        assert_eq!(semantic_tokens.data[3].length, 9);
         assert_eq!(semantic_tokens.data[3].delta_start, 0);
         assert_eq!(semantic_tokens.data[3].delta_line, 1);
         assert_eq!(
             semantic_tokens.data[3].token_type,
             server
-                .get_semantic_token_type_index(&SemanticTokenType::KEYWORD)
-                .unwrap()
-        );
-        assert_eq!(semantic_tokens.data[4].length, 9);
-        assert_eq!(semantic_tokens.data[4].delta_start, 6);
-        assert_eq!(semantic_tokens.data[4].delta_line, 0);
-        assert_eq!(
-            semantic_tokens.data[4].token_type,
-            server
                 .get_semantic_token_type_index(&SemanticTokenType::VARIABLE)
                 .unwrap()
         );
-        assert_eq!(semantic_tokens.data[5].length, 1);
-        assert_eq!(semantic_tokens.data[5].delta_start, 10);
+        assert_eq!(semantic_tokens.data[4].length, 1);
+        assert_eq!(semantic_tokens.data[4].delta_start, 10);
         assert_eq!(
-            semantic_tokens.data[5].token_type,
+            semantic_tokens.data[4].token_type,
             server
                 .get_semantic_token_type_index(&SemanticTokenType::OPERATOR)
                 .unwrap()
         );
-        assert_eq!(semantic_tokens.data[6].length, 3);
-        assert_eq!(semantic_tokens.data[6].delta_start, 2);
+        assert_eq!(semantic_tokens.data[5].length, 3);
+        assert_eq!(semantic_tokens.data[5].delta_start, 2);
         assert_eq!(
-            semantic_tokens.data[6].token_type,
+            semantic_tokens.data[5].token_type,
             server
                 .get_semantic_token_type_index(&SemanticTokenType::NUMBER)
                 .unwrap()
@@ -1329,7 +1320,7 @@ async fn test_kcl_lsp_document_symbol() {
                 uri: "file:///test.kcl".try_into().unwrap(),
                 language_id: "kcl".to_string(),
                 version: 1,
-                text: r#"const myVar = 1
+                text: r#"myVar = 1
 startSketchOn('XY')"#
                     .to_string(),
             },
@@ -1369,7 +1360,7 @@ async fn test_kcl_lsp_document_symbol_tag() {
                 uri: "file:///test.kcl".try_into().unwrap(),
                 language_id: "kcl".to_string(),
                 version: 1,
-                text: r#"const part001 = startSketchOn('XY')
+                text: r#"part001 = startSketchOn('XY')
   |> startProfileAt([11.19, 28.35], %)
   |> line([28.67, -13.25], %, $here)
   |> line([-4.12, -22.81], %)
@@ -1466,13 +1457,13 @@ async fn test_kcl_lsp_formatting_extra_parens() {
 // A ball bearing is a type of rolling-element bearing that uses balls to maintain the separation between the bearing races. The primary purpose of a ball bearing is to reduce rotational friction and support radial and axial loads. 
 
 // Define constants like ball diameter, inside diameter, overhange length, and thickness
-const sphereDia = 0.5
-const insideDia = 1
-const thickness = 0.25
-const overHangLength = .4
+sphereDia = 0.5
+insideDia = 1
+thickness = 0.25
+overHangLength = .4
 
 // Sketch and revolve the inside bearing piece
-const insideRevolve = startSketchOn('XZ')
+insideRevolve = startSketchOn('XZ')
   |> startProfileAt([insideDia / 2, 0], %)
   |> line([0, thickness + sphereDia / 2], %)
   |> line([overHangLength, 0], %)
@@ -1486,7 +1477,7 @@ const insideRevolve = startSketchOn('XZ')
   |> revolve({ axis: 'y' }, %)
 
 // Sketch and revolve one of the balls and duplicate it using a circular pattern. (This is currently a workaround, we have a bug with rotating on a sketch that touches the rotation axis)
-const sphere = startSketchOn('XZ')
+sphere = startSketchOn('XZ')
   |> startProfileAt([
        0.05 + insideDia / 2 + thickness,
        0 - 0.05
@@ -1508,7 +1499,7 @@ const sphere = startSketchOn('XZ')
      }, %)
 
 // Sketch and revolve the outside bearing
-const outsideRevolve = startSketchOn('XZ')
+outsideRevolve = startSketchOn('XZ')
   |> startProfileAt([
        insideDia / 2 + thickness + sphereDia,
        0
@@ -1638,7 +1629,7 @@ async fn test_kcl_lsp_rename() {
                 uri: "file:///test.kcl".try_into().unwrap(),
                 language_id: "kcl".to_string(),
                 version: 1,
-                text: r#"const thing= 1"#.to_string(),
+                text: r#"thing= 1"#.to_string(),
             },
         })
         .await;
@@ -1650,7 +1641,7 @@ async fn test_kcl_lsp_rename() {
                 text_document: tower_lsp::lsp_types::TextDocumentIdentifier {
                     uri: "file:///test.kcl".try_into().unwrap(),
                 },
-                position: tower_lsp::lsp_types::Position { line: 0, character: 8 },
+                position: tower_lsp::lsp_types::Position { line: 0, character: 2 },
             },
             new_name: "newName".to_string(),
             work_done_progress_params: Default::default(),
@@ -1667,7 +1658,7 @@ async fn test_kcl_lsp_rename() {
         vec![tower_lsp::lsp_types::TextEdit {
             range: tower_lsp::lsp_types::Range {
                 start: tower_lsp::lsp_types::Position { line: 0, character: 0 },
-                end: tower_lsp::lsp_types::Position { line: 0, character: 13 }
+                end: tower_lsp::lsp_types::Position { line: 0, character: 7 }
             },
             new_text: "newName = 1\n".to_string()
         }]
@@ -1773,7 +1764,7 @@ async fn test_kcl_lsp_diagnostic_has_lints() {
                 uri: "file:///testlint.kcl".try_into().unwrap(),
                 language_id: "kcl".to_string(),
                 version: 1,
-                text: r#"let THING = 10"#.to_string(),
+                text: r#"THING = 10"#.to_string(),
             },
         })
         .await;
@@ -1859,7 +1850,7 @@ async fn test_copilot_lsp_completions_raw() {
     let completions = server
         .get_completions(
             "kcl".to_string(),
-            r#"const bracket = startSketchOn('XY')
+            r#"bracket = startSketchOn('XY')
   |> startProfileAt([0, 0], %)
   "#
             .to_string(),
@@ -1878,7 +1869,7 @@ async fn test_copilot_lsp_completions_raw() {
     let completions_hit_cache = server
         .get_completions(
             "kcl".to_string(),
-            r#"const bracket = startSketchOn('XY')
+            r#"bracket = startSketchOn('XY')
   |> startProfileAt([0, 0], %)
   "#
             .to_string(),
@@ -1918,7 +1909,7 @@ async fn test_copilot_lsp_completions() {
             path: "file:///test.copilot".to_string(),
             position: crate::lsp::copilot::types::CopilotPosition { line: 3, character: 3 },
             relative_path: "test.copilot".to_string(),
-            source: r#"const bracket = startSketchOn('XY')
+            source: r#"bracket = startSketchOn('XY')
   |> startProfileAt([0, 0], %)
   
   |> close(%)
@@ -2066,7 +2057,7 @@ async fn test_lsp_initialized() {
 async fn test_kcl_lsp_on_change_update_ast() {
     let server = kcl_lsp_server(false).await.unwrap();
 
-    let same_text = r#"const thing = 1"#.to_string();
+    let same_text = r#"thing = 1"#.to_string();
 
     // Send open file.
     server
@@ -2102,7 +2093,7 @@ async fn test_kcl_lsp_on_change_update_ast() {
     assert_eq!(ast, server.ast_map.get("file:///test.kcl").unwrap().clone());
 
     // Update the text.
-    let new_text = r#"const thing = 2"#.to_string();
+    let new_text = r#"thing = 2"#.to_string();
     // Send change file.
     server
         .did_change(tower_lsp::lsp_types::DidChangeTextDocumentParams {
@@ -2128,7 +2119,7 @@ async fn test_kcl_lsp_on_change_update_ast() {
 async fn kcl_test_kcl_lsp_on_change_update_memory() {
     let server = kcl_lsp_server(true).await.unwrap();
 
-    let same_text = r#"const thing = 1"#.to_string();
+    let same_text = r#"thing = 1"#.to_string();
 
     // Send open file.
     server
@@ -2164,7 +2155,7 @@ async fn kcl_test_kcl_lsp_on_change_update_memory() {
     assert_eq!(memory, server.memory_map.get("file:///test.kcl").unwrap().clone());
 
     // Update the text.
-    let new_text = r#"const thing = 2"#.to_string();
+    let new_text = r#"thing = 2"#.to_string();
     // Send change file.
     server
         .did_change(tower_lsp::lsp_types::DidChangeTextDocumentParams {
@@ -2188,7 +2179,7 @@ async fn kcl_test_kcl_lsp_update_units() {
     let server = kcl_lsp_server(true).await.unwrap();
 
     let same_text = r#"fn cube = (pos, scale) => {
-  const sg = startSketchOn('XY')
+  sg = startSketchOn('XY')
     |> startProfileAt(pos, %)
     |> line([0, scale], %)
     |> line([scale, 0], %)
@@ -2196,7 +2187,7 @@ async fn kcl_test_kcl_lsp_update_units() {
 
   return sg
 }
-const part001 = cube([0,0], 20)
+part001 = cube([0,0], 20)
     |> close(%)
     |> extrude(20, %)"#
         .to_string();
@@ -2215,7 +2206,7 @@ const part001 = cube([0,0], 20)
 
     // Get the tokens.
     let tokens = server.token_map.get("file:///test.kcl").unwrap().clone();
-    assert_eq!(tokens.len(), 124);
+    assert_eq!(tokens.len(), 120);
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
@@ -2305,7 +2296,7 @@ async fn test_kcl_lsp_diagnostics_on_parse_error() {
     assert_diagnostic_count(server.diagnostics_map.get("file:///test.kcl").as_deref(), 1);
 
     // Update the text.
-    let new_text = r#"const thing = 2"#.to_string();
+    let new_text = r#"thing = 2"#.to_string();
     // Send change file.
     server
         .did_change(tower_lsp::lsp_types::DidChangeTextDocumentParams {
@@ -2336,7 +2327,7 @@ async fn kcl_test_kcl_lsp_diagnostics_on_execution_error() {
                 uri: "file:///test.kcl".try_into().unwrap(),
                 language_id: "kcl".to_string(),
                 version: 1,
-                text: r#"const part001 = startSketchOn('XY')
+                text: r#"part001 = startSketchOn('XY')
   |> startProfileAt([-10, -10], %)
   |> line([20, 0], %)
   |> line([0, 20], %)
@@ -2356,7 +2347,7 @@ async fn kcl_test_kcl_lsp_diagnostics_on_execution_error() {
     assert_diagnostic_count(server.diagnostics_map.get("file:///test.kcl").as_deref(), 1);
 
     // Update the text.
-    let new_text = r#"const part001 = startSketchOn('XY')
+    let new_text = r#"part001 = startSketchOn('XY')
   |> startProfileAt([-10, -10], %)
   |> line([20, 0], %)
   |> line([0, 20], %)
@@ -2394,7 +2385,7 @@ async fn kcl_test_kcl_lsp_full_to_empty_file_updates_ast_and_memory() {
                 uri: "file:///test.kcl".try_into().unwrap(),
                 language_id: "kcl".to_string(),
                 version: 1,
-                text: r#"const part001 = startSketchOn('XY')
+                text: r#"part001 = startSketchOn('XY')
   |> startProfileAt([-10, -10], %)
   |> line([20, 0], %)
   |> line([0, 20], %)
@@ -2443,7 +2434,7 @@ async fn kcl_test_kcl_lsp_full_to_empty_file_updates_ast_and_memory() {
 async fn kcl_test_kcl_lsp_code_unchanged_but_has_diagnostics_reexecute() {
     let server = kcl_lsp_server(true).await.unwrap();
 
-    let code = r#"const part001 = startSketchOn('XY')
+    let code = r#"part001 = startSketchOn('XY')
   |> startProfileAt([-10, -10], %)
   |> line([20, 0], %)
   |> line([0, 20], %)
@@ -2536,7 +2527,7 @@ async fn kcl_test_kcl_lsp_code_unchanged_but_has_diagnostics_reexecute() {
 async fn kcl_test_kcl_lsp_code_and_ast_unchanged_but_has_diagnostics_reexecute() {
     let server = kcl_lsp_server(true).await.unwrap();
 
-    let code = r#"const part001 = startSketchOn('XY')
+    let code = r#"part001 = startSketchOn('XY')
   |> startProfileAt([-10, -10], %)
   |> line([20, 0], %)
   |> line([0, 20], %)
@@ -2624,7 +2615,7 @@ async fn kcl_test_kcl_lsp_code_and_ast_unchanged_but_has_diagnostics_reexecute()
 async fn kcl_test_kcl_lsp_code_and_ast_units_unchanged_but_has_diagnostics_reexecute_on_unit_change() {
     let server = kcl_lsp_server(true).await.unwrap();
 
-    let code = r#"const part001 = startSketchOn('XY')
+    let code = r#"part001 = startSketchOn('XY')
   |> startProfileAt([-10, -10], %)
   |> line([20, 0], %)
   |> line([0, 20], %)
@@ -2715,7 +2706,7 @@ async fn kcl_test_kcl_lsp_code_and_ast_units_unchanged_but_has_diagnostics_reexe
 async fn kcl_test_kcl_lsp_code_and_ast_units_unchanged_but_has_memory_reexecute_on_unit_change() {
     let server = kcl_lsp_server(true).await.unwrap();
 
-    let code = r#"const part001 = startSketchOn('XY')
+    let code = r#"part001 = startSketchOn('XY')
   |> startProfileAt([-10, -10], %)
   |> line([20, 0], %)
   |> line([0, 20], %)
@@ -2785,7 +2776,7 @@ async fn kcl_test_kcl_lsp_code_and_ast_units_unchanged_but_has_memory_reexecute_
 async fn kcl_test_kcl_lsp_cant_execute_set() {
     let server = kcl_lsp_server(true).await.unwrap();
 
-    let code = r#"const part001 = startSketchOn('XY')
+    let code = r#"part001 = startSketchOn('XY')
   |> startProfileAt([-10, -10], %)
   |> line([20, 0], %)
   |> line([0, 20], %)
@@ -2982,7 +2973,7 @@ async fn test_kcl_lsp_folding() {
 async fn kcl_test_kcl_lsp_code_with_parse_error_and_ast_unchanged_but_has_diagnostics_reparse() {
     let server = kcl_lsp_server(false).await.unwrap();
 
-    let code = r#"const part001 = startSketchOn('XY')
+    let code = r#"part001 = startSketchOn('XY')
   |> startProfileAt([-10, -10], %)
   |> line([20, 0], %)
   |> line([0, 20], %)
@@ -3036,8 +3027,8 @@ async fn kcl_test_kcl_lsp_code_with_parse_error_and_ast_unchanged_but_has_diagno
 async fn kcl_test_kcl_lsp_code_with_lint_and_ast_unchanged_but_has_diagnostics_reparse() {
     let server = kcl_lsp_server(false).await.unwrap();
 
-    let code = r#"const LINT = 1
-const part001 = startSketchOn('XY')
+    let code = r#"LINT = 1
+part001 = startSketchOn('XY')
   |> startProfileAt([-10, -10], %)
   |> line([20, 0], %)
   |> line([0, 20], %)
@@ -3090,8 +3081,8 @@ const part001 = startSketchOn('XY')
 async fn kcl_test_kcl_lsp_code_with_lint_and_parse_error_and_ast_unchanged_but_has_diagnostics_reparse() {
     let server = kcl_lsp_server(false).await.unwrap();
 
-    let code = r#"const LINT = 1
-const part001 = startSketchOn('XY')
+    let code = r#"LINT = 1
+part001 = startSketchOn('XY')
   |> startProfileAt([-10, -10], %)
   |> line([20, 0], %)
   |> line([0, 20], %)
@@ -3145,8 +3136,8 @@ const part001 = startSketchOn('XY')
 async fn kcl_test_kcl_lsp_code_lint_and_ast_unchanged_but_has_diagnostics_reexecute() {
     let server = kcl_lsp_server(true).await.unwrap();
 
-    let code = r#"const LINT = 1
-const part001 = startSketchOn('XY')
+    let code = r#"LINT = 1
+part001 = startSketchOn('XY')
   |> startProfileAt([-10, -10], %)
   |> line([20, 0], %)
   |> line([0, 20], %, $seg01)
@@ -3210,8 +3201,8 @@ const part001 = startSketchOn('XY')
 async fn kcl_test_kcl_lsp_code_lint_reexecute_new_lint() {
     let server = kcl_lsp_server(true).await.unwrap();
 
-    let code = r#"const LINT = 1
-const part001 = startSketchOn('XY')
+    let code = r#"LINT = 1
+part001 = startSketchOn('XY')
   |> startProfileAt([-10, -10], %)
   |> line([20, 0], %)
   |> line([0, 20], %, $seg01)
@@ -3253,14 +3244,14 @@ const part001 = startSketchOn('XY')
             content_changes: vec![tower_lsp::lsp_types::TextDocumentContentChangeEvent {
                 range: None,
                 range_length: None,
-                text: r#"const part001 = startSketchOn('XY')
+                text: r#"part001 = startSketchOn('XY')
   |> startProfileAt([-10, -10], %)
   |> line([20, 0], %)
   |> line([0, 20], %, $seg01)
   |> line([-20, 0], %, $seg01)
   |> close(%)
   |> extrude(3.14, %)
-const NEW_LINT = 1"#
+NEW_LINT = 1"#
                     .to_string(),
             }],
         })
@@ -3283,8 +3274,8 @@ const NEW_LINT = 1"#
 async fn kcl_test_kcl_lsp_code_lint_reexecute_new_ast_error() {
     let server = kcl_lsp_server(true).await.unwrap();
 
-    let code = r#"const LINT = 1
-const part001 = startSketchOn('XY')
+    let code = r#"LINT = 1
+part001 = startSketchOn('XY')
   |> startProfileAt([-10, -10], %)
   |> line([20, 0], %)
   |> line([0, 20], %, $seg01)
@@ -3326,14 +3317,14 @@ const part001 = startSketchOn('XY')
             content_changes: vec![tower_lsp::lsp_types::TextDocumentContentChangeEvent {
                 range: None,
                 range_length: None,
-                text: r#"const part001 = startSketchOn('XY')
+                text: r#"part001 = startSketchOn('XY')
   |> ^^^^startProfileAt([-10, -10], %)
   |> line([20, 0], %)
   |> line([0, 20], %, $seg01)
   |> line([-20, 0], %, $seg01)
   |> close(%)
   |> extrude(3.14, %)
-const NEW_LINT = 1"#
+NEW_LINT = 1"#
                     .to_string(),
             }],
         })
@@ -3356,8 +3347,8 @@ const NEW_LINT = 1"#
 async fn kcl_test_kcl_lsp_code_lint_reexecute_had_lint_new_parse_error() {
     let server = kcl_lsp_server(true).await.unwrap();
 
-    let code = r#"const LINT = 1
-const part001 = startSketchOn('XY')
+    let code = r#"LINT = 1
+part001 = startSketchOn('XY')
   |> startProfileAt([-10, -10], %)
   |> line([20, 0], %)
   |> line([0, 20], %)
@@ -3408,14 +3399,14 @@ const part001 = startSketchOn('XY')
             content_changes: vec![tower_lsp::lsp_types::TextDocumentContentChangeEvent {
                 range: None,
                 range_length: None,
-                text: r#"const part001 = startSketchOn('XY')
+                text: r#"part001 = startSketchOn('XY')
   |> ^^^^startProfileAt([-10, -10], %)
   |> line([20, 0], %)
   |> line([0, 20], %)
   |> line([-20, 0], %)
   |> close(%)
   |> extrude(3.14, %)
-const NEW_LINT = 1"#
+NEW_LINT = 1"#
                     .to_string(),
             }],
         })
@@ -3447,8 +3438,8 @@ const NEW_LINT = 1"#
 async fn kcl_test_kcl_lsp_code_lint_reexecute_had_lint_new_execution_error() {
     let server = kcl_lsp_server(true).await.unwrap();
 
-    let code = r#"const LINT = 1
-const part001 = startSketchOn('XY')
+    let code = r#"LINT = 1
+part001 = startSketchOn('XY')
   |> startProfileAt([-10, -10], %)
   |> line([20, 0], %)
   |> line([0, 20], %)
@@ -3503,8 +3494,8 @@ const part001 = startSketchOn('XY')
             content_changes: vec![tower_lsp::lsp_types::TextDocumentContentChangeEvent {
                 range: None,
                 range_length: None,
-                text: r#"const LINT = 1
-const part001 = startSketchOn('XY')
+                text: r#"LINT = 1
+part001 = startSketchOn('XY')
   |> startProfileAt([-10, -10], %)
   |> line([20, 0], %, $seg01)
   |> line([0, 20], %, $seg01)
@@ -3552,7 +3543,7 @@ async fn kcl_test_kcl_lsp_completions_number_literal() {
                 uri: "file:///test.kcl".try_into().unwrap(),
                 language_id: "kcl".to_string(),
                 version: 1,
-                text: "const thing = 10".to_string(),
+                text: "thing = 10".to_string(),
             },
         })
         .await;
@@ -3563,7 +3554,7 @@ async fn kcl_test_kcl_lsp_completions_number_literal() {
                 text_document: tower_lsp::lsp_types::TextDocumentIdentifier {
                     uri: "file:///test.kcl".try_into().unwrap(),
                 },
-                position: tower_lsp::lsp_types::Position { line: 0, character: 15 },
+                position: tower_lsp::lsp_types::Position { line: 0, character: 10 },
             },
             context: None,
             partial_result_params: Default::default(),

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__a.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__a.snap
@@ -6,11 +6,11 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 143,
+        "end": 137,
         "id": {
-          "end": 15,
+          "end": 9,
           "name": "boxSketch",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
@@ -20,36 +20,36 @@ expression: actual
                 {
                   "elements": [
                     {
-                      "end": 34,
+                      "end": 28,
                       "raw": "0",
-                      "start": 33,
+                      "start": 27,
                       "type": "Literal",
                       "type": "Literal",
                       "value": 0.0
                     },
                     {
-                      "end": 37,
+                      "end": 31,
                       "raw": "0",
-                      "start": 36,
+                      "start": 30,
                       "type": "Literal",
                       "type": "Literal",
                       "value": 0.0
                     }
                   ],
-                  "end": 38,
-                  "start": 32,
+                  "end": 32,
+                  "start": 26,
                   "type": "ArrayExpression",
                   "type": "ArrayExpression"
                 }
               ],
               "callee": {
-                "end": 31,
+                "end": 25,
                 "name": "startSketchAt",
-                "start": 18,
+                "start": 12,
                 "type": "Identifier"
               },
-              "end": 39,
-              "start": 18,
+              "end": 33,
+              "start": 12,
               "type": "CallExpression",
               "type": "CallExpression"
             },
@@ -58,42 +58,42 @@ expression: actual
                 {
                   "elements": [
                     {
-                      "end": 54,
+                      "end": 48,
                       "raw": "0",
-                      "start": 53,
+                      "start": 47,
                       "type": "Literal",
                       "type": "Literal",
                       "value": 0.0
                     },
                     {
-                      "end": 58,
+                      "end": 52,
                       "raw": "10",
-                      "start": 56,
+                      "start": 50,
                       "type": "Literal",
                       "type": "Literal",
                       "value": 10.0
                     }
                   ],
-                  "end": 59,
-                  "start": 52,
+                  "end": 53,
+                  "start": 46,
                   "type": "ArrayExpression",
                   "type": "ArrayExpression"
                 },
                 {
-                  "end": 62,
-                  "start": 61,
+                  "end": 56,
+                  "start": 55,
                   "type": "PipeSubstitution",
                   "type": "PipeSubstitution"
                 }
               ],
               "callee": {
-                "end": 51,
+                "end": 45,
                 "name": "line",
-                "start": 47,
+                "start": 41,
                 "type": "Identifier"
               },
-              "end": 63,
-              "start": 47,
+              "end": 57,
+              "start": 41,
               "type": "CallExpression",
               "type": "CallExpression"
             },
@@ -103,48 +103,48 @@ expression: actual
                   "elements": [
                     {
                       "argument": {
-                        "end": 88,
+                        "end": 82,
                         "raw": "5",
-                        "start": 87,
+                        "start": 81,
                         "type": "Literal",
                         "type": "Literal",
                         "value": 5.0
                       },
-                      "end": 88,
+                      "end": 82,
                       "operator": "-",
-                      "start": 86,
+                      "start": 80,
                       "type": "UnaryExpression",
                       "type": "UnaryExpression"
                     },
                     {
-                      "end": 91,
+                      "end": 85,
                       "raw": "5",
-                      "start": 90,
+                      "start": 84,
                       "type": "Literal",
                       "type": "Literal",
                       "value": 5.0
                     }
                   ],
-                  "end": 92,
-                  "start": 85,
+                  "end": 86,
+                  "start": 79,
                   "type": "ArrayExpression",
                   "type": "ArrayExpression"
                 },
                 {
-                  "end": 95,
-                  "start": 94,
+                  "end": 89,
+                  "start": 88,
                   "type": "PipeSubstitution",
                   "type": "PipeSubstitution"
                 }
               ],
               "callee": {
-                "end": 84,
+                "end": 78,
                 "name": "tangentialArc",
-                "start": 71,
+                "start": 65,
                 "type": "Identifier"
               },
-              "end": 96,
-              "start": 71,
+              "end": 90,
+              "start": 65,
               "type": "CallExpression",
               "type": "CallExpression"
             },
@@ -153,96 +153,96 @@ expression: actual
                 {
                   "elements": [
                     {
-                      "end": 111,
+                      "end": 105,
                       "raw": "5",
-                      "start": 110,
+                      "start": 104,
                       "type": "Literal",
                       "type": "Literal",
                       "value": 5.0
                     },
                     {
                       "argument": {
-                        "end": 116,
+                        "end": 110,
                         "raw": "15",
-                        "start": 114,
+                        "start": 108,
                         "type": "Literal",
                         "type": "Literal",
                         "value": 15.0
                       },
-                      "end": 116,
+                      "end": 110,
                       "operator": "-",
-                      "start": 113,
+                      "start": 107,
                       "type": "UnaryExpression",
                       "type": "UnaryExpression"
                     }
                   ],
-                  "end": 117,
-                  "start": 109,
+                  "end": 111,
+                  "start": 103,
                   "type": "ArrayExpression",
                   "type": "ArrayExpression"
                 },
                 {
-                  "end": 120,
-                  "start": 119,
+                  "end": 114,
+                  "start": 113,
                   "type": "PipeSubstitution",
                   "type": "PipeSubstitution"
                 }
               ],
               "callee": {
-                "end": 108,
+                "end": 102,
                 "name": "line",
-                "start": 104,
+                "start": 98,
                 "type": "Identifier"
               },
-              "end": 121,
-              "start": 104,
+              "end": 115,
+              "start": 98,
               "type": "CallExpression",
               "type": "CallExpression"
             },
             {
               "arguments": [
                 {
-                  "end": 139,
+                  "end": 133,
                   "raw": "10",
-                  "start": 137,
+                  "start": 131,
                   "type": "Literal",
                   "type": "Literal",
                   "value": 10.0
                 },
                 {
-                  "end": 142,
-                  "start": 141,
+                  "end": 136,
+                  "start": 135,
                   "type": "PipeSubstitution",
                   "type": "PipeSubstitution"
                 }
               ],
               "callee": {
-                "end": 136,
+                "end": 130,
                 "name": "extrude",
-                "start": 129,
+                "start": 123,
                 "type": "Identifier"
               },
-              "end": 143,
-              "start": 129,
+              "end": 137,
+              "start": 123,
               "type": "CallExpression",
               "type": "CallExpression"
             }
           ],
-          "end": 143,
-          "start": 18,
+          "end": 137,
+          "start": 12,
           "type": "PipeExpression",
           "type": "PipeExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 143,
+      "end": 137,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 144,
+  "end": 138,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__aa.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__aa.snap
@@ -6,37 +6,37 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 17,
+        "end": 11,
         "id": {
-          "end": 8,
+          "end": 2,
           "name": "sg",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
           "argument": {
-            "end": 17,
+            "end": 11,
             "name": "scale",
-            "start": 12,
+            "start": 6,
             "type": "Identifier",
             "type": "Identifier"
           },
-          "end": 17,
+          "end": 11,
           "operator": "-",
-          "start": 11,
+          "start": 5,
           "type": "UnaryExpression",
           "type": "UnaryExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 17,
+      "end": 11,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 17,
+  "end": 11,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__ac.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__ac.snap
@@ -6,29 +6,29 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 23,
+        "end": 17,
         "id": {
-          "end": 13,
+          "end": 7,
           "name": "myArray",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
-          "end": 23,
+          "end": 17,
           "endElement": {
-            "end": 22,
+            "end": 16,
             "raw": "10",
-            "start": 20,
+            "start": 14,
             "type": "Literal",
             "type": "Literal",
             "value": 10.0
           },
           "endInclusive": true,
-          "start": 16,
+          "start": 10,
           "startElement": {
-            "end": 18,
+            "end": 12,
             "raw": "0",
-            "start": 17,
+            "start": 11,
             "type": "Literal",
             "type": "Literal",
             "value": 0.0
@@ -36,16 +36,16 @@ expression: actual
           "type": "ArrayRangeExpression",
           "type": "ArrayRangeExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 23,
+      "end": 17,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 23,
+  "end": 17,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__af.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__af.snap
@@ -6,11 +6,11 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 165,
+        "end": 159,
         "id": {
-          "end": 14,
+          "end": 8,
           "name": "mySketch",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
@@ -20,36 +20,36 @@ expression: actual
                 {
                   "elements": [
                     {
-                      "end": 33,
+                      "end": 27,
                       "raw": "0",
-                      "start": 32,
+                      "start": 26,
                       "type": "Literal",
                       "type": "Literal",
                       "value": 0.0
                     },
                     {
-                      "end": 35,
+                      "end": 29,
                       "raw": "0",
-                      "start": 34,
+                      "start": 28,
                       "type": "Literal",
                       "type": "Literal",
                       "value": 0.0
                     }
                   ],
-                  "end": 36,
-                  "start": 31,
+                  "end": 30,
+                  "start": 25,
                   "type": "ArrayExpression",
                   "type": "ArrayExpression"
                 }
               ],
               "callee": {
-                "end": 30,
+                "end": 24,
                 "name": "startSketchAt",
-                "start": 17,
+                "start": 11,
                 "type": "Identifier"
               },
-              "end": 37,
-              "start": 17,
+              "end": 31,
+              "start": 11,
               "type": "CallExpression",
               "type": "CallExpression"
             },
@@ -58,49 +58,49 @@ expression: actual
                 {
                   "elements": [
                     {
-                      "end": 58,
+                      "end": 52,
                       "raw": "0",
-                      "start": 57,
+                      "start": 51,
                       "type": "Literal",
                       "type": "Literal",
                       "value": 0.0
                     },
                     {
-                      "end": 61,
+                      "end": 55,
                       "raw": "1",
-                      "start": 60,
+                      "start": 54,
                       "type": "Literal",
                       "type": "Literal",
                       "value": 1.0
                     }
                   ],
-                  "end": 62,
-                  "start": 56,
+                  "end": 56,
+                  "start": 50,
                   "type": "ArrayExpression",
                   "type": "ArrayExpression"
                 },
                 {
-                  "end": 65,
-                  "start": 64,
+                  "end": 59,
+                  "start": 58,
                   "type": "PipeSubstitution",
                   "type": "PipeSubstitution"
                 },
                 {
-                  "end": 74,
-                  "start": 67,
+                  "end": 68,
+                  "start": 61,
                   "type": "TagDeclarator",
                   "type": "TagDeclarator",
                   "value": "myPath"
                 }
               ],
               "callee": {
-                "end": 55,
+                "end": 49,
                 "name": "lineTo",
-                "start": 49,
+                "start": 43,
                 "type": "Identifier"
               },
-              "end": 75,
-              "start": 49,
+              "end": 69,
+              "start": 43,
               "type": "CallExpression",
               "type": "CallExpression"
             },
@@ -109,42 +109,42 @@ expression: actual
                 {
                   "elements": [
                     {
-                      "end": 96,
+                      "end": 90,
                       "raw": "1",
-                      "start": 95,
+                      "start": 89,
                       "type": "Literal",
                       "type": "Literal",
                       "value": 1.0
                     },
                     {
-                      "end": 99,
+                      "end": 93,
                       "raw": "1",
-                      "start": 98,
+                      "start": 92,
                       "type": "Literal",
                       "type": "Literal",
                       "value": 1.0
                     }
                   ],
-                  "end": 100,
-                  "start": 94,
+                  "end": 94,
+                  "start": 88,
                   "type": "ArrayExpression",
                   "type": "ArrayExpression"
                 },
                 {
-                  "end": 103,
-                  "start": 102,
+                  "end": 97,
+                  "start": 96,
                   "type": "PipeSubstitution",
                   "type": "PipeSubstitution"
                 }
               ],
               "callee": {
-                "end": 93,
+                "end": 87,
                 "name": "lineTo",
-                "start": 87,
+                "start": 81,
                 "type": "Identifier"
               },
-              "end": 104,
-              "start": 87,
+              "end": 98,
+              "start": 81,
               "type": "CallExpression",
               "type": "CallExpression"
             },
@@ -153,88 +153,88 @@ expression: actual
                 {
                   "elements": [
                     {
-                      "end": 125,
+                      "end": 119,
                       "raw": "1",
-                      "start": 124,
+                      "start": 118,
                       "type": "Literal",
                       "type": "Literal",
                       "value": 1.0
                     },
                     {
-                      "end": 128,
+                      "end": 122,
                       "raw": "0",
-                      "start": 127,
+                      "start": 121,
                       "type": "Literal",
                       "type": "Literal",
                       "value": 0.0
                     }
                   ],
-                  "end": 129,
-                  "start": 123,
+                  "end": 123,
+                  "start": 117,
                   "type": "ArrayExpression",
                   "type": "ArrayExpression"
                 },
                 {
-                  "end": 132,
-                  "start": 131,
+                  "end": 126,
+                  "start": 125,
                   "type": "PipeSubstitution",
                   "type": "PipeSubstitution"
                 },
                 {
-                  "end": 144,
-                  "start": 134,
+                  "end": 138,
+                  "start": 128,
                   "type": "TagDeclarator",
                   "type": "TagDeclarator",
                   "value": "rightPath"
                 }
               ],
               "callee": {
-                "end": 122,
+                "end": 116,
                 "name": "lineTo",
-                "start": 116,
+                "start": 110,
                 "type": "Identifier"
               },
-              "end": 145,
-              "start": 116,
+              "end": 139,
+              "start": 110,
               "type": "CallExpression",
               "type": "CallExpression"
             },
             {
               "arguments": [
                 {
-                  "end": 164,
-                  "start": 163,
+                  "end": 158,
+                  "start": 157,
                   "type": "PipeSubstitution",
                   "type": "PipeSubstitution"
                 }
               ],
               "callee": {
-                "end": 162,
+                "end": 156,
                 "name": "close",
-                "start": 157,
+                "start": 151,
                 "type": "Identifier"
               },
-              "end": 165,
-              "start": 157,
+              "end": 159,
+              "start": 151,
               "type": "CallExpression",
               "type": "CallExpression"
             }
           ],
-          "end": 165,
-          "start": 17,
+          "end": 159,
+          "start": 11,
           "type": "PipeExpression",
           "type": "PipeExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 165,
+      "end": 159,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 165,
+  "end": 159,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__ag.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__ag.snap
@@ -6,11 +6,11 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 70,
+        "end": 64,
         "id": {
-          "end": 14,
+          "end": 8,
           "name": "mySketch",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
@@ -20,36 +20,36 @@ expression: actual
                 {
                   "elements": [
                     {
-                      "end": 33,
+                      "end": 27,
                       "raw": "0",
-                      "start": 32,
+                      "start": 26,
                       "type": "Literal",
                       "type": "Literal",
                       "value": 0.0
                     },
                     {
-                      "end": 35,
+                      "end": 29,
                       "raw": "0",
-                      "start": 34,
+                      "start": 28,
                       "type": "Literal",
                       "type": "Literal",
                       "value": 0.0
                     }
                   ],
-                  "end": 36,
-                  "start": 31,
+                  "end": 30,
+                  "start": 25,
                   "type": "ArrayExpression",
                   "type": "ArrayExpression"
                 }
               ],
               "callee": {
-                "end": 30,
+                "end": 24,
                 "name": "startSketchAt",
-                "start": 17,
+                "start": 11,
                 "type": "Identifier"
               },
-              "end": 37,
-              "start": 17,
+              "end": 31,
+              "start": 11,
               "type": "CallExpression",
               "type": "CallExpression"
             },
@@ -58,81 +58,81 @@ expression: actual
                 {
                   "elements": [
                     {
-                      "end": 50,
+                      "end": 44,
                       "raw": "1",
-                      "start": 49,
+                      "start": 43,
                       "type": "Literal",
                       "type": "Literal",
                       "value": 1.0
                     },
                     {
-                      "end": 53,
+                      "end": 47,
                       "raw": "1",
-                      "start": 52,
+                      "start": 46,
                       "type": "Literal",
                       "type": "Literal",
                       "value": 1.0
                     }
                   ],
-                  "end": 54,
-                  "start": 48,
+                  "end": 48,
+                  "start": 42,
                   "type": "ArrayExpression",
                   "type": "ArrayExpression"
                 },
                 {
-                  "end": 57,
-                  "start": 56,
+                  "end": 51,
+                  "start": 50,
                   "type": "PipeSubstitution",
                   "type": "PipeSubstitution"
                 }
               ],
               "callee": {
-                "end": 47,
+                "end": 41,
                 "name": "lineTo",
-                "start": 41,
+                "start": 35,
                 "type": "Identifier"
               },
-              "end": 58,
-              "start": 41,
+              "end": 52,
+              "start": 35,
               "type": "CallExpression",
               "type": "CallExpression"
             },
             {
               "arguments": [
                 {
-                  "end": 69,
-                  "start": 68,
+                  "end": 63,
+                  "start": 62,
                   "type": "PipeSubstitution",
                   "type": "PipeSubstitution"
                 }
               ],
               "callee": {
-                "end": 67,
+                "end": 61,
                 "name": "close",
-                "start": 62,
+                "start": 56,
                 "type": "Identifier"
               },
-              "end": 70,
-              "start": 62,
+              "end": 64,
+              "start": 56,
               "type": "CallExpression",
               "type": "CallExpression"
             }
           ],
-          "end": 70,
-          "start": 17,
+          "end": 64,
+          "start": 11,
           "type": "PipeExpression",
           "type": "PipeExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 70,
+      "end": 64,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 70,
+  "end": 64,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__ah.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__ah.snap
@@ -6,44 +6,44 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 30,
+        "end": 24,
         "id": {
-          "end": 11,
+          "end": 5,
           "name": "myBox",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
           "arguments": [
             {
-              "end": 29,
+              "end": 23,
               "name": "p",
-              "start": 28,
+              "start": 22,
               "type": "Identifier",
               "type": "Identifier"
             }
           ],
           "callee": {
-            "end": 27,
+            "end": 21,
             "name": "startSketchAt",
-            "start": 14,
+            "start": 8,
             "type": "Identifier"
           },
-          "end": 30,
-          "start": 14,
+          "end": 24,
+          "start": 8,
           "type": "CallExpression",
           "type": "CallExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 30,
+      "end": 24,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 30,
+  "end": 24,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__ai.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__ai.snap
@@ -6,11 +6,11 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 29,
+        "end": 23,
         "id": {
-          "end": 11,
+          "end": 5,
           "name": "myBox",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
@@ -18,69 +18,69 @@ expression: actual
             {
               "arguments": [
                 {
-                  "end": 17,
+                  "end": 11,
                   "raw": "1",
-                  "start": 16,
+                  "start": 10,
                   "type": "Literal",
                   "type": "Literal",
                   "value": 1.0
                 }
               ],
               "callee": {
-                "end": 15,
+                "end": 9,
                 "name": "f",
-                "start": 14,
+                "start": 8,
                 "type": "Identifier"
               },
-              "end": 18,
-              "start": 14,
+              "end": 12,
+              "start": 8,
               "type": "CallExpression",
               "type": "CallExpression"
             },
             {
               "arguments": [
                 {
-                  "end": 25,
+                  "end": 19,
                   "raw": "2",
-                  "start": 24,
+                  "start": 18,
                   "type": "Literal",
                   "type": "Literal",
                   "value": 2.0
                 },
                 {
-                  "end": 28,
-                  "start": 27,
+                  "end": 22,
+                  "start": 21,
                   "type": "PipeSubstitution",
                   "type": "PipeSubstitution"
                 }
               ],
               "callee": {
-                "end": 23,
+                "end": 17,
                 "name": "g",
-                "start": 22,
+                "start": 16,
                 "type": "Identifier"
               },
-              "end": 29,
-              "start": 22,
+              "end": 23,
+              "start": 16,
               "type": "CallExpression",
               "type": "CallExpression"
             }
           ],
-          "end": 29,
-          "start": 14,
+          "end": 23,
+          "start": 8,
           "type": "PipeExpression",
           "type": "PipeExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 29,
+      "end": 23,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 29,
+  "end": 23,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__aj.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__aj.snap
@@ -6,11 +6,11 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 49,
+        "end": 43,
         "id": {
-          "end": 11,
+          "end": 5,
           "name": "myBox",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
@@ -18,21 +18,21 @@ expression: actual
             {
               "arguments": [
                 {
-                  "end": 29,
+                  "end": 23,
                   "name": "p",
-                  "start": 28,
+                  "start": 22,
                   "type": "Identifier",
                   "type": "Identifier"
                 }
               ],
               "callee": {
-                "end": 27,
+                "end": 21,
                 "name": "startSketchAt",
-                "start": 14,
+                "start": 8,
                 "type": "Identifier"
               },
-              "end": 30,
-              "start": 14,
+              "end": 24,
+              "start": 8,
               "type": "CallExpression",
               "type": "CallExpression"
             },
@@ -41,60 +41,60 @@ expression: actual
                 {
                   "elements": [
                     {
-                      "end": 41,
+                      "end": 35,
                       "raw": "0",
-                      "start": 40,
+                      "start": 34,
                       "type": "Literal",
                       "type": "Literal",
                       "value": 0.0
                     },
                     {
-                      "end": 44,
+                      "end": 38,
                       "name": "l",
-                      "start": 43,
+                      "start": 37,
                       "type": "Identifier",
                       "type": "Identifier"
                     }
                   ],
-                  "end": 45,
-                  "start": 39,
+                  "end": 39,
+                  "start": 33,
                   "type": "ArrayExpression",
                   "type": "ArrayExpression"
                 },
                 {
-                  "end": 48,
-                  "start": 47,
+                  "end": 42,
+                  "start": 41,
                   "type": "PipeSubstitution",
                   "type": "PipeSubstitution"
                 }
               ],
               "callee": {
-                "end": 38,
+                "end": 32,
                 "name": "line",
-                "start": 34,
+                "start": 28,
                 "type": "Identifier"
               },
-              "end": 49,
-              "start": 34,
+              "end": 43,
+              "start": 28,
               "type": "CallExpression",
               "type": "CallExpression"
             }
           ],
-          "end": 49,
-          "start": 14,
+          "end": 43,
+          "start": 8,
           "type": "PipeExpression",
           "type": "PipeExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 49,
+      "end": 43,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 49,
+  "end": 43,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__ap.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__ap.snap
@@ -6,11 +6,11 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 37,
+        "end": 31,
         "id": {
-          "end": 14,
+          "end": 8,
           "name": "mySketch",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
@@ -18,49 +18,49 @@ expression: actual
             {
               "elements": [
                 {
-                  "end": 33,
+                  "end": 27,
                   "raw": "0",
-                  "start": 32,
+                  "start": 26,
                   "type": "Literal",
                   "type": "Literal",
                   "value": 0.0
                 },
                 {
-                  "end": 35,
+                  "end": 29,
                   "raw": "0",
-                  "start": 34,
+                  "start": 28,
                   "type": "Literal",
                   "type": "Literal",
                   "value": 0.0
                 }
               ],
-              "end": 36,
-              "start": 31,
+              "end": 30,
+              "start": 25,
               "type": "ArrayExpression",
               "type": "ArrayExpression"
             }
           ],
           "callee": {
-            "end": 30,
+            "end": 24,
             "name": "startSketchAt",
-            "start": 17,
+            "start": 11,
             "type": "Identifier"
           },
-          "end": 37,
-          "start": 17,
+          "end": 31,
+          "start": 11,
           "type": "CallExpression",
           "type": "CallExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 37,
+      "end": 31,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 37,
+  "end": 31,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__b.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__b.snap
@@ -6,19 +6,19 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 36,
+        "end": 30,
         "id": {
-          "end": 11,
+          "end": 5,
           "name": "myVar",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
           "arguments": [
             {
-              "end": 19,
+              "end": 13,
               "raw": "5",
-              "start": 18,
+              "start": 12,
               "type": "Literal",
               "type": "Literal",
               "value": 5.0
@@ -27,61 +27,61 @@ expression: actual
               "argument": {
                 "arguments": [
                   {
-                    "end": 31,
+                    "end": 25,
                     "raw": "5",
-                    "start": 30,
+                    "start": 24,
                     "type": "Literal",
                     "type": "Literal",
                     "value": 5.0
                   },
                   {
-                    "end": 34,
+                    "end": 28,
                     "raw": "4",
-                    "start": 33,
+                    "start": 27,
                     "type": "Literal",
                     "type": "Literal",
                     "value": 4.0
                   }
                 ],
                 "callee": {
-                  "end": 29,
+                  "end": 23,
                   "name": "legLen",
-                  "start": 23,
+                  "start": 17,
                   "type": "Identifier"
                 },
-                "end": 35,
-                "start": 23,
+                "end": 29,
+                "start": 17,
                 "type": "CallExpression",
                 "type": "CallExpression"
               },
-              "end": 35,
+              "end": 29,
               "operator": "-",
-              "start": 22,
+              "start": 16,
               "type": "UnaryExpression",
               "type": "UnaryExpression"
             }
           ],
           "callee": {
-            "end": 17,
+            "end": 11,
             "name": "min",
-            "start": 14,
+            "start": 8,
             "type": "Identifier"
           },
-          "end": 36,
-          "start": 14,
+          "end": 30,
+          "start": 8,
           "type": "CallExpression",
           "type": "CallExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 36,
+      "end": 30,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 36,
+  "end": 30,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__ba.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__ba.snap
@@ -6,11 +6,11 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 132,
+        "end": 126,
         "id": {
-          "end": 16,
+          "end": 10,
           "name": "sketch001",
-          "start": 7,
+          "start": 1,
           "type": "Identifier"
         },
         "init": {
@@ -18,53 +18,53 @@ expression: actual
             {
               "arguments": [
                 {
-                  "end": 37,
+                  "end": 31,
                   "raw": "'XY'",
-                  "start": 33,
+                  "start": 27,
                   "type": "Literal",
                   "type": "Literal",
                   "value": "XY"
                 }
               ],
               "callee": {
-                "end": 32,
+                "end": 26,
                 "name": "startSketchOn",
-                "start": 19,
+                "start": 13,
                 "type": "Identifier"
               },
-              "end": 38,
-              "start": 19,
+              "end": 32,
+              "start": 13,
               "type": "CallExpression",
               "type": "CallExpression"
             },
             {
               "arguments": [
                 {
-                  "end": 131,
-                  "start": 130,
+                  "end": 125,
+                  "start": 124,
                   "type": "PipeSubstitution",
                   "type": "PipeSubstitution"
                 }
               ],
               "callee": {
-                "end": 129,
+                "end": 123,
                 "name": "startProfileAt",
-                "start": 115,
+                "start": 109,
                 "type": "Identifier"
               },
-              "end": 132,
-              "start": 115,
+              "end": 126,
+              "start": 109,
               "type": "CallExpression",
               "type": "CallExpression"
             }
           ],
-          "end": 132,
+          "end": 126,
           "nonCodeMeta": {
             "nonCodeNodes": {
               "0": [
                 {
-                  "end": 52,
-                  "start": 41,
+                  "end": 46,
+                  "start": 35,
                   "type": "NonCodeNode",
                   "value": {
                     "type": "blockComment",
@@ -73,8 +73,8 @@ expression: actual
                   }
                 },
                 {
-                  "end": 74,
-                  "start": 55,
+                  "end": 68,
+                  "start": 49,
                   "type": "NonCodeNode",
                   "value": {
                     "type": "blockComment",
@@ -83,8 +83,8 @@ expression: actual
                   }
                 },
                 {
-                  "end": 98,
-                  "start": 77,
+                  "end": 92,
+                  "start": 71,
                   "type": "NonCodeNode",
                   "value": {
                     "type": "blockComment",
@@ -93,8 +93,8 @@ expression: actual
                   }
                 },
                 {
-                  "end": 109,
-                  "start": 101,
+                  "end": 103,
+                  "start": 95,
                   "type": "NonCodeNode",
                   "value": {
                     "type": "blockComment",
@@ -106,20 +106,20 @@ expression: actual
             },
             "startNodes": []
           },
-          "start": 19,
+          "start": 13,
           "type": "PipeExpression",
           "type": "PipeExpression"
         },
-        "start": 7,
+        "start": 1,
         "type": "VariableDeclarator"
       },
-      "end": 132,
+      "end": 126,
       "kind": "const",
       "start": 1,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 133,
+  "end": 127,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__bb.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__bb.snap
@@ -6,91 +6,91 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 31,
+        "end": 25,
         "id": {
-          "end": 11,
+          "end": 5,
           "name": "my14",
-          "start": 7,
+          "start": 1,
           "type": "Identifier"
         },
         "init": {
-          "end": 31,
+          "end": 25,
           "left": {
-            "end": 19,
+            "end": 13,
             "left": {
-              "end": 15,
+              "end": 9,
               "raw": "4",
-              "start": 14,
+              "start": 8,
               "type": "Literal",
               "type": "Literal",
               "value": 4.0
             },
             "operator": "^",
             "right": {
-              "end": 19,
+              "end": 13,
               "raw": "2",
-              "start": 18,
+              "start": 12,
               "type": "Literal",
               "type": "Literal",
               "value": 2.0
             },
-            "start": 14,
+            "start": 8,
             "type": "BinaryExpression",
             "type": "BinaryExpression"
           },
           "operator": "-",
           "right": {
-            "end": 31,
+            "end": 25,
             "left": {
-              "end": 27,
+              "end": 21,
               "left": {
-                "end": 23,
+                "end": 17,
                 "raw": "3",
-                "start": 22,
+                "start": 16,
                 "type": "Literal",
                 "type": "Literal",
                 "value": 3.0
               },
               "operator": "^",
               "right": {
-                "end": 27,
+                "end": 21,
                 "raw": "2",
-                "start": 26,
+                "start": 20,
                 "type": "Literal",
                 "type": "Literal",
                 "value": 2.0
               },
-              "start": 22,
+              "start": 16,
               "type": "BinaryExpression",
               "type": "BinaryExpression"
             },
             "operator": "*",
             "right": {
-              "end": 31,
+              "end": 25,
               "raw": "2",
-              "start": 30,
+              "start": 24,
               "type": "Literal",
               "type": "Literal",
               "value": 2.0
             },
-            "start": 22,
+            "start": 16,
             "type": "BinaryExpression",
             "type": "BinaryExpression"
           },
-          "start": 14,
+          "start": 8,
           "type": "BinaryExpression",
           "type": "BinaryExpression"
         },
-        "start": 7,
+        "start": 1,
         "type": "VariableDeclarator"
       },
-      "end": 31,
+      "end": 25,
       "kind": "const",
       "start": 1,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 32,
+  "end": 26,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__bc.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__bc.snap
@@ -6,79 +6,79 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 74,
+        "end": 68,
         "id": {
-          "end": 7,
+          "end": 1,
           "name": "x",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
           "cond": {
-            "end": 17,
+            "end": 11,
             "raw": "true",
-            "start": 13,
+            "start": 7,
             "type": "Literal",
             "type": "Literal",
             "value": true
           },
           "digest": null,
           "else_ifs": [],
-          "end": 74,
+          "end": 68,
           "final_else": {
             "body": [
               {
-                "end": 64,
+                "end": 58,
                 "expression": {
-                  "end": 64,
+                  "end": 58,
                   "raw": "4",
-                  "start": 63,
+                  "start": 57,
                   "type": "Literal",
                   "type": "Literal",
                   "value": 4.0
                 },
-                "start": 63,
+                "start": 57,
                 "type": "ExpressionStatement",
                 "type": "ExpressionStatement"
               }
             ],
-            "end": 73,
-            "start": 63
+            "end": 67,
+            "start": 57
           },
-          "start": 10,
+          "start": 4,
           "then_val": {
             "body": [
               {
-                "end": 33,
+                "end": 27,
                 "expression": {
-                  "end": 33,
+                  "end": 27,
                   "raw": "3",
-                  "start": 32,
+                  "start": 26,
                   "type": "Literal",
                   "type": "Literal",
                   "value": 3.0
                 },
-                "start": 32,
+                "start": 26,
                 "type": "ExpressionStatement",
                 "type": "ExpressionStatement"
               }
             ],
-            "end": 42,
-            "start": 32
+            "end": 36,
+            "start": 26
           },
           "type": "IfExpression",
           "type": "IfExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 74,
+      "end": 68,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 74,
+  "end": 68,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__bd.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__bd.snap
@@ -6,18 +6,18 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 121,
+        "end": 115,
         "id": {
-          "end": 7,
+          "end": 1,
           "name": "x",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
           "cond": {
-            "end": 17,
+            "end": 11,
             "raw": "true",
-            "start": 13,
+            "start": 7,
             "type": "Literal",
             "type": "Literal",
             "value": true
@@ -28,105 +28,105 @@ expression: actual
               "cond": {
                 "arguments": [
                   {
-                    "end": 63,
+                    "end": 57,
                     "name": "radius",
-                    "start": 57,
+                    "start": 51,
                     "type": "Identifier",
                     "type": "Identifier"
                   }
                 ],
                 "callee": {
-                  "end": 56,
+                  "end": 50,
                   "name": "func",
-                  "start": 52,
+                  "start": 46,
                   "type": "Identifier"
                 },
-                "end": 64,
-                "start": 52,
+                "end": 58,
+                "start": 46,
                 "type": "CallExpression",
                 "type": "CallExpression"
               },
               "digest": null,
-              "end": 90,
-              "start": 44,
+              "end": 84,
+              "start": 38,
               "then_val": {
                 "body": [
                   {
-                    "end": 80,
+                    "end": 74,
                     "expression": {
-                      "end": 80,
+                      "end": 74,
                       "raw": "4",
-                      "start": 79,
+                      "start": 73,
                       "type": "Literal",
                       "type": "Literal",
                       "value": 4.0
                     },
-                    "start": 79,
+                    "start": 73,
                     "type": "ExpressionStatement",
                     "type": "ExpressionStatement"
                   }
                 ],
-                "end": 89,
-                "start": 65
+                "end": 83,
+                "start": 59
               },
               "type": "ElseIf"
             }
           ],
-          "end": 121,
+          "end": 115,
           "final_else": {
             "body": [
               {
-                "end": 111,
+                "end": 105,
                 "expression": {
-                  "end": 111,
+                  "end": 105,
                   "raw": "5",
-                  "start": 110,
+                  "start": 104,
                   "type": "Literal",
                   "type": "Literal",
                   "value": 5.0
                 },
-                "start": 110,
+                "start": 104,
                 "type": "ExpressionStatement",
                 "type": "ExpressionStatement"
               }
             ],
-            "end": 120,
-            "start": 110
+            "end": 114,
+            "start": 104
           },
-          "start": 10,
+          "start": 4,
           "then_val": {
             "body": [
               {
-                "end": 33,
+                "end": 27,
                 "expression": {
-                  "end": 33,
+                  "end": 27,
                   "raw": "3",
-                  "start": 32,
+                  "start": 26,
                   "type": "Literal",
                   "type": "Literal",
                   "value": 3.0
                 },
-                "start": 32,
+                "start": 26,
                 "type": "ExpressionStatement",
                 "type": "ExpressionStatement"
               }
             ],
-            "end": 42,
-            "start": 32
+            "end": 36,
+            "start": 26
           },
           "type": "IfExpression",
           "type": "IfExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 121,
+      "end": 115,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 121,
+  "end": 115,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__bh.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__bh.snap
@@ -6,85 +6,85 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 42,
+        "end": 36,
         "id": {
-          "end": 9,
+          "end": 3,
           "name": "obj",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
-          "end": 42,
+          "end": 36,
           "properties": [
             {
-              "end": 30,
+              "end": 24,
               "key": {
-                "end": 19,
+                "end": 13,
                 "name": "center",
-                "start": 13,
+                "start": 7,
                 "type": "Identifier"
               },
-              "start": 13,
+              "start": 7,
               "type": "ObjectProperty",
               "value": {
                 "elements": [
                   {
-                    "end": 25,
+                    "end": 19,
                     "raw": "10",
-                    "start": 23,
+                    "start": 17,
                     "type": "Literal",
                     "type": "Literal",
                     "value": 10.0
                   },
                   {
-                    "end": 29,
+                    "end": 23,
                     "raw": "10",
-                    "start": 27,
+                    "start": 21,
                     "type": "Literal",
                     "type": "Literal",
                     "value": 10.0
                   }
                 ],
-                "end": 30,
-                "start": 22,
+                "end": 24,
+                "start": 16,
                 "type": "ArrayExpression",
                 "type": "ArrayExpression"
               }
             },
             {
-              "end": 41,
+              "end": 35,
               "key": {
-                "end": 38,
+                "end": 32,
                 "name": "radius",
-                "start": 32,
+                "start": 26,
                 "type": "Identifier"
               },
-              "start": 32,
+              "start": 26,
               "type": "ObjectProperty",
               "value": {
-                "end": 41,
+                "end": 35,
                 "raw": "5",
-                "start": 40,
+                "start": 34,
                 "type": "Literal",
                 "type": "Literal",
                 "value": 5.0
               }
             }
           ],
-          "start": 12,
+          "start": 6,
           "type": "ObjectExpression",
           "type": "ObjectExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 42,
+      "end": 36,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 42,
+  "end": 36,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__c.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__c.snap
@@ -6,11 +6,11 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 35,
+        "end": 29,
         "id": {
-          "end": 11,
+          "end": 5,
           "name": "myVar",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
@@ -19,69 +19,69 @@ expression: actual
               "argument": {
                 "arguments": [
                   {
-                    "end": 27,
+                    "end": 21,
                     "raw": "5",
-                    "start": 26,
+                    "start": 20,
                     "type": "Literal",
                     "type": "Literal",
                     "value": 5.0
                   },
                   {
-                    "end": 30,
+                    "end": 24,
                     "raw": "4",
-                    "start": 29,
+                    "start": 23,
                     "type": "Literal",
                     "type": "Literal",
                     "value": 4.0
                   }
                 ],
                 "callee": {
-                  "end": 25,
+                  "end": 19,
                   "name": "legLen",
-                  "start": 19,
+                  "start": 13,
                   "type": "Identifier"
                 },
-                "end": 31,
-                "start": 19,
+                "end": 25,
+                "start": 13,
                 "type": "CallExpression",
                 "type": "CallExpression"
               },
-              "end": 31,
+              "end": 25,
               "operator": "-",
-              "start": 18,
+              "start": 12,
               "type": "UnaryExpression",
               "type": "UnaryExpression"
             },
             {
-              "end": 34,
+              "end": 28,
               "raw": "5",
-              "start": 33,
+              "start": 27,
               "type": "Literal",
               "type": "Literal",
               "value": 5.0
             }
           ],
           "callee": {
-            "end": 17,
+            "end": 11,
             "name": "min",
-            "start": 14,
+            "start": 8,
             "type": "Identifier"
           },
-          "end": 35,
-          "start": 14,
+          "end": 29,
+          "start": 8,
           "type": "CallExpression",
           "type": "CallExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 35,
+      "end": 29,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 35,
+  "end": 29,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__d.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__d.snap
@@ -6,82 +6,82 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 36,
+        "end": 30,
         "id": {
-          "end": 11,
+          "end": 5,
           "name": "myVar",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
           "body": [
             {
-              "end": 19,
+              "end": 13,
               "left": {
-                "end": 15,
+                "end": 9,
                 "raw": "5",
-                "start": 14,
+                "start": 8,
                 "type": "Literal",
                 "type": "Literal",
                 "value": 5.0
               },
               "operator": "+",
               "right": {
-                "end": 19,
+                "end": 13,
                 "raw": "6",
-                "start": 18,
+                "start": 12,
                 "type": "Literal",
                 "type": "Literal",
                 "value": 6.0
               },
-              "start": 14,
+              "start": 8,
               "type": "BinaryExpression",
               "type": "BinaryExpression"
             },
             {
               "arguments": [
                 {
-                  "end": 32,
+                  "end": 26,
                   "raw": "45",
-                  "start": 30,
+                  "start": 24,
                   "type": "Literal",
                   "type": "Literal",
                   "value": 45.0
                 },
                 {
-                  "end": 35,
-                  "start": 34,
+                  "end": 29,
+                  "start": 28,
                   "type": "PipeSubstitution",
                   "type": "PipeSubstitution"
                 }
               ],
               "callee": {
-                "end": 29,
+                "end": 23,
                 "name": "myFunc",
-                "start": 23,
+                "start": 17,
                 "type": "Identifier"
               },
-              "end": 36,
-              "start": 23,
+              "end": 30,
+              "start": 17,
               "type": "CallExpression",
               "type": "CallExpression"
             }
           ],
-          "end": 36,
-          "start": 14,
+          "end": 30,
+          "start": 8,
           "type": "PipeExpression",
           "type": "PipeExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 36,
+      "end": 30,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 36,
+  "end": 30,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__d2.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__d2.snap
@@ -6,51 +6,51 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 27,
+        "end": 21,
         "id": {
-          "end": 7,
+          "end": 1,
           "name": "x",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
-          "end": 27,
+          "end": 21,
           "left": {
             "argument": {
-              "end": 15,
+              "end": 9,
               "name": "leg2",
-              "start": 11,
+              "start": 5,
               "type": "Identifier",
               "type": "Identifier"
             },
-            "end": 15,
+            "end": 9,
             "operator": "-",
-            "start": 10,
+            "start": 4,
             "type": "UnaryExpression",
             "type": "UnaryExpression"
           },
           "operator": "+",
           "right": {
-            "end": 27,
+            "end": 21,
             "name": "thickness",
-            "start": 18,
+            "start": 12,
             "type": "Identifier",
             "type": "Identifier"
           },
-          "start": 10,
+          "start": 4,
           "type": "BinaryExpression",
           "type": "BinaryExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 27,
+      "end": 21,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 27,
+  "end": 21,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__f.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__f.snap
@@ -6,38 +6,38 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 11,
+        "end": 5,
         "id": {
-          "end": 7,
+          "end": 1,
           "name": "x",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
-          "end": 11,
+          "end": 5,
           "raw": "1",
-          "start": 10,
+          "start": 4,
           "type": "Literal",
           "type": "Literal",
           "value": 1.0
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 11,
+      "end": 5,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 40,
+  "end": 34,
   "nonCodeMeta": {
     "nonCodeNodes": {
       "0": [
         {
-          "end": 40,
-          "start": 11,
+          "end": 34,
+          "start": 5,
           "type": "NonCodeNode",
           "value": {
             "type": "inlineComment",

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__h.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__h.snap
@@ -6,21 +6,40 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 26,
+        "end": 20,
         "id": {
-          "end": 9,
+          "end": 3,
           "name": "obj",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
-          "end": 26,
+          "end": 20,
           "properties": [
+            {
+              "end": 12,
+              "key": {
+                "end": 9,
+                "name": "a",
+                "start": 8,
+                "type": "Identifier"
+              },
+              "start": 8,
+              "type": "ObjectProperty",
+              "value": {
+                "end": 12,
+                "raw": "1",
+                "start": 11,
+                "type": "Literal",
+                "type": "Literal",
+                "value": 1.0
+              }
+            },
             {
               "end": 18,
               "key": {
                 "end": 15,
-                "name": "a",
+                "name": "b",
                 "start": 14,
                 "type": "Identifier"
               },
@@ -28,41 +47,22 @@ expression: actual
               "type": "ObjectProperty",
               "value": {
                 "end": 18,
-                "raw": "1",
-                "start": 17,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 1.0
-              }
-            },
-            {
-              "end": 24,
-              "key": {
-                "end": 21,
-                "name": "b",
-                "start": 20,
-                "type": "Identifier"
-              },
-              "start": 20,
-              "type": "ObjectProperty",
-              "value": {
-                "end": 24,
                 "raw": "2",
-                "start": 23,
+                "start": 17,
                 "type": "Literal",
                 "type": "Literal",
                 "value": 2.0
               }
             }
           ],
-          "start": 12,
+          "start": 6,
           "type": "ObjectExpression",
           "type": "ObjectExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 26,
+      "end": 20,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
@@ -70,19 +70,19 @@ expression: actual
     },
     {
       "declaration": {
-        "end": 55,
+        "end": 43,
         "id": {
-          "end": 43,
+          "end": 31,
           "name": "height",
-          "start": 37,
+          "start": 25,
           "type": "Identifier"
         },
         "init": {
-          "end": 55,
+          "end": 43,
           "left": {
-            "end": 47,
+            "end": 35,
             "raw": "1",
-            "start": 46,
+            "start": 34,
             "type": "Literal",
             "type": "Literal",
             "value": 1.0
@@ -90,39 +90,39 @@ expression: actual
           "operator": "-",
           "right": {
             "computed": false,
-            "end": 55,
+            "end": 43,
             "object": {
-              "end": 53,
+              "end": 41,
               "name": "obj",
-              "start": 50,
+              "start": 38,
               "type": "Identifier",
               "type": "Identifier"
             },
             "property": {
-              "end": 55,
+              "end": 43,
               "name": "a",
-              "start": 54,
+              "start": 42,
               "type": "Identifier",
               "type": "Identifier"
             },
-            "start": 50,
+            "start": 38,
             "type": "MemberExpression",
             "type": "MemberExpression"
           },
-          "start": 46,
+          "start": 34,
           "type": "BinaryExpression",
           "type": "BinaryExpression"
         },
-        "start": 37,
+        "start": 25,
         "type": "VariableDeclarator"
       },
-      "end": 55,
+      "end": 43,
       "kind": "const",
-      "start": 31,
+      "start": 25,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 55,
+  "end": 43,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__i.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__i.snap
@@ -6,21 +6,40 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 26,
+        "end": 20,
         "id": {
-          "end": 9,
+          "end": 3,
           "name": "obj",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
-          "end": 26,
+          "end": 20,
           "properties": [
+            {
+              "end": 12,
+              "key": {
+                "end": 9,
+                "name": "a",
+                "start": 8,
+                "type": "Identifier"
+              },
+              "start": 8,
+              "type": "ObjectProperty",
+              "value": {
+                "end": 12,
+                "raw": "1",
+                "start": 11,
+                "type": "Literal",
+                "type": "Literal",
+                "value": 1.0
+              }
+            },
             {
               "end": 18,
               "key": {
                 "end": 15,
-                "name": "a",
+                "name": "b",
                 "start": 14,
                 "type": "Identifier"
               },
@@ -28,41 +47,22 @@ expression: actual
               "type": "ObjectProperty",
               "value": {
                 "end": 18,
-                "raw": "1",
-                "start": 17,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 1.0
-              }
-            },
-            {
-              "end": 24,
-              "key": {
-                "end": 21,
-                "name": "b",
-                "start": 20,
-                "type": "Identifier"
-              },
-              "start": 20,
-              "type": "ObjectProperty",
-              "value": {
-                "end": 24,
                 "raw": "2",
-                "start": 23,
+                "start": 17,
                 "type": "Literal",
                 "type": "Literal",
                 "value": 2.0
               }
             }
           ],
-          "start": 12,
+          "start": 6,
           "type": "ObjectExpression",
           "type": "ObjectExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 26,
+      "end": 20,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
@@ -70,19 +70,19 @@ expression: actual
     },
     {
       "declaration": {
-        "end": 59,
+        "end": 47,
         "id": {
-          "end": 44,
+          "end": 32,
           "name": "height",
-          "start": 38,
+          "start": 26,
           "type": "Identifier"
         },
         "init": {
-          "end": 59,
+          "end": 47,
           "left": {
-            "end": 48,
+            "end": 36,
             "raw": "1",
-            "start": 47,
+            "start": 35,
             "type": "Literal",
             "type": "Literal",
             "value": 1.0
@@ -90,40 +90,40 @@ expression: actual
           "operator": "-",
           "right": {
             "computed": false,
-            "end": 59,
+            "end": 47,
             "object": {
-              "end": 54,
+              "end": 42,
               "name": "obj",
-              "start": 51,
+              "start": 39,
               "type": "Identifier",
               "type": "Identifier"
             },
             "property": {
-              "end": 58,
+              "end": 46,
               "raw": "\"a\"",
-              "start": 55,
+              "start": 43,
               "type": "Literal",
               "type": "Literal",
               "value": "a"
             },
-            "start": 51,
+            "start": 39,
             "type": "MemberExpression",
             "type": "MemberExpression"
           },
-          "start": 47,
+          "start": 35,
           "type": "BinaryExpression",
           "type": "BinaryExpression"
         },
-        "start": 38,
+        "start": 26,
         "type": "VariableDeclarator"
       },
-      "end": 59,
+      "end": 47,
       "kind": "const",
-      "start": 32,
+      "start": 26,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 59,
+  "end": 47,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__j.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__j.snap
@@ -6,21 +6,40 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 26,
+        "end": 20,
         "id": {
-          "end": 9,
+          "end": 3,
           "name": "obj",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
-          "end": 26,
+          "end": 20,
           "properties": [
+            {
+              "end": 12,
+              "key": {
+                "end": 9,
+                "name": "a",
+                "start": 8,
+                "type": "Identifier"
+              },
+              "start": 8,
+              "type": "ObjectProperty",
+              "value": {
+                "end": 12,
+                "raw": "1",
+                "start": 11,
+                "type": "Literal",
+                "type": "Literal",
+                "value": 1.0
+              }
+            },
             {
               "end": 18,
               "key": {
                 "end": 15,
-                "name": "a",
+                "name": "b",
                 "start": 14,
                 "type": "Identifier"
               },
@@ -28,41 +47,22 @@ expression: actual
               "type": "ObjectProperty",
               "value": {
                 "end": 18,
-                "raw": "1",
-                "start": 17,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 1.0
-              }
-            },
-            {
-              "end": 24,
-              "key": {
-                "end": 21,
-                "name": "b",
-                "start": 20,
-                "type": "Identifier"
-              },
-              "start": 20,
-              "type": "ObjectProperty",
-              "value": {
-                "end": 24,
                 "raw": "2",
-                "start": 23,
+                "start": 17,
                 "type": "Literal",
                 "type": "Literal",
                 "value": 2.0
               }
             }
           ],
-          "start": 12,
+          "start": 6,
           "type": "ObjectExpression",
           "type": "ObjectExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 26,
+      "end": 20,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
@@ -70,60 +70,60 @@ expression: actual
     },
     {
       "declaration": {
-        "end": 58,
+        "end": 46,
         "id": {
-          "end": 43,
+          "end": 31,
           "name": "height",
-          "start": 37,
+          "start": 25,
           "type": "Identifier"
         },
         "init": {
-          "end": 58,
+          "end": 46,
           "left": {
             "computed": false,
-            "end": 54,
+            "end": 42,
             "object": {
-              "end": 49,
+              "end": 37,
               "name": "obj",
-              "start": 46,
+              "start": 34,
               "type": "Identifier",
               "type": "Identifier"
             },
             "property": {
-              "end": 53,
+              "end": 41,
               "raw": "\"a\"",
-              "start": 50,
+              "start": 38,
               "type": "Literal",
               "type": "Literal",
               "value": "a"
             },
-            "start": 46,
+            "start": 34,
             "type": "MemberExpression",
             "type": "MemberExpression"
           },
           "operator": "-",
           "right": {
-            "end": 58,
+            "end": 46,
             "raw": "1",
-            "start": 57,
+            "start": 45,
             "type": "Literal",
             "type": "Literal",
             "value": 1.0
           },
-          "start": 46,
+          "start": 34,
           "type": "BinaryExpression",
           "type": "BinaryExpression"
         },
-        "start": 37,
+        "start": 25,
         "type": "VariableDeclarator"
       },
-      "end": 58,
+      "end": 46,
       "kind": "const",
-      "start": 31,
+      "start": 25,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 58,
+  "end": 46,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__k.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__k.snap
@@ -6,21 +6,40 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 26,
+        "end": 20,
         "id": {
-          "end": 9,
+          "end": 3,
           "name": "obj",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
-          "end": 26,
+          "end": 20,
           "properties": [
+            {
+              "end": 12,
+              "key": {
+                "end": 9,
+                "name": "a",
+                "start": 8,
+                "type": "Identifier"
+              },
+              "start": 8,
+              "type": "ObjectProperty",
+              "value": {
+                "end": 12,
+                "raw": "1",
+                "start": 11,
+                "type": "Literal",
+                "type": "Literal",
+                "value": 1.0
+              }
+            },
             {
               "end": 18,
               "key": {
                 "end": 15,
-                "name": "a",
+                "name": "b",
                 "start": 14,
                 "type": "Identifier"
               },
@@ -28,41 +47,22 @@ expression: actual
               "type": "ObjectProperty",
               "value": {
                 "end": 18,
-                "raw": "1",
-                "start": 17,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 1.0
-              }
-            },
-            {
-              "end": 24,
-              "key": {
-                "end": 21,
-                "name": "b",
-                "start": 20,
-                "type": "Identifier"
-              },
-              "start": 20,
-              "type": "ObjectProperty",
-              "value": {
-                "end": 24,
                 "raw": "2",
-                "start": 23,
+                "start": 17,
                 "type": "Literal",
                 "type": "Literal",
                 "value": 2.0
               }
             }
           ],
-          "start": 12,
+          "start": 6,
           "type": "ObjectExpression",
           "type": "ObjectExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 26,
+      "end": 20,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
@@ -70,21 +70,21 @@ expression: actual
     },
     {
       "declaration": {
-        "end": 63,
+        "end": 51,
         "id": {
-          "end": 43,
+          "end": 31,
           "name": "height",
-          "start": 37,
+          "start": 25,
           "type": "Identifier"
         },
         "init": {
           "elements": [
             {
-              "end": 59,
+              "end": 47,
               "left": {
-                "end": 48,
+                "end": 36,
                 "raw": "1",
-                "start": 47,
+                "start": 35,
                 "type": "Literal",
                 "type": "Literal",
                 "value": 1.0
@@ -92,54 +92,54 @@ expression: actual
               "operator": "-",
               "right": {
                 "computed": false,
-                "end": 59,
+                "end": 47,
                 "object": {
-                  "end": 54,
+                  "end": 42,
                   "name": "obj",
-                  "start": 51,
+                  "start": 39,
                   "type": "Identifier",
                   "type": "Identifier"
                 },
                 "property": {
-                  "end": 58,
+                  "end": 46,
                   "raw": "\"a\"",
-                  "start": 55,
+                  "start": 43,
                   "type": "Literal",
                   "type": "Literal",
                   "value": "a"
                 },
-                "start": 51,
+                "start": 39,
                 "type": "MemberExpression",
                 "type": "MemberExpression"
               },
-              "start": 47,
+              "start": 35,
               "type": "BinaryExpression",
               "type": "BinaryExpression"
             },
             {
-              "end": 62,
+              "end": 50,
               "raw": "0",
-              "start": 61,
+              "start": 49,
               "type": "Literal",
               "type": "Literal",
               "value": 0.0
             }
           ],
-          "end": 63,
-          "start": 46,
+          "end": 51,
+          "start": 34,
           "type": "ArrayExpression",
           "type": "ArrayExpression"
         },
-        "start": 37,
+        "start": 25,
         "type": "VariableDeclarator"
       },
-      "end": 63,
+      "end": 51,
       "kind": "const",
-      "start": 31,
+      "start": 25,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 63,
+  "end": 51,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__l.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__l.snap
@@ -6,21 +6,40 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 26,
+        "end": 20,
         "id": {
-          "end": 9,
+          "end": 3,
           "name": "obj",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
-          "end": 26,
+          "end": 20,
           "properties": [
+            {
+              "end": 12,
+              "key": {
+                "end": 9,
+                "name": "a",
+                "start": 8,
+                "type": "Identifier"
+              },
+              "start": 8,
+              "type": "ObjectProperty",
+              "value": {
+                "end": 12,
+                "raw": "1",
+                "start": 11,
+                "type": "Literal",
+                "type": "Literal",
+                "value": 1.0
+              }
+            },
             {
               "end": 18,
               "key": {
                 "end": 15,
-                "name": "a",
+                "name": "b",
                 "start": 14,
                 "type": "Identifier"
               },
@@ -28,41 +47,22 @@ expression: actual
               "type": "ObjectProperty",
               "value": {
                 "end": 18,
-                "raw": "1",
-                "start": 17,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 1.0
-              }
-            },
-            {
-              "end": 24,
-              "key": {
-                "end": 21,
-                "name": "b",
-                "start": 20,
-                "type": "Identifier"
-              },
-              "start": 20,
-              "type": "ObjectProperty",
-              "value": {
-                "end": 24,
                 "raw": "2",
-                "start": 23,
+                "start": 17,
                 "type": "Literal",
                 "type": "Literal",
                 "value": 2.0
               }
             }
           ],
-          "start": 12,
+          "start": 6,
           "type": "ObjectExpression",
           "type": "ObjectExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 26,
+      "end": 20,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
@@ -70,76 +70,76 @@ expression: actual
     },
     {
       "declaration": {
-        "end": 63,
+        "end": 51,
         "id": {
-          "end": 43,
+          "end": 31,
           "name": "height",
-          "start": 37,
+          "start": 25,
           "type": "Identifier"
         },
         "init": {
           "elements": [
             {
-              "end": 59,
+              "end": 47,
               "left": {
                 "computed": false,
-                "end": 55,
+                "end": 43,
                 "object": {
-                  "end": 50,
+                  "end": 38,
                   "name": "obj",
-                  "start": 47,
+                  "start": 35,
                   "type": "Identifier",
                   "type": "Identifier"
                 },
                 "property": {
-                  "end": 54,
+                  "end": 42,
                   "raw": "\"a\"",
-                  "start": 51,
+                  "start": 39,
                   "type": "Literal",
                   "type": "Literal",
                   "value": "a"
                 },
-                "start": 47,
+                "start": 35,
                 "type": "MemberExpression",
                 "type": "MemberExpression"
               },
               "operator": "-",
               "right": {
-                "end": 59,
+                "end": 47,
                 "raw": "1",
-                "start": 58,
+                "start": 46,
                 "type": "Literal",
                 "type": "Literal",
                 "value": 1.0
               },
-              "start": 47,
+              "start": 35,
               "type": "BinaryExpression",
               "type": "BinaryExpression"
             },
             {
-              "end": 62,
+              "end": 50,
               "raw": "0",
-              "start": 61,
+              "start": 49,
               "type": "Literal",
               "type": "Literal",
               "value": 0.0
             }
           ],
-          "end": 63,
-          "start": 46,
+          "end": 51,
+          "start": 34,
           "type": "ArrayExpression",
           "type": "ArrayExpression"
         },
-        "start": 37,
+        "start": 25,
         "type": "VariableDeclarator"
       },
-      "end": 63,
+      "end": 51,
       "kind": "const",
-      "start": 31,
+      "start": 25,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 63,
+  "end": 51,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__m.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__m.snap
@@ -6,21 +6,40 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 26,
+        "end": 20,
         "id": {
-          "end": 9,
+          "end": 3,
           "name": "obj",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
-          "end": 26,
+          "end": 20,
           "properties": [
+            {
+              "end": 12,
+              "key": {
+                "end": 9,
+                "name": "a",
+                "start": 8,
+                "type": "Identifier"
+              },
+              "start": 8,
+              "type": "ObjectProperty",
+              "value": {
+                "end": 12,
+                "raw": "1",
+                "start": 11,
+                "type": "Literal",
+                "type": "Literal",
+                "value": 1.0
+              }
+            },
             {
               "end": 18,
               "key": {
                 "end": 15,
-                "name": "a",
+                "name": "b",
                 "start": 14,
                 "type": "Identifier"
               },
@@ -28,41 +47,22 @@ expression: actual
               "type": "ObjectProperty",
               "value": {
                 "end": 18,
-                "raw": "1",
-                "start": 17,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 1.0
-              }
-            },
-            {
-              "end": 24,
-              "key": {
-                "end": 21,
-                "name": "b",
-                "start": 20,
-                "type": "Identifier"
-              },
-              "start": 20,
-              "type": "ObjectProperty",
-              "value": {
-                "end": 24,
                 "raw": "2",
-                "start": 23,
+                "start": 17,
                 "type": "Literal",
                 "type": "Literal",
                 "value": 2.0
               }
             }
           ],
-          "start": 12,
+          "start": 6,
           "type": "ObjectExpression",
           "type": "ObjectExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 26,
+      "end": 20,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
@@ -70,76 +70,76 @@ expression: actual
     },
     {
       "declaration": {
-        "end": 62,
+        "end": 50,
         "id": {
-          "end": 43,
+          "end": 31,
           "name": "height",
-          "start": 37,
+          "start": 25,
           "type": "Identifier"
         },
         "init": {
           "elements": [
             {
-              "end": 58,
+              "end": 46,
               "left": {
                 "computed": false,
-                "end": 55,
+                "end": 43,
                 "object": {
-                  "end": 50,
+                  "end": 38,
                   "name": "obj",
-                  "start": 47,
+                  "start": 35,
                   "type": "Identifier",
                   "type": "Identifier"
                 },
                 "property": {
-                  "end": 54,
+                  "end": 42,
                   "raw": "\"a\"",
-                  "start": 51,
+                  "start": 39,
                   "type": "Literal",
                   "type": "Literal",
                   "value": "a"
                 },
-                "start": 47,
+                "start": 35,
                 "type": "MemberExpression",
                 "type": "MemberExpression"
               },
               "operator": "-",
               "right": {
-                "end": 58,
+                "end": 46,
                 "raw": "1",
-                "start": 57,
+                "start": 45,
                 "type": "Literal",
                 "type": "Literal",
                 "value": 1.0
               },
-              "start": 47,
+              "start": 35,
               "type": "BinaryExpression",
               "type": "BinaryExpression"
             },
             {
-              "end": 61,
+              "end": 49,
               "raw": "0",
-              "start": 60,
+              "start": 48,
               "type": "Literal",
               "type": "Literal",
               "value": 0.0
             }
           ],
-          "end": 62,
-          "start": 46,
+          "end": 50,
+          "start": 34,
           "type": "ArrayExpression",
           "type": "ArrayExpression"
         },
-        "start": 37,
+        "start": 25,
         "type": "VariableDeclarator"
       },
-      "end": 62,
+      "end": 50,
       "kind": "const",
-      "start": 31,
+      "start": 25,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 62,
+  "end": 50,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__n.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__n.snap
@@ -6,19 +6,19 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 24,
+        "end": 18,
         "id": {
-          "end": 12,
+          "end": 6,
           "name": "height",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
-          "end": 24,
+          "end": 18,
           "left": {
-            "end": 16,
+            "end": 10,
             "raw": "1",
-            "start": 15,
+            "start": 9,
             "type": "Literal",
             "type": "Literal",
             "value": 1.0
@@ -26,39 +26,39 @@ expression: actual
           "operator": "-",
           "right": {
             "computed": false,
-            "end": 24,
+            "end": 18,
             "object": {
-              "end": 22,
+              "end": 16,
               "name": "obj",
-              "start": 19,
+              "start": 13,
               "type": "Identifier",
               "type": "Identifier"
             },
             "property": {
-              "end": 24,
+              "end": 18,
               "name": "a",
-              "start": 23,
+              "start": 17,
               "type": "Identifier",
               "type": "Identifier"
             },
-            "start": 19,
+            "start": 13,
             "type": "MemberExpression",
             "type": "MemberExpression"
           },
-          "start": 15,
+          "start": 9,
           "type": "BinaryExpression",
           "type": "BinaryExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 24,
+      "end": 18,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 24,
+  "end": 18,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__o.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__o.snap
@@ -6,61 +6,61 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 21,
+        "end": 15,
         "id": {
-          "end": 9,
+          "end": 3,
           "name": "six",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
-          "end": 21,
+          "end": 15,
           "left": {
-            "end": 17,
+            "end": 11,
             "left": {
-              "end": 13,
+              "end": 7,
               "raw": "1",
-              "start": 12,
+              "start": 6,
               "type": "Literal",
               "type": "Literal",
               "value": 1.0
             },
             "operator": "+",
             "right": {
-              "end": 17,
+              "end": 11,
               "raw": "2",
-              "start": 16,
+              "start": 10,
               "type": "Literal",
               "type": "Literal",
               "value": 2.0
             },
-            "start": 12,
+            "start": 6,
             "type": "BinaryExpression",
             "type": "BinaryExpression"
           },
           "operator": "+",
           "right": {
-            "end": 21,
+            "end": 15,
             "raw": "3",
-            "start": 20,
+            "start": 14,
             "type": "Literal",
             "type": "Literal",
             "value": 3.0
           },
-          "start": 12,
+          "start": 6,
           "type": "BinaryExpression",
           "type": "BinaryExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 21,
+      "end": 15,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 21,
+  "end": 15,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__p.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__p.snap
@@ -6,61 +6,61 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 22,
+        "end": 16,
         "id": {
-          "end": 10,
+          "end": 4,
           "name": "five",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
-          "end": 22,
+          "end": 16,
           "left": {
-            "end": 18,
+            "end": 12,
             "left": {
-              "end": 14,
+              "end": 8,
               "raw": "3",
-              "start": 13,
+              "start": 7,
               "type": "Literal",
               "type": "Literal",
               "value": 3.0
             },
             "operator": "*",
             "right": {
-              "end": 18,
+              "end": 12,
               "raw": "1",
-              "start": 17,
+              "start": 11,
               "type": "Literal",
               "type": "Literal",
               "value": 1.0
             },
-            "start": 13,
+            "start": 7,
             "type": "BinaryExpression",
             "type": "BinaryExpression"
           },
           "operator": "+",
           "right": {
-            "end": 22,
+            "end": 16,
             "raw": "2",
-            "start": 21,
+            "start": 15,
             "type": "Literal",
             "type": "Literal",
             "value": 2.0
           },
-          "start": 13,
+          "start": 7,
           "type": "BinaryExpression",
           "type": "BinaryExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 22,
+      "end": 16,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 22,
+  "end": 16,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__q.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__q.snap
@@ -6,61 +6,61 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 30,
+        "end": 24,
         "id": {
-          "end": 12,
+          "end": 6,
           "name": "height",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
           "elements": [
             {
               "computed": false,
-              "end": 25,
+              "end": 19,
               "object": {
-                "end": 20,
+                "end": 14,
                 "name": "obj",
-                "start": 17,
+                "start": 11,
                 "type": "Identifier",
                 "type": "Identifier"
               },
               "property": {
-                "end": 24,
+                "end": 18,
                 "raw": "\"a\"",
-                "start": 21,
+                "start": 15,
                 "type": "Literal",
                 "type": "Literal",
                 "value": "a"
               },
-              "start": 17,
+              "start": 11,
               "type": "MemberExpression",
               "type": "MemberExpression"
             },
             {
-              "end": 28,
+              "end": 22,
               "raw": "0",
-              "start": 27,
+              "start": 21,
               "type": "Literal",
               "type": "Literal",
               "value": 0.0
             }
           ],
-          "end": 30,
-          "start": 15,
+          "end": 24,
+          "start": 9,
           "type": "ArrayExpression",
           "type": "ArrayExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 30,
+      "end": 24,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 30,
+  "end": 24,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__r.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__r.snap
@@ -6,21 +6,40 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 26,
+        "end": 20,
         "id": {
-          "end": 9,
+          "end": 3,
           "name": "obj",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
-          "end": 26,
+          "end": 20,
           "properties": [
+            {
+              "end": 12,
+              "key": {
+                "end": 9,
+                "name": "a",
+                "start": 8,
+                "type": "Identifier"
+              },
+              "start": 8,
+              "type": "ObjectProperty",
+              "value": {
+                "end": 12,
+                "raw": "1",
+                "start": 11,
+                "type": "Literal",
+                "type": "Literal",
+                "value": 1.0
+              }
+            },
             {
               "end": 18,
               "key": {
                 "end": 15,
-                "name": "a",
+                "name": "b",
                 "start": 14,
                 "type": "Identifier"
               },
@@ -28,41 +47,22 @@ expression: actual
               "type": "ObjectProperty",
               "value": {
                 "end": 18,
-                "raw": "1",
-                "start": 17,
-                "type": "Literal",
-                "type": "Literal",
-                "value": 1.0
-              }
-            },
-            {
-              "end": 24,
-              "key": {
-                "end": 21,
-                "name": "b",
-                "start": 20,
-                "type": "Identifier"
-              },
-              "start": 20,
-              "type": "ObjectProperty",
-              "value": {
-                "end": 24,
                 "raw": "2",
-                "start": 23,
+                "start": 17,
                 "type": "Literal",
                 "type": "Literal",
                 "value": 2.0
               }
             }
           ],
-          "start": 12,
+          "start": 6,
           "type": "ObjectExpression",
           "type": "ObjectExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 26,
+      "end": 20,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
@@ -70,45 +70,45 @@ expression: actual
     },
     {
       "declaration": {
-        "end": 54,
+        "end": 42,
         "id": {
-          "end": 43,
+          "end": 31,
           "name": "height",
-          "start": 37,
+          "start": 25,
           "type": "Identifier"
         },
         "init": {
           "computed": false,
-          "end": 54,
+          "end": 42,
           "object": {
-            "end": 49,
+            "end": 37,
             "name": "obj",
-            "start": 46,
+            "start": 34,
             "type": "Identifier",
             "type": "Identifier"
           },
           "property": {
-            "end": 53,
+            "end": 41,
             "raw": "\"a\"",
-            "start": 50,
+            "start": 38,
             "type": "Literal",
             "type": "Literal",
             "value": "a"
           },
-          "start": 46,
+          "start": 34,
           "type": "MemberExpression",
           "type": "MemberExpression"
         },
-        "start": 37,
+        "start": 25,
         "type": "VariableDeclarator"
       },
-      "end": 54,
+      "end": 42,
       "kind": "const",
-      "start": 31,
+      "start": 25,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 54,
+  "end": 42,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__s.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__s.snap
@@ -6,59 +6,59 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 27,
+        "end": 21,
         "id": {
-          "end": 10,
+          "end": 4,
           "name": "prop",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
           "computed": true,
-          "end": 27,
+          "end": 21,
           "object": {
             "computed": false,
-            "end": 22,
+            "end": 16,
             "object": {
-              "end": 15,
+              "end": 9,
               "name": "yo",
-              "start": 13,
+              "start": 7,
               "type": "Identifier",
               "type": "Identifier"
             },
             "property": {
-              "end": 21,
+              "end": 15,
               "raw": "\"one\"",
-              "start": 16,
+              "start": 10,
               "type": "Literal",
               "type": "Literal",
               "value": "one"
             },
-            "start": 13,
+            "start": 7,
             "type": "MemberExpression",
             "type": "MemberExpression"
           },
           "property": {
-            "end": 26,
+            "end": 20,
             "name": "two",
-            "start": 23,
+            "start": 17,
             "type": "Identifier",
             "type": "Identifier"
           },
-          "start": 13,
+          "start": 7,
           "type": "MemberExpression",
           "type": "MemberExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 27,
+      "end": 21,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 27,
+  "end": 21,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__t.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__t.snap
@@ -6,44 +6,44 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 17,
+        "end": 11,
         "id": {
-          "end": 9,
+          "end": 3,
           "name": "pt1",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
           "computed": true,
-          "end": 17,
+          "end": 11,
           "object": {
-            "end": 14,
+            "end": 8,
             "name": "b1",
-            "start": 12,
+            "start": 6,
             "type": "Identifier",
             "type": "Identifier"
           },
           "property": {
-            "end": 16,
+            "end": 10,
             "name": "x",
-            "start": 15,
+            "start": 9,
             "type": "Identifier",
             "type": "Identifier"
           },
-          "start": 12,
+          "start": 6,
           "type": "MemberExpression",
           "type": "MemberExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 17,
+      "end": 11,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 17,
+  "end": 11,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__u.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__u.snap
@@ -6,86 +6,86 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 34,
+        "end": 28,
         "id": {
-          "end": 10,
+          "end": 4,
           "name": "prop",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
           "computed": false,
-          "end": 34,
+          "end": 28,
           "object": {
             "computed": false,
-            "end": 29,
+            "end": 23,
             "object": {
               "computed": false,
-              "end": 23,
+              "end": 17,
               "object": {
                 "computed": false,
-                "end": 19,
+                "end": 13,
                 "object": {
-                  "end": 15,
+                  "end": 9,
                   "name": "yo",
-                  "start": 13,
+                  "start": 7,
                   "type": "Identifier",
                   "type": "Identifier"
                 },
                 "property": {
-                  "end": 19,
+                  "end": 13,
                   "name": "one",
-                  "start": 16,
+                  "start": 10,
                   "type": "Identifier",
                   "type": "Identifier"
                 },
-                "start": 13,
+                "start": 7,
                 "type": "MemberExpression",
                 "type": "MemberExpression"
               },
               "property": {
-                "end": 23,
+                "end": 17,
                 "name": "two",
-                "start": 20,
+                "start": 14,
                 "type": "Identifier",
                 "type": "Identifier"
               },
-              "start": 13,
+              "start": 7,
               "type": "MemberExpression",
               "type": "MemberExpression"
             },
             "property": {
-              "end": 29,
+              "end": 23,
               "name": "three",
-              "start": 24,
+              "start": 18,
               "type": "Identifier",
               "type": "Identifier"
             },
-            "start": 13,
+            "start": 7,
             "type": "MemberExpression",
             "type": "MemberExpression"
           },
           "property": {
-            "end": 34,
+            "end": 28,
             "name": "four",
-            "start": 30,
+            "start": 24,
             "type": "Identifier",
             "type": "Identifier"
           },
-          "start": 13,
+          "start": 7,
           "type": "MemberExpression",
           "type": "MemberExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 34,
+      "end": 28,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 34,
+  "end": 28,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__v.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__v.snap
@@ -6,45 +6,45 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 17,
+        "end": 11,
         "id": {
-          "end": 9,
+          "end": 3,
           "name": "pt1",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
           "computed": false,
-          "end": 17,
+          "end": 11,
           "object": {
-            "end": 14,
+            "end": 8,
             "name": "b1",
-            "start": 12,
+            "start": 6,
             "type": "Identifier",
             "type": "Identifier"
           },
           "property": {
-            "end": 16,
+            "end": 10,
             "raw": "0",
-            "start": 15,
+            "start": 9,
             "type": "Literal",
             "type": "Literal",
             "value": 0.0
           },
-          "start": 12,
+          "start": 6,
           "type": "MemberExpression",
           "type": "MemberExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 17,
+      "end": 11,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 17,
+  "end": 11,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__w.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__w.snap
@@ -6,45 +6,45 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 22,
+        "end": 16,
         "id": {
-          "end": 9,
+          "end": 3,
           "name": "pt1",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
           "computed": false,
-          "end": 22,
+          "end": 16,
           "object": {
-            "end": 14,
+            "end": 8,
             "name": "b1",
-            "start": 12,
+            "start": 6,
             "type": "Identifier",
             "type": "Identifier"
           },
           "property": {
-            "end": 21,
+            "end": 15,
             "raw": "'zero'",
-            "start": 15,
+            "start": 9,
             "type": "Literal",
             "type": "Literal",
             "value": "zero"
           },
-          "start": 12,
+          "start": 6,
           "type": "MemberExpression",
           "type": "MemberExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 22,
+      "end": 16,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 22,
+  "end": 16,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__x.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__x.snap
@@ -6,44 +6,44 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 19,
+        "end": 13,
         "id": {
-          "end": 9,
+          "end": 3,
           "name": "pt1",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
           "computed": false,
-          "end": 19,
+          "end": 13,
           "object": {
-            "end": 14,
+            "end": 8,
             "name": "b1",
-            "start": 12,
+            "start": 6,
             "type": "Identifier",
             "type": "Identifier"
           },
           "property": {
-            "end": 19,
+            "end": 13,
             "name": "zero",
-            "start": 15,
+            "start": 9,
             "type": "Identifier",
             "type": "Identifier"
           },
-          "start": 12,
+          "start": 6,
           "type": "MemberExpression",
           "type": "MemberExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 19,
+      "end": 13,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 19,
+  "end": 13,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__y.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__y.snap
@@ -6,44 +6,44 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 29,
+        "end": 23,
         "id": {
-          "end": 8,
+          "end": 2,
           "name": "sg",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
           "arguments": [
             {
-              "end": 28,
+              "end": 22,
               "name": "pos",
-              "start": 25,
+              "start": 19,
               "type": "Identifier",
               "type": "Identifier"
             }
           ],
           "callee": {
-            "end": 24,
+            "end": 18,
             "name": "startSketchAt",
-            "start": 11,
+            "start": 5,
             "type": "Identifier"
           },
-          "end": 29,
-          "start": 11,
+          "end": 23,
+          "start": 5,
           "type": "CallExpression",
           "type": "CallExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 29,
+      "end": 23,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 29,
+  "end": 23,
   "start": 0
 }

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__z.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__z.snap
@@ -6,11 +6,11 @@ expression: actual
   "body": [
     {
       "declaration": {
-        "end": 53,
+        "end": 47,
         "id": {
-          "end": 8,
+          "end": 2,
           "name": "sg",
-          "start": 6,
+          "start": 0,
           "type": "Identifier"
         },
         "init": {
@@ -18,21 +18,21 @@ expression: actual
             {
               "arguments": [
                 {
-                  "end": 28,
+                  "end": 22,
                   "name": "pos",
-                  "start": 25,
+                  "start": 19,
                   "type": "Identifier",
                   "type": "Identifier"
                 }
               ],
               "callee": {
-                "end": 24,
+                "end": 18,
                 "name": "startSketchAt",
-                "start": 11,
+                "start": 5,
                 "type": "Identifier"
               },
-              "end": 29,
-              "start": 11,
+              "end": 23,
+              "start": 5,
               "type": "CallExpression",
               "type": "CallExpression"
             },
@@ -41,67 +41,67 @@ expression: actual
                 {
                   "elements": [
                     {
-                      "end": 40,
+                      "end": 34,
                       "raw": "0",
-                      "start": 39,
+                      "start": 33,
                       "type": "Literal",
                       "type": "Literal",
                       "value": 0.0
                     },
                     {
                       "argument": {
-                        "end": 48,
+                        "end": 42,
                         "name": "scale",
-                        "start": 43,
+                        "start": 37,
                         "type": "Identifier",
                         "type": "Identifier"
                       },
-                      "end": 48,
+                      "end": 42,
                       "operator": "-",
-                      "start": 42,
+                      "start": 36,
                       "type": "UnaryExpression",
                       "type": "UnaryExpression"
                     }
                   ],
-                  "end": 49,
-                  "start": 38,
+                  "end": 43,
+                  "start": 32,
                   "type": "ArrayExpression",
                   "type": "ArrayExpression"
                 },
                 {
-                  "end": 52,
-                  "start": 51,
+                  "end": 46,
+                  "start": 45,
                   "type": "PipeSubstitution",
                   "type": "PipeSubstitution"
                 }
               ],
               "callee": {
-                "end": 37,
+                "end": 31,
                 "name": "line",
-                "start": 33,
+                "start": 27,
                 "type": "Identifier"
               },
-              "end": 53,
-              "start": 33,
+              "end": 47,
+              "start": 27,
               "type": "CallExpression",
               "type": "CallExpression"
             }
           ],
-          "end": 53,
-          "start": 11,
+          "end": 47,
+          "start": 5,
           "type": "PipeExpression",
           "type": "PipeExpression"
         },
-        "start": 6,
+        "start": 0,
         "type": "VariableDeclarator"
       },
-      "end": 53,
+      "end": 47,
       "kind": "const",
       "start": 0,
       "type": "VariableDeclaration",
       "type": "VariableDeclaration"
     }
   ],
-  "end": 53,
+  "end": 47,
   "start": 0
 }


### PR DESCRIPTION
The changes are quite minor, but fixing the tests was a lot :-( 

This PR adds warnings for:
* unnecessary let, const, or var
* importing whole modules is experimental (technically not even implemented, but I expect it will be a bit wobbly for a while)