### PR TITLE
Annotations syntax and per-file default units preparatory work

### DIFF
--- a/src/wasm-lib/kcl/src/execution/annotations.rs
+++ b/src/wasm-lib/kcl/src/execution/annotations.rs
@@ -1,0 +1,73 @@
+//! Data on available annotations.
+
+use super::kcl_value::{UnitAngle, UnitLen};
+use crate::{
+    errors::KclErrorDetails,
+    parsing::ast::types::{Expr, Node, NonCodeValue, ObjectProperty},
+    KclError, SourceRange,
+};
+
+pub(super) const SETTINGS: &str = "settings";
+pub(super) const SETTINGS_UNIT_LENGTH: &str = "defaultLengthUnit";
+pub(super) const SETTINGS_UNIT_ANGLE: &str = "defaultAngleUnit";
+
+pub(super) fn expect_properties<'a>(
+    for_key: &'static str,
+    annotation: &'a NonCodeValue,
+    source_range: SourceRange,
+) -> Result<&'a [Node<ObjectProperty>], KclError> {
+    match annotation {
+        NonCodeValue::Annotation { name, properties } => {
+            assert_eq!(name.name, for_key);
+            Ok(&**properties.as_ref().ok_or_else(|| {
+                KclError::Semantic(KclErrorDetails {
+                    message: format!("Empty `{for_key}` annotation"),
+                    source_ranges: vec![source_range],
+                })
+            })?)
+        }
+        _ => unreachable!(),
+    }
+}
+
+pub(super) fn expect_ident(expr: &Expr) -> Result<&str, KclError> {
+    match expr {
+        Expr::Identifier(id) => Ok(&id.name),
+        e => Err(KclError::Semantic(KclErrorDetails {
+            message: "Unexpected settings value, expected a simple name, e.g., `mm`".to_owned(),
+            source_ranges: vec![e.into()],
+        })),
+    }
+}
+
+impl UnitLen {
+    pub(super) fn from_str(s: &str, source_range: SourceRange) -> Result<Self, KclError> {
+        match s {
+            "mm" => Ok(UnitLen::Mm),
+            "cm" => Ok(UnitLen::Cm),
+            "m" => Ok(UnitLen::M),
+            "inch" | "in" => Ok(UnitLen::Inches),
+            "ft" => Ok(UnitLen::Feet),
+            "yd" => Ok(UnitLen::Yards),
+            value => Err(KclError::Semantic(KclErrorDetails {
+                message: format!(
+                    "Unexpected settings value: `{value}`; expected one of `mm`, `cm`, `m`, `inch`, `ft`, `yd`"
+                ),
+                source_ranges: vec![source_range],
+            })),
+        }
+    }
+}
+
+impl UnitAngle {
+    pub(super) fn from_str(s: &str, source_range: SourceRange) -> Result<Self, KclError> {
+        match s {
+            "deg" => Ok(UnitAngle::Degrees),
+            "rad" => Ok(UnitAngle::Radians),
+            value => Err(KclError::Semantic(KclErrorDetails {
+                message: format!("Unexpected settings value: `{value}`; expected one of `deg`, `rad`"),
+                source_ranges: vec![source_range],
+            })),
+        }
+    }
+}

--- a/src/wasm-lib/kcl/src/execution/kcl_value.rs
+++ b/src/wasm-lib/kcl/src/execution/kcl_value.rs
@@ -8,7 +8,10 @@ use crate::{
     errors::KclErrorDetails,
     exec::{ProgramMemory, Sketch},
     execution::{Face, ImportedGeometry, MemoryFunction, Metadata, Plane, SketchSet, Solid, SolidSet, TagIdentifier},
-    parsing::ast::types::{FunctionExpression, KclNone, LiteralValue, TagDeclarator, TagNode},
+    parsing::{
+        ast::types::{FunctionExpression, KclNone, LiteralValue, TagDeclarator, TagNode},
+        token::NumericSuffix,
+    },
     std::{args::Arg, FnAsArg},
     ExecState, ExecutorContext, KclError, ModuleId, SourceRange,
 };
@@ -558,6 +561,55 @@ impl KclValue {
                 &ctx,
             )
             .await
+        }
+    }
+}
+
+// TODO called UnitLen so as not to clash with UnitLength in settings)
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Eq)]
+#[ts(export)]
+#[serde(tag = "type")]
+pub enum UnitLen {
+    Mm,
+    Cm,
+    M,
+    Inches,
+    Feet,
+    Yards,
+}
+
+impl TryFrom<NumericSuffix> for UnitLen {
+    type Error = ();
+
+    fn try_from(suffix: NumericSuffix) -> std::result::Result<Self, Self::Error> {
+        match suffix {
+            NumericSuffix::Mm => Ok(Self::Mm),
+            NumericSuffix::Cm => Ok(Self::Cm),
+            NumericSuffix::M => Ok(Self::M),
+            NumericSuffix::Inch => Ok(Self::Inches),
+            NumericSuffix::Ft => Ok(Self::Feet),
+            NumericSuffix::Yd => Ok(Self::Yards),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Eq)]
+#[ts(export)]
+#[serde(tag = "type")]
+pub enum UnitAngle {
+    Degrees,
+    Radians,
+}
+
+impl TryFrom<NumericSuffix> for UnitAngle {
+    type Error = ();
+
+    fn try_from(suffix: NumericSuffix) -> std::result::Result<Self, Self::Error> {
+        match suffix {
+            NumericSuffix::Deg => Ok(Self::Degrees),
+            NumericSuffix::Rad => Ok(Self::Radians),
+            _ => Err(()),
         }
     }
 }

--- a/src/wasm-lib/kcl/src/parsing/ast/types/mod.rs
+++ b/src/wasm-lib/kcl/src/parsing/ast/types/mod.rs
@@ -1006,6 +1006,13 @@ impl NonCodeNode {
             NonCodeValue::Annotation { name, .. } => name.name.clone(),
         }
     }
