### PR TITLE
Re-enable test 'code pane closed at start' after electron migration

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,7 +1,7 @@
 name: E2E Tests
 on:
   push:
-    branches: [ main ]
+    branches: [ main, pierremtb/issue4838-re-enable-code-pane-closed-at-start ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,7 +1,7 @@
 name: E2E Tests
 on:
   push:
-    branches: [ main, pierremtb/issue4838-re-enable-code-pane-closed-at-start ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/e2e/playwright/basic-sketch.spec.ts
+++ b/e2e/playwright/basic-sketch.spec.ts
@@ -149,7 +149,7 @@ test.describe('Basic sketch', () => {
     await doBasicSketch(page, homePage, ['code'])
   })
 
-  test.fixme('code pane closed at start', async ({ page, homePage }) => {
+  test('code pane closed at start', async ({ page, homePage }) => {
     // Load the app with the code panes
     await page.addInitScript(async (persistModelingContext) => {
       localStorage.setItem(


### PR DESCRIPTION
Part of the list of follow-ups after #4484, see #4838