### PR TITLE
Fix to not error when using imported whole modules

### DIFF
--- a/src/wasm-lib/kcl/src/execution/mod.rs
+++ b/src/wasm-lib/kcl/src/execution/mod.rs
@@ -2642,15 +2642,15 @@ impl ExecutorContext {
                     let (result, _, _) = self
                         .exec_module(module_id, exec_state, ExecutionKind::Normal, metadata.source_range)
                         .await?;
-                    result.ok_or_else(|| {
-                        KclError::Semantic(KclErrorDetails {
-                            message: format!(
-                                "Evaluating module `{}` as part of an assembly did not produce a result",
-                                identifier.name
-                            ),
-                            source_ranges: vec![metadata.source_range, meta[0].source_range],
-                        })
-                    })?
+                    result.unwrap_or_else(|| {
+                        // The module didn't have a return value.
+                        let mut new_meta = vec![metadata.to_owned()];
+                        new_meta.extend(meta);
+                        KclValue::KclNone {
+                            value: Default::default(),
+                            meta: new_meta,
+                        }
+                    })
                 } else {
                     value
                 }

--- a/src/wasm-lib/kcl/src/execution/mod.rs
+++ b/src/wasm-lib/kcl/src/execution/mod.rs
@@ -2643,7 +2643,12 @@ impl ExecutorContext {
                         .exec_module(module_id, exec_state, ExecutionKind::Normal, metadata.source_range)
                         .await?;
                     result.unwrap_or_else(|| {
-                        // The module didn't have a return value.
+                        // The module didn't have a return value.  Currently,
+                        // the only way to have a return value is with the final
+                        // statement being an expression statement.
+                        //
+                        // TODO: Make a warning when we support them in the
+                        // execution phase.
                         let mut new_meta = vec![metadata.to_owned()];
                         new_meta.extend(meta);
                         KclValue::KclNone {


### PR DESCRIPTION
When you use a whole module, it gives this error.

```kcl
import 'robot-arm-base.kcl' as robotArmBase

robotArmBase
```

```
Executing module `robotArmBase` as part of an assembly did not produce a result
```

As far as I know, there's no way to produce a result from a whole module. So I think we can ignore this and return an empty KCL value.

Part of #4683.
[Slack](https://kittycadworkspace.slack.com/archives/C06L2RHP9SL/p1738002224480849)