### PR TITLE
Make the test executor a bit more patient

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1721933792,
-        "narHash": "sha256-zYVwABlQnxpbaHMfX6Wt9jhyQstFYwN2XjleOJV3VVg=",
+        "lastModified": 1736320768,
+        "narHash": "sha256-nIYdTAiKIGnFNugbomgBJR+Xv5F1ZQU+HfaBqJKroC0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2122a9b35b35719ad9a395fe783eabb092df01b1",
+        "rev": "4bc9c909d9ac828a039f288cf872d16d38185db8",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1718428119,
-        "narHash": "sha256-WdWDpNaq6u1IPtxtYHHWpl5BmabtpmLnMAx0RdJ/vo8=",
+        "lastModified": 1728538411,
+        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e6cea36f83499eb4e9cd184c8a8e823296b50ad5",
+        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1721960387,
-        "narHash": "sha256-o21ax+745ETGXrcgc/yUuLw1SI77ymp3xEpJt+w/kks=",
+        "lastModified": 1736476219,
+        "narHash": "sha256-+qyv3QqdZCdZ3cSO/cbpEY6tntyYjfe1bB12mdpNFaY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9cbf831c5b20a53354fc12758abd05966f9f1699",
+        "rev": "de30cc5963da22e9742bbbbb9a3344570ed237b9",
         "type": "github"
       },
       "original": {

--- a/src/wasm-lib/kcl-to-core/src/conn_mock_core.rs
+++ b/src/wasm-lib/kcl-to-core/src/conn_mock_core.rs
@@ -502,4 +502,6 @@ impl kcl_lib::EngineManager for EngineConnection {
             })),
         }
     }
+
+    async fn close(&self) {}
 }

--- a/src/wasm-lib/kcl/src/engine/conn.rs
+++ b/src/wasm-lib/kcl/src/engine/conn.rs
@@ -114,8 +114,6 @@ impl std::fmt::Debug for TcpReadHandle {
 
 impl Drop for TcpReadHandle {
     fn drop(&mut self) {
-        crate::logln!("DROPPING TcpReadHandle");
-
         // Drop the read handle.
         self.handle.abort();
     }

--- a/src/wasm-lib/kcl/src/engine/conn_mock.rs
+++ b/src/wasm-lib/kcl/src/engine/conn_mock.rs
@@ -160,4 +160,6 @@ impl crate::engine::EngineManager for EngineConnection {
             })),
         }
     }
+
+    async fn close(&self) {}
 }

--- a/src/wasm-lib/kcl/src/engine/conn_wasm.rs
+++ b/src/wasm-lib/kcl/src/engine/conn_wasm.rs
@@ -267,4 +267,7 @@ impl crate::engine::EngineManager for EngineConnection {
 
         Ok(ws_result)
     }
+
+    // maybe we can actually impl this here? not sure how atm.
+    async fn close(&self) {}
 }

--- a/src/wasm-lib/kcl/src/engine/mod.rs
+++ b/src/wasm-lib/kcl/src/engine/mod.rs
@@ -600,6 +600,9 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
     fn get_session_data(&self) -> Option<ModelingSessionData> {
         None
     }
+
+    /// Close the engine connection and wait for it to finish.
+    async fn close(&self);
 }
 
 #[derive(Debug, Hash, Eq, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]

--- a/src/wasm-lib/kcl/src/execution/mod.rs
+++ b/src/wasm-lib/kcl/src/execution/mod.rs
@@ -2626,6 +2626,10 @@ impl ExecutorContext {
 
         self.prepare_snapshot().await
     }
+
+    pub async fn close(&self) {
+        self.engine.close().await;
+    }
 }
 
 /// For each argument given,

--- a/src/wasm-lib/tests/executor/cache.rs
+++ b/src/wasm-lib/tests/executor/cache.rs
@@ -52,6 +52,8 @@ async fn cache_test(test_name: &str, variations: Vec<Variation<'_>>) -> Result<V
         });
     }
 
+    ctx.close().await;
+
     Ok(img_results)
 }
 


### PR DESCRIPTION
I've added a `close` method on the EngineContext, EngineConnection, EngineManager.

This method sends close on the websocket then waits until it becomes inactive. This is really useful in tests in a single threaded context where there is only one engine available.

In rare circumstances a race occurs with the engine render thread shutting down. This currently causes all sorts of undefined behavior on the engine which I'm fixing upstream. However, the fix still just rejects new modeling websockets, so we need to listen to the engine w.r.t. closing our websocket connection and not just rely on cleanup via drop semantics.

I've tested this with an engine locally by inserting a false 5 second delay before sending close.

For internal reference:
https://github.com/KittyCAD/engine/pull/2978