### PR TITLE
Remove type coercion

### DIFF
--- a/src/lang/std/artifactGraph.ts
+++ b/src/lang/std/artifactGraph.ts
@@ -871,15 +871,3 @@ export function codeRefFromRange(range: SourceRange, ast: Program): CodeRef {
     pathToNode: getNodePathFromSourceRange(ast, range),
   }
 }
-
-export function isSolid2D(artifact: Artifact): artifact is solid2D {
-  return (artifact as solid2D).pathId !== undefined
-}
-
-export function isSegment(artifact: Artifact): artifact is SegmentArtifact {
-  return (artifact as SegmentArtifact).pathId !== undefined
-}
-
-export function isSweep(artifact: Artifact): artifact is SweepArtifact {
-  return (artifact as SweepArtifact).pathId !== undefined
-}

--- a/src/lib/commandBarConfigs/validators.ts
+++ b/src/lib/commandBarConfigs/validators.ts
@@ -3,7 +3,6 @@ import { engineCommandManager } from 'lib/singletons'
 import { uuidv4 } from 'lib/utils'
 import { CommandBarContext } from 'machines/commandBarMachine'
 import { Selections } from 'lib/selections'
-import { isSolid2D, isSegment, isSweep } from 'lang/std/artifactGraph'
 
 export const disableDryRunWithRetry = async (numberOfRetries = 3) => {
   for (let tries = 0; tries < numberOfRetries; tries++) {
@@ -64,7 +63,7 @@ export const revolveAxisValidator = async ({
     return 'Unable to revolve, sketch not found'
   }
 
-  if (!(isSolid2D(artifact) || isSegment(artifact) || isSweep(artifact))) {
+  if (!('pathId' in artifact)) {
     return 'Unable to revolve, sketch has no path'
   }
 


### PR DESCRIPTION
I noticed this post the revolve merge and it triggered me haha, we should not be forcing types like this with `as`.

Really these util functions should be defined like
```ts
export function isSolid2D(artifact: Artifact): artifact is Solid2DArtifact {
  return artifact.type === 'solid2D'
}

export function isSegment(artifact: Artifact): artifact is SegmentArtifact {
  return artifact.type === 'segment'
}

export function isSweep(artifact: Artifact): artifact is SweepArtifact {
  return artifact.type === 'sweep'
}
```

But when I looked at how they were used, it was evident, they simply were not needed anyway.