### PR TITLE
chore: implemented multiple instances instead of multiple appications?

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,15 @@ import argvFromYargs from './commandLineArgs'
 
 let mainWindow: BrowserWindow | null = null
 
+// Supporting multiple instances instead of multiple applications
+let cmdQPressed = false
+const instances: BrowserWindow[] = []
+const gotTheLock = app.requestSingleInstanceLock()
+if (!gotTheLock) {
+  app.quit()
+  process.exit(0)
+}
+
 // Check the command line arguments for a project path
 const args = parseCLIArgs()
 
@@ -117,15 +126,33 @@ const createWindow = (filePath?: string): BrowserWindow => {
 
   newWindow.show()
 
+  instances.push(newWindow)
   return newWindow
+}
+
+// before-quit with multiple instances
+if (process.platform === 'darwin') {
+  // Quit from the dock context menu should quit the application directly
+  app.on('before-quit', () => {
+    cmdQPressed = true
+  })
 }
 
 // Quit when all windows are closed, even on macOS. There, it's common
 // for applications and their menu bar to stay active until the user quits
 // explicitly with Cmd + Q, but it is a really weird behavior with our app.
+// app.on('window-all-closed', () => {
+//   app.quit()
+// })
 app.on('window-all-closed', () => {
-  app.quit()
+  if (cmdQPressed || process.platform !== 'darwin') {
+    app.quit()
+  }
 })
+
+// Various actions can trigger this event, such as launching the application for the first time,
+// attempting to re-launch the application when it's already running, or clicking on the application's dock or taskbar icon.
+app.on('activate', () => createWindow())
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
@@ -134,6 +161,10 @@ app.on('ready', (event, data) => {
   // Create the mainWindow
   mainWindow = createWindow()
 })
+
+// This event will be emitted inside the primary instance of your application when a second instance
+// has been executed and calls app.requestSingleInstanceLock().
+app.on('second-instance', (event, argv, workingDirectory) => createWindow())
 
 // For now there is no good reason to separate these out to another file(s)
 // There is just not enough code to warrant it and further abstracts everything


### PR DESCRIPTION
closes https://github.com/KittyCAD/modeling-app/issues/4262
documentation https://www.electronjs.org/docs/latest/api/app

# Issue

When booting multiple applications the N+1 applications take 7-8s seconds to boot because of some lock not being released. We are booting multiple electron applications instead of booting multiple BrowserWindows

# Solution

Using the `app` API from electron and a suggestion [here](https://github.com/electron/electron/issues/13163) this will allow us to boot multiple electron BrowserWindows and track them. This speeds up the boot time. This is all using the native `app` API. 

One thing I don't exactly know is if this is the most graceful way to exit the application that should not boot? This still allows the second instance to be kicked off since `app.requestSingleInstanceLock` was invoked. We need the 2nd process to be killed so the first process makes a second browser window with the event triggered from `requestSingleInstanceLock`
```
const gotTheLock = app.requestSingleInstanceLock()
if (!gotTheLock) {
  app.quit()
  process.exit(0)
}
```
