### PR TITLE
Feature tree filter tests

### DIFF
--- a/src/components/ModelingSidebar/ModelingPanes/FeatureTreePane.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/FeatureTreePane.tsx
@@ -7,9 +7,9 @@ import { useKclContext } from 'lang/KclProvider'
 import { codeRefFromRange, getArtifactFromRange } from 'lang/std/artifactGraph'
 import { sourceRangeFromRust } from 'lang/wasm'
 import {
+  filterOperations,
   getOperationIcon,
   getOperationLabel,
-  operationFilters,
 } from 'lib/operations'
 import { editorManager, engineCommandManager, kclManager } from 'lib/singletons'
 import { reportRejection } from 'lib/trap'
@@ -38,10 +38,7 @@ export const FeatureTreePane = () => {
     : kclManager.lastSuccessfulOperations
 
   // We filter out operations that are not useful to show in the feature tree
-  const operationList = operationFilters.reduce(
-    (acc, filter) => acc.filter(filter),
-    unfilteredOperationList
-  )
+  const operationList = filterOperations(unfilteredOperationList)
 
   function goToError() {
     modelingSend({

--- a/src/lib/operations.test.ts
+++ b/src/lib/operations.test.ts
@@ -44,8 +44,6 @@ describe('operations filtering', () => {
     expect(actual).toEqual([
       stdlib('std1'),
       userCall('foo'),
-      stdlib('std2'),
-      stdlib('std3'),
       stdlib('std4'),
       stdlib('std5'),
     ])
@@ -81,7 +79,6 @@ describe('operations filtering', () => {
     expect(actual).toEqual([
       stdlib('std1'),
       userCall('foo'),
-      stdlib('std2'),
       stdlib('std3'),
       stdlib('std4'),
       userCall('foo2'),
@@ -109,12 +106,10 @@ describe('operations filtering', () => {
     expect(actual).toEqual([
       stdlib('std1'),
       userCall('foo'),
-      stdlib('std2'),
       stdlib('std3'),
       stdlib('std4'),
       userCall('foo2'),
       userCall('foo3-nested'),
-      stdlib('std7'),
       stdlib('std8'),
     ])
   })

--- a/src/lib/operations.test.ts
+++ b/src/lib/operations.test.ts
@@ -1,0 +1,84 @@
+import { defaultRustSourceRange } from 'lang/wasm'
+import { filterOperations } from './operations'
+import { Operation } from 'wasm-lib/kcl/bindings/Operation'
+
+function stdlib(name: string): Operation {
+  return {
+    type: 'StdLibCall',
+    name,
+    unlabeledArg: null,
+    labeledArgs: {},
+    sourceRange: defaultRustSourceRange(),
+    isError: false,
+  }
+}
+
+function userCall(name: string): Operation {
+  return {
+    type: 'UserDefinedFunctionCall',
+    name,
+    functionSourceRange: defaultRustSourceRange(),
+    unlabeledArg: null,
+    labeledArgs: {},
+    sourceRange: defaultRustSourceRange(),
+  }
+}
+function userReturn(): Operation {
+  return {
+    type: 'UserDefinedFunctionReturn',
+  }
+}
+
+describe('operations filtering', () => {
+  it('drops stdlib operations inside a user-defined function call', async () => {
+    const operations = [
+      stdlib('std1'),
+      userCall('foo'),
+      stdlib('std2'),
+      stdlib('std3'),
+      userReturn(),
+      stdlib('std4'),
+      stdlib('std5'),
+    ]
+    const actual = filterOperations(operations)
+    expect(actual).toEqual([
+      stdlib('std1'),
+      userCall('foo'),
+      stdlib('std2'),
+      stdlib('std3'),
+      stdlib('std4'),
+      stdlib('std5'),
+    ])
+  })
+  it('drops user-defined function calls that contain no stdlib operations', async () => {
+    const operations = [
+      stdlib('std1'),
+      userCall('foo'),
+      userReturn(),
+      stdlib('std2'),
+      stdlib('std3'),
+    ]
+    const actual = filterOperations(operations)
+    expect(actual).toEqual([stdlib('std1'), stdlib('std2'), stdlib('std3')])
+  })
+  it('drops all user-defined function return operations', async () => {
+    // The returns allow us to group operations with the call, but we never
+    // display the returns.
+    const operations = [
+      stdlib('std1'),
+      userCall('foo'),
+      stdlib('std2'),
+      userReturn(),
+      stdlib('std3'),
+      stdlib('std4'),
+    ]
+    const actual = filterOperations(operations)
+    expect(actual).toEqual([
+      stdlib('std1'),
+      userCall('foo'),
+      stdlib('std2'),
+      stdlib('std3'),
+      stdlib('std4'),
+    ])
+  })
+})

--- a/src/lib/operations.test.ts
+++ b/src/lib/operations.test.ts
@@ -109,7 +109,6 @@ describe('operations filtering', () => {
       stdlib('std3'),
       stdlib('std4'),
       userCall('foo2'),
-      userCall('foo3-nested'),
       stdlib('std8'),
     ])
   })

--- a/src/lib/operations.test.ts
+++ b/src/lib/operations.test.ts
@@ -54,10 +54,17 @@ describe('operations filtering', () => {
       userCall('foo'),
       userReturn(),
       stdlib('std2'),
+      userCall('bar'),
+      userReturn(),
       stdlib('std3'),
     ]
     const actual = filterOperations(operations)
     expect(actual).toEqual([stdlib('std1'), stdlib('std2'), stdlib('std3')])
+  })
+  it('preserves user-defined function calls at the end of the list', async () => {
+    const operations = [stdlib('std1'), userCall('foo')]
+    const actual = filterOperations(operations)
+    expect(actual).toEqual([stdlib('std1'), userCall('foo')])
   })
   it('drops all user-defined function return operations', async () => {
     // The returns allow us to group operations with the call, but we never

--- a/src/lib/operations.test.ts
+++ b/src/lib/operations.test.ts
@@ -71,6 +71,11 @@ describe('operations filtering', () => {
       userReturn(),
       stdlib('std3'),
       stdlib('std4'),
+      userCall('foo2'),
+      stdlib('std5'),
+      stdlib('std6'),
+      userReturn(),
+      stdlib('std7'),
     ]
     const actual = filterOperations(operations)
     expect(actual).toEqual([
@@ -79,6 +84,38 @@ describe('operations filtering', () => {
       stdlib('std2'),
       stdlib('std3'),
       stdlib('std4'),
+      userCall('foo2'),
+      stdlib('std7'),
+    ])
+  })
+  it('correctly filters with nested function calls', async () => {
+    const operations = [
+      stdlib('std1'),
+      userCall('foo'),
+      stdlib('std2'),
+      userReturn(),
+      stdlib('std3'),
+      stdlib('std4'),
+      userCall('foo2'),
+      stdlib('std5'),
+      userCall('foo3-nested'),
+      stdlib('std6'),
+      userReturn(),
+      stdlib('std7'),
+      userReturn(),
+      stdlib('std8'),
+    ]
+    const actual = filterOperations(operations)
+    expect(actual).toEqual([
+      stdlib('std1'),
+      userCall('foo'),
+      stdlib('std2'),
+      stdlib('std3'),
+      stdlib('std4'),
+      userCall('foo2'),
+      userCall('foo3-nested'),
+      stdlib('std7'),
+      stdlib('std8'),
     ])
   })
 })

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -100,10 +100,20 @@ export function getOperationIcon(op: Operation): CustomIconName {
 }
 
 /**
+ * Apply all filters to a list of operations.
+ */
+export function filterOperations(operations: Operation[]): Operation[] {
+  return operationFilters.reduce(
+    (acc, filter) => acc.filter(filter),
+    operations
+  )
+}
+
+/**
  * The filters to apply to a list of operations
  * for use in the feature tree UI
  */
-export const operationFilters = [
+const operationFilters = [
   isNotUserFunctionWithNoOperations,
   isNotStdLibInUserFunction,
   isNotUserFunctionReturn,
@@ -114,7 +124,7 @@ export const operationFilters = [
  * between a UserDefinedFunctionCall and the next UserDefinedFunctionReturn
  * from a list of operations
  */
-export function isNotStdLibInUserFunction(
+function isNotStdLibInUserFunction(
   operation: Operation,
   index: number,
   allOperations: Operation[]
@@ -140,7 +150,7 @@ export function isNotStdLibInUserFunction(
  * that don't have any operations inside them
  * from a list of operations
  */
-export function isNotUserFunctionWithNoOperations(
+function isNotUserFunctionWithNoOperations(
   operation: Operation,
   index: number,
   allOperations: Operation[]
@@ -158,6 +168,6 @@ export function isNotUserFunctionWithNoOperations(
  * A third filter to exclude UserDefinedFunctionReturn operations
  * from a list of operations
  */
-export function isNotUserFunctionReturn(operation: Operation) {
+function isNotUserFunctionReturn(operation: Operation) {
   return operation.type !== 'UserDefinedFunctionReturn'
 }

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -144,40 +144,36 @@ function isNotInsideUserFunction(operations: Operation[]): Operation[] {
 }
 
 /**
- * A filter to exclude UserDefinedFunctionCall operations
- * that don't have any operations inside them
- * from a list of operations
+ * A filter to exclude UserDefinedFunctionCall operations and their
+ * corresponding UserDefinedFunctionReturn that don't have any operations inside
+ * them from a list of operations.
  */
 function isNotUserFunctionWithNoOperations(
   operations: Operation[]
 ): Operation[] {
-  const ops: Operation[] = []
-  for (let i = 0; i < operations.length; i++) {
-    const op = operations[i]
-    if (op.type !== 'UserDefinedFunctionCall') {
-      // Not a call.  Preserve it.
-      ops.push(op)
-      continue
-    }
-    // If this is a call at the end of the array, skip it.
-    const nextIndex = i + 1
-    if (nextIndex >= operations.length) continue
+  return operations.filter((op, index) => {
+    if (
+      op.type === 'UserDefinedFunctionCall' &&
+      // If this is a call at the end of the array, it's preserved.
+      index < operations.length - 1 &&
+      operations[index + 1].type === 'UserDefinedFunctionReturn'
+    )
+      return false
+    if (
+      op.type === 'UserDefinedFunctionReturn' &&
+      // If this return is at the beginning of the array, it's preserved.
+      index > 0 &&
+      operations[index - 1].type === 'UserDefinedFunctionCall'
+    )
+      return false
 
-    const nextOp = operations[nextIndex]
-    if (nextOp.type === 'UserDefinedFunctionReturn') {
-      // Next op is a return.  Skip the call and the return.
-      i++
-      continue
-    }
-    // Preserve the call.
-    ops.push(op)
-  }
-  return ops
+    return true
+  })
 }
 
 /**
- * A third filter to exclude UserDefinedFunctionReturn operations
- * from a list of operations
+ * A filter to exclude UserDefinedFunctionReturn operations from a list of
+ * operations.
  */
 function isNotUserFunctionReturn(ops: Operation[]): Operation[] {
   return ops.filter((op) => op.type !== 'UserDefinedFunctionReturn')


### PR DESCRIPTION
I made a few fixes to the operations filters.

I changed the signature of filter functions because they needed to consume an entire list of operations at once. Filtering out stdlib calls inside user-defined functions needed this. It needs to track the call depth by traversing the entire list. It can't work only looking locally at or around a single index.