### PR TITLE
Add packages to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,10 @@
 version: 2
 updates:
   - package-ecosystem: 'npm' # See documentation for possible values
-    directory: '/' # Location of package manifests
+    directories:
+      - '/'
+      - '/packages/codemirror-lang-kcl/'
+      - '/packages/codemirror-lsp-client/'
     schedule:
       interval: 'weekly'
     reviewers:


### PR DESCRIPTION
Our subpackages have fallen out of date.