### PR TITLE
Add parsing keyword function calls inside pipelines

### DIFF
--- a/src/wasm-lib/kcl/src/parsing/parser.rs
+++ b/src/wasm-lib/kcl/src/parsing/parser.rs
@@ -2568,9 +2568,17 @@ fn typecheck(spec_arg: &crate::docs::StdLibFnArg, arg: &&Expr) -> PResult<()> {
     Ok(())
 }
 
+/// Either a positional or keyword function call.
+fn fn_call_pos_or_kw(i: &mut TokenSlice) -> PResult<Expr> {
+    alt((
+        fn_call.map(Box::new).map(Expr::CallExpression),
+        fn_call_kw.map(Box::new).map(Expr::CallExpressionKw),
+    ))
+    .parse_next(i)
+}
+
 fn labelled_fn_call(i: &mut TokenSlice) -> PResult<Expr> {
-    let call = fn_call.parse_next(i)?;
-    let expr = Expr::CallExpression(Box::new(call));
+    let expr = fn_call_pos_or_kw.parse_next(i)?;
 
     let label = opt(label).parse_next(i)?;
     match label {
@@ -4654,6 +4662,7 @@ my14 = 4 ^ 2 - 3 ^ 2 * 2
         kw_function_decl_with_default_and_type,
         r#"fn foo(x?: number = 2) { return 1 }"#
     );
+    snapshot_test!(kw_function_call_in_pipe, r#"val = 1 |> f(arg = x)"#);
 }
 
 #[allow(unused)]

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__kw_function_call_in_pipe.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__kw_function_call_in_pipe.snap
@@ -1,0 +1,75 @@
+---
+source: kcl/src/parsing/parser.rs
+assertion_line: 4674
+expression: actual
+snapshot_kind: text
+---
+{
+  "body": [
+    {
+      "declaration": {
+        "end": 21,
+        "id": {
+          "end": 3,
+          "name": "val",
+          "start": 0,
+          "type": "Identifier"
+        },
+        "init": {
+          "body": [
+            {
+              "end": 7,
+              "raw": "1",
+              "start": 6,
+              "type": "Literal",
+              "type": "Literal",
+              "value": 1.0
+            },
+            {
+              "arguments": [
+                {
+                  "type": "LabeledArg",
+                  "label": {
+                    "type": "Identifier",
+                    "name": "arg"
+                  },
+                  "arg": {
+                    "end": 20,
+                    "name": "x",
+                    "start": 19,
+                    "type": "Identifier",
+                    "type": "Identifier"
+                  }
+                }
+              ],
+              "callee": {
+                "end": 12,
+                "name": "f",
+                "start": 11,
+                "type": "Identifier"
+              },
+              "end": 21,
+              "start": 11,
+              "type": "CallExpressionKw",
+              "type": "CallExpressionKw",
+              "unlabeled": null
+            }
+          ],
+          "end": 21,
+          "start": 6,
+          "type": "PipeExpression",
+          "type": "PipeExpression"
+        },
+        "start": 0,
+        "type": "VariableDeclarator"
+      },
+      "end": 21,
+      "kind": "const",
+      "start": 0,
+      "type": "VariableDeclaration",
+      "type": "VariableDeclaration"
+    }
+  ],
+  "end": 21,
+  "start": 0
+}


### PR DESCRIPTION
Extracted from #4826. Needed by #4893.