### PR TITLE
fix: replace whitespace with a `-` so that ids are valid and scroll to works

### DIFF
--- a/src/components/Settings/AllKeybindingsFields.tsx
+++ b/src/components/Settings/AllKeybindingsFields.tsx
@@ -10,7 +10,7 @@ interface AllKeybindingsFieldsProps {}
 
 export const AllKeybindingsFields = forwardRef(
   (
-    props: AllKeybindingsFieldsProps,
+    _props: AllKeybindingsFieldsProps,
     scrollRef: ForwardedRef<HTMLDivElement>
   ) => {
     // This is how we will get the interaction map from the context
@@ -25,7 +25,7 @@ export const AllKeybindingsFields = forwardRef(
             .map(([category, categoryItems]) => (
               <div className="flex flex-col gap-4 px-2 pr-4">
                 <h2
-                  id={`category-${category}`}
+                  id={`category-${category.replaceAll(/\s/g, '-')}`}
                   className="text-xl mt-6 first-of-type:mt-0 capitalize font-bold"
                 >
                   {category}

--- a/src/components/Settings/KeybindingsSectionsList.tsx
+++ b/src/components/Settings/KeybindingsSectionsList.tsx
@@ -19,7 +19,7 @@ export function KeybindingsSectionsList({
             key={category}
             onClick={() =>
               scrollRef.current
-                ?.querySelector(`#category-${category}`)
+                ?.querySelector(`#category-${category.replaceAll(/\s/g, '-')}`)
                 ?.scrollIntoView({
                   block: 'center',
                   behavior: 'smooth',

--- a/src/lib/settings/initialKeybindings.ts
+++ b/src/lib/settings/initialKeybindings.ts
@@ -12,7 +12,7 @@ export type InteractionMapItem = {
  * Controls both the available names for interaction map categories
  * and the order in which they are displayed.
  */
-export const interactionMapCategories = [
+const interactionMapCategories = [
   'Sketching',
   'Modeling',
   'Command Palette',


### PR DESCRIPTION
Recreation of #4601 in an authorized branch, @TomPridham is the author of this code.

Here is his original PR description (thanks for writing it Tom!):

I couldn't find an existing issue. I noticed the scrollto behavior didn't work for keybind settings that included whitespace because they were generating invalid ids, e.g. `id="categoryCommand Palette"`. It isn't a problem for the User settings because the display strings were `decamelized` object properties
before:
[Screencast from 2024-11-27 13-30-48.webm](https://github.com/user-attachments/assets/8c993a31-6a36-4aa4-80ae-88416405848f)
after:
[Screencast from 2024-11-27 13-32-29.webm](https://github.com/user-attachments/assets/d624ed67-c29d-416c-a15a-ba3b0c5baa42)