### PR TITLE
Show deprecated indicator in CodeMirror autocomplete

### DIFF
--- a/packages/codemirror-lsp-client/src/plugin/lsp.ts
+++ b/packages/codemirror-lsp-client/src/plugin/lsp.ts
@@ -368,13 +368,20 @@ export class LanguageServerPlugin implements PluginValue {
         sortText,
         filterText,
       }) => {
+        const detailText = [
+          deprecated ? 'Deprecated' : undefined,
+          labelDetails ? labelDetails.detail : detail,
+        ]
+          // Don't let undefined appear.
+          .filter(Boolean)
+          .join(' ')
         const completion: Completion & {
           filterText: string
           sortText?: string
           apply: string
         } = {
           label,
-          detail: labelDetails ? labelDetails.detail : detail,
+          detail: detailText,
           apply: label,
           type: kind && CompletionItemKindMap[kind].toLowerCase(),
           sortText: sortText ?? label,
@@ -382,7 +389,11 @@ export class LanguageServerPlugin implements PluginValue {
         }
         if (documentation) {
           completion.info = () => {
-            const htmlString = formatMarkdownContents(documentation)
+            const deprecatedHtml = deprecated
+              ? '<p><strong>Deprecated</strong></p>'
+              : ''
+            const htmlString =
+              deprecatedHtml + formatMarkdownContents(documentation)
             const htmlNode = document.createElement('div')
             htmlNode.style.display = 'contents'
             htmlNode.innerHTML = htmlString


### PR DESCRIPTION
We should get rid of `startSketchAt` #4652, but until then, as a user, it's easy to mix them up. It's nice to be able to quickly see which is the bad one. Before, completions didn't look at whether the field was deprecated. Now it's both in the list and at the top of the documentation in bold.

<img width="957" alt="Screenshot 2025-01-09 at 1 16 54 AM" src="https://github.com/user-attachments/assets/85f5d4cb-e2aa-4a29-81a1-c098ec37df07" />
