### PR TITLE
Don't wait for `!isExecuting` to play the stream

### DIFF
--- a/e2e/playwright/fixtures/sceneFixture.ts
+++ b/e2e/playwright/fixtures/sceneFixture.ts
@@ -36,7 +36,8 @@ type DragFromHandler = (
 
 export class SceneFixture {
   public page: Page
-
+  public streamWrapper!: Locator
+  public loadingIndicator!: Locator
   private exeIndicator!: Locator
 
   constructor(page: Page) {
@@ -64,6 +65,8 @@ export class SceneFixture {
     this.page = page
 
     this.exeIndicator = page.getByTestId('model-state-indicator-execution-done')
+    this.streamWrapper = page.getByTestId('stream')
+    this.loadingIndicator = this.streamWrapper.getByTestId('loading')
   }
 
   makeMouseHelpers = (

--- a/e2e/playwright/regression-tests.spec.ts
+++ b/e2e/playwright/regression-tests.spec.ts
@@ -640,7 +640,7 @@ extrude001 = extrude(50, sketch001)
     })
     await test.step(`The part should start loading quickly, not waiting until execution is complete`, async () => {
       await scene.expectPixelColor(
-        [106, 106, 106],
+        [143, 143, 143],
         { x: (viewport?.width ?? 1200) / 2, y: (viewport?.height ?? 500) / 2 },
         10
       )

--- a/e2e/playwright/regression-tests.spec.ts
+++ b/e2e/playwright/regression-tests.spec.ts
@@ -642,7 +642,7 @@ extrude001 = extrude(50, sketch001)
       await scene.expectPixelColor(
         [143, 143, 143],
         { x: (viewport?.width ?? 1200) / 2, y: (viewport?.height ?? 500) / 2 },
-        10
+        15
       )
     })
   })

--- a/e2e/playwright/regression-tests.spec.ts
+++ b/e2e/playwright/regression-tests.spec.ts
@@ -614,6 +614,38 @@ extrude001 = extrude(50, sketch001)
       await expect(gizmo).toBeVisible()
     })
   })
+
+  test(`Refreshing the app doesn't cause the stream to pause on long-executing files`, async ({
+    context,
+    homePage,
+    scene,
+    toolbar,
+    viewport,
+  }) => {
+    await context.folderSetupFn(async (dir) => {
+      const legoDir = path.join(dir, 'lego')
+      await fsp.mkdir(legoDir, { recursive: true })
+      await fsp.copyFile(
+        executorInputPath('lego.kcl'),
+        path.join(legoDir, 'main.kcl')
+      )
+    })
+
+    await test.step(`Test setup`, async () => {
+      await homePage.openProject('lego')
+      await toolbar.closePane('code')
+    })
+    await test.step(`Waiting for the loading spinner to disappear`, async () => {
+      await scene.loadingIndicator.waitFor({ state: 'detached' })
+    })
+    await test.step(`The part should start loading quickly, not waiting until execution is complete`, async () => {
+      await scene.expectPixelColor(
+        [106, 106, 106],
+        { x: (viewport?.width ?? 1200) / 2, y: (viewport?.height ?? 500) / 2 },
+        10
+      )
+    })
+  })
 })
 
 async function clickExportButton(page: Page) {

--- a/src/components/Stream.tsx
+++ b/src/components/Stream.tsx
@@ -218,20 +218,6 @@ export const Stream = () => {
     }
   }, [IDLE, streamState])
 
-  /**
-   * Play the vid
-   */
-  useEffect(() => {
-    if (!kclManager.isExecuting) {
-      setTimeout(() => {
-        // execute in the next event loop
-        videoRef.current?.play().catch((e) => {
-          console.warn('Video playing was prevented', e, videoRef.current)
-        })
-      })
-    }
-  }, [kclManager.isExecuting])
-
   useEffect(() => {
     if (
       typeof window === 'undefined' ||
@@ -243,9 +229,15 @@ export const Stream = () => {
 
     // The browser complains if we try to load a new stream without pausing first.
     // Do not immediately play the stream!
+    // we instead use a setTimeout to play the stream in the next event loop
     try {
       videoRef.current.srcObject = mediaStream
       videoRef.current.pause()
+      setTimeout(() => {
+        videoRef.current?.play().catch((e) => {
+          console.warn('Video playing was prevented', e, videoRef.current)
+        })
+      })
     } catch (e) {
       console.warn('Attempted to pause stream while play was still loading', e)
     }


### PR DESCRIPTION
Adds a regression test to ensure that long-running KCL files show something building on screen and that the stream doesn't wait for execution to be completed to play the stream.

closes https://github.com/KittyCAD/modeling-app/issues/4966