### PR TITLE
KCL parser: fns with optional keyword args can set defaults

### DIFF
--- a/src/wasm-lib/kcl/src/parsing/ast/types/mod.rs
+++ b/src/wasm-lib/kcl/src/parsing/ast/types/mod.rs
@@ -2810,7 +2810,8 @@ pub struct Parameter {
     pub identifier: Node<Identifier>,
     /// The type of the parameter.
     /// This is optional if the user defines a type.
-    #[serde(skip)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(skip)]
     pub type_: Option<FnArgType>,
     /// Is the parameter optional?
     /// If so, what is its default value?

--- a/src/wasm-lib/kcl/src/parsing/parser.rs
+++ b/src/wasm-lib/kcl/src/parsing/parser.rs
@@ -2298,11 +2298,11 @@ fn parameter(i: &mut TokenSlice) -> PResult<ParamDescription> {
         labeled: found_at_sign.is_none(),
         arg_name,
         type_,
-        default_value: match (question_mark, default_literal) {
-            (Some(_), Some(lit)) => Some(DefaultParamVal::Literal(lit.inner)),
-            (Some(_), None) => Some(DefaultParamVal::none()),
-            (None, None) => None,
-            (None, Some(lit)) => {
+        default_value: match (question_mark.is_some(), default_literal) {
+            (true, Some(lit)) => Some(DefaultParamVal::Literal(lit.inner)),
+            (true, None) => Some(DefaultParamVal::none()),
+            (false, None) => None,
+            (false, Some(lit)) => {
                 let msg = "You're trying to set a default value for an argument, but only optional arguments can have default values, and this argument is mandatory. Try putting a ? after the argument name, to make the argument optional.";
                 let e = CompilationError::fatal((&lit).into(), msg);
                 return Err(ErrMode::Backtrack(ContextError::from(e)));

--- a/src/wasm-lib/kcl/src/parsing/parser.rs
+++ b/src/wasm-lib/kcl/src/parsing/parser.rs
@@ -2284,10 +2284,11 @@ struct ParamDescription {
 }
 
 fn parameter(i: &mut TokenSlice) -> PResult<ParamDescription> {
-    let (found_at_sign, arg_name, question_mark, type_, _ws, default_literal) = (
+    let (found_at_sign, arg_name, question_mark, _, type_, _ws, default_literal) = (
         opt(at_sign),
         any.verify(|token: &Token| !matches!(token.token_type, TokenType::Brace) || token.value != ")"),
         opt(question_mark),
+        opt(whitespace),
         opt((colon, opt(whitespace), argument_type).map(|tup| tup.2)),
         opt(whitespace),
         opt((equals, opt(whitespace), literal).map(|(_, _, literal)| literal)),

--- a/src/wasm-lib/kcl/src/parsing/parser.rs
+++ b/src/wasm-lib/kcl/src/parsing/parser.rs
@@ -2280,23 +2280,33 @@ struct ParamDescription {
     labeled: bool,
     arg_name: Token,
     type_: std::option::Option<FnArgType>,
-    is_optional: bool,
+    default_value: Option<DefaultParamVal>,
 }
 
 fn parameter(i: &mut TokenSlice) -> PResult<ParamDescription> {
-    let (found_at_sign, arg_name, optional, _, type_) = (
+    let (found_at_sign, arg_name, question_mark, type_, _ws, default_literal) = (
         opt(at_sign),
         any.verify(|token: &Token| !matches!(token.token_type, TokenType::Brace) || token.value != ")"),
         opt(question_mark),
-        opt(whitespace),
         opt((colon, opt(whitespace), argument_type).map(|tup| tup.2)),
+        opt(whitespace),
+        opt((equals, opt(whitespace), literal).map(|(_, _, literal)| literal)),
     )
         .parse_next(i)?;
     Ok(ParamDescription {
         labeled: found_at_sign.is_none(),
         arg_name,
         type_,
-        is_optional: optional.is_some(),
+        default_value: match (question_mark, default_literal) {
+            (Some(_), Some(lit)) => Some(DefaultParamVal::Literal(lit.inner)),
+            (Some(_), None) => Some(DefaultParamVal::none()),
+            (None, None) => None,
+            (None, Some(lit)) => {
+                let msg = "You're trying to set a default value for an argument, but only optional arguments can have default values, and this argument is mandatory. Try putting a ? after the argument name, to make the argument optional.";
+                let e = CompilationError::fatal((&lit).into(), msg);
+                return Err(ErrMode::Backtrack(ContextError::from(e)));
+            }
+        },
     })
 }
 
@@ -2315,7 +2325,7 @@ fn parameters(i: &mut TokenSlice) -> PResult<Vec<Parameter>> {
                  labeled,
                  arg_name,
                  type_,
-                 is_optional,
+                 default_value,
              }| {
                 let identifier =
                     Node::<Identifier>::try_from(arg_name).and_then(Node::<Identifier>::into_valid_binding_name)?;
@@ -2323,11 +2333,7 @@ fn parameters(i: &mut TokenSlice) -> PResult<Vec<Parameter>> {
                 Ok(Parameter {
                     identifier,
                     type_,
-                    default_value: if is_optional {
-                        Some(DefaultParamVal::none())
-                    } else {
-                        None
-                    },
+                    default_value,
                     labeled,
                     digest: None,
                 })
@@ -4459,6 +4465,11 @@ my14 = 4 ^ 2 - 3 ^ 2 * 2
     snapshot_test!(kw_function_all_named, r#"val = foo(x: a, y: b)"#);
     snapshot_test!(kw_function_decl_all_labeled, r#"fn foo(x, y) { return 1 }"#);
     snapshot_test!(kw_function_decl_first_unlabeled, r#"fn foo(@x, y) { return 1 }"#);
+    snapshot_test!(kw_function_decl_with_default_no_type, r#"fn foo(x? = 2) { return 1 }"#);
+    snapshot_test!(
+        kw_function_decl_with_default_and_type,
+        r#"fn foo(x?: number = 2) { return 1 }"#
+    );
 }
 
 #[allow(unused)]

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__kw_function_decl_with_default_and_type.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__kw_function_decl_with_default_and_type.snap
@@ -45,6 +45,10 @@ snapshot_kind: text
                 "start": 7,
                 "type": "Identifier"
               },
+              "type_": {
+                "type": "Primitive",
+                "type": "Number"
+              },
               "default_value": {
                 "type": "Literal",
                 "type": "Literal",

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__kw_function_decl_with_default_and_type.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__kw_function_decl_with_default_and_type.snap
@@ -1,0 +1,72 @@
+---
+source: kcl/src/parsing/parser.rs
+expression: actual
+snapshot_kind: text
+---
+{
+  "body": [
+    {
+      "declaration": {
+        "end": 35,
+        "id": {
+          "end": 6,
+          "name": "foo",
+          "start": 3,
+          "type": "Identifier"
+        },
+        "init": {
+          "body": {
+            "body": [
+              {
+                "argument": {
+                  "end": 33,
+                  "raw": "1",
+                  "start": 32,
+                  "type": "Literal",
+                  "type": "Literal",
+                  "value": 1.0
+                },
+                "end": 33,
+                "start": 25,
+                "type": "ReturnStatement",
+                "type": "ReturnStatement"
+              }
+            ],
+            "end": 35,
+            "start": 23
+          },
+          "end": 35,
+          "params": [
+            {
+              "type": "Parameter",
+              "identifier": {
+                "end": 8,
+                "name": "x",
+                "start": 7,
+                "type": "Identifier"
+              },
+              "default_value": {
+                "type": "Literal",
+                "type": "Literal",
+                "value": 2.0,
+                "raw": "2"
+              }
+            }
+          ],
+          "start": 6,
+          "type": "FunctionExpression",
+          "type": "FunctionExpression"
+        },
+        "start": 3,
+        "type": "VariableDeclarator"
+      },
+      "end": 35,
+      "kind": "fn",
+      "start": 0,
+      "type": "VariableDeclaration",
+      "type": "VariableDeclaration"
+    }
+  ],
+  "end": 35,
+  "start": 0
+}

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__kw_function_decl_with_default_no_type.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__kw_function_decl_with_default_no_type.snap
@@ -1,0 +1,72 @@
+---
+source: kcl/src/parsing/parser.rs
+expression: actual
+snapshot_kind: text
+---
+{
+  "body": [
+    {
+      "declaration": {
+        "end": 27,
+        "id": {
+          "end": 6,
+          "name": "foo",
+          "start": 3,
+          "type": "Identifier"
+        },
+        "init": {
+          "body": {
+            "body": [
+              {
+                "argument": {
+                  "end": 25,
+                  "raw": "1",
+                  "start": 24,
+                  "type": "Literal",
+                  "type": "Literal",
+                  "value": 1.0
+                },
+                "end": 25,
+                "start": 17,
+                "type": "ReturnStatement",
+                "type": "ReturnStatement"
+              }
+            ],
+            "end": 27,
+            "start": 15
+          },
+          "end": 27,
+          "params": [
+            {
+              "type": "Parameter",
+              "identifier": {
+                "end": 8,
+                "name": "x",
+                "start": 7,
+                "type": "Identifier"
+              },
+              "default_value": {
+                "type": "Literal",
+                "type": "Literal",
+                "value": 2.0,
+                "raw": "2"
+              }
+            }
+          ],
+          "start": 6,
+          "type": "FunctionExpression",
+          "type": "FunctionExpression"
+        },
+        "start": 3,
+        "type": "VariableDeclarator"
+      },
+      "end": 27,
+      "kind": "fn",
+      "start": 0,
+      "type": "VariableDeclaration",
+      "type": "VariableDeclaration"
+    }
+  ],
+  "end": 27,
+  "start": 0
+}

--- a/src/wasm-lib/kcl/src/simulation_tests.rs
+++ b/src/wasm-lib/kcl/src/simulation_tests.rs
@@ -1562,7 +1562,7 @@ mod kw_fn_too_few_args {
     /// Test that KCL is executed correctly.
     #[tokio::test(flavor = "multi_thread")]
     async fn kcl_test_execute() {
-        super::execute(TEST_NAME, true).await
+        super::execute(TEST_NAME, false).await
     }
 }
 mod kw_fn_unlabeled_but_has_label {
@@ -1583,6 +1583,27 @@ mod kw_fn_unlabeled_but_has_label {
     /// Test that KCL is executed correctly.
     #[tokio::test(flavor = "multi_thread")]
     async fn kcl_test_execute() {
-        super::execute(TEST_NAME, true).await
+        super::execute(TEST_NAME, false).await
+    }
+}
+mod kw_fn_with_defaults {
+    const TEST_NAME: &str = "kw_fn_with_defaults";
+
+    /// Test parsing KCL.
+    #[test]
+    fn parse() {
+        super::parse(TEST_NAME)
+    }
+
+    /// Test that parsing and unparsing KCL produces the original KCL input.
+    #[test]
+    fn unparse() {
+        super::unparse(TEST_NAME)
+    }
+
+    /// Test that KCL is executed correctly.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn kcl_test_execute() {
+        super::execute(TEST_NAME, false).await
     }
 }

--- a/src/wasm-lib/kcl/src/unparser.rs
+++ b/src/wasm-lib/kcl/src/unparser.rs
@@ -3,10 +3,10 @@ use std::fmt::Write;
 use crate::parsing::{
     ast::types::{
         ArrayExpression, ArrayRangeExpression, BinaryExpression, BinaryOperator, BinaryPart, BodyItem, CallExpression,
-        CallExpressionKw, Expr, FnArgType, FormatOptions, FunctionExpression, IfExpression, ImportSelector,
-        ImportStatement, ItemVisibility, LabeledArg, Literal, LiteralIdentifier, LiteralValue, MemberExpression,
-        MemberObject, Node, NonCodeValue, ObjectExpression, Parameter, PipeExpression, Program, TagDeclarator,
-        UnaryExpression, VariableDeclaration, VariableKind,
+        CallExpressionKw, DefaultParamVal, Expr, FnArgType, FormatOptions, FunctionExpression, IfExpression,
+        ImportSelector, ImportStatement, ItemVisibility, LabeledArg, Literal, LiteralIdentifier, LiteralValue,
+        MemberExpression, MemberObject, Node, NonCodeValue, ObjectExpression, Parameter, PipeExpression, Program,
+        TagDeclarator, UnaryExpression, VariableDeclaration, VariableKind,
     },
     PIPE_OPERATOR,
 };
@@ -662,15 +662,18 @@ impl FunctionExpression {
 
 impl Parameter {
     pub fn recast(&self, options: &FormatOptions, indentation_level: usize) -> String {
-        let mut result = format!(
-            "{}{}",
-            if self.labeled { "" } else { "@" },
-            self.identifier.name.clone()
-        );
+        let at_sign = if self.labeled { "" } else { "@" };
+        let identifier = &self.identifier.name;
+        let question_mark = if self.default_value.is_some() { "?" } else { "" };
+        let mut result = format!("{at_sign}{identifier}{question_mark}");
         if let Some(ty) = &self.type_ {
             result += ": ";
             result += &ty.recast(options, indentation_level);
         }
+        if let Some(DefaultParamVal::Literal(ref literal)) = self.default_value {
+            let lit = literal.recast();
+            result.push_str(&format!(" = {lit}"));
+        };
 
         result
     }

--- a/src/wasm-lib/kcl/tests/kw_fn_with_defaults/ast.snap
+++ b/src/wasm-lib/kcl/tests/kw_fn_with_defaults/ast.snap
@@ -1,0 +1,207 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Result of parsing kw_fn_with_defaults.kcl
+snapshot_kind: text
+---
+{
+  "Ok": {
+    "body": [
+      {
+        "declaration": {
+          "end": 45,
+          "id": {
+            "end": 12,
+            "name": "increment",
+            "start": 3,
+            "type": "Identifier"
+          },
+          "init": {
+            "body": {
+              "body": [
+                {
+                  "argument": {
+                    "end": 43,
+                    "left": {
+                      "end": 38,
+                      "name": "x",
+                      "start": 37,
+                      "type": "Identifier",
+                      "type": "Identifier"
+                    },
+                    "operator": "+",
+                    "right": {
+                      "end": 43,
+                      "name": "by",
+                      "start": 41,
+                      "type": "Identifier",
+                      "type": "Identifier"
+                    },
+                    "start": 37,
+                    "type": "BinaryExpression",
+                    "type": "BinaryExpression"
+                  },
+                  "end": 43,
+                  "start": 30,
+                  "type": "ReturnStatement",
+                  "type": "ReturnStatement"
+                }
+              ],
+              "end": 45,
+              "start": 26
+            },
+            "end": 45,
+            "params": [
+              {
+                "type": "Parameter",
+                "identifier": {
+                  "end": 15,
+                  "name": "x",
+                  "start": 14,
+                  "type": "Identifier"
+                },
+                "labeled": false
+              },
+              {
+                "type": "Parameter",
+                "identifier": {
+                  "end": 19,
+                  "name": "by",
+                  "start": 17,
+                  "type": "Identifier"
+                },
+                "default_value": {
+                  "type": "Literal",
+                  "type": "Literal",
+                  "value": 1.0,
+                  "raw": "1"
+                }
+              }
+            ],
+            "start": 12,
+            "type": "FunctionExpression",
+            "type": "FunctionExpression"
+          },
+          "start": 3,
+          "type": "VariableDeclarator"
+        },
+        "end": 45,
+        "kind": "fn",
+        "start": 0,
+        "type": "VariableDeclaration",
+        "type": "VariableDeclaration"
+      },
+      {
+        "declaration": {
+          "end": 65,
+          "id": {
+            "end": 50,
+            "name": "two",
+            "start": 47,
+            "type": "Identifier"
+          },
+          "init": {
+            "arguments": [
+              {
+                "end": 64,
+                "raw": "1",
+                "start": 63,
+                "type": "Literal",
+                "type": "Literal",
+                "value": 1.0
+              }
+            ],
+            "callee": {
+              "end": 62,
+              "name": "increment",
+              "start": 53,
+              "type": "Identifier"
+            },
+            "end": 65,
+            "start": 53,
+            "type": "CallExpression",
+            "type": "CallExpression"
+          },
+          "start": 47,
+          "type": "VariableDeclarator"
+        },
+        "end": 65,
+        "kind": "const",
+        "start": 47,
+        "type": "VariableDeclaration",
+        "type": "VariableDeclaration"
+      },
+      {
+        "declaration": {
+          "end": 98,
+          "id": {
+            "end": 75,
+            "name": "twentyOne",
+            "start": 66,
+            "type": "Identifier"
+          },
+          "init": {
+            "arguments": [
+              {
+                "type": "LabeledArg",
+                "label": {
+                  "type": "Identifier",
+                  "name": "by"
+                },
+                "arg": {
+                  "end": 97,
+                  "raw": "20",
+                  "start": 95,
+                  "type": "Literal",
+                  "type": "Literal",
+                  "value": 20.0
+                }
+              }
+            ],
+            "callee": {
+              "end": 87,
+              "name": "increment",
+              "start": 78,
+              "type": "Identifier"
+            },
+            "end": 98,
+            "start": 78,
+            "type": "CallExpressionKw",
+            "type": "CallExpressionKw",
+            "unlabeled": {
+              "end": 89,
+              "raw": "1",
+              "start": 88,
+              "type": "Literal",
+              "type": "Literal",
+              "value": 1.0
+            }
+          },
+          "start": 66,
+          "type": "VariableDeclarator"
+        },
+        "end": 98,
+        "kind": "const",
+        "start": 66,
+        "type": "VariableDeclaration",
+        "type": "VariableDeclaration"
+      }
+    ],
+    "end": 99,
+    "nonCodeMeta": {
+      "nonCodeNodes": {
+        "0": [
+          {
+            "end": 47,
+            "start": 45,
+            "type": "NonCodeNode",
+            "value": {
+              "type": "newLine"
+            }
+          }
+        ]
+      },
+      "startNodes": []
+    },
+    "start": 0
+  }
+}

--- a/src/wasm-lib/kcl/tests/kw_fn_with_defaults/input.kcl
+++ b/src/wasm-lib/kcl/tests/kw_fn_with_defaults/input.kcl
@@ -1,0 +1,6 @@
+fn increment(@x, by? = 1) {
+  return x + by
+}
+
+two = increment(1)
+twentyOne = increment(1, by: 20)

--- a/src/wasm-lib/kcl/tests/kw_fn_with_defaults/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/kw_fn_with_defaults/program_memory.snap
@@ -1,0 +1,177 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Program memory after executing kw_fn_with_defaults.kcl
+snapshot_kind: text
+---
+{
+  "environments": [
+    {
+      "bindings": {
+        "HALF_TURN": {
+          "type": "Number",
+          "value": 180.0,
+          "__meta": []
+        },
+        "QUARTER_TURN": {
+          "type": "Number",
+          "value": 90.0,
+          "__meta": []
+        },
+        "THREE_QUARTER_TURN": {
+          "type": "Number",
+          "value": 270.0,
+          "__meta": []
+        },
+        "ZERO": {
+          "type": "Number",
+          "value": 0.0,
+          "__meta": []
+        },
+        "increment": {
+          "type": "Function",
+          "expression": {
+            "body": {
+              "body": [
+                {
+                  "argument": {
+                    "end": 43,
+                    "left": {
+                      "end": 38,
+                      "name": "x",
+                      "start": 37,
+                      "type": "Identifier",
+                      "type": "Identifier"
+                    },
+                    "operator": "+",
+                    "right": {
+                      "end": 43,
+                      "name": "by",
+                      "start": 41,
+                      "type": "Identifier",
+                      "type": "Identifier"
+                    },
+                    "start": 37,
+                    "type": "BinaryExpression",
+                    "type": "BinaryExpression"
+                  },
+                  "end": 43,
+                  "start": 30,
+                  "type": "ReturnStatement",
+                  "type": "ReturnStatement"
+                }
+              ],
+              "end": 45,
+              "start": 26
+            },
+            "end": 45,
+            "params": [
+              {
+                "type": "Parameter",
+                "identifier": {
+                  "end": 15,
+                  "name": "x",
+                  "start": 14,
+                  "type": "Identifier"
+                },
+                "labeled": false
+              },
+              {
+                "type": "Parameter",
+                "identifier": {
+                  "end": 19,
+                  "name": "by",
+                  "start": 17,
+                  "type": "Identifier"
+                },
+                "default_value": {
+                  "type": "Literal",
+                  "type": "Literal",
+                  "value": 1.0,
+                  "raw": "1"
+                }
+              }
+            ],
+            "start": 12,
+            "type": "FunctionExpression"
+          },
+          "memory": {
+            "environments": [
+              {
+                "bindings": {
+                  "HALF_TURN": {
+                    "type": "Number",
+                    "value": 180.0,
+                    "__meta": []
+                  },
+                  "QUARTER_TURN": {
+                    "type": "Number",
+                    "value": 90.0,
+                    "__meta": []
+                  },
+                  "THREE_QUARTER_TURN": {
+                    "type": "Number",
+                    "value": 270.0,
+                    "__meta": []
+                  },
+                  "ZERO": {
+                    "type": "Number",
+                    "value": 0.0,
+                    "__meta": []
+                  }
+                },
+                "parent": null
+              }
+            ],
+            "currentEnv": 0,
+            "return": null
+          },
+          "__meta": [
+            {
+              "sourceRange": [
+                12,
+                45,
+                0
+              ]
+            }
+          ]
+        },
+        "twentyOne": {
+          "type": "Number",
+          "value": 21.0,
+          "__meta": [
+            {
+              "sourceRange": [
+                88,
+                89,
+                0
+              ]
+            },
+            {
+              "sourceRange": [
+                95,
+                97,
+                0
+              ]
+            }
+          ]
+        },
+        "two": {
+          "type": "Number",
+          "value": 2.0,
+          "__meta": [
+            {
+              "sourceRange": [
+                63,
+                64,
+                0
+              ]
+            }
+          ]
+        }
+      },
+      "parent": null
+    }
+  ],
+  "currentEnv": 0,
+  "return": null
+}


### PR DESCRIPTION
Part of #4600