### PR TITLE
Fix: Properly setting selection range when KCL editor is not mounted.

### DIFF
--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -49,6 +49,7 @@ import {
   handleSelectionBatch,
   Selections,
   updateSelections,
+  computeEditorSelectionForCompleteSelection,
 } from 'lib/selections'
 import { applyConstraintIntersect } from './Toolbar/Intersect'
 import { applyConstraintAbsDistance } from './Toolbar/SetAbsDistance'
@@ -91,6 +92,7 @@ import { IndexLoaderData } from 'lib/types'
 import { Node } from 'wasm-lib/kcl/bindings/Node'
 import { promptToEditFlow } from 'lib/promptToEdit'
 import { kclEditorActor } from 'machines/kclEditorMachine'
+import { EditorSelection, SelectionRange } from '@codemirror/state'
 
 type MachineContext<T extends AnyStateMachine> = {
   state: StateFrom<T>
@@ -340,6 +342,7 @@ export const ModelingMachineProvider = ({
                 selections,
               })
               if (codeMirrorSelection) {
+                console.log('codeMirrorSelection', codeMirrorSelection)
                 kclEditorActor.send({
                   type: 'setLastSelectionEvent',
                   data: {
@@ -387,7 +390,15 @@ export const ModelingMachineProvider = ({
             }
 
             if (setSelections.selectionType === 'completeSelection') {
-              editorManager.selectRange(setSelections.selection)
+              const codeMirrorSelection =
+                computeEditorSelectionForCompleteSelection(setSelections)
+              kclEditorActor.send({
+                type: 'setLastSelectionEvent',
+                data: {
+                  codeMirrorSelection,
+                  scrollIntoView: false,
+                },
+              })
               if (!sketchDetails)
                 return {
                   selectionRanges: setSelections.selection,

--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -92,7 +92,6 @@ import { IndexLoaderData } from 'lib/types'
 import { Node } from 'wasm-lib/kcl/bindings/Node'
 import { promptToEditFlow } from 'lib/promptToEdit'
 import { kclEditorActor } from 'machines/kclEditorMachine'
-import { EditorSelection, SelectionRange } from '@codemirror/state'
 
 type MachineContext<T extends AnyStateMachine> = {
   state: StateFrom<T>

--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -49,7 +49,6 @@ import {
   handleSelectionBatch,
   Selections,
   updateSelections,
-  computeEditorSelectionForCompleteSelection,
 } from 'lib/selections'
 import { applyConstraintIntersect } from './Toolbar/Intersect'
 import { applyConstraintAbsDistance } from './Toolbar/SetAbsDistance'
@@ -389,8 +388,9 @@ export const ModelingMachineProvider = ({
             }
 
             if (setSelections.selectionType === 'completeSelection') {
-              const codeMirrorSelection =
-                computeEditorSelectionForCompleteSelection(setSelections)
+              const codeMirrorSelection = editorManager.createEditorSelection(
+                setSelections.selection
+              )
               kclEditorActor.send({
                 type: 'setLastSelectionEvent',
                 data: {

--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -340,7 +340,6 @@ export const ModelingMachineProvider = ({
                 selections,
               })
               if (codeMirrorSelection) {
-                console.log('codeMirrorSelection', codeMirrorSelection)
                 kclEditorActor.send({
                   type: 'setLastSelectionEvent',
                   data: {

--- a/src/editor/manager.ts
+++ b/src/editor/manager.ts
@@ -315,6 +315,21 @@ export default class EditorManager {
     if (selections?.graphSelections?.length === 0) {
       return
     }
+
+    if (!this._editorView) {
+      return
+    }
+    const codeBaseSelections = this.createEditorSelection(selections)
+    this._editorView.dispatch({
+      selection: codeBaseSelections,
+      annotations: [
+        updateOutsideEditorEvent,
+        Transaction.addToHistory.of(false),
+      ],
+    })
+  }
+
+  createEditorSelection(selections: Selections) {
     let codeBasedSelections = []
     for (const selection of selections.graphSelections) {
       const safeEnd = Math.min(
@@ -331,18 +346,7 @@ export default class EditorManager {
         .range[1]
     const safeEnd = Math.min(end, this._editorView?.state.doc.length || end)
     codeBasedSelections.push(EditorSelection.cursor(safeEnd))
-
-    if (!this._editorView) {
-      return
-    }
-
-    this._editorView.dispatch({
-      selection: EditorSelection.create(codeBasedSelections, 1),
-      annotations: [
-        updateOutsideEditorEvent,
-        Transaction.addToHistory.of(false),
-      ],
-    })
+    return EditorSelection.create(codeBasedSelections, 1)
   }
 
   // We will ONLY get here if the user called a select event.

--- a/src/lib/selections.ts
+++ b/src/lib/selections.ts
@@ -354,16 +354,16 @@ export function handleSelectionBatch({
       ranges.push(EditorSelection.cursor(safeEnd))
     }
   })
-  if (ranges.length) console.log('ranges!', ranges)
-  return {
-    engineEvents,
-    codeMirrorSelection: EditorSelection.create(
-      ranges,
-      selections.graphSelections.length - 1
-    ),
-    updateSceneObjectColors: () =>
-      updateSceneObjectColors(selections.graphSelections),
-  }
+  if (ranges.length)
+    return {
+      engineEvents,
+      codeMirrorSelection: EditorSelection.create(
+        ranges,
+        selections.graphSelections.length - 1
+      ),
+      updateSceneObjectColors: () =>
+        updateSceneObjectColors(selections.graphSelections),
+    }
 
   return {
     codeMirrorSelection: EditorSelection.create(

--- a/src/lib/selections.ts
+++ b/src/lib/selections.ts
@@ -11,7 +11,7 @@ import {
   Expr,
   defaultSourceRange,
 } from 'lang/wasm'
-import { ModelingMachineEvent, SetSelections } from 'machines/modelingMachine'
+import { ModelingMachineEvent } from 'machines/modelingMachine'
 import { isNonNullable, uuidv4 } from 'lib/utils'
 import { EditorSelection, SelectionRange } from '@codemirror/state'
 import { getNormalisedCoordinates, isOverlap } from 'lib/utils'
@@ -293,33 +293,6 @@ export function getEventForSegmentSelection(
       },
     },
   }
-}
-
-export function computeEditorSelectionForCompleteSelection(
-  setSelections: SetSelections
-): EditorSelection {
-  if (
-    setSelections.selectionType === 'completeSelection' &&
-    setSelections.selection.graphSelections?.length > 0
-  ) {
-    const ranges: ReturnType<typeof EditorSelection.cursor>[] = []
-    setSelections.selection.graphSelections.forEach(({ codeRef }) => {
-      if (codeRef.range?.[1]) {
-        const safeEnd = Math.min(codeRef.range[1], codeManager.code.length)
-        ranges.push(EditorSelection.cursor(safeEnd))
-      }
-    })
-    const editorSelection = EditorSelection.create(
-      ranges,
-      setSelections.selection.graphSelections.length - 1
-    )
-    return editorSelection
-  }
-
-  return EditorSelection.create(
-    [EditorSelection.cursor(codeManager.code.length)],
-    0
-  )
 }
 
 export function handleSelectionBatch({


### PR DESCRIPTION
closes #4859 

# Issue

`lastSelectionEvent` is not properly set in one of the `set selection` workflows so when the KCL editor is mounted it will break.

# Implementation

In the `completeSelection` workflow which is the selection workflow when a constraint is applied I properly compute the new selection range for the AST mod. I pass this range to the `setLastSelectionEvent` which then highlights the code in codemirror.

If the range cannot be computed I select the bottom of the file by default so we can always have some selection event.

# Future notes

It would be nice to have a clearer workflow for selection throughout the system. We have artifact selections as well as editor selections and then multiple different selection visuals within each one. 

```
Selection
+ Entity
  + highlight
  + select
+ Code Mirror
  + Highlight range
  + cursor location
  + Line selection
+ Global State
  + Code mirror selection
  + Artifact graph selection
+ Ways to select
  + User
  + Through code
```