### PR TITLE
Deprecate startSketchAt() stdlib function

### DIFF
--- a/docs/kcl/index.md
+++ b/docs/kcl/index.md
@@ -101,7 +101,6 @@ layout: manual
 * [`sin`](kcl/sin)
 * [`sqrt`](kcl/sqrt)
 * [`startProfileAt`](kcl/startProfileAt)
-* [`startSketchAt`](kcl/startSketchAt)
 * [`startSketchOn`](kcl/startSketchOn)
 * [`sweep`](kcl/sweep)
 * [`tan`](kcl/tan)

--- a/docs/kcl/patternTransform.md
+++ b/docs/kcl/patternTransform.md
@@ -95,7 +95,8 @@ fn cube(length, center) {
   p2 = [l + x, l + y]
   p3 = [l + x, -l + y]
 
-  return startSketchAt(p0)
+  return startSketchOn('XY')
+    |> startProfileAt(p0, %)
     |> lineTo(p1, %)
     |> lineTo(p2, %)
     |> lineTo(p3, %)
@@ -132,7 +133,8 @@ fn cube(length, center) {
   p2 = [l + x, l + y]
   p3 = [l + x, -l + y]
 
-  return startSketchAt(p0)
+  return startSketchOn('XY')
+    |> startProfileAt(p0, %)
     |> lineTo(p1, %)
     |> lineTo(p2, %)
     |> lineTo(p3, %)
@@ -195,7 +197,8 @@ fn transform(i) {
     { rotation = { angle = 45 * i } }
   ]
 }
-startSketchAt([0, 0])
+startSketchOn('XY')
+  |> startProfileAt([0, 0], %)
   |> polygon({
        radius = 10,
        numSides = 4,

--- a/docs/kcl/reduce.md
+++ b/docs/kcl/reduce.md
@@ -79,10 +79,11 @@ fn decagon(radius) {
   stepAngle = 1 / 10 * tau()
 
   // Start the decagon sketch at this point.
-  startOfDecagonSketch = startSketchAt([cos(0) * radius, sin(0) * radius])
+  startOfDecagonSketch = startSketchOn('XY')
+    |> startProfileAt([cos(0) * radius, sin(0) * radius], %)
 
-  // Use a `reduce` to draw the remaining decagon sides.
-  // For each number in the array 1..10, run the given function,
+    // Use a `reduce` to draw the remaining decagon sides.
+    // For each number in the array 1..10, run the given function,
   // which takes a partially-sketched decagon and adds one more edge to it.
   fullDecagon = reduce([1..10], startOfDecagonSketch, fn(i, partialDecagon) {
     // Draw one edge of the decagon.
@@ -97,7 +98,8 @@ fn decagon(radius) {
 /* The `decagon` above is basically like this pseudo-code:
 fn decagon(radius):
     stepAngle = (1/10) * tau()
-    startOfDecagonSketch = startSketchAt([(cos(0)*radius), (sin(0) * radius)])
+    plane = startSketchOn('XY')
+    startOfDecagonSketch = startProfileAt([(cos(0)*radius), (sin(0) * radius)], plane)
 
     // Here's the reduce part.
     partialDecagon = startOfDecagonSketch

--- a/docs/kcl/segEnd.md
+++ b/docs/kcl/segEnd.md
@@ -28,7 +28,8 @@ segEnd(tag: TagIdentifier) -> [number]
 
 ```js
 w = 15
-cube = startSketchAt([0, 0])
+cube = startSketchOn('XY')
+  |> startProfileAt([0, 0], %)
   |> line([w, 0], %, $line1)
   |> line([0, w], %, $line2)
   |> line([-w, 0], %, $line3)
@@ -37,7 +38,8 @@ cube = startSketchAt([0, 0])
   |> extrude(5, %)
 
 fn cylinder(radius, tag) {
-  return startSketchAt([0, 0])
+  return startSketchOn('XY')
+    |> startProfileAt([0, 0], %)
     |> circle({
          radius = radius,
          center = segEnd(tag)

--- a/docs/kcl/segStart.md
+++ b/docs/kcl/segStart.md
@@ -28,7 +28,8 @@ segStart(tag: TagIdentifier) -> [number]
 
 ```js
 w = 15
-cube = startSketchAt([0, 0])
+cube = startSketchOn('XY')
+  |> startProfileAt([0, 0], %)
   |> line([w, 0], %, $line1)
   |> line([0, w], %, $line2)
   |> line([-w, 0], %, $line3)
@@ -37,7 +38,8 @@ cube = startSketchAt([0, 0])
   |> extrude(5, %)
 
 fn cylinder(radius, tag) {
-  return startSketchAt([0, 0])
+  return startSketchOn('XY')
+    |> startProfileAt([0, 0], %)
     |> circle({
          radius = radius,
          center = segStart(tag)

--- a/docs/kcl/startSketchAt.md
+++ b/docs/kcl/startSketchAt.md
@@ -4,6 +4,8 @@ excerpt: "Start a new 2-dimensional sketch at a given point on the 'XY' plane."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated.
+
 Start a new 2-dimensional sketch at a given point on the 'XY' plane.
 
 

--- a/src/wasm-lib/kcl/src/std/array.rs
+++ b/src/wasm-lib/kcl/src/std/array.rs
@@ -144,7 +144,8 @@ pub async fn reduce(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 ///   stepAngle = (1/10) * tau()
 ///
 ///   // Start the decagon sketch at this point.
-///   startOfDecagonSketch = startSketchAt([(cos(0)*radius), (sin(0) * radius)])
+///   startOfDecagonSketch = startSketchOn('XY')
+///     |> startProfileAt([(cos(0)*radius), (sin(0) * radius)], %)
 ///
 ///   // Use a `reduce` to draw the remaining decagon sides.
 ///   // For each number in the array 1..10, run the given function,
@@ -164,7 +165,8 @@ pub async fn reduce(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 /// The `decagon` above is basically like this pseudo-code:
 /// fn decagon(radius):
 ///     stepAngle = (1/10) * tau()
-///     startOfDecagonSketch = startSketchAt([(cos(0)*radius), (sin(0) * radius)])
+///     plane = startSketchOn('XY')
+///     startOfDecagonSketch = startProfileAt([(cos(0)*radius), (sin(0) * radius)], plane)
 ///
 ///     // Here's the reduce part.
 ///     partialDecagon = startOfDecagonSketch

--- a/src/wasm-lib/kcl/src/std/patterns.rs
+++ b/src/wasm-lib/kcl/src/std/patterns.rs
@@ -179,7 +179,8 @@ pub async fn pattern_transform_2d(exec_state: &mut ExecState, args: Args) -> Res
 ///   p2 = [ l + x,  l + y]
 ///   p3 = [ l + x, -l + y]
 ///
-///   return startSketchAt(p0)
+///   return startSketchOn('XY')
+///   |> startProfileAt(p0, %)
 ///   |> lineTo(p1, %)
 ///   |> lineTo(p2, %)
 ///   |> lineTo(p3, %)
@@ -218,7 +219,8 @@ pub async fn pattern_transform_2d(exec_state: &mut ExecState, args: Args) -> Res
 ///   p2 = [ l + x,  l + y]
 ///   p3 = [ l + x, -l + y]
 ///   
-///   return startSketchAt(p0)
+///   return startSketchOn('XY')
+///   |> startProfileAt(p0, %)
 ///   |> lineTo(p1, %)
 ///   |> lineTo(p2, %)
 ///   |> lineTo(p3, %)
@@ -274,7 +276,8 @@ pub async fn pattern_transform_2d(exec_state: &mut ExecState, args: Args) -> Res
 ///     { rotation: { angle: 45 * i } },
 ///   ]
 /// }
-/// startSketchAt([0, 0])
+/// startSketchOn('XY')
+///   |> startProfileAt([0, 0], %)
 ///   |> polygon({
 ///        radius: 10,
 ///        numSides: 4,

--- a/src/wasm-lib/kcl/src/std/segment.rs
+++ b/src/wasm-lib/kcl/src/std/segment.rs
@@ -22,7 +22,8 @@ pub async fn segment_end(exec_state: &mut ExecState, args: Args) -> Result<KclVa
 ///
 /// ```no_run
 /// w = 15
-/// cube = startSketchAt([0, 0])
+/// cube = startSketchOn('XY')
+///   |> startProfileAt([0, 0], %)
 ///   |> line([w, 0], %, $line1)
 ///   |> line([0, w], %, $line2)
 ///   |> line([-w, 0], %, $line3)
@@ -31,7 +32,8 @@ pub async fn segment_end(exec_state: &mut ExecState, args: Args) -> Result<KclVa
 ///   |> extrude(5, %)
 ///
 /// fn cylinder(radius, tag) {
-///   return startSketchAt([0, 0])
+///   return startSketchOn('XY')
+///   |> startProfileAt([0, 0], %)
 ///   |> circle({ radius = radius, center = segEnd(tag) }, %)
 ///   |> extrude(radius, %)
 /// }
@@ -141,7 +143,8 @@ pub async fn segment_start(exec_state: &mut ExecState, args: Args) -> Result<Kcl
 ///
 /// ```no_run
 /// w = 15
-/// cube = startSketchAt([0, 0])
+/// cube = startSketchOn('XY')
+///   |> startProfileAt([0, 0], %)
 ///   |> line([w, 0], %, $line1)
 ///   |> line([0, w], %, $line2)
 ///   |> line([-w, 0], %, $line3)
@@ -150,7 +153,8 @@ pub async fn segment_start(exec_state: &mut ExecState, args: Args) -> Result<Kcl
 ///   |> extrude(5, %)
 ///
 /// fn cylinder(radius, tag) {
-///   return startSketchAt([0, 0])
+///   return startSketchOn('XY')
+///   |> startProfileAt([0, 0], %)
 ///   |> circle({ radius = radius, center = segStart(tag) }, %)
 ///   |> extrude(radius, %)
 /// }

--- a/src/wasm-lib/kcl/src/std/sketch.rs
+++ b/src/wasm-lib/kcl/src/std/sketch.rs
@@ -889,6 +889,7 @@ pub async fn start_sketch_at(exec_state: &mut ExecState, args: Args) -> Result<K
 /// ```
 #[stdlib {
     name = "startSketchAt",
+    deprecated = true,
 }]
 async fn inner_start_sketch_at(data: [f64; 2], exec_state: &mut ExecState, args: Args) -> Result<Sketch, KclError> {
     // Let's assume it's the XY plane for now, this is just for backwards compatibility.


### PR DESCRIPTION
Part of #4652.

Instead of `startSketchAt([1, 2])` where the XY plane is implicit, use:

```kcl
startSketchOn('XY')
  |> startProfileAt([1, 2], %)
```