### PR TITLE
CM KCL: Support `=` in record init

### DIFF
--- a/packages/codemirror-lang-kcl/src/kcl.grammar
+++ b/packages/codemirror-lang-kcl/src/kcl.grammar
@@ -57,7 +57,7 @@ expression[@isGroup=Expression] {
 
 UnaryOp { AddOp | BangOp }
 
-ObjectProperty { PropertyName ":" expression }
+ObjectProperty { PropertyName (":" | Equals) expression }
 
 ArgumentList { "(" commaSep<expression> ")" }
 

--- a/packages/codemirror-lang-kcl/test/key.txt
+++ b/packages/codemirror-lang-kcl/test/key.txt
@@ -1,0 +1,20 @@
+# colon (deprecated)
+
+x = { k: 123 }
+
+==>
+Program(VariableDeclaration(VariableDefinition,
+                            Equals,
+                            ObjectExpression(ObjectProperty(PropertyName,
+                                                            Number))))
+
+# equal
+
+x = { k = 123 }
+
+==>
+Program(VariableDeclaration(VariableDefinition,
+                            Equals,
+                            ObjectExpression(ObjectProperty(PropertyName,
+                                                            Equals,
+                                                            Number))))


### PR DESCRIPTION
## What

Add support for the new style init of object properties in `codemirror-lang-kcl`.

## Why

This was breaking folding in the editor.

Eg folding `startSketchOn` of [src/wasm-lib/kcl/tests/tan_arc_x_line/input.kcl](https://github.com/KittyCAD/modeling-app/blob/3c53babb5026a92faa95fd7786e1112ea5cedd9d/src/wasm-lib/kcl/tests/tan_arc_x_line/input.kcl#L7) before:

![shot](https://github.com/user-attachments/assets/0e313bc6-8d5c-4493-ad91-79e9e7f3d8fa)

Vs after the PR:

![shot-pr](https://github.com/user-attachments/assets/b5ce31e1-c205-4209-9ba9-864feaa1cd3f)

## References

`=` was added in /pull/4519.