### PR TITLE
Bump ts-rs from 10.0.0 to 10.1.0

### DIFF
--- a/src/wasm-lib/Cargo.lock
+++ b/src/wasm-lib/Cargo.lock
@@ -3993,15 +3993,15 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ts-rs"
-version = "10.0.0"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a2f31991cee3dce1ca4f929a8a04fdd11fd8801aac0f2030b0fa8a0a3fef6b9"
+checksum = "e640d9b0964e9d39df633548591090ab92f7a4567bc31d3891af23471a3365c6"
 dependencies = [
  "chrono",
  "indexmap 2.7.0",
  "lazy_static",
  "serde_json",
- "thiserror 1.0.68",
+ "thiserror 2.0.0",
  "ts-rs-macros",
  "url",
  "uuid",
@@ -4009,9 +4009,9 @@ dependencies = [
 
 [[package]]
 name = "ts-rs-macros"
-version = "10.0.0"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea0b99e8ec44abd6f94a18f28f7934437809dd062820797c52401298116f70e"
+checksum = "0e9d8656589772eeec2cf7a8264d9cda40fb28b9bc53118ceb9e8c07f8f38730"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/wasm-lib/kcl/Cargo.toml
+++ b/src/wasm-lib/kcl/Cargo.toml
@@ -60,7 +60,7 @@ sha2 = "0.10.8"
 tabled = { version = "0.15.0", optional = true }
 thiserror = "2.0.0"
 toml = "0.8.19"
-ts-rs = { version = "10.0.0", features = [
+ts-rs = { version = "10.1.0", features = [
     "uuid-impl",
     "url-impl",
     "chrono-impl",


### PR DESCRIPTION
https://github.com/Aleph-Alpha/ts-rs/releases/tag/v10.1.0

- Fix variants with empty struct https://github.com/Aleph-Alpha/ts-rs/pull/371
- Match `kittycad-modeling-cmds` v0.2.86 from https://github.com/KittyCAD/modeling-api/pull/708