### PR TITLE
Add Rust side artifacts for startSketchOn face or plane

### DIFF
--- a/src/lang/KclSingleton.ts
+++ b/src/lang/KclSingleton.ts
@@ -313,8 +313,6 @@ export class KclManager {
       this.addDiagnostics(await lintAst({ ast: ast }))
       setSelectionFilterToDefault(execState.memory, this.engineCommandManager)
 
-      console.log('executeAst artifacts', execState.artifacts)
-
       if (args.zoomToFit) {
         let zoomObjectId: string | undefined = ''
         if (args.zoomOnRangeAndType) {
@@ -359,7 +357,10 @@ export class KclManager {
     }
     this.ast = { ...ast }
     // updateArtifactGraph relies on updated executeState/programMemory
-    await this.engineCommandManager.updateArtifactGraph(this.ast)
+    await this.engineCommandManager.updateArtifactGraph(
+      this.ast,
+      execState.artifacts
+    )
     this._executeCallback()
     if (!isInterrupted)
       sceneInfra.modelingSend({ type: 'code edit during sketch' })

--- a/src/lang/KclSingleton.ts
+++ b/src/lang/KclSingleton.ts
@@ -313,6 +313,8 @@ export class KclManager {
       this.addDiagnostics(await lintAst({ ast: ast }))
       setSelectionFilterToDefault(execState.memory, this.engineCommandManager)
 
+      console.log('executeAst artifacts', execState.artifacts)
+
       if (args.zoomToFit) {
         let zoomObjectId: string | undefined = ''
         if (args.zoomOnRangeAndType) {

--- a/src/lang/std/__snapshots__/artifactGraph.test.ts.snap
+++ b/src/lang/std/__snapshots__/artifactGraph.test.ts.snap
@@ -212,7 +212,19 @@ Map {
     "type": "wall",
   },
   "UUID-10" => {
-    "codeRef": undefined,
+    "codeRef": {
+      "pathToNode": [
+        [
+          "body",
+          "",
+        ],
+      ],
+      "range": [
+        312,
+        344,
+        true,
+      ],
+    },
     "edgeCutEdgeIds": [],
     "id": "UUID",
     "pathIds": [

--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -1,6 +1,7 @@
 import {
   defaultRustSourceRange,
   defaultSourceRange,
+  ExecState,
   Program,
   RustSourceRange,
   SourceRange,
@@ -2116,11 +2117,15 @@ export class EngineCommandManager extends EventTarget {
       Object.values(this.pendingCommands).map((a) => a.promise)
     )
   }
-  updateArtifactGraph(ast: Node<Program>) {
+  updateArtifactGraph(
+    ast: Node<Program>,
+    execStateArtifacts: ExecState['artifacts']
+  ) {
     this.artifactGraph = createArtifactGraph({
       orderedCommands: this.orderedCommands,
       responseMap: this.responseMap,
       ast,
+      execStateArtifacts,
     })
     // TODO check if these still need to be deferred once e2e tests are working again.
     if (this.artifactGraph.size) {

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -44,7 +44,11 @@ import { CompilationError } from 'wasm-lib/kcl/bindings/CompilationError'
 import { SourceRange as RustSourceRange } from 'wasm-lib/kcl/bindings/SourceRange'
 import { getAllCurrentSettings } from 'lib/settings/settingsUtils'
 import { KclErrorWithOutputs } from 'wasm-lib/kcl/bindings/KclErrorWithOutputs'
+import { Artifact } from 'wasm-lib/kcl/bindings/Artifact'
+import { ArtifactId } from 'wasm-lib/kcl/bindings/ArtifactId'
 
+export type { Artifact } from 'wasm-lib/kcl/bindings/Artifact'
+export type { ArtifactId } from 'wasm-lib/kcl/bindings/ArtifactId'
 export type { Configuration } from 'wasm-lib/kcl/bindings/Configuration'
 export type { Program } from '../wasm-lib/kcl/bindings/Program'
 export type { Expr } from '../wasm-lib/kcl/bindings/Expr'
@@ -245,6 +249,7 @@ export const isPathToNodeNumber = (
 
 export interface ExecState {
   memory: ProgramMemory
+  artifacts: { [key in ArtifactId]?: Artifact }
 }
 
 /**
@@ -254,12 +259,14 @@ export interface ExecState {
 export function emptyExecState(): ExecState {
   return {
     memory: ProgramMemory.empty(),
+    artifacts: {},
   }
 }
 
 function execStateFromRaw(raw: RawExecState): ExecState {
   return {
     memory: ProgramMemory.fromRaw(raw.modLocal.memory),
+    artifacts: raw.global.artifacts,
   }
 }
 

--- a/src/wasm-lib/kcl/src/execution/artifact.rs
+++ b/src/wasm-lib/kcl/src/execution/artifact.rs
@@ -1,0 +1,47 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::SourceRange;
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Hash, ts_rs::TS, JsonSchema)]
+#[ts(export)]
+pub struct ArtifactId(Uuid);
+
+impl ArtifactId {
+    pub fn new(uuid: Uuid) -> Self {
+        Self(uuid)
+    }
+}
+
+impl From<Uuid> for ArtifactId {
+    fn from(uuid: Uuid) -> Self {
+        Self::new(uuid)
+    }
+}
+
+impl From<&Uuid> for ArtifactId {
+    fn from(uuid: &Uuid) -> Self {
+        Self::new(*uuid)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[ts(export)]
+#[serde(rename_all = "camelCase")]
+pub struct Artifact {
+    pub id: ArtifactId,
+    #[serde(flatten)]
+    pub inner: ArtifactInner,
+    pub source_range: SourceRange,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[ts(export)]
+#[serde(tag = "type")]
+pub enum ArtifactInner {
+    #[serde(rename_all = "camelCase")]
+    StartSketchOnFace { face_id: Uuid },
+    #[serde(rename_all = "camelCase")]
+    StartSketchOnPlane { plane_id: Uuid },
+}

--- a/src/wasm-lib/kcl/src/execution/mod.rs
+++ b/src/wasm-lib/kcl/src/execution/mod.rs
@@ -25,6 +25,7 @@ pub use kcl_value::{KclObjectFields, KclValue};
 use uuid::Uuid;
 
 mod annotations;
+mod artifact;
 pub(crate) mod cache;
 mod cad_op;
 mod exec_ast;
@@ -47,6 +48,7 @@ use crate::{
 };
 
 // Re-exports.
+pub use artifact::{Artifact, ArtifactId, ArtifactInner};
 pub use cad_op::Operation;
 
 /// State for executing a program.
@@ -68,6 +70,8 @@ pub struct GlobalState {
     pub path_to_source_id: IndexMap<std::path::PathBuf, ModuleId>,
     /// Map from module ID to module info.
     pub module_infos: IndexMap<ModuleId, ModuleInfo>,
+    /// Output map of UUIDs to artifacts.
+    pub artifacts: IndexMap<ArtifactId, Artifact>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
@@ -134,6 +138,11 @@ impl ExecState {
         self.global.id_generator.next_uuid()
     }
 
+    pub fn add_artifact(&mut self, artifact: Artifact) {
+        let id = artifact.id;
+        self.global.artifacts.insert(id, artifact);
+    }
+
     async fn add_module(
         &mut self,
         path: std::path::PathBuf,
@@ -171,6 +180,7 @@ impl GlobalState {
             id_generator: Default::default(),
             path_to_source_id: Default::default(),
             module_infos: Default::default(),
+            artifacts: Default::default(),
         };
 
         // TODO(#4434): Use the top-level file's path.


### PR DESCRIPTION
Stacked on #4828.

Addresses https://github.com/KittyCAD/modeling-app/pull/4828#discussion_r1889345877.

See the console.log in `KclSingleton.ts`. Note there's 2 cases: plane and face.

<img width="1624" alt="Screenshot 2024-12-18 at 5 30 43 PM" src="https://github.com/user-attachments/assets/9ac1cec4-0536-4e31-8a53-3d7c802df71f" />
