### PR TITLE
Fix KCL warnings in doc comments from let, const, and new fn syntax

### DIFF
--- a/docs/kcl/reduce.md
+++ b/docs/kcl/reduce.md
@@ -43,7 +43,7 @@ fn sum(arr) {
 
 /* The above is basically like this pseudo-code:
 fn sum(arr):
-    let sumSoFar = 0
+    sumSoFar = 0
     for i in arr:
         sumSoFar = add(sumSoFar, i)
     return sumSoFar */
@@ -96,14 +96,14 @@ fn decagon(radius) {
 
 /* The `decagon` above is basically like this pseudo-code:
 fn decagon(radius):
-    let stepAngle = (1/10) * tau()
-    let startOfDecagonSketch = startSketchAt([(cos(0)*radius), (sin(0) * radius)])
+    stepAngle = (1/10) * tau()
+    startOfDecagonSketch = startSketchAt([(cos(0)*radius), (sin(0) * radius)])
 
     // Here's the reduce part.
-    let partialDecagon = startOfDecagonSketch
+    partialDecagon = startOfDecagonSketch
     for i in [1..10]:
-        let x = cos(stepAngle * i) * radius
-        let y = sin(stepAngle * i) * radius
+        x = cos(stepAngle * i) * radius
+        y = sin(stepAngle * i) * radius
         partialDecagon = lineTo([x, y], partialDecagon)
     fullDecagon = partialDecagon // it's now full
     return fullDecagon */

--- a/src/wasm-lib/kcl/src/std/array.rs
+++ b/src/wasm-lib/kcl/src/std/array.rs
@@ -30,7 +30,7 @@ pub async fn map(exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kcl
 /// Given a list like `[a, b, c]`, and a function like `f`, returns
 /// `[f(a), f(b), f(c)]`
 /// ```no_run
-/// const r = 10 // radius
+/// r = 10 // radius
 /// fn drawCircle(id) {
 ///   return startSketchOn("XY")
 ///     |> circle({ center: [id * 2 * r, 0], radius: r}, %)
@@ -39,15 +39,15 @@ pub async fn map(exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kcl
 /// // Call `drawCircle`, passing in each element of the array.
 /// // The outputs from each `drawCircle` form a new array,
 /// // which is the return value from `map`.
-/// const circles = map(
+/// circles = map(
 ///   [1..3],
 ///   drawCircle
 /// )
 /// ```
 /// ```no_run
-/// const r = 10 // radius
+/// r = 10 // radius
 /// // Call `map`, using an anonymous function instead of a named one.
-/// const circles = map(
+/// circles = map(
 ///   [1..3],
 ///   fn(id) {
 ///     return startSketchOn("XY")
@@ -106,17 +106,17 @@ pub async fn reduce(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 /// using the previous value and the element.
 /// ```no_run
 /// // This function adds two numbers.
-/// fn add = (a, b) => { return a + b }
+/// fn add(a, b) { return a + b }
 ///
 /// // This function adds an array of numbers.
 /// // It uses the `reduce` function, to call the `add` function on every
 /// // element of the `arr` parameter. The starting value is 0.
-/// fn sum = (arr) => { return reduce(arr, 0, add) }
+/// fn sum(arr) { return reduce(arr, 0, add) }
 ///
 /// /*
 /// The above is basically like this pseudo-code:
 /// fn sum(arr):
-///     let sumSoFar = 0
+///     sumSoFar = 0
 ///     for i in arr:
 ///         sumSoFar = add(sumSoFar, i)
 ///     return sumSoFar
@@ -139,7 +139,7 @@ pub async fn reduce(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 /// ```
 /// ```no_run
 /// // Declare a function that sketches a decagon.
-/// fn decagon = (radius) => {
+/// fn decagon(radius) {
 ///   // Each side of the decagon is turned this many degrees from the previous angle.
 ///   stepAngle = (1/10) * tau()
 ///
@@ -151,8 +151,8 @@ pub async fn reduce(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 ///   // which takes a partially-sketched decagon and adds one more edge to it.
 ///   fullDecagon = reduce([1..10], startOfDecagonSketch, fn(i, partialDecagon) {
 ///       // Draw one edge of the decagon.
-///       let x = cos(stepAngle * i) * radius
-///       let y = sin(stepAngle * i) * radius
+///       x = cos(stepAngle * i) * radius
+///       y = sin(stepAngle * i) * radius
 ///       return lineTo([x, y], partialDecagon)
 ///   })
 ///
@@ -163,14 +163,14 @@ pub async fn reduce(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 /// /*
 /// The `decagon` above is basically like this pseudo-code:
 /// fn decagon(radius):
-///     let stepAngle = (1/10) * tau()
-///     let startOfDecagonSketch = startSketchAt([(cos(0)*radius), (sin(0) * radius)])
+///     stepAngle = (1/10) * tau()
+///     startOfDecagonSketch = startSketchAt([(cos(0)*radius), (sin(0) * radius)])
 ///
 ///     // Here's the reduce part.
-///     let partialDecagon = startOfDecagonSketch
+///     partialDecagon = startOfDecagonSketch
 ///     for i in [1..10]:
-///         let x = cos(stepAngle * i) * radius
-///         let y = sin(stepAngle * i) * radius
+///         x = cos(stepAngle * i) * radius
+///         y = sin(stepAngle * i) * radius
 ///         partialDecagon = lineTo([x, y], partialDecagon)
 ///     fullDecagon = partialDecagon // it's now full
 ///     return fullDecagon
@@ -224,8 +224,8 @@ async fn call_reduce_closure<'a>(
 /// Returns a new array with the element appended.
 ///
 /// ```no_run
-/// let arr = [1, 2, 3]
-/// let new_arr = push(arr, 4)
+/// arr = [1, 2, 3]
+/// new_arr = push(arr, 4)
 /// assertEqual(new_arr[3], 4, 0.00001, "4 was added to the end of the array")
 /// ```
 #[stdlib {

--- a/src/wasm-lib/kcl/src/std/assert.rs
+++ b/src/wasm-lib/kcl/src/std/assert.rs
@@ -31,7 +31,7 @@ pub async fn assert(_exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 /// is false.
 ///
 /// ```no_run
-/// const myVar = true
+/// myVar = true
 /// assert(myVar, "should always be true")
 /// ```
 #[stdlib {
@@ -70,8 +70,8 @@ pub async fn assert_gt(_exec_state: &mut ExecState, args: Args) -> Result<KclVal
 /// otherwise raise an error.
 ///
 /// ```no_run
-/// let n = 1.0285
-/// let o = 1.0286
+/// n = 1.0285
+/// o = 1.0286
 /// assertEqual(n, o, 0.01, "n is within the given tolerance for o")
 /// ```
 #[stdlib {

--- a/src/wasm-lib/kcl/src/std/chamfer.rs
+++ b/src/wasm-lib/kcl/src/std/chamfer.rs
@@ -43,19 +43,19 @@ pub async fn chamfer(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 ///
 /// ```no_run
 /// // Chamfer a mounting plate.
-/// const width = 20
-/// const length = 10
-/// const thickness = 1
-/// const chamferLength = 2
+/// width = 20
+/// length = 10
+/// thickness = 1
+/// chamferLength = 2
 ///
-/// const mountingPlateSketch = startSketchOn("XY")
+/// mountingPlateSketch = startSketchOn("XY")
 ///   |> startProfileAt([-width/2, -length/2], %)
 ///   |> lineTo([width/2, -length/2], %, $edge1)
 ///   |> lineTo([width/2, length/2], %, $edge2)
 ///   |> lineTo([-width/2, length/2], %, $edge3)
 ///   |> close(%, $edge4)
 ///
-/// const mountingPlate = extrude(thickness, mountingPlateSketch)
+/// mountingPlate = extrude(thickness, mountingPlateSketch)
 ///   |> chamfer({
 ///     length = chamferLength,
 ///     tags = [
@@ -69,8 +69,8 @@ pub async fn chamfer(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 ///
 /// ```no_run
 /// // Sketch on the face of a chamfer.
-/// fn cube = (pos, scale) => {
-/// const sg = startSketchOn('XY')
+/// fn cube(pos, scale) {
+/// sg = startSketchOn('XY')
 ///     |> startProfileAt(pos, %)
 ///     |> line([0, scale], %)
 ///     |> line([scale, 0], %)
@@ -79,7 +79,7 @@ pub async fn chamfer(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 ///     return sg
 /// }
 ///
-/// const part001 = cube([0,0], 20)
+/// part001 = cube([0,0], 20)
 ///     |> close(%, $line1)
 ///     |> extrude(20, %)
 ///     |> chamfer({
@@ -87,7 +87,7 @@ pub async fn chamfer(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 ///         tags = [getOppositeEdge(line1)]
 ///     }, %, $chamfer1) // We tag the chamfer to reference it later.
 ///
-/// const sketch001 = startSketchOn(part001, chamfer1)
+/// sketch001 = startSketchOn(part001, chamfer1)
 ///     |> startProfileAt([10, 10], %)
 ///     |> line([2, 0], %)
 ///     |> line([0, 2], %)

--- a/src/wasm-lib/kcl/src/std/convert.rs
+++ b/src/wasm-lib/kcl/src/std/convert.rs
@@ -21,7 +21,7 @@ pub async fn int(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 /// DEPRECATED use floor(), ceil(), or round().
 ///
 /// ```no_run
-/// let n = int(ceil(5/2))
+/// n = int(ceil(5/2))
 /// assertEqual(n, 3, 0.0001, "5/2 = 2.5, rounded up makes 3")
 /// // Draw n cylinders.
 /// startSketchOn('XZ')

--- a/src/wasm-lib/kcl/src/std/extrude.rs
+++ b/src/wasm-lib/kcl/src/std/extrude.rs
@@ -33,7 +33,7 @@ pub async fn extrude(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 /// cut into an existing solid.
 ///
 /// ```no_run
-/// const example = startSketchOn('XZ')
+/// example = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([10, 0], %)
 ///   |> arc({
@@ -54,7 +54,7 @@ pub async fn extrude(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 /// ```
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([-10, 0], %)
 ///   |> arc({
 ///     angleStart = 120,
@@ -72,7 +72,7 @@ pub async fn extrude(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 ///   |> line([-5, -2], %)
 ///   |> close(%)
 ///
-/// const example = extrude(10, exampleSketch)
+/// example = extrude(10, exampleSketch)
 /// ```
 #[stdlib {
     name = "extrude"

--- a/src/wasm-lib/kcl/src/std/fillet.rs
+++ b/src/wasm-lib/kcl/src/std/fillet.rs
@@ -68,19 +68,19 @@ pub async fn fillet(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 /// will smoothly blend the transition.
 ///
 /// ```no_run
-/// const width = 20
-/// const length = 10
-/// const thickness = 1
-/// const filletRadius = 2
+/// width = 20
+/// length = 10
+/// thickness = 1
+/// filletRadius = 2
 ///
-/// const mountingPlateSketch = startSketchOn("XY")
+/// mountingPlateSketch = startSketchOn("XY")
 ///   |> startProfileAt([-width/2, -length/2], %)
 ///   |> lineTo([width/2, -length/2], %, $edge1)
 ///   |> lineTo([width/2, length/2], %, $edge2)
 ///   |> lineTo([-width/2, length/2], %, $edge3)
 ///   |> close(%, $edge4)
 ///
-/// const mountingPlate = extrude(thickness, mountingPlateSketch)
+/// mountingPlate = extrude(thickness, mountingPlateSketch)
 ///   |> fillet({
 ///     radius = filletRadius,
 ///     tags = [
@@ -93,19 +93,19 @@ pub async fn fillet(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 /// ```
 ///
 /// ```no_run
-/// const width = 20
-/// const length = 10
-/// const thickness = 1
-/// const filletRadius = 1
+/// width = 20
+/// length = 10
+/// thickness = 1
+/// filletRadius = 1
 ///
-/// const mountingPlateSketch = startSketchOn("XY")
+/// mountingPlateSketch = startSketchOn("XY")
 ///   |> startProfileAt([-width/2, -length/2], %)
 ///   |> lineTo([width/2, -length/2], %, $edge1)
 ///   |> lineTo([width/2, length/2], %, $edge2)
 ///   |> lineTo([-width/2, length/2], %, $edge3)
 ///   |> close(%, $edge4)
 ///
-/// const mountingPlate = extrude(thickness, mountingPlateSketch)
+/// mountingPlate = extrude(thickness, mountingPlateSketch)
 ///   |> fillet({
 ///     radius = filletRadius,
 ///     tolerance = 0.000001,
@@ -195,7 +195,7 @@ pub async fn get_opposite_edge(exec_state: &mut ExecState, args: Args) -> Result
 /// Get the opposite edge to the edge given.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([10, 0], %)
 ///   |> angledLine({
@@ -213,7 +213,7 @@ pub async fn get_opposite_edge(exec_state: &mut ExecState, args: Args) -> Result
 ///   }, %, $referenceEdge)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 ///   |> fillet({
 ///     radius = 3,
 ///     tags = [getOppositeEdge(referenceEdge)],
@@ -268,7 +268,7 @@ pub async fn get_next_adjacent_edge(exec_state: &mut ExecState, args: Args) -> R
 /// Get the next adjacent edge to the edge given.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([10, 0], %)
 ///   |> angledLine({
@@ -286,7 +286,7 @@ pub async fn get_next_adjacent_edge(exec_state: &mut ExecState, args: Args) -> R
 ///   }, %, $referenceEdge)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 ///   |> fillet({
 ///     radius = 3,
 ///     tags = [getNextAdjacentEdge(referenceEdge)],
@@ -353,7 +353,7 @@ pub async fn get_previous_adjacent_edge(exec_state: &mut ExecState, args: Args) 
 /// Get the previous adjacent edge to the edge given.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([10, 0], %)
 ///   |> angledLine({
@@ -371,7 +371,7 @@ pub async fn get_previous_adjacent_edge(exec_state: &mut ExecState, args: Args) 
 ///   }, %, $referenceEdge)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 ///   |> fillet({
 ///     radius = 3,
 ///     tags = [getPreviousAdjacentEdge(referenceEdge)],

--- a/src/wasm-lib/kcl/src/std/helix.rs
+++ b/src/wasm-lib/kcl/src/std/helix.rs
@@ -42,7 +42,7 @@ pub async fn helix(exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 /// Create a helix on a cylinder.
 ///
 /// ```no_run
-/// const part001 = startSketchOn('XY')
+/// part001 = startSketchOn('XY')
 ///   |> circle({ center: [5, 5], radius: 10 }, %)
 ///   |> extrude(10, %)
 ///   |> helix({

--- a/src/wasm-lib/kcl/src/std/import.rs
+++ b/src/wasm-lib/kcl/src/std/import.rs
@@ -148,23 +148,23 @@ pub async fn import(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 /// [KCL modules](/docs/kcl/modules).
 ///
 /// ```no_run
-/// const model = import("tests/inputs/cube.obj")
+/// model = import("tests/inputs/cube.obj")
 /// ```
 ///
 /// ```no_run
-/// const model = import("tests/inputs/cube.obj", {format: "obj", units: "m"})
+/// model = import("tests/inputs/cube.obj", {format: "obj", units: "m"})
 /// ```
 ///
 /// ```no_run
-/// const model = import("tests/inputs/cube.gltf")
+/// model = import("tests/inputs/cube.gltf")
 /// ```
 ///
 /// ```no_run
-/// const model = import("tests/inputs/cube.sldprt")
+/// model = import("tests/inputs/cube.sldprt")
 /// ```
 ///
 /// ```no_run
-/// const model = import("tests/inputs/cube.step")
+/// model = import("tests/inputs/cube.step")
 /// ```
 ///
 /// ```no_run

--- a/src/wasm-lib/kcl/src/std/loft.rs
+++ b/src/wasm-lib/kcl/src/std/loft.rs
@@ -63,7 +63,7 @@ pub async fn loft(exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 ///
 /// ```no_run
 /// // Loft a square and a triangle.
-/// const squareSketch = startSketchOn('XY')
+/// squareSketch = startSketchOn('XY')
 ///     |> startProfileAt([-100, 200], %)
 ///     |> line([200, 0], %)
 ///     |> line([0, -200], %)
@@ -71,7 +71,7 @@ pub async fn loft(exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 ///     |> lineTo([profileStartX(%), profileStartY(%)], %)
 ///     |> close(%)
 ///
-/// const triangleSketch = startSketchOn(offsetPlane('XY', 75))
+/// triangleSketch = startSketchOn(offsetPlane('XY', 75))
 ///     |> startProfileAt([0, 125], %)
 ///     |> line([-15, -30], %)
 ///     |> line([30, 0], %)
@@ -83,7 +83,7 @@ pub async fn loft(exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 ///
 /// ```no_run
 /// // Loft a square, a circle, and another circle.
-/// const squareSketch = startSketchOn('XY')
+/// squareSketch = startSketchOn('XY')
 ///     |> startProfileAt([-100, 200], %)
 ///     |> line([200, 0], %)
 ///     |> line([0, -200], %)
@@ -91,10 +91,10 @@ pub async fn loft(exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 ///     |> lineTo([profileStartX(%), profileStartY(%)], %)
 ///     |> close(%)
 ///
-/// const circleSketch0 = startSketchOn(offsetPlane('XY', 75))
+/// circleSketch0 = startSketchOn(offsetPlane('XY', 75))
 ///     |> circle({ center = [0, 100], radius = 50 }, %)
 ///
-/// const circleSketch1 = startSketchOn(offsetPlane('XY', 150))
+/// circleSketch1 = startSketchOn(offsetPlane('XY', 150))
 ///     |> circle({ center = [0, 100], radius = 20 }, %)
 ///
 /// loft([squareSketch, circleSketch0, circleSketch1])
@@ -102,7 +102,7 @@ pub async fn loft(exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 ///
 /// ```no_run
 /// // Loft a square, a circle, and another circle with options.
-/// const squareSketch = startSketchOn('XY')
+/// squareSketch = startSketchOn('XY')
 ///     |> startProfileAt([-100, 200], %)
 ///     |> line([200, 0], %)
 ///     |> line([0, -200], %)
@@ -110,10 +110,10 @@ pub async fn loft(exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 ///     |> lineTo([profileStartX(%), profileStartY(%)], %)
 ///     |> close(%)
 ///
-/// const circleSketch0 = startSketchOn(offsetPlane('XY', 75))
+/// circleSketch0 = startSketchOn(offsetPlane('XY', 75))
 ///     |> circle({ center = [0, 100], radius = 50 }, %)
 ///
-/// const circleSketch1 = startSketchOn(offsetPlane('XY', 150))
+/// circleSketch1 = startSketchOn(offsetPlane('XY', 150))
 ///     |> circle({ center = [0, 100], radius = 20 }, %)
 ///
 /// loft([squareSketch, circleSketch0, circleSketch1], {

--- a/src/wasm-lib/kcl/src/std/math.rs
+++ b/src/wasm-lib/kcl/src/std/math.rs
@@ -48,7 +48,7 @@ pub async fn cos(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 /// Compute the cosine of a number (in radians).
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([0, 0], %)
 ///   |> angledLine({
 ///     angle = 30,
@@ -57,7 +57,7 @@ pub async fn cos(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 ///   |> yLineTo(0, %)
 ///   |> close(%)
 ///  
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "cos",
@@ -78,7 +78,7 @@ pub async fn sin(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 /// Compute the sine of a number (in radians).
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([0, 0], %)
 ///   |> angledLine({
 ///     angle = 50,
@@ -87,7 +87,7 @@ pub async fn sin(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 ///   |> yLineTo(0, %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "sin",
@@ -108,7 +108,7 @@ pub async fn tan(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 /// Compute the tangent of a number (in radians).
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([0, 0], %)
 ///   |> angledLine({
 ///     angle = 50,
@@ -117,7 +117,7 @@ pub async fn tan(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 ///   |> yLineTo(0, %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "tan",
@@ -137,12 +137,12 @@ pub async fn pi(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kcl
 /// Return the value of `pi`. Archimedes’ constant (π).
 ///
 /// ```no_run
-/// const circumference = 70
+/// circumference = 70
 ///
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///  |> circle({ center = [0, 0], radius = circumference/ (2 * pi()) }, %)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "pi",
@@ -163,7 +163,7 @@ pub async fn sqrt(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 /// Compute the square root of a number.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([0, 0], %)
 ///   |> angledLine({
 ///     angle = 50,
@@ -172,7 +172,7 @@ pub async fn sqrt(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 ///   |> yLineTo(0, %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "sqrt",
@@ -193,9 +193,9 @@ pub async fn abs(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 /// Compute the absolute value of a number.
 ///
 /// ```no_run
-/// const myAngle = -120
+/// myAngle = -120
 ///
-/// const sketch001 = startSketchOn('XZ')
+/// sketch001 = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([8, 0], %)
 ///   |> angledLine({
@@ -209,7 +209,7 @@ pub async fn abs(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 ///   }, %)
 ///   |> close(%)
 ///
-/// const baseExtrusion = extrude(5, sketch001)
+/// baseExtrusion = extrude(5, sketch001)
 /// ```
 #[stdlib {
     name = "abs",
@@ -230,14 +230,14 @@ pub async fn round(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 /// Round a number to the nearest integer.
 ///
 /// ```no_run
-/// const sketch001 = startSketchOn('XZ')
+/// sketch001 = startSketchOn('XZ')
 ///    |> startProfileAt([0, 0], %)
 ///    |> lineTo([12, 10], %)
 ///    |> line([round(7.02986), 0], %)
 ///    |> yLineTo(0, %)
 ///    |> close(%)
 ///
-///  const extrude001 = extrude(5, sketch001)
+/// extrude001 = extrude(5, sketch001)
 /// ```
 #[stdlib {
     name = "round",
@@ -258,14 +258,14 @@ pub async fn floor(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 /// Compute the largest integer less than or equal to a number.
 ///
 /// ```no_run
-/// const sketch001 = startSketchOn('XZ')
+/// sketch001 = startSketchOn('XZ')
 ///    |> startProfileAt([0, 0], %)
 ///    |> lineTo([12, 10], %)
 ///    |> line([floor(7.02986), 0], %)
 ///    |> yLineTo(0, %)
 ///    |> close(%)
 ///
-///  const extrude001 = extrude(5, sketch001)
+/// extrude001 = extrude(5, sketch001)
 /// ```
 #[stdlib {
     name = "floor",
@@ -286,14 +286,14 @@ pub async fn ceil(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 /// Compute the smallest integer greater than or equal to a number.
 ///
 /// ```no_run
-/// const sketch001 = startSketchOn('XZ')
+/// sketch001 = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> lineTo([12, 10], %)
 ///   |> line([ceil(7.02986), 0], %)
 ///   |> yLineTo(0, %)
 ///   |> close(%)
 ///
-/// const extrude001 = extrude(5, sketch001)
+/// extrude001 = extrude(5, sketch001)
 /// ```
 #[stdlib {
     name = "ceil",
@@ -314,7 +314,7 @@ pub async fn min(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 /// Compute the minimum of the given arguments.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([0, 0], %)
 ///   |> angledLine({
 ///     angle = 70,
@@ -323,7 +323,7 @@ pub async fn min(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 ///   |> line([20, 0], %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "min",
@@ -351,7 +351,7 @@ pub async fn max(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 /// Compute the maximum of the given arguments.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([0, 0], %)
 ///   |> angledLine({
 ///     angle = 70,
@@ -360,7 +360,7 @@ pub async fn max(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 ///   |> line([20, 0], %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "max",
@@ -402,7 +402,7 @@ pub async fn pow(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 /// Compute the number to a power.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([0, 0], %)
 ///   |> angledLine({
 ///     angle = 50,
@@ -411,7 +411,7 @@ pub async fn pow(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 ///   |> yLineTo(0, %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "pow",
@@ -432,7 +432,7 @@ pub async fn acos(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 /// Compute the arccosine of a number (in radians).
 ///
 /// ```no_run
-/// const sketch001 = startSketchOn('XZ')
+/// sketch001 = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> angledLine({
 ///     angle = toDegrees(acos(0.5)),
@@ -442,7 +442,7 @@ pub async fn acos(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 ///   |> lineTo([12, 0], %)
 ///   |> close(%)
 ///
-/// const extrude001 = extrude(5, sketch001)
+/// extrude001 = extrude(5, sketch001)
 /// ```
 #[stdlib {
     name = "acos",
@@ -463,7 +463,7 @@ pub async fn asin(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 /// Compute the arcsine of a number (in radians).
 ///
 /// ```no_run
-/// const sketch001 = startSketchOn('XZ')
+/// sketch001 = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> angledLine({
 ///     angle = toDegrees(asin(0.5)),
@@ -472,7 +472,7 @@ pub async fn asin(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 ///   |> yLineTo(0, %)
 ///   |> close(%)
 ///
-/// const extrude001 = extrude(5, sketch001)
+/// extrude001 = extrude(5, sketch001)
 /// ```
 #[stdlib {
     name = "asin",
@@ -493,7 +493,7 @@ pub async fn atan(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 /// Compute the arctangent of a number (in radians).
 ///
 /// ```no_run
-/// const sketch001 = startSketchOn('XZ')
+/// sketch001 = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> angledLine({
 ///     angle = toDegrees(atan(1.25)),
@@ -502,7 +502,7 @@ pub async fn atan(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 ///   |> yLineTo(0, %)
 ///   |> close(%)
 ///
-/// const extrude001 = extrude(5, sketch001)
+/// extrude001 = extrude(5, sketch001)
 /// ```
 #[stdlib {
     name = "atan",
@@ -544,14 +544,14 @@ pub async fn log(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 /// and `log10()` can produce more accurate results for base 10.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([log(100, 5), 0], %)
 ///   |> line([5, 8], %)
 ///   |> line([-10, 0], %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "log",
@@ -572,14 +572,14 @@ pub async fn log2(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 /// Compute the base 2 logarithm of the number.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([log2(100), 0], %)
 ///   |> line([5, 8], %)
 ///   |> line([-10, 0], %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "log2",
@@ -600,14 +600,14 @@ pub async fn log10(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 /// Compute the base 10 logarithm of the number.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([log10(100), 0], %)
 ///   |> line([5, 8], %)
 ///   |> line([-10, 0], %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "log10",
@@ -628,14 +628,14 @@ pub async fn ln(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kcl
 /// Compute the natural logarithm of the number.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([ln(100), 15], %)
 ///   |> line([5, -6], %)
 ///   |> line([-10, -10], %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "ln",
@@ -655,7 +655,7 @@ pub async fn e(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclE
 /// Return the value of Euler’s number `e`.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([0, 0], %)
 ///   |> angledLine({
 ///     angle = 30,
@@ -664,7 +664,7 @@ pub async fn e(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclE
 ///   |> yLineTo(0, %)
 ///   |> close(%)
 ///  
-/// const example = extrude(10, exampleSketch)
+/// example = extrude(10, exampleSketch)
 /// ```
 #[stdlib {
     name = "e",
@@ -684,7 +684,7 @@ pub async fn tau(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 /// Return the value of `tau`. The full circle constant (τ). Equal to 2π.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([0, 0], %)
 ///   |> angledLine({
 ///     angle = 50,
@@ -693,7 +693,7 @@ pub async fn tau(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 ///   |> yLineTo(0, %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "tau",
@@ -714,7 +714,7 @@ pub async fn to_radians(_exec_state: &mut ExecState, args: Args) -> Result<KclVa
 /// Converts a number from degrees to radians.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([0, 0], %)
 ///   |> angledLine({
 ///     angle = 50,
@@ -723,7 +723,7 @@ pub async fn to_radians(_exec_state: &mut ExecState, args: Args) -> Result<KclVa
 ///   |> yLineTo(0, %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "toRadians",
@@ -744,7 +744,7 @@ pub async fn to_degrees(_exec_state: &mut ExecState, args: Args) -> Result<KclVa
 /// Converts a number from radians to degrees.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([0, 0], %)
 ///   |> angledLine({
 ///     angle = 50,
@@ -753,7 +753,7 @@ pub async fn to_degrees(_exec_state: &mut ExecState, args: Args) -> Result<KclVa
 ///   |> yLineTo(0, %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "toDegrees",

--- a/src/wasm-lib/kcl/src/std/mirror.rs
+++ b/src/wasm-lib/kcl/src/std/mirror.rs
@@ -40,7 +40,7 @@ pub async fn mirror_2d(exec_state: &mut ExecState, args: Args) -> Result<KclValu
 ///
 /// ```no_run
 /// // Mirror an un-closed sketch across the Y axis.
-/// const sketch001 = startSketchOn('XZ')
+/// sketch001 = startSketchOn('XZ')
 ///     |> startProfileAt([0, 10], %)
 ///     |> line([15, 0], %)
 ///     |> line([-7, -3], %)
@@ -52,38 +52,38 @@ pub async fn mirror_2d(exec_state: &mut ExecState, args: Args) -> Result<KclValu
 ///     |> line([-19, -0], %)
 ///     |> mirror2d({axis = 'Y'}, %)
 ///
-/// const example = extrude(10, sketch001)
+/// example = extrude(10, sketch001)
 /// ```
 ///
 /// ```no_run
 /// // Mirror a un-closed sketch across the Y axis.
-/// const sketch001 = startSketchOn('XZ')
+/// sketch001 = startSketchOn('XZ')
 ///     |> startProfileAt([0, 8.5], %)
 ///     |> line([20, -8.5], %)
 ///     |> line([-20, -8.5], %)
 ///     |> mirror2d({axis = 'Y'}, %)
 ///
-/// const example = extrude(10, sketch001)
+/// example = extrude(10, sketch001)
 /// ```
 ///
 /// ```no_run
 /// // Mirror a un-closed sketch across an edge.
-/// const helper001 = startSketchOn('XZ')
+/// helper001 = startSketchOn('XZ')
 ///  |> startProfileAt([0, 0], %)
 ///  |> line([0, 10], %, $edge001)
 ///
-/// const sketch001 = startSketchOn('XZ')
+/// sketch001 = startSketchOn('XZ')
 ///     |> startProfileAt([0, 8.5], %)
 ///     |> line([20, -8.5], %)
 ///     |> line([-20, -8.5], %)
 ///     |> mirror2d({axis = edge001}, %)
 ///
-/// const example = extrude(10, sketch001)
+/// example = extrude(10, sketch001)
 /// ```
 ///
 /// ```no_run
 /// // Mirror an un-closed sketch across a custom axis.
-/// const sketch001 = startSketchOn('XZ')
+/// sketch001 = startSketchOn('XZ')
 ///     |> startProfileAt([0, 8.5], %)
 ///     |> line([20, -8.5], %)
 ///     |> line([-20, -8.5], %)
@@ -96,7 +96,7 @@ pub async fn mirror_2d(exec_state: &mut ExecState, args: Args) -> Result<KclValu
 ///   }
 /// }, %)
 ///
-/// const example = extrude(10, sketch001)
+/// example = extrude(10, sketch001)
 /// ```
 #[stdlib {
     name = "mirror2d",

--- a/src/wasm-lib/kcl/src/std/patterns.rs
+++ b/src/wasm-lib/kcl/src/std/patterns.rs
@@ -146,12 +146,12 @@ pub async fn pattern_transform_2d(exec_state: &mut ExecState, args: Args) -> Res
 ///
 /// ```no_run
 /// // Each instance will be shifted along the X axis.
-/// fn transform = (id) => {
+/// fn transform(id) {
 ///   return { translate = [4 * id, 0, 0] }
 /// }
 ///
 /// // Sketch 4 cylinders.
-/// const sketch001 = startSketchOn('XZ')
+/// sketch001 = startSketchOn('XZ')
 ///   |> circle({ center = [0, 0], radius = 2 }, %)
 ///   |> extrude(5, %)
 ///   |> patternTransform(4, transform, %)
@@ -160,24 +160,24 @@ pub async fn pattern_transform_2d(exec_state: &mut ExecState, args: Args) -> Res
 /// // Each instance will be shifted along the X axis,
 /// // with a gap between the original (at x = 0) and the first replica
 /// // (at x = 8). This is because `id` starts at 1.
-/// fn transform = (id) => {
+/// fn transform(id) {
 ///   return { translate: [4 * (1+id), 0, 0] }
 /// }
 ///
-/// const sketch001 = startSketchOn('XZ')
+/// sketch001 = startSketchOn('XZ')
 ///   |> circle({ center = [0, 0], radius = 2 }, %)
 ///   |> extrude(5, %)
 ///   |> patternTransform(4, transform, %)
 /// ```
 /// ```no_run
-/// fn cube = (length, center) => {
-///   let l = length/2
-///   let x = center[0]
-///   let y = center[1]
-///   let p0 = [-l + x, -l + y]
-///   let p1 = [-l + x,  l + y]
-///   let p2 = [ l + x,  l + y]
-///   let p3 = [ l + x, -l + y]
+/// fn cube(length, center) {
+///   l = length/2
+///   x = center[0]
+///   y = center[1]
+///   p0 = [-l + x, -l + y]
+///   p1 = [-l + x,  l + y]
+///   p2 = [ l + x,  l + y]
+///   p3 = [ l + x, -l + y]
 ///
 ///   return startSketchAt(p0)
 ///   |> lineTo(p1, %)
@@ -188,8 +188,8 @@ pub async fn pattern_transform_2d(exec_state: &mut ExecState, args: Args) -> Res
 ///   |> extrude(length, %)
 /// }
 ///
-/// let width = 20
-/// fn transform = (i) => {
+/// width = 20
+/// fn transform(i) {
 ///   return {
 ///     // Move down each time.
 ///     translate = [0, 0, -i * width],
@@ -203,20 +203,20 @@ pub async fn pattern_transform_2d(exec_state: &mut ExecState, args: Args) -> Res
 ///   }
 /// }
 ///
-/// let myCubes =
+/// myCubes =
 ///   cube(width, [100,0])
 ///   |> patternTransform(25, transform, %)
 /// ```
 ///
 /// ```no_run
-/// fn cube = (length, center) => {
-///   let l = length/2
-///   let x = center[0]
-///   let y = center[1]
-///   let p0 = [-l + x, -l + y]
-///   let p1 = [-l + x,  l + y]
-///   let p2 = [ l + x,  l + y]
-///   let p3 = [ l + x, -l + y]
+/// fn cube(length, center) {
+///   l = length/2
+///   x = center[0]
+///   y = center[1]
+///   p0 = [-l + x, -l + y]
+///   p1 = [-l + x,  l + y]
+///   p2 = [ l + x,  l + y]
+///   p3 = [ l + x, -l + y]
 ///   
 ///   return startSketchAt(p0)
 ///   |> lineTo(p1, %)
@@ -227,8 +227,8 @@ pub async fn pattern_transform_2d(exec_state: &mut ExecState, args: Args) -> Res
 ///   |> extrude(length, %)
 /// }
 ///
-/// let width = 20
-/// fn transform = (i) => {
+/// width = 20
+/// fn transform(i) {
 ///   return {
 ///     translate = [0, 0, -i * width],
 ///     rotation = {
@@ -238,36 +238,36 @@ pub async fn pattern_transform_2d(exec_state: &mut ExecState, args: Args) -> Res
 ///     }
 ///   }
 /// }
-/// let myCubes =
+/// myCubes =
 ///   cube(width, [100,100])
 ///   |> patternTransform(4, transform, %)
 /// ```
 /// ```no_run
 /// // Parameters
-/// const r = 50    // base radius
-/// const h = 10    // layer height
-/// const t = 0.005 // taper factor [0-1)
+/// r = 50    // base radius
+/// h = 10    // layer height
+/// t = 0.005 // taper factor [0-1)
 /// // Defines how to modify each layer of the vase.
 /// // Each replica is shifted up the Z axis, and has a smoothly-varying radius
-/// fn transform = (replicaId) => {
-///   let scale = r * abs(1 - (t * replicaId)) * (5 + cos(replicaId / 8))
+/// fn transform(replicaId) {
+///   scale = r * abs(1 - (t * replicaId)) * (5 + cos(replicaId / 8))
 ///   return {
 ///     translate = [0, 0, replicaId * 10],
 ///     scale = [scale, scale, 0],
 ///   }
 /// }
 /// // Each layer is just a pretty thin cylinder.
-/// fn layer = () => {
+/// fn layer() {
 ///   return startSketchOn("XY") // or some other plane idk
 ///     |> circle({ center = [0, 0], radius = 1 }, %, $tag1)
 ///     |> extrude(h, %)
 /// }
 /// // The vase is 100 layers tall.
 /// // The 100 layers are replica of each other, with a slight transformation applied to each.
-/// let vase = layer() |> patternTransform(100, transform, %)
+/// vase = layer() |> patternTransform(100, transform, %)
 /// ```
 /// ```
-/// fn transform = (i) => {
+/// fn transform(i) {
 ///   // Transform functions can return multiple transforms. They'll be applied in order.
 ///   return [
 ///     { translate: [30 * i, 0, 0] },
@@ -312,7 +312,7 @@ async fn inner_pattern_transform<'a>(
 /// Just like patternTransform, but works on 2D sketches not 3D solids.
 /// ```no_run
 /// // Each instance will be shifted along the X axis.
-/// fn transform = (id) => {
+/// fn transform(id) {
 ///   return { translate: [4 * id, 0] }
 /// }
 ///
@@ -689,7 +689,7 @@ pub async fn pattern_linear_2d(exec_state: &mut ExecState, args: Args) -> Result
 /// of distance between each repetition, some specified number of times.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> circle({ center = [0, 0], radius = 1 }, %)
 ///   |> patternLinear2d({
 ///        axis = [1, 0],
@@ -697,7 +697,7 @@ pub async fn pattern_linear_2d(exec_state: &mut ExecState, args: Args) -> Result
 ///        distance = 4
 ///      }, %)
 ///
-/// const example = extrude(1, exampleSketch)
+/// example = extrude(1, exampleSketch)
 /// ```
 #[stdlib {
     name = "patternLinear2d",
@@ -746,14 +746,14 @@ pub async fn pattern_linear_3d(exec_state: &mut ExecState, args: Args) -> Result
 /// of distance between each repetition, some specified number of times.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([0, 2], %)
 ///   |> line([3, 1], %)
 ///   |> line([0, -4], %)
 ///   |> close(%)
 ///
-/// const example = extrude(1, exampleSketch)
+/// example = extrude(1, exampleSketch)
 ///   |> patternLinear3d({
 ///       axis = [1, 0, 1],
 ///       instances = 7,
@@ -900,7 +900,7 @@ pub async fn pattern_circular_2d(exec_state: &mut ExecState, args: Args) -> Resu
 /// solid with respect to the center of the circle is maintained.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([.5, 25], %)
 ///   |> line([0, 5], %)
 ///   |> line([-1, 0], %)
@@ -913,7 +913,7 @@ pub async fn pattern_circular_2d(exec_state: &mut ExecState, args: Args) -> Resu
 ///        rotateDuplicates = true
 ///      }, %)
 ///
-/// const example = extrude(1, exampleSketch)
+/// example = extrude(1, exampleSketch)
 /// ```
 #[stdlib {
     name = "patternCircular2d",
@@ -967,10 +967,10 @@ pub async fn pattern_circular_3d(exec_state: &mut ExecState, args: Args) -> Resu
 /// solid with respect to the center of the circle is maintained.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> circle({ center = [0, 0], radius = 1 }, %)
 ///
-/// const example = extrude(-5, exampleSketch)
+/// example = extrude(-5, exampleSketch)
 ///   |> patternCircular3d({
 ///        axis = [1, -1, 0],
 ///        center = [10, -20, 0],

--- a/src/wasm-lib/kcl/src/std/planes.rs
+++ b/src/wasm-lib/kcl/src/std/planes.rs
@@ -65,7 +65,7 @@ pub async fn offset_plane(exec_state: &mut ExecState, args: Args) -> Result<KclV
 ///
 /// ```no_run
 /// // Loft a square and a circle on the `XY` plane using offset.
-/// const squareSketch = startSketchOn('XY')
+/// squareSketch = startSketchOn('XY')
 ///     |> startProfileAt([-100, 200], %)
 ///     |> line([200, 0], %)
 ///     |> line([0, -200], %)
@@ -73,7 +73,7 @@ pub async fn offset_plane(exec_state: &mut ExecState, args: Args) -> Result<KclV
 ///     |> lineTo([profileStartX(%), profileStartY(%)], %)
 ///     |> close(%)
 ///
-/// const circleSketch = startSketchOn(offsetPlane('XY', 150))
+/// circleSketch = startSketchOn(offsetPlane('XY', 150))
 ///     |> circle({ center = [0, 100], radius = 50 }, %)
 ///
 /// loft([squareSketch, circleSketch])
@@ -81,7 +81,7 @@ pub async fn offset_plane(exec_state: &mut ExecState, args: Args) -> Result<KclV
 ///
 /// ```no_run
 /// // Loft a square and a circle on the `XZ` plane using offset.
-/// const squareSketch = startSketchOn('XZ')
+/// squareSketch = startSketchOn('XZ')
 ///     |> startProfileAt([-100, 200], %)
 ///     |> line([200, 0], %)
 ///     |> line([0, -200], %)
@@ -89,7 +89,7 @@ pub async fn offset_plane(exec_state: &mut ExecState, args: Args) -> Result<KclV
 ///     |> lineTo([profileStartX(%), profileStartY(%)], %)
 ///     |> close(%)
 ///
-/// const circleSketch = startSketchOn(offsetPlane('XZ', 150))
+/// circleSketch = startSketchOn(offsetPlane('XZ', 150))
 ///     |> circle({ center = [0, 100], radius = 50 }, %)
 ///
 /// loft([squareSketch, circleSketch])
@@ -97,7 +97,7 @@ pub async fn offset_plane(exec_state: &mut ExecState, args: Args) -> Result<KclV
 ///
 /// ```no_run
 /// // Loft a square and a circle on the `YZ` plane using offset.
-/// const squareSketch = startSketchOn('YZ')
+/// squareSketch = startSketchOn('YZ')
 ///     |> startProfileAt([-100, 200], %)
 ///     |> line([200, 0], %)
 ///     |> line([0, -200], %)
@@ -105,7 +105,7 @@ pub async fn offset_plane(exec_state: &mut ExecState, args: Args) -> Result<KclV
 ///     |> lineTo([profileStartX(%), profileStartY(%)], %)
 ///     |> close(%)
 ///
-/// const circleSketch = startSketchOn(offsetPlane('YZ', 150))
+/// circleSketch = startSketchOn(offsetPlane('YZ', 150))
 ///     |> circle({ center = [0, 100], radius = 50 }, %)
 ///
 /// loft([squareSketch, circleSketch])
@@ -113,7 +113,7 @@ pub async fn offset_plane(exec_state: &mut ExecState, args: Args) -> Result<KclV
 ///
 /// ```no_run
 /// // Loft a square and a circle on the `-XZ` plane using offset.
-/// const squareSketch = startSketchOn('-XZ')
+/// squareSketch = startSketchOn('-XZ')
 ///     |> startProfileAt([-100, 200], %)
 ///     |> line([200, 0], %)
 ///     |> line([0, -200], %)
@@ -121,7 +121,7 @@ pub async fn offset_plane(exec_state: &mut ExecState, args: Args) -> Result<KclV
 ///     |> lineTo([profileStartX(%), profileStartY(%)], %)
 ///     |> close(%)
 ///
-/// const circleSketch = startSketchOn(offsetPlane('-XZ', -150))
+/// circleSketch = startSketchOn(offsetPlane('-XZ', -150))
 ///     |> circle({ center = [0, 100], radius = 50 }, %)
 ///
 /// loft([squareSketch, circleSketch])

--- a/src/wasm-lib/kcl/src/std/polar.rs
+++ b/src/wasm-lib/kcl/src/std/polar.rs
@@ -34,7 +34,7 @@ pub async fn polar(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 /// cartesian (x/y/z grid) coordinates.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> line(polar({angle: 30, length: 5}), %, $thing)
 ///   |> line([0, 5], %)
@@ -42,7 +42,7 @@ pub async fn polar(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 ///   |> line([-20, 10], %)
 ///   |> close(%)
 ///  
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "polar",

--- a/src/wasm-lib/kcl/src/std/revolve.rs
+++ b/src/wasm-lib/kcl/src/std/revolve.rs
@@ -113,7 +113,7 @@ pub async fn revolve(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 /// Revolve occurs around a local sketch axis rather than a global axis.
 ///
 /// ```no_run
-/// const part001 = startSketchOn('XY')
+/// part001 = startSketchOn('XY')
 ///     |> startProfileAt([4, 12], %)
 ///     |> line([2, 0], %)
 ///     |> line([0, -6], %)
@@ -128,7 +128,7 @@ pub async fn revolve(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 ///
 /// ```no_run
 /// // A donut shape.
-/// const sketch001 = startSketchOn('XY')
+/// sketch001 = startSketchOn('XY')
 ///     |> circle({ center = [15, 0], radius = 5 }, %)
 ///     |> revolve({
 ///         angle = 360,
@@ -137,7 +137,7 @@ pub async fn revolve(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 /// ```
 ///
 /// ```no_run
-/// const part001 = startSketchOn('XY')
+/// part001 = startSketchOn('XY')
 ///     |> startProfileAt([4, 12], %)
 ///     |> line([2, 0], %)
 ///     |> line([0, -6], %)
@@ -151,7 +151,7 @@ pub async fn revolve(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 /// ```
 ///
 /// ```no_run
-/// const part001 = startSketchOn('XY')
+/// part001 = startSketchOn('XY')
 ///     |> startProfileAt([4, 12], %)
 ///     |> line([2, 0], %)
 ///     |> line([0, -6], %)
@@ -162,7 +162,7 @@ pub async fn revolve(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 ///     |> line([-2, 0], %)
 ///     |> close(%)
 ///     |> revolve({axis = 'y', angle = 180}, %)
-/// const part002 = startSketchOn(part001, 'end')
+/// part002 = startSketchOn(part001, 'end')
 ///     |> startProfileAt([4.5, -5], %)
 ///     |> line([0, 5], %)
 ///     |> line([5, 0], %)
@@ -172,7 +172,7 @@ pub async fn revolve(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 /// ```
 ///
 /// ```no_run
-/// const box = startSketchOn('XY')
+/// box = startSketchOn('XY')
 ///     |> startProfileAt([0, 0], %)
 ///     |> line([0, 20], %)
 ///     |> line([20, 0], %)
@@ -180,7 +180,7 @@ pub async fn revolve(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 ///     |> close(%)
 ///     |> extrude(20, %)
 ///
-/// const sketch001 = startSketchOn(box, "END")
+/// sketch001 = startSketchOn(box, "END")
 ///     |> circle({ center = [10,10], radius = 4 }, %)
 ///     |> revolve({
 ///         angle = -90,
@@ -189,7 +189,7 @@ pub async fn revolve(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 /// ```
 ///
 /// ```no_run
-/// const box = startSketchOn('XY')
+/// box = startSketchOn('XY')
 ///     |> startProfileAt([0, 0], %)
 ///     |> line([0, 20], %)
 ///     |> line([20, 0], %)
@@ -197,7 +197,7 @@ pub async fn revolve(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 ///     |> close(%)
 ///     |> extrude(20, %)
 ///
-/// const sketch001 = startSketchOn(box, "END")
+/// sketch001 = startSketchOn(box, "END")
 ///     |> circle({ center = [10,10], radius = 4 }, %)
 ///     |> revolve({
 ///         angle = 90,
@@ -206,7 +206,7 @@ pub async fn revolve(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 /// ```
 ///
 /// ```no_run
-/// const box = startSketchOn('XY')
+/// box = startSketchOn('XY')
 ///     |> startProfileAt([0, 0], %)
 ///     |> line([0, 20], %)
 ///     |> line([20, 0], %)
@@ -214,7 +214,7 @@ pub async fn revolve(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 ///     |> close(%)
 ///     |> extrude(20, %)
 ///
-/// const sketch001 = startSketchOn(box, "END")
+/// sketch001 = startSketchOn(box, "END")
 ///     |> circle({ center = [10,10], radius = 4 }, %)
 ///     |> revolve({
 ///         angle = 90,
@@ -224,14 +224,14 @@ pub async fn revolve(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 /// ```
 ///
 /// ```no_run
-/// const sketch001 = startSketchOn('XY')
+/// sketch001 = startSketchOn('XY')
 ///   |> startProfileAt([10, 0], %)
 ///   |> line([5, -5], %)
 ///   |> line([5, 5], %)
 ///   |> lineTo([profileStartX(%), profileStartY(%)], %)
 ///   |> close(%)
 ///
-/// const part001 = revolve({
+/// part001 = revolve({
 ///   axis = {
 ///     custom: {
 ///       axis = [0.0, 1.0],

--- a/src/wasm-lib/kcl/src/std/segment.rs
+++ b/src/wasm-lib/kcl/src/std/segment.rs
@@ -30,7 +30,7 @@ pub async fn segment_end(exec_state: &mut ExecState, args: Args) -> Result<KclVa
 ///   |> close(%)
 ///   |> extrude(5, %)
 ///
-/// fn cylinder = (radius, tag) => {
+/// fn cylinder(radius, tag) {
 ///   return startSketchAt([0, 0])
 ///   |> circle({ radius = radius, center = segEnd(tag) }, %)
 ///   |> extrude(radius, %)
@@ -67,7 +67,7 @@ pub async fn segment_end_x(exec_state: &mut ExecState, args: Args) -> Result<Kcl
 /// Compute the ending point of the provided line segment along the 'x' axis.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([20, 0], %, $thing)
 ///   |> line([0, 5], %)
@@ -75,7 +75,7 @@ pub async fn segment_end_x(exec_state: &mut ExecState, args: Args) -> Result<Kcl
 ///   |> line([-20, 10], %)
 ///   |> close(%)
 ///  
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "segEndX",
@@ -103,7 +103,7 @@ pub async fn segment_end_y(exec_state: &mut ExecState, args: Args) -> Result<Kcl
 /// Compute the ending point of the provided line segment along the 'y' axis.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([20, 0], %)
 ///   |> line([0, 3], %, $thing)
@@ -112,7 +112,7 @@ pub async fn segment_end_y(exec_state: &mut ExecState, args: Args) -> Result<Kcl
 ///   |> line([-10, 0], %)
 ///   |> close(%)
 ///  
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "segEndY",
@@ -149,7 +149,7 @@ pub async fn segment_start(exec_state: &mut ExecState, args: Args) -> Result<Kcl
 ///   |> close(%)
 ///   |> extrude(5, %)
 ///
-/// fn cylinder = (radius, tag) => {
+/// fn cylinder(radius, tag) {
 ///   return startSketchAt([0, 0])
 ///   |> circle({ radius = radius, center = segStart(tag) }, %)
 ///   |> extrude(radius, %)
@@ -186,7 +186,7 @@ pub async fn segment_start_x(exec_state: &mut ExecState, args: Args) -> Result<K
 /// Compute the starting point of the provided line segment along the 'x' axis.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([20, 0], %, $thing)
 ///   |> line([0, 5], %)
@@ -194,7 +194,7 @@ pub async fn segment_start_x(exec_state: &mut ExecState, args: Args) -> Result<K
 ///   |> line([-20, 10], %)
 ///   |> close(%)
 ///  
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "segStartX",
@@ -222,7 +222,7 @@ pub async fn segment_start_y(exec_state: &mut ExecState, args: Args) -> Result<K
 /// Compute the starting point of the provided line segment along the 'y' axis.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([20, 0], %)
 ///   |> line([0, 3], %, $thing)
@@ -231,7 +231,7 @@ pub async fn segment_start_y(exec_state: &mut ExecState, args: Args) -> Result<K
 ///   |> line([-10, 0], %)
 ///   |> close(%)
 ///  
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "segStartY",
@@ -259,7 +259,7 @@ pub async fn last_segment_x(_exec_state: &mut ExecState, args: Args) -> Result<K
 /// sketch.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([5, 0], %)
 ///   |> line([20, 5], %)
@@ -267,7 +267,7 @@ pub async fn last_segment_x(_exec_state: &mut ExecState, args: Args) -> Result<K
 ///   |> line([-15, 0], %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "lastSegX",
@@ -299,7 +299,7 @@ pub async fn last_segment_y(_exec_state: &mut ExecState, args: Args) -> Result<K
 /// sketch.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([5, 0], %)
 ///   |> line([20, 5], %)
@@ -307,7 +307,7 @@ pub async fn last_segment_y(_exec_state: &mut ExecState, args: Args) -> Result<K
 ///   |> line([-15, 0], %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "lastSegY",
@@ -337,7 +337,7 @@ pub async fn segment_length(exec_state: &mut ExecState, args: Args) -> Result<Kc
 /// Compute the length of the provided line segment.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([0, 0], %)
 ///   |> angledLine({
 ///     angle = 60,
@@ -353,7 +353,7 @@ pub async fn segment_length(exec_state: &mut ExecState, args: Args) -> Result<Kc
 ///   }, %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "segLen",
@@ -383,7 +383,7 @@ pub async fn segment_angle(exec_state: &mut ExecState, args: Args) -> Result<Kcl
 /// Compute the angle (in degrees) of the provided line segment.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([10, 0], %)
 ///   |> line([5, 10], %, $seg01)
@@ -393,7 +393,7 @@ pub async fn segment_angle(exec_state: &mut ExecState, args: Args) -> Result<Kcl
 ///   |> angledLine([segAng(seg01), -15], %)
 ///   |> close(%)
 ///
-/// const example = extrude(4, exampleSketch)
+/// example = extrude(4, exampleSketch)
 /// ```
 #[stdlib {
     name = "segAng",
@@ -528,7 +528,7 @@ pub async fn angle_to_match_length_x(exec_state: &mut ExecState, args: Args) -> 
 /// Returns the angle to match the given length for x.
 ///
 /// ```no_run
-/// const sketch001 = startSketchOn('XZ')
+/// sketch001 = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([2, 5], %, $seg01)
 ///   |> angledLineToX([
@@ -537,7 +537,7 @@ pub async fn angle_to_match_length_x(exec_state: &mut ExecState, args: Args) -> 
 ///      ], %)
 ///   |> close(%)
 ///
-/// const extrusion = extrude(5, sketch001)
+/// extrusion = extrude(5, sketch001)
 /// ```
 #[stdlib {
     name = "angleToMatchLengthX",
@@ -591,7 +591,7 @@ pub async fn angle_to_match_length_y(exec_state: &mut ExecState, args: Args) -> 
 /// Returns the angle to match the given length for y.
 ///
 /// ```no_run
-/// const sketch001 = startSketchOn('XZ')
+/// sketch001 = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([1, 2], %, $seg01)
 ///   |> angledLine({
@@ -601,7 +601,7 @@ pub async fn angle_to_match_length_y(exec_state: &mut ExecState, args: Args) -> 
 ///   |> yLineTo(0, %)
 ///   |> close(%)
 ///  
-/// const extrusion = extrude(5, sketch001)
+/// extrusion = extrude(5, sketch001)
 /// ```
 #[stdlib {
     name = "angleToMatchLengthY",

--- a/src/wasm-lib/kcl/src/std/shapes.rs
+++ b/src/wasm-lib/kcl/src/std/shapes.rs
@@ -56,14 +56,14 @@ pub async fn circle(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 /// the provided (x, y) origin point.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("-XZ")
+/// exampleSketch = startSketchOn("-XZ")
 ///   |> circle({ center = [0, 0], radius = 10 }, %)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([-15, 0], %)
 ///   |> line([30, 0], %)
 ///   |> line([0, 30], %)
@@ -71,7 +71,7 @@ pub async fn circle(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 ///   |> close(%)
 ///   |> hole(circle({ center = [0, 15], radius = 5 }, %), %)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "circle",

--- a/src/wasm-lib/kcl/src/std/shell.rs
+++ b/src/wasm-lib/kcl/src/std/shell.rs
@@ -38,7 +38,7 @@ pub async fn shell(exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 ///
 /// ```no_run
 /// // Remove the end face for the extrusion.
-/// const firstSketch = startSketchOn('XY')
+/// firstSketch = startSketchOn('XY')
 ///     |> startProfileAt([-12, 12], %)
 ///     |> line([24, 0], %)
 ///     |> line([0, -24], %)
@@ -55,7 +55,7 @@ pub async fn shell(exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 ///
 /// ```no_run
 /// // Remove the start face for the extrusion.
-/// const firstSketch = startSketchOn('-XZ')
+/// firstSketch = startSketchOn('-XZ')
 ///     |> startProfileAt([-12, 12], %)
 ///     |> line([24, 0], %)
 ///     |> line([0, -24], %)
@@ -72,7 +72,7 @@ pub async fn shell(exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 ///
 /// ```no_run
 /// // Remove a tagged face and the end face for the extrusion.
-/// const firstSketch = startSketchOn('XY')
+/// firstSketch = startSketchOn('XY')
 ///     |> startProfileAt([-12, 12], %)
 ///     |> line([24, 0], %)
 ///     |> line([0, -24], %)
@@ -89,7 +89,7 @@ pub async fn shell(exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 ///
 /// ```no_run
 /// // Remove multiple faces at once.
-/// const firstSketch = startSketchOn('XY')
+/// firstSketch = startSketchOn('XY')
 ///     |> startProfileAt([-12, 12], %)
 ///     |> line([24, 0], %)
 ///     |> line([0, -24], %)
@@ -106,8 +106,8 @@ pub async fn shell(exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 ///
 /// ```no_run
 /// // Shell a sketch on face.
-/// let size = 100
-/// const case = startSketchOn('-XZ')
+/// size = 100
+/// case = startSketchOn('-XZ')
 ///     |> startProfileAt([-size, -size], %)
 ///     |> line([2 * size, 0], %)
 ///     |> line([0, 2 * size], %)
@@ -115,11 +115,11 @@ pub async fn shell(exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 ///     |> close(%)
 ///     |> extrude(65, %)
 ///
-/// const thing1 = startSketchOn(case, 'end')
+/// thing1 = startSketchOn(case, 'end')
 ///     |> circle({ center = [-size / 2, -size / 2], radius = 25 }, %)
 ///     |> extrude(50, %)
 ///
-/// const thing2 = startSketchOn(case, 'end')
+/// thing2 = startSketchOn(case, 'end')
 ///     |> circle({ center = [size / 2, -size / 2], radius = 25 }, %)
 ///     |> extrude(50, %)
 ///
@@ -129,8 +129,8 @@ pub async fn shell(exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 ///
 /// ```no_run
 /// // Shell a sketch on face object on the end face.
-/// let size = 100
-/// const case = startSketchOn('XY')
+/// size = 100
+/// case = startSketchOn('XY')
 ///     |> startProfileAt([-size, -size], %)
 ///     |> line([2 * size, 0], %)
 ///     |> line([0, 2 * size], %)
@@ -138,11 +138,11 @@ pub async fn shell(exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 ///     |> close(%)
 ///     |> extrude(65, %)
 ///
-/// const thing1 = startSketchOn(case, 'end')
+/// thing1 = startSketchOn(case, 'end')
 ///     |> circle({ center = [-size / 2, -size / 2], radius = 25 }, %)
 ///     |> extrude(50, %)
 ///
-/// const thing2 = startSketchOn(case, 'end')
+/// thing2 = startSketchOn(case, 'end')
 ///     |> circle({ center = [size / 2, -size / 2], radius = 25 }, %)
 ///     |> extrude(50, %)
 ///
@@ -154,8 +154,8 @@ pub async fn shell(exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 /// // Shell sketched on face objects on the end face, include all sketches to shell
 /// // the entire object.
 ///
-/// let size = 100
-/// const case = startSketchOn('XY')
+/// size = 100
+/// case = startSketchOn('XY')
 ///     |> startProfileAt([-size, -size], %)
 ///     |> line([2 * size, 0], %)
 ///     |> line([0, 2 * size], %)
@@ -163,11 +163,11 @@ pub async fn shell(exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 ///     |> close(%)
 ///     |> extrude(65, %)
 ///
-/// const thing1 = startSketchOn(case, 'end')
+/// thing1 = startSketchOn(case, 'end')
 ///     |> circle({ center = [-size / 2, -size / 2], radius = 25 }, %)
 ///     |> extrude(50, %)
 ///
-/// const thing2 = startSketchOn(case, 'end')
+/// thing2 = startSketchOn(case, 'end')
 ///     |> circle({ center = [size / 2, -size / 2], radius = 25 }, %)
 ///     |> extrude(50, %)
 ///
@@ -257,7 +257,7 @@ pub async fn hollow(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 ///
 /// ```no_run
 /// // Hollow a basic sketch.
-/// const firstSketch = startSketchOn('XY')
+/// firstSketch = startSketchOn('XY')
 ///     |> startProfileAt([-12, 12], %)
 ///     |> line([24, 0], %)
 ///     |> line([0, -24], %)
@@ -269,7 +269,7 @@ pub async fn hollow(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 ///
 /// ```no_run
 /// // Hollow a basic sketch.
-/// const firstSketch = startSketchOn('-XZ')
+/// firstSketch = startSketchOn('-XZ')
 ///     |> startProfileAt([-12, 12], %)
 ///     |> line([24, 0], %)
 ///     |> line([0, -24], %)
@@ -281,8 +281,8 @@ pub async fn hollow(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 ///
 /// ```no_run
 /// // Hollow a sketch on face object.
-/// let size = 100
-/// const case = startSketchOn('-XZ')
+/// size = 100
+/// case = startSketchOn('-XZ')
 ///     |> startProfileAt([-size, -size], %)
 ///     |> line([2 * size, 0], %)
 ///     |> line([0, 2 * size], %)
@@ -290,11 +290,11 @@ pub async fn hollow(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 ///     |> close(%)
 ///     |> extrude(65, %)
 ///
-/// const thing1 = startSketchOn(case, 'end')
+/// thing1 = startSketchOn(case, 'end')
 ///     |> circle({ center = [-size / 2, -size / 2], radius = 25 }, %)
 ///     |> extrude(50, %)
 ///
-/// const thing2 = startSketchOn(case, 'end')
+/// thing2 = startSketchOn(case, 'end')
 ///     |> circle({ center = [size / 2, -size / 2], radius = 25 }, %)
 ///     |> extrude(50, %)
 ///

--- a/src/wasm-lib/kcl/src/std/sketch.rs
+++ b/src/wasm-lib/kcl/src/std/sketch.rs
@@ -104,14 +104,14 @@ pub async fn line_to(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 /// Draw a line from the current origin to some absolute (x, y) point.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([0, 0], %)
 ///   |> lineTo([10, 0], %)
 ///   |> lineTo([0, 10], %)
 ///   |> lineTo([-10, 0], %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "lineTo",
@@ -175,7 +175,7 @@ pub async fn x_line_to(exec_state: &mut ExecState, args: Args) -> Result<KclValu
 /// then xLineTo(4) draws a line from (1, 1) to (4, 1)
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> xLineTo(15, %)
 ///   |> angledLine({
@@ -191,7 +191,7 @@ pub async fn x_line_to(exec_state: &mut ExecState, args: Args) -> Result<KclValu
 ///   |> xLineTo(10, %)
 ///   |> close(%)
 ///
-/// const example = extrude(10, exampleSketch)
+/// example = extrude(10, exampleSketch)
 /// ```
 #[stdlib {
     name = "xLineTo",
@@ -225,7 +225,7 @@ pub async fn y_line_to(exec_state: &mut ExecState, args: Args) -> Result<KclValu
 /// then yLineTo(4) draws a line from (1, 1) to (1, 4)
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([0, 0], %)
 ///   |> angledLine({
 ///     angle = 50,
@@ -234,7 +234,7 @@ pub async fn y_line_to(exec_state: &mut ExecState, args: Args) -> Result<KclValu
 ///   |> yLineTo(0, %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "yLineTo",
@@ -266,25 +266,25 @@ pub async fn line(exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 /// from the current position.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([25, 15], %)
 ///   |> line([5, -6], %)
 ///   |> line([-10, -10], %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XZ")
+/// exampleSketch = startSketchOn("XZ")
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([10, 0], %)
 ///   |> line([0, 10], %)
 ///   |> line([-10, 0], %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "line",
@@ -349,7 +349,7 @@ pub async fn x_line(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 /// from the current position along the 'x' axis.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> xLine(15, %)
 ///   |> angledLine({
@@ -365,7 +365,7 @@ pub async fn x_line(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 ///   |> xLine(-15, %)
 ///   |> close(%)
 ///
-/// const example = extrude(10, exampleSketch)
+/// example = extrude(10, exampleSketch)
 /// ```
 #[stdlib {
     name = "xLine",
@@ -394,7 +394,7 @@ pub async fn y_line(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 /// from the current position along the 'y' axis.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> yLine(15, %)
 ///   |> angledLine({
@@ -405,7 +405,7 @@ pub async fn y_line(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 ///   |> yLine(-5, %)
 ///   |> close(%)
 ///
-/// const example = extrude(10, exampleSketch)
+/// example = extrude(10, exampleSketch)
 /// ```
 #[stdlib {
     name = "yLine",
@@ -450,7 +450,7 @@ pub async fn angled_line(exec_state: &mut ExecState, args: Args) -> Result<KclVa
 /// measure of some angle and distance.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> yLineTo(15, %)
 ///   |> angledLine({
@@ -461,7 +461,7 @@ pub async fn angled_line(exec_state: &mut ExecState, args: Args) -> Result<KclVa
 ///   |> yLineTo(0, %)
 ///   |> close(%)
 ///
-/// const example = extrude(10, exampleSketch)
+/// example = extrude(10, exampleSketch)
 /// ```
 #[stdlib {
     name = "angledLine",
@@ -537,14 +537,14 @@ pub async fn angled_line_of_x_length(exec_state: &mut ExecState, args: Args) -> 
 /// along some angle (in degrees) for some relative length in the 'x' dimension.
 ///
 /// ```no_run
-/// const sketch001 = startSketchOn('XZ')
+/// sketch001 = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> angledLineOfXLength({ angle = 45, length = 10 }, %, $edge1)
 ///   |> angledLineOfXLength({ angle = -15, length = 20 }, %, $edge2)
 ///   |> line([0, -5], %)
 ///   |> close(%, $edge3)
 ///
-/// const extrusion = extrude(10, sketch001)
+/// extrusion = extrude(10, sketch001)
 /// ```
 #[stdlib {
     name = "angledLineOfXLength",
@@ -608,14 +608,14 @@ pub async fn angled_line_to_x(exec_state: &mut ExecState, args: Args) -> Result<
 /// in the 'x' dimension.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> angledLineToX({ angle = 30, to = 10 }, %)
 ///   |> line([0, 10], %)
 ///   |> line([-10, 0], %)
 ///   |> close(%)
 ///  
-/// const example = extrude(10, exampleSketch)
+/// example = extrude(10, exampleSketch)
 /// ```
 #[stdlib {
     name = "angledLineToX",
@@ -667,7 +667,7 @@ pub async fn angled_line_of_y_length(exec_state: &mut ExecState, args: Args) -> 
 /// along some angle (in degrees) for some relative length in the 'y' dimension.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([10, 0], %)
 ///   |> angledLineOfYLength({ angle = 45, length = 10 }, %)
@@ -676,7 +676,7 @@ pub async fn angled_line_of_y_length(exec_state: &mut ExecState, args: Args) -> 
 ///   |> line([-10, 0], %)
 ///   |> line([0, -30], %)
 ///
-/// const example = extrude(10, exampleSketch)
+/// example = extrude(10, exampleSketch)
 /// ```
 #[stdlib {
     name = "angledLineOfYLength",
@@ -729,14 +729,14 @@ pub async fn angled_line_to_y(exec_state: &mut ExecState, args: Args) -> Result<
 /// in the 'y' dimension.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> angledLineToY({ angle = 60, to = 20 }, %)
 ///   |> line([-20, 0], %)
 ///   |> angledLineToY({ angle = 70, to = 10 }, %)
 ///   |> close(%)
 ///
-/// const example = extrude(10, exampleSketch)
+/// example = extrude(10, exampleSketch)
 /// ```
 #[stdlib {
     name = "angledLineToY",
@@ -802,7 +802,7 @@ pub async fn angled_line_that_intersects(exec_state: &mut ExecState, args: Args)
 /// segment.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> lineTo([5, 10], %)
 ///   |> lineTo([-10, 10], %, $lineToIntersect)
@@ -814,7 +814,7 @@ pub async fn angled_line_that_intersects(exec_state: &mut ExecState, args: Args)
 ///      }, %)
 ///   |> close(%)
 ///
-/// const example = extrude(10, exampleSketch)
+/// example = extrude(10, exampleSketch)
 /// ```
 #[stdlib {
     name = "angledLineThatIntersects",
@@ -859,33 +859,33 @@ pub async fn start_sketch_at(exec_state: &mut ExecState, args: Args) -> Result<K
 /// Start a new 2-dimensional sketch at a given point on the 'XY' plane.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchAt([0, 0])
+/// exampleSketch = startSketchAt([0, 0])
 ///   |> line([10, 0], %)
 ///   |> line([0, 10], %)
 ///   |> line([-10, 0], %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 ///
 /// ```no_run
-/// const exampleSketch = startSketchAt([10, 10])
+/// exampleSketch = startSketchAt([10, 10])
 ///   |> line([10, 0], %)
 ///   |> line([0, 10], %)
 ///   |> line([-10, 0], %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 ///
 /// ```no_run
-/// const exampleSketch = startSketchAt([-10, 23])
+/// exampleSketch = startSketchAt([-10, 23])
 ///   |> line([10, 0], %)
 ///   |> line([0, 10], %)
 ///   |> line([-10, 0], %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "startSketchAt",
@@ -961,65 +961,65 @@ pub async fn start_sketch_on(exec_state: &mut ExecState, args: Args) -> Result<K
 /// Start a new 2-dimensional sketch on a specific plane or face.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XY")
+/// exampleSketch = startSketchOn("XY")
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([10, 0], %)
 ///   |> line([0, 10], %)
 ///   |> line([-10, 0], %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 ///
-/// const exampleSketch002 = startSketchOn(example, 'end')
+/// exampleSketch002 = startSketchOn(example, 'end')
 ///   |> startProfileAt([1, 1], %)
 ///   |> line([8, 0], %)
 ///   |> line([0, 8], %)
 ///   |> line([-8, 0], %)
 ///   |> close(%)
 ///
-/// const example002 = extrude(5, exampleSketch002)
+/// example002 = extrude(5, exampleSketch002)
 ///
-/// const exampleSketch003 = startSketchOn(example002, 'end')
+/// exampleSketch003 = startSketchOn(example002, 'end')
 ///   |> startProfileAt([2, 2], %)
 ///   |> line([6, 0], %)
 ///   |> line([0, 6], %)
 ///   |> line([-6, 0], %)
 ///   |> close(%)
 ///
-/// const example003 = extrude(5, exampleSketch003)
+/// example003 = extrude(5, exampleSketch003)
 /// ```
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn("XY")
+/// exampleSketch = startSketchOn("XY")
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([10, 0], %)
 ///   |> line([0, 10], %, $sketchingFace)
 ///   |> line([-10, 0], %)
 ///   |> close(%)
 ///
-/// const example = extrude(10, exampleSketch)
+/// example = extrude(10, exampleSketch)
 ///
-/// const exampleSketch002 = startSketchOn(example, sketchingFace)
+/// exampleSketch002 = startSketchOn(example, sketchingFace)
 ///   |> startProfileAt([1, 1], %)
 ///   |> line([8, 0], %)
 ///   |> line([0, 8], %)
 ///   |> line([-8, 0], %)
 ///   |> close(%, $sketchingFace002)
 ///
-/// const example002 = extrude(10, exampleSketch002)
+/// example002 = extrude(10, exampleSketch002)
 ///
-/// const exampleSketch003 = startSketchOn(example002, sketchingFace002)
+/// exampleSketch003 = startSketchOn(example002, sketchingFace002)
 ///   |> startProfileAt([-8, 12], %)
 ///   |> line([0, 6], %)
 ///   |> line([6, 0], %)
 ///   |> line([0, -6], %)
 ///   |> close(%)
 ///
-/// const example003 = extrude(5, exampleSketch003)
+/// example003 = extrude(5, exampleSketch003)
 /// ```
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XY')
+/// exampleSketch = startSketchOn('XY')
 ///   |> startProfileAt([4, 12], %)
 ///   |> line([2, 0], %)
 ///   |> line([0, -6], %)
@@ -1030,20 +1030,20 @@ pub async fn start_sketch_on(exec_state: &mut ExecState, args: Args) -> Result<K
 ///   |> line([-2, 0], %)
 ///   |> close(%)
 ///
-/// const example = revolve({ axis: 'y', angle: 180 }, exampleSketch)
+/// example = revolve({ axis: 'y', angle: 180 }, exampleSketch)
 ///  
-/// const exampleSketch002 = startSketchOn(example, 'end')
+/// exampleSketch002 = startSketchOn(example, 'end')
 ///   |> startProfileAt([4.5, -5], %)
 ///   |> line([0, 5], %)
 ///   |> line([5, 0], %)
 ///   |> line([0, -5], %)
 ///   |> close(%)
 ///
-/// const example002 = extrude(5, exampleSketch002)
+/// example002 = extrude(5, exampleSketch002)
 /// ```
 ///
 /// ```no_run
-/// const a1 = startSketchOn({
+/// a1 = startSketchOn({
 ///       plane: {
 ///         origin = { x = 0, y = 0, z = 0 },
 ///         xAxis = { x = 1, y = 0, z = 0 },
@@ -1177,36 +1177,36 @@ pub async fn start_profile_at(exec_state: &mut ExecState, args: Args) -> Result<
 /// Start a new profile at a given point.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([10, 0], %)
 ///   |> line([0, 10], %)
 ///   |> line([-10, 0], %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('-XZ')
+/// exampleSketch = startSketchOn('-XZ')
 ///   |> startProfileAt([10, 10], %)
 ///   |> line([10, 0], %)
 ///   |> line([0, 10], %)
 ///   |> line([-10, 0], %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('-XZ')
+/// exampleSketch = startSketchOn('-XZ')
 ///   |> startProfileAt([-10, 23], %)
 ///   |> line([10, 0], %)
 ///   |> line([0, 10], %)
 ///   |> line([-10, 0], %)
 ///   |> close(%)
 ///
-/// const example = extrude(5, exampleSketch)
+/// example = extrude(5, exampleSketch)
 /// ```
 #[stdlib {
     name = "startProfileAt",
@@ -1320,7 +1320,7 @@ pub async fn profile_start_x(_exec_state: &mut ExecState, args: Args) -> Result<
 /// value.
 ///
 /// ```no_run
-/// const sketch001 = startSketchOn('XY')
+/// sketch001 = startSketchOn('XY')
 ///  |> startProfileAt([5, 2], %)
 ///  |> angledLine([-26.6, 50], %)
 ///  |> angledLine([90, 50], %)
@@ -1344,7 +1344,7 @@ pub async fn profile_start_y(_exec_state: &mut ExecState, args: Args) -> Result<
 /// value.
 ///
 /// ```no_run
-/// const sketch001 = startSketchOn('XY')
+/// sketch001 = startSketchOn('XY')
 ///  |> startProfileAt([5, 2], %)
 ///  |> angledLine({ angle = -60, length = 14 }, %)
 ///  |> angledLineToY({ angle = 30, to = profileStartY(%) }, %)
@@ -1367,7 +1367,7 @@ pub async fn profile_start(_exec_state: &mut ExecState, args: Args) -> Result<Kc
 /// value.
 ///
 /// ```no_run
-/// const sketch001 = startSketchOn('XY')
+/// sketch001 = startSketchOn('XY')
 ///  |> startProfileAt([5, 2], %)
 ///  |> angledLine({ angle = 120, length = 50 }, %, $seg01)
 ///  |> angledLine({ angle = segAng(seg01) + 120, length = 50 }, %)
@@ -1406,13 +1406,13 @@ pub async fn close(exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 /// ```
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('-XZ')
+/// exampleSketch = startSketchOn('-XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([10, 0], %)
 ///   |> line([0, 10], %)
 ///   |> close(%)
 ///
-/// const example = extrude(10, exampleSketch)
+/// example = extrude(10, exampleSketch)
 /// ```
 #[stdlib {
     name = "close",
@@ -1524,7 +1524,7 @@ pub async fn arc(exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kcl
 /// for to construct your shape, you're likely looking for tangentialArc.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([10, 0], %)
 ///   |> arc({
@@ -1533,7 +1533,7 @@ pub async fn arc(exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kcl
 ///        radius = 16
 ///      }, %)
 ///   |> close(%)
-/// const example = extrude(10, exampleSketch)
+/// example = extrude(10, exampleSketch)
 /// ```
 #[stdlib {
     name = "arc",
@@ -1631,14 +1631,14 @@ pub async fn arc_to(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 /// the start and end.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> arcTo({
 ///         end = [10,0],
 ///         interior = [5,5]
 ///      }, %)
 ///   |> close(%)
-/// const example = extrude(10, exampleSketch)
+/// example = extrude(10, exampleSketch)
 /// ```
 #[stdlib {
     name = "arcTo",
@@ -1767,7 +1767,7 @@ pub async fn tangential_arc(exec_state: &mut ExecState, args: Args) -> Result<Kc
 /// degrees along the imaginary circle.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> angledLine({
 ///     angle = 60,
@@ -1780,7 +1780,7 @@ pub async fn tangential_arc(exec_state: &mut ExecState, args: Args) -> Result<Kc
 ///   }, %)
 ///   |> close(%)
 ///
-/// const example = extrude(10, exampleSketch)
+/// example = extrude(10, exampleSketch)
 /// ```
 #[stdlib {
     name = "tangentialArc",
@@ -1900,7 +1900,7 @@ pub async fn tangential_arc_to_relative(exec_state: &mut ExecState, args: Args) 
 /// coordinates.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> angledLine({
 ///     angle = 60,
@@ -1910,7 +1910,7 @@ pub async fn tangential_arc_to_relative(exec_state: &mut ExecState, args: Args) 
 ///   |> line([10, -15], %)
 ///   |> close(%)
 ///
-/// const example = extrude(10, exampleSketch)
+/// example = extrude(10, exampleSketch)
 /// ```
 #[stdlib {
     name = "tangentialArcTo",
@@ -1966,7 +1966,7 @@ async fn inner_tangential_arc_to(
 /// distance away.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> angledLine({
 ///     angle = 45,
@@ -1976,7 +1976,7 @@ async fn inner_tangential_arc_to(
 ///   |> line([-10, 0], %)
 ///   |> close(%)
 ///
-/// const example = extrude(10, exampleSketch)
+/// example = extrude(10, exampleSketch)
 /// ```
 #[stdlib {
     name = "tangentialArcToRelative",
@@ -2108,7 +2108,7 @@ pub async fn bezier_curve(exec_state: &mut ExecState, args: Args) -> Result<KclV
 /// shape.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XZ')
+/// exampleSketch = startSketchOn('XZ')
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([0, 10], %)
 ///   |> bezierCurve({
@@ -2119,7 +2119,7 @@ pub async fn bezier_curve(exec_state: &mut ExecState, args: Args) -> Result<KclV
 ///   |> lineTo([10, 0], %)
 ///   |> close(%)
 ///
-/// const example = extrude(10, exampleSketch)
+/// example = extrude(10, exampleSketch)
 /// ```
 #[stdlib {
     name = "bezierCurve",
@@ -2188,7 +2188,7 @@ pub async fn hole(exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 /// Use a 2-dimensional sketch to cut a hole in another 2-dimensional sketch.
 ///
 /// ```no_run
-/// const exampleSketch = startSketchOn('XY')
+/// exampleSketch = startSketchOn('XY')
 ///   |> startProfileAt([0, 0], %)
 ///   |> line([0, 5], %)
 ///   |> line([5, 0], %)
@@ -2197,24 +2197,24 @@ pub async fn hole(exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 ///   |> hole(circle({ center = [1, 1], radius = .25 }, %), %)
 ///   |> hole(circle({ center = [1, 4], radius = .25 }, %), %)
 ///
-/// const example = extrude(1, exampleSketch)
+/// example = extrude(1, exampleSketch)
 /// ```
 ///
 /// ```no_run
-/// fn squareHoleSketch = () => {
-///     const squareSketch = startSketchOn('-XZ')
-///       |> startProfileAt([-1, -1], %)
-///       |> line([2, 0], %)
-///       |> line([0, 2], %)
-///       |> line([-2, 0], %)
-///       |> close(%)
-///     return squareSketch
-///   }
+/// fn squareHoleSketch() {
+///   squareSketch = startSketchOn('-XZ')
+///     |> startProfileAt([-1, -1], %)
+///     |> line([2, 0], %)
+///     |> line([0, 2], %)
+///     |> line([-2, 0], %)
+///     |> close(%)
+///   return squareSketch
+/// }
 ///
-///  const exampleSketch = startSketchOn('-XZ')
+/// exampleSketch = startSketchOn('-XZ')
 ///     |> circle({ center = [0, 0], radius = 3 }, %)
 ///     |> hole(squareHoleSketch(), %)
-///  const example = extrude(1, exampleSketch)
+/// example = extrude(1, exampleSketch)
 /// ```
 #[stdlib {
     name = "hole",

--- a/src/wasm-lib/kcl/src/std/units.rs
+++ b/src/wasm-lib/kcl/src/std/units.rs
@@ -34,7 +34,7 @@ pub async fn mm(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kcl
 /// `10 * (1/25.4)`, if the project settings are in inches.
 ///
 /// ```no_run
-/// const totalWidth = 10 * mm()
+/// totalWidth = 10 * mm()
 /// ```
 #[stdlib {
     name = "mm",
@@ -75,7 +75,7 @@ pub async fn inch(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 /// `10 * 25.4`, if the project settings are in millimeters.
 ///
 /// ```no_run
-/// const totalWidth = 10 * inch()
+/// totalWidth = 10 * inch()
 /// ```
 #[stdlib {
     name = "inch",
@@ -117,7 +117,7 @@ pub async fn ft(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kcl
 /// `10 * 304.8`, if the project settings are in millimeters.
 ///
 /// ```no_run
-/// const totalWidth = 10 * ft()
+/// totalWidth = 10 * ft()
 /// ```
 #[stdlib {
     name = "ft",
@@ -159,7 +159,7 @@ pub async fn m(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclE
 /// `10 * 1000`, if the project settings are in millimeters.
 ///
 /// ```no_run
-/// const totalWidth = 10 * m()
+/// totalWidth = 10 * m()
 /// ```
 #[stdlib {
     name = "m",
@@ -201,7 +201,7 @@ pub async fn cm(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kcl
 /// `10 * 10`, if the project settings are in millimeters.
 ///
 /// ```no_run
-/// const totalWidth = 10 * cm()
+/// totalWidth = 10 * cm()
 /// ```
 #[stdlib {
     name = "cm",
@@ -243,7 +243,7 @@ pub async fn yd(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kcl
 /// `10 * 914.4`, if the project settings are in millimeters.
 ///
 /// ```no_run
-/// const totalWidth = 10 * yd()
+/// totalWidth = 10 * yd()
 /// ```
 #[stdlib {
     name = "yd",


### PR DESCRIPTION
I removed `let` in pseudocode in reduce docs. Could go either way.