+
+    pub fn annotation(&self, expected_name: &str) -> Option<&NonCodeValue> {
+        match &self.value {
+            a @ NonCodeValue::Annotation { name, .. } if name.name == expected_name => Some(a),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]

--- a/src/wasm-lib/kcl/src/parsing/parser.rs
+++ b/src/wasm-lib/kcl/src/parsing/parser.rs
@@ -320,7 +320,6 @@ fn annotation(i: &mut TokenSlice) -> PResult<Node<NonCodeNode>> {
     };
 
     let value = NonCodeValue::Annotation { name, properties };
-    eprintln!("found {value:?}");
     Ok(Node::new(
         NonCodeNode { value, digest: None },
         at.start,

--- a/src/wasm-lib/kcl/src/parsing/token/mod.rs
+++ b/src/wasm-lib/kcl/src/parsing/token/mod.rs
@@ -56,14 +56,13 @@ impl NumericSuffix {
 impl FromStr for NumericSuffix {
     type Err = CompilationError;
 
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "_" => Ok(NumericSuffix::Count),
             "mm" => Ok(NumericSuffix::Mm),
             "cm" => Ok(NumericSuffix::Cm),
             "m" => Ok(NumericSuffix::M),
-            "inch" => Ok(NumericSuffix::Inch),
-            "in" => Ok(NumericSuffix::Inch),
+            "inch" | "in" => Ok(NumericSuffix::Inch),
             "ft" => Ok(NumericSuffix::Ft),
             "yd" => Ok(NumericSuffix::Yd),
             "deg" => Ok(NumericSuffix::Deg),

--- a/src/wasm-lib/kcl/src/unparser.rs
+++ b/src/wasm-lib/kcl/src/unparser.rs
@@ -3,10 +3,10 @@ use std::fmt::Write;
 use crate::parsing::{
     ast::types::{
         ArrayExpression, ArrayRangeExpression, BinaryExpression, BinaryOperator, BinaryPart, BodyItem, CallExpression,
-        CallExpressionKw, DefaultParamVal, Expr, FnArgType, FormatOptions, FunctionExpression, IfExpression,
-        ImportSelector, ImportStatement, ItemVisibility, LabeledArg, Literal, LiteralIdentifier, LiteralValue,
-        MemberExpression, MemberObject, Node, NonCodeValue, ObjectExpression, Parameter, PipeExpression, Program,
-        TagDeclarator, UnaryExpression, VariableDeclaration, VariableKind,
+        CallExpressionKw, CommentStyle, DefaultParamVal, Expr, FnArgType, FormatOptions, FunctionExpression,
+        IfExpression, ImportSelector, ImportStatement, ItemVisibility, LabeledArg, Literal, LiteralIdentifier,
+        LiteralValue, MemberExpression, MemberObject, Node, NonCodeNode, NonCodeValue, ObjectExpression, Parameter,
+        PipeExpression, Program, TagDeclarator, UnaryExpression, VariableDeclaration, VariableKind,
     },
     PIPE_OPERATOR,
 };
@@ -55,7 +55,7 @@ impl Program {
                         self.non_code_meta
                             .start_nodes
                             .iter()
-                            .map(|start| start.format(&indentation))
+                            .map(|start| start.recast(options, indentation_level))
                             .collect()
                     }
                 } else {
@@ -76,7 +76,7 @@ impl Program {
                         .iter()
                         .enumerate()
                         .map(|(i, custom_white_space_or_comment)| {
-                            let formatted = custom_white_space_or_comment.format(&indentation);
+                            let formatted = custom_white_space_or_comment.recast(options, indentation_level);
                             if i == 0 && !formatted.trim().is_empty() {
                                 if let NonCodeValue::BlockComment { .. } = custom_white_space_or_comment.value {
                                     format!("\n{}", formatted)
@@ -115,7 +115,75 @@ impl NonCodeValue {
     fn should_cause_array_newline(&self) -> bool {
         match self {
             Self::InlineComment { .. } => false,
-            Self::BlockComment { .. } | Self::NewLineBlockComment { .. } | Self::NewLine => true,
+            Self::BlockComment { .. } | Self::NewLineBlockComment { .. } | Self::NewLine | Self::Annotation { .. } => {
+                true
+            }
+        }
+    }
+}
+
+impl Node<NonCodeNode> {
+    fn recast(&self, options: &FormatOptions, indentation_level: usize) -> String {
+        let indentation = options.get_indentation(indentation_level);
+        match &self.value {
+            NonCodeValue::InlineComment {
+                value,
+                style: CommentStyle::Line,
+            } => format!(" // {}\n", value),
+            NonCodeValue::InlineComment {
+                value,
+                style: CommentStyle::Block,
+            } => format!(" /* {} */", value),
+            NonCodeValue::BlockComment { value, style } => match style {
+                CommentStyle::Block => format!("{}/* {} */", indentation, value),
+                CommentStyle::Line => {
+                    if value.trim().is_empty() {
+                        format!("{}//\n", indentation)
+                    } else {
+                        format!("{}// {}\n", indentation, value.trim())
+                    }
+                }
+            },
+            NonCodeValue::NewLineBlockComment { value, style } => {
+                let add_start_new_line = if self.start == 0 { "" } else { "\n\n" };
+                match style {
+                    CommentStyle::Block => format!("{}{}/* {} */\n", add_start_new_line, indentation, value),
+                    CommentStyle::Line => {
+                        if value.trim().is_empty() {
+                            format!("{}{}//\n", add_start_new_line, indentation)
+                        } else {
+                            format!("{}{}// {}\n", add_start_new_line, indentation, value.trim())
+                        }
+                    }
+                }
+            }
+            NonCodeValue::NewLine => "\n\n".to_string(),
+            NonCodeValue::Annotation { name, properties } => {
+                let mut result = "@".to_owned();
+                result.push_str(&name.name);
+                if let Some(properties) = properties {
+                    result.push('(');
+                    result.push_str(
+                        &properties
+                            .iter()
+                            .map(|prop| {
+                                format!(
+                                    "{} = {}",
+                                    prop.key.name,
+                                    prop.value
+                                        .recast(options, indentation_level + 1, ExprContext::Other)
+                                        .trim()
+                                )
+                            })
+                            .collect::<Vec<String>>()
+                            .join(", "),
+                    );
+                    result.push(')');
+                    result.push('\n');
+                }
+
+                result
+            }
         }
     }
 }
@@ -343,7 +411,7 @@ impl ArrayExpression {
                         .iter()
                         .map(|nc| {
                             found_line_comment |= nc.value.should_cause_array_newline();
-                            nc.format("")
+                            nc.recast(options, 0)
                         })
                         .collect::<Vec<_>>()
                 } else {
@@ -481,7 +549,7 @@ impl ObjectExpression {
         let format_items: Vec<_> = (0..num_items)
             .flat_map(|i| {
                 if let Some(noncode) = self.non_code_meta.non_code_nodes.get(&i) {
-                    noncode.iter().map(|nc| nc.format("")).collect::<Vec<_>>()
+                    noncode.iter().map(|nc| nc.recast(options, 0)).collect::<Vec<_>>()
                 } else {
                     let prop = props.next().unwrap();
                     // Use a comma unless it's the last item
@@ -617,10 +685,13 @@ impl Node<PipeExpression> {
                 if let Some(non_code_meta_value) = non_code_meta.non_code_nodes.get(&index) {
                     for val in non_code_meta_value {
                         let formatted = if val.end == self.end {
-                            let indentation = options.get_indentation(indentation_level);
-                            val.format(&indentation).trim_end_matches('\n').to_string()
+                            val.recast(options, indentation_level)
+                                .trim_end_matches('\n')
+                                .to_string()
                         } else {
-                            val.format(&indentation).trim_end_matches('\n').to_string()
+                            val.recast(options, indentation_level + 1)
+                                .trim_end_matches('\n')
+                                .to_string()
                         };
                         if let NonCodeValue::BlockComment { .. } = val.value {
                             s += "\n";
@@ -1252,7 +1323,8 @@ part001 = startSketchOn('XY')
 
     #[test]
     fn test_recast_large_file() {
-        let some_program_string = r#"// define nts
+        let some_program_string = r#"@settings(units=mm)
+// define nts
 radius = 6.0
 width = 144.0
 length = 83.0
@@ -1376,7 +1448,8 @@ tabs_l = startSketchOn({
         // Its VERY important this comes back with zero new lines.
         assert_eq!(
             recasted,
-            r#"// define nts
+            r#"@settings(units = mm)
+// define nts
 radius = 6.0
 width = 144.0
 length = 83.0


### PR DESCRIPTION
To complete the per-file units work, the following is required:

- probably some tests for the units annotations
- actually use the units settings from the exec state in the std lib functions
- decide on the units names: we've previously used `units`. In this PR I've used `defaultLengthUnit` and `defaultAngleUnit` which is more self-explanatory, but more verbose. Not sure what we should actually go with.
- remove units from the project settings in Rust and the frontend, and (I think) from the CLI or engine API or anywhere else they are used. Not sure if we need to do this gently or if we should just make a breaking change.
- any frontend/UI support
- maybe and non-blocking, track units for values (I've done a little work on this already)