### PR TITLE
Fix artifact types to be more accurate

### DIFF
--- a/src/lang/std/artifactGraph.test.ts
+++ b/src/lang/std/artifactGraph.test.ts
@@ -705,7 +705,7 @@ describe('testing getArtifactsToUpdate', () => {
         segIds: [],
         id: expect.any(String),
         planeId: 'UUID-1',
-        sweepId: '',
+        sweepId: undefined,
         codeRef: {
           pathToNode: [['body', '']],
           range: [37, 64, true],
@@ -743,7 +743,7 @@ describe('testing getArtifactsToUpdate', () => {
         type: 'segment',
         id: expect.any(String),
         pathId: expect.any(String),
-        surfaceId: '',
+        surfaceId: undefined,
         edgeIds: [],
         codeRef: {
           range: [70, 86, true],
@@ -770,7 +770,7 @@ describe('testing getArtifactsToUpdate', () => {
         id: expect.any(String),
         consumedEdgeId: expect.any(String),
         edgeIds: [],
-        surfaceId: '',
+        surfaceId: undefined,
         codeRef: {
           range: [260, 299, true],
           pathToNode: [['body', '']],

--- a/src/lang/std/artifactGraph.ts
+++ b/src/lang/std/artifactGraph.ts
@@ -37,7 +37,7 @@ export interface PathArtifact extends BaseArtifact {
   type: 'path'
   planeId: ArtifactId
   segIds: Array<ArtifactId>
-  sweepId: ArtifactId
+  sweepId?: ArtifactId
   solid2dId?: ArtifactId
   codeRef: CodeRef
 }
@@ -60,7 +60,7 @@ export interface PathArtifactRich extends BaseArtifact {
 export interface SegmentArtifact extends BaseArtifact {
   type: 'segment'
   pathId: ArtifactId
-  surfaceId: ArtifactId
+  surfaceId?: ArtifactId
   edgeIds: Array<ArtifactId>
   edgeCutId?: ArtifactId
   codeRef: CodeRef
@@ -68,7 +68,7 @@ export interface SegmentArtifact extends BaseArtifact {
 interface SegmentArtifactRich extends BaseArtifact {
   type: 'segment'
   path: PathArtifact
-  surf: WallArtifact
+  surf?: WallArtifact
   edges: Array<SweepEdge>
   edgeCut?: EdgeCut
   codeRef: CodeRef
@@ -120,7 +120,7 @@ interface EdgeCut extends BaseArtifact {
   subType: 'fillet' | 'chamfer'
   consumedEdgeId: ArtifactId
   edgeIds: Array<ArtifactId>
-  surfaceId: ArtifactId
+  surfaceId?: ArtifactId
   codeRef: CodeRef
 }
 
@@ -308,7 +308,7 @@ export function getArtifactsToUpdate({
         id,
         segIds: [],
         planeId: currentPlaneId,
-        sweepId: '',
+        sweepId: undefined,
         codeRef: { range, pathToNode },
       },
     })
@@ -343,7 +343,7 @@ export function getArtifactsToUpdate({
         type: 'segment',
         id,
         pathId,
-        surfaceId: '',
+        surfaceId: undefined,
         edgeIds: [],
         codeRef: { range, pathToNode },
       },
@@ -450,7 +450,8 @@ export function getArtifactsToUpdate({
                 id: face_id,
                 segId: curve_id,
                 edgeCutEdgeIds: [],
-                sweepId: path.sweepId,
+                // TODO: Add explicit check for sweepId.  Should never use ''
+                sweepId: path.sweepId ?? '',
                 pathIds: [],
               },
             })
@@ -458,15 +459,17 @@ export function getArtifactsToUpdate({
               id: curve_id,
               artifact: { ...seg, surfaceId: face_id },
             })
-            const sweep = getArtifact(path.sweepId)
-            if (sweep?.type === 'sweep') {
-              returnArr.push({
-                id: path.sweepId,
-                artifact: {
-                  ...sweep,
-                  surfaceIds: [face_id],
-                },
-              })
+            if (path.sweepId) {
+              const sweep = getArtifact(path.sweepId)
+              if (sweep?.type === 'sweep') {
+                returnArr.push({
+                  id: path.sweepId,
+                  artifact: {
+                    ...sweep,
+                    surfaceIds: [face_id],
+                  },
+                })
+              }
             }
           }
         }
@@ -483,19 +486,22 @@ export function getArtifactsToUpdate({
               id: face_id,
               subType: cap === 'bottom' ? 'start' : 'end',
               edgeCutEdgeIds: [],
-              sweepId: path.sweepId,
+              // TODO: Add explicit check for sweepId.  Should never use ''
+              sweepId: path.sweepId ?? '',
               pathIds: [],
             },
           })
-          const sweep = getArtifact(path.sweepId)
-          if (sweep?.type !== 'sweep') return
-          returnArr.push({
-            id: path.sweepId,
-            artifact: {
-              ...sweep,
-              surfaceIds: [face_id],
-            },
-          })
+          if (path.sweepId) {
+            const sweep = getArtifact(path.sweepId)
+            if (sweep?.type !== 'sweep') return
+            returnArr.push({
+              id: path.sweepId,
+              artifact: {
+                ...sweep,
+                surfaceIds: [face_id],
+              },
+            })
+          }
         }
       }
     })
@@ -533,7 +539,8 @@ export function getArtifactsToUpdate({
               ? 'adjacent'
               : 'opposite',
           segId: cmd.edge_id,
-          sweepId: path.sweepId,
+          // TODO: Add explicit check for sweepId.  Should never use ''
+          sweepId: path.sweepId ?? '',
         },
       },
       {
@@ -544,7 +551,7 @@ export function getArtifactsToUpdate({
         },
       },
       {
-        id: path.sweepId,
+        id: sweep.id,
         artifact: {
           ...sweep,
           edgeIds: [response.data.modeling_response.data.edge],
@@ -560,7 +567,7 @@ export function getArtifactsToUpdate({
         subType: cmd.cut_type,
         consumedEdgeId: cmd.edge_id,
         edgeIds: [],
-        surfaceId: '',
+        surfaceId: undefined,
         codeRef: { range, pathToNode },
       },
     })
@@ -722,10 +729,12 @@ export function expandSegment(
     { key: segment.pathId, types: ['path'] },
     artifactGraph
   )
-  const surf = getArtifactOfTypes(
-    { key: segment.surfaceId, types: ['wall'] },
-    artifactGraph
-  )
+  const surf = segment.surfaceId
+    ? getArtifactOfTypes(
+        { key: segment.surfaceId, types: ['wall'] },
+        artifactGraph
+      )
+    : undefined
   const edges = getArtifactsOfTypes(
     { keys: segment.edgeIds, types: ['sweepEdge'] },
     artifactGraph
@@ -842,6 +851,7 @@ export function getSweepFromSuspectedSweepSurface(
       artifactGraph
     )
     if (err(path)) return path
+    if (!path.sweepId) return new Error('Path does not have a sweepId')
     return getArtifactOfTypes(
       { key: path.sweepId, types: ['sweep'] },
       artifactGraph
@@ -859,6 +869,7 @@ export function getSweepFromSuspectedPath(
 ): SweepArtifact | Error {
   const path = getArtifactOfTypes({ key: id, types: ['path'] }, artifactGraph)
   if (err(path)) return path
+  if (!path.sweepId) return new Error('Path does not have a sweepId')
   return getArtifactOfTypes(
     { key: path.sweepId, types: ['sweep'] },
     artifactGraph

--- a/src/lib/promptToEdit.ts
+++ b/src/lib/promptToEdit.ts
@@ -137,7 +137,7 @@ See later source ranges for more context. about the sweep`,
             { key: artifact.pathId, types: ['path'] },
             artifactGraph
           )
-          if (!err(path)) {
+          if (!err(path) && path.sweepId) {
             const sweep = getArtifactOfTypes(
               { key: path.sweepId, types: ['sweep'] },
               artifactGraph

--- a/src/lib/selections.ts
+++ b/src/lib/selections.ts
@@ -670,6 +670,7 @@ export function codeToIdSelections(
           }
         }
         if (type === 'extrude-wall' && entry.artifact.type === 'segment') {
+          if (!entry.artifact.surfaceId) return
           const wall = engineCommandManager.artifactGraph.get(
             entry.artifact.surfaceId
           )
@@ -714,6 +715,7 @@ export function codeToIdSelections(
           (type === 'end-cap' || type === 'start-cap') &&
           entry.artifact.type === 'path'
         ) {
+          if (!entry.artifact.sweepId) return
           const extrusion = getArtifactOfTypes(
             {
               key: entry.artifact.sweepId,


### PR DESCRIPTION
Part of #4860.

It doesn't make sense that a `Path` always has a sweep, for example. Code that uses the artifacts should be aware of the potential for a missing value and handle it.

The new `TODO`s in `artifactGraph.ts` should be impossible. If it ever does have an undefined value, it will preserve the current behavior of using empty string. All this code is going away soon, so I didn't bother to add a new error handling path.