### PR TITLE
Use Chromium instead of Chrome for Playwright Electron

### DIFF
--- a/playwright.electron.config.ts
+++ b/playwright.electron.config.ts
@@ -35,7 +35,6 @@ export default defineConfig({
       name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
-        channel: 'chromium',
         contextOptions: {
           /* Chromium is the only one with these permission types */
           permissions: ['clipboard-write', 'clipboard-read'],

--- a/playwright.electron.config.ts
+++ b/playwright.electron.config.ts
@@ -32,10 +32,10 @@ export default defineConfig({
   },
   projects: [
     {
-      name: 'Google Chrome',
+      name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
-        channel: 'chrome',
+        channel: 'chromium',
         contextOptions: {
           /* Chromium is the only one with these permission types */
           permissions: ['clipboard-write', 'clipboard-read'],


### PR DESCRIPTION
This allows playwright electron tests to run on linux arm64, for which Chrome doesn't exist. If anything, this should also bring us closer to what Electron packages. 