### PR TITLE
Minor bits and pieces

### DIFF
--- a/docs/kcl/index.md
+++ b/docs/kcl/index.md
@@ -53,7 +53,6 @@ layout: manual
 * [`hollow`](kcl/hollow)
 * [`import`](kcl/import)
 * [`inch`](kcl/inch)
-* [`int`](kcl/int)
 * [`lastSegX`](kcl/lastSegX)
 * [`lastSegY`](kcl/lastSegY)
 * [`legAngX`](kcl/legAngX)

--- a/docs/kcl/int.md
+++ b/docs/kcl/int.md
@@ -4,6 +4,8 @@ excerpt: "Convert a number to an integer."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated.
+
 Convert a number to an integer.
 
 DEPRECATED use floor(), ceil(), or round().

--- a/src/wasm-lib/kcl/src/execution/exec_ast.rs
+++ b/src/wasm-lib/kcl/src/execution/exec_ast.rs
@@ -21,8 +21,6 @@ use crate::{
 
 use super::cad_op::{OpArg, Operation};
 
-const FLOAT_TO_INT_MAX_DELTA: f64 = 0.01;
-
 impl BinaryPart {
     #[async_recursion]
     pub async fn get_result(&self, exec_state: &mut ExecState, ctx: &ExecutorContext) -> Result<KclValue, KclError> {
@@ -974,10 +972,9 @@ fn jvalue_to_prop(value: &KclValue, property_sr: Vec<SourceRange>, name: &str) -
             if num < 0.0 {
                 return make_err(format!("'{num}' is negative, so you can't index an array with it"))
             }
-            let nearest_int = num.round();
-            let delta = num-nearest_int;
-            if delta < FLOAT_TO_INT_MAX_DELTA {
-                Ok(Property::UInt(nearest_int as usize))
+            let nearest_int = crate::try_f64_to_usize(num);
+            if let Some(nearest_int) = nearest_int {
+                Ok(Property::UInt(nearest_int))
             } else {
                 make_err(format!("'{num}' is not an integer, so you can't index an array with it"))
             }
@@ -988,6 +985,7 @@ fn jvalue_to_prop(value: &KclValue, property_sr: Vec<SourceRange>, name: &str) -
         }
     }
 }
+
 impl Property {
     fn type_name(&self) -> &'static str {
         match self {

--- a/src/wasm-lib/kcl/src/parsing/parser.rs
+++ b/src/wasm-lib/kcl/src/parsing/parser.rs
@@ -4329,17 +4329,6 @@ sketch001 = startSketchOn('XZ') |> startProfileAt([90.45, 119.09, %)"#;
     }
 
     #[test]
-    fn warn_fn_int() {
-        let some_program_string = r#"int(1.0)
-int(42.3)"#;
-        let (_, errs) = assert_no_err(some_program_string);
-        assert_eq!(errs.len(), 2);
-        let replaced = errs[1].apply_suggestion(some_program_string).unwrap();
-        let replaced = errs[0].apply_suggestion(&replaced).unwrap();
-        assert_eq!(replaced, "1.0\nround(42.3)");
-    }
-
-    #[test]
     fn warn_fn_decl() {
         let some_program_string = r#"fn foo = () => {
     return 0

--- a/src/wasm-lib/kcl/src/std/convert.rs
+++ b/src/wasm-lib/kcl/src/std/convert.rs
@@ -34,6 +34,7 @@ pub async fn int(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 #[stdlib {
     name = "int",
     tags = ["convert"],
+    deprecated = true,
 }]
 fn inner_int(num: f64) -> Result<f64, KclError> {
     Ok(num)


### PR DESCRIPTION
Two minor fixups:
- Use the std lib deprecation mechanism for the `int` function, rather than a hack in the parser
- Remove an epsilon from float to int conversion to make it match more recent float to int conversions