### PR TITLE
Remove project.toml fetch during Open Sample

### DIFF
--- a/e2e/playwright/testing-samples-loading.spec.ts
+++ b/e2e/playwright/testing-samples-loading.spec.ts
@@ -69,7 +69,6 @@ test.describe('Testing in-app sample loading', () => {
       await confirmButton.click()
 
       await editor.expectEditor.toContain('// ' + newSample.title)
-      await expect(unitsToast('mm')).toBeVisible()
     })
   })
 
@@ -158,7 +157,6 @@ test.describe('Testing in-app sample loading', () => {
         await editor.expectEditor.toContain('// ' + sampleOne.title)
         await expect(newlyCreatedFile(sampleOne.file)).toBeVisible()
         await expect(projectMenuButton).toContainText(sampleOne.file)
-        await expect(unitsToast('mm')).toBeVisible()
       })
 
       await test.step(`Now overwrite the current file`, async () => {

--- a/e2e/playwright/testing-samples-loading.spec.ts
+++ b/e2e/playwright/testing-samples-loading.spec.ts
@@ -69,7 +69,7 @@ test.describe('Testing in-app sample loading', () => {
       await confirmButton.click()
 
       await editor.expectEditor.toContain('// ' + newSample.title)
-      await expect(unitsToast('in')).toBeVisible()
+      await expect(unitsToast('mm')).toBeVisible()
     })
   })
 
@@ -158,7 +158,7 @@ test.describe('Testing in-app sample loading', () => {
         await editor.expectEditor.toContain('// ' + sampleOne.title)
         await expect(newlyCreatedFile(sampleOne.file)).toBeVisible()
         await expect(projectMenuButton).toContainText(sampleOne.file)
-        await expect(unitsToast('in')).toBeVisible()
+        await expect(unitsToast('mm')).toBeVisible()
       })
 
       await test.step(`Now overwrite the current file`, async () => {

--- a/e2e/playwright/testing-samples-loading.spec.ts
+++ b/e2e/playwright/testing-samples-loading.spec.ts
@@ -186,7 +186,6 @@ test.describe('Testing in-app sample loading', () => {
         await expect(newlyCreatedFile(sampleOne.file)).toBeVisible()
         await expect(newlyCreatedFile(sampleTwo.file)).not.toBeVisible()
         await expect(projectMenuButton).toContainText(sampleOne.file)
-        await expect(unitsToast('mm')).toBeVisible()
       })
     }
   )

--- a/src/lib/kclCommands.ts
+++ b/src/lib/kclCommands.ts
@@ -1,13 +1,10 @@
 import { CommandBarOverwriteWarning } from 'components/CommandBarOverwriteWarning'
 import { Command, CommandArgumentOption } from './commandTypes'
-import { codeManager, kclManager } from './singletons'
+import { kclManager } from './singletons'
 import { isDesktop } from './isDesktop'
-import { FILE_EXT, PROJECT_SETTINGS_FILE_NAME } from './constants'
+import { FILE_EXT } from './constants'
 import { UnitLength_type } from '@kittycad/lib/dist/types/src/models'
-import { parseProjectSettings } from 'lang/wasm'
-import { err, reportRejection } from './trap'
-import { projectConfigurationToSettingsPayload } from './settings/settingsUtils'
-import { copyFileShareLink } from './links'
+import { reportRejection } from './trap'
 import { IndexLoaderData } from './types'
 
 interface OnSubmitProps {
@@ -68,55 +65,23 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
         const sampleCodeUrl = `https://raw.githubusercontent.com/KittyCAD/kcl-samples/main/${encodeURIComponent(
           projectPathPart
         )}/${encodeURIComponent(primaryKclFile)}`
-        const sampleSettingsFileUrl = `https://raw.githubusercontent.com/KittyCAD/kcl-samples/main/${encodeURIComponent(
-          projectPathPart
-        )}/${PROJECT_SETTINGS_FILE_NAME}`
 
-        Promise.allSettled([fetch(sampleCodeUrl), fetch(sampleSettingsFileUrl)])
-          .then((results) => {
-            const a =
-              'value' in results[0] ? results[0].value : results[0].reason
-            const b =
-              'value' in results[1] ? results[1].value : results[1].reason
-            return [a, b]
-          })
-          .then(
-            async ([
-              codeResponse,
-              settingsResponse,
-            ]): Promise<OnSubmitProps> => {
-              if (!codeResponse.ok) {
-                console.error(
-                  'Failed to fetch sample code:',
-                  codeResponse.statusText
-                )
-                return Promise.reject(new Error('Failed to fetch sample code'))
-              }
-              const code = await codeResponse.text()
-
-              // It's possible that a sample doesn't have a project.toml
-              // associated with it.
-              let projectSettingsPayload: ReturnType<
-                typeof projectConfigurationToSettingsPayload
-              > = {}
-              if (settingsResponse.ok) {
-                const parsedProjectSettings = parseProjectSettings(
-                  await settingsResponse.text()
-                )
-                if (!err(parsedProjectSettings)) {
-                  projectSettingsPayload =
-                    projectConfigurationToSettingsPayload(parsedProjectSettings)
-                }
-              }
-
-              return {
-                sampleName: data.sample.split('/')[0] + FILE_EXT,
-                code,
-                method: data.method,
-                sampleUnits: projectSettingsPayload.modeling?.defaultUnit,
-              }
+        fetch(sampleCodeUrl)
+          .then(async (codeResponse): Promise<OnSubmitProps> => {
+            if (!codeResponse.ok) {
+              console.error(
+                'Failed to fetch sample code:',
+                codeResponse.statusText
+              )
+              return Promise.reject(new Error('Failed to fetch sample code'))
             }
-          )
+            const code = await codeResponse.text()
+            return {
+              sampleName: data.sample.split('/')[0] + FILE_EXT,
+              code,
+              method: data.method,
+            }
+          })
           .then((props) => {
             if (props?.code) {
               commandProps.specialPropsForSampleCommand

--- a/src/lib/kclCommands.ts
+++ b/src/lib/kclCommands.ts
@@ -113,8 +113,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
                 sampleName: data.sample.split('/')[0] + FILE_EXT,
                 code,
                 method: data.method,
-                sampleUnits:
-                  projectSettingsPayload.modeling?.defaultUnit,
+                sampleUnits: projectSettingsPayload.modeling?.defaultUnit,
               }
             }
           )

--- a/src/lib/kclCommands.ts
+++ b/src/lib/kclCommands.ts
@@ -114,7 +114,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
                 code,
                 method: data.method,
                 sampleUnits:
-                  projectSettingsPayload.modeling?.defaultUnit || 'mm',
+                  projectSettingsPayload.modeling?.defaultUnit,
               }
             }
           )


### PR DESCRIPTION
Following https://github.com/KittyCAD/kcl-samples/pull/152

This will still be missing an update on the unit indicator in the bottom right corner, in a future PR.