### PR TITLE
test: Add testing the artifact graph when there's an execution error

### DIFF
--- a/src/wasm-lib/kcl/src/simulation_tests.rs
+++ b/src/wasm-lib/kcl/src/simulation_tests.rs
@@ -106,7 +106,7 @@ async fn execute(test_name: &str, render_to_png: bool) {
                     ".environments[].**[].z[]" => rounded_redaction(4),
                 });
             });
-            snapshot_common(
+            assert_common_snapshots(
                 test_name,
                 exec_state.mod_local.operations,
                 exec_state.global.artifact_commands,
@@ -131,7 +131,7 @@ async fn execute(test_name: &str, render_to_png: bool) {
                         insta::assert_snapshot!("execution_error", report);
                     });
 
-                    snapshot_common(
+                    assert_common_snapshots(
                         test_name,
                         error.operations,
                         error.artifact_commands,
@@ -151,7 +151,7 @@ async fn execute(test_name: &str, render_to_png: bool) {
 
 /// Assert snapshots that should happen both when KCL execution succeeds and
 /// when it results in an error.
-fn snapshot_common(
+fn assert_common_snapshots(
     test_name: &str,
     operations: Vec<Operation>,
     artifact_commands: Vec<ArtifactCommand>,

--- a/src/wasm-lib/kcl/src/simulation_tests.rs
+++ b/src/wasm-lib/kcl/src/simulation_tests.rs
@@ -206,6 +206,27 @@ mod cube {
         super::execute(TEST_NAME, true).await
     }
 }
+mod cube_with_error {
+    const TEST_NAME: &str = "cube_with_error";
+
+    /// Test parsing KCL.
+    #[test]
+    fn parse() {
+        super::parse(TEST_NAME)
+    }
+
+    /// Test that parsing and unparsing KCL produces the original KCL input.
+    #[test]
+    fn unparse() {
+        super::unparse(TEST_NAME)
+    }
+
+    /// Test that KCL is executed correctly.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn kcl_test_execute() {
+        super::execute(TEST_NAME, true).await
+    }
+}
 mod artifact_graph_example_code1 {
     const TEST_NAME: &str = "artifact_graph_example_code1";
 

--- a/src/wasm-lib/kcl/tests/argument_error/artifact_graph_flowchart.snap
+++ b/src/wasm-lib/kcl/tests/argument_error/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph flowchart argument_error.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/argument_error/artifact_graph_flowchart.snap.md
+++ b/src/wasm-lib/kcl/tests/argument_error/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/src/wasm-lib/kcl/tests/argument_error/artifact_graph_mind_map.snap
+++ b/src/wasm-lib/kcl/tests/argument_error/artifact_graph_mind_map.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph mind map argument_error.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/argument_error/artifact_graph_mind_map.snap.md
+++ b/src/wasm-lib/kcl/tests/argument_error/artifact_graph_mind_map.snap.md
@@ -1,0 +1,4 @@
+```mermaid
+mindmap
+  root
+```

--- a/src/wasm-lib/kcl/tests/array_elem_pop_empty_fail/artifact_graph_flowchart.snap
+++ b/src/wasm-lib/kcl/tests/array_elem_pop_empty_fail/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph flowchart array_elem_pop_empty_fail.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/array_elem_pop_empty_fail/artifact_graph_flowchart.snap.md
+++ b/src/wasm-lib/kcl/tests/array_elem_pop_empty_fail/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/src/wasm-lib/kcl/tests/array_elem_pop_empty_fail/artifact_graph_mind_map.snap
+++ b/src/wasm-lib/kcl/tests/array_elem_pop_empty_fail/artifact_graph_mind_map.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph mind map array_elem_pop_empty_fail.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/array_elem_pop_empty_fail/artifact_graph_mind_map.snap.md
+++ b/src/wasm-lib/kcl/tests/array_elem_pop_empty_fail/artifact_graph_mind_map.snap.md
@@ -1,0 +1,4 @@
+```mermaid
+mindmap
+  root
+```

--- a/src/wasm-lib/kcl/tests/array_elem_pop_fail/artifact_graph_flowchart.snap
+++ b/src/wasm-lib/kcl/tests/array_elem_pop_fail/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph flowchart array_elem_pop_fail.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/array_elem_pop_fail/artifact_graph_flowchart.snap.md
+++ b/src/wasm-lib/kcl/tests/array_elem_pop_fail/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/src/wasm-lib/kcl/tests/array_elem_pop_fail/artifact_graph_mind_map.snap
+++ b/src/wasm-lib/kcl/tests/array_elem_pop_fail/artifact_graph_mind_map.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph mind map array_elem_pop_fail.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/array_elem_pop_fail/artifact_graph_mind_map.snap.md
+++ b/src/wasm-lib/kcl/tests/array_elem_pop_fail/artifact_graph_mind_map.snap.md
@@ -1,0 +1,4 @@
+```mermaid
+mindmap
+  root
+```

--- a/src/wasm-lib/kcl/tests/array_elem_push_fail/artifact_graph_flowchart.snap
+++ b/src/wasm-lib/kcl/tests/array_elem_push_fail/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph flowchart array_elem_push_fail.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/array_elem_push_fail/artifact_graph_flowchart.snap.md
+++ b/src/wasm-lib/kcl/tests/array_elem_push_fail/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/src/wasm-lib/kcl/tests/array_elem_push_fail/artifact_graph_mind_map.snap
+++ b/src/wasm-lib/kcl/tests/array_elem_push_fail/artifact_graph_mind_map.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph mind map array_elem_push_fail.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/array_elem_push_fail/artifact_graph_mind_map.snap.md
+++ b/src/wasm-lib/kcl/tests/array_elem_push_fail/artifact_graph_mind_map.snap.md
@@ -1,0 +1,4 @@
+```mermaid
+mindmap
+  root
+```

--- a/src/wasm-lib/kcl/tests/array_index_oob/artifact_graph_flowchart.snap
+++ b/src/wasm-lib/kcl/tests/array_index_oob/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph flowchart array_index_oob.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/array_index_oob/artifact_graph_flowchart.snap.md
+++ b/src/wasm-lib/kcl/tests/array_index_oob/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/src/wasm-lib/kcl/tests/array_index_oob/artifact_graph_mind_map.snap
+++ b/src/wasm-lib/kcl/tests/array_index_oob/artifact_graph_mind_map.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph mind map array_index_oob.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/array_index_oob/artifact_graph_mind_map.snap.md
+++ b/src/wasm-lib/kcl/tests/array_index_oob/artifact_graph_mind_map.snap.md
@@ -1,0 +1,4 @@
+```mermaid
+mindmap
+  root
+```

--- a/src/wasm-lib/kcl/tests/comparisons_multiple/artifact_graph_flowchart.snap
+++ b/src/wasm-lib/kcl/tests/comparisons_multiple/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph flowchart comparisons_multiple.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/comparisons_multiple/artifact_graph_flowchart.snap.md
+++ b/src/wasm-lib/kcl/tests/comparisons_multiple/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/src/wasm-lib/kcl/tests/comparisons_multiple/artifact_graph_mind_map.snap
+++ b/src/wasm-lib/kcl/tests/comparisons_multiple/artifact_graph_mind_map.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph mind map comparisons_multiple.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/comparisons_multiple/artifact_graph_mind_map.snap.md
+++ b/src/wasm-lib/kcl/tests/comparisons_multiple/artifact_graph_mind_map.snap.md
@@ -1,0 +1,4 @@
+```mermaid
+mindmap
+  root
+```

--- a/src/wasm-lib/kcl/tests/cube_with_error/artifact_commands.snap
+++ b/src/wasm-lib/kcl/tests/cube_with_error/artifact_commands.snap
@@ -1,0 +1,538 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact commands cube_with_error.kcl
+---
+[
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      0,
+      0,
+      0
+    ],
+    "command": {
+      "type": "make_plane",
+      "origin": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "x_axis": {
+        "x": 1.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "y_axis": {
+        "x": 0.0,
+        "y": 1.0,
+        "z": 0.0
+      },
+      "size": 100.0,
+      "clobber": false,
+      "hide": true
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      0,
+      0,
+      0
+    ],
+    "command": {
+      "type": "plane_set_color",
+      "plane_id": "[uuid]",
+      "color": {
+        "r": 0.7,
+        "g": 0.28,
+        "b": 0.28,
+        "a": 0.4
+      }
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      0,
+      0,
+      0
+    ],
+    "command": {
+      "type": "make_plane",
+      "origin": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "x_axis": {
+        "x": 0.0,
+        "y": 1.0,
+        "z": 0.0
+      },
+      "y_axis": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 1.0
+      },
+      "size": 100.0,
+      "clobber": false,
+      "hide": true
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      0,
+      0,
+      0
+    ],
+    "command": {
+      "type": "plane_set_color",
+      "plane_id": "[uuid]",
+      "color": {
+        "r": 0.28,
+        "g": 0.7,
+        "b": 0.28,
+        "a": 0.4
+      }
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      0,
+      0,
+      0
+    ],
+    "command": {
+      "type": "make_plane",
+      "origin": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "x_axis": {
+        "x": 1.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "y_axis": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 1.0
+      },
+      "size": 100.0,
+      "clobber": false,
+      "hide": true
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      0,
+      0,
+      0
+    ],
+    "command": {
+      "type": "plane_set_color",
+      "plane_id": "[uuid]",
+      "color": {
+        "r": 0.28,
+        "g": 0.28,
+        "b": 0.7,
+        "a": 0.4
+      }
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      0,
+      0,
+      0
+    ],
+    "command": {
+      "type": "make_plane",
+      "origin": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "x_axis": {
+        "x": -1.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "y_axis": {
+        "x": 0.0,
+        "y": 1.0,
+        "z": 0.0
+      },
+      "size": 100.0,
+      "clobber": false,
+      "hide": true
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      0,
+      0,
+      0
+    ],
+    "command": {
+      "type": "make_plane",
+      "origin": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "x_axis": {
+        "x": 0.0,
+        "y": -1.0,
+        "z": 0.0
+      },
+      "y_axis": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 1.0
+      },
+      "size": 100.0,
+      "clobber": false,
+      "hide": true
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      0,
+      0,
+      0
+    ],
+    "command": {
+      "type": "make_plane",
+      "origin": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "x_axis": {
+        "x": -1.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "y_axis": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 1.0
+      },
+      "size": 100.0,
+      "clobber": false,
+      "hide": true
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      0,
+      0,
+      0
+    ],
+    "command": {
+      "type": "edge_lines_visible",
+      "hidden": false
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      0,
+      0,
+      0
+    ],
+    "command": {
+      "type": "set_scene_units",
+      "unit": "mm"
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      0,
+      0,
+      0
+    ],
+    "command": {
+      "type": "object_visible",
+      "object_id": "[uuid]",
+      "hidden": true
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      0,
+      0,
+      0
+    ],
+    "command": {
+      "type": "object_visible",
+      "object_id": "[uuid]",
+      "hidden": true
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      177,
+      194,
+      0
+    ],
+    "command": {
+      "type": "make_plane",
+      "origin": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "x_axis": {
+        "x": 1.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "y_axis": {
+        "x": 0.0,
+        "y": 1.0,
+        "z": 0.0
+      },
+      "size": 60.0,
+      "clobber": false,
+      "hide": true
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      177,
+      194,
+      0
+    ],
+    "command": {
+      "type": "enable_sketch_mode",
+      "entity_id": "[uuid]",
+      "ortho": false,
+      "animated": false,
+      "adjust_camera": false,
+      "planar_normal": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 1.0
+      }
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      177,
+      194,
+      0
+    ],
+    "command": {
+      "type": "start_path"
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      177,
+      194,
+      0
+    ],
+    "command": {
+      "type": "move_path_pen",
+      "path": "[uuid]",
+      "to": {
+        "x": -20.0,
+        "y": -20.0,
+        "z": 0.0
+      }
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      202,
+      215,
+      0
+    ],
+    "command": {
+      "type": "extend_path",
+      "path": "[uuid]",
+      "segment": {
+        "type": "line",
+        "end": {
+          "x": -20.0,
+          "y": 20.0,
+          "z": 0.0
+        },
+        "relative": false
+      }
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      223,
+      236,
+      0
+    ],
+    "command": {
+      "type": "extend_path",
+      "path": "[uuid]",
+      "segment": {
+        "type": "line",
+        "end": {
+          "x": 20.0,
+          "y": 20.0,
+          "z": 0.0
+        },
+        "relative": false
+      }
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      244,
+      257,
+      0
+    ],
+    "command": {
+      "type": "extend_path",
+      "path": "[uuid]",
+      "segment": {
+        "type": "line",
+        "end": {
+          "x": 20.0,
+          "y": -20.0,
+          "z": 0.0
+        },
+        "relative": false
+      }
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      265,
+      278,
+      0
+    ],
+    "command": {
+      "type": "extend_path",
+      "path": "[uuid]",
+      "segment": {
+        "type": "line",
+        "end": {
+          "x": -20.0,
+          "y": -20.0,
+          "z": 0.0
+        },
+        "relative": false
+      }
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      286,
+      294,
+      0
+    ],
+    "command": {
+      "type": "close_path",
+      "path_id": "[uuid]"
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      286,
+      294,
+      0
+    ],
+    "command": {
+      "type": "sketch_mode_disable"
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      302,
+      320,
+      0
+    ],
+    "command": {
+      "type": "enable_sketch_mode",
+      "entity_id": "[uuid]",
+      "ortho": false,
+      "animated": false,
+      "adjust_camera": false,
+      "planar_normal": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 1.0
+      }
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      302,
+      320,
+      0
+    ],
+    "command": {
+      "type": "extrude",
+      "target": "[uuid]",
+      "distance": 40.0,
+      "faces": null
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      302,
+      320,
+      0
+    ],
+    "command": {
+      "type": "sketch_mode_disable"
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      302,
+      320,
+      0
+    ],
+    "command": {
+      "type": "object_bring_to_front",
+      "object_id": "[uuid]"
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [
+      302,
+      320,
+      0
+    ],
+    "command": {
+      "type": "solid3d_get_extrusion_face_info",
+      "object_id": "[uuid]",
+      "edge_id": "[uuid]"
+    }
+  }
+]

--- a/src/wasm-lib/kcl/tests/cube_with_error/artifact_graph_flowchart.snap
+++ b/src/wasm-lib/kcl/tests/cube_with_error/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph flowchart cube_with_error.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/cube_with_error/artifact_graph_flowchart.snap.md
+++ b/src/wasm-lib/kcl/tests/cube_with_error/artifact_graph_flowchart.snap.md
@@ -1,0 +1,38 @@
+```mermaid
+flowchart LR
+  subgraph path2 [Path]
+    2["Path<br>[177, 194, 0]"]
+    3["Segment<br>[202, 215, 0]"]
+    4["Segment<br>[223, 236, 0]"]
+    5["Segment<br>[244, 257, 0]"]
+    6["Segment<br>[265, 278, 0]"]
+    7["Segment<br>[286, 294, 0]"]
+    8[Solid2d]
+  end
+  1["Plane<br>[177, 194, 0]"]
+  9["Sweep Extrusion<br>[302, 320, 0]"]
+  10[Wall]
+  11[Wall]
+  12[Wall]
+  13[Wall]
+  14["Cap Start"]
+  15["Cap End"]
+  1 --- 2
+  2 --- 3
+  2 --- 4
+  2 --- 5
+  2 --- 6
+  2 --- 7
+  2 ---- 9
+  2 --- 8
+  3 --- 13
+  4 --- 12
+  5 --- 11
+  6 --- 10
+  9 --- 10
+  9 --- 11
+  9 --- 12
+  9 --- 13
+  9 --- 14
+  9 --- 15
+```

--- a/src/wasm-lib/kcl/tests/cube_with_error/artifact_graph_mind_map.snap
+++ b/src/wasm-lib/kcl/tests/cube_with_error/artifact_graph_mind_map.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph mind map cube_with_error.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/cube_with_error/artifact_graph_mind_map.snap.md
+++ b/src/wasm-lib/kcl/tests/cube_with_error/artifact_graph_mind_map.snap.md
@@ -1,0 +1,23 @@
+```mermaid
+mindmap
+  root
+    Plane
+      Path
+        Segment
+          Wall
+        Segment
+          Wall
+        Segment
+          Wall
+        Segment
+          Wall
+        Segment
+        Sweep Extrusion
+          Wall
+          Wall
+          Wall
+          Wall
+          Cap Start
+          Cap End
+        Solid2d
+```

--- a/src/wasm-lib/kcl/tests/cube_with_error/ast.snap
+++ b/src/wasm-lib/kcl/tests/cube_with_error/ast.snap
@@ -1,0 +1,809 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Result of parsing cube_with_error.kcl
+---
+{
+  "Ok": {
+    "body": [
+      {
+        "declaration": {
+          "end": 322,
+          "id": {
+            "end": 7,
+            "name": "cube",
+            "start": 3,
+            "type": "Identifier"
+          },
+          "init": {
+            "body": {
+              "body": [
+                {
+                  "declaration": {
+                    "end": 42,
+                    "id": {
+                      "end": 29,
+                      "name": "l",
+                      "start": 28,
+                      "type": "Identifier"
+                    },
+                    "init": {
+                      "end": 42,
+                      "left": {
+                        "end": 38,
+                        "name": "length",
+                        "start": 32,
+                        "type": "Identifier",
+                        "type": "Identifier"
+                      },
+                      "operator": "/",
+                      "right": {
+                        "end": 42,
+                        "raw": "2",
+                        "start": 41,
+                        "type": "Literal",
+                        "type": "Literal",
+                        "value": {
+                          "value": 2.0,
+                          "suffix": "None"
+                        }
+                      },
+                      "start": 32,
+                      "type": "BinaryExpression",
+                      "type": "BinaryExpression"
+                    },
+                    "start": 28,
+                    "type": "VariableDeclarator"
+                  },
+                  "end": 42,
+                  "kind": "const",
+                  "start": 28,
+                  "type": "VariableDeclaration",
+                  "type": "VariableDeclaration"
+                },
+                {
+                  "declaration": {
+                    "end": 58,
+                    "id": {
+                      "end": 46,
+                      "name": "x",
+                      "start": 45,
+                      "type": "Identifier"
+                    },
+                    "init": {
+                      "computed": false,
+                      "end": 58,
+                      "object": {
+                        "end": 55,
+                        "name": "center",
+                        "start": 49,
+                        "type": "Identifier",
+                        "type": "Identifier"
+                      },
+                      "property": {
+                        "end": 57,
+                        "raw": "0",
+                        "start": 56,
+                        "type": "Literal",
+                        "type": "Literal",
+                        "value": {
+                          "value": 0.0,
+                          "suffix": "None"
+                        }
+                      },
+                      "start": 49,
+                      "type": "MemberExpression",
+                      "type": "MemberExpression"
+                    },
+                    "start": 45,
+                    "type": "VariableDeclarator"
+                  },
+                  "end": 58,
+                  "kind": "const",
+                  "start": 45,
+                  "type": "VariableDeclaration",
+                  "type": "VariableDeclaration"
+                },
+                {
+                  "declaration": {
+                    "end": 74,
+                    "id": {
+                      "end": 62,
+                      "name": "y",
+                      "start": 61,
+                      "type": "Identifier"
+                    },
+                    "init": {
+                      "computed": false,
+                      "end": 74,
+                      "object": {
+                        "end": 71,
+                        "name": "center",
+                        "start": 65,
+                        "type": "Identifier",
+                        "type": "Identifier"
+                      },
+                      "property": {
+                        "end": 73,
+                        "raw": "1",
+                        "start": 72,
+                        "type": "Literal",
+                        "type": "Literal",
+                        "value": {
+                          "value": 1.0,
+                          "suffix": "None"
+                        }
+                      },
+                      "start": 65,
+                      "type": "MemberExpression",
+                      "type": "MemberExpression"
+                    },
+                    "start": 61,
+                    "type": "VariableDeclarator"
+                  },
+                  "end": 74,
+                  "kind": "const",
+                  "start": 61,
+                  "type": "VariableDeclaration",
+                  "type": "VariableDeclaration"
+                },
+                {
+                  "declaration": {
+                    "end": 98,
+                    "id": {
+                      "end": 79,
+                      "name": "p0",
+                      "start": 77,
+                      "type": "Identifier"
+                    },
+                    "init": {
+                      "elements": [
+                        {
+                          "end": 89,
+                          "left": {
+                            "argument": {
+                              "end": 85,
+                              "name": "l",
+                              "start": 84,
+                              "type": "Identifier",
+                              "type": "Identifier"
+                            },
+                            "end": 85,
+                            "operator": "-",
+                            "start": 83,
+                            "type": "UnaryExpression",
+                            "type": "UnaryExpression"
+                          },
+                          "operator": "+",
+                          "right": {
+                            "end": 89,
+                            "name": "x",
+                            "start": 88,
+                            "type": "Identifier",
+                            "type": "Identifier"
+                          },
+                          "start": 83,
+                          "type": "BinaryExpression",
+                          "type": "BinaryExpression"
+                        },
+                        {
+                          "end": 97,
+                          "left": {
+                            "argument": {
+                              "end": 93,
+                              "name": "l",
+                              "start": 92,
+                              "type": "Identifier",
+                              "type": "Identifier"
+                            },
+                            "end": 93,
+                            "operator": "-",
+                            "start": 91,
+                            "type": "UnaryExpression",
+                            "type": "UnaryExpression"
+                          },
+                          "operator": "+",
+                          "right": {
+                            "end": 97,
+                            "name": "y",
+                            "start": 96,
+                            "type": "Identifier",
+                            "type": "Identifier"
+                          },
+                          "start": 91,
+                          "type": "BinaryExpression",
+                          "type": "BinaryExpression"
+                        }
+                      ],
+                      "end": 98,
+                      "start": 82,
+                      "type": "ArrayExpression",
+                      "type": "ArrayExpression"
+                    },
+                    "start": 77,
+                    "type": "VariableDeclarator"
+                  },
+                  "end": 98,
+                  "kind": "const",
+                  "start": 77,
+                  "type": "VariableDeclaration",
+                  "type": "VariableDeclaration"
+                },
+                {
+                  "declaration": {
+                    "end": 121,
+                    "id": {
+                      "end": 103,
+                      "name": "p1",
+                      "start": 101,
+                      "type": "Identifier"
+                    },
+                    "init": {
+                      "elements": [
+                        {
+                          "end": 113,
+                          "left": {
+                            "argument": {
+                              "end": 109,
+                              "name": "l",
+                              "start": 108,
+                              "type": "Identifier",
+                              "type": "Identifier"
+                            },
+                            "end": 109,
+                            "operator": "-",
+                            "start": 107,
+                            "type": "UnaryExpression",
+                            "type": "UnaryExpression"
+                          },
+                          "operator": "+",
+                          "right": {
+                            "end": 113,
+                            "name": "x",
+                            "start": 112,
+                            "type": "Identifier",
+                            "type": "Identifier"
+                          },
+                          "start": 107,
+                          "type": "BinaryExpression",
+                          "type": "BinaryExpression"
+                        },
+                        {
+                          "end": 120,
+                          "left": {
+                            "end": 116,
+                            "name": "l",
+                            "start": 115,
+                            "type": "Identifier",
+                            "type": "Identifier"
+                          },
+                          "operator": "+",
+                          "right": {
+                            "end": 120,
+                            "name": "y",
+                            "start": 119,
+                            "type": "Identifier",
+                            "type": "Identifier"
+                          },
+                          "start": 115,
+                          "type": "BinaryExpression",
+                          "type": "BinaryExpression"
+                        }
+                      ],
+                      "end": 121,
+                      "start": 106,
+                      "type": "ArrayExpression",
+                      "type": "ArrayExpression"
+                    },
+                    "start": 101,
+                    "type": "VariableDeclarator"
+                  },
+                  "end": 121,
+                  "kind": "const",
+                  "start": 101,
+                  "type": "VariableDeclaration",
+                  "type": "VariableDeclaration"
+                },
+                {
+                  "declaration": {
+                    "end": 143,
+                    "id": {
+                      "end": 126,
+                      "name": "p2",
+                      "start": 124,
+                      "type": "Identifier"
+                    },
+                    "init": {
+                      "elements": [
+                        {
+                          "end": 135,
+                          "left": {
+                            "end": 131,
+                            "name": "l",
+                            "start": 130,
+                            "type": "Identifier",
+                            "type": "Identifier"
+                          },
+                          "operator": "+",
+                          "right": {
+                            "end": 135,
+                            "name": "x",
+                            "start": 134,
+                            "type": "Identifier",
+                            "type": "Identifier"
+                          },
+                          "start": 130,
+                          "type": "BinaryExpression",
+                          "type": "BinaryExpression"
+                        },
+                        {
+                          "end": 142,
+                          "left": {
+                            "end": 138,
+                            "name": "l",
+                            "start": 137,
+                            "type": "Identifier",
+                            "type": "Identifier"
+                          },
+                          "operator": "+",
+                          "right": {
+                            "end": 142,
+                            "name": "y",
+                            "start": 141,
+                            "type": "Identifier",
+                            "type": "Identifier"
+                          },
+                          "start": 137,
+                          "type": "BinaryExpression",
+                          "type": "BinaryExpression"
+                        }
+                      ],
+                      "end": 143,
+                      "start": 129,
+                      "type": "ArrayExpression",
+                      "type": "ArrayExpression"
+                    },
+                    "start": 124,
+                    "type": "VariableDeclarator"
+                  },
+                  "end": 143,
+                  "kind": "const",
+                  "start": 124,
+                  "type": "VariableDeclaration",
+                  "type": "VariableDeclaration"
+                },
+                {
+                  "declaration": {
+                    "end": 166,
+                    "id": {
+                      "end": 148,
+                      "name": "p3",
+                      "start": 146,
+                      "type": "Identifier"
+                    },
+                    "init": {
+                      "elements": [
+                        {
+                          "end": 157,
+                          "left": {
+                            "end": 153,
+                            "name": "l",
+                            "start": 152,
+                            "type": "Identifier",
+                            "type": "Identifier"
+                          },
+                          "operator": "+",
+                          "right": {
+                            "end": 157,
+                            "name": "x",
+                            "start": 156,
+                            "type": "Identifier",
+                            "type": "Identifier"
+                          },
+                          "start": 152,
+                          "type": "BinaryExpression",
+                          "type": "BinaryExpression"
+                        },
+                        {
+                          "end": 165,
+                          "left": {
+                            "argument": {
+                              "end": 161,
+                              "name": "l",
+                              "start": 160,
+                              "type": "Identifier",
+                              "type": "Identifier"
+                            },
+                            "end": 161,
+                            "operator": "-",
+                            "start": 159,
+                            "type": "UnaryExpression",
+                            "type": "UnaryExpression"
+                          },
+                          "operator": "+",
+                          "right": {
+                            "end": 165,
+                            "name": "y",
+                            "start": 164,
+                            "type": "Identifier",
+                            "type": "Identifier"
+                          },
+                          "start": 159,
+                          "type": "BinaryExpression",
+                          "type": "BinaryExpression"
+                        }
+                      ],
+                      "end": 166,
+                      "start": 151,
+                      "type": "ArrayExpression",
+                      "type": "ArrayExpression"
+                    },
+                    "start": 146,
+                    "type": "VariableDeclarator"
+                  },
+                  "end": 166,
+                  "kind": "const",
+                  "start": 146,
+                  "type": "VariableDeclaration",
+                  "type": "VariableDeclaration"
+                },
+                {
+                  "argument": {
+                    "body": [
+                      {
+                        "arguments": [
+                          {
+                            "end": 193,
+                            "name": "p0",
+                            "start": 191,
+                            "type": "Identifier",
+                            "type": "Identifier"
+                          }
+                        ],
+                        "callee": {
+                          "end": 190,
+                          "name": "startSketchAt",
+                          "start": 177,
+                          "type": "Identifier"
+                        },
+                        "end": 194,
+                        "start": 177,
+                        "type": "CallExpression",
+                        "type": "CallExpression"
+                      },
+                      {
+                        "arguments": [
+                          {
+                            "end": 211,
+                            "name": "p1",
+                            "start": 209,
+                            "type": "Identifier",
+                            "type": "Identifier"
+                          },
+                          {
+                            "end": 214,
+                            "start": 213,
+                            "type": "PipeSubstitution",
+                            "type": "PipeSubstitution"
+                          }
+                        ],
+                        "callee": {
+                          "end": 208,
+                          "name": "lineTo",
+                          "start": 202,
+                          "type": "Identifier"
+                        },
+                        "end": 215,
+                        "start": 202,
+                        "type": "CallExpression",
+                        "type": "CallExpression"
+                      },
+                      {
+                        "arguments": [
+                          {
+                            "end": 232,
+                            "name": "p2",
+                            "start": 230,
+                            "type": "Identifier",
+                            "type": "Identifier"
+                          },
+                          {
+                            "end": 235,
+                            "start": 234,
+                            "type": "PipeSubstitution",
+                            "type": "PipeSubstitution"
+                          }
+                        ],
+                        "callee": {
+                          "end": 229,
+                          "name": "lineTo",
+                          "start": 223,
+                          "type": "Identifier"
+                        },
+                        "end": 236,
+                        "start": 223,
+                        "type": "CallExpression",
+                        "type": "CallExpression"
+                      },
+                      {
+                        "arguments": [
+                          {
+                            "end": 253,
+                            "name": "p3",
+                            "start": 251,
+                            "type": "Identifier",
+                            "type": "Identifier"
+                          },
+                          {
+                            "end": 256,
+                            "start": 255,
+                            "type": "PipeSubstitution",
+                            "type": "PipeSubstitution"
+                          }
+                        ],
+                        "callee": {
+                          "end": 250,
+                          "name": "lineTo",
+                          "start": 244,
+                          "type": "Identifier"
+                        },
+                        "end": 257,
+                        "start": 244,
+                        "type": "CallExpression",
+                        "type": "CallExpression"
+                      },
+                      {
+                        "arguments": [
+                          {
+                            "end": 274,
+                            "name": "p0",
+                            "start": 272,
+                            "type": "Identifier",
+                            "type": "Identifier"
+                          },
+                          {
+                            "end": 277,
+                            "start": 276,
+                            "type": "PipeSubstitution",
+                            "type": "PipeSubstitution"
+                          }
+                        ],
+                        "callee": {
+                          "end": 271,
+                          "name": "lineTo",
+                          "start": 265,
+                          "type": "Identifier"
+                        },
+                        "end": 278,
+                        "start": 265,
+                        "type": "CallExpression",
+                        "type": "CallExpression"
+                      },
+                      {
+                        "arguments": [
+                          {
+                            "end": 293,
+                            "start": 292,
+                            "type": "PipeSubstitution",
+                            "type": "PipeSubstitution"
+                          }
+                        ],
+                        "callee": {
+                          "end": 291,
+                          "name": "close",
+                          "start": 286,
+                          "type": "Identifier"
+                        },
+                        "end": 294,
+                        "start": 286,
+                        "type": "CallExpression",
+                        "type": "CallExpression"
+                      },
+                      {
+                        "arguments": [
+                          {
+                            "end": 316,
+                            "name": "length",
+                            "start": 310,
+                            "type": "Identifier",
+                            "type": "Identifier"
+                          },
+                          {
+                            "end": 319,
+                            "start": 318,
+                            "type": "PipeSubstitution",
+                            "type": "PipeSubstitution"
+                          }
+                        ],
+                        "callee": {
+                          "end": 309,
+                          "name": "extrude",
+                          "start": 302,
+                          "type": "Identifier"
+                        },
+                        "end": 320,
+                        "start": 302,
+                        "type": "CallExpression",
+                        "type": "CallExpression"
+                      }
+                    ],
+                    "end": 320,
+                    "start": 177,
+                    "type": "PipeExpression",
+                    "type": "PipeExpression"
+                  },
+                  "end": 320,
+                  "start": 170,
+                  "type": "ReturnStatement",
+                  "type": "ReturnStatement"
+                }
+              ],
+              "end": 322,
+              "nonCodeMeta": {
+                "nonCodeNodes": {
+                  "6": [
+                    {
+                      "end": 170,
+                      "start": 166,
+                      "type": "NonCodeNode",
+                      "value": {
+                        "type": "newLine"
+                      }
+                    }
+                  ]
+                },
+                "startNodes": []
+              },
+              "start": 24
+            },
+            "end": 322,
+            "params": [
+              {
+                "type": "Parameter",
+                "identifier": {
+                  "end": 14,
+                  "name": "length",
+                  "start": 8,
+                  "type": "Identifier"
+                }
+              },
+              {
+                "type": "Parameter",
+                "identifier": {
+                  "end": 22,
+                  "name": "center",
+                  "start": 16,
+                  "type": "Identifier"
+                }
+              }
+            ],
+            "start": 7,
+            "type": "FunctionExpression",
+            "type": "FunctionExpression"
+          },
+          "start": 3,
+          "type": "VariableDeclarator"
+        },
+        "end": 322,
+        "kind": "fn",
+        "start": 0,
+        "type": "VariableDeclaration",
+        "type": "VariableDeclaration"
+      },
+      {
+        "declaration": {
+          "end": 349,
+          "id": {
+            "end": 330,
+            "name": "myCube",
+            "start": 324,
+            "type": "Identifier"
+          },
+          "init": {
+            "arguments": [
+              {
+                "end": 340,
+                "raw": "40",
+                "start": 338,
+                "type": "Literal",
+                "type": "Literal",
+                "value": {
+                  "value": 40.0,
+                  "suffix": "None"
+                }
+              },
+              {
+                "elements": [
+                  {
+                    "end": 344,
+                    "raw": "0",
+                    "start": 343,
+                    "type": "Literal",
+                    "type": "Literal",
+                    "value": {
+                      "value": 0.0,
+                      "suffix": "None"
+                    }
+                  },
+                  {
+                    "end": 347,
+                    "raw": "0",
+                    "start": 346,
+                    "type": "Literal",
+                    "type": "Literal",
+                    "value": {
+                      "value": 0.0,
+                      "suffix": "None"
+                    }
+                  }
+                ],
+                "end": 348,
+                "start": 342,
+                "type": "ArrayExpression",
+                "type": "ArrayExpression"
+              }
+            ],
+            "callee": {
+              "end": 337,
+              "name": "cube",
+              "start": 333,
+              "type": "Identifier"
+            },
+            "end": 349,
+            "start": 333,
+            "type": "CallExpression",
+            "type": "CallExpression"
+          },
+          "start": 324,
+          "type": "VariableDeclarator"
+        },
+        "end": 349,
+        "kind": "const",
+        "start": 324,
+        "type": "VariableDeclaration",
+        "type": "VariableDeclaration"
+      },
+      {
+        "end": 398,
+        "expression": {
+          "end": 398,
+          "name": "foo",
+          "start": 395,
+          "type": "Identifier",
+          "type": "Identifier"
+        },
+        "start": 395,
+        "type": "ExpressionStatement",
+        "type": "ExpressionStatement"
+      }
+    ],
+    "end": 399,
+    "nonCodeMeta": {
+      "nonCodeNodes": {
+        "0": [
+          {
+            "end": 324,
+            "start": 322,
+            "type": "NonCodeNode",
+            "value": {
+              "type": "newLine"
+            }
+          }
+        ],
+        "1": [
+          {
+            "end": 394,
+            "start": 349,
+            "type": "NonCodeNode",
+            "value": {
+              "type": "newLineBlockComment",
+              "value": "Error, after creating meaningful output.",
+              "style": "line"
+            }
+          }
+        ]
+      },
+      "startNodes": []
+    },
+    "start": 0
+  }
+}

--- a/src/wasm-lib/kcl/tests/cube_with_error/execution_error.snap
+++ b/src/wasm-lib/kcl/tests/cube_with_error/execution_error.snap
@@ -1,0 +1,12 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Error from executing cube_with_error.kcl
+---
+KCL UndefinedValue error
+
+  × undefined value: memory item key `foo` is not defined
+    ╭─[22:1]
+ 21 │ // Error, after creating meaningful output.
+ 22 │ foo
+    · ───
+    ╰────

--- a/src/wasm-lib/kcl/tests/cube_with_error/input.kcl
+++ b/src/wasm-lib/kcl/tests/cube_with_error/input.kcl
@@ -1,0 +1,22 @@
+fn cube(length, center) {
+  l = length / 2
+  x = center[0]
+  y = center[1]
+  p0 = [-l + x, -l + y]
+  p1 = [-l + x, l + y]
+  p2 = [l + x, l + y]
+  p3 = [l + x, -l + y]
+
+  return startSketchAt(p0)
+    |> lineTo(p1, %)
+    |> lineTo(p2, %)
+    |> lineTo(p3, %)
+    |> lineTo(p0, %)
+    |> close(%)
+    |> extrude(length, %)
+}
+
+myCube = cube(40, [0, 0])
+
+// Error, after creating meaningful output.
+foo

--- a/src/wasm-lib/kcl/tests/cube_with_error/ops.snap
+++ b/src/wasm-lib/kcl/tests/cube_with_error/ops.snap
@@ -1,0 +1,51 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Operations executed cube_with_error.kcl
+---
+[
+  {
+    "type": "UserDefinedFunctionCall",
+    "name": "cube",
+    "functionSourceRange": [
+      7,
+      322,
+      0
+    ],
+    "unlabeledArg": null,
+    "labeledArgs": {},
+    "sourceRange": [
+      333,
+      349,
+      0
+    ]
+  },
+  {
+    "labeledArgs": {
+      "length": {
+        "sourceRange": [
+          310,
+          316,
+          0
+        ]
+      },
+      "sketch_set": {
+        "sourceRange": [
+          318,
+          319,
+          0
+        ]
+      }
+    },
+    "name": "extrude",
+    "sourceRange": [
+      302,
+      320,
+      0
+    ],
+    "type": "StdLibCall",
+    "unlabeledArg": null
+  },
+  {
+    "type": "UserDefinedFunctionReturn"
+  }
+]

--- a/src/wasm-lib/kcl/tests/import_cycle1/artifact_graph_flowchart.snap
+++ b/src/wasm-lib/kcl/tests/import_cycle1/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph flowchart import_cycle1.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/import_cycle1/artifact_graph_flowchart.snap.md
+++ b/src/wasm-lib/kcl/tests/import_cycle1/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/src/wasm-lib/kcl/tests/import_cycle1/artifact_graph_mind_map.snap
+++ b/src/wasm-lib/kcl/tests/import_cycle1/artifact_graph_mind_map.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph mind map import_cycle1.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/import_cycle1/artifact_graph_mind_map.snap.md
+++ b/src/wasm-lib/kcl/tests/import_cycle1/artifact_graph_mind_map.snap.md
@@ -1,0 +1,4 @@
+```mermaid
+mindmap
+  root
+```

--- a/src/wasm-lib/kcl/tests/invalid_index_fractional/artifact_graph_flowchart.snap
+++ b/src/wasm-lib/kcl/tests/invalid_index_fractional/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph flowchart invalid_index_fractional.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/invalid_index_fractional/artifact_graph_flowchart.snap.md
+++ b/src/wasm-lib/kcl/tests/invalid_index_fractional/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/src/wasm-lib/kcl/tests/invalid_index_fractional/artifact_graph_mind_map.snap
+++ b/src/wasm-lib/kcl/tests/invalid_index_fractional/artifact_graph_mind_map.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph mind map invalid_index_fractional.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/invalid_index_fractional/artifact_graph_mind_map.snap.md
+++ b/src/wasm-lib/kcl/tests/invalid_index_fractional/artifact_graph_mind_map.snap.md
@@ -1,0 +1,4 @@
+```mermaid
+mindmap
+  root
+```

--- a/src/wasm-lib/kcl/tests/invalid_index_negative/artifact_graph_flowchart.snap
+++ b/src/wasm-lib/kcl/tests/invalid_index_negative/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph flowchart invalid_index_negative.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/invalid_index_negative/artifact_graph_flowchart.snap.md
+++ b/src/wasm-lib/kcl/tests/invalid_index_negative/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/src/wasm-lib/kcl/tests/invalid_index_negative/artifact_graph_mind_map.snap
+++ b/src/wasm-lib/kcl/tests/invalid_index_negative/artifact_graph_mind_map.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph mind map invalid_index_negative.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/invalid_index_negative/artifact_graph_mind_map.snap.md
+++ b/src/wasm-lib/kcl/tests/invalid_index_negative/artifact_graph_mind_map.snap.md
@@ -1,0 +1,4 @@
+```mermaid
+mindmap
+  root
+```

--- a/src/wasm-lib/kcl/tests/invalid_index_str/artifact_graph_flowchart.snap
+++ b/src/wasm-lib/kcl/tests/invalid_index_str/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph flowchart invalid_index_str.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/invalid_index_str/artifact_graph_flowchart.snap.md
+++ b/src/wasm-lib/kcl/tests/invalid_index_str/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/src/wasm-lib/kcl/tests/invalid_index_str/artifact_graph_mind_map.snap
+++ b/src/wasm-lib/kcl/tests/invalid_index_str/artifact_graph_mind_map.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph mind map invalid_index_str.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/invalid_index_str/artifact_graph_mind_map.snap.md
+++ b/src/wasm-lib/kcl/tests/invalid_index_str/artifact_graph_mind_map.snap.md
@@ -1,0 +1,4 @@
+```mermaid
+mindmap
+  root
+```

--- a/src/wasm-lib/kcl/tests/invalid_member_object/artifact_graph_flowchart.snap
+++ b/src/wasm-lib/kcl/tests/invalid_member_object/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph flowchart invalid_member_object.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/invalid_member_object/artifact_graph_flowchart.snap.md
+++ b/src/wasm-lib/kcl/tests/invalid_member_object/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/src/wasm-lib/kcl/tests/invalid_member_object/artifact_graph_mind_map.snap
+++ b/src/wasm-lib/kcl/tests/invalid_member_object/artifact_graph_mind_map.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph mind map invalid_member_object.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/invalid_member_object/artifact_graph_mind_map.snap.md
+++ b/src/wasm-lib/kcl/tests/invalid_member_object/artifact_graph_mind_map.snap.md
@@ -1,0 +1,4 @@
+```mermaid
+mindmap
+  root
+```

--- a/src/wasm-lib/kcl/tests/invalid_member_object_prop/artifact_graph_flowchart.snap
+++ b/src/wasm-lib/kcl/tests/invalid_member_object_prop/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph flowchart invalid_member_object_prop.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/invalid_member_object_prop/artifact_graph_flowchart.snap.md
+++ b/src/wasm-lib/kcl/tests/invalid_member_object_prop/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/src/wasm-lib/kcl/tests/invalid_member_object_prop/artifact_graph_mind_map.snap
+++ b/src/wasm-lib/kcl/tests/invalid_member_object_prop/artifact_graph_mind_map.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph mind map invalid_member_object_prop.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/invalid_member_object_prop/artifact_graph_mind_map.snap.md
+++ b/src/wasm-lib/kcl/tests/invalid_member_object_prop/artifact_graph_mind_map.snap.md
@@ -1,0 +1,4 @@
+```mermaid
+mindmap
+  root
+```

--- a/src/wasm-lib/kcl/tests/kw_fn_too_few_args/artifact_graph_flowchart.snap
+++ b/src/wasm-lib/kcl/tests/kw_fn_too_few_args/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph flowchart kw_fn_too_few_args.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/kw_fn_too_few_args/artifact_graph_flowchart.snap.md
+++ b/src/wasm-lib/kcl/tests/kw_fn_too_few_args/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/src/wasm-lib/kcl/tests/kw_fn_too_few_args/artifact_graph_mind_map.snap
+++ b/src/wasm-lib/kcl/tests/kw_fn_too_few_args/artifact_graph_mind_map.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph mind map kw_fn_too_few_args.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/kw_fn_too_few_args/artifact_graph_mind_map.snap.md
+++ b/src/wasm-lib/kcl/tests/kw_fn_too_few_args/artifact_graph_mind_map.snap.md
@@ -1,0 +1,4 @@
+```mermaid
+mindmap
+  root
+```

--- a/src/wasm-lib/kcl/tests/kw_fn_unlabeled_but_has_label/artifact_graph_flowchart.snap
+++ b/src/wasm-lib/kcl/tests/kw_fn_unlabeled_but_has_label/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph flowchart kw_fn_unlabeled_but_has_label.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/kw_fn_unlabeled_but_has_label/artifact_graph_flowchart.snap.md
+++ b/src/wasm-lib/kcl/tests/kw_fn_unlabeled_but_has_label/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/src/wasm-lib/kcl/tests/kw_fn_unlabeled_but_has_label/artifact_graph_mind_map.snap
+++ b/src/wasm-lib/kcl/tests/kw_fn_unlabeled_but_has_label/artifact_graph_mind_map.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph mind map kw_fn_unlabeled_but_has_label.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/kw_fn_unlabeled_but_has_label/artifact_graph_mind_map.snap.md
+++ b/src/wasm-lib/kcl/tests/kw_fn_unlabeled_but_has_label/artifact_graph_mind_map.snap.md
@@ -1,0 +1,4 @@
+```mermaid
+mindmap
+  root
+```

--- a/src/wasm-lib/kcl/tests/non_string_key_of_object/artifact_graph_flowchart.snap
+++ b/src/wasm-lib/kcl/tests/non_string_key_of_object/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph flowchart non_string_key_of_object.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/non_string_key_of_object/artifact_graph_flowchart.snap.md
+++ b/src/wasm-lib/kcl/tests/non_string_key_of_object/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/src/wasm-lib/kcl/tests/non_string_key_of_object/artifact_graph_mind_map.snap
+++ b/src/wasm-lib/kcl/tests/non_string_key_of_object/artifact_graph_mind_map.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph mind map non_string_key_of_object.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/non_string_key_of_object/artifact_graph_mind_map.snap.md
+++ b/src/wasm-lib/kcl/tests/non_string_key_of_object/artifact_graph_mind_map.snap.md
@@ -1,0 +1,4 @@
+```mermaid
+mindmap
+  root
+```

--- a/src/wasm-lib/kcl/tests/object_prop_not_found/artifact_graph_flowchart.snap
+++ b/src/wasm-lib/kcl/tests/object_prop_not_found/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph flowchart object_prop_not_found.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/object_prop_not_found/artifact_graph_flowchart.snap.md
+++ b/src/wasm-lib/kcl/tests/object_prop_not_found/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/src/wasm-lib/kcl/tests/object_prop_not_found/artifact_graph_mind_map.snap
+++ b/src/wasm-lib/kcl/tests/object_prop_not_found/artifact_graph_mind_map.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph mind map object_prop_not_found.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/object_prop_not_found/artifact_graph_mind_map.snap.md
+++ b/src/wasm-lib/kcl/tests/object_prop_not_found/artifact_graph_mind_map.snap.md
@@ -1,0 +1,4 @@
+```mermaid
+mindmap
+  root
+```

--- a/src/wasm-lib/kcl/tests/pipe_substitution_inside_function_called_from_pipeline/artifact_graph_flowchart.snap
+++ b/src/wasm-lib/kcl/tests/pipe_substitution_inside_function_called_from_pipeline/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph flowchart pipe_substitution_inside_function_called_from_pipeline.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/pipe_substitution_inside_function_called_from_pipeline/artifact_graph_flowchart.snap.md
+++ b/src/wasm-lib/kcl/tests/pipe_substitution_inside_function_called_from_pipeline/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/src/wasm-lib/kcl/tests/pipe_substitution_inside_function_called_from_pipeline/artifact_graph_mind_map.snap
+++ b/src/wasm-lib/kcl/tests/pipe_substitution_inside_function_called_from_pipeline/artifact_graph_mind_map.snap
@@ -1,0 +1,6 @@
+---
+source: kcl/src/simulation_tests.rs
+description: Artifact graph mind map pipe_substitution_inside_function_called_from_pipeline.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/src/wasm-lib/kcl/tests/pipe_substitution_inside_function_called_from_pipeline/artifact_graph_mind_map.snap.md
+++ b/src/wasm-lib/kcl/tests/pipe_substitution_inside_function_called_from_pipeline/artifact_graph_mind_map.snap.md
@@ -1,0 +1,4 @@
+```mermaid
+mindmap
+  root
+```


### PR DESCRIPTION
Follow-up to #5068 to test artifact graph output when there's a KCL execution error. The frontend expects that we always generate it, even when there's an error.

Interestingly, the output is different for a cube when there's an error afterwards. Compare the generated output files of the old `cube` test vs. the new `cube_with_error` test. It's missing the outgoing `solid3d_get_opposite_edge` and `solid3d_get_next_adjacent_edge` commands and everything that results from them.