### PR TITLE
Fix wasm init deprecation warning

### DIFF
--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -123,7 +123,7 @@ const initialise = async () => {
     const fullUrl = wasmUrl()
     const input = await fetch(fullUrl)
     const buffer = await input.arrayBuffer()
-    return await init(buffer)
+    return await init({ module_or_path: buffer })
   } catch (e) {
     console.log('Error initialising WASM', e)
     return Promise.reject(e)


### PR DESCRIPTION
See `__wbg_init()` in `src/wasm-lib/pkg/wasm_lib.js`.