### PR TITLE
KCL: Unlabeled first param defaults to %

### DIFF
--- a/src/wasm-lib/kcl/src/execution/exec_ast.rs
+++ b/src/wasm-lib/kcl/src/execution/exec_ast.rs
@@ -384,6 +384,7 @@ impl Node<CallExpressionKw> {
             },
             self.into(),
             ctx.clone(),
+            exec_state.mod_local.pipe_value.clone().map(Arg::synthetic),
         );
         match ctx.stdlib.get_either(fn_name) {
             FunctionKind::Core(func) => {
@@ -532,7 +533,12 @@ impl Node<CallExpression> {
                 };
 
                 // Attempt to call the function.
-                let args = crate::std::Args::new(fn_args, self.into(), ctx.clone());
+                let args = crate::std::Args::new(
+                    fn_args,
+                    self.into(),
+                    ctx.clone(),
+                    exec_state.mod_local.pipe_value.clone().map(Arg::synthetic),
+                );
                 let result = {
                     // Don't early-return in this block.
                     let result = func.std_lib_fn()(exec_state, args).await;

--- a/src/wasm-lib/kcl/src/parsing/parser.rs
+++ b/src/wasm-lib/kcl/src/parsing/parser.rs
@@ -347,22 +347,6 @@ fn pipe_expression(i: &mut TokenSlice) -> PResult<Node<PipeExpression>> {
     ))
     .parse_next(i)?;
 
-    // All child parsers have been run.
-    // First, ensure they all have a % in their args.
-    let calls_without_substitution = tail.iter().find_map(|(_nc, call_expr, _nc2)| {
-        if !call_expr.has_substitution_arg() {
-            Some(call_expr.into())
-        } else {
-            None
-        }
-    });
-    if let Some(source_range) = calls_without_substitution {
-        let err = CompilationError::fatal(
-            source_range,
-            "All expressions in a pipeline must use the % (substitution operator)",
-        );
-        return Err(ErrMode::Cut(err.into()));
-    }
     // Time to structure the return value.
     let mut code_count = 0;
     let mut max_noncode_end = 0;
@@ -4123,19 +4107,6 @@ let other_thing = 2 * cos(3)"#;
 let myBox = box([0,0], -3, -16, -10)
 "#;
         crate::parsing::top_level_parse(some_program_string).unwrap();
-    }
-
-    #[test]
-    fn must_use_percent_in_pipeline_fn() {
-        let some_program_string = r#"
-        foo()
-            |> bar(2)
-        "#;
-        assert_err(
-            some_program_string,
-            "All expressions in a pipeline must use the % (substitution operator)",
-            [30, 36],
-        );
     }
 
     #[test]

--- a/src/wasm-lib/kcl/src/std/args.rs
+++ b/src/wasm-lib/kcl/src/std/args.rs
@@ -61,28 +61,34 @@ impl KwArgs {
 pub struct Args {
     /// Positional args.
     pub args: Vec<Arg>,
+    /// Keyword arguments
     pub kw_args: KwArgs,
     pub source_range: SourceRange,
     pub ctx: ExecutorContext,
+    /// If this call happens inside a pipe (|>) expression, this holds the LHS of that |>.
+    /// Otherwise it's None.
+    pipe_value: Option<Arg>,
 }
 
 impl Args {
-    pub fn new(args: Vec<Arg>, source_range: SourceRange, ctx: ExecutorContext) -> Self {
+    pub fn new(args: Vec<Arg>, source_range: SourceRange, ctx: ExecutorContext, pipe_value: Option<Arg>) -> Self {
         Self {
             args,
             kw_args: Default::default(),
             source_range,
             ctx,
+            pipe_value,
         }
     }
 
     /// Collect the given keyword arguments.
-    pub fn new_kw(kw_args: KwArgs, source_range: SourceRange, ctx: ExecutorContext) -> Self {
+    pub fn new_kw(kw_args: KwArgs, source_range: SourceRange, ctx: ExecutorContext, pipe_value: Option<Arg>) -> Self {
         Self {
             args: Default::default(),
             kw_args,
             source_range,
             ctx,
+            pipe_value,
         }
     }
 
@@ -101,6 +107,7 @@ impl Args {
                 settings: Default::default(),
                 context_type: crate::execution::ContextType::Mock,
             },
+            pipe_value: None,
         })
     }
 
@@ -138,6 +145,7 @@ impl Args {
             .unlabeled
             .as_ref()
             .or(self.args.first())
+            .or(self.pipe_value.as_ref())
             .ok_or(KclError::Semantic(KclErrorDetails {
                 source_ranges: vec![self.source_range],
                 message: format!("This function requires a value for the special unlabeled first parameter, '{label}'"),


### PR DESCRIPTION
Part of #4600

KCL functions can declare one special argument that doesn't require a label on its parameter when called.

This PR will default that arg to % (the current pipeline) if not given.