### PR TITLE
fix: don't error on failure to fetch privacy settings

### DIFF
--- a/src/wasm-lib/src/wasm.rs
+++ b/src/wasm-lib/src/wasm.rs
@@ -308,7 +308,7 @@ pub async fn kcl_lsp_run(
     let mut zoo_client = kittycad::Client::new(token);
     zoo_client.set_base_url(baseurl.as_str());
 
-    // Check if we can send telememtry for this user.
+    // Check if we can send telemetry for this user.
     let can_send_telemetry = match zoo_client.users().get_privacy_settings().await {
         Ok(privacy_settings) => privacy_settings.can_train_on_data,
         Err(err) => {
@@ -319,7 +319,7 @@ pub async fn kcl_lsp_run(
             {
                 true
             } else {
-                return Err(err.to_string().into());
+                false
             }
         }
     };

--- a/src/wasm-lib/src/wasm.rs
+++ b/src/wasm-lib/src/wasm.rs
@@ -319,6 +319,7 @@ pub async fn kcl_lsp_run(
             {
                 true
             } else {
+                web_sys::console::warn_1(&format!("Failed to get privacy settings: {err:?}").into());
                 false
             }
         }


### PR DESCRIPTION
Replaces/closes #4798. Fixes #4739.

We no longer propagate the error. Log and ignore it instead.
![image](https://github.com/user-attachments/assets/828a4218-cc9d-41da-9e2d-c46ac9716ac2)

@TomPridham