### PR TITLE
Make commands disable, not unregister, based on their machineActor

### DIFF
--- a/public/kcl-samples-manifest-fallback.json
+++ b/public/kcl-samples-manifest-fallback.json
@@ -1,151 +1,181 @@
 [
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "80-20-rail/main.kcl",
     "title": "80/20 Rail",
     "description": "An 80/20 extruded aluminum linear rail. T-slot profile adjustable by profile height, rail length, and origin position"
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "a-parametric-bearing-pillow-block/main.kcl",
     "title": "A Parametric Bearing Pillow Block",
     "description": "A bearing pillow block, also known as a plummer block or pillow block bearing, is a pedestal used to provide support for a rotating shaft with the help of compatible bearings and various accessories. Housing a bearing, the pillow block provides a secure and stable foundation that allows the shaft to rotate smoothly within its machinery setup. These components are essential in a wide range of mechanical systems and machinery, playing a key role in reducing friction and supporting radial and axial loads."
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "ball-bearing/main.kcl",
     "title": "Ball Bearing",
     "description": "A ball bearing is a type of rolling-element bearing that uses balls to maintain the separation between the bearing races. The primary purpose of a ball bearing is to reduce rotational friction and support radial and axial loads."
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "bracket/main.kcl",
     "title": "Shelf Bracket",
     "description": "This is a bracket that holds a shelf. It is made of aluminum and is designed to hold a force of 300 lbs. The bracket is 6 inches wide and the force is applied at the end of the shelf, 12 inches from the wall. The bracket has a factor of safety of 1.2. The legs of the bracket are 5 inches and 2 inches long. The thickness of the bracket is calculated from the constraints provided."
   },
   {
     "file": "brake-caliper.kcl",
+    "pathFromProjectDirectoryToFirstFile": "car-wheel-assembly/brake-caliper.kcl",
     "title": "Brake Caliper",
     "description": "Brake calipers are used to squeeze the brake pads against the rotor, causing larger and larger amounts of friction depending on how hard the brakes are pressed."
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "dodecahedron/main.kcl",
     "title": "Hollow Dodecahedron",
     "description": "A regular dodecahedron or pentagonal dodecahedron is a dodecahedron composed of regular pentagonal faces, three meeting at each vertex. This example shows constructing the individual faces of the dodecahedron and extruding inwards."
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "enclosure/main.kcl",
     "title": "Enclosure",
     "description": "An enclosure body and sealing lid for storing items"
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "flange-with-patterns/main.kcl",
     "title": "Flange",
     "description": "A flange is a flat rim, collar, or rib, typically forged or cast, that is used to strengthen an object, guide it, or attach it to another object. Flanges are known for their use in various applications, including piping, plumbing, and mechanical engineering, among others."
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "flange-xy/main.kcl",
     "title": "Flange with XY coordinates",
     "description": "A flange is a flat rim, collar, or rib, typically forged or cast, that is used to strengthen an object, guide it, or attach it to another object. Flanges are known for their use in various applications, including piping, plumbing, and mechanical engineering, among others."
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "focusrite-scarlett-mounting-bracket/main.kcl",
     "title": "A mounting bracket for the Focusrite Scarlett Solo audio interface",
     "description": "This is a bracket that holds an audio device underneath a desk or shelf. The audio device has dimensions of 144mm wide, 80mm length and 45mm depth with fillets of 6mm. This mounting bracket is designed to be 3D printed with PLA material"
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "food-service-spatula/main.kcl",
     "title": "Food Service Spatula",
     "description": "Use these spatulas for mixing, flipping, and scraping."
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "french-press/main.kcl",
     "title": "French Press",
     "description": "A french press immersion coffee maker"
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "gear/main.kcl",
     "title": "Spur Gear",
     "description": "A rotating machine part having cut teeth or, in the case of a cogwheel, inserted teeth (called cogs), which mesh with another toothed part to transmit torque. Geared devices can change the speed, torque, and direction of a power source. The two elements that define a gear are its circular shape and the teeth that are integrated into its outer edge, which are designed to fit into the teeth of another gear."
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "gear-rack/main.kcl",
     "title": "100mm Gear Rack",
     "description": "A flat bar or rail that is engraved with teeth along its length. These teeth are designed to mesh with the teeth of a gear, known as a pinion. When the pinion, a small cylindrical gear, rotates, its teeth engage with the teeth on the rack, causing the rack to move linearly. Conversely, linear motion applied to the rack will cause the pinion to rotate."
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "hex-nut/main.kcl",
     "title": "Hex nut",
     "description": "A hex nut is a type of fastener with a threaded hole and a hexagonal outer shape, used in a wide variety of applications to secure parts together. The hexagonal shape allows for a greater torque to be applied with wrenches or tools, making it one of the most common nut types in hardware."
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "i-beam/main.kcl",
     "title": "I-beam",
     "description": "A structural metal beam with an I shaped cross section. Often used in construction"
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "kitt/main.kcl",
     "title": "Kitt",
     "description": "The beloved KittyCAD mascot in a voxelized style."
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "lego/main.kcl",
     "title": "Lego Brick",
     "description": "A standard Lego brick. This is a small, plastic construction block toy that can be interlocked with other blocks to build various structures, models, and figures. There are a lot of hacks used in this code."
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "mounting-plate/main.kcl",
     "title": "Mounting Plate",
     "description": "A flat piece of material, often metal or plastic, that serves as a support or base for attaching, securing, or mounting various types of equipment, devices, or components."
   },
   {
     "file": "globals.kcl",
+    "pathFromProjectDirectoryToFirstFile": "multi-axis-robot/globals.kcl",
     "title": "Global constants for the multi-axis robot",
     "description": ""
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "pipe/main.kcl",
     "title": "Pipe",
     "description": "A tubular section or hollow cylinder, usually but not necessarily of circular cross-section, used mainly to convey substances that can flow."
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "pipe-flange-assembly/main.kcl",
     "title": "Pipe and Flange Assembly",
     "description": "A crucial component in various piping systems, designed to facilitate the connection, disconnection, and access to piping for inspection, cleaning, and modifications. This assembly combines pipes (long cylindrical conduits) with flanges (plate-like fittings) to create a secure yet detachable joint."
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "pipe-with-bend/main.kcl",
     "title": "Pipe with bend",
     "description": "A tubular section or hollow cylinder, usually but not necessarily of circular cross-section, used mainly to convey substances that can flow."
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "poopy-shoe/main.kcl",
     "title": "Poopy Shoe",
     "description": "poop shute for bambu labs printer - optimized for printing."
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "router-template-cross-bar/main.kcl",
     "title": "Router template for a cross bar",
     "description": "A guide for routing a notch into a cross bar."
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "router-template-slate/main.kcl",
     "title": "Router template for a slate",
     "description": "A guide for routing a slate for a cross bar."
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "sheet-metal-bracket/main.kcl",
     "title": "Sheet Metal Bracket",
     "description": "A component typically made from flat sheet metal through various manufacturing processes such as bending, punching, cutting, and forming. These brackets are used to support, attach, or mount other hardware components, often providing a structural or functional base for assembly."
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "socket-head-cap-screw/main.kcl",
     "title": "Socket Head Cap Screw",
     "description": "This is for a #10-24 screw that is 1.00 inches long. A socket head cap screw is a type of fastener that is widely used in a variety of applications requiring a high strength fastening solution. It is characterized by its cylindrical head and internal hexagonal drive, which allows for tightening with an Allen wrench or hex key."
   },
   {
     "file": "antenna.kcl",
+    "pathFromProjectDirectoryToFirstFile": "walkie-talkie/antenna.kcl",
     "title": "Antenna",
     "description": ""
   },
   {
     "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "washer/main.kcl",
     "title": "Washer",
     "description": "A small, typically disk-shaped component with a hole in the middle, used in a wide range of applications, primarily in conjunction with fasteners like bolts and screws. Washers distribute the load of a fastener across a broader area. This is especially important when the fastening surface is soft or uneven, as it helps to prevent damage to the surface and ensures the load is evenly distributed, reducing the risk of the fastener becoming loose over time."
   }

