### PR TITLE
Use app foreground color for focus outline button color so there's no hue collision

### DIFF
--- a/src/components/CommandBar/CommandBarHeader.tsx
+++ b/src/components/CommandBar/CommandBarHeader.tsx
@@ -194,7 +194,7 @@ function ReviewingButton() {
       autoFocus
       type="submit"
       form="review-form"
-      className="w-fit !p-0 rounded-sm border !border-primary hover:shadow"
+      className="w-fit !p-0 rounded-sm hover:shadow"
       iconStart={{
         icon: 'checkmark',
         bgClassName: 'p-1 rounded-sm !bg-primary hover:brightness-110',
@@ -212,7 +212,7 @@ function GatheringArgsButton() {
       Element="button"
       type="submit"
       form="arg-form"
-      className="w-fit !p-0 rounded-sm border !border-primary hover:shadow"
+      className="w-fit !p-0 rounded-sm hover:shadow"
       iconStart={{
         icon: 'arrowRight',
         bgClassName: 'p-1 rounded-sm !bg-primary hover:brightness-110',

--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -210,7 +210,7 @@ function ProjectMenuPopover({
   return (
     <Popover className="relative">
       <Popover.Button
-        className="gap-1 rounded-sm h-9 mr-auto max-h-min min-w-max border-0 py-1 px-2 flex items-center focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary dark:hover:bg-chalkboard-90"
+        className="gap-1 rounded-sm h-9 mr-auto max-h-min min-w-max border-0 py-1 px-2 flex items-center  focus-visible:outline-appForeground dark:hover:bg-chalkboard-90"
         data-testid="project-sidebar-toggle"
       >
         <div className="flex flex-col items-start py-0.5">

--- a/src/components/UserSidebarMenu.tsx
+++ b/src/components/UserSidebarMenu.tsx
@@ -168,7 +168,7 @@ const UserSidebarMenu = ({ user }: { user?: User }) => {
   return (
     <Popover className="relative">
       <Popover.Button
-        className="relative group border-0 w-fit min-w-max p-0 rounded-l-full focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary"
+        className="relative group border-0 w-fit min-w-max p-0 rounded-l-full focus-visible:outline-appForeground"
         data-testid="user-sidebar-toggle"
       >
         <div className="flex items-center">
@@ -240,7 +240,7 @@ const UserSidebarMenu = ({ user }: { user?: User }) => {
                     <li key={id} className="contents">
                       <ActionButton
                         {...rest}
-                        className="!font-sans flex items-center gap-2 rounded-sm py-1.5 px-2 cursor-pointer hover:bg-chalkboard-20 dark:hover:bg-chalkboard-80 border-none text-left"
+                        className="!font-sans flex items-center gap-2 rounded-sm py-1.5 px-2 cursor-pointer hover:bg-chalkboard-20 dark:hover:bg-chalkboard-80 !border-none text-left focus-visible:outline-appForeground"
                         onMouseUp={() => {
                           close()
                         }}

--- a/src/index.css
+++ b/src/index.css
@@ -85,7 +85,8 @@ textarea,
 }
 
 button {
-  @apply border border-chalkboard-30 m-0.5 px-3 rounded text-xs focus-visible:ring-primary;
+  @apply border border-chalkboard-30 m-0.5 px-3 rounded text-xs;
+  @apply focus-visible:outline-chalkboard-100;
 }
 
 button:hover {
@@ -93,7 +94,7 @@ button:hover {
 }
 
 .dark button {
-  @apply border-chalkboard-70 focus-visible:ring-primary/50;
+  @apply border-chalkboard-70 focus-visible:outline-chalkboard-10;
 }
 
 .dark button:hover {
@@ -318,6 +319,11 @@ code {
 
   button.reset:hover {
     @apply bg-transparent border-transparent;
+  }
+
+  /* Add an outline that matches the app foreground (or text) color */
+  .outline-appForeground {
+    @apply outline-chalkboard-100 dark:outline-chalkboard-10;
   }
 }
 


### PR DESCRIPTION
Towards #4851.

The browser-chosen focus outline color is hard to see against our default primary-colored buttons, and the Electron-chosen yellow can be hard to see if the user has set their primary color toward yellow. This sidesteps that issue by making the outline the text color, resulting in a thick black outline in light mode and a thick white outline in dark mode.