### PR TITLE
fix: make error for missing a closing bracket clearer

### DIFF
--- a/src/wasm-lib/kcl/src/parsing/parser.rs
+++ b/src/wasm-lib/kcl/src/parsing/parser.rs
@@ -12,6 +12,7 @@ use winnow::{
     token::{any, one_of, take_till},
 };
 
+use super::{ast::types::LabelledExpression, token::NumericSuffix};
 use crate::{
     docs::StdLibFn,
     errors::{CompilationError, Severity, Tag},
@@ -32,8 +33,6 @@ use crate::{
     unparser::ExprContext,
     SourceRange,
 };
-
-use super::{ast::types::LabelledExpression, token::NumericSuffix};
 
 thread_local! {
     /// The current `ParseContext`. `None` if parsing is not currently happening on this thread.
@@ -683,8 +682,8 @@ pub enum NonCodeOr<T> {
 fn array(i: &mut TokenSlice) -> PResult<Expr> {
     alt((
         array_empty.map(Box::new).map(Expr::ArrayExpression),
-        array_elem_by_elem.map(Box::new).map(Expr::ArrayExpression),
         array_end_start.map(Box::new).map(Expr::ArrayRangeExpression),
+        array_elem_by_elem.map(Box::new).map(Expr::ArrayExpression),
     ))
     .parse_next(i)
 }
@@ -732,7 +731,20 @@ pub(crate) fn array_elem_by_elem(i: &mut TokenSlice) -> PResult<Node<ArrayExpres
     .context(expected("array contents, a list of elements (like [1, 2, 3])"))
     .parse_next(i)?;
     ignore_whitespace(i);
-    let end = close_bracket(i)?.end;
+    let end = close_bracket(i)
+        .map_err(|e| {
+            if let Some(mut err) = e.clone().into_inner() {
+                err.cause = Some(CompilationError::fatal(
+                    open.as_source_range(),
+                    "Array is missing a closing bracket(`]`)",
+                ));
+                ErrMode::Cut(err)
+            } else {
+                // ErrMode::Incomplete, not sure if it's actually possible to end up with this here
+                e
+            }
+        })?
+        .end;
 
     // Sort the array's elements (i.e. expression nodes) from the noncode nodes.
     let (elements, non_code_nodes): (Vec<_>, HashMap<usize, _>) = elements.into_iter().enumerate().fold(
@@ -4309,6 +4321,13 @@ let myBox = box([0,0], -3, -16, -10)
     |> line([5, 5], %, $sketching)
     "#;
         assert_no_err(some_program_string);
+    }
+
+    #[test]
+    fn test_parse_missing_closing_bracket() {
+        let some_program_string = r#"
+sketch001 = startSketchOn('XZ') |> startProfileAt([90.45, 119.09, %)"#;
+        assert_err(some_program_string, "Array is missing a closing bracket(`]`)", [51, 52]);
     }
 
     #[test]


### PR DESCRIPTION
closes #4871 
puts an error on the opening bracket of an array missing a closing bracket
![Screenshot from 2024-12-30 17-10-54](https://github.com/user-attachments/assets/072326ef-fde9-4289-8f48-b4500022b0e9)
the actual error message
![Screenshot from 2024-12-30 21-48-12](https://github.com/user-attachments/assets/1272c154-6ba3-4c00-8882-a29020ba9513)
