### PR TITLE
Upgrade all wasm-bindgen dependencies together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,6 @@ updates:
       serde-dependencies:
         patterns:
           - "serde*"
+      wasm-bindgen-deps:
+        patterns:
+          - "wasm-bindgen*"


### PR DESCRIPTION
I needed to do this manually before in #4732, in particular `wasm-bindgen-futures`.