### PR TITLE
fix: remove noisy log line in linux

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -218,6 +218,7 @@ ipcMain.handle('kittycad', (event, data) => {
     )(data.args)
 })
 
+// Used to find other devices on the local network, e.g. 3D printers, CNC machines, etc.
 ipcMain.handle('find_machine_api', () => {
   const timeoutAfterMs = 5000
   return new Promise((resolve, reject) => {
@@ -228,7 +229,6 @@ ipcMain.handle('find_machine_api', () => {
       console.error(error)
       resolve(null)
     })
-    console.log('Looking for machine API...')
     bonjourEt.find(
       { protocol: 'tcp', type: 'machine-api' },
       (service: Service) => {


### PR DESCRIPTION
closes #4024 
At first, I thought this was something that should just get skipped on Linux, because Bonjour is a Windows/Mac app, but it seems like the library is using Bonjour to refer to zeroconf networking in general. So, it should work, but it doesn't seem like the success callback ever actually gets triggered on Linux. It also doesn't seem to trigger any sort of error behavior. I have the avahi-daemon installed and running and can see a local printer by running `ippfind`, so not entirely sure what the deal is. Seems like the `bonjour-service` library is expecting there to be a `PTR` record for the mdns server, but avahi doesn't supply one, so the library returns null

So, this just removes that logline because it's spammy. I can open an issue about the machine finding if y'all think that's worth looking at