### PR TITLE
Add building the artifact graph in sketch mode

### DIFF
--- a/rust/kcl-lib/src/engine/mod.rs
+++ b/rust/kcl-lib/src/engine/mod.rs
@@ -228,6 +228,10 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
         cmd: &ModelingCmd,
     ) -> Result<(), crate::errors::KclError> {
         // In isolated mode, we don't send the command to the engine.
+        //
+        // Note: It's important to allow commands through for the mock engine
+        // because it needs the commands to build the artifact graph in sketch
+        // mode.
         if self.execution_kind().await.is_isolated() {
             return Ok(());
         }
@@ -253,6 +257,10 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
         cmd: &ModelingCmd,
     ) -> Result<(), crate::errors::KclError> {
         // In isolated mode, we don't send the command to the engine.
+        //
+        // Note: It's important to allow commands through for the mock engine
+        // because it needs the commands to build the artifact graph in sketch
+        // mode.
         if self.execution_kind().await.is_isolated() {
             return Ok(());
         }

--- a/rust/kcl-lib/src/execution/artifact.rs
+++ b/rust/kcl-lib/src/execution/artifact.rs
@@ -488,6 +488,11 @@ impl ArtifactGraph {
     pub fn len(&self) -> usize {
         self.map.len()
     }
+
+    #[cfg(test)]
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&ArtifactId, &Artifact)> {
+        self.map.iter()
+    }
 }
 
 pub(super) fn build_artifact_graph(

--- a/rust/kcl-lib/src/execution/cache.rs
+++ b/rust/kcl-lib/src/execution/cache.rs
@@ -14,7 +14,7 @@ use crate::{
 lazy_static::lazy_static! {
     /// A static mutable lock for updating the last successful execution state for the cache.
     static ref OLD_AST: Arc<RwLock<Option<OldAstState>>> = Default::default();
-    // The last successful run's memory. Not cleared after an unssuccessful run.
+    // The last successful run's memory. Not cleared after an unsuccessful run.
     static ref PREV_MEMORY: Arc<RwLock<Option<Stack>>> = Default::default();
 }
 

--- a/rust/kcl-lib/src/lib.rs
+++ b/rust/kcl-lib/src/lib.rs
@@ -86,7 +86,8 @@ pub use errors::{
     CompilationError, ConnectionError, ExecError, KclError, KclErrorWithOutputs, Report, ReportWithOutputs,
 };
 pub use execution::{
-    bust_cache, clear_mem_cache, ExecOutcome, ExecState, ExecutorContext, ExecutorSettings, MetaSettings, Point2d,
+    bust_cache, clear_mem_cache, clear_mock_ids, ExecOutcome, ExecState, ExecutorContext, ExecutorSettings,
+    MetaSettings, Point2d,
 };
 pub use lsp::{
     copilot::Backend as CopilotLspBackend,

--- a/rust/kcl-lib/tests/basic_fillet_cube_next_adjacent/artifact_graph_flowchart.snap
+++ b/rust/kcl-lib/tests/basic_fillet_cube_next_adjacent/artifact_graph_flowchart.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Artifact graph flowchart basic_fillet_cube_next_adjacent.kcl
 extension: md
 snapshot_kind: binary

--- a/rust/kcl-lib/tests/basic_fillet_cube_next_adjacent/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/basic_fillet_cube_next_adjacent/artifact_graph_flowchart.snap.md
@@ -24,6 +24,7 @@ flowchart LR
   20["SweepEdge Adjacent"]
   21["SweepEdge Opposite"]
   22["SweepEdge Adjacent"]
+  23["EdgeCut Fillet<br>[202, 284, 0]"]
   1 --- 2
   2 --- 3
   2 --- 4
@@ -57,4 +58,5 @@ flowchart LR
   8 --- 20
   8 --- 21
   8 --- 22
+  16 <--x 23
 ```

--- a/rust/kcl-lib/tests/basic_fillet_cube_next_adjacent/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/basic_fillet_cube_next_adjacent/artifact_graph_flowchart.snap.md
@@ -24,7 +24,7 @@ flowchart LR
   20["SweepEdge Adjacent"]
   21["SweepEdge Opposite"]
   22["SweepEdge Adjacent"]
-  23["EdgeCut Fillet<br>[202, 284, 0]"]
+  23["EdgeCut Fillet<br>[238, 294, 0]"]
   1 --- 2
   2 --- 3
   2 --- 4

--- a/rust/kcl-lib/tests/basic_fillet_cube_previous_adjacent/artifact_graph_flowchart.snap
+++ b/rust/kcl-lib/tests/basic_fillet_cube_previous_adjacent/artifact_graph_flowchart.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Artifact graph flowchart basic_fillet_cube_previous_adjacent.kcl
 extension: md
 snapshot_kind: binary

--- a/rust/kcl-lib/tests/basic_fillet_cube_previous_adjacent/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/basic_fillet_cube_previous_adjacent/artifact_graph_flowchart.snap.md
@@ -24,7 +24,7 @@ flowchart LR
   20["SweepEdge Adjacent"]
   21["SweepEdge Opposite"]
   22["SweepEdge Adjacent"]
-  23["EdgeCut Fillet<br>[202, 288, 0]"]
+  23["EdgeCut Fillet<br>[238, 298, 0]"]
   1 --- 2
   2 --- 3
   2 --- 4

--- a/rust/kcl-lib/tests/basic_fillet_cube_previous_adjacent/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/basic_fillet_cube_previous_adjacent/artifact_graph_flowchart.snap.md
@@ -24,6 +24,7 @@ flowchart LR
   20["SweepEdge Adjacent"]
   21["SweepEdge Opposite"]
   22["SweepEdge Adjacent"]
+  23["EdgeCut Fillet<br>[202, 288, 0]"]
   1 --- 2
   2 --- 3
   2 --- 4
@@ -57,4 +58,5 @@ flowchart LR
   8 --- 20
   8 --- 21
   8 --- 22
+  18 <--x 23
 ```

--- a/rust/kcl-lib/tests/kcl_samples/multi-axis-robot/artifact_graph_flowchart.snap
+++ b/rust/kcl-lib/tests/kcl_samples/multi-axis-robot/artifact_graph_flowchart.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Artifact graph flowchart multi-axis-robot.kcl
 extension: md
 snapshot_kind: binary

--- a/rust/kcl-lib/tests/kcl_samples/multi-axis-robot/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/multi-axis-robot/artifact_graph_flowchart.snap.md
@@ -14,146 +14,146 @@ flowchart LR
     29["Segment<br>[1137, 1194, 3]"]
     30[Solid2d]
   end
-  subgraph path36 [Path]
-    36["Path<br>[1413, 1450, 3]"]
-    37["Segment<br>[1413, 1450, 3]"]
-    38[Solid2d]
+  subgraph path37 [Path]
+    37["Path<br>[1413, 1450, 3]"]
+    38["Segment<br>[1413, 1450, 3]"]
+    39[Solid2d]
   end
-  subgraph path44 [Path]
-    44["Path<br>[1582, 1721, 3]"]
-    45["Segment<br>[1582, 1721, 3]"]
-    46[Solid2d]
+  subgraph path45 [Path]
+    45["Path<br>[1582, 1721, 3]"]
+    46["Segment<br>[1582, 1721, 3]"]
+    47[Solid2d]
   end
-  subgraph path51 [Path]
-    51["Path<br>[1966, 2105, 3]"]
-    52["Segment<br>[1966, 2105, 3]"]
-    53[Solid2d]
+  subgraph path52 [Path]
+    52["Path<br>[1966, 2105, 3]"]
+    53["Segment<br>[1966, 2105, 3]"]
+    54[Solid2d]
   end
-  subgraph path59 [Path]
-    59["Path<br>[205, 265, 4]"]
-    60["Segment<br>[205, 265, 4]"]
-    61[Solid2d]
+  subgraph path60 [Path]
+    60["Path<br>[205, 265, 4]"]
+    61["Segment<br>[205, 265, 4]"]
+    62[Solid2d]
   end
-  subgraph path69 [Path]
-    69["Path<br>[516, 552, 4]"]
-    70["Segment<br>[558, 602, 4]"]
-    71["Segment<br>[608, 696, 4]"]
-    72["Segment<br>[702, 751, 4]"]
-    73["Segment<br>[757, 813, 4]"]
-    74["Segment<br>[819, 826, 4]"]
-    75[Solid2d]
+  subgraph path70 [Path]
+    70["Path<br>[516, 552, 4]"]
+    71["Segment<br>[558, 602, 4]"]
+    72["Segment<br>[608, 696, 4]"]
+    73["Segment<br>[702, 751, 4]"]
+    74["Segment<br>[757, 813, 4]"]
+    75["Segment<br>[819, 826, 4]"]
+    76[Solid2d]
   end
-  subgraph path91 [Path]
-    91["Path<br>[923, 1091, 4]"]
-    92["Segment<br>[923, 1091, 4]"]
-    93[Solid2d]
+  subgraph path92 [Path]
+    92["Path<br>[923, 1091, 4]"]
+    93["Segment<br>[923, 1091, 4]"]
+    94[Solid2d]
   end
-  subgraph path99 [Path]
-    99["Path<br>[1316, 1462, 4]"]
-    100["Segment<br>[1316, 1462, 4]"]
-    101[Solid2d]
+  subgraph path101 [Path]
+    101["Path<br>[1316, 1462, 4]"]
+    102["Segment<br>[1316, 1462, 4]"]
+    103[Solid2d]
   end
-  subgraph path107 [Path]
-    107["Path<br>[1778, 1943, 4]"]
-    108["Segment<br>[1778, 1943, 4]"]
-    109[Solid2d]
+  subgraph path109 [Path]
+    109["Path<br>[1778, 1943, 4]"]
+    110["Segment<br>[1778, 1943, 4]"]
+    111[Solid2d]
   end
-  subgraph path116 [Path]
-    116["Path<br>[2189, 2229, 4]"]
-    117["Segment<br>[2189, 2229, 4]"]
-    118[Solid2d]
+  subgraph path118 [Path]
+    118["Path<br>[2189, 2229, 4]"]
+    119["Segment<br>[2189, 2229, 4]"]
+    120[Solid2d]
   end
-  subgraph path128 [Path]
-    128["Path<br>[253, 396, 5]"]
-    129["Segment<br>[402, 518, 5]"]
-    130["Segment<br>[524, 602, 5]"]
-    131["Segment<br>[608, 724, 5]"]
-    132["Segment<br>[730, 786, 5]"]
-    133["Segment<br>[792, 799, 5]"]
-    134[Solid2d]
+  subgraph path130 [Path]
+    130["Path<br>[253, 396, 5]"]
+    131["Segment<br>[402, 518, 5]"]
+    132["Segment<br>[524, 602, 5]"]
+    133["Segment<br>[608, 724, 5]"]
+    134["Segment<br>[730, 786, 5]"]
+    135["Segment<br>[792, 799, 5]"]
+    136[Solid2d]
   end
-  subgraph path150 [Path]
-    150["Path<br>[915, 979, 5]"]
-    151["Segment<br>[915, 979, 5]"]
-    152[Solid2d]
+  subgraph path152 [Path]
+    152["Path<br>[915, 979, 5]"]
+    153["Segment<br>[915, 979, 5]"]
+    154[Solid2d]
   end
-  subgraph path158 [Path]
-    158["Path<br>[1169, 1364, 5]"]
-    159["Segment<br>[1169, 1364, 5]"]
-    160[Solid2d]
+  subgraph path161 [Path]
+    161["Path<br>[1169, 1364, 5]"]
+    162["Segment<br>[1169, 1364, 5]"]
+    163[Solid2d]
   end
-  subgraph path166 [Path]
-    166["Path<br>[1588, 1632, 5]"]
-    167["Segment<br>[1588, 1632, 5]"]
-    168[Solid2d]
+  subgraph path170 [Path]
+    170["Path<br>[1588, 1632, 5]"]
+    171["Segment<br>[1588, 1632, 5]"]
+    172[Solid2d]
   end
-  subgraph path174 [Path]
-    174["Path<br>[1869, 2060, 5]"]
-    175["Segment<br>[1869, 2060, 5]"]
-    176[Solid2d]
+  subgraph path178 [Path]
+    178["Path<br>[1869, 2060, 5]"]
+    179["Segment<br>[1869, 2060, 5]"]
+    180[Solid2d]
   end
-  subgraph path182 [Path]
-    182["Path<br>[2412, 2586, 5]"]
-    183["Segment<br>[2412, 2586, 5]"]
-    184[Solid2d]
+  subgraph path186 [Path]
+    186["Path<br>[2412, 2586, 5]"]
+    187["Segment<br>[2412, 2586, 5]"]
+    188[Solid2d]
   end
-  subgraph path191 [Path]
-    191["Path<br>[273, 506, 6]"]
-    192["Segment<br>[512, 631, 6]"]
-    193["Segment<br>[637, 717, 6]"]
-    194["Segment<br>[723, 842, 6]"]
-    195["Segment<br>[848, 918, 6]"]
-    196["Segment<br>[924, 931, 6]"]
-    197[Solid2d]
+  subgraph path195 [Path]
+    195["Path<br>[273, 506, 6]"]
+    196["Segment<br>[512, 631, 6]"]
+    197["Segment<br>[637, 717, 6]"]
+    198["Segment<br>[723, 842, 6]"]
+    199["Segment<br>[848, 918, 6]"]
+    200["Segment<br>[924, 931, 6]"]
+    201[Solid2d]
   end
-  subgraph path213 [Path]
-    213["Path<br>[1045, 1245, 6]"]
-    214["Segment<br>[1045, 1245, 6]"]
-    215[Solid2d]
+  subgraph path217 [Path]
+    217["Path<br>[1045, 1245, 6]"]
+    218["Segment<br>[1045, 1245, 6]"]
+    219[Solid2d]
   end
-  subgraph path221 [Path]
-    221["Path<br>[1471, 1659, 6]"]
-    222["Segment<br>[1471, 1659, 6]"]
-    223[Solid2d]
+  subgraph path226 [Path]
+    226["Path<br>[1471, 1659, 6]"]
+    227["Segment<br>[1471, 1659, 6]"]
+    228[Solid2d]
   end
-  subgraph path229 [Path]
-    229["Path<br>[2079, 2364, 6]"]
-    230["Segment<br>[2079, 2364, 6]"]
-    231[Solid2d]
+  subgraph path234 [Path]
+    234["Path<br>[2079, 2364, 6]"]
+    235["Segment<br>[2079, 2364, 6]"]
+    236[Solid2d]
   end
-  subgraph path238 [Path]
-    238["Path<br>[2463, 2746, 6]"]
-    239["Segment<br>[2463, 2746, 6]"]
-    240[Solid2d]
+  subgraph path243 [Path]
+    243["Path<br>[2463, 2746, 6]"]
+    244["Segment<br>[2463, 2746, 6]"]
+    245[Solid2d]
   end
-  subgraph path247 [Path]
-    247["Path<br>[2900, 2938, 6]"]
-    248["Segment<br>[2900, 2938, 6]"]
-    249[Solid2d]
+  subgraph path252 [Path]
+    252["Path<br>[2900, 2938, 6]"]
+    253["Segment<br>[2900, 2938, 6]"]
+    254[Solid2d]
   end
-  subgraph path256 [Path]
-    256["Path<br>[3068, 3293, 6]"]
-    257["Segment<br>[3299, 3393, 6]"]
-    258["Segment<br>[3399, 3542, 6]"]
-    259["Segment<br>[3548, 3642, 6]"]
-    260["Segment<br>[3648, 3750, 6]"]
-    261["Segment<br>[3756, 3858, 6]"]
-    262["Segment<br>[3864, 3964, 6]"]
-    263["Segment<br>[3970, 4026, 6]"]
-    264["Segment<br>[4032, 4039, 6]"]
-    265[Solid2d]
+  subgraph path261 [Path]
+    261["Path<br>[3068, 3293, 6]"]
+    262["Segment<br>[3299, 3393, 6]"]
+    263["Segment<br>[3399, 3542, 6]"]
+    264["Segment<br>[3548, 3642, 6]"]
+    265["Segment<br>[3648, 3750, 6]"]
+    266["Segment<br>[3756, 3858, 6]"]
+    267["Segment<br>[3864, 3964, 6]"]
+    268["Segment<br>[3970, 4026, 6]"]
+    269["Segment<br>[4032, 4039, 6]"]
+    270[Solid2d]
   end
-  subgraph path290 [Path]
-    290["Path<br>[4168, 4393, 6]"]
-    291["Segment<br>[4399, 4495, 6]"]
-    292["Segment<br>[4501, 4649, 6]"]
-    293["Segment<br>[4655, 4751, 6]"]
-    294["Segment<br>[4757, 4861, 6]"]
-    295["Segment<br>[4867, 4971, 6]"]
-    296["Segment<br>[4977, 5079, 6]"]
-    297["Segment<br>[5085, 5141, 6]"]
-    298["Segment<br>[5147, 5154, 6]"]
-    299[Solid2d]
+  subgraph path295 [Path]
+    295["Path<br>[4168, 4393, 6]"]
+    296["Segment<br>[4399, 4495, 6]"]
+    297["Segment<br>[4501, 4649, 6]"]
+    298["Segment<br>[4655, 4751, 6]"]
+    299["Segment<br>[4757, 4861, 6]"]
+    300["Segment<br>[4867, 4971, 6]"]
+    301["Segment<br>[4977, 5079, 6]"]
+    302["Segment<br>[5085, 5141, 6]"]
+    303["Segment<br>[5147, 5154, 6]"]
+    304[Solid2d]
   end
   1["Plane<br>[203, 222, 3]"]
   9["Sweep Extrusion<br>[716, 763, 3]"]
@@ -180,218 +180,223 @@ flowchart LR
   33["Cap End"]
   34["SweepEdge Opposite"]
   35["SweepEdge Adjacent"]
-  39["Sweep Extrusion<br>[1464, 1494, 3]"]
-  40[Wall]
-  41["Cap End"]
-  42["SweepEdge Opposite"]
-  43["SweepEdge Adjacent"]
-  47["Sweep Extrusion<br>[1868, 1915, 3]"]
-  48[Wall]
-  49["SweepEdge Opposite"]
-  50["SweepEdge Adjacent"]
-  54["Sweep Extrusion<br>[2240, 2287, 3]"]
-  55[Wall]
-  56["SweepEdge Opposite"]
-  57["SweepEdge Adjacent"]
-  58["Plane<br>[176, 199, 4]"]
-  62["Sweep Extrusion<br>[279, 317, 4]"]
-  63[Wall]
-  64["Cap Start"]
-  65["Cap End"]
-  66["SweepEdge Opposite"]
-  67["SweepEdge Adjacent"]
-  68["Plane<br>[487, 510, 4]"]
-  76["Sweep Extrusion<br>[841, 871, 4]"]
-  77[Wall]
+  36["EdgeCut Fillet<br>[1280, 1362, 3]"]
+  40["Sweep Extrusion<br>[1464, 1494, 3]"]
+  41[Wall]
+  42["Cap End"]
+  43["SweepEdge Opposite"]
+  44["SweepEdge Adjacent"]
+  48["Sweep Extrusion<br>[1868, 1915, 3]"]
+  49[Wall]
+  50["SweepEdge Opposite"]
+  51["SweepEdge Adjacent"]
+  55["Sweep Extrusion<br>[2240, 2287, 3]"]
+  56[Wall]
+  57["SweepEdge Opposite"]
+  58["SweepEdge Adjacent"]
+  59["Plane<br>[176, 199, 4]"]
+  63["Sweep Extrusion<br>[279, 317, 4]"]
+  64[Wall]
+  65["Cap Start"]
+  66["Cap End"]
+  67["SweepEdge Opposite"]
+  68["SweepEdge Adjacent"]
+  69["Plane<br>[487, 510, 4]"]
+  77["Sweep Extrusion<br>[841, 871, 4]"]
   78[Wall]
   79[Wall]
   80[Wall]
-  81["Cap Start"]
-  82["Cap End"]
-  83["SweepEdge Opposite"]
-  84["SweepEdge Adjacent"]
-  85["SweepEdge Opposite"]
-  86["SweepEdge Adjacent"]
-  87["SweepEdge Opposite"]
-  88["SweepEdge Adjacent"]
-  89["SweepEdge Opposite"]
-  90["SweepEdge Adjacent"]
-  94["Sweep Extrusion<br>[1105, 1137, 4]"]
-  95[Wall]
-  96["Cap End"]
-  97["SweepEdge Opposite"]
-  98["SweepEdge Adjacent"]
-  102["Sweep Extrusion<br>[1694, 1726, 4]"]
-  103[Wall]
-  104["Cap End"]
-  105["SweepEdge Opposite"]
-  106["SweepEdge Adjacent"]
-  110["Sweep Extrusion<br>[1957, 1990, 4]"]
-  111[Wall]
-  112["Cap End"]
-  113["SweepEdge Opposite"]
-  114["SweepEdge Adjacent"]
-  115["Plane<br>[2160, 2183, 4]"]
-  119["Sweep Extrusion<br>[2231, 2262, 4]"]
-  120[Wall]
-  121["Cap Start"]
-  122["Cap End"]
-  123["SweepEdge Opposite"]
-  124["SweepEdge Adjacent"]
-  125["EdgeCut Fillet<br>[323, 406, 4]"]
-  126["EdgeCut Fillet<br>[1996, 2079, 4]"]
-  127["Plane<br>[224, 247, 5]"]
-  135["Sweep Extrusion<br>[813, 861, 5]"]
-  136[Wall]
-  137[Wall]
+  81[Wall]
+  82["Cap Start"]
+  83["Cap End"]
+  84["SweepEdge Opposite"]
+  85["SweepEdge Adjacent"]
+  86["SweepEdge Opposite"]
+  87["SweepEdge Adjacent"]
+  88["SweepEdge Opposite"]
+  89["SweepEdge Adjacent"]
+  90["SweepEdge Opposite"]
+  91["SweepEdge Adjacent"]
+  95["Sweep Extrusion<br>[1105, 1137, 4]"]
+  96[Wall]
+  97["Cap End"]
+  98["SweepEdge Opposite"]
+  99["SweepEdge Adjacent"]
+  100["EdgeCut Fillet<br>[1143, 1226, 4]"]
+  104["Sweep Extrusion<br>[1694, 1726, 4]"]
+  105[Wall]
+  106["Cap End"]
+  107["SweepEdge Opposite"]
+  108["SweepEdge Adjacent"]
+  112["Sweep Extrusion<br>[1957, 1990, 4]"]
+  113[Wall]
+  114["Cap End"]
+  115["SweepEdge Opposite"]
+  116["SweepEdge Adjacent"]
+  117["Plane<br>[2160, 2183, 4]"]
+  121["Sweep Extrusion<br>[2231, 2262, 4]"]
+  122[Wall]
+  123["Cap Start"]
+  124["Cap End"]
+  125["SweepEdge Opposite"]
+  126["SweepEdge Adjacent"]
+  127["EdgeCut Fillet<br>[323, 406, 4]"]
+  128["EdgeCut Fillet<br>[1996, 2079, 4]"]
+  129["Plane<br>[224, 247, 5]"]
+  137["Sweep Extrusion<br>[813, 861, 5]"]
   138[Wall]
   139[Wall]
-  140["Cap Start"]
-  141["Cap End"]
-  142["SweepEdge Opposite"]
-  143["SweepEdge Adjacent"]
+  140[Wall]
+  141[Wall]
+  142["Cap Start"]
+  143["Cap End"]
   144["SweepEdge Opposite"]
   145["SweepEdge Adjacent"]
   146["SweepEdge Opposite"]
   147["SweepEdge Adjacent"]
   148["SweepEdge Opposite"]
   149["SweepEdge Adjacent"]
-  153["Sweep Extrusion<br>[994, 1027, 5]"]
-  154[Wall]
-  155["Cap End"]
-  156["SweepEdge Opposite"]
-  157["SweepEdge Adjacent"]
-  161["Sweep Extrusion<br>[1379, 1409, 5]"]
-  162[Wall]
-  163["Cap End"]
-  164["SweepEdge Opposite"]
-  165["SweepEdge Adjacent"]
-  169["Sweep Extrusion<br>[1784, 1817, 5]"]
-  170[Wall]
-  171["Cap End"]
-  172["SweepEdge Opposite"]
-  173["SweepEdge Adjacent"]
-  177["Sweep Extrusion<br>[2327, 2360, 5]"]
-  178[Wall]
-  179["Cap End"]
-  180["SweepEdge Opposite"]
-  181["SweepEdge Adjacent"]
-  185["Sweep Extrusion<br>[2588, 2618, 5]"]
-  186[Wall]
-  187["Cap End"]
-  188["SweepEdge Opposite"]
-  189["SweepEdge Adjacent"]
-  190["Plane<br>[244, 267, 6]"]
-  198["Sweep Extrusion<br>[945, 993, 6]"]
-  199[Wall]
-  200[Wall]
-  201[Wall]
-  202[Wall]
-  203["Cap Start"]
-  204["Cap End"]
-  205["SweepEdge Opposite"]
-  206["SweepEdge Adjacent"]
-  207["SweepEdge Opposite"]
-  208["SweepEdge Adjacent"]
+  150["SweepEdge Opposite"]
+  151["SweepEdge Adjacent"]
+  155["Sweep Extrusion<br>[994, 1027, 5]"]
+  156[Wall]
+  157["Cap End"]
+  158["SweepEdge Opposite"]
+  159["SweepEdge Adjacent"]
+  160["EdgeCut Fillet<br>[1033, 1116, 5]"]
+  164["Sweep Extrusion<br>[1379, 1409, 5]"]
+  165[Wall]
+  166["Cap End"]
+  167["SweepEdge Opposite"]
+  168["SweepEdge Adjacent"]
+  169["EdgeCut Fillet<br>[1415, 1498, 5]"]
+  173["Sweep Extrusion<br>[1784, 1817, 5]"]
+  174[Wall]
+  175["Cap End"]
+  176["SweepEdge Opposite"]
+  177["SweepEdge Adjacent"]
+  181["Sweep Extrusion<br>[2327, 2360, 5]"]
+  182[Wall]
+  183["Cap End"]
+  184["SweepEdge Opposite"]
+  185["SweepEdge Adjacent"]
+  189["Sweep Extrusion<br>[2588, 2618, 5]"]
+  190[Wall]
+  191["Cap End"]
+  192["SweepEdge Opposite"]
+  193["SweepEdge Adjacent"]
+  194["Plane<br>[244, 267, 6]"]
+  202["Sweep Extrusion<br>[945, 993, 6]"]
+  203[Wall]
+  204[Wall]
+  205[Wall]
+  206[Wall]
+  207["Cap Start"]
+  208["Cap End"]
   209["SweepEdge Opposite"]
   210["SweepEdge Adjacent"]
   211["SweepEdge Opposite"]
   212["SweepEdge Adjacent"]
-  216["Sweep Extrusion<br>[1260, 1293, 6]"]
-  217[Wall]
-  218["Cap End"]
-  219["SweepEdge Opposite"]
-  220["SweepEdge Adjacent"]
-  224["Sweep Extrusion<br>[1923, 1956, 6]"]
-  225[Wall]
-  226["Cap End"]
-  227["SweepEdge Opposite"]
-  228["SweepEdge Adjacent"]
-  232["Sweep Extrusion<br>[2378, 2411, 6]"]
-  233[Wall]
-  234["Cap Start"]
-  235["Cap End"]
-  236["SweepEdge Opposite"]
-  237["SweepEdge Adjacent"]
-  241["Sweep Extrusion<br>[2761, 2794, 6]"]
-  242[Wall]
-  243["Cap Start"]
-  244["Cap End"]
-  245["SweepEdge Opposite"]
-  246["SweepEdge Adjacent"]
-  250["Sweep Extrusion<br>[2953, 2987, 6]"]
-  251[Wall]
-  252["Cap Start"]
-  253["Cap End"]
-  254["SweepEdge Opposite"]
-  255["SweepEdge Adjacent"]
-  266["Sweep Extrusion<br>[4054, 4087, 6]"]
-  267[Wall]
-  268[Wall]
-  269[Wall]
-  270[Wall]
-  271[Wall]
+  213["SweepEdge Opposite"]
+  214["SweepEdge Adjacent"]
+  215["SweepEdge Opposite"]
+  216["SweepEdge Adjacent"]
+  220["Sweep Extrusion<br>[1260, 1293, 6]"]
+  221[Wall]
+  222["Cap End"]
+  223["SweepEdge Opposite"]
+  224["SweepEdge Adjacent"]
+  225["EdgeCut Fillet<br>[1299, 1382, 6]"]
+  229["Sweep Extrusion<br>[1923, 1956, 6]"]
+  230[Wall]
+  231["Cap End"]
+  232["SweepEdge Opposite"]
+  233["SweepEdge Adjacent"]
+  237["Sweep Extrusion<br>[2378, 2411, 6]"]
+  238[Wall]
+  239["Cap Start"]
+  240["Cap End"]
+  241["SweepEdge Opposite"]
+  242["SweepEdge Adjacent"]
+  246["Sweep Extrusion<br>[2761, 2794, 6]"]
+  247[Wall]
+  248["Cap Start"]
+  249["Cap End"]
+  250["SweepEdge Opposite"]
+  251["SweepEdge Adjacent"]
+  255["Sweep Extrusion<br>[2953, 2987, 6]"]
+  256[Wall]
+  257["Cap Start"]
+  258["Cap End"]
+  259["SweepEdge Opposite"]
+  260["SweepEdge Adjacent"]
+  271["Sweep Extrusion<br>[4054, 4087, 6]"]
   272[Wall]
   273[Wall]
-  274["Cap Start"]
-  275["Cap End"]
-  276["SweepEdge Opposite"]
-  277["SweepEdge Adjacent"]
-  278["SweepEdge Opposite"]
-  279["SweepEdge Adjacent"]
-  280["SweepEdge Opposite"]
-  281["SweepEdge Adjacent"]
-  282["SweepEdge Opposite"]
-  283["SweepEdge Adjacent"]
-  284["SweepEdge Opposite"]
-  285["SweepEdge Adjacent"]
-  286["SweepEdge Opposite"]
-  287["SweepEdge Adjacent"]
-  288["SweepEdge Opposite"]
-  289["SweepEdge Adjacent"]
-  300["Sweep Extrusion<br>[5156, 5189, 6]"]
-  301[Wall]
-  302[Wall]
-  303[Wall]
-  304[Wall]
-  305[Wall]
+  274[Wall]
+  275[Wall]
+  276[Wall]
+  277[Wall]
+  278[Wall]
+  279["Cap Start"]
+  280["Cap End"]
+  281["SweepEdge Opposite"]
+  282["SweepEdge Adjacent"]
+  283["SweepEdge Opposite"]
+  284["SweepEdge Adjacent"]
+  285["SweepEdge Opposite"]
+  286["SweepEdge Adjacent"]
+  287["SweepEdge Opposite"]
+  288["SweepEdge Adjacent"]
+  289["SweepEdge Opposite"]
+  290["SweepEdge Adjacent"]
+  291["SweepEdge Opposite"]
+  292["SweepEdge Adjacent"]
+  293["SweepEdge Opposite"]
+  294["SweepEdge Adjacent"]
+  305["Sweep Extrusion<br>[5156, 5189, 6]"]
   306[Wall]
   307[Wall]
-  308["Cap Start"]
-  309["Cap End"]
-  310["SweepEdge Opposite"]
-  311["SweepEdge Adjacent"]
-  312["SweepEdge Opposite"]
-  313["SweepEdge Adjacent"]
-  314["SweepEdge Opposite"]
-  315["SweepEdge Adjacent"]
-  316["SweepEdge Opposite"]
-  317["SweepEdge Adjacent"]
-  318["SweepEdge Opposite"]
-  319["SweepEdge Adjacent"]
-  320["SweepEdge Opposite"]
-  321["SweepEdge Adjacent"]
-  322["SweepEdge Opposite"]
-  323["SweepEdge Adjacent"]
-  324["StartSketchOnFace<br>[1099, 1131, 3]"]
-  325["StartSketchOnFace<br>[1375, 1407, 3]"]
-  326["StartSketchOnFace<br>[1544, 1576, 3]"]
-  327["StartSketchOnFace<br>[1928, 1960, 3]"]
-  328["StartSketchOnFace<br>[885, 917, 4]"]
-  329["StartSketchOnFace<br>[1278, 1310, 4]"]
-  330["StartSketchOnFace<br>[1740, 1772, 4]"]
-  331["StartSketchOnFace<br>[875, 909, 5]"]
-  332["StartSketchOnFace<br>[1129, 1163, 5]"]
-  333["StartSketchOnFace<br>[1550, 1582, 5]"]
-  334["StartSketchOnFace<br>[1831, 1863, 5]"]
-  335["StartSketchOnFace<br>[2374, 2406, 5]"]
-  336["StartSketchOnFace<br>[1007, 1039, 6]"]
-  337["StartSketchOnFace<br>[1433, 1465, 6]"]
-  338["StartSketchOnFace<br>[2039, 2073, 6]"]
-  339["StartSketchOnFace<br>[2425, 2457, 6]"]
-  340["StartSketchOnFace<br>[2860, 2894, 6]"]
-  341["StartSketchOnFace<br>[3028, 3062, 6]"]
-  342["StartSketchOnFace<br>[4128, 4162, 6]"]
+  308[Wall]
+  309[Wall]
+  310[Wall]
+  311[Wall]
+  312[Wall]
+  313["Cap Start"]
+  314["Cap End"]
+  315["SweepEdge Opposite"]
+  316["SweepEdge Adjacent"]
+  317["SweepEdge Opposite"]
+  318["SweepEdge Adjacent"]
+  319["SweepEdge Opposite"]
+  320["SweepEdge Adjacent"]
+  321["SweepEdge Opposite"]
+  322["SweepEdge Adjacent"]
+  323["SweepEdge Opposite"]
+  324["SweepEdge Adjacent"]
+  325["SweepEdge Opposite"]
+  326["SweepEdge Adjacent"]
+  327["SweepEdge Opposite"]
+  328["SweepEdge Adjacent"]
+  329["StartSketchOnFace<br>[1099, 1131, 3]"]
+  330["StartSketchOnFace<br>[1375, 1407, 3]"]
+  331["StartSketchOnFace<br>[1544, 1576, 3]"]
+  332["StartSketchOnFace<br>[1928, 1960, 3]"]
+  333["StartSketchOnFace<br>[885, 917, 4]"]
+  334["StartSketchOnFace<br>[1278, 1310, 4]"]
+  335["StartSketchOnFace<br>[1740, 1772, 4]"]
+  336["StartSketchOnFace<br>[875, 909, 5]"]
+  337["StartSketchOnFace<br>[1129, 1163, 5]"]
+  338["StartSketchOnFace<br>[1550, 1582, 5]"]
+  339["StartSketchOnFace<br>[1831, 1863, 5]"]
+  340["StartSketchOnFace<br>[2374, 2406, 5]"]
+  341["StartSketchOnFace<br>[1007, 1039, 6]"]
+  342["StartSketchOnFace<br>[1433, 1465, 6]"]
+  343["StartSketchOnFace<br>[2039, 2073, 6]"]
+  344["StartSketchOnFace<br>[2425, 2457, 6]"]
+  345["StartSketchOnFace<br>[2860, 2894, 6]"]
+  346["StartSketchOnFace<br>[3028, 3062, 6]"]
+  347["StartSketchOnFace<br>[4128, 4162, 6]"]
   1 --- 2
   2 --- 3
   2 --- 4
@@ -427,8 +432,8 @@ flowchart LR
   9 --- 22
   9 --- 23
   15 --- 28
-  15 --- 44
-  15 --- 51
+  15 --- 45
+  15 --- 52
   17 <--x 24
   19 <--x 25
   21 <--x 26
@@ -443,436 +448,441 @@ flowchart LR
   31 --- 33
   31 --- 34
   31 --- 35
-  33 --- 36
-  36 --- 37
-  36 ---- 39
-  36 --- 38
-  37 --- 40
-  37 --- 42
-  37 --- 43
-  39 --- 40
-  39 --- 41
-  39 --- 42
-  39 --- 43
-  44 --- 45
-  44 ---- 47
-  44 --- 46
-  45 --- 48
-  45 --- 49
-  45 --- 50
-  47 --- 48
-  47 --- 49
-  47 --- 50
-  51 --- 52
-  51 ---- 54
-  51 --- 53
-  52 --- 55
-  52 --- 56
-  52 --- 57
-  54 --- 55
-  54 --- 56
-  54 --- 57
-  58 --- 59
+  33 --- 37
+  34 <--x 36
+  37 --- 38
+  37 ---- 40
+  37 --- 39
+  38 --- 41
+  38 --- 43
+  38 --- 44
+  40 --- 41
+  40 --- 42
+  40 --- 43
+  40 --- 44
+  45 --- 46
+  45 ---- 48
+  45 --- 47
+  46 --- 49
+  46 --- 50
+  46 --- 51
+  48 --- 49
+  48 --- 50
+  48 --- 51
+  52 --- 53
+  52 ---- 55
+  52 --- 54
+  53 --- 56
+  53 --- 57
+  53 --- 58
+  55 --- 56
+  55 --- 57
+  55 --- 58
   59 --- 60
-  59 ---- 62
-  59 --- 61
-  60 --- 63
-  60 --- 66
-  60 --- 67
-  62 --- 63
-  62 --- 64
-  62 --- 65
-  62 --- 66
-  62 --- 67
-  68 --- 69
+  60 --- 61
+  60 ---- 63
+  60 --- 62
+  61 --- 64
+  61 --- 67
+  61 --- 68
+  63 --- 64
+  63 --- 65
+  63 --- 66
+  63 --- 67
+  63 --- 68
   69 --- 70
-  69 --- 71
-  69 --- 72
-  69 --- 73
-  69 --- 74
-  69 ---- 76
-  69 --- 75
-  70 --- 77
-  70 --- 83
-  70 --- 84
+  70 --- 71
+  70 --- 72
+  70 --- 73
+  70 --- 74
+  70 --- 75
+  70 ---- 77
+  70 --- 76
   71 --- 78
+  71 --- 84
   71 --- 85
-  71 --- 86
   72 --- 79
+  72 --- 86
   72 --- 87
-  72 --- 88
   73 --- 80
+  73 --- 88
   73 --- 89
-  73 --- 90
-  76 --- 77
-  76 --- 78
-  76 --- 79
-  76 --- 80
-  76 --- 81
-  76 --- 82
-  76 --- 83
-  76 --- 84
-  76 --- 85
-  76 --- 86
-  76 --- 87
-  76 --- 88
-  76 --- 89
-  76 --- 90
-  82 --- 91
-  91 --- 92
-  91 ---- 94
-  91 --- 93
-  92 --- 95
-  92 --- 97
-  92 --- 98
-  94 --- 95
-  94 --- 96
-  94 --- 97
-  94 --- 98
-  96 --- 99
-  96 --- 107
-  99 --- 100
-  99 ---- 102
-  99 --- 101
-  100 --- 103
-  100 --- 105
-  100 --- 106
-  102 --- 103
-  102 --- 104
+  74 --- 81
+  74 --- 90
+  74 --- 91
+  77 --- 78
+  77 --- 79
+  77 --- 80
+  77 --- 81
+  77 --- 82
+  77 --- 83
+  77 --- 84
+  77 --- 85
+  77 --- 86
+  77 --- 87
+  77 --- 88
+  77 --- 89
+  77 --- 90
+  77 --- 91
+  83 --- 92
+  92 --- 93
+  92 ---- 95
+  92 --- 94
+  93 --- 96
+  93 --- 98
+  93 --- 99
+  95 --- 96
+  95 --- 97
+  95 --- 98
+  95 --- 99
+  97 --- 101
+  97 --- 109
+  98 <--x 100
+  101 --- 102
+  101 ---- 104
+  101 --- 103
   102 --- 105
-  102 --- 106
-  107 --- 108
-  107 ---- 110
-  107 --- 109
-  108 --- 111
-  108 --- 113
-  108 --- 114
-  110 --- 111
-  110 --- 112
+  102 --- 107
+  102 --- 108
+  104 --- 105
+  104 --- 106
+  104 --- 107
+  104 --- 108
+  109 --- 110
+  109 ---- 112
+  109 --- 111
   110 --- 113
-  110 --- 114
-  115 --- 116
-  116 --- 117
-  116 ---- 119
-  116 --- 118
-  117 --- 120
-  117 --- 123
-  117 --- 124
-  119 --- 120
-  119 --- 121
+  110 --- 115
+  110 --- 116
+  112 --- 113
+  112 --- 114
+  112 --- 115
+  112 --- 116
+  117 --- 118
+  118 --- 119
+  118 ---- 121
+  118 --- 120
   119 --- 122
-  119 --- 123
-  119 --- 124
-  66 <--x 125
-  113 <--x 126
-  127 --- 128
-  128 --- 129
-  128 --- 130
-  128 --- 131
-  128 --- 132
-  128 --- 133
-  128 ---- 135
-  128 --- 134
-  129 --- 136
-  129 --- 142
-  129 --- 143
-  130 --- 137
-  130 --- 144
-  130 --- 145
+  119 --- 125
+  119 --- 126
+  121 --- 122
+  121 --- 123
+  121 --- 124
+  121 --- 125
+  121 --- 126
+  67 <--x 127
+  115 <--x 128
+  129 --- 130
+  130 --- 131
+  130 --- 132
+  130 --- 133
+  130 --- 134
+  130 --- 135
+  130 ---- 137
+  130 --- 136
   131 --- 138
-  131 --- 146
-  131 --- 147
+  131 --- 144
+  131 --- 145
   132 --- 139
-  132 --- 148
-  132 --- 149
-  135 --- 136
-  135 --- 137
-  135 --- 138
-  135 --- 139
-  135 --- 140
-  135 --- 141
-  135 --- 142
-  135 --- 143
-  135 --- 144
-  135 --- 145
-  135 --- 146
-  135 --- 147
-  135 --- 148
-  135 --- 149
-  140 --- 150
-  140 --- 158
-  141 --- 182
-  150 --- 151
-  150 ---- 153
-  150 --- 152
-  151 --- 154
-  151 --- 156
-  151 --- 157
-  153 --- 154
-  153 --- 155
+  132 --- 146
+  132 --- 147
+  133 --- 140
+  133 --- 148
+  133 --- 149
+  134 --- 141
+  134 --- 150
+  134 --- 151
+  137 --- 138
+  137 --- 139
+  137 --- 140
+  137 --- 141
+  137 --- 142
+  137 --- 143
+  137 --- 144
+  137 --- 145
+  137 --- 146
+  137 --- 147
+  137 --- 148
+  137 --- 149
+  137 --- 150
+  137 --- 151
+  142 --- 152
+  142 --- 161
+  143 --- 186
+  152 --- 153
+  152 ---- 155
+  152 --- 154
   153 --- 156
-  153 --- 157
-  155 --- 166
-  158 --- 159
-  158 ---- 161
-  158 --- 160
-  159 --- 162
-  159 --- 164
-  159 --- 165
+  153 --- 158
+  153 --- 159
+  155 --- 156
+  155 --- 157
+  155 --- 158
+  155 --- 159
+  157 --- 170
+  158 <--x 160
   161 --- 162
+  161 ---- 164
   161 --- 163
-  161 --- 164
-  161 --- 165
-  163 --- 174
-  166 --- 167
-  166 ---- 169
-  166 --- 168
-  167 --- 170
-  167 --- 172
-  167 --- 173
-  169 --- 170
-  169 --- 171
-  169 --- 172
-  169 --- 173
-  174 --- 175
-  174 ---- 177
-  174 --- 176
-  175 --- 178
-  175 --- 180
-  175 --- 181
-  177 --- 178
-  177 --- 179
-  177 --- 180
-  177 --- 181
-  182 --- 183
-  182 ---- 185
-  182 --- 184
-  183 --- 186
-  183 --- 188
-  183 --- 189
-  185 --- 186
-  185 --- 187
-  185 --- 188
-  185 --- 189
-  190 --- 191
-  191 --- 192
-  191 --- 193
-  191 --- 194
-  191 --- 195
-  191 --- 196
-  191 ---- 198
-  191 --- 197
-  192 --- 199
-  192 --- 205
-  192 --- 206
-  193 --- 200
-  193 --- 207
-  193 --- 208
-  194 --- 201
-  194 --- 209
-  194 --- 210
-  195 --- 202
-  195 --- 211
-  195 --- 212
-  198 --- 199
-  198 --- 200
-  198 --- 201
-  198 --- 202
-  198 --- 203
-  198 --- 204
+  162 --- 165
+  162 --- 167
+  162 --- 168
+  164 --- 165
+  164 --- 166
+  164 --- 167
+  164 --- 168
+  166 --- 178
+  167 <--x 169
+  170 --- 171
+  170 ---- 173
+  170 --- 172
+  171 --- 174
+  171 --- 176
+  171 --- 177
+  173 --- 174
+  173 --- 175
+  173 --- 176
+  173 --- 177
+  178 --- 179
+  178 ---- 181
+  178 --- 180
+  179 --- 182
+  179 --- 184
+  179 --- 185
+  181 --- 182
+  181 --- 183
+  181 --- 184
+  181 --- 185
+  186 --- 187
+  186 ---- 189
+  186 --- 188
+  187 --- 190
+  187 --- 192
+  187 --- 193
+  189 --- 190
+  189 --- 191
+  189 --- 192
+  189 --- 193
+  194 --- 195
+  195 --- 196
+  195 --- 197
+  195 --- 198
+  195 --- 199
+  195 --- 200
+  195 ---- 202
+  195 --- 201
+  196 --- 203
+  196 --- 209
+  196 --- 210
+  197 --- 204
+  197 --- 211
+  197 --- 212
   198 --- 205
-  198 --- 206
-  198 --- 207
-  198 --- 208
-  198 --- 209
-  198 --- 210
-  198 --- 211
-  198 --- 212
-  203 --- 229
-  204 --- 213
-  204 --- 238
-  213 --- 214
-  213 ---- 216
-  213 --- 215
-  214 --- 217
-  214 --- 219
-  214 --- 220
-  216 --- 217
-  216 --- 218
-  216 --- 219
-  216 --- 220
+  198 --- 213
+  198 --- 214
+  199 --- 206
+  199 --- 215
+  199 --- 216
+  202 --- 203
+  202 --- 204
+  202 --- 205
+  202 --- 206
+  202 --- 207
+  202 --- 208
+  202 --- 209
+  202 --- 210
+  202 --- 211
+  202 --- 212
+  202 --- 213
+  202 --- 214
+  202 --- 215
+  202 --- 216
+  207 --- 234
+  208 --- 217
+  208 --- 243
+  217 --- 218
+  217 ---- 220
+  217 --- 219
   218 --- 221
-  221 --- 222
-  221 ---- 224
-  221 --- 223
-  222 --- 225
-  222 --- 227
-  222 --- 228
-  224 --- 225
-  224 --- 226
-  224 --- 227
-  224 --- 228
+  218 --- 223
+  218 --- 224
+  220 --- 221
+  220 --- 222
+  220 --- 223
+  220 --- 224
+  222 --- 226
+  223 <--x 225
+  226 --- 227
+  226 ---- 229
+  226 --- 228
+  227 --- 230
+  227 --- 232
+  227 --- 233
   229 --- 230
-  229 ---- 232
   229 --- 231
-  230 --- 233
-  230 --- 236
-  230 --- 237
-  232 --- 233
-  232 --- 234
-  232 --- 235
-  232 --- 236
-  232 --- 237
-  238 --- 239
-  238 ---- 241
-  238 --- 240
-  239 --- 242
-  239 --- 245
-  239 --- 246
-  241 --- 242
-  241 --- 243
-  241 --- 244
-  241 --- 245
-  241 --- 246
-  243 --- 247
-  247 --- 248
-  247 ---- 250
-  247 --- 249
-  248 --- 251
-  248 --- 254
-  248 --- 255
-  250 --- 251
-  250 --- 252
-  250 --- 253
-  250 --- 254
-  250 --- 255
-  252 --- 256
-  252 --- 290
-  256 --- 257
-  256 --- 258
-  256 --- 259
-  256 --- 260
-  256 --- 261
-  256 --- 262
-  256 --- 263
-  256 --- 264
-  256 ---- 266
-  256 --- 265
-  257 --- 267
-  257 --- 276
-  257 --- 277
-  258 --- 268
-  258 --- 278
-  258 --- 279
-  259 --- 269
-  259 --- 280
-  259 --- 281
-  260 --- 270
-  260 --- 282
-  260 --- 283
-  261 --- 271
-  261 --- 284
-  261 --- 285
+  229 --- 232
+  229 --- 233
+  234 --- 235
+  234 ---- 237
+  234 --- 236
+  235 --- 238
+  235 --- 241
+  235 --- 242
+  237 --- 238
+  237 --- 239
+  237 --- 240
+  237 --- 241
+  237 --- 242
+  243 --- 244
+  243 ---- 246
+  243 --- 245
+  244 --- 247
+  244 --- 250
+  244 --- 251
+  246 --- 247
+  246 --- 248
+  246 --- 249
+  246 --- 250
+  246 --- 251
+  248 --- 252
+  252 --- 253
+  252 ---- 255
+  252 --- 254
+  253 --- 256
+  253 --- 259
+  253 --- 260
+  255 --- 256
+  255 --- 257
+  255 --- 258
+  255 --- 259
+  255 --- 260
+  257 --- 261
+  257 --- 295
+  261 --- 262
+  261 --- 263
+  261 --- 264
+  261 --- 265
+  261 --- 266
+  261 --- 267
+  261 --- 268
+  261 --- 269
+  261 ---- 271
+  261 --- 270
   262 --- 272
-  262 --- 286
-  262 --- 287
+  262 --- 281
+  262 --- 282
   263 --- 273
-  263 --- 288
-  263 --- 289
-  266 --- 267
-  266 --- 268
-  266 --- 269
-  266 --- 270
-  266 --- 271
-  266 --- 272
-  266 --- 273
-  266 --- 274
-  266 --- 275
+  263 --- 283
+  263 --- 284
+  264 --- 274
+  264 --- 285
+  264 --- 286
+  265 --- 275
+  265 --- 287
+  265 --- 288
   266 --- 276
-  266 --- 277
-  266 --- 278
-  266 --- 279
-  266 --- 280
-  266 --- 281
-  266 --- 282
-  266 --- 283
-  266 --- 284
-  266 --- 285
-  266 --- 286
-  266 --- 287
-  266 --- 288
   266 --- 289
-  290 --- 291
-  290 --- 292
-  290 --- 293
-  290 --- 294
-  290 --- 295
-  290 --- 296
-  290 --- 297
-  290 --- 298
-  290 ---- 300
-  290 --- 299
-  291 --- 307
-  291 --- 322
-  291 --- 323
-  292 --- 306
-  292 --- 320
-  292 --- 321
-  293 --- 305
-  293 --- 318
-  293 --- 319
-  294 --- 304
-  294 --- 316
-  294 --- 317
+  266 --- 290
+  267 --- 277
+  267 --- 291
+  267 --- 292
+  268 --- 278
+  268 --- 293
+  268 --- 294
+  271 --- 272
+  271 --- 273
+  271 --- 274
+  271 --- 275
+  271 --- 276
+  271 --- 277
+  271 --- 278
+  271 --- 279
+  271 --- 280
+  271 --- 281
+  271 --- 282
+  271 --- 283
+  271 --- 284
+  271 --- 285
+  271 --- 286
+  271 --- 287
+  271 --- 288
+  271 --- 289
+  271 --- 290
+  271 --- 291
+  271 --- 292
+  271 --- 293
+  271 --- 294
+  295 --- 296
+  295 --- 297
+  295 --- 298
+  295 --- 299
+  295 --- 300
+  295 --- 301
+  295 --- 302
   295 --- 303
-  295 --- 314
-  295 --- 315
-  296 --- 302
+  295 ---- 305
+  295 --- 304
   296 --- 312
-  296 --- 313
-  297 --- 301
-  297 --- 310
+  296 --- 327
+  296 --- 328
   297 --- 311
-  300 --- 301
-  300 --- 302
-  300 --- 303
-  300 --- 304
-  300 --- 305
-  300 --- 306
-  300 --- 307
+  297 --- 325
+  297 --- 326
+  298 --- 310
+  298 --- 323
+  298 --- 324
+  299 --- 309
+  299 --- 321
+  299 --- 322
   300 --- 308
-  300 --- 309
-  300 --- 310
-  300 --- 311
-  300 --- 312
-  300 --- 313
-  300 --- 314
-  300 --- 315
-  300 --- 316
-  300 --- 317
-  300 --- 318
   300 --- 319
   300 --- 320
-  300 --- 321
-  300 --- 322
-  300 --- 323
-  15 <--x 324
-  33 <--x 325
-  15 <--x 326
-  15 <--x 327
-  82 <--x 328
-  96 <--x 329
-  96 <--x 330
-  140 <--x 331
-  140 <--x 332
-  155 <--x 333
-  163 <--x 334
-  141 <--x 335
-  204 <--x 336
-  218 <--x 337
-  203 <--x 338
-  204 <--x 339
-  243 <--x 340
-  252 <--x 341
-  252 <--x 342
+  301 --- 307
+  301 --- 317
+  301 --- 318
+  302 --- 306
+  302 --- 315
+  302 --- 316
+  305 --- 306
+  305 --- 307
+  305 --- 308
+  305 --- 309
+  305 --- 310
+  305 --- 311
+  305 --- 312
+  305 --- 313
+  305 --- 314
+  305 --- 315
+  305 --- 316
+  305 --- 317
+  305 --- 318
+  305 --- 319
+  305 --- 320
+  305 --- 321
+  305 --- 322
+  305 --- 323
+  305 --- 324
+  305 --- 325
+  305 --- 326
+  305 --- 327
+  305 --- 328
+  15 <--x 329
+  33 <--x 330
+  15 <--x 331
+  15 <--x 332
+  83 <--x 333
+  97 <--x 334
+  97 <--x 335
+  142 <--x 336
+  142 <--x 337
+  157 <--x 338
+  166 <--x 339
+  143 <--x 340
+  208 <--x 341
+  222 <--x 342
+  207 <--x 343
+  208 <--x 344
+  248 <--x 345
+  257 <--x 346
+  257 <--x 347
 ```

--- a/rust/kcl-wasm-lib/src/wasm.rs
+++ b/rust/kcl-wasm-lib/src/wasm.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use futures::stream::TryStreamExt;
 use gloo_utils::format::JsValueSerdeExt;
 use kcl_lib::{
-    bust_cache, clear_mem_cache, exec::IdGenerator, pretty::NumericSuffix, CoreDump, EngineManager, ModuleId, Point2d,
-    Program,
+    bust_cache, clear_mem_cache, clear_mock_ids, exec::IdGenerator, pretty::NumericSuffix, CoreDump, EngineManager,
+    ModuleId, Point2d, Program,
 };
 use tower_lsp::{LspService, Server};
 use wasm_bindgen::prelude::*;
@@ -20,6 +20,7 @@ pub async fn clear_scene_and_bust_cache(
 
     bust_cache().await;
     clear_mem_cache().await;
+    clear_mock_ids().await;
 
     let engine = kcl_lib::wasm_engine::EngineConnection::new(engine_manager)
         .await

--- a/src/lang/KclSingleton.ts
+++ b/src/lang/KclSingleton.ts
@@ -482,6 +482,7 @@ export class KclManager {
       this.lastSuccessfulVariables = execState.variables
       this.lastSuccessfulOperations = execState.operations
     }
+    this.engineCommandManager.updateArtifactGraph(execState.artifactGraph)
   }
   cancelAllExecutions() {
     this._cancelTokens.forEach((_, key) => {

--- a/src/lang/KclSingleton.ts
+++ b/src/lang/KclSingleton.ts
@@ -476,8 +476,7 @@ export class KclManager {
     })
 
     this._logs = logs
-    this._execState = execState
-    this._variables = execState.variables
+    this.execState = execState
     if (!errors.length) {
       this.lastSuccessfulVariables = execState.variables
       this.lastSuccessfulOperations = execState.operations


### PR DESCRIPTION
Resolves #5166.

Thanks to #5068, we can build the majority of the artifact graph without the engine. I verified that the graph gets built without exiting sketch mode. The bulk of the changes are making the IDs stable since we don't want mock execution to use the same IDs as real execution.

Note: Mock UUIDs never match real UUIDs. They have their own `IdGenerator`. I talked with @Irev-Dev and it seemed fine that entering or exiting sketch mode would clear the user's selection. So UUIDs not matching between the two modes should be fine.

I made a Rust-side test, but not a TS-side test. It isn't user-facing. Presumably, whatever user-facing feature that relies on this will get tested.