### PR TITLE
KCL keyword args: calling user-defined functions

### DIFF
--- a/src/wasm-lib/kcl/src/simulation_tests.rs
+++ b/src/wasm-lib/kcl/src/simulation_tests.rs
@@ -1544,3 +1544,45 @@ mod tag_proxied_through_function_does_not_define_var {
         super::execute(TEST_NAME, false).await
     }
 }
+mod kw_fn_too_few_args {
+    const TEST_NAME: &str = "kw_fn_too_few_args";
+
+    /// Test parsing KCL.
+    #[test]
+    fn parse() {
+        super::parse(TEST_NAME)
+    }
+
+    /// Test that parsing and unparsing KCL produces the original KCL input.
+    #[test]
+    fn unparse() {
+        super::unparse(TEST_NAME)
+    }
+
+    /// Test that KCL is executed correctly.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn kcl_test_execute() {
+        super::execute(TEST_NAME, true).await
+    }
+}
+mod kw_fn_unlabeled_but_has_label {
+    const TEST_NAME: &str = "kw_fn_unlabeled_but_has_label";
+
+    /// Test parsing KCL.
+    #[test]
+    fn parse() {
+        super::parse(TEST_NAME)
+    }
+
+    /// Test that parsing and unparsing KCL produces the original KCL input.
+    #[test]
+    fn unparse() {
+        super::unparse(TEST_NAME)
+    }
+
+    /// Test that KCL is executed correctly.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn kcl_test_execute() {
+        super::execute(TEST_NAME, true).await
+    }
+}

--- a/src/wasm-lib/kcl/src/std/args.rs
+++ b/src/wasm-lib/kcl/src/std/args.rs
@@ -50,6 +50,13 @@ pub struct KwArgs {
     pub labeled: HashMap<String, Arg>,
 }
 
