### PR TITLE
Revert "warn on unneccessary brackets (#4769)"

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-ignore-words-list: crate,everytime,inout,co-ordinate,ot,nwo,absolutey,atleast,ue,afterall,ket
+ignore-words-list: crate,everytime,inout,co-ordinate,ot,nwo,absolutey,atleast,ue,afterall
 skip: **/target,node_modules,build,**/Cargo.lock,./docs/kcl/*.md,.yarn.lock,**/yarn.lock,./openapi/*.json,./src/lib/machine-api.d.ts

--- a/src/wasm-lib/kcl/src/parsing/parser.rs
+++ b/src/wasm-lib/kcl/src/parsing/parser.rs
@@ -4,7 +4,7 @@
 use std::{cell::RefCell, collections::HashMap, str::FromStr};
 
 use winnow::{
-    combinator::{alt, opt, peek, preceded, repeat, separated, separated_pair, terminated},
+    combinator::{alt, delimited, opt, peek, preceded, repeat, separated, separated_pair, terminated},
     dispatch,
     error::{ErrMode, StrContext, StrContextValue},
     prelude::*,
@@ -1662,24 +1662,12 @@ fn label(i: &mut TokenSlice) -> PResult<Node<Identifier>> {
 }
 
 fn unnecessarily_bracketed(i: &mut TokenSlice) -> PResult<Expr> {
-    let (bra, result, ket) = (
+    delimited(
         terminated(open_paren, opt(whitespace)),
         expression,
         preceded(opt(whitespace), close_paren),
     )
-        .parse_next(i)?;
-
-    let expr_range: SourceRange = (&result).into();
-
-    ParseContext::warn(CompilationError::with_suggestion(
-        SourceRange::new(bra.start, ket.end, result.module_id()),
-        None,
-        "Unnecessary parentheses around sub-expression",
-        Some(("Remove parentheses", i.text(expr_range))),
-        Tag::Unnecessary,
-    ));
-
-    Ok(result)
+    .parse_next(i)
 }
 
 fn expr_allowed_in_pipe_expr(i: &mut TokenSlice) -> PResult<Expr> {
@@ -4254,15 +4242,6 @@ var baz = 2
  baz = 2
 "#
         );
-    }
-
-    #[test]
-    fn warn_unneccessary_parens() {
-        let some_program_string = r#"foo((a + b))"#;
-        let (_, errs) = assert_no_err(some_program_string);
-        assert_eq!(errs.len(), 1);
-        let replaced = errs[0].apply_suggestion(some_program_string).unwrap();
-        assert_eq!(replaced, r#"foo(a + b)"#);
     }
 }
 

--- a/src/wasm-lib/kcl/src/parsing/token/mod.rs
+++ b/src/wasm-lib/kcl/src/parsing/token/mod.rs
@@ -27,18 +27,11 @@ pub(crate) use tokeniser::RESERVED_WORDS;
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct TokenStream {
     tokens: Vec<Token>,
-    // TODO this could easily be borrowed except that the LSP caches token streams
-    source: String,
-    module_id: ModuleId,
 }
 
 impl TokenStream {
-    fn new(tokens: Vec<Token>, source: String, module_id: ModuleId) -> Self {
-        Self {
-            tokens,
-            source,
-            module_id,
-        }
+    fn new(tokens: Vec<Token>) -> Self {
+        Self { tokens }
     }
 
     pub(super) fn remove_unknown(&mut self) -> Vec<Token> {
@@ -60,11 +53,6 @@ impl TokenStream {
 
     pub fn as_slice(&self) -> TokenSlice {
         TokenSlice::from(self)
-    }
-
-    pub fn text(&self, range: SourceRange) -> &str {
-        debug_assert_eq!(range.module_id(), self.module_id);
-        &self.source[range.start()..range.end()]
     }
 }
 
@@ -106,10 +94,6 @@ impl<'a> std::ops::Deref for TokenSlice<'a> {
 impl<'a> TokenSlice<'a> {
     pub fn token(&self, i: usize) -> &Token {
         &self.stream.tokens[i + self.start]
-    }
-
-    pub fn text(&self, range: SourceRange) -> &str {
-        self.stream.text(range)
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &Token> {

--- a/src/wasm-lib/kcl/src/parsing/token/tokeniser.rs
+++ b/src/wasm-lib/kcl/src/parsing/token/tokeniser.rs
@@ -69,11 +69,7 @@ pub(super) fn lex(i: &str, module_id: ModuleId) -> Result<TokenStream, ParseErro
         input: Located::new(i),
         state,
     };
-    Ok(TokenStream::new(
-        repeat(0.., token).parse(input)?,
-        i.to_owned(),
-        module_id,
-    ))
+    Ok(TokenStream::new(repeat(0.., token).parse(input)?))
 }
 
 pub(super) type Input<'a> = Stateful<Located<&'a str>, State>;


### PR DESCRIPTION
This reverts commit 4b6bbbe2c5e4b3ed50329ca3c2aac812f98d6dce (PR #4769) because these tests are failing:

        FAIL [   0.013s] kcl-lib parsing::parser::tests::assign_brackets
        FAIL [   0.012s] kcl-lib parsing::parser::tests::test_arg