### PR TITLE
Fix SourceRange values in OrderedCommands to match the TS type

### DIFF
--- a/src/lang/std/__snapshots__/artifactGraph.test.ts.snap
+++ b/src/lang/std/__snapshots__/artifactGraph.test.ts.snap
@@ -13,7 +13,7 @@ Map {
       "range": [
         12,
         31,
-        0,
+        true,
       ],
     },
     "id": "UUID",
@@ -33,7 +33,7 @@ Map {
       "range": [
         37,
         64,
-        0,
+        true,
       ],
     },
     "id": "UUID",
@@ -60,7 +60,7 @@ Map {
       "range": [
         70,
         86,
-        0,
+        true,
       ],
     },
     "edgeIds": [
@@ -83,7 +83,7 @@ Map {
       "range": [
         92,
         119,
-        0,
+        true,
       ],
     },
     "edgeCutId": "UUID",
@@ -107,7 +107,7 @@ Map {
       "range": [
         125,
         150,
-        0,
+        true,
       ],
     },
     "edgeIds": [
@@ -130,7 +130,7 @@ Map {
       "range": [
         156,
         203,
-        0,
+        true,
       ],
     },
     "edgeIds": [
@@ -153,7 +153,7 @@ Map {
       "range": [
         209,
         217,
-        0,
+        true,
       ],
     },
     "edgeIds": [],
@@ -177,7 +177,7 @@ Map {
       "range": [
         231,
         254,
-        0,
+        true,
       ],
     },
     "edgeIds": [
@@ -320,7 +320,7 @@ Map {
       "range": [
         260,
         299,
-        0,
+        true,
       ],
     },
     "consumedEdgeId": "UUID",
@@ -340,7 +340,7 @@ Map {
       "range": [
         350,
         377,
-        0,
+        true,
       ],
     },
     "id": "UUID",
@@ -366,7 +366,7 @@ Map {
       "range": [
         383,
         398,
-        0,
+        true,
       ],
     },
     "edgeIds": [
@@ -389,7 +389,7 @@ Map {
       "range": [
         404,
         420,
-        0,
+        true,
       ],
     },
     "edgeIds": [
@@ -412,7 +412,7 @@ Map {
       "range": [
         426,
         473,
-        0,
+        true,
       ],
     },
     "edgeIds": [
@@ -435,7 +435,7 @@ Map {
       "range": [
         479,
         487,
-        0,
+        true,
       ],
     },
     "edgeIds": [],
@@ -459,7 +459,7 @@ Map {
       "range": [
         501,
         522,
-        0,
+        true,
       ],
     },
     "edgeIds": [

--- a/src/lang/std/artifactGraph.test.ts
+++ b/src/lang/std/artifactGraph.test.ts
@@ -661,7 +661,7 @@ describe('testing getArtifactsToUpdate', () => {
         sweepId: '',
         codeRef: {
           pathToNode: [['body', '']],
-          range: [37, 64, 0],
+          range: [37, 64, true],
         },
       },
     ])
@@ -674,7 +674,7 @@ describe('testing getArtifactsToUpdate', () => {
         surfaceIds: [],
         edgeIds: [],
         codeRef: {
-          range: [231, 254, 0],
+          range: [231, 254, true],
           pathToNode: [['body', '']],
         },
       },
@@ -685,7 +685,7 @@ describe('testing getArtifactsToUpdate', () => {
         planeId: expect.any(String),
         sweepId: expect.any(String),
         codeRef: {
-          range: [37, 64, 0],
+          range: [37, 64, true],
           pathToNode: [['body', '']],
         },
         solid2dId: expect.any(String),
@@ -699,7 +699,7 @@ describe('testing getArtifactsToUpdate', () => {
         surfaceId: '',
         edgeIds: [],
         codeRef: {
-          range: [70, 86, 0],
+          range: [70, 86, true],
           pathToNode: [['body', '']],
         },
       },
@@ -710,7 +710,7 @@ describe('testing getArtifactsToUpdate', () => {
         planeId: expect.any(String),
         sweepId: expect.any(String),
         codeRef: {
-          range: [37, 64, 0],
+          range: [37, 64, true],
           pathToNode: [['body', '']],
         },
         solid2dId: expect.any(String),
@@ -725,7 +725,7 @@ describe('testing getArtifactsToUpdate', () => {
         edgeIds: [],
         surfaceId: '',
         codeRef: {
-          range: [260, 299, 0],
+          range: [260, 299, true],
           pathToNode: [['body', '']],
         },
       },
@@ -736,7 +736,7 @@ describe('testing getArtifactsToUpdate', () => {
         surfaceId: expect.any(String),
         edgeIds: expect.any(Array),
         codeRef: {
-          range: [92, 119, 0],
+          range: [92, 119, true],
           pathToNode: [['body', '']],
         },
         edgeCutId: expect.any(String),
@@ -758,7 +758,7 @@ describe('testing getArtifactsToUpdate', () => {
         surfaceId: expect.any(String),
         edgeIds: expect.any(Array),
         codeRef: {
-          range: [156, 203, 0],
+          range: [156, 203, true],
           pathToNode: [['body', '']],
         },
       },
@@ -770,7 +770,7 @@ describe('testing getArtifactsToUpdate', () => {
         surfaceIds: expect.any(Array),
         edgeIds: expect.any(Array),
         codeRef: {
-          range: [231, 254, 0],
+          range: [231, 254, true],
           pathToNode: [['body', '']],
         },
       },
@@ -789,7 +789,7 @@ describe('testing getArtifactsToUpdate', () => {
         surfaceId: expect.any(String),
         edgeIds: expect.any(Array),
         codeRef: {
-          range: [125, 150, 0],
+          range: [125, 150, true],
           pathToNode: [['body', '']],
         },
       },
@@ -801,7 +801,7 @@ describe('testing getArtifactsToUpdate', () => {
         surfaceIds: expect.any(Array),
         edgeIds: expect.any(Array),
         codeRef: {
-          range: [231, 254, 0],
+          range: [231, 254, true],
           pathToNode: [['body', '']],
         },
       },
@@ -820,7 +820,7 @@ describe('testing getArtifactsToUpdate', () => {
         surfaceId: expect.any(String),
         edgeIds: expect.any(Array),
         codeRef: {
-          range: [92, 119, 0],
+          range: [92, 119, true],
           pathToNode: [['body', '']],
         },
         edgeCutId: expect.any(String),
@@ -833,7 +833,7 @@ describe('testing getArtifactsToUpdate', () => {
         surfaceIds: expect.any(Array),
         edgeIds: expect.any(Array),
         codeRef: {
-          range: [231, 254, 0],
+          range: [231, 254, true],
           pathToNode: [['body', '']],
         },
       },
@@ -852,7 +852,7 @@ describe('testing getArtifactsToUpdate', () => {
         surfaceId: expect.any(String),
         edgeIds: expect.any(Array),
         codeRef: {
-          range: [70, 86, 0],
+          range: [70, 86, true],
           pathToNode: [['body', '']],
         },
       },
@@ -864,7 +864,7 @@ describe('testing getArtifactsToUpdate', () => {
         surfaceIds: expect.any(Array),
         edgeIds: expect.any(Array),
         codeRef: {
-          range: [231, 254, 0],
+          range: [231, 254, true],
           pathToNode: [['body', '']],
         },
       },
@@ -884,7 +884,7 @@ describe('testing getArtifactsToUpdate', () => {
         surfaceIds: expect.any(Array),
         edgeIds: expect.any(Array),
         codeRef: {
-          range: [231, 254, 0],
+          range: [231, 254, true],
           pathToNode: [['body', '']],
         },
       },
@@ -904,7 +904,7 @@ describe('testing getArtifactsToUpdate', () => {
         surfaceIds: expect.any(Array),
         edgeIds: expect.any(Array),
         codeRef: {
-          range: [231, 254, 0],
+          range: [231, 254, true],
           pathToNode: [['body', '']],
         },
       },

--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -1,4 +1,11 @@
-import { defaultSourceRange, Program, SourceRange } from 'lang/wasm'
+import {
+  defaultRustSourceRange,
+  defaultSourceRange,
+  Program,
+  RustSourceRange,
+  SourceRange,
+  sourceRangeFromRust,
+} from 'lang/wasm'
 import { VITE_KC_API_WS_MODELING_URL, VITE_KC_DEV_TOKEN } from 'env'
 import { Models } from '@kittycad/lib'
 import { exportSave } from 'lib/exportSave'
@@ -1302,8 +1309,8 @@ export enum EngineCommandManagerEvents {
 
 interface PendingMessage {
   command: EngineCommand
-  range: SourceRange
-  idToRangeMap: { [key: string]: SourceRange }
+  range: RustSourceRange
+  idToRangeMap: { [key: string]: RustSourceRange }
   resolve: (data: [Models['WebSocketResponse_type']]) => void
   reject: (reason: string) => void
   promise: Promise<[Models['WebSocketResponse_type']]>
@@ -1993,7 +2000,7 @@ export class EngineCommandManager extends EventTarget {
       {
         command,
         idToRangeMap: {},
-        range: defaultSourceRange(),
+        range: defaultRustSourceRange(),
       },
       true // isSceneCommand
     )
@@ -2024,9 +2031,9 @@ export class EngineCommandManager extends EventTarget {
       return Promise.reject(new Error('rangeStr is undefined'))
     if (commandStr === undefined)
       return Promise.reject(new Error('commandStr is undefined'))
-    const range: SourceRange = JSON.parse(rangeStr)
+    const range: RustSourceRange = JSON.parse(rangeStr)
     const command: EngineCommand = JSON.parse(commandStr)
-    const idToRangeMap: { [key: string]: SourceRange } =
+    const idToRangeMap: { [key: string]: RustSourceRange } =
       JSON.parse(idToRangeStr)
 
     // Current executeAst is stale, going to interrupt, a new executeAst will trigger
@@ -2069,10 +2076,14 @@ export class EngineCommandManager extends EventTarget {
     if (message.command.type === 'modeling_cmd_req') {
       this.orderedCommands.push({
         command: message.command,
-        range: message.range,
+        range: sourceRangeFromRust(message.range),
       })
     } else if (message.command.type === 'modeling_cmd_batch_req') {
       message.command.requests.forEach((req) => {
+        const cmdId = req.cmd_id || ''
+        const range = cmdId
+          ? sourceRangeFromRust(message.idToRangeMap[cmdId])
+          : defaultSourceRange()
         const cmd: EngineCommand = {
           type: 'modeling_cmd_req',
           cmd_id: req.cmd_id,
@@ -2080,7 +2091,7 @@ export class EngineCommandManager extends EventTarget {
         }
         this.orderedCommands.push({
           command: cmd,
-          range: message.idToRangeMap[req.cmd_id || ''],
+          range,
         })
       })
     }

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -65,6 +65,7 @@ export type { BinaryPart } from '../wasm-lib/kcl/bindings/BinaryPart'
 export type { Literal } from '../wasm-lib/kcl/bindings/Literal'
 export type { LiteralValue } from '../wasm-lib/kcl/bindings/LiteralValue'
 export type { ArrayExpression } from '../wasm-lib/kcl/bindings/ArrayExpression'
+export type { SourceRange as RustSourceRange } from 'wasm-lib/kcl/bindings/SourceRange'
 
 export type SyntaxType =
   | 'Program'
@@ -115,6 +116,13 @@ export function sourceRangeFromRust(s: RustSourceRange): SourceRange {
  */
 export function defaultSourceRange(): SourceRange {
   return [0, 0, true]
+}
+
+/**
+ * Create a default RustSourceRange for testing or as a placeholder.
+ */
+export function defaultRustSourceRange(): RustSourceRange {
+  return [0, 0, 0]
 }
 
 export const wasmUrl = () => {


### PR DESCRIPTION
Follow up to #4603 to make the values of `SourceRange`s in `OrderedCommands` match the TS type. When sending engine commands in Rust/WASM, it calls the TS with Rust source ranges where the value is a `number`. We need to convert that to `boolean` before storing it in our data structures.

The proxying through JSON erases the type. When JSON parsing, we need to manually say what we believe the type to be. So this slipped through.

@nrc, FYI.