### PR TITLE
fix: make error for missing a closing bracket clearer

### DIFF
--- a/src/lang/abstractSyntaxTree.test.ts
+++ b/src/lang/abstractSyntaxTree.test.ts
@@ -47,7 +47,7 @@ describe('parsing errors', () => {
     const result = parse(code)
     if (err(result)) throw result
     const error = result.errors[0]
-    expect(error.message).toBe('Unexpected token: (')
-    expect(error.sourceRange).toEqual([27, 28, 0])
+    expect(error.message).toBe('Array is missing a closing bracket(`]`)')
+    expect(error.sourceRange).toEqual([28, 29, 0])
   })
 })


### PR DESCRIPTION
Authored by @TomPridham
Replaces/closes #4881.

closes #4871 
puts an error on the opening bracket of an array missing a closing bracket
![Screenshot from 2024-12-30 17-10-54](https://github.com/user-attachments/assets/072326ef-fde9-4289-8f48-b4500022b0e9)
the actual error message
![Screenshot from 2024-12-30 21-48-12](https://github.com/user-attachments/assets/1272c154-6ba3-4c00-8882-a29020ba9513)
