### PR TITLE
Remove draft PR filter on e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -18,7 +18,6 @@ permissions:
 jobs:
 
   check-rust-changes:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     outputs:
       rust-changed: ${{ steps.filter.outputs.rust }}
@@ -35,7 +34,6 @@ jobs:
               - 'src/wasm-lib/**'
 
   electron:
-    if: github.event.pull_request.draft == false
     timeout-minutes: 60
     name: playwright:electron:${{ matrix.os }} ${{ matrix.shardIndex }} ${{ matrix.shardTotal }}
     strategy:


### PR DESCRIPTION
Current set up prevents the tests from running once the PR goes from draft to ready, which was the intent. This is forcing ppl to commit again, which defeats the original purpose of saving compute time. Let's remove it for now.