### PR TITLE
Enable KCL logging in cargo test CI check

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -50,6 +50,7 @@ jobs:
         env:
           KITTYCAD_API_TOKEN: ${{secrets.KITTYCAD_API_TOKEN}}
           RUST_MIN_STACK: 10485760000
+          ZOO_LOG: '1'
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
Trying to debug "websocket closed early" failures in CI.