### PR TITLE
Reduce the amount of data sent back to JS/TS from WASM

### DIFF
--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -35,7 +35,7 @@ import { Configuration } from 'wasm-lib/kcl/bindings/Configuration'
 import { DeepPartial } from 'lib/types'
 import { ProjectConfiguration } from 'wasm-lib/kcl/bindings/ProjectConfiguration'
 import { Sketch } from '../wasm-lib/kcl/bindings/Sketch'
-import { ExecState as RawExecState } from '../wasm-lib/kcl/bindings/ExecState'
+import { ExecOutcome } from 'wasm-lib/kcl/bindings/ExecOutcome'
 import { ProgramMemory as RawProgramMemory } from '../wasm-lib/kcl/bindings/ProgramMemory'
 import { EnvironmentRef } from '../wasm-lib/kcl/bindings/EnvironmentRef'
 import { Environment } from '../wasm-lib/kcl/bindings/Environment'
@@ -260,10 +260,10 @@ export function emptyExecState(): ExecState {
   }
 }
 
-function execStateFromRaw(raw: RawExecState): ExecState {
+function execStateFromRust(execOutcome: ExecOutcome): ExecState {
   return {
-    memory: ProgramMemory.fromRaw(raw.modLocal.memory),
-    operations: raw.modLocal.operations,
+    memory: ProgramMemory.fromRaw(execOutcome.memory),
+    operations: execOutcome.operations,
   }
 }
 
@@ -535,14 +535,14 @@ export const _executor = async (
         jsAppSettings = getAllCurrentSettings(lastSettingsSnapshot)
       }
     }
-    const execState: RawExecState = await execute(
+    const execOutcome: ExecOutcome = await execute(
       JSON.stringify(node),
       JSON.stringify(programMemoryOverride?.toRaw() || null),
       JSON.stringify({ settings: jsAppSettings }),
       engineCommandManager,
       fileSystemManager
     )
-    return execStateFromRaw(execState)
+    return execStateFromRust(execOutcome)
   } catch (e: any) {
     console.log(e)
     const parsed: KclErrorWithOutputs = JSON.parse(e.toString())

--- a/src/wasm-lib/src/wasm.rs
+++ b/src/wasm-lib/src/wasm.rs
@@ -133,7 +133,7 @@ pub async fn execute(
     // gloo-serialize crate instead.
     // DO NOT USE serde_wasm_bindgen::to_value(&exec_state).map_err(|e| e.to_string())
     // it will break the frontend.
-    JsValue::from_serde(&exec_state).map_err(|e| e.to_string())
+    JsValue::from_serde(&exec_state.to_wasm_outcome()).map_err(|e| e.to_string())
 }
 
 // wasm_bindgen wrapper for execute


### PR DESCRIPTION
Not ready for merging. See comments below.

Part of #4437.

We only send back the fields that are actually used. And for ProgramMemory, we clear out the memory inside closures since they're not used on the JS/TS side, as far as I know.