### PR TITLE
CM KCL: numbers must have digits after dot

### DIFF
--- a/packages/codemirror-lang-kcl/src/kcl.grammar
+++ b/packages/codemirror-lang-kcl/src/kcl.grammar
@@ -85,7 +85,7 @@ commaSep1NoTrailingComma<term> { term ("," term)* }
 @tokens {
   String[isolate] { "'" ("\\" _ | !['\\])* "'" | '"' ("\\" _ | !["\\])* '"' }
 
-  Number { "." @digit+ | @digit+ ("." @digit*)? }
+  Number { "." @digit+ | @digit+ ("." @digit+)? }
   @precedence { Number, "." }
 
   AddOp { "+" | "-" }

--- a/packages/codemirror-lang-kcl/test/range.txt
+++ b/packages/codemirror-lang-kcl/test/range.txt
@@ -1,0 +1,43 @@
+# spaced
+
+a = [0 .. 1]
+
+==>
+Program(VariableDeclaration(VariableDefinition,
+                            Equals,
+                            ArrayExpression(IntegerRange(Number,
+                                                         Number))))
+
+# compact
+
+a = [0..1]
+
+==>
+Program(VariableDeclaration(VariableDefinition,
+                            Equals,
+                            ArrayExpression(IntegerRange(Number,
+                                                         Number))))
+
+# expr spaced
+
+a = [start .. start + 10]
+
+==>
+Program(VariableDeclaration(VariableDefinition,
+                            Equals,
+                            ArrayExpression(IntegerRange(VariableName,
+                                                         BinaryExpression(VariableName,
+                                                                          AddOp,
+                                                                          Number)))))
+
+# expr compact
+
+a = [start..start + 10]
+
+==>
+Program(VariableDeclaration(VariableDefinition,
+                            Equals,
+                            ArrayExpression(IntegerRange(VariableName,
+                                                         BinaryExpression(VariableName,
+                                                                          AddOp,
+                                                                          Number)))))


### PR DESCRIPTION
## What

In `codemirror-lang-kcl`, require at least one digit after the decimal point in `Number`.

## Why

The Lezer parser was failing to parse integer ranges like `[0..100]`, where the dots are right next the numbers. This was causing a slight highlighting problem for ranges.

And requiring digits looks to be consistent with fn `number` in [tokeniser.rs](https://github.com/KittyCAD/modeling-app/blob/97cef4d16c6315a702630d59dbf2671249838f23/src/wasm-lib/kcl/src/parsing/token/tokeniser.rs#L149).

## Example

Before the PR, the `..` is highlighted the same color as the number (you might have to zoom to notice):

![shot-main](https://github.com/user-attachments/assets/aa119893-1df7-43fb-8ff6-87f330565e40)

Vs after the PR, the `..` is correctly black:

![shot-pr](https://github.com/user-attachments/assets/c7080373-f8b5-493a-b480-6a72467a4f29)

I'm guessing this was also causing the missing red underline on line 1 in the first image, due to some interplay between LSP (which parses the line with error) and CM (which was parsing the line as a valid expr of 3 numbers).