### PR TITLE
Developer workflow: added auto generated workspace file from vitest extension in vscode

### DIFF
--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,10 +1,10 @@
 import { defineWorkspace } from 'vitest/config'
 
 export default defineWorkspace([
-  "./vite.main.config.ts",
-  "./vite.base.config.ts",
-  "./vite.config.ts",
-  "./vite.preload.config.ts",
-  "./vite.renderer.config.ts",
-  "./packages/codemirror-lang-kcl/vitest.main.config.ts"
+  './vite.main.config.ts',
+  './vite.base.config.ts',
+  './vite.config.ts',
+  './vite.preload.config.ts',
+  './vite.renderer.config.ts',
+  './packages/codemirror-lang-kcl/vitest.main.config.ts',
 ])

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,10 @@
+import { defineWorkspace } from 'vitest/config'
+
+export default defineWorkspace([
+  "./vite.main.config.ts",
+  "./vite.base.config.ts",
+  "./vite.config.ts",
+  "./vite.preload.config.ts",
+  "./vite.renderer.config.ts",
+  "./packages/codemirror-lang-kcl/vitest.main.config.ts"
+])


### PR DESCRIPTION
# Issue

How can devs run vitest in vscode with debug mode?

# Implementation 

I installed the latest `vitest` extension published by `vitest`. The extension complained about multiple config files and then suggested a workspace file to be generated. I am committing the auto generated file which let me run the tests. 

# Steps to run vitest + vscode
- Install vitest from vitest
- Create a file called vitest.workspace.ts in the root of modelingapp (I created this file automatically when I pressed the button when it suggested this file to be created. Don't know if we need to change anything)
- Go to testing pane and click the refresh icon
- You can now run tests from the testing pane or the `*.test.ts` files.
- Some vitest files require localhost:3000 to serve `"GET /wasm_lib_bg.wasm" "node-fetch"`
- Open a terminal and run `yarn simpleserver:bg` in the modelingapp directory.
- You can kill the server with `yarn kill-port 3000` or your favorite way to kill the port.

The localhost server serves the .wasm file.

