### PR TITLE
chore: disabled file watcher which prevents faster file write

### DIFF
--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -188,24 +188,25 @@ const FileTreeItem = ({
   // Because subtrees only render when they are opened, that means this
   // only listens when they open. Because this acts like a useEffect, when
   // the ReactNodes are destroyed, so is this listener :)
-  useFileSystemWatcher(
-    async (eventType, path) => {
-      // Prevents a cyclic read / write causing editor problems such as
-      // misplaced cursor positions.
-      if (codeManager.writeCausedByAppCheckedInFileTreeFileSystemWatcher) {
-        codeManager.writeCausedByAppCheckedInFileTreeFileSystemWatcher = false
-        return
-      }
+  /** Disabling this in favor of faster file writes until we fix file writing **/
+  /* useFileSystemWatcher(
+   *   async (eventType, path) => {
+   *     // Prevents a cyclic read / write causing editor problems such as
+   *     // misplaced cursor positions.
+   *     if (codeManager.writeCausedByAppCheckedInFileTreeFileSystemWatcher) {
+   *       codeManager.writeCausedByAppCheckedInFileTreeFileSystemWatcher = false
+   *       return
+   *     }
 
-      if (isCurrentFile && eventType === 'change') {
-        let code = await window.electron.readFile(path, { encoding: 'utf-8' })
-        code = normalizeLineEndings(code)
-        codeManager.updateCodeStateEditor(code)
-      }
-      fileSend({ type: 'Refresh' })
-    },
-    [fileOrDir.path]
-  )
+   *     if (isCurrentFile && eventType === 'change') {
+   *       let code = await window.electron.readFile(path, { encoding: 'utf-8' })
+   *       code = normalizeLineEndings(code)
+   *       codeManager.updateCodeStateEditor(code)
+   *     }
+   *     fileSend({ type: 'Refresh' })
+   *   },
+   *   [fileOrDir.path]
+   * ) */
 
   const showNewTreeEntry =
     newTreeEntry !== undefined &&

--- a/src/lang/codeManager.ts
+++ b/src/lang/codeManager.ts
@@ -149,7 +149,7 @@ export default class CodeManager {
               toast.error('Error saving file, please check file permissions')
               reject(err)
             })
-        }, 1000)
+        }, 10)
       })
     } else {
       safeLSSetItem(PERSIST_CODE_KEY, this.code)


### PR DESCRIPTION
# Issue

Writing to disk is too slow, it has a `setTimeout` to prevent an issue with the `useFileSystemWatcher` when you externally edit a source file and it writes back into the code pane.

# Fix

I am disabling the feature that allows externally editing the KCL source code. This only works when your file tree is opened which is a gotcha anyway. Once we implement a better file writing system we can fix this watcher.

```
      // Only write our buffer contents to file once per second. Any faster
      // and file-system watchers which read, will receive empty data during
      // writes.
```

# Implementation

- 1000ms to 10ms to keep this same workflow for the comment about `React`.
- Disable the `useFileSystemWatcher` that writes to the code pane

# Future work

- Implement better file writing system
- Implement a file watcher that works when you have that file "selected" or opened in the code pane, not just when the file tree is opened.
- Ensure there is no race condition between writing a file to disk and the watcher getting empty file data on accident. 