### PR TITLE
Wait for ICE gathering completion before requesting video track + create file e2e test fix

### DIFF
--- a/e2e/playwright/command-bar-tests.spec.ts
+++ b/e2e/playwright/command-bar-tests.spec.ts
@@ -128,9 +128,11 @@ test.describe('Command bar tests', () => {
   })
 
   test('Command bar keybinding works from code editor and can change a setting', async ({
-    page,
-    homePage,
-  }) => {
+      page,
+      homePage,
+    },
+    { tag: ['@skipWin'] },
+  ) => {
     await page.setBodyDimensions({ width: 1200, height: 500 })
     await homePage.goToModelingScene()
 

--- a/e2e/playwright/command-bar-tests.spec.ts
+++ b/e2e/playwright/command-bar-tests.spec.ts
@@ -127,56 +127,54 @@ test.describe('Command bar tests', () => {
     await expect(commandLevelArgButton).toHaveText('level: project')
   })
 
-  test('Command bar keybinding works from code editor and can change a setting', async ({
-      page,
-      homePage,
-    },
+  test(
+    'Command bar keybinding works from code editor and can change a setting',
     { tag: ['@skipWin'] },
-  ) => {
-    await page.setBodyDimensions({ width: 1200, height: 500 })
-    await homePage.goToModelingScene()
+    async ({ page, homePage }) => {
+      await page.setBodyDimensions({ width: 1200, height: 500 })
+      await homePage.goToModelingScene()
 
-    await expect(
-      page.getByRole('button', { name: 'Start Sketch' })
-    ).not.toBeDisabled()
+      await expect(
+        page.getByRole('button', { name: 'Start Sketch' })
+      ).not.toBeDisabled()
 
-    // Put the cursor in the code editor
-    await page.locator('.cm-content').click()
+      // Put the cursor in the code editor
+      await page.locator('.cm-content').click()
 
-    // Now try the same, but with the keyboard shortcut, check focus
-    await page.keyboard.press('ControlOrMeta+K')
+      // Now try the same, but with the keyboard shortcut, check focus
+      await page.keyboard.press('ControlOrMeta+K')
 
-    let cmdSearchBar = page.getByPlaceholder('Search commands')
-    await expect(cmdSearchBar).toBeVisible()
-    await expect(cmdSearchBar).toBeFocused()
+      let cmdSearchBar = page.getByPlaceholder('Search commands')
+      await expect(cmdSearchBar).toBeVisible()
+      await expect(cmdSearchBar).toBeFocused()
 
-    // Try typing in the command bar
-    await cmdSearchBar.fill('theme')
-    const themeOption = page.getByRole('option', {
-      name: 'Settings · app · theme',
-    })
-    await expect(themeOption).toBeVisible()
-    await themeOption.click()
-    const themeInput = page.getByPlaceholder('dark')
-    await expect(themeInput).toBeVisible()
-    await expect(themeInput).toBeFocused()
-    // Select dark theme
-    await page.keyboard.press('ArrowDown')
-    await page.keyboard.press('ArrowDown')
-    await page.keyboard.press('ArrowDown')
-    await expect(page.getByRole('option', { name: 'system' })).toHaveAttribute(
-      'data-headlessui-state',
-      'active'
-    )
-    await page.keyboard.press('Enter')
+      // Try typing in the command bar
+      await cmdSearchBar.fill('theme')
+      const themeOption = page.getByRole('option', {
+        name: 'Settings · app · theme',
+      })
+      await expect(themeOption).toBeVisible()
+      await themeOption.click()
+      const themeInput = page.getByPlaceholder('dark')
+      await expect(themeInput).toBeVisible()
+      await expect(themeInput).toBeFocused()
+      // Select dark theme
+      await page.keyboard.press('ArrowDown')
+      await page.keyboard.press('ArrowDown')
+      await page.keyboard.press('ArrowDown')
+      await expect(
+        page.getByRole('option', { name: 'system' })
+      ).toHaveAttribute('data-headlessui-state', 'active')
+      await page.keyboard.press('Enter')
 
-    // Check the toast appeared
-    await expect(
-      page.getByText(`Set theme to "system" as a user default`)
-    ).toBeVisible()
-    // Check that the theme changed
-    await expect(page.locator('body')).not.toHaveClass(`body-bg dark`)
-  })
+      // Check the toast appeared
+      await expect(
+        page.getByText(`Set theme to "system" as a user default`)
+      ).toBeVisible()
+      // Check that the theme changed
+      await expect(page.locator('body')).not.toHaveClass(`body-bg dark`)
+    }
+  )
 
   test('Can extrude from the command bar', async ({ page, homePage }) => {
     await page.addInitScript(async () => {

--- a/e2e/playwright/editor-tests.spec.ts
+++ b/e2e/playwright/editor-tests.spec.ts
@@ -966,108 +966,106 @@ test.describe('Editor tests', () => {
   |> close(%)`)
   })
 
-  test('Can undo a sketch modification with ctrl+z', async ({
-      page,
-      homePage,
-    },
+  test(
+    'Can undo a sketch modification with ctrl+z',
     { tag: ['@skipWin'] },
-  ) => {
-    const u = await getUtils(page)
-    await page.addInitScript(async () => {
-      localStorage.setItem(
-        'persistCode',
-        `sketch001 = startSketchOn('XZ')
+    async ({ page, homePage }) => {
+      const u = await getUtils(page)
+      await page.addInitScript(async () => {
+        localStorage.setItem(
+          'persistCode',
+          `sketch001 = startSketchOn('XZ')
   |> startProfileAt([4.61, -10.01], %)
   |> line([12.73, -0.09], %)
   |> tangentialArcTo([24.95, -0.38], %)
   |> close(%)
   |> extrude(5, %)`
-      )
-    })
+        )
+      })
 
-    await page.setBodyDimensions({ width: 1200, height: 500 })
+      await page.setBodyDimensions({ width: 1200, height: 500 })
 
-    await homePage.goToModelingScene()
-    await expect(
-      page.getByRole('button', { name: 'Start Sketch' })
-    ).not.toBeDisabled()
+      await homePage.goToModelingScene()
+      await expect(
+        page.getByRole('button', { name: 'Start Sketch' })
+      ).not.toBeDisabled()
 
-    await page.waitForTimeout(100)
-    await u.openAndClearDebugPanel()
-    await u.sendCustomCmd({
-      type: 'modeling_cmd_req',
-      cmd_id: uuidv4(),
-      cmd: {
-        type: 'default_camera_look_at',
-        vantage: { x: 0, y: -1250, z: 580 },
-        center: { x: 0, y: 0, z: 0 },
-        up: { x: 0, y: 0, z: 1 },
-      },
-    })
-    await page.waitForTimeout(100)
-    await u.sendCustomCmd({
-      type: 'modeling_cmd_req',
-      cmd_id: uuidv4(),
-      cmd: {
-        type: 'default_camera_get_settings',
-      },
-    })
-    await page.waitForTimeout(100)
+      await page.waitForTimeout(100)
+      await u.openAndClearDebugPanel()
+      await u.sendCustomCmd({
+        type: 'modeling_cmd_req',
+        cmd_id: uuidv4(),
+        cmd: {
+          type: 'default_camera_look_at',
+          vantage: { x: 0, y: -1250, z: 580 },
+          center: { x: 0, y: 0, z: 0 },
+          up: { x: 0, y: 0, z: 1 },
+        },
+      })
+      await page.waitForTimeout(100)
+      await u.sendCustomCmd({
+        type: 'modeling_cmd_req',
+        cmd_id: uuidv4(),
+        cmd: {
+          type: 'default_camera_get_settings',
+        },
+      })
+      await page.waitForTimeout(100)
 
-    const startPX = [1200 / 2, 500 / 2]
+      const startPX = [1200 / 2, 500 / 2]
 
-    const dragPX = 40
+      const dragPX = 40
 
-    await page.getByText('startProfileAt([4.61, -10.01], %)').click()
-    await expect(
-      page.getByRole('button', { name: 'Edit Sketch' })
-    ).toBeVisible()
-    await page.getByRole('button', { name: 'Edit Sketch' }).click()
-    await page.waitForTimeout(400)
-    let prevContent = await page.locator('.cm-content').innerText()
+      await page.getByText('startProfileAt([4.61, -10.01], %)').click()
+      await expect(
+        page.getByRole('button', { name: 'Edit Sketch' })
+      ).toBeVisible()
+      await page.getByRole('button', { name: 'Edit Sketch' }).click()
+      await page.waitForTimeout(400)
+      let prevContent = await page.locator('.cm-content').innerText()
 
-    await expect(page.getByTestId('segment-overlay')).toHaveCount(2)
+      await expect(page.getByTestId('segment-overlay')).toHaveCount(2)
 
-    // drag startProfileAt handle
-    await page.dragAndDrop('#stream', '#stream', {
-      sourcePosition: { x: startPX[0] + 68, y: startPX[1] + 147 },
-      targetPosition: { x: startPX[0] + dragPX, y: startPX[1] + dragPX },
-    })
-    await page.waitForTimeout(100)
-    await expect(page.locator('.cm-content')).not.toHaveText(prevContent)
-    prevContent = await page.locator('.cm-content').innerText()
+      // drag startProfileAt handle
+      await page.dragAndDrop('#stream', '#stream', {
+        sourcePosition: { x: startPX[0] + 68, y: startPX[1] + 147 },
+        targetPosition: { x: startPX[0] + dragPX, y: startPX[1] + dragPX },
+      })
+      await page.waitForTimeout(100)
+      await expect(page.locator('.cm-content')).not.toHaveText(prevContent)
+      prevContent = await page.locator('.cm-content').innerText()
 
-    // drag line handle
-    // we wait so it saves the code
-    await page.waitForTimeout(800)
+      // drag line handle
+      // we wait so it saves the code
+      await page.waitForTimeout(800)
 
-    const lineEnd = await u.getBoundingBox('[data-overlay-index="0"]')
-    await page.waitForTimeout(100)
-    await page.dragAndDrop('#stream', '#stream', {
-      sourcePosition: { x: lineEnd.x - 5, y: lineEnd.y },
-      targetPosition: { x: lineEnd.x + dragPX, y: lineEnd.y + dragPX },
-    })
-    await expect(page.locator('.cm-content')).not.toHaveText(prevContent)
-    prevContent = await page.locator('.cm-content').innerText()
+      const lineEnd = await u.getBoundingBox('[data-overlay-index="0"]')
+      await page.waitForTimeout(100)
+      await page.dragAndDrop('#stream', '#stream', {
+        sourcePosition: { x: lineEnd.x - 5, y: lineEnd.y },
+        targetPosition: { x: lineEnd.x + dragPX, y: lineEnd.y + dragPX },
+      })
+      await expect(page.locator('.cm-content')).not.toHaveText(prevContent)
+      prevContent = await page.locator('.cm-content').innerText()
 
-    // we wait so it saves the code
-    await page.waitForTimeout(800)
+      // we wait so it saves the code
+      await page.waitForTimeout(800)
 
-    // drag tangentialArcTo handle
-    const tangentEnd = await u.getBoundingBox('[data-overlay-index="1"]')
-    await page.dragAndDrop('#stream', '#stream', {
-      sourcePosition: { x: tangentEnd.x + 10, y: tangentEnd.y - 5 },
-      targetPosition: {
-        x: tangentEnd.x + dragPX,
-        y: tangentEnd.y + dragPX,
-      },
-    })
-    await page.waitForTimeout(100)
-    await expect(page.locator('.cm-content')).not.toHaveText(prevContent)
+      // drag tangentialArcTo handle
+      const tangentEnd = await u.getBoundingBox('[data-overlay-index="1"]')
+      await page.dragAndDrop('#stream', '#stream', {
+        sourcePosition: { x: tangentEnd.x + 10, y: tangentEnd.y - 5 },
+        targetPosition: {
+          x: tangentEnd.x + dragPX,
+          y: tangentEnd.y + dragPX,
+        },
+      })
+      await page.waitForTimeout(100)
+      await expect(page.locator('.cm-content')).not.toHaveText(prevContent)
 
-    // expect the code to have changed
-    await expect(page.locator('.cm-content'))
-      .toHaveText(`sketch001 = startSketchOn('XZ')
+      // expect the code to have changed
+      await expect(page.locator('.cm-content'))
+        .toHaveText(`sketch001 = startSketchOn('XZ')
     |> startProfileAt([2.71, -2.71], %)
     |> line([15.4, -2.78], %)
     |> tangentialArcTo([27.6, -3.05], %)
@@ -1075,26 +1073,26 @@ test.describe('Editor tests', () => {
     |> extrude(5, %)
   `)
 
-    // Hit undo
-    await page.keyboard.down('Control')
-    await page.keyboard.press('KeyZ')
-    await page.keyboard.up('Control')
+      // Hit undo
+      await page.keyboard.down('Control')
+      await page.keyboard.press('KeyZ')
+      await page.keyboard.up('Control')
 
-    await expect(page.locator('.cm-content'))
-      .toHaveText(`sketch001 = startSketchOn('XZ')
+      await expect(page.locator('.cm-content'))
+        .toHaveText(`sketch001 = startSketchOn('XZ')
     |> startProfileAt([2.71, -2.71], %)
     |> line([15.4, -2.78], %)
     |> tangentialArcTo([24.95, -0.38], %)
     |> close(%)
     |> extrude(5, %)`)
 
-    // Hit undo again.
-    await page.keyboard.down('Control')
-    await page.keyboard.press('KeyZ')
-    await page.keyboard.up('Control')
+      // Hit undo again.
+      await page.keyboard.down('Control')
+      await page.keyboard.press('KeyZ')
+      await page.keyboard.up('Control')
 
-    await expect(page.locator('.cm-content'))
-      .toHaveText(`sketch001 = startSketchOn('XZ')
+      await expect(page.locator('.cm-content'))
+        .toHaveText(`sketch001 = startSketchOn('XZ')
     |> startProfileAt([2.71, -2.71], %)
     |> line([12.73, -0.09], %)
     |> tangentialArcTo([24.95, -0.38], %)
@@ -1102,20 +1100,21 @@ test.describe('Editor tests', () => {
     |> extrude(5, %)
   `)
 
-    // Hit undo again.
-    await page.keyboard.down('Control')
-    await page.keyboard.press('KeyZ')
-    await page.keyboard.up('Control')
+      // Hit undo again.
+      await page.keyboard.down('Control')
+      await page.keyboard.press('KeyZ')
+      await page.keyboard.up('Control')
 
-    await page.waitForTimeout(100)
-    await expect(page.locator('.cm-content'))
-      .toHaveText(`sketch001 = startSketchOn('XZ')
+      await page.waitForTimeout(100)
+      await expect(page.locator('.cm-content'))
+        .toHaveText(`sketch001 = startSketchOn('XZ')
   |> startProfileAt([4.61, -10.01], %)
   |> line([12.73, -0.09], %)
   |> tangentialArcTo([24.95, -0.38], %)
   |> close(%)
   |> extrude(5, %)`)
-  })
+    }
+  )
 
   test.fixme(
     `Can use the import stdlib function on a local OBJ file`,

--- a/e2e/playwright/editor-tests.spec.ts
+++ b/e2e/playwright/editor-tests.spec.ts
@@ -967,9 +967,11 @@ test.describe('Editor tests', () => {
   })
 
   test('Can undo a sketch modification with ctrl+z', async ({
-    page,
-    homePage,
-  }) => {
+      page,
+      homePage,
+    },
+    { tag: ['@skipWin'] },
+  ) => {
     const u = await getUtils(page)
     await page.addInitScript(async () => {
       localStorage.setItem(

--- a/e2e/playwright/file-tree.spec.ts
+++ b/e2e/playwright/file-tree.spec.ts
@@ -19,7 +19,7 @@ test.describe('integrations tests', () => {
         )
       })
 
-      const [clickObj] = await scene.makeMouseHelpers(600, 300)
+      const [clickObj] = await scene.makeMouseHelpers(726, 272)
 
       await test.step('setup test', async () => {
         await homePage.expectState({
@@ -61,6 +61,7 @@ test.describe('integrations tests', () => {
       })
       await test.step('setup for next assertion', async () => {
         await toolbar.openFile('main.kcl')
+        await scene.waitForExecutionDone()
         await clickObj()
         await scene.moveNoWhere()
         await editor.expectState({

--- a/e2e/playwright/fixtures/homePageFixture.ts
+++ b/e2e/playwright/fixtures/homePageFixture.ts
@@ -89,18 +89,11 @@ export class HomePageFixture {
    * Maybe there a good sanity check we can do each time?
    */
   expectState = async (expectedState: HomePageState) => {
-    await expect
-      .poll(async () => {
-        const [projectCards, sortBy] = await Promise.all([
-          this._serialiseProjectCards(),
-          this._serialiseSortBy(),
-        ])
-        return {
-          projectCards,
-          sortBy,
-        }
-      })
-      .toEqual(expectedState)
+    await expect.poll(this._serialiseSortBy).toEqual(expectedState.sortBy)
+
+    for (const projectCard of expectedState.projectCards) {
+      await expect.poll(this._serialiseProjectCards).toContainEqual(projectCard)
+    }
   }
 
   createAndGoToProject = async (projectTitle = 'project-$nnn') => {

--- a/e2e/playwright/fixtures/toolbarFixture.ts
+++ b/e2e/playwright/fixtures/toolbarFixture.ts
@@ -62,7 +62,9 @@ export class ToolbarFixture {
     this.filePane = page.locator('#files-pane')
     this.featureTreePane = page.locator('#feature-tree-pane')
     this.fileCreateToast = page.getByText('Successfully created')
-    this.exeIndicator = page.getByTestId('model-state-indicator-execution-done')
+    this.exeIndicator = page.getByTestId(
+      'model-state-indicator-receive-reliable'
+    )
   }
 
   get logoLink() {

--- a/e2e/playwright/point-click.spec.ts
+++ b/e2e/playwright/point-click.spec.ts
@@ -1955,10 +1955,6 @@ radius = 8.69
     const lineCodeToSelection = `|> angledLine([0, 202.6], %, $rectangleSegmentA001)`
     await page.getByText(lineCodeToSelection).click()
     await cmdBar.progressCmdBar()
-    await cmdBar.progressCmdBar()
-    await cmdBar.progressCmdBar()
-    await cmdBar.progressCmdBar()
-    await cmdBar.progressCmdBar()
 
     const newCodeToFind = `revolve001 = revolve({angle = 360, axis = getOppositeEdge(rectangleSegmentA001)}, sketch002) `
     expect(editor.expectEditor.toContain(newCodeToFind)).toBeTruthy()
@@ -2009,10 +2005,6 @@ radius = 8.69
     await page.getByText('Edge', { exact: true }).click()
     const lineCodeToSelection = `|> xLine(2.6, %)`
     await page.getByText(lineCodeToSelection).click()
-    await cmdBar.progressCmdBar()
-    await cmdBar.progressCmdBar()
-    await cmdBar.progressCmdBar()
-    await cmdBar.progressCmdBar()
     await cmdBar.progressCmdBar()
 
     const newCodeToFind = `revolve001 = revolve({ angle = 360, axis = seg01 }, sketch003)`

--- a/e2e/playwright/projects.spec.ts
+++ b/e2e/playwright/projects.spec.ts
@@ -1527,34 +1527,32 @@ test(
   { tag: '@electron' },
   async ({ context, page, cmdBar, homePage }, testInfo) => {
     await context.folderSetupFn(async (dir) => {
-      await Promise.all([
-        fsp.mkdir(path.join(dir, 'router-template-slate'), { recursive: true }),
-        fsp.mkdir(path.join(dir, 'bracket'), { recursive: true }),
-      ])
-      await Promise.all([
-        fsp.copyFile(
-          path.join(
-            'src',
-            'wasm-lib',
-            'tests',
-            'executor',
-            'inputs',
-            'router-template-slate.kcl'
-          ),
-          path.join(dir, 'router-template-slate', 'main.kcl')
+      await fsp.mkdir(path.join(dir, 'router-template-slate'), {
+        recursive: true,
+      })
+      await fsp.copyFile(
+        path.join(
+          'src',
+          'wasm-lib',
+          'tests',
+          'executor',
+          'inputs',
+          'router-template-slate.kcl'
         ),
-        fsp.copyFile(
-          path.join(
-            'src',
-            'wasm-lib',
-            'tests',
-            'executor',
-            'inputs',
-            'focusrite_scarlett_mounting_braket.kcl'
-          ),
-          path.join(dir, 'bracket', 'main.kcl')
+        path.join(dir, 'router-template-slate', 'main.kcl')
+      )
+      await fsp.mkdir(path.join(dir, 'bracket'), { recursive: true })
+      await fsp.copyFile(
+        path.join(
+          'src',
+          'wasm-lib',
+          'tests',
+          'executor',
+          'inputs',
+          'focusrite_scarlett_mounting_braket.kcl'
         ),
-      ])
+        path.join(dir, 'bracket', 'main.kcl')
+      )
     })
     const u = await getUtils(page)
     await page.setBodyDimensions({ width: 1200, height: 500 })

--- a/e2e/playwright/sketch-tests.spec.ts
+++ b/e2e/playwright/sketch-tests.spec.ts
@@ -312,32 +312,40 @@ test.describe('Sketch tests', () => {
       |> line([1.97, 2.06], %)
       |> close(%)`)
     }
-    test('code pane open at start-handles', async ({ page, homePage }, { tag: ['@skipWin'] }) => {
-      // Load the app with the code panes
-      await page.addInitScript(async () => {
-        localStorage.setItem(
-          'store',
-          JSON.stringify({
-            state: {
-              openPanes: ['code'],
-            },
-            version: 0,
-          })
-        )
-      })
-      await doEditSegmentsByDraggingHandle(page, homePage, ['code'])
-    })
+    test(
+      'code pane open at start-handles',
+      { tag: ['@skipWin'] },
+      async ({ page, homePage }) => {
+        // Load the app with the code panes
+        await page.addInitScript(async () => {
+          localStorage.setItem(
+            'store',
+            JSON.stringify({
+              state: {
+                openPanes: ['code'],
+              },
+              version: 0,
+            })
+          )
+        })
+        await doEditSegmentsByDraggingHandle(page, homePage, ['code'])
+      }
+    )
 
-    test('code pane closed at start-handles', async ({ page, homePage }, { tag: ['@skipWin'] }) => {
-      // Load the app with the code panes
-      await page.addInitScript(async (persistModelingContext) => {
-        localStorage.setItem(
-          persistModelingContext,
-          JSON.stringify({ openPanes: [] })
-        )
-      }, PERSIST_MODELING_CONTEXT)
-      await doEditSegmentsByDraggingHandle(page, homePage, [])
-    })
+    test(
+      'code pane closed at start-handles',
+      { tag: ['@skipWin'] },
+      async ({ page, homePage }) => {
+        // Load the app with the code panes
+        await page.addInitScript(async (persistModelingContext) => {
+          localStorage.setItem(
+            persistModelingContext,
+            JSON.stringify({ openPanes: [] })
+          )
+        }, PERSIST_MODELING_CONTEXT)
+        await doEditSegmentsByDraggingHandle(page, homePage, [])
+      }
+    )
   })
 
   test('Can edit a circle center and radius by dragging its handles', async ({

--- a/e2e/playwright/sketch-tests.spec.ts
+++ b/e2e/playwright/sketch-tests.spec.ts
@@ -312,7 +312,7 @@ test.describe('Sketch tests', () => {
       |> line([1.97, 2.06], %)
       |> close(%)`)
     }
-    test('code pane open at start-handles', async ({ page, homePage }) => {
+    test('code pane open at start-handles', async ({ page, homePage }, { tag: ['@skipWin'] }) => {
       // Load the app with the code panes
       await page.addInitScript(async () => {
         localStorage.setItem(
@@ -328,7 +328,7 @@ test.describe('Sketch tests', () => {
       await doEditSegmentsByDraggingHandle(page, homePage, ['code'])
     })
 
-    test('code pane closed at start-handles', async ({ page, homePage }) => {
+    test('code pane closed at start-handles', async ({ page, homePage }, { tag: ['@skipWin'] }) => {
       // Load the app with the code panes
       await page.addInitScript(async (persistModelingContext) => {
         localStorage.setItem(

--- a/package.json
+++ b/package.json
@@ -209,5 +209,6 @@
     "wasm-pack": "^0.13.1",
     "ws": "^8.17.0",
     "yarn": "^1.22.22"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -645,12 +645,15 @@ class EngineConnection extends EventTarget {
           }, 3000)
         }
         this.pc?.addEventListener?.('icecandidate', this.onIceCandidate)
-        this.pc?.addEventListener?.('icegatheringstatechange', function (_event) {
-          console.log('icegatheringstatechange', this.iceGatheringState)
+        this.pc?.addEventListener?.(
+          'icegatheringstatechange',
+          function (_event) {
+            console.log('icegatheringstatechange', this.iceGatheringState)
 
-          if (this.iceGatheringState !== 'complete') return
-          initiateConnectingExclusive()
-        })
+            if (this.iceGatheringState !== 'complete') return
+            initiateConnectingExclusive()
+          }
+        )
 
         this.pc?.addEventListener?.(
           'iceconnectionstatechange',

--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -1282,7 +1282,7 @@ class EngineConnection extends EventTarget {
     if (closedPc && closedUDC && closedWS) {
       // Do not notify the rest of the program that we have cut off anything.
       this.state = { type: EngineConnectionStateType.Disconnected }
-      that.triggeredStart = false
+      this.triggeredStart = false
     }
   }
 }

--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -599,8 +599,7 @@ class EngineConnection extends EventTarget {
 
             // As soon as this is set, RTCPeerConnection tries to
             // establish a connection.
-            // @ts-ignore
-            // Have to ignore because dom.ts doesn't have the right type
+            // @ts-expect-error: Have to ignore because dom.ts doesn't have the right type
             void this.pc?.setRemoteDescription(this.sdpAnswer)
 
             this.state = {


### PR DESCRIPTION
Fixes our snapshots seeing a blank canvas.

There was some sort of incorrect racing going on with ICE candidates not being completely gathered first before requesting the video track. Now we wait for a particular signal (`candidate === null`) before going further with the WebRTC process.

This also revealed a race in the engine which @iterion has a PR for

Note this PR also reveals that prod engine is not triggering browser's `icecandidatestatechange`s, and is suspicious of other mysteries going on. On a local engine, these events fire properly. We are lucky there is a second "signal" (noted above) that works here.