### PR TITLE
ci: Fix panic in cargo bench job

### DIFF
--- a/.github/workflows/cargo-bench.yml
+++ b/.github/workflows/cargo-bench.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install dependencies
         run: |
           cargo install cargo-criterion

--- a/.github/workflows/cargo-bench.yml
+++ b/.github/workflows/cargo-bench.yml
@@ -24,7 +24,7 @@ name: cargo bench
 jobs:
   cargo-bench:
     name: Benchmark with iai
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -32,7 +32,9 @@ jobs:
         run: |
           cargo install cargo-criterion
           sudo apt update
-          sudo apt install -y valgrind
+          # Need a version of valgrind before 3.21.0.
+          # https://github.com/bheisler/iai/issues/34
+          sudo apt install -y valgrind=1:3.18.1-1ubuntu2
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.6.1
       - name: Benchmark kcl library


### PR DESCRIPTION
Need to downgrade valgrind. To do that, I downgraded to Ubuntu 22.04. This might be slower since it's no longer using the 8 core runner. But at least it runs now.

See https://github.com/bheisler/iai/issues/34.