### PR TITLE
Add dependabot group for all serde dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,24 +5,24 @@
 
 version: 2
 updates:
-    - package-ecosystem: 'npm' # See documentation for possible values
-      directory: '/' # Location of package manifests
-      schedule:
-          interval: 'weekly'
-      reviewers:
-          - franknoirot
-          - irev-dev
-    - package-ecosystem: 'github-actions' # See documentation for possible values
-      directory: '/' # Location of package manifests
-      schedule:
-          interval: 'weekly'
-      reviewers:
-          - adamchalmers
-          - jessfraz
-    - package-ecosystem: 'cargo' # See documentation for possible values
-      directory: '/src/wasm-lib/' # Location of package manifests
-      schedule:
-          interval: 'weekly'
-      reviewers:
-          - adamchalmers
-          - jessfraz
+  - package-ecosystem: 'npm' # See documentation for possible values
+    directory: '/' # Location of package manifests
+    schedule:
+      interval: 'weekly'
+    reviewers:
+      - franknoirot
+      - irev-dev
+  - package-ecosystem: 'github-actions' # See documentation for possible values
+    directory: '/' # Location of package manifests
+    schedule:
+      interval: 'weekly'
+    reviewers:
+      - adamchalmers
+      - jessfraz
+  - package-ecosystem: 'cargo' # See documentation for possible values
+    directory: '/src/wasm-lib/' # Location of package manifests
+    schedule:
+      interval: 'weekly'
+    reviewers:
+      - adamchalmers
+      - jessfraz

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,7 @@ updates:
     reviewers:
       - adamchalmers
       - jessfraz
+    groups:
+      serde-dependencies:
+        patterns:
+          - "serde*"


### PR DESCRIPTION
Make Dependabot bump all serde dependencies in a single PR.

See [Dependabot groups](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--).

Formatting was done in a separate commit.