+impl KwArgs {
+    /// How many arguments are there?
+    pub fn len(&self) -> usize {
+        self.labeled.len() + if self.unlabeled.is_some() { 1 } else { 0 }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Args {
     /// Positional args.

--- a/src/wasm-lib/kcl/tests/kw_fn/ast.snap
+++ b/src/wasm-lib/kcl/tests/kw_fn/ast.snap
@@ -78,52 +78,195 @@ snapshot_kind: text
       },
       {
         "declaration": {
-          "end": 55,
+          "end": 77,
           "id": {
-            "end": 40,
+            "end": 43,
+            "name": "add",
+            "start": 40,
+            "type": "Identifier"
+          },
+          "init": {
+            "body": {
+              "body": [
+                {
+                  "argument": {
+                    "end": 75,
+                    "left": {
+                      "end": 67,
+                      "name": "x",
+                      "start": 66,
+                      "type": "Identifier",
+                      "type": "Identifier"
+                    },
+                    "operator": "+",
+                    "right": {
+                      "end": 75,
+                      "name": "delta",
+                      "start": 70,
+                      "type": "Identifier",
+                      "type": "Identifier"
+                    },
+                    "start": 66,
+                    "type": "BinaryExpression",
+                    "type": "BinaryExpression"
+                  },
+                  "end": 75,
+                  "start": 59,
+                  "type": "ReturnStatement",
+                  "type": "ReturnStatement"
+                }
+              ],
+              "end": 77,
+              "start": 55
+            },
+            "end": 77,
+            "params": [
+              {
+                "type": "Parameter",
+                "identifier": {
+                  "end": 46,
+                  "name": "x",
+                  "start": 45,
+                  "type": "Identifier"
+                },
+                "labeled": false
+              },
+              {
+                "type": "Parameter",
+                "identifier": {
+                  "end": 53,
+                  "name": "delta",
+                  "start": 48,
+                  "type": "Identifier"
+                }
+              }
+            ],
+            "start": 43,
+            "type": "FunctionExpression",
+            "type": "FunctionExpression"
+          },
+          "start": 40,
+          "type": "VariableDeclarator"
+        },
+        "end": 77,
+        "kind": "fn",
+        "start": 37,
+        "type": "VariableDeclaration",
+        "type": "VariableDeclaration"
+      },
+      {
+        "declaration": {
+          "end": 97,
+          "id": {
+            "end": 82,
             "name": "two",
-            "start": 37,
+            "start": 79,
             "type": "Identifier"
           },
           "init": {
             "arguments": [
               {
-                "end": 54,
+                "end": 96,
                 "raw": "1",
-                "start": 53,
+                "start": 95,
                 "type": "Literal",
                 "type": "Literal",
                 "value": 1.0
               }
             ],
             "callee": {
-              "end": 52,
+              "end": 94,
               "name": "increment",
-              "start": 43,
+              "start": 85,
               "type": "Identifier"
             },
-            "end": 55,
-            "start": 43,
+            "end": 97,
+            "start": 85,
             "type": "CallExpression",
             "type": "CallExpression"
           },
-          "start": 37,
+          "start": 79,
           "type": "VariableDeclarator"
         },
-        "end": 55,
+        "end": 97,
         "kind": "const",
-        "start": 37,
+        "start": 79,
+        "type": "VariableDeclaration",
+        "type": "VariableDeclaration"
+      },
+      {
+        "declaration": {
+          "end": 122,
+          "id": {
+            "end": 103,
+            "name": "three",
+            "start": 98,
+            "type": "Identifier"
+          },
+          "init": {
+            "arguments": [
+              {
+                "type": "LabeledArg",
+                "label": {
+                  "type": "Identifier",
+                  "name": "delta"
+                },
+                "arg": {
+                  "end": 121,
+                  "raw": "2",
+                  "start": 120,
+                  "type": "Literal",
+                  "type": "Literal",
+                  "value": 2.0
+                }
+              }
+            ],
+            "callee": {
+              "end": 109,
+              "name": "add",
+              "start": 106,
+              "type": "Identifier"
+            },
+            "end": 122,
+            "start": 106,
+            "type": "CallExpressionKw",
+            "type": "CallExpressionKw",
+            "unlabeled": {
+              "end": 111,
+              "raw": "1",
+              "start": 110,
+              "type": "Literal",
+              "type": "Literal",
+              "value": 1.0
+            }
+          },
+          "start": 98,
+          "type": "VariableDeclarator"
+        },
+        "end": 122,
+        "kind": "const",
+        "start": 98,
         "type": "VariableDeclaration",
         "type": "VariableDeclaration"
       }
     ],
-    "end": 56,
+    "end": 123,
     "nonCodeMeta": {
       "nonCodeNodes": {
         "0": [
           {
             "end": 37,
             "start": 35,
+            "type": "NonCodeNode",
+            "value": {
+              "type": "newLine"
+            }
+          }
+        ],
+        "1": [
+          {
+            "end": 79,
+            "start": 77,
             "type": "NonCodeNode",
             "value": {
               "type": "newLine"

--- a/src/wasm-lib/kcl/tests/kw_fn/input.kcl
+++ b/src/wasm-lib/kcl/tests/kw_fn/input.kcl
@@ -2,4 +2,9 @@ fn increment(@x) {
   return x + 1
 }
 
+fn add(@x, delta) {
+  return x + delta
+}
+
 two = increment(1)
+three = add(1, delta: 2)

--- a/src/wasm-lib/kcl/tests/kw_fn/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/kw_fn/program_memory.snap
@@ -27,6 +27,202 @@ snapshot_kind: text
           "value": 0.0,
           "__meta": []
         },
+        "add": {
+          "type": "Function",
+          "expression": {
+            "body": {
+              "body": [
+                {
+                  "argument": {
+                    "end": 75,
+                    "left": {
+                      "end": 67,
+                      "name": "x",
+                      "start": 66,
+                      "type": "Identifier",
+                      "type": "Identifier"
+                    },
+                    "operator": "+",
+                    "right": {
+                      "end": 75,
+                      "name": "delta",
+                      "start": 70,
+                      "type": "Identifier",
+                      "type": "Identifier"
+                    },
+                    "start": 66,
+                    "type": "BinaryExpression",
+                    "type": "BinaryExpression"
+                  },
+                  "end": 75,
+                  "start": 59,
+                  "type": "ReturnStatement",
+                  "type": "ReturnStatement"
+                }
+              ],
+              "end": 77,
+              "start": 55
+            },
+            "end": 77,
+            "params": [
+              {
+                "type": "Parameter",
+                "identifier": {
+                  "end": 46,
+                  "name": "x",
+                  "start": 45,
+                  "type": "Identifier"
+                },
+                "labeled": false
+              },
+              {
+                "type": "Parameter",
+                "identifier": {
+                  "end": 53,
+                  "name": "delta",
+                  "start": 48,
+                  "type": "Identifier"
+                }
+              }
+            ],
+            "start": 43,
+            "type": "FunctionExpression"
+          },
+          "memory": {
+            "environments": [
+              {
+                "bindings": {
+                  "HALF_TURN": {
+                    "type": "Number",
+                    "value": 180.0,
+                    "__meta": []
+                  },
+                  "QUARTER_TURN": {
+                    "type": "Number",
+                    "value": 90.0,
+                    "__meta": []
+                  },
+                  "THREE_QUARTER_TURN": {
+                    "type": "Number",
+                    "value": 270.0,
+                    "__meta": []
+                  },
+                  "ZERO": {
+                    "type": "Number",
+                    "value": 0.0,
+                    "__meta": []
+                  },
+                  "increment": {
+                    "type": "Function",
+                    "expression": {
+                      "body": {
+                        "body": [
+                          {
+                            "argument": {
+                              "end": 33,
+                              "left": {
+                                "end": 29,
+                                "name": "x",
+                                "start": 28,
+                                "type": "Identifier",
+                                "type": "Identifier"
+                              },
+                              "operator": "+",
+                              "right": {
+                                "end": 33,
+                                "raw": "1",
+                                "start": 32,
+                                "type": "Literal",
+                                "type": "Literal",
+                                "value": 1.0
+                              },
+                              "start": 28,
+                              "type": "BinaryExpression",
+                              "type": "BinaryExpression"
+                            },
+                            "end": 33,
+                            "start": 21,
+                            "type": "ReturnStatement",
+                            "type": "ReturnStatement"
+                          }
+                        ],
+                        "end": 35,
+                        "start": 17
+                      },
+                      "end": 35,
+                      "params": [
+                        {
+                          "type": "Parameter",
+                          "identifier": {
+                            "end": 15,
+                            "name": "x",
+                            "start": 14,
+                            "type": "Identifier"
+                          },
+                          "labeled": false
+                        }
+                      ],
+                      "start": 12,
+                      "type": "FunctionExpression"
+                    },
+                    "memory": {
+                      "environments": [
+                        {
+                          "bindings": {
+                            "HALF_TURN": {
+                              "type": "Number",
+                              "value": 180.0,
+                              "__meta": []
+                            },
+                            "QUARTER_TURN": {
+                              "type": "Number",
+                              "value": 90.0,
+                              "__meta": []
+                            },
+                            "THREE_QUARTER_TURN": {
+                              "type": "Number",
+                              "value": 270.0,
+                              "__meta": []
+                            },
+                            "ZERO": {
+                              "type": "Number",
+                              "value": 0.0,
+                              "__meta": []
+                            }
+                          },
+                          "parent": null
+                        }
+                      ],
+                      "currentEnv": 0,
+                      "return": null
+                    },
+                    "__meta": [
+                      {
+                        "sourceRange": [
+                          12,
+                          35,
+                          0
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "parent": null
+              }
+            ],
+            "currentEnv": 0,
+            "return": null
+          },
+          "__meta": [
+            {
+              "sourceRange": [
+                43,
+                77,
+                0
+              ]
+            }
+          ]
+        },
         "increment": {
           "type": "Function",
           "expression": {
@@ -121,14 +317,34 @@ snapshot_kind: text
             }
           ]
         },
+        "three": {
+          "type": "Number",
+          "value": 3.0,
+          "__meta": [
+            {
+              "sourceRange": [
+                110,
+                111,
+                0
+              ]
+            },
+            {
+              "sourceRange": [
+                120,
+                121,
+                0
+              ]
+            }
+          ]
+        },
         "two": {
           "type": "Number",
           "value": 2.0,
           "__meta": [
             {
               "sourceRange": [
-                53,
-                54,
+                95,
+                96,
                 0
               ]
             },

--- a/src/wasm-lib/kcl/tests/kw_fn_too_few_args/ast.snap
+++ b/src/wasm-lib/kcl/tests/kw_fn_too_few_args/ast.snap
@@ -1,0 +1,153 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Result of parsing kw_fn_too_few_args.kcl
+snapshot_kind: text
+---
+{
+  "Ok": {
+    "body": [
+      {
+        "declaration": {
+          "end": 31,
+          "id": {
+            "end": 6,
+            "name": "add",
+            "start": 3,
+            "type": "Identifier"
+          },
+          "init": {
+            "body": {
+              "body": [
+                {
+                  "argument": {
+                    "end": 29,
+                    "left": {
+                      "end": 25,
+                      "name": "x",
+                      "start": 24,
+                      "type": "Identifier",
+                      "type": "Identifier"
+                    },
+                    "operator": "+",
+                    "right": {
+                      "end": 29,
+                      "name": "y",
+                      "start": 28,
+                      "type": "Identifier",
+                      "type": "Identifier"
+                    },
+                    "start": 24,
+                    "type": "BinaryExpression",
+                    "type": "BinaryExpression"
+                  },
+                  "end": 29,
+                  "start": 17,
+                  "type": "ReturnStatement",
+                  "type": "ReturnStatement"
+                }
+              ],
+              "end": 31,
+              "start": 13
+            },
+            "end": 31,
+            "params": [
+              {
+                "type": "Parameter",
+                "identifier": {
+                  "end": 8,
+                  "name": "x",
+                  "start": 7,
+                  "type": "Identifier"
+                }
+              },
+              {
+                "type": "Parameter",
+                "identifier": {
+                  "end": 11,
+                  "name": "y",
+                  "start": 10,
+                  "type": "Identifier"
+                }
+              }
+            ],
+            "start": 6,
+            "type": "FunctionExpression",
+            "type": "FunctionExpression"
+          },
+          "start": 3,
+          "type": "VariableDeclarator"
+        },
+        "end": 31,
+        "kind": "fn",
+        "start": 0,
+        "type": "VariableDeclaration",
+        "type": "VariableDeclaration"
+      },
+      {
+        "declaration": {
+          "end": 50,
+          "id": {
+            "end": 38,
+            "name": "three",
+            "start": 33,
+            "type": "Identifier"
+          },
+          "init": {
+            "arguments": [
+              {
+                "type": "LabeledArg",
+                "label": {
+                  "type": "Identifier",
+                  "name": "x"
+                },
+                "arg": {
+                  "end": 49,
+                  "raw": "1",
+                  "start": 48,
+                  "type": "Literal",
+                  "type": "Literal",
+                  "value": 1.0
+                }
+              }
+            ],
+            "callee": {
+              "end": 44,
+              "name": "add",
+              "start": 41,
+              "type": "Identifier"
+            },
+            "end": 50,
+            "start": 41,
+            "type": "CallExpressionKw",
+            "type": "CallExpressionKw",
+            "unlabeled": null
+          },
+          "start": 33,
+          "type": "VariableDeclarator"
+        },
+        "end": 50,
+        "kind": "const",
+        "start": 33,
+        "type": "VariableDeclaration",
+        "type": "VariableDeclaration"
+      }
+    ],
+    "end": 51,
+    "nonCodeMeta": {
+      "nonCodeNodes": {
+        "0": [
+          {
+            "end": 33,
+            "start": 31,
+            "type": "NonCodeNode",
+            "value": {
+              "type": "newLine"
+            }
+          }
+        ]
+      },
+      "startNodes": []
+    },
+    "start": 0
+  }
+}

--- a/src/wasm-lib/kcl/tests/kw_fn_too_few_args/execution_error.snap
+++ b/src/wasm-lib/kcl/tests/kw_fn_too_few_args/execution_error.snap
@@ -1,0 +1,17 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Error from executing kw_fn_too_few_args.kcl
+snapshot_kind: text
+---
+KCL Semantic error
+
+  × semantic: This function requires a parameter y, but you haven't passed
+  │ it one.
+   ╭─[1:7]
+ 1 │ ╭─▶ fn add(x, y) {
+ 2 │ │     return x + y
+ 3 │ ╰─▶ }
+ 4 │     
+ 5 │     three = add(x: 1)
+   ·             ─────────
+   ╰────

--- a/src/wasm-lib/kcl/tests/kw_fn_too_few_args/input.kcl
+++ b/src/wasm-lib/kcl/tests/kw_fn_too_few_args/input.kcl
@@ -1,0 +1,5 @@
+fn add(x, y) {
+  return x + y
+}
+
+three = add(x: 1)

--- a/src/wasm-lib/kcl/tests/kw_fn_unlabeled_but_has_label/ast.snap
+++ b/src/wasm-lib/kcl/tests/kw_fn_unlabeled_but_has_label/ast.snap
@@ -1,0 +1,146 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Result of parsing kw_fn_unlabeled_but_has_label.kcl
+snapshot_kind: text
+---
+{
+  "Ok": {
+    "body": [
+      {
+        "declaration": {
+          "end": 29,
+          "id": {
+            "end": 6,
+            "name": "add",
+            "start": 3,
+            "type": "Identifier"
+          },
+          "init": {
+            "body": {
+              "body": [
+                {
+                  "argument": {
+                    "end": 27,
+                    "left": {
+                      "end": 23,
+                      "name": "x",
+                      "start": 22,
+                      "type": "Identifier",
+                      "type": "Identifier"
+                    },
+                    "operator": "+",
+                    "right": {
+                      "end": 27,
+                      "raw": "1",
+                      "start": 26,
+                      "type": "Literal",
+                      "type": "Literal",
+                      "value": 1.0
+                    },
+                    "start": 22,
+                    "type": "BinaryExpression",
+                    "type": "BinaryExpression"
+                  },
+                  "end": 27,
+                  "start": 15,
+                  "type": "ReturnStatement",
+                  "type": "ReturnStatement"
+                }
+              ],
+              "end": 29,
+              "start": 11
+            },
+            "end": 29,
+            "params": [
+              {
+                "type": "Parameter",
+                "identifier": {
+                  "end": 9,
+                  "name": "x",
+                  "start": 8,
+                  "type": "Identifier"
+                },
+                "labeled": false
+              }
+            ],
+            "start": 6,
+            "type": "FunctionExpression",
+            "type": "FunctionExpression"
+          },
+          "start": 3,
+          "type": "VariableDeclarator"
+        },
+        "end": 29,
+        "kind": "fn",
+        "start": 0,
+        "type": "VariableDeclaration",
+        "type": "VariableDeclaration"
+      },
+      {
+        "declaration": {
+          "end": 46,
+          "id": {
+            "end": 34,
+            "name": "two",
+            "start": 31,
+            "type": "Identifier"
+          },
+          "init": {
+            "arguments": [
+              {
+                "type": "LabeledArg",
+                "label": {
+                  "type": "Identifier",
+                  "name": "x"
+                },
+                "arg": {
+                  "end": 45,
+                  "raw": "1",
+                  "start": 44,
+                  "type": "Literal",
+                  "type": "Literal",
+                  "value": 1.0
+                }
+              }
+            ],
+            "callee": {
+              "end": 40,
+              "name": "add",
+              "start": 37,
+              "type": "Identifier"
+            },
+            "end": 46,
+            "start": 37,
+            "type": "CallExpressionKw",
+            "type": "CallExpressionKw",
+            "unlabeled": null
+          },
+          "start": 31,
+          "type": "VariableDeclarator"
+        },
+        "end": 46,
+        "kind": "const",
+        "start": 31,
+        "type": "VariableDeclaration",
+        "type": "VariableDeclaration"
+      }
+    ],
+    "end": 47,
+    "nonCodeMeta": {
+      "nonCodeNodes": {
+        "0": [
+          {
+            "end": 31,
+            "start": 29,
+            "type": "NonCodeNode",
+            "value": {
+              "type": "newLine"
+            }
+          }
+        ]
+      },
+      "startNodes": []
+    },
+    "start": 0
+  }
+}

--- a/src/wasm-lib/kcl/tests/kw_fn_unlabeled_but_has_label/execution_error.snap
+++ b/src/wasm-lib/kcl/tests/kw_fn_unlabeled_but_has_label/execution_error.snap
@@ -1,0 +1,17 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Error from executing kw_fn_unlabeled_but_has_label.kcl
+snapshot_kind: text
+---
+KCL Semantic error
+
+  × semantic: The function does declare a parameter named 'x', but this
+  │ parameter doesn't use a label. Try removing the `x:`
+   ╭─[1:7]
+ 1 │ ╭─▶ fn add(@x) {
+ 2 │ │     return x + 1
+ 3 │ ╰─▶ }
+ 4 │     
+ 5 │     two = add(x: 1)
+   ·           ─────────
+   ╰────

--- a/src/wasm-lib/kcl/tests/kw_fn_unlabeled_but_has_label/input.kcl
+++ b/src/wasm-lib/kcl/tests/kw_fn_unlabeled_but_has_label/input.kcl
@@ -1,0 +1,5 @@
+fn add(@x) {
+  return x + 1
+}
+
+two = add(x: 1)


### PR DESCRIPTION
Part of https://github.com/KittyCAD/modeling-app/issues/4600

You can now call a user-defined function via keyword args. E.g.

```
fn increment(@x) {
  return x + 1
}

fn add(@x, delta) {
  return x + delta
}

two = increment(1)
three = add(1, delta: 2)
```