### PR TITLE
Remove the old Loft GitHub issue link in the toolbar

### DIFF
--- a/src/lib/toolbar.ts
+++ b/src/lib/toolbar.ts
@@ -150,10 +150,6 @@ export const toolbarConfig: Record<ToolbarModeName, ToolbarMode> = {
             label: 'KCL docs',
             url: 'https://zoo.dev/docs/kcl/loft',
           },
-          {
-            label: 'GitHub discussion',
-            url: 'https://github.com/KittyCAD/modeling-app/discussions/613',
-          },
         ],
       },
       'break',


### PR DESCRIPTION
Now that it's available, it shouldn't be there anymore.

Before:
<img width="528" alt="image" src="https://github.com/user-attachments/assets/3ed8c369-24cf-43c6-8513-ee2e16e6923e" />


After:
<img width="549" alt="image" src="https://github.com/user-attachments/assets/dadd2439-4a39-4c4e-ba64-ee4a4cffaf47" />
