### PR TITLE
Reserve syntax for units of measure

### DIFF
--- a/src/wasm-lib/kcl/src/errors.rs
+++ b/src/wasm-lib/kcl/src/errors.rs
@@ -353,7 +353,6 @@ pub struct CompilationError {
 }
 
 impl CompilationError {
-    #[allow(dead_code)]
     pub(crate) fn err(source_range: SourceRange, message: impl ToString) -> CompilationError {
         CompilationError {
             source_range,

--- a/src/wasm-lib/kcl/src/parsing/ast/types/mod.rs
+++ b/src/wasm-lib/kcl/src/parsing/ast/types/mod.rs
@@ -1928,6 +1928,10 @@ impl Identifier {
         })
     }
 
+    pub fn is_nameable(&self) -> bool {
+        !self.name.starts_with('_')
+    }
+
     /// Rename all identifiers that have the old name to the new given name.
     fn rename(&mut self, old_name: &str, new_name: &str) {
         if self.name == old_name {

--- a/src/wasm-lib/kcl/src/parsing/parser.rs
+++ b/src/wasm-lib/kcl/src/parsing/parser.rs
@@ -453,9 +453,16 @@ pub(crate) fn unsigned_number_literal(i: &mut TokenSlice) -> PResult<Node<Litera
     let (value, token) = any
         .try_map(|token: Token| match token.token_type {
             TokenType::Number => {
-                let x: f64 = token.value.parse().map_err(|_| {
+                let x: f64 = token.numeric_value().ok_or_else(|| {
                     CompilationError::fatal(token.as_source_range(), format!("Invalid float: {}", token.value))
                 })?;
+
+                if token.numeric_suffix().is_some() {
+                    ParseContext::warn(CompilationError::err(
+                        (&token).into(),
+                        "Unit of Measure suffixes are experimental and currently do nothing.",
+                    ));
+                }
 
                 Ok((LiteralValue::Number(x), token))
             }

--- a/src/wasm-lib/kcl/src/parsing/token/mod.rs
+++ b/src/wasm-lib/kcl/src/parsing/token/mod.rs
@@ -1,7 +1,7 @@
 // Clippy does not agree with rustc here for some reason.
 #![allow(clippy::needless_lifetimes)]
 
-use std::{fmt, iter::Enumerate, num::NonZeroUsize};
+use std::{fmt, iter::Enumerate, num::NonZeroUsize, str::FromStr};
 
 use anyhow::Result;
 use parse_display::Display;
@@ -23,6 +23,48 @@ mod tokeniser;
 
 #[cfg(test)]
 pub(crate) use tokeniser::RESERVED_WORDS;
+
+// Note the ordering, it's important that `m` comes after `mm` and `cm`.
+pub const NUM_SUFFIXES: [&str; 6] = ["mm", "cm", "m", "inch", "ft", "yd"];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NumericSuffix {
+    None,
+    Count,
+    Mm,
+    Cm,
+    M,
+    Inch,
+    Ft,
+    Yd,
+}
+
+impl NumericSuffix {
+    #[allow(dead_code)]
+    pub fn is_none(self) -> bool {
+        self == Self::None
+    }
+
+    pub fn is_some(self) -> bool {
+        self != Self::None
+    }
+}
+
+impl FromStr for NumericSuffix {
+    type Err = ();
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "mm" => Ok(NumericSuffix::Mm),
+            "cm" => Ok(NumericSuffix::Cm),
+            "m" => Ok(NumericSuffix::M),
+            "inch" => Ok(NumericSuffix::Inch),
+            "ft" => Ok(NumericSuffix::Ft),
+            "yd" => Ok(NumericSuffix::Yd),
+            _ => Err(()),
+        }
+    }
+}
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct TokenStream {
@@ -367,6 +409,36 @@ impl Token {
             "export" => Some(ItemVisibility::Export),
             _ => None,
         }
+    }
+
+    pub fn numeric_value(&self) -> Option<f64> {
+        if self.token_type != TokenType::Number {
+            return None;
+        }
+        let value = &self.value;
+        let value = value
+            .split_once(|c: char| c == '_' || c.is_ascii_alphabetic())
+            .map(|(s, _)| s)
+            .unwrap_or(value);
+        value.parse().ok()
+    }
+
+    pub fn numeric_suffix(&self) -> NumericSuffix {
+        if self.token_type != TokenType::Number {
+            return NumericSuffix::None;
+        }
+
+        if self.value.ends_with('_') {
+            return NumericSuffix::Count;
+        }
+
+        for suffix in NUM_SUFFIXES {
+            if self.value.ends_with(suffix) {
+                return suffix.parse().unwrap();
+            }
+        }
+
+        NumericSuffix::None
     }
 
     /// Is this token the beginning of a variable/function declaration?

--- a/src/wasm-lib/kcl/src/parsing/token/mod.rs
+++ b/src/wasm-lib/kcl/src/parsing/token/mod.rs
@@ -17,6 +17,7 @@ use crate::{
     errors::KclError,
     parsing::ast::types::{ItemVisibility, VariableKind},
     source_range::{ModuleId, SourceRange},
+    CompilationError,
 };
 
 mod tokeniser;
@@ -25,7 +26,7 @@ mod tokeniser;
 pub(crate) use tokeniser::RESERVED_WORDS;
 
 // Note the ordering, it's important that `m` comes after `mm` and `cm`.
-pub const NUM_SUFFIXES: [&str; 6] = ["mm", "cm", "m", "inch", "ft", "yd"];
+pub const NUM_SUFFIXES: [&str; 8] = ["mm", "cm", "m", "inch", "ft", "yd", "deg", "rad"];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum NumericSuffix {
@@ -37,6 +38,8 @@ pub enum NumericSuffix {
     Inch,
     Ft,
     Yd,
+    Deg,
+    Rad,
 }
 
 impl NumericSuffix {
@@ -51,17 +54,20 @@ impl NumericSuffix {
 }
 
 impl FromStr for NumericSuffix {
-    type Err = ();
+    type Err = CompilationError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s {
+            "_" => Ok(NumericSuffix::Count),
             "mm" => Ok(NumericSuffix::Mm),
             "cm" => Ok(NumericSuffix::Cm),
             "m" => Ok(NumericSuffix::M),
             "inch" => Ok(NumericSuffix::Inch),
             "ft" => Ok(NumericSuffix::Ft),
             "yd" => Ok(NumericSuffix::Yd),
-            _ => Err(()),
+            "deg" => Ok(NumericSuffix::Deg),
+            "rad" => Ok(NumericSuffix::Rad),
+            _ => Err(CompilationError::err(SourceRange::default(), "invalid unit of measure")),
         }
     }
 }

--- a/src/wasm-lib/kcl/src/parsing/token/mod.rs
+++ b/src/wasm-lib/kcl/src/parsing/token/mod.rs
@@ -26,7 +26,7 @@ mod tokeniser;
 pub(crate) use tokeniser::RESERVED_WORDS;
 
 // Note the ordering, it's important that `m` comes after `mm` and `cm`.
-pub const NUM_SUFFIXES: [&str; 8] = ["mm", "cm", "m", "inch", "ft", "yd", "deg", "rad"];
+pub const NUM_SUFFIXES: [&str; 9] = ["mm", "cm", "m", "inch", "in", "ft", "yd", "deg", "rad"];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum NumericSuffix {
@@ -63,6 +63,7 @@ impl FromStr for NumericSuffix {
             "cm" => Ok(NumericSuffix::Cm),
             "m" => Ok(NumericSuffix::M),
             "inch" => Ok(NumericSuffix::Inch),
+            "in" => Ok(NumericSuffix::Inch),
             "ft" => Ok(NumericSuffix::Ft),
             "yd" => Ok(NumericSuffix::Yd),
             "deg" => Ok(NumericSuffix::Deg),

--- a/src/wasm-lib/kcl/src/parsing/token/tokeniser.rs
+++ b/src/wasm-lib/kcl/src/parsing/token/tokeniser.rs
@@ -146,9 +146,9 @@ fn line_comment(i: &mut Input<'_>) -> PResult<Token> {
 fn number(i: &mut Input<'_>) -> PResult<Token> {
     let number_parser = alt((
         // Digits before the decimal point.
-        (digit1, opt(('.', digit1))).map(|_| ()),
+        (digit1, opt(('.', digit1)), opt('_'), opt(alt(super::NUM_SUFFIXES))).map(|_| ()),
         // No digits before the decimal point.
-        ('.', digit1).map(|_| ()),
+        ('.', digit1, opt('_'), opt(alt(super::NUM_SUFFIXES))).map(|_| ()),
     ));
     let (value, range) = number_parser.take().with_span().parse_next(i)?;
     Ok(Token::from_range(
@@ -378,7 +378,8 @@ mod tests {
         assert!(p.parse_next(&mut input).is_err(), "parsed {s} but should have failed");
     }
 
-    fn assert_parse_ok<'i, P, O, E>(mut p: P, s: &'i str)
+    // Returns the token and whether any more input is remaining to tokenize.
+    fn assert_parse_ok<'i, P, O, E>(mut p: P, s: &'i str) -> (O, bool)
     where
         E: std::fmt::Debug,
         O: std::fmt::Debug,
@@ -391,14 +392,27 @@ mod tests {
         };
         let res = p.parse_next(&mut input);
         assert!(res.is_ok(), "failed to parse {s}, got {}", res.unwrap_err());
+        (res.unwrap(), !input.is_empty())
     }
 
     #[test]
     fn test_number() {
-        for valid in [
-            "1", "1 abc", "1.1", "1.1 abv", "1.1 abv", "1", ".1", "5?", "5 + 6", "5 + a", "5.5", "1abc",
+        for (valid, expected) in [
+            ("1", false),
+            ("1 abc", true),
+            ("1.1", false),
+            ("1.1 abv", true),
+            ("1.1 abv", true),
+            ("1", false),
+            (".1", false),
+            ("5?", true),
+            ("5 + 6", true),
+            ("5 + a", true),
+            ("5.5", false),
+            ("1abc", true),
         ] {
-            assert_parse_ok(number, valid);
+            let (_, remaining) = assert_parse_ok(number, valid);
+            assert_eq!(expected, remaining, "`{valid}` expected another token to be {expected}");
         }
 
         for invalid in ["a", "?", "?5"] {
@@ -412,6 +426,27 @@ mod tests {
         };
 
         assert_eq!(number.parse(input).unwrap().value, "0.0000000000");
+    }
+
+    #[test]
+    fn test_number_suffix() {
+        for (valid, expected_val, expected_next) in [
+            ("1_", 1.0, false),
+            ("1_mm", 1.0, false),
+            ("1_yd", 1.0, false),
+            ("1m", 1.0, false),
+            ("1inch", 1.0, false),
+            ("1toot", 1.0, true),
+            ("1.4inch t", 1.4, true),
+        ] {
+            let (t, remaining) = assert_parse_ok(number, valid);
+            assert_eq!(expected_next, remaining);
+            assert_eq!(
+                Some(expected_val),
+                t.numeric_value(),
+                "{valid} has incorrect numeric value, expected {expected_val} {t:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/wasm-lib/kcl/src/parsing/token/tokeniser.rs
+++ b/src/wasm-lib/kcl/src/parsing/token/tokeniser.rs
@@ -50,7 +50,6 @@ lazy_static! {
         set.insert("record", TokenType::Keyword);
         set.insert("struct", TokenType::Keyword);
         set.insert("object", TokenType::Keyword);
-        set.insert("_", TokenType::Keyword);
 
         set.insert("string", TokenType::Type);
         set.insert("number", TokenType::Type);

--- a/src/wasm-lib/tests/executor/inputs/lsystem.kcl
+++ b/src/wasm-lib/tests/executor/inputs/lsystem.kcl
@@ -27,7 +27,7 @@ fn Gte = (a, b) => { return Not(Lt(a, b)) }
 
 deg = pi()*2 / 360
 
-fn setSketch = (state, _q) => {
+fn setSketch = (state, q) => {
   return {
     depthMax: state.depthMax,
     depth: state.depth + 1,
@@ -35,43 +35,43 @@ fn setSketch = (state, _q) => {
     factor: state.factor,
     currentAngle: state.currentAngle,
     angle: state.angle,
-    _q: _q
+    q
   }
 }
 
-fn setDepth = (state, _q) => {
+fn setDepth = (state, q) => {
   return {
     depthMax: state.depthMax,
-    depth: _q,
+    depth: q,
     currentLength: state.currentLength,
     factor: state.factor,
     currentAngle: state.currentAngle,
     angle: state.angle,
-    _q:  state._q
+    q: state.q
   }
 }
 
-fn setAngle = (state, _q) => {
+fn setAngle = (state, q) => {
   return {
     depthMax: state.depthMax,
     depth: state.depth,
     currentLength: state.currentLength,
     factor: state.factor,
-    currentAngle: _q,
+    currentAngle: q,
     angle: state.angle,
-    _q:  state._q
+    q: state.q
   }
 }
 
-fn setLength = (state, _q) => {
+fn setLength = (state, q) => {
   return {
     depthMax: state.depthMax,
     depth: state.depth,
-    currentLength: _q,
+    currentLength: q,
     factor: state.factor,
     currentAngle: state.currentAngle,
     angle: state.angle,
-    _q:  state._q
+    q: state.q
   }
 }
 
@@ -95,7 +95,7 @@ fn F = (state, F) => {
 
   } else {
     // Pass onto the next instruction
-    state |> setSketch(%, angledLine({ angle: state.currentAngle, length: state.currentLength }, state._q))
+    state |> setSketch(%, angledLine({ angle: state.currentAngle, length: state.currentLength }, state.q))
   }
 }
 
@@ -107,7 +107,7 @@ fn LSystem = (args, axioms) => {
     factor: args.factor,
     currentAngle: 0,
     angle: args.angle,
-    _q: startSketchAt([0, 0]),
+    q: startSketchAt([0, 0]),
   })
 }
 
@@ -115,7 +115,7 @@ LSystem({
   iterations: 1,
   factor: 1.36,
   angle: 60,
-}, (_q) => {
-  result = _q |> F(%, F) |> Add(%) |> Add(%) |> F(%, F) |> Add(%) |> Add(%) |> F(%, F) 
-  return result._q
+}, (q) => {
+  result = q |> F(%, F) |> Add(%) |> Add(%) |> F(%, F) |> Add(%) |> Add(%) |> F(%, F) 
+  return result.q
 })


### PR DESCRIPTION
This PR parses but not does not store in the AST a variety of syntax which I think is enough to implement unit of measure types. I don't have a full design, but this reservation does not commit us, it just ensures we have space. (It was also useful to think through the design). The syntax which is parsed is:

- numeric literal suffixes, both `42mm` and `42_mm` (I'm not sure if we want one or the other or both) and `42_` to assert no unit (i.e., a counting number). To this end, this PR makes leading underscores have non-referencing semantics, i.e., they can be used to declare unused constants.
- UoM-generic types, e.g., `number(mm)` (note I'm using `()` deliberately so we could if we want use `<>` purely for type generics).
- type ascription, i.e., `e: T` this is not directly related to UoM, but I believe we'll need it to allow the user to assert that a downcast is safe, again we're not committed to this, it's just reserved.
- ~~a general annotation syntax which allows `@foo` or `@foo = expr` anywhere a comment could be. I've wired this one into the AST because I think we want to use it for per-file units nevermind full UoM.~~