### PR TITLE
CM KCL: `=` and `=>` are optional in fn declarations

### DIFF
--- a/packages/codemirror-lang-kcl/src/kcl.grammar
+++ b/packages/codemirror-lang-kcl/src/kcl.grammar
@@ -17,7 +17,7 @@
 
 statement[@isGroup=Statement] {
   ImportStatement { kw<"import"> ImportItems ImportFrom String } |
-  FunctionDeclaration { kw<"export">? kw<"fn"> VariableDefinition Equals ParamList Arrow Body } |
+  FunctionDeclaration { kw<"export">? kw<"fn"> VariableDefinition Equals? ParamList Arrow? Body } |
   VariableDeclaration { kw<"export">? (kw<"var"> | kw<"let"> | kw<"const">)? VariableDefinition Equals expression } |
   ReturnStatement { kw<"return"> expression } |
   ExpressionStatement { expression }

--- a/packages/codemirror-lang-kcl/test/fn.txt
+++ b/packages/codemirror-lang-kcl/test/fn.txt
@@ -1,0 +1,60 @@
+# full
+
+fn two = () => {
+  return 2
+}
+
+==>
+
+Program(FunctionDeclaration(fn,
+                            VariableDefinition,
+                            Equals,
+                            ParamList,
+                            Arrow,
+                            Body(ReturnStatement(return,
+                                                 Number))))
+
+# = is optional
+
+fn one () => {
+  return 1
+}
+
+==>
+
+Program(FunctionDeclaration(fn,
+                            VariableDefinition,
+                            ParamList,
+                            Arrow,
+                            Body(ReturnStatement(return,
+                                                 Number))))
+
+# => is optional
+
+fn one = () {
+  return 1
+}
+
+==>
+
+Program(FunctionDeclaration(fn,
+                            VariableDefinition,
+                            Equals,
+                            ParamList,
+                            Body(ReturnStatement(return,
+                                                 Number))))
+
+# terse
+
+fn two() {
+  return 2
+}
+
+==>
+
+Program(FunctionDeclaration(fn,
+                            VariableDefinition,
+                            ParamList,
+                            Body(ReturnStatement(return,
+                                                 Number))))
+


### PR DESCRIPTION
## What

Make `=` and `=>` optional in `FunctionDeclaration` in the CodeMirror KCL grammar.

## Why

The grammar was failing to parse some functions correctly.

Mostly everything was still working, but see for example before PR:

![shot](https://github.com/user-attachments/assets/253737e0-4f5a-4a1b-ae53-b0a075b0d17e)

vs after PR (return is highlighted properly):

![shot-pr](https://github.com/user-attachments/assets/a82a6c83-f897-4b29-aa9b-d2ce195b53bb)

Note that `return` is still missing highlighting in function expressions, eg in the code in [docs/kcl/int.md](https://github.com/KittyCAD/modeling-app/blob/66834931aa472f75967857b7f126d7225597fbbf/docs/kcl/int.md#L41) but maybe that's intentional. Either way, should be a separate PR.

## References

`=` and `=>` were make optional in /pull/4577.