--- a/src/components/CommandBar/CommandBar.tsx
+++ b/src/components/CommandBar/CommandBar.tsx
@@ -22,6 +22,7 @@ export const CommandBar = () => {
 
   // Close the command bar when navigating
   useEffect(() => {
+    if (commandBarState.matches('Closed')) return
     commandBarSend({ type: 'Close' })
   }, [pathname])
 

--- a/src/components/CommandComboBox.tsx
+++ b/src/components/CommandComboBox.tsx
@@ -5,6 +5,7 @@ import { Command } from 'lib/commandTypes'
 import { useEffect, useState } from 'react'
 import { CustomIcon } from './CustomIcon'
 import { getActorNextEvents } from 'lib/utils'
+import { sortCommands } from 'lib/commandUtils'
 
 function CommandComboBox({
   options,
@@ -21,38 +22,12 @@ function CommandComboBox({
     options.find((o) => 'isCurrent' in o && o.isCurrent) || null
   // sort disabled commands to the bottom
   const sortedOptions = options
-    .map((option) => ({
-      option,
+    .map((command) => ({
+      command,
       disabled: optionIsDisabled(option),
     }))
-    .sort((a, b) => {
-      // Disabled commands should be at the bottom
-      if (a.disabled && !b.disabled) {
-        return 1
-      }
-      if (b.disabled && !a.disabled) {
-        return -1
-      }
-      // Settings commands should be next-to-last
-      if (a.option.groupId === 'settings' && b.option.groupId !== 'settings') {
-        return 1
-      }
-      if (b.option.groupId === 'settings' && a.option.groupId !== 'settings') {
-        return -1
-      }
-      // Modeling commands should be first
-      if (a.option.groupId === 'modeling' && b.option.groupId !== 'modeling') {
-        return -1
-      }
-      if (b.option.groupId === 'modeling' && a.option.groupId !== 'modeling') {
-        return 1
-      }
-      // Sort alphabetically
-      return (a.option.displayName || a.option.name).localeCompare(
-        b.option.displayName || b.option.name
-      )
-    })
-    .map(({ option }) => option)
+    .sort(sortCommands)
+    .map(({ command }) => command)
 
   const fuse = new Fuse(sortedOptions, {
     keys: ['displayName', 'name', 'description'],

--- a/src/components/CommandComboBox.tsx
+++ b/src/components/CommandComboBox.tsx
@@ -24,7 +24,7 @@ function CommandComboBox({
   const sortedOptions = options
     .map((command) => ({
       command,
-      disabled: optionIsDisabled(option),
+      disabled: optionIsDisabled(command),
     }))
     .sort(sortCommands)
     .map(({ command }) => command)

--- a/src/components/CommandComboBox.tsx
+++ b/src/components/CommandComboBox.tsx
@@ -4,6 +4,7 @@ import { useCommandsContext } from 'hooks/useCommandsContext'
 import { Command } from 'lib/commandTypes'
 import { useEffect, useState } from 'react'
 import { CustomIcon } from './CustomIcon'
+import { getActorNextEvents } from 'lib/utils'
 
 function CommandComboBox({
   options,
@@ -73,7 +74,8 @@ function CommandComboBox({
           <Combobox.Option
             key={option.groupId + option.name + (option.displayName || '')}
             value={option}
-            className="flex items-center gap-4 px-4 py-1.5 first:mt-2 last:mb-2 ui-active:bg-primary/10 dark:ui-active:bg-chalkboard-90"
+            className="flex items-center gap-4 px-4 py-1.5 first:mt-2 last:mb-2 ui-active:bg-primary/10 dark:ui-active:bg-chalkboard-90 ui-disabled:!text-chalkboard-50"
+            disabled={optionIsDisabled(option)}
           >
             {'icon' in option && option.icon && (
               <CustomIcon name={option.icon} className="w-5 h-5" />
@@ -96,3 +98,11 @@ function CommandComboBox({
 }
 
 export default CommandComboBox
+
+function optionIsDisabled(option: Command): boolean {
+  return (
+    'machineActor' in option &&
+    option.machineActor !== undefined &&
+    !getActorNextEvents(option.machineActor.getSnapshot()).includes(option.name)
+  )
+}

--- a/src/lib/commandBarConfigs/projectsCommandConfig.ts
+++ b/src/lib/commandBarConfigs/projectsCommandConfig.ts
@@ -63,12 +63,11 @@ export const projectsCommandBarConfig: StateMachineCommandSetConfig<
       name: {
         inputType: 'options',
         required: true,
-        options: [],
-        optionsFromContext: (context) =>
-          context.projects.map((p) => ({
+        options: (_, context) =>
+          context?.projects.map((p) => ({
             name: p.name!,
             value: p.name!,
-          })),
+          })) || [],
       },
     },
   },
@@ -80,12 +79,11 @@ export const projectsCommandBarConfig: StateMachineCommandSetConfig<
       oldName: {
         inputType: 'options',
         required: true,
-        options: [],
-        optionsFromContext: (context) =>
-          context.projects.map((p) => ({
+        options: (_, context) =>
+          context?.projects.map((p) => ({
             name: p.name!,
             value: p.name!,
-          })),
+          })) || [],
       },
       newName: {
         inputType: 'string',

--- a/src/lib/commandTypes.ts
+++ b/src/lib/commandTypes.ts
@@ -76,6 +76,7 @@ export type Command<
     | ((
         commandBarContext: { argumentsToSubmit: Record<string, unknown> } // Should be the commandbarMachine's context, but it creates a circular dependency
       ) => string | ReactNode)
+  machineActor?: Actor<T>
   onSubmit: (data?: CommandSchema) => void
   onCancel?: () => void
   args?: {

--- a/src/lib/commandUtils.test.ts
+++ b/src/lib/commandUtils.test.ts
@@ -1,0 +1,49 @@
+import { CommandWithDisabledState, sortCommands } from './commandUtils'
+
+function commandWithDisabled(
+  name: string,
+  disabled: boolean,
+  groupId = 'modeling'
+): CommandWithDisabledState {
+  return {
+    command: {
+      name,
+      groupId,
+      needsReview: false,
+      onSubmit: () => {},
+    },
+    disabled,
+  }
+}
+
+describe('Command sorting', () => {
+  it(`Puts modeling commands first`, () => {
+    const initial = [
+      commandWithDisabled('a', false, 'settings'),
+      commandWithDisabled('b', false, 'modeling'),
+      commandWithDisabled('c', false, 'settings'),
+    ]
+    const sorted = initial.sort(sortCommands)
+    expect(sorted[0].command.groupId).toBe('modeling')
+  })
+
+  it(`Puts disabled commands last`, () => {
+    const initial = [
+      commandWithDisabled('a', true, 'modeling'),
+      commandWithDisabled('z', false, 'modeling'),
+      commandWithDisabled('a', false, 'settings'),
+    ]
+    const sorted = initial.sort(sortCommands)
+    expect(sorted[sorted.length - 1].disabled).toBe(true)
+  })
+
+  it(`Puts settings commands second to last`, () => {
+    const initial = [
+      commandWithDisabled('a', true, 'modeling'),
+      commandWithDisabled('z', false, 'modeling'),
+      commandWithDisabled('a', false, 'settings'),
+    ]
+    const sorted = initial.sort(sortCommands)
+    expect(sorted[1].command.groupId).toBe('settings')
+  })
+})

--- a/src/lib/commandUtils.ts
+++ b/src/lib/commandUtils.ts
@@ -2,6 +2,9 @@
 // That object also contains some metadata about what to do with the KCL expression,
 // such as whether we need to create a new variable for it.
 // This function extracts the value field from those arg payloads and returns
+
+import { Command } from './commandTypes'
+
 // The arg object with all its field as natural values that the command to be executed will expect.
 export function getCommandArgumentKclValuesOnly(args: Record<string, unknown>) {
   return Object.fromEntries(
@@ -11,5 +14,44 @@ export function getCommandArgumentKclValuesOnly(args: Record<string, unknown>) {
       }
       return [key, value]
     })
+  )
+}
+
+export interface CommandWithDisabledState {
+  command: Command
+  disabled: boolean
+}
+
+/**
+ * Sorting logic for commands in the command combo box.
+ */
+export function sortCommands(
+  a: CommandWithDisabledState,
+  b: CommandWithDisabledState
+) {
+  // Disabled commands should be at the bottom
+  if (a.disabled && !b.disabled) {
+    return 1
+  }
+  if (b.disabled && !a.disabled) {
+    return -1
+  }
+  // Settings commands should be next-to-last
+  if (a.command.groupId === 'settings' && b.command.groupId !== 'settings') {
+    return 1
+  }
+  if (b.command.groupId === 'settings' && a.command.groupId !== 'settings') {
+    return -1
+  }
+  // Modeling commands should be first
+  if (a.command.groupId === 'modeling' && b.command.groupId !== 'modeling') {
+    return -1
+  }
+  if (b.command.groupId === 'modeling' && a.command.groupId !== 'modeling') {
+    return 1
+  }
+  // Sort alphabetically
+  return (a.command.displayName || a.command.name).localeCompare(
+    b.command.displayName || b.command.name
   )
 }

--- a/src/lib/createMachineCommand.ts
+++ b/src/lib/createMachineCommand.ts
@@ -96,6 +96,7 @@ export function createMachineCommand<
     icon,
     description: commandConfig.description,
     needsReview: commandConfig.needsReview || false,
+    machineActor: actor,
     onSubmit: (data?: S[typeof type]) => {
       if (data !== undefined && data !== null) {
         send({ type, data })

--- a/src/machines/commandBarMachine.ts
+++ b/src/machines/commandBarMachine.ts
@@ -119,6 +119,9 @@ export const commandBarMachine = setup({
         selectedCommand?.onSubmit()
       }
     },
+    'Clear selected command': assign({
+      selectedCommand: undefined,
+    }),
     'Set current argument to first non-skippable': assign({
       currentArgument: ({ context, event }) => {
         const { selectedCommand } = context
@@ -246,6 +249,7 @@ export const commandBarMachine = setup({
       context.selectedCommand?.needsReview || false,
     'Command has no arguments': () => false,
     'All arguments are skippable': () => false,
+    'Has selected command': ({ context }) => !!context.selectedCommand,
   },
   actors: {
     'Validate argument': fromPromise(
@@ -394,7 +398,7 @@ export const commandBarMachine = setup({
     ),
   },
 }).createMachine({
-  /** @xstate-layout N4IgpgJg5mDOIC5QGED2BbdBDAdhABAEJYBOAxMgDaqxgDaADALqKgAONAlgC6eo6sQAD0QBaAJwA6AGwAmAKwBmBoukAWafIAcDcSoA0IAJ6JZDaZIDs8hgzV6AjA61a1DWQF8PhtJlwFiciowUkYWJBAOWB4+AQiRBFF5CwdpcVkHS1lpVyU5QxNEh1lFGTUsrUUtOQd5SwZLLx8MbDwiUkkqGkgyAHk2MBwwwSiY-kEEswZJbPltM0U3eXLZAsRFeQcrerUHRbTFvfkmkF9WgI6u2ggyADFONv98WkowAGNufDeW-2GI0d443iiHESkktUUilkskqdiUWjWCAcDC0kjUqnElkc6lkoK0JzOT0CnWo1zIAEEIARvn48LA-uwuIC4qAEqIHJjJPJcYtxFoYdJFFjVsZEG5pqCquJxJoGvJxOUCT82sSrj0AEpgdCoABuYC+yog9OYIyZsQmYmhWzMmTqLnU0kyikRGVRbj5lg2SmUam5StpFxIkgAymBXh8HlADQGyKHw58aecGZEzUDWYgchY7CisWoSlpQQ5EVDLJJxKkdIpyypUop-ed2kHCW0Xu9uD1kwDzcCEJCtlUNgWhZZ1OlnaKEBpZJItHVzDZ5xlpPWiZdDc8w22O7JwozosyLUj3KiZZY85YtMUNgx5Ii81JuS5xBtPVCCyuVR0AOJYbgACzAEhI3wUgoAAV3QQZuFgCg-1wGAvjAkgSCgkCSHAyCcG4TtUxZYRED2TQZGSOw80qaQ7ARCc9mmZYSjPPFpDSQUP0DSQf3-QDgNAiCoJggAROBNw+aMkxNf5cMPHJSjPWRdhvZ9LGcF0b0kVQ8ycDRNkvNRWMbdjfwAoCcCjHjMOgyRyQAdywGITPwB42DA7hYzAgAjdAeDQjCoJw-du3TJE6mnWwoT0NIUTUAs71sMtdGsRYCyUtI9OJDijO49DeKw2BJAANSwShOAgX9IzICB+DASQHh1VAAGsqp1Qrit-MBySy8y-LGPCElSeoy2lZJcwcNRfXHQpBWmWQsRsPYdDPZJUu-QyuPssy+Py5qSt4EyyEAkhUCDNhKF-AAzQ70EkJqiu2tqOt88S926w9UhhLlykWXFHXcTJixsd60hHGxNj2Jag01HVODAKzXI8rzE1+R6U38tN8IQJSuR0OZ0gvHQXHGxBPWmUdppUWwFV0MHJAhqGYcpAh1qwrqDx7ZFajUmVpulEbqlqREsfBTQ0jcPM5P5KmaehshNW1PVvOy7Cka7VHeoYDkyjSPQtAvPMqkRQU1BnX1+UydFkQvCWwEhqWAFEIC8xnFd3ZHntZuTDZG4ob1nGxPTUfXrBnS8nDmEpT2ObxTnXVUALeOrgPanycvKyrqpwWqGqurbWsThXjWd5WesQZYtmBkplCceplIncK0SrXYqnccxxcj5s2OQWP4-s3PzJgiqcCqmr6sa7P2x7vi6AcAvJJ7XEy0dUFMWsFxlnKfn+S5CL3E9Jiuapjv3i7qNx+T-bDskY6zourObpz+6cuZgK0Y5Ua0TqEvXDkJR-YnR0s1xjkIMnDln3uuVsHwOxT1NCjIuR5nCSBUExJi1huRqyooUTYpYnzeyUFkKsy4Tg4FQBAOAgg26Nmga7QKohshSBtNYXGDonQumtPYaQfsSjLBHDefepJICUJZtQ4oMx8wXj6jebGt4JwbC2OiVwig9hh2hLpVu0cOhxjbMBBGeABFPwSA3ERRMlhKWCn9WRVQzZQirMo0BAYNzxn4RJGBh5MRbGXsHawGQFBmLrpUasOQorOAjs0OxaUVrGVMvfaCuiVYEV2KWTYg1yxyA0i6ZYaIPSL3lOkS8wSo6hOWpxCJ8te6WRsnZKMjlnIxNgSNIiiTF6vVSdI9JM1taXlxLzTwqiClBnSqtSJScLIFVvjtKANSXquENqoJwtgyZzRFIUQ4MhqgNACdNTQCpLbWyshMnsjpSwjXRJYHecgcmImsLIz0odNAaGqPiHpDYY6HwTlE+ATiqHPwohYewWQshmGhHrCcJz5Bck5toZwGhMheC8EAA */
+  /** @xstate-layout N4IgpgJg5mDOIC5QGED2BbdBDAdhABAEJYBOAxMgDaqxgDaADALqKgAONAlgC6eo6sQAD0QBaAIwB2AHTiAHAE45AZjkAmdcoaSArCoA0IAJ6JxDOdJ2SF4gCySHaqZIa2Avm8NpMuAsXJUYKSMLEggHLA8fAJhIgiiOgBssokKTpJqiXK2OsqJaoYm8eJqytKJ9hqq+eJW2h5eGNh4RKRkAGKcLb74tJRgAMbc+ANNviGCEVH8gnEKubK5ympVrrlyhabm0rZ5CtYM4hVq83ININ7NfqTSVDSQZADybGA4E2FTvDOxiGoMDNJMjo9H9lLYGDpKpsEModOJpA5XOIwakwcidOdLj1-LdqLQIGQAIIQAijHx4WDvdhcL4xUBxURqSTw3LzfYKZSSOQZWzQ5S1crMuTAiElRKuTFjFo4u74sgAJTA6FQADcwCMpRBKcxJjTorMxEzkhouftuXCGGpIdCpADmZJxfzJLY5Cp5pLydcSLj7gSqeE9d96Yh+TppKoXfkGKdlHloUyFIDUvMXBzbFl3J4LprWt6AMpgfpDLpQDWesgFovDMlXf2ffU-BBZZKuczWWylRRwvlM6Q2LIMZQ2QdHZQeq65245vqDbgPOuBunCEP88MqPQchwVNLKaHptTSYUuRI6f4npyJcfYm5Ylozobz8ShamRWkGhBmeTSQeJX+JXQ6H88jQnCMiugoELCpypQKJeWa3l6U6er0hazvOajPgGr4NsGH6WhYsHOkycglLCEJ7iclgaIosKSLGGgKFe0o3AA4lg3AABZgCQJb4KQUAAK7oK83CwBQHG4DAIwCSQJAiXxJCCcJODcAu2FBsuH55GGJ7irYHYqHpGzGKYWiWB2nK2Kcv6wWO8E5jibGcdxvH8UJIliQAInAqFDGWtY6h8i7vlkZREbYZg6JuwEmQgfxhnkHbiHYJ7yHYTGIU5XE8TgpZucponSISADuWBRLl+BdGwAncBWAkAEboDwClKSJanTEucS1Bk36DicDCpOYLoKHu-x9tGuhgoozKpBlk5ZS5FX5R50gAGpYJQnAQOxJZkBA-BgNIXQqqgADWh0qhtW3sWAeYlv0hKKe5KntW+YRFGi5RyOKDrZEaUW8pppTguGuwDRFEO-nNjnsdlrlPQVsBrVd228LlZDcSQqDemwlDsQAZtj6DSJdm2o7d91gI9rUvYFL4dYIH0RV9P0Zv9CiA3EwMAmCWgVHYKVwY0yE4oqKqcGAxV1Y1zU1uMdNYQzjbMpYcgQlFxFq66u6xXRALbkyg7-Bz0bQzcYsS1LxIEMttOYfWGldYcCWwQmNiRrU0Jq2GRxJCbHZqC6ahm96FuSwqSqquqtuqQrDudVs4iJhUyZtn9qjQokYKHjk6hSLsZhciH0hh1LACiEDNTHr04ZpJT6bIEXxcKp50YDRT-mGrrJbUgFDp3xfIFxAynbx1PPaJe0HUdOAnedJMozd4+IzXjuIJCLIQqUWjJS4MVFBByS7BzyJq38WTB-ZIs3sPo8VcvHlTzgh3HWdF2L3OD8qZST66upCdxUTLBJOUUHB6GFPpSQXt1CWEGpaOiv4EyD1vmPBGj9MbY2kLjAmRMF5kyXmg7+q8AFJwbjkXQEVsj5FyO3RAiQjjfi5CReYPck7iA8FmHAqAIBwEEAhXMf8la4VEMsWwgJuTTXNGYK0tC4rwkDvsAaSQ-qlAhIPPEkBBFvWEVycoFQhywUHGaHWH04Q7FUNBdc+x2FXwnDiSss5eJyzwFo2ucQIplBWHrcEVhuoFFirCeEuxsj8mWEOFYmZhZ2JvNOXyc4ICuLXggaxCJwG70AiUHQfIzHBKHGYDMJFhTFwWjlPKhDRKJJIRFGQcIFBsiOIHJw8ZIQ7CUGrY+9g9AnmKbDRaZSaaFRKmVNGpYqo1Uqe+FKYZan1PyElbJYjrB6C5CUJQ9DL5ROvN6Ep8MBlI3WvgkZEzGzyAbnkZK-wjan38UzeEzZtBswdADYupdjm4XoTIOwuwHB5HyGkYyRRdBBLosCIE6ZvpnFsVs24KD77lPgEFf+kzxRH32EyFYlpOzQjAZYV2ehTkfI4W4IAA */
   context: {
     commands: [],
     selectedCommand: undefined,
@@ -421,14 +425,6 @@ export const commandBarMachine = setup({
           target: 'Selecting command',
         },
 
-        'Find and select command': {
-          target: 'Command selected',
-          actions: [
-            'Find and select command',
-            'Initialize arguments to submit',
-          ],
-        },
-
         'Add commands': {
           target: 'Closed',
 
@@ -440,8 +436,6 @@ export const commandBarMachine = setup({
                 ),
             }),
           ],
-
-          reenter: false,
         },
 
         'Remove commands': {
@@ -458,9 +452,12 @@ export const commandBarMachine = setup({
                 ),
             }),
           ],
-
-          reenter: false,
         },
+      },
+
+      always: {
+        target: 'Command selected',
+        guard: 'Has selected command',
       },
     },
 
@@ -478,7 +475,7 @@ export const commandBarMachine = setup({
         {
           target: 'Closed',
           guard: 'Command has no arguments',
-          actions: ['Execute command'],
+          actions: ['Execute command', 'Clear selected command'],
         },
         {
           target: 'Checking Arguments',
@@ -548,7 +545,7 @@ export const commandBarMachine = setup({
       on: {
         'Submit command': {
           target: 'Closed',
-          actions: ['Execute command'],
+          actions: ['Execute command', 'Clear selected command'],
         },
 
         'Add argument': {
@@ -580,7 +577,7 @@ export const commandBarMachine = setup({
           },
           {
             target: 'Closed',
-            actions: 'Execute command',
+            actions: ['Execute command', 'Clear selected command'],
           },
         ],
         onError: [
@@ -600,12 +597,18 @@ export const commandBarMachine = setup({
 
     Close: {
       target: '.Closed',
+      actions: 'Clear selected command',
     },
 
     Clear: {
       target: '#Command Bar',
       reenter: false,
       actions: ['Clear argument data'],
+    },
+
+    'Find and select command': {
+      target: '.Command selected',
+      actions: ['Find and select command', 'Initialize arguments to submit'],
     },
   },
 })


### PR DESCRIPTION
Broken out from #4166. Commands have been registered and unregistered based on the actor's state in `useStateMachineCommands`, resulting in a lot of churn in commands. This makes it so that only the connection state flushes the registered commands, not every actor's state. 

Additionally, it sorts the commands in the command palette options input to surface modeling commands, suppress disabled commands, and otherwise alphabetize.