### PR TITLE
fix: writes to disk when the user accepts the prompt to edit

### DIFF
--- a/src/components/ToastTextToCad.tsx
+++ b/src/components/ToastTextToCad.tsx
@@ -470,8 +470,17 @@ export function ToastPromptToEditCadSuccess({
             onClick={() => {
               sendTelemetry(modelId, 'accepted', token).catch(reportRejection)
               toast.dismiss(toastId)
+
               // Write new content to disk since they have accepted.
-              codeManager.writeToFile()
+              codeManager
+                .writeToFile()
+                .then(() => {
+                  // no-op
+                })
+                .catch((e) => {
+                  console.error('Failed to save prompt-to-edit to disk')
+                  console.error(e)
+                })
             }}
           >
             Accept

--- a/src/components/ToastTextToCad.tsx
+++ b/src/components/ToastTextToCad.tsx
@@ -470,6 +470,8 @@ export function ToastPromptToEditCadSuccess({
             onClick={() => {
               sendTelemetry(modelId, 'accepted', token).catch(reportRejection)
               toast.dismiss(toastId)
+              // Write new content to disk since they have accepted.
+              codeManager.writeToFile()
             }}
           >
             Accept


### PR DESCRIPTION
# Bug

When the user performs `prompt-to-edit` and hits `accept` the content will not be saved to disk if they refresh the page.

# Fix

Force write to disk when the user presses `accept`