### PR TITLE
Remove extra margin on some code editor menu items

### DIFF
--- a/src/components/ModelingSidebar/ModelingPanes/KclEditorMenu.module.css
+++ b/src/components/ModelingSidebar/ModelingPanes/KclEditorMenu.module.css
@@ -3,7 +3,7 @@
   @apply font-mono !no-underline text-xs font-bold select-none text-chalkboard-90;
   @apply ui-active:bg-primary/10 ui-active:text-primary ui-active:text-inherit;
   @apply transition-colors ease-out;
-  margin: 0;
+  @apply m-0;
 }
 
 :global(.dark) .button {

--- a/src/components/ModelingSidebar/ModelingPanes/KclEditorMenu.module.css
+++ b/src/components/ModelingSidebar/ModelingPanes/KclEditorMenu.module.css
@@ -3,6 +3,7 @@
   @apply font-mono !no-underline text-xs font-bold select-none text-chalkboard-90;
   @apply ui-active:bg-primary/10 ui-active:text-primary ui-active:text-inherit;
   @apply transition-colors ease-out;
+  margin: 0;
 }
 
 :global(.dark) .button {


### PR DESCRIPTION
Fixes #5047

Only the ones that are buttons not links.

### Before
![image](https://github.com/user-attachments/assets/421204b1-7eae-4677-97b4-95fcde994f9c)
![image](https://github.com/user-attachments/assets/8daca720-5b96-45fb-ade6-5f28954f14be)
![image](https://github.com/user-attachments/assets/df89d6dd-ee06-476c-9d02-631be6940298)

### After 😌 
![image](https://github.com/user-attachments/assets/2a3dc0a1-4a4d-45e4-996b-809944dc9918)


