### PR TITLE
Change diagnostic action button to primary color

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -317,3 +317,8 @@ code {
 #code-mirror-override .cm-editor {
   height: 100% !important;
 }
+
+/* Can't use #code-mirror-override here as we're outside of this div */
+.body-bg .cm-diagnosticAction {
+  @apply bg-primary;
+}


### PR DESCRIPTION
Fixes #4715

Changed the color to `primary` so it's consistently contrasting with the background in dark and light modes, see below.

<img width="601" alt="image" src="https://github.com/user-attachments/assets/8b31f00b-a177-4d38-a9c0-7958f7d0f226">

<img width="603" alt="image" src="https://github.com/user-attachments/assets/fd54dbf5-e665-4a6f-b401-beee2b2591d7">
