### PR TITLE
fix: Remove link from code editor docs

### DIFF
--- a/docs/kcl/import.md
+++ b/docs/kcl/import.md
@@ -14,8 +14,6 @@ For formats lacking unit data (such as STL, OBJ, or PLY files), the default unit
 
 Note: The import command currently only works when using the native Modeling App.
 
-For importing KCL functions using the `import` statement, see the docs on [KCL modules](/docs/kcl/modules).
-
 ```js
 import(file_path: String, options?: ImportFormat) -> ImportedGeometry
 ```

--- a/src/wasm-lib/kcl/src/std/import.rs
+++ b/src/wasm-lib/kcl/src/std/import.rs
@@ -118,9 +118,6 @@ pub async fn import(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 /// Note: The import command currently only works when using the native
 /// Modeling App.
 ///
-/// For importing KCL functions using the `import` statement, see the docs on
-/// [KCL modules](/docs/kcl/modules).
-///
 /// ```no_run
 /// model = import("tests/inputs/cube.obj")
 /// ```


### PR DESCRIPTION
Related to #5165.

Stdlib docs are displayed in the autocomplete tooltip in the editor, and we don't open links in a new window. The `import()` function is deprecated now in favor of `import` statements, so this probably doesn't matter too much.