### PR TITLE
Match package license to LICENSE file

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "description": "Edit CAD visually or with code",
   "main": ".vite/build/main.js",
-  "license": "none",
+  "license": "MIT",
   "dependencies": {
     "@codemirror/autocomplete": "^6.17.0",
     "@codemirror/commands": "^6.6.0",


### PR DESCRIPTION
## What

Use `MIT` in package.json.

## Why

Matches the `LICENSE` file. Consistent with `packages/codemirror-lsp-client/package.json`.

## References

Field was set to `none` in 6ba050727a0e424d04b74a6cd3c0e41d55c078c3 in /pull/3315.

I guess that was just done in a rush, because there was already an MIT LICENCE file present (/pull/765).
