### PR TITLE
Add artifact ID to KCL values that have them

### DIFF
--- a/docs/kcl/types/ArtifactId.md
+++ b/docs/kcl/types/ArtifactId.md
@@ -1,0 +1,15 @@
+---
+title: "ArtifactId"
+excerpt: ""
+layout: manual
+---
+
+
+**Type:** `string` (`uuid`)
+
+
+
+
+
+
+

--- a/docs/kcl/types/Face.md
+++ b/docs/kcl/types/Face.md
@@ -17,6 +17,7 @@ A face.
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `id` |`string`| The id of the face. | No |
+| `artifactId` |[`ArtifactId`](/docs/kcl/types/ArtifactId)| The artifact ID. | No |
 | `value` |`string`| The tag of the face. | No |
 | `xAxis` |[`Point3d`](/docs/kcl/types/Point3d)| What should the face’s X axis be? | No |
 | `yAxis` |[`Point3d`](/docs/kcl/types/Point3d)| What should the face’s Y axis be? | No |

--- a/docs/kcl/types/Helix.md
+++ b/docs/kcl/types/Helix.md
@@ -17,6 +17,7 @@ A helix.
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `value` |`string`| The id of the helix. | No |
+| `artifactId` |[`ArtifactId`](/docs/kcl/types/ArtifactId)| The artifact ID. | No |
 | `revolutions` |`number`| Number of revolutions. | No |
 | `angleStart` |`number`| Start angle (in degrees). | No |
 | `ccw` |`boolean`| Is the helix rotation counter clockwise? | No |

--- a/docs/kcl/types/HelixValue.md
+++ b/docs/kcl/types/HelixValue.md
@@ -17,6 +17,7 @@ A helix.
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `value` |`string`| The id of the helix. | No |
+| `artifactId` |[`ArtifactId`](/docs/kcl/types/ArtifactId)| The artifact ID. | No |
 | `revolutions` |`number`| Number of revolutions. | No |
 | `angleStart` |`number`| Start angle (in degrees). | No |
 | `ccw` |`boolean`| Is the helix rotation counter clockwise? | No |

--- a/docs/kcl/types/Plane.md
+++ b/docs/kcl/types/Plane.md
@@ -17,6 +17,7 @@ A plane.
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `id` |`string`| The id of the plane. | No |
+| `artifactId` |[`ArtifactId`](/docs/kcl/types/ArtifactId)| The artifact ID. | No |
 | `value` |[`PlaneType`](/docs/kcl/types/PlaneType)| A plane. | No |
 | `origin` |[`Point3d`](/docs/kcl/types/Point3d)| Origin of the plane. | No |
 | `xAxis` |[`Point3d`](/docs/kcl/types/Point3d)| What should the plane’s X axis be? | No |

--- a/docs/kcl/types/Sketch.md
+++ b/docs/kcl/types/Sketch.md
@@ -21,6 +21,7 @@ A sketch is a collection of paths.
 | `on` |[`SketchSurface`](/docs/kcl/types/SketchSurface)| What the sketch is on (can be a plane or a face). | No |
 | `start` |[`BasePath`](/docs/kcl/types/BasePath)| The starting path. | No |
 | `tags` |`object`| Tag identifiers that have been declared in this sketch. | No |
+| `artifactId` |[`ArtifactId`](/docs/kcl/types/ArtifactId)| The original id of the sketch. This stays the same even if the sketch is is sketched on face etc. | No |
 | `units` |[`UnitLen`](/docs/kcl/types/UnitLen)| A sketch is a collection of paths. | No |
 | `__meta` |`[` [`Metadata`](/docs/kcl/types/Metadata) `]`| Metadata. | No |
 

--- a/docs/kcl/types/SketchSet.md
+++ b/docs/kcl/types/SketchSet.md
@@ -30,6 +30,7 @@ A sketch is a collection of paths.
 | `on` |[`SketchSurface`](/docs/kcl/types/SketchSurface)| What the sketch is on (can be a plane or a face). | No |
 | `start` |[`BasePath`](/docs/kcl/types/BasePath)| The starting path. | No |
 | `tags` |`object`| Tag identifiers that have been declared in this sketch. | No |
+| `artifactId` |[`ArtifactId`](/docs/kcl/types/ArtifactId)| The original id of the sketch. This stays the same even if the sketch is is sketched on face etc. | No |
 | `units` |[`UnitLen`](/docs/kcl/types/UnitLen)| A sketch or a group of sketches. | No |
 | `__meta` |`[` [`Metadata`](/docs/kcl/types/Metadata) `]`| Metadata. | No |
 

--- a/docs/kcl/types/SketchSurface.md
+++ b/docs/kcl/types/SketchSurface.md
@@ -26,6 +26,7 @@ A plane.
 |----------|------|-------------|----------|
 | `type` |enum: `plane`|  | No |
 | `id` |`string`| The id of the plane. | No |
+| `artifactId` |[`ArtifactId`](/docs/kcl/types/ArtifactId)| The artifact ID. | No |
 | `value` |[`PlaneType`](/docs/kcl/types/PlaneType)| A sketch type. | No |
 | `origin` |[`Point3d`](/docs/kcl/types/Point3d)| Origin of the plane. | No |
 | `xAxis` |[`Point3d`](/docs/kcl/types/Point3d)| What should the plane’s X axis be? | No |
@@ -50,6 +51,7 @@ A face.
 |----------|------|-------------|----------|
 | `type` |enum: `face`|  | No |
 | `id` |`string`| The id of the face. | No |
+| `artifactId` |[`ArtifactId`](/docs/kcl/types/ArtifactId)| The artifact ID. | No |
 | `value` |`string`| The tag of the face. | No |
 | `xAxis` |[`Point3d`](/docs/kcl/types/Point3d)| What should the face’s X axis be? | No |
 | `yAxis` |[`Point3d`](/docs/kcl/types/Point3d)| What should the face’s Y axis be? | No |

--- a/docs/kcl/types/Solid.md
+++ b/docs/kcl/types/Solid.md
@@ -17,6 +17,7 @@ An solid is a collection of extrude surfaces.
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `id` |`string`| The id of the solid. | No |
+| `artifactId` |[`ArtifactId`](/docs/kcl/types/ArtifactId)| The artifact ID of the solid.  Unlike `id`, this doesn't change. | No |
 | `value` |`[` [`ExtrudeSurface`](/docs/kcl/types/ExtrudeSurface) `]`| The extrude surfaces. | No |
 | `sketch` |[`Sketch`](/docs/kcl/types/Sketch)| The sketch. | No |
 | `height` |`number`| The height of the solid. | No |

--- a/docs/kcl/types/SolidSet.md
+++ b/docs/kcl/types/SolidSet.md
@@ -26,6 +26,7 @@ An solid is a collection of extrude surfaces.
 |----------|------|-------------|----------|
 | `type` |enum: `solid`|  | No |
 | `id` |`string`| The id of the solid. | No |
+| `artifactId` |[`ArtifactId`](/docs/kcl/types/ArtifactId)| The artifact ID of the solid.  Unlike `id`, this doesn't change. | No |
 | `value` |`[` [`ExtrudeSurface`](/docs/kcl/types/ExtrudeSurface) `]`| The extrude surfaces. | No |
 | `sketch` |[`Sketch`](/docs/kcl/types/Sketch)| The sketch. | No |
 | `height` |`number`| The height of the solid. | No |

--- a/src/lang/artifact.test.ts
+++ b/src/lang/artifact.test.ts
@@ -54,6 +54,7 @@ const mySketch001 = startSketchOn('XY')
           },
         ],
         id: expect.any(String),
+        artifactId: expect.any(String),
         units: {
           type: 'Mm',
         },
@@ -78,6 +79,7 @@ const mySketch001 = startSketchOn('XY')
       value: {
         type: 'Solid',
         id: expect.any(String),
+        artifactId: expect.any(String),
         value: [
           {
             type: 'extrudePlane',
@@ -96,6 +98,7 @@ const mySketch001 = startSketchOn('XY')
         ],
         sketch: {
           id: expect.any(String),
+          artifactId: expect.any(String),
           units: {
             type: 'Mm',
           },
@@ -169,6 +172,7 @@ const sk2 = startSketchOn('XY')
         value: {
           type: 'Solid',
           id: expect.any(String),
+          artifactId: expect.any(String),
           value: [
             {
               type: 'extrudePlane',
@@ -199,6 +203,7 @@ const sk2 = startSketchOn('XY')
           ],
           sketch: {
             id: expect.any(String),
+            artifactId: expect.any(String),
             __meta: expect.any(Array),
             on: expect.any(Object),
             start: expect.any(Object),
@@ -272,6 +277,7 @@ const sk2 = startSketchOn('XY')
         value: {
           type: 'Solid',
           id: expect.any(String),
+          artifactId: expect.any(String),
           value: [
             {
               type: 'extrudePlane',
@@ -302,6 +308,7 @@ const sk2 = startSketchOn('XY')
           ],
           sketch: {
             id: expect.any(String),
+            artifactId: expect.any(String),
             units: {
               type: 'Mm',
             },

--- a/src/lang/executor.test.ts
+++ b/src/lang/executor.test.ts
@@ -221,6 +221,7 @@ const newVar = myVar + 1`
           },
         ],
         id: expect.any(String),
+        artifactId: expect.any(String),
         units: {
           type: 'Mm',
         },

--- a/src/wasm-lib/kcl/src/execution/artifact.rs
+++ b/src/wasm-lib/kcl/src/execution/artifact.rs
@@ -8,6 +8,7 @@ use kittycad_modeling_cmds::{
     websocket::{BatchResponse, OkWebSocketResponseData, WebSocketResponse},
     EnableSketchMode, ModelingCmd, SketchModeDisable,
 };
+use schemars::JsonSchema;
 use serde::{ser::SerializeSeq, Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -37,7 +38,7 @@ pub struct ArtifactCommand {
     pub command: ModelingCmd,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Hash, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Hash, ts_rs::TS, JsonSchema)]
 #[ts(export_to = "Artifact.ts")]
 pub struct ArtifactId(Uuid);
 

--- a/src/wasm-lib/kcl/src/execution/geometry.rs
+++ b/src/wasm-lib/kcl/src/execution/geometry.rs
@@ -6,6 +6,7 @@ use parse_display::{Display, FromStr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use super::ArtifactId;
 use crate::{
     errors::KclError,
     execution::{ExecState, Metadata, TagEngineInfo, TagIdentifier, UnitLen},
@@ -216,6 +217,8 @@ pub struct ImportedGeometry {
 pub struct Helix {
     /// The id of the helix.
     pub value: uuid::Uuid,
+    /// The artifact ID.
+    pub artifact_id: ArtifactId,
     /// Number of revolutions.
     pub revolutions: f64,
     /// Start angle (in degrees).
@@ -234,6 +237,8 @@ pub struct Helix {
 pub struct Plane {
     /// The id of the plane.
     pub id: uuid::Uuid,
+    /// The artifact ID.
+    pub artifact_id: ArtifactId,
     // The code for the plane either a string or custom.
     pub value: PlaneType,
     /// Origin of the plane.
@@ -255,6 +260,7 @@ impl Plane {
         match value {
             crate::std::sketch::PlaneData::XY => Plane {
                 id,
+                artifact_id: id.into(),
                 origin: Point3d::new(0.0, 0.0, 0.0),
                 x_axis: Point3d::new(1.0, 0.0, 0.0),
                 y_axis: Point3d::new(0.0, 1.0, 0.0),
@@ -265,6 +271,7 @@ impl Plane {
             },
             crate::std::sketch::PlaneData::NegXY => Plane {
                 id,
+                artifact_id: id.into(),
                 origin: Point3d::new(0.0, 0.0, 0.0),
                 x_axis: Point3d::new(1.0, 0.0, 0.0),
                 y_axis: Point3d::new(0.0, 1.0, 0.0),
@@ -275,6 +282,7 @@ impl Plane {
             },
             crate::std::sketch::PlaneData::XZ => Plane {
                 id,
+                artifact_id: id.into(),
                 origin: Point3d::new(0.0, 0.0, 0.0),
                 x_axis: Point3d::new(1.0, 0.0, 0.0),
                 y_axis: Point3d::new(0.0, 0.0, 1.0),
@@ -285,6 +293,7 @@ impl Plane {
             },
             crate::std::sketch::PlaneData::NegXZ => Plane {
                 id,
+                artifact_id: id.into(),
                 origin: Point3d::new(0.0, 0.0, 0.0),
                 x_axis: Point3d::new(-1.0, 0.0, 0.0),
                 y_axis: Point3d::new(0.0, 0.0, 1.0),
@@ -295,6 +304,7 @@ impl Plane {
             },
             crate::std::sketch::PlaneData::YZ => Plane {
                 id,
+                artifact_id: id.into(),
                 origin: Point3d::new(0.0, 0.0, 0.0),
                 x_axis: Point3d::new(0.0, 1.0, 0.0),
                 y_axis: Point3d::new(0.0, 0.0, 1.0),
@@ -305,6 +315,7 @@ impl Plane {
             },
             crate::std::sketch::PlaneData::NegYZ => Plane {
                 id,
+                artifact_id: id.into(),
                 origin: Point3d::new(0.0, 0.0, 0.0),
                 x_axis: Point3d::new(0.0, 1.0, 0.0),
                 y_axis: Point3d::new(0.0, 0.0, 1.0),
@@ -320,6 +331,7 @@ impl Plane {
                 z_axis,
             } => Plane {
                 id,
+                artifact_id: id.into(),
                 origin: *origin,
                 x_axis: *x_axis,
                 y_axis: *y_axis,
@@ -350,6 +362,8 @@ impl Plane {
 pub struct Face {
     /// The id of the face.
     pub id: uuid::Uuid,
+    /// The artifact ID.
+    pub artifact_id: ArtifactId,
     /// The tag of the face.
     pub value: String,
     /// What should the face’s X axis be?
@@ -404,8 +418,7 @@ pub struct Sketch {
     pub tags: IndexMap<String, TagIdentifier>,
     /// The original id of the sketch. This stays the same even if the sketch is
     /// is sketched on face etc.
-    #[serde(skip)]
-    pub original_id: uuid::Uuid,
+    pub artifact_id: ArtifactId,
     pub units: UnitLen,
     /// Metadata.
     #[serde(rename = "__meta")]
@@ -517,6 +530,8 @@ impl Sketch {
 pub struct Solid {
     /// The id of the solid.
     pub id: uuid::Uuid,
+    /// The artifact ID of the solid.  Unlike `id`, this doesn't change.
+    pub artifact_id: ArtifactId,
     /// The extrude surfaces.
     pub value: Vec<ExtrudeSurface>,
     /// The sketch.

--- a/src/wasm-lib/kcl/src/execution/memory.rs
+++ b/src/wasm-lib/kcl/src/execution/memory.rs
@@ -180,7 +180,7 @@ impl Environment {
             let KclValue::Sketch { value } = val else { continue };
             let mut sketch = value.to_owned();
 
-            if sketch.original_id == sg.original_id {
+            if sketch.artifact_id == sg.artifact_id {
                 for tag in sg.tags.iter() {
                     sketch.tags.insert(tag.0.clone(), tag.1.clone());
                 }

--- a/src/wasm-lib/kcl/src/std/helix.rs
+++ b/src/wasm-lib/kcl/src/std/helix.rs
@@ -117,6 +117,7 @@ async fn inner_helix(
 
     let helix_result = Box::new(HelixValue {
         value: id,
+        artifact_id: id.into(),
         revolutions,
         angle_start,
         ccw: ccw.unwrap_or(false),

--- a/src/wasm-lib/kcl/src/std/loft.rs
+++ b/src/wasm-lib/kcl/src/std/loft.rs
@@ -159,5 +159,5 @@ async fn inner_loft(
     let mut sketch = sketches[0].clone();
     // Override its id with the loft id so we can get its faces later
     sketch.id = id;
-    do_post_extrude(sketch, 0.0, exec_state, args).await
+    do_post_extrude(sketch, id.into(), 0.0, exec_state, args).await
 }

--- a/src/wasm-lib/kcl/src/std/revolve.rs
+++ b/src/wasm-lib/kcl/src/std/revolve.rs
@@ -230,5 +230,5 @@ async fn inner_revolve(
         }
     }
 
-    do_post_extrude(sketch, 0.0, exec_state, args).await
+    do_post_extrude(sketch, id.into(), 0.0, exec_state, args).await
 }

--- a/src/wasm-lib/kcl/src/std/sketch.rs
+++ b/src/wasm-lib/kcl/src/std/sketch.rs
@@ -1164,6 +1164,7 @@ async fn start_sketch_on_face(
 
     Ok(Box::new(Face {
         id: extrude_plane_id,
+        artifact_id: extrude_plane_id.into(),
         value: tag.to_string(),
         // TODO: get this from the extrude plane data.
         x_axis: solid.sketch.on.x_axis(),
@@ -1359,7 +1360,7 @@ pub(crate) async fn inner_start_profile_at(
 
     let sketch = Sketch {
         id: path_id,
-        original_id: path_id,
+        artifact_id: path_id.into(),
         on: sketch_surface.clone(),
         paths: vec![],
         units,

--- a/src/wasm-lib/kcl/src/std/sweep.rs
+++ b/src/wasm-lib/kcl/src/std/sweep.rs
@@ -131,5 +131,5 @@ async fn inner_sweep(
     )
     .await?;
 
-    do_post_extrude(sketch, 0.0, exec_state, args).await
+    do_post_extrude(sketch, id.into(), 0.0, exec_state, args).await
 }

--- a/src/wasm-lib/kcl/tests/angled_line/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/angled_line/program_memory.snap
@@ -31,6 +31,7 @@ description: Program memory after executing angled_line.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -237,6 +238,7 @@ description: Program memory after executing angled_line.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -343,6 +345,7 @@ description: Program memory after executing angled_line.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/artifact_graph_example_code1/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/artifact_graph_example_code1/program_memory.snap
@@ -32,6 +32,7 @@ snapshot_kind: text
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -206,6 +207,7 @@ snapshot_kind: text
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -371,6 +373,7 @@ snapshot_kind: text
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -415,6 +418,7 @@ snapshot_kind: text
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -538,6 +542,7 @@ snapshot_kind: text
               "on": {
                 "type": "face",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "seg02",
                 "xAxis": {
                   "x": 1.0,
@@ -557,6 +562,7 @@ snapshot_kind: text
                 "solid": {
                   "type": "Solid",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": [
                     {
                       "faceId": "[uuid]",
@@ -731,6 +737,7 @@ snapshot_kind: text
                     "on": {
                       "type": "plane",
                       "id": "[uuid]",
+                      "artifactId": "[uuid]",
                       "value": "XY",
                       "origin": {
                         "x": 0.0,
@@ -896,6 +903,7 @@ snapshot_kind: text
                         ]
                       }
                     },
+                    "artifactId": "[uuid]",
                     "units": {
                       "type": "Mm"
                     },
@@ -966,6 +974,7 @@ snapshot_kind: text
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -1236,6 +1245,7 @@ snapshot_kind: text
             "on": {
               "type": "plane",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": "XY",
               "origin": {
                 "x": 0.0,
@@ -1401,6 +1411,7 @@ snapshot_kind: text
                 ]
               }
             },
+            "artifactId": "[uuid]",
             "units": {
               "type": "Mm"
             },
@@ -1505,6 +1516,7 @@ snapshot_kind: text
             "on": {
               "type": "face",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": "seg02",
               "xAxis": {
                 "x": 1.0,
@@ -1524,6 +1536,7 @@ snapshot_kind: text
               "solid": {
                 "type": "Solid",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": [
                   {
                     "faceId": "[uuid]",
@@ -1698,6 +1711,7 @@ snapshot_kind: text
                   "on": {
                     "type": "plane",
                     "id": "[uuid]",
+                    "artifactId": "[uuid]",
                     "value": "XY",
                     "origin": {
                       "x": 0.0,
@@ -1863,6 +1877,7 @@ snapshot_kind: text
                       ]
                     }
                   },
+                  "artifactId": "[uuid]",
                   "units": {
                     "type": "Mm"
                   },
@@ -1933,6 +1948,7 @@ snapshot_kind: text
                 ]
               }
             },
+            "artifactId": "[uuid]",
             "units": {
               "type": "Mm"
             },

--- a/src/wasm-lib/kcl/tests/artifact_graph_example_code_no_3d/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/artifact_graph_example_code_no_3d/program_memory.snap
@@ -287,6 +287,7 @@ snapshot_kind: text
             "on": {
               "type": "plane",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": "YZ",
               "origin": {
                 "x": 0.0,
@@ -466,6 +467,7 @@ snapshot_kind: text
                 ]
               }
             },
+            "artifactId": "[uuid]",
             "units": {
               "type": "Mm"
             },
@@ -560,6 +562,7 @@ snapshot_kind: text
             "on": {
               "type": "plane",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": "XZ",
               "origin": {
                 "x": 0.0,
@@ -605,6 +608,7 @@ snapshot_kind: text
                 ]
               }
             },
+            "artifactId": "[uuid]",
             "units": {
               "type": "Mm"
             },

--- a/src/wasm-lib/kcl/tests/artifact_graph_example_code_offset_planes/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/artifact_graph_example_code_offset_planes/program_memory.snap
@@ -31,6 +31,7 @@ snapshot_kind: text
           "type": "Plane",
           "value": {
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": "Custom",
             "origin": {
               "x": 0.0,
@@ -62,6 +63,7 @@ snapshot_kind: text
           "type": "Plane",
           "value": {
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": "Custom",
             "origin": {
               "x": 0.0,
@@ -93,6 +95,7 @@ snapshot_kind: text
           "type": "Plane",
           "value": {
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": "Custom",
             "origin": {
               "x": 10.0,
@@ -150,6 +153,7 @@ snapshot_kind: text
             "on": {
               "type": "plane",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": "Custom",
               "origin": {
                 "x": 0.0,
@@ -195,6 +199,7 @@ snapshot_kind: text
                 ]
               }
             },
+            "artifactId": "[uuid]",
             "units": {
               "type": "Mm"
             },

--- a/src/wasm-lib/kcl/tests/artifact_graph_sketch_on_face_etc/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/artifact_graph_sketch_on_face_etc/program_memory.snap
@@ -32,6 +32,7 @@ snapshot_kind: text
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -165,6 +166,7 @@ snapshot_kind: text
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XZ",
                 "origin": {
                   "x": 0.0,
@@ -271,6 +273,7 @@ snapshot_kind: text
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -306,6 +309,7 @@ snapshot_kind: text
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -429,6 +433,7 @@ snapshot_kind: text
               "on": {
                 "type": "face",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "seg01",
                 "xAxis": {
                   "x": 1.0,
@@ -448,6 +453,7 @@ snapshot_kind: text
                 "solid": {
                   "type": "Solid",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": [
                     {
                       "faceId": "[uuid]",
@@ -581,6 +587,7 @@ snapshot_kind: text
                     "on": {
                       "type": "plane",
                       "id": "[uuid]",
+                      "artifactId": "[uuid]",
                       "value": "XZ",
                       "origin": {
                         "x": 0.0,
@@ -687,6 +694,7 @@ snapshot_kind: text
                         ]
                       }
                     },
+                    "artifactId": "[uuid]",
                     "units": {
                       "type": "Mm"
                     },
@@ -748,6 +756,7 @@ snapshot_kind: text
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -783,6 +792,7 @@ snapshot_kind: text
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -916,6 +926,7 @@ snapshot_kind: text
               "on": {
                 "type": "face",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "end",
                 "xAxis": {
                   "x": 1.0,
@@ -935,6 +946,7 @@ snapshot_kind: text
                 "solid": {
                   "type": "Solid",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": [
                     {
                       "faceId": "[uuid]",
@@ -1058,6 +1070,7 @@ snapshot_kind: text
                     "on": {
                       "type": "face",
                       "id": "[uuid]",
+                      "artifactId": "[uuid]",
                       "value": "seg01",
                       "xAxis": {
                         "x": 1.0,
@@ -1077,6 +1090,7 @@ snapshot_kind: text
                       "solid": {
                         "type": "Solid",
                         "id": "[uuid]",
+                        "artifactId": "[uuid]",
                         "value": [
                           {
                             "faceId": "[uuid]",
@@ -1210,6 +1224,7 @@ snapshot_kind: text
                           "on": {
                             "type": "plane",
                             "id": "[uuid]",
+                            "artifactId": "[uuid]",
                             "value": "XZ",
                             "origin": {
                               "x": 0.0,
@@ -1316,6 +1331,7 @@ snapshot_kind: text
                               ]
                             }
                           },
+                          "artifactId": "[uuid]",
                           "units": {
                             "type": "Mm"
                           },
@@ -1377,6 +1393,7 @@ snapshot_kind: text
                         ]
                       }
                     },
+                    "artifactId": "[uuid]",
                     "units": {
                       "type": "Mm"
                     },
@@ -1499,6 +1516,7 @@ snapshot_kind: text
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -1534,6 +1552,7 @@ snapshot_kind: text
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -1657,6 +1676,7 @@ snapshot_kind: text
               "on": {
                 "type": "face",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "seg02",
                 "xAxis": {
                   "x": 1.0,
@@ -1676,6 +1696,7 @@ snapshot_kind: text
                 "solid": {
                   "type": "Solid",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": [
                     {
                       "faceId": "[uuid]",
@@ -1809,6 +1830,7 @@ snapshot_kind: text
                     "on": {
                       "type": "face",
                       "id": "[uuid]",
+                      "artifactId": "[uuid]",
                       "value": "end",
                       "xAxis": {
                         "x": 1.0,
@@ -1828,6 +1850,7 @@ snapshot_kind: text
                       "solid": {
                         "type": "Solid",
                         "id": "[uuid]",
+                        "artifactId": "[uuid]",
                         "value": [
                           {
                             "faceId": "[uuid]",
@@ -1951,6 +1974,7 @@ snapshot_kind: text
                           "on": {
                             "type": "face",
                             "id": "[uuid]",
+                            "artifactId": "[uuid]",
                             "value": "seg01",
                             "xAxis": {
                               "x": 1.0,
@@ -1970,6 +1994,7 @@ snapshot_kind: text
                             "solid": {
                               "type": "Solid",
                               "id": "[uuid]",
+                              "artifactId": "[uuid]",
                               "value": [
                                 {
                                   "faceId": "[uuid]",
@@ -2103,6 +2128,7 @@ snapshot_kind: text
                                 "on": {
                                   "type": "plane",
                                   "id": "[uuid]",
+                                  "artifactId": "[uuid]",
                                   "value": "XZ",
                                   "origin": {
                                     "x": 0.0,
@@ -2209,6 +2235,7 @@ snapshot_kind: text
                                     ]
                                   }
                                 },
+                                "artifactId": "[uuid]",
                                 "units": {
                                   "type": "Mm"
                                 },
@@ -2270,6 +2297,7 @@ snapshot_kind: text
                               ]
                             }
                           },
+                          "artifactId": "[uuid]",
                           "units": {
                             "type": "Mm"
                           },
@@ -2392,6 +2420,7 @@ snapshot_kind: text
                         ]
                       }
                     },
+                    "artifactId": "[uuid]",
                     "units": {
                       "type": "Mm"
                     },
@@ -2453,6 +2482,7 @@ snapshot_kind: text
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -2698,6 +2728,7 @@ snapshot_kind: text
             "on": {
               "type": "plane",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": "XZ",
               "origin": {
                 "x": 0.0,
@@ -2804,6 +2835,7 @@ snapshot_kind: text
                 ]
               }
             },
+            "artifactId": "[uuid]",
             "units": {
               "type": "Mm"
             },
@@ -2908,6 +2940,7 @@ snapshot_kind: text
             "on": {
               "type": "face",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": "seg01",
               "xAxis": {
                 "x": 1.0,
@@ -2927,6 +2960,7 @@ snapshot_kind: text
               "solid": {
                 "type": "Solid",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": [
                   {
                     "faceId": "[uuid]",
@@ -3060,6 +3094,7 @@ snapshot_kind: text
                   "on": {
                     "type": "plane",
                     "id": "[uuid]",
+                    "artifactId": "[uuid]",
                     "value": "XZ",
                     "origin": {
                       "x": 0.0,
@@ -3166,6 +3201,7 @@ snapshot_kind: text
                       ]
                     }
                   },
+                  "artifactId": "[uuid]",
                   "units": {
                     "type": "Mm"
                   },
@@ -3227,6 +3263,7 @@ snapshot_kind: text
                 ]
               }
             },
+            "artifactId": "[uuid]",
             "units": {
               "type": "Mm"
             },
@@ -3336,6 +3373,7 @@ snapshot_kind: text
             "on": {
               "type": "face",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": "end",
               "xAxis": {
                 "x": 1.0,
@@ -3355,6 +3393,7 @@ snapshot_kind: text
               "solid": {
                 "type": "Solid",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": [
                   {
                     "faceId": "[uuid]",
@@ -3478,6 +3517,7 @@ snapshot_kind: text
                   "on": {
                     "type": "face",
                     "id": "[uuid]",
+                    "artifactId": "[uuid]",
                     "value": "seg01",
                     "xAxis": {
                       "x": 1.0,
@@ -3497,6 +3537,7 @@ snapshot_kind: text
                     "solid": {
                       "type": "Solid",
                       "id": "[uuid]",
+                      "artifactId": "[uuid]",
                       "value": [
                         {
                           "faceId": "[uuid]",
@@ -3630,6 +3671,7 @@ snapshot_kind: text
                         "on": {
                           "type": "plane",
                           "id": "[uuid]",
+                          "artifactId": "[uuid]",
                           "value": "XZ",
                           "origin": {
                             "x": 0.0,
@@ -3736,6 +3778,7 @@ snapshot_kind: text
                             ]
                           }
                         },
+                        "artifactId": "[uuid]",
                         "units": {
                           "type": "Mm"
                         },
@@ -3797,6 +3840,7 @@ snapshot_kind: text
                       ]
                     }
                   },
+                  "artifactId": "[uuid]",
                   "units": {
                     "type": "Mm"
                   },
@@ -3919,6 +3963,7 @@ snapshot_kind: text
                 ]
               }
             },
+            "artifactId": "[uuid]",
             "units": {
               "type": "Mm"
             },
@@ -4023,6 +4068,7 @@ snapshot_kind: text
             "on": {
               "type": "face",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": "seg02",
               "xAxis": {
                 "x": 1.0,
@@ -4042,6 +4088,7 @@ snapshot_kind: text
               "solid": {
                 "type": "Solid",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": [
                   {
                     "faceId": "[uuid]",
@@ -4175,6 +4222,7 @@ snapshot_kind: text
                   "on": {
                     "type": "face",
                     "id": "[uuid]",
+                    "artifactId": "[uuid]",
                     "value": "end",
                     "xAxis": {
                       "x": 1.0,
@@ -4194,6 +4242,7 @@ snapshot_kind: text
                     "solid": {
                       "type": "Solid",
                       "id": "[uuid]",
+                      "artifactId": "[uuid]",
                       "value": [
                         {
                           "faceId": "[uuid]",
@@ -4317,6 +4366,7 @@ snapshot_kind: text
                         "on": {
                           "type": "face",
                           "id": "[uuid]",
+                          "artifactId": "[uuid]",
                           "value": "seg01",
                           "xAxis": {
                             "x": 1.0,
@@ -4336,6 +4386,7 @@ snapshot_kind: text
                           "solid": {
                             "type": "Solid",
                             "id": "[uuid]",
+                            "artifactId": "[uuid]",
                             "value": [
                               {
                                 "faceId": "[uuid]",
@@ -4469,6 +4520,7 @@ snapshot_kind: text
                               "on": {
                                 "type": "plane",
                                 "id": "[uuid]",
+                                "artifactId": "[uuid]",
                                 "value": "XZ",
                                 "origin": {
                                   "x": 0.0,
@@ -4575,6 +4627,7 @@ snapshot_kind: text
                                   ]
                                 }
                               },
+                              "artifactId": "[uuid]",
                               "units": {
                                 "type": "Mm"
                               },
@@ -4636,6 +4689,7 @@ snapshot_kind: text
                             ]
                           }
                         },
+                        "artifactId": "[uuid]",
                         "units": {
                           "type": "Mm"
                         },
@@ -4758,6 +4812,7 @@ snapshot_kind: text
                       ]
                     }
                   },
+                  "artifactId": "[uuid]",
                   "units": {
                     "type": "Mm"
                   },
@@ -4819,6 +4874,7 @@ snapshot_kind: text
                 ]
               }
             },
+            "artifactId": "[uuid]",
             "units": {
               "type": "Mm"
             },

--- a/src/wasm-lib/kcl/tests/basic_fillet_cube_close_opposite/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/basic_fillet_cube_close_opposite/program_memory.snap
@@ -31,6 +31,7 @@ description: Program memory after executing basic_fillet_cube_close_opposite.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -195,6 +196,7 @@ description: Program memory after executing basic_fillet_cube_close_opposite.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -419,6 +421,7 @@ description: Program memory after executing basic_fillet_cube_close_opposite.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/basic_fillet_cube_end/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/basic_fillet_cube_end/program_memory.snap
@@ -31,6 +31,7 @@ description: Program memory after executing basic_fillet_cube_end.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -185,6 +186,7 @@ description: Program memory after executing basic_fillet_cube_end.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -350,6 +352,7 @@ description: Program memory after executing basic_fillet_cube_end.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/basic_fillet_cube_next_adjacent/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/basic_fillet_cube_next_adjacent/program_memory.snap
@@ -31,6 +31,7 @@ description: Program memory after executing basic_fillet_cube_next_adjacent.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -205,6 +206,7 @@ description: Program memory after executing basic_fillet_cube_next_adjacent.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -488,6 +490,7 @@ description: Program memory after executing basic_fillet_cube_next_adjacent.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/basic_fillet_cube_previous_adjacent/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/basic_fillet_cube_previous_adjacent/program_memory.snap
@@ -31,6 +31,7 @@ description: Program memory after executing basic_fillet_cube_previous_adjacent.
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -205,6 +206,7 @@ description: Program memory after executing basic_fillet_cube_previous_adjacent.
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -488,6 +490,7 @@ description: Program memory after executing basic_fillet_cube_previous_adjacent.
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/basic_fillet_cube_start/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/basic_fillet_cube_start/program_memory.snap
@@ -31,6 +31,7 @@ description: Program memory after executing basic_fillet_cube_start.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -185,6 +186,7 @@ description: Program memory after executing basic_fillet_cube_start.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -350,6 +352,7 @@ description: Program memory after executing basic_fillet_cube_start.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/big_number_angle_to_match_length_x/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/big_number_angle_to_match_length_x/program_memory.snap
@@ -31,6 +31,7 @@ description: Program memory after executing big_number_angle_to_match_length_x.k
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -144,6 +145,7 @@ description: Program memory after executing big_number_angle_to_match_length_x.k
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -250,6 +252,7 @@ description: Program memory after executing big_number_angle_to_match_length_x.k
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/big_number_angle_to_match_length_y/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/big_number_angle_to_match_length_y/program_memory.snap
@@ -31,6 +31,7 @@ description: Program memory after executing big_number_angle_to_match_length_y.k
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -144,6 +145,7 @@ description: Program memory after executing big_number_angle_to_match_length_y.k
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -250,6 +252,7 @@ description: Program memory after executing big_number_angle_to_match_length_y.k
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/circle_three_point/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/circle_three_point/program_memory.snap
@@ -31,6 +31,7 @@ description: Program memory after executing circle_three_point.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -78,6 +79,7 @@ description: Program memory after executing circle_three_point.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -123,6 +125,7 @@ description: Program memory after executing circle_three_point.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/circular_pattern3d_a_pattern/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/circular_pattern3d_a_pattern/program_memory.snap
@@ -31,6 +31,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -165,6 +166,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XZ",
                 "origin": {
                   "x": 0.0,
@@ -210,6 +212,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -246,6 +249,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -380,6 +384,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -425,6 +430,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -457,6 +463,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -591,6 +598,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -636,6 +644,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -668,6 +677,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -802,6 +812,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -847,6 +858,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -879,6 +891,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -1013,6 +1026,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -1058,6 +1072,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -1090,6 +1105,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -1224,6 +1240,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -1269,6 +1286,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -1301,6 +1319,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -1435,6 +1454,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -1480,6 +1500,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -1512,6 +1533,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -1646,6 +1668,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -1691,6 +1714,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -1728,6 +1752,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -1862,6 +1887,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -1907,6 +1933,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -1939,6 +1966,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -2073,6 +2101,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -2118,6 +2147,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -2150,6 +2180,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -2284,6 +2315,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -2329,6 +2361,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -2361,6 +2394,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -2495,6 +2529,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -2540,6 +2575,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -2572,6 +2608,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -2706,6 +2743,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -2751,6 +2789,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -2783,6 +2822,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -2917,6 +2957,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -2962,6 +3003,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -2994,6 +3036,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -3128,6 +3171,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -3173,6 +3217,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -3205,6 +3250,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -3339,6 +3385,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -3384,6 +3431,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -3416,6 +3464,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -3550,6 +3599,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -3595,6 +3645,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -3627,6 +3678,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -3761,6 +3813,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -3806,6 +3859,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -3838,6 +3892,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -3972,6 +4027,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -4017,6 +4073,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -4049,6 +4106,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -4183,6 +4241,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -4228,6 +4287,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -4260,6 +4320,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -4394,6 +4455,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -4439,6 +4501,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -4471,6 +4534,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -4605,6 +4669,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -4650,6 +4715,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -4682,6 +4748,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -4816,6 +4883,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -4861,6 +4929,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -4893,6 +4962,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -5027,6 +5097,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -5072,6 +5143,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -5104,6 +5176,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -5238,6 +5311,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -5283,6 +5357,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -5315,6 +5390,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -5449,6 +5525,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -5494,6 +5571,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -5526,6 +5604,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -5660,6 +5739,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -5705,6 +5785,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -5737,6 +5818,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -5871,6 +5953,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -5916,6 +5999,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -5948,6 +6032,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -6082,6 +6167,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -6127,6 +6213,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -6159,6 +6246,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -6293,6 +6381,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -6338,6 +6427,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -6370,6 +6460,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -6504,6 +6595,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -6549,6 +6641,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -6581,6 +6674,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -6715,6 +6809,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -6760,6 +6855,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -6792,6 +6888,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -6926,6 +7023,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -6971,6 +7069,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -7003,6 +7102,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -7137,6 +7237,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -7182,6 +7283,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -7214,6 +7316,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -7348,6 +7451,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -7393,6 +7497,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -7425,6 +7530,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -7559,6 +7665,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -7604,6 +7711,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -7636,6 +7744,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -7770,6 +7879,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -7815,6 +7925,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -7847,6 +7958,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -7981,6 +8093,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -8026,6 +8139,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -8058,6 +8172,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -8192,6 +8307,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -8237,6 +8353,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -8269,6 +8386,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -8403,6 +8521,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -8448,6 +8567,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -8480,6 +8600,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -8614,6 +8735,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -8659,6 +8781,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -8691,6 +8814,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -8825,6 +8949,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -8870,6 +8995,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -8902,6 +9028,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -9036,6 +9163,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -9081,6 +9209,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -9113,6 +9242,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -9247,6 +9377,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -9292,6 +9423,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -9324,6 +9456,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -9458,6 +9591,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -9503,6 +9637,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -9535,6 +9670,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -9669,6 +9805,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -9714,6 +9851,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -9746,6 +9884,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -9880,6 +10019,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -9925,6 +10065,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -9957,6 +10098,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -10091,6 +10233,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -10136,6 +10279,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -10168,6 +10312,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -10302,6 +10447,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -10347,6 +10493,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -10379,6 +10526,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -10513,6 +10661,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -10558,6 +10707,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -10590,6 +10740,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -10724,6 +10875,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -10769,6 +10921,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -10801,6 +10954,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -10935,6 +11089,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -10980,6 +11135,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -11012,6 +11168,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -11146,6 +11303,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -11191,6 +11349,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -11223,6 +11382,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -11357,6 +11517,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -11402,6 +11563,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -11434,6 +11596,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -11568,6 +11731,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -11613,6 +11777,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -11645,6 +11810,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -11779,6 +11945,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -11824,6 +11991,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -11856,6 +12024,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -11990,6 +12159,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -12035,6 +12205,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -12067,6 +12238,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -12201,6 +12373,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -12246,6 +12419,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -12278,6 +12452,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -12412,6 +12587,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -12457,6 +12633,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -12489,6 +12666,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -12623,6 +12801,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -12668,6 +12847,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -12700,6 +12880,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -12834,6 +13015,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -12879,6 +13061,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -12911,6 +13094,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -13045,6 +13229,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -13090,6 +13275,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -13122,6 +13308,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -13256,6 +13443,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -13301,6 +13489,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -13333,6 +13522,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -13467,6 +13657,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -13512,6 +13703,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -13544,6 +13736,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -13678,6 +13871,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -13723,6 +13917,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -13755,6 +13950,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -13889,6 +14085,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -13934,6 +14131,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -13966,6 +14164,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -14100,6 +14299,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -14145,6 +14345,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -14177,6 +14378,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -14311,6 +14513,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -14356,6 +14559,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -14388,6 +14592,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -14522,6 +14727,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -14567,6 +14773,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -14599,6 +14806,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -14733,6 +14941,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -14778,6 +14987,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -14810,6 +15020,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -14944,6 +15155,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -14989,6 +15201,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -15021,6 +15234,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -15155,6 +15369,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -15200,6 +15415,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -15232,6 +15448,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -15366,6 +15583,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -15411,6 +15629,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -15443,6 +15662,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -15577,6 +15797,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -15622,6 +15843,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -15654,6 +15876,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -15788,6 +16011,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -15833,6 +16057,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -15865,6 +16090,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -15999,6 +16225,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -16044,6 +16271,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -16076,6 +16304,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -16210,6 +16439,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -16255,6 +16485,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -16287,6 +16518,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -16421,6 +16653,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -16466,6 +16699,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -16498,6 +16732,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -16632,6 +16867,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -16677,6 +16913,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -16709,6 +16946,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -16843,6 +17081,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -16888,6 +17127,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -16920,6 +17160,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -17054,6 +17295,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -17099,6 +17341,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -17131,6 +17374,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -17265,6 +17509,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -17310,6 +17555,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -17342,6 +17588,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -17476,6 +17723,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -17521,6 +17769,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -17553,6 +17802,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -17687,6 +17937,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -17732,6 +17983,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -17764,6 +18016,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -17898,6 +18151,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -17943,6 +18197,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -17975,6 +18230,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -18109,6 +18365,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -18154,6 +18411,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -18186,6 +18444,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -18320,6 +18579,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -18365,6 +18625,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -18397,6 +18658,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -18531,6 +18793,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -18576,6 +18839,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -18608,6 +18872,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -18742,6 +19007,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -18787,6 +19053,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -18819,6 +19086,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -18953,6 +19221,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -18998,6 +19267,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -19030,6 +19300,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -19164,6 +19435,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -19209,6 +19481,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -19241,6 +19514,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -19375,6 +19649,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -19420,6 +19695,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -19452,6 +19728,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -19586,6 +19863,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -19631,6 +19909,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -19663,6 +19942,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -19797,6 +20077,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -19842,6 +20123,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -19874,6 +20156,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -20008,6 +20291,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -20053,6 +20337,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -20085,6 +20370,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -20219,6 +20505,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -20264,6 +20551,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -20296,6 +20584,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -20430,6 +20719,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -20475,6 +20765,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -20507,6 +20798,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -20641,6 +20933,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -20686,6 +20979,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -20718,6 +21012,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -20852,6 +21147,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -20897,6 +21193,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -20929,6 +21226,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -21063,6 +21361,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -21108,6 +21407,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -21140,6 +21440,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -21274,6 +21575,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -21319,6 +21621,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -21351,6 +21654,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -21485,6 +21789,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -21530,6 +21835,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -21562,6 +21868,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -21696,6 +22003,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -21741,6 +22049,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -21773,6 +22082,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -21907,6 +22217,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -21952,6 +22263,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -21984,6 +22296,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -22118,6 +22431,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -22163,6 +22477,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -22195,6 +22510,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -22329,6 +22645,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -22374,6 +22691,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -22406,6 +22724,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -22540,6 +22859,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -22585,6 +22905,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -22617,6 +22938,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -22751,6 +23073,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -22796,6 +23119,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -22828,6 +23152,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -22962,6 +23287,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -23007,6 +23333,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -23039,6 +23366,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -23173,6 +23501,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -23218,6 +23547,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -23250,6 +23580,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -23384,6 +23715,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -23429,6 +23761,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -23461,6 +23794,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -23595,6 +23929,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -23640,6 +23975,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -23672,6 +24008,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -23806,6 +24143,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -23851,6 +24189,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -23883,6 +24222,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -24017,6 +24357,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -24062,6 +24403,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -24094,6 +24436,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -24228,6 +24571,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -24273,6 +24617,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -24305,6 +24650,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -24439,6 +24785,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -24484,6 +24831,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -24516,6 +24864,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -24650,6 +24999,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -24695,6 +25045,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -24727,6 +25078,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -24861,6 +25213,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -24906,6 +25259,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -24938,6 +25292,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -25072,6 +25427,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -25117,6 +25473,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -25149,6 +25506,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -25283,6 +25641,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -25328,6 +25687,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -25360,6 +25720,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -25494,6 +25855,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -25539,6 +25901,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -25571,6 +25934,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -25705,6 +26069,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -25750,6 +26115,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -25782,6 +26148,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -25916,6 +26283,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -25961,6 +26329,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -25993,6 +26362,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -26127,6 +26497,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -26172,6 +26543,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -26204,6 +26576,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -26338,6 +26711,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -26383,6 +26757,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -26415,6 +26790,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -26549,6 +26925,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -26594,6 +26971,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -26626,6 +27004,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -26760,6 +27139,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -26805,6 +27185,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -26837,6 +27218,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -26971,6 +27353,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -27016,6 +27399,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -27048,6 +27432,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -27182,6 +27567,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -27227,6 +27613,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -27259,6 +27646,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -27393,6 +27781,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -27438,6 +27827,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -27470,6 +27860,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -27604,6 +27995,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -27649,6 +28041,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -27681,6 +28074,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -27815,6 +28209,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -27860,6 +28255,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -27892,6 +28288,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -28026,6 +28423,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -28071,6 +28469,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -28103,6 +28502,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -28237,6 +28637,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -28282,6 +28683,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -28314,6 +28716,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -28448,6 +28851,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -28493,6 +28897,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -28525,6 +28930,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -28659,6 +29065,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -28704,6 +29111,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -28736,6 +29144,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -28870,6 +29279,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -28915,6 +29325,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -28947,6 +29358,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -29081,6 +29493,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -29126,6 +29539,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -29158,6 +29572,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -29292,6 +29707,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -29337,6 +29753,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -29369,6 +29786,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -29503,6 +29921,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -29548,6 +29967,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -29580,6 +30000,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -29714,6 +30135,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -29759,6 +30181,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -29791,6 +30214,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -29925,6 +30349,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -29970,6 +30395,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -30002,6 +30428,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -30136,6 +30563,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -30181,6 +30609,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -30213,6 +30642,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -30347,6 +30777,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -30392,6 +30823,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -30424,6 +30856,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -30558,6 +30991,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -30603,6 +31037,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -30635,6 +31070,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -30769,6 +31205,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -30814,6 +31251,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -30846,6 +31284,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -30980,6 +31419,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -31025,6 +31465,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -31057,6 +31498,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -31191,6 +31633,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -31236,6 +31679,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -31268,6 +31712,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -31402,6 +31847,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -31447,6 +31893,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -31479,6 +31926,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -31613,6 +32061,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -31658,6 +32107,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -31690,6 +32140,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -31824,6 +32275,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -31869,6 +32321,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -31901,6 +32354,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -32035,6 +32489,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -32080,6 +32535,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -32112,6 +32568,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -32246,6 +32703,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -32291,6 +32749,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -32323,6 +32782,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -32457,6 +32917,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -32502,6 +32963,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -32534,6 +32996,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -32668,6 +33131,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -32713,6 +33177,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -32745,6 +33210,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -32879,6 +33345,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -32924,6 +33391,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -32956,6 +33424,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -33090,6 +33559,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -33135,6 +33605,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -33167,6 +33638,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -33301,6 +33773,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -33346,6 +33819,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -33378,6 +33852,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -33512,6 +33987,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -33557,6 +34033,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -33589,6 +34066,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -33723,6 +34201,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -33768,6 +34247,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -33800,6 +34280,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -33934,6 +34415,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -33979,6 +34461,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -34011,6 +34494,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -34145,6 +34629,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -34190,6 +34675,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -34222,6 +34708,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -34356,6 +34843,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -34401,6 +34889,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -34433,6 +34922,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -34567,6 +35057,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -34612,6 +35103,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -34644,6 +35136,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -34778,6 +35271,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -34823,6 +35317,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -34855,6 +35350,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -34989,6 +35485,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -35034,6 +35531,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -35066,6 +35564,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -35200,6 +35699,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -35245,6 +35745,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -35277,6 +35778,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -35411,6 +35913,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -35456,6 +35959,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -35488,6 +35992,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -35622,6 +36127,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -35667,6 +36173,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -35699,6 +36206,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -35833,6 +36341,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -35878,6 +36387,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -35910,6 +36420,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -36044,6 +36555,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -36089,6 +36601,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -36121,6 +36634,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -36255,6 +36769,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -36300,6 +36815,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -36332,6 +36848,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -36466,6 +36983,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -36511,6 +37029,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -36543,6 +37062,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -36677,6 +37197,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -36722,6 +37243,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -36754,6 +37276,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -36888,6 +37411,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -36933,6 +37457,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -36965,6 +37490,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -37099,6 +37625,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -37144,6 +37671,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -37176,6 +37704,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -37310,6 +37839,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -37355,6 +37885,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -37387,6 +37918,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -37521,6 +38053,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -37566,6 +38099,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -37598,6 +38132,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -37732,6 +38267,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -37777,6 +38313,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -37809,6 +38346,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -37943,6 +38481,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -37988,6 +38527,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -38020,6 +38560,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -38154,6 +38695,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -38199,6 +38741,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -38231,6 +38774,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -38365,6 +38909,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -38410,6 +38955,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -38442,6 +38988,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -38576,6 +39123,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -38621,6 +39169,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -38653,6 +39202,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -38787,6 +39337,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -38832,6 +39383,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -38864,6 +39416,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -38998,6 +39551,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -39043,6 +39597,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -39075,6 +39630,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -39209,6 +39765,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -39254,6 +39811,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -39286,6 +39844,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -39420,6 +39979,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -39465,6 +40025,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -39497,6 +40058,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -39631,6 +40193,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -39676,6 +40239,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -39708,6 +40272,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -39842,6 +40407,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -39887,6 +40453,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -39919,6 +40486,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -40053,6 +40621,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -40098,6 +40667,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -40130,6 +40700,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -40264,6 +40835,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -40309,6 +40881,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -40341,6 +40914,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -40475,6 +41049,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -40520,6 +41095,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -40552,6 +41128,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -40686,6 +41263,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -40731,6 +41309,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -40763,6 +41342,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -40897,6 +41477,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -40942,6 +41523,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -40974,6 +41556,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -41108,6 +41691,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -41153,6 +41737,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -41185,6 +41770,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -41319,6 +41905,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -41364,6 +41951,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -41396,6 +41984,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -41530,6 +42119,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -41575,6 +42165,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -41607,6 +42198,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -41741,6 +42333,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -41786,6 +42379,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -41818,6 +42412,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -41952,6 +42547,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -41997,6 +42593,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -42029,6 +42626,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -42163,6 +42761,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -42208,6 +42807,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -42240,6 +42840,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -42374,6 +42975,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -42419,6 +43021,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -42451,6 +43054,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -42585,6 +43189,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -42630,6 +43235,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -42662,6 +43268,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -42796,6 +43403,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -42841,6 +43449,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -42873,6 +43482,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -43007,6 +43617,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -43052,6 +43663,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -43084,6 +43696,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -43218,6 +43831,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -43263,6 +43877,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -43295,6 +43910,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -43429,6 +44045,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -43474,6 +44091,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -43506,6 +44124,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -43640,6 +44259,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -43685,6 +44305,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -43717,6 +44338,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -43851,6 +44473,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -43896,6 +44519,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -43928,6 +44552,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -44062,6 +44687,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -44107,6 +44733,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -44139,6 +44766,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -44273,6 +44901,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -44318,6 +44947,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -44350,6 +44980,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -44484,6 +45115,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -44529,6 +45161,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -44561,6 +45194,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -44695,6 +45329,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -44740,6 +45375,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -44772,6 +45408,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -44906,6 +45543,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -44951,6 +45589,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -44983,6 +45622,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -45117,6 +45757,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -45162,6 +45803,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -45194,6 +45836,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -45328,6 +45971,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -45373,6 +46017,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -45405,6 +46050,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -45539,6 +46185,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -45584,6 +46231,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -45616,6 +46264,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -45750,6 +46399,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -45795,6 +46445,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -45827,6 +46478,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -45961,6 +46613,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -46006,6 +46659,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -46038,6 +46692,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -46172,6 +46827,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -46217,6 +46873,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -46249,6 +46906,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -46383,6 +47041,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -46428,6 +47087,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -46460,6 +47120,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -46594,6 +47255,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -46639,6 +47301,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -46671,6 +47334,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -46805,6 +47469,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -46850,6 +47515,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -46882,6 +47548,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -47016,6 +47683,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -47061,6 +47729,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -47093,6 +47762,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -47227,6 +47897,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -47272,6 +47943,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -47304,6 +47976,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -47438,6 +48111,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -47483,6 +48157,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -47515,6 +48190,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -47649,6 +48325,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -47694,6 +48371,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -47726,6 +48404,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -47860,6 +48539,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -47905,6 +48585,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -47937,6 +48618,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -48071,6 +48753,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -48116,6 +48799,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -48148,6 +48832,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -48282,6 +48967,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -48327,6 +49013,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -48359,6 +49046,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -48493,6 +49181,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -48538,6 +49227,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -48570,6 +49260,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -48704,6 +49395,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -48749,6 +49441,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -48781,6 +49474,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -48915,6 +49609,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -48960,6 +49655,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -48992,6 +49688,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -49126,6 +49823,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -49171,6 +49869,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -49203,6 +49902,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -49337,6 +50037,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -49382,6 +50083,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -49414,6 +50116,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -49548,6 +50251,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -49593,6 +50297,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -49625,6 +50330,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -49759,6 +50465,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -49804,6 +50511,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -49836,6 +50544,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -49970,6 +50679,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -50015,6 +50725,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -50047,6 +50758,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -50181,6 +50893,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -50226,6 +50939,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -50258,6 +50972,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -50392,6 +51107,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -50437,6 +51153,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -50469,6 +51186,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -50603,6 +51321,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -50648,6 +51367,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -50680,6 +51400,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -50814,6 +51535,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -50859,6 +51581,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -50891,6 +51614,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -51025,6 +51749,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -51070,6 +51795,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -51102,6 +51828,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -51236,6 +51963,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -51281,6 +52009,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -51313,6 +52042,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -51447,6 +52177,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -51492,6 +52223,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -51524,6 +52256,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -51658,6 +52391,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -51703,6 +52437,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -51735,6 +52470,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -51869,6 +52605,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -51914,6 +52651,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -51946,6 +52684,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -52080,6 +52819,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -52125,6 +52865,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -52157,6 +52898,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -52291,6 +53033,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -52336,6 +53079,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -52368,6 +53112,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -52502,6 +53247,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -52547,6 +53293,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -52579,6 +53326,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -52713,6 +53461,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -52758,6 +53507,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -52790,6 +53540,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -52924,6 +53675,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -52969,6 +53721,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -53001,6 +53754,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -53135,6 +53889,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -53180,6 +53935,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -53212,6 +53968,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -53346,6 +54103,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -53391,6 +54149,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -53423,6 +54182,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -53557,6 +54317,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -53602,6 +54363,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -53634,6 +54396,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -53768,6 +54531,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -53813,6 +54577,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -53845,6 +54610,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -53979,6 +54745,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -54024,6 +54791,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -54056,6 +54824,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -54190,6 +54959,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -54235,6 +55005,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -54267,6 +55038,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -54401,6 +55173,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -54446,6 +55219,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -54478,6 +55252,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -54612,6 +55387,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -54657,6 +55433,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -54689,6 +55466,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -54823,6 +55601,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -54868,6 +55647,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -54900,6 +55680,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -55034,6 +55815,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -55079,6 +55861,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -55111,6 +55894,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -55245,6 +56029,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -55290,6 +56075,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -55322,6 +56108,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -55456,6 +56243,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -55501,6 +56289,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -55533,6 +56322,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -55667,6 +56457,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -55712,6 +56503,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -55744,6 +56536,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -55878,6 +56671,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -55923,6 +56717,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -55955,6 +56750,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -56089,6 +56885,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -56134,6 +56931,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -56166,6 +56964,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -56300,6 +57099,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -56345,6 +57145,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -56377,6 +57178,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -56511,6 +57313,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -56556,6 +57359,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -56588,6 +57392,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -56722,6 +57527,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -56767,6 +57573,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -56799,6 +57606,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -56933,6 +57741,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -56978,6 +57787,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -57010,6 +57820,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -57144,6 +57955,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -57189,6 +58001,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -57221,6 +58034,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -57355,6 +58169,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -57400,6 +58215,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -57432,6 +58248,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -57566,6 +58383,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -57611,6 +58429,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -57643,6 +58462,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -57777,6 +58597,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -57822,6 +58643,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -57854,6 +58676,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -57988,6 +58811,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -58033,6 +58857,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -58065,6 +58890,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -58199,6 +59025,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -58244,6 +59071,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -58276,6 +59104,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -58410,6 +59239,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -58455,6 +59285,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -58487,6 +59318,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -58621,6 +59453,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -58666,6 +59499,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -58698,6 +59532,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -58832,6 +59667,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -58877,6 +59713,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -58909,6 +59746,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -59043,6 +59881,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -59088,6 +59927,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -59120,6 +59960,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -59254,6 +60095,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -59299,6 +60141,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -59331,6 +60174,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -59465,6 +60309,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -59510,6 +60355,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -59542,6 +60388,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -59676,6 +60523,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -59721,6 +60569,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -59753,6 +60602,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -59887,6 +60737,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -59932,6 +60783,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -59964,6 +60816,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -60098,6 +60951,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -60143,6 +60997,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -60175,6 +61030,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -60309,6 +61165,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -60354,6 +61211,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -60386,6 +61244,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -60520,6 +61379,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -60565,6 +61425,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -60597,6 +61458,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -60731,6 +61593,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -60776,6 +61639,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -60808,6 +61672,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -60942,6 +61807,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -60987,6 +61853,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -61019,6 +61886,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -61153,6 +62021,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -61198,6 +62067,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -61230,6 +62100,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -61364,6 +62235,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -61409,6 +62281,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -61441,6 +62314,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -61575,6 +62449,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -61620,6 +62495,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -61652,6 +62528,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -61786,6 +62663,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -61831,6 +62709,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -61863,6 +62742,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -61997,6 +62877,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -62042,6 +62923,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -62074,6 +62956,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -62208,6 +63091,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -62253,6 +63137,7 @@ description: Program memory after executing circular_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },

--- a/src/wasm-lib/kcl/tests/cube/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/cube/program_memory.snap
@@ -742,6 +742,7 @@ description: Program memory after executing cube.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -896,6 +897,7 @@ description: Program memory after executing cube.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -941,6 +943,7 @@ description: Program memory after executing cube.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/fillet-and-shell/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/fillet-and-shell/program_memory.snap
@@ -44,6 +44,7 @@ description: Program memory after executing fillet-and-shell.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -218,6 +219,7 @@ description: Program memory after executing fillet-and-shell.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -501,6 +503,7 @@ description: Program memory after executing fillet-and-shell.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -1324,6 +1327,7 @@ description: Program memory after executing fillet-and-shell.kcl
                     "value": {
                       "type": "Solid",
                       "id": "[uuid]",
+                      "artifactId": "[uuid]",
                       "value": [
                         {
                           "faceId": "[uuid]",
@@ -1498,6 +1502,7 @@ description: Program memory after executing fillet-and-shell.kcl
                         "on": {
                           "type": "plane",
                           "id": "[uuid]",
+                          "artifactId": "[uuid]",
                           "value": "XY",
                           "origin": {
                             "x": 0.0,
@@ -1781,6 +1786,7 @@ description: Program memory after executing fillet-and-shell.kcl
                             ]
                           }
                         },
+                        "artifactId": "[uuid]",
                         "units": {
                           "type": "Mm"
                         },
@@ -2336,6 +2342,7 @@ description: Program memory after executing fillet-and-shell.kcl
                       "on": {
                         "type": "plane",
                         "id": "[uuid]",
+                        "artifactId": "[uuid]",
                         "value": "XY",
                         "origin": {
                           "x": 0.0,
@@ -2381,6 +2388,7 @@ description: Program memory after executing fillet-and-shell.kcl
                           ]
                         }
                       },
+                      "artifactId": "[uuid]",
                       "units": {
                         "type": "Mm"
                       },
@@ -2619,6 +2627,7 @@ description: Program memory after executing fillet-and-shell.kcl
             "on": {
               "type": "plane",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": "XY",
               "origin": {
                 "x": 0.0,
@@ -2664,6 +2673,7 @@ description: Program memory after executing fillet-and-shell.kcl
                 ]
               }
             },
+            "artifactId": "[uuid]",
             "units": {
               "type": "Mm"
             },

--- a/src/wasm-lib/kcl/tests/function_sketch/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/function_sketch/program_memory.snap
@@ -440,6 +440,7 @@ description: Program memory after executing function_sketch.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -574,6 +575,7 @@ description: Program memory after executing function_sketch.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -619,6 +621,7 @@ description: Program memory after executing function_sketch.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/function_sketch_with_position/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/function_sketch_with_position/program_memory.snap
@@ -426,6 +426,7 @@ description: Program memory after executing function_sketch_with_position.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -560,6 +561,7 @@ description: Program memory after executing function_sketch_with_position.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -605,6 +607,7 @@ description: Program memory after executing function_sketch_with_position.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/helix_ccw/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/helix_ccw/program_memory.snap
@@ -31,6 +31,7 @@ description: Program memory after executing helix_ccw.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -78,6 +79,7 @@ description: Program memory after executing helix_ccw.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -123,6 +125,7 @@ description: Program memory after executing helix_ccw.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/i_shape/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/i_shape/program_memory.snap
@@ -596,6 +596,7 @@ description: Program memory after executing i_shape.kcl
             "on": {
               "type": "plane",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": "XY",
               "origin": {
                 "x": 0.0,
@@ -641,6 +642,7 @@ description: Program memory after executing i_shape.kcl
                 ]
               }
             },
+            "artifactId": "[uuid]",
             "units": {
               "type": "Mm"
             },
@@ -739,6 +741,7 @@ description: Program memory after executing i_shape.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -1573,6 +1576,7 @@ description: Program memory after executing i_shape.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -1618,6 +1622,7 @@ description: Program memory after executing i_shape.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -1871,6 +1876,7 @@ description: Program memory after executing i_shape.kcl
             "on": {
               "type": "plane",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": "XY",
               "origin": {
                 "x": 0.0,
@@ -1916,6 +1922,7 @@ description: Program memory after executing i_shape.kcl
                 ]
               }
             },
+            "artifactId": "[uuid]",
             "units": {
               "type": "Mm"
             },

--- a/src/wasm-lib/kcl/tests/import_function_not_sketch/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/import_function_not_sketch/program_memory.snap
@@ -1,7 +1,6 @@
 ---
 source: kcl/src/simulation_tests.rs
 description: Program memory after executing import_function_not_sketch.kcl
-snapshot_kind: text
 ---
 {
   "environments": [
@@ -166,6 +165,7 @@ snapshot_kind: text
                               "value": {
                                 "type": "Solid",
                                 "id": "[uuid]",
+                                "artifactId": "[uuid]",
                                 "value": [
                                   {
                                     "faceId": "[uuid]",
@@ -424,6 +424,7 @@ snapshot_kind: text
                                   "on": {
                                     "type": "plane",
                                     "id": "[uuid]",
+                                    "artifactId": "[uuid]",
                                     "value": "XY",
                                     "origin": {
                                       "x": 0.0,
@@ -469,6 +470,7 @@ snapshot_kind: text
                                       ]
                                     }
                                   },
+                                  "artifactId": "[uuid]",
                                   "units": {
                                     "type": "Mm"
                                   },
@@ -597,6 +599,7 @@ snapshot_kind: text
                     "value": {
                       "type": "Solid",
                       "id": "[uuid]",
+                      "artifactId": "[uuid]",
                       "value": [
                         {
                           "faceId": "[uuid]",
@@ -855,6 +858,7 @@ snapshot_kind: text
                         "on": {
                           "type": "plane",
                           "id": "[uuid]",
+                          "artifactId": "[uuid]",
                           "value": "XY",
                           "origin": {
                             "x": 0.0,
@@ -900,6 +904,7 @@ snapshot_kind: text
                             ]
                           }
                         },
+                        "artifactId": "[uuid]",
                         "units": {
                           "type": "Mm"
                         },

--- a/src/wasm-lib/kcl/tests/import_whole/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/import_whole/program_memory.snap
@@ -31,6 +31,7 @@ description: Program memory after executing import_whole.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -78,6 +79,7 @@ description: Program memory after executing import_whole.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -123,6 +125,7 @@ description: Program memory after executing import_whole.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Inches"
               },

--- a/src/wasm-lib/kcl/tests/kittycad_svg/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/kittycad_svg/program_memory.snap
@@ -31,6 +31,7 @@ description: Program memory after executing kittycad_svg.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -8772,6 +8773,7 @@ description: Program memory after executing kittycad_svg.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -8817,6 +8819,7 @@ description: Program memory after executing kittycad_svg.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/linear_pattern3d_a_pattern/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/linear_pattern3d_a_pattern/program_memory.snap
@@ -31,6 +31,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -165,6 +166,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XZ",
                 "origin": {
                   "x": 0.0,
@@ -210,6 +212,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -246,6 +249,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -380,6 +384,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -425,6 +430,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -457,6 +463,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -591,6 +598,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -636,6 +644,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -668,6 +677,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -802,6 +812,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -847,6 +858,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -879,6 +891,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -1013,6 +1026,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -1058,6 +1072,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -1090,6 +1105,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -1224,6 +1240,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -1269,6 +1286,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -1301,6 +1319,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -1435,6 +1454,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -1480,6 +1500,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -1512,6 +1533,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -1646,6 +1668,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -1691,6 +1714,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -1728,6 +1752,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -1862,6 +1887,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -1907,6 +1933,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -1939,6 +1966,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -2073,6 +2101,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -2118,6 +2147,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -2150,6 +2180,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -2284,6 +2315,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -2329,6 +2361,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -2361,6 +2394,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -2495,6 +2529,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -2540,6 +2575,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -2572,6 +2608,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -2706,6 +2743,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -2751,6 +2789,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -2783,6 +2822,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -2917,6 +2957,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -2962,6 +3003,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -2994,6 +3036,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -3128,6 +3171,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -3173,6 +3217,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -3205,6 +3250,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -3339,6 +3385,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -3384,6 +3431,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -3416,6 +3464,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -3550,6 +3599,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -3595,6 +3645,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -3627,6 +3678,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -3761,6 +3813,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -3806,6 +3859,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -3838,6 +3892,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -3972,6 +4027,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -4017,6 +4073,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -4049,6 +4106,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -4183,6 +4241,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -4228,6 +4287,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -4260,6 +4320,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -4394,6 +4455,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -4439,6 +4501,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -4471,6 +4534,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -4605,6 +4669,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -4650,6 +4715,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -4682,6 +4748,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -4816,6 +4883,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -4861,6 +4929,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -4893,6 +4962,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -5027,6 +5097,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -5072,6 +5143,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -5104,6 +5176,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -5238,6 +5311,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -5283,6 +5357,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -5315,6 +5390,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -5449,6 +5525,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -5494,6 +5571,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -5526,6 +5604,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -5660,6 +5739,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -5705,6 +5785,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -5737,6 +5818,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -5871,6 +5953,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -5916,6 +5999,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -5948,6 +6032,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -6082,6 +6167,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -6127,6 +6213,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -6159,6 +6246,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -6293,6 +6381,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -6338,6 +6427,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -6370,6 +6460,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -6504,6 +6595,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -6549,6 +6641,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -6581,6 +6674,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -6715,6 +6809,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -6760,6 +6855,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -6792,6 +6888,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -6926,6 +7023,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -6971,6 +7069,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -7003,6 +7102,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -7137,6 +7237,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -7182,6 +7283,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -7214,6 +7316,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -7348,6 +7451,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -7393,6 +7497,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -7425,6 +7530,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -7559,6 +7665,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -7604,6 +7711,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -7636,6 +7744,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -7770,6 +7879,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -7815,6 +7925,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -7847,6 +7958,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -7981,6 +8093,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -8026,6 +8139,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -8058,6 +8172,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -8192,6 +8307,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -8237,6 +8353,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -8269,6 +8386,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -8403,6 +8521,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -8448,6 +8567,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -8480,6 +8600,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -8614,6 +8735,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -8659,6 +8781,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -8691,6 +8814,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -8825,6 +8949,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -8870,6 +8995,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -8902,6 +9028,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -9036,6 +9163,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -9081,6 +9209,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -9113,6 +9242,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -9247,6 +9377,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -9292,6 +9423,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -9324,6 +9456,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -9458,6 +9591,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -9503,6 +9637,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -9535,6 +9670,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -9669,6 +9805,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -9714,6 +9851,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -9746,6 +9884,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -9880,6 +10019,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -9925,6 +10065,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -9957,6 +10098,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -10091,6 +10233,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -10136,6 +10279,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -10168,6 +10312,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -10302,6 +10447,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -10347,6 +10493,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -10379,6 +10526,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -10513,6 +10661,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -10558,6 +10707,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -10590,6 +10740,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -10724,6 +10875,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -10769,6 +10921,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -10801,6 +10954,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -10935,6 +11089,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -10980,6 +11135,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -11012,6 +11168,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -11146,6 +11303,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -11191,6 +11349,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -11223,6 +11382,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -11357,6 +11517,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -11402,6 +11563,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -11434,6 +11596,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -11568,6 +11731,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -11613,6 +11777,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -11645,6 +11810,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -11779,6 +11945,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -11824,6 +11991,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },
@@ -11856,6 +12024,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
             {
               "type": "Solid",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": [
                 {
                   "faceId": "[uuid]",
@@ -11990,6 +12159,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                 "on": {
                   "type": "plane",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": "XZ",
                   "origin": {
                     "x": 0.0,
@@ -12035,6 +12205,7 @@ description: Program memory after executing linear_pattern3d_a_pattern.kcl
                     ]
                   }
                 },
+                "artifactId": "[uuid]",
                 "units": {
                   "type": "Mm"
                 },

--- a/src/wasm-lib/kcl/tests/mike_stress_test/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/mike_stress_test/program_memory.snap
@@ -31,6 +31,7 @@ description: Program memory after executing mike_stress_test.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -31072,6 +31073,7 @@ description: Program memory after executing mike_stress_test.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -31117,6 +31119,7 @@ description: Program memory after executing mike_stress_test.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/neg_xz_plane/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/neg_xz_plane/program_memory.snap
@@ -31,6 +31,7 @@ description: Program memory after executing neg_xz_plane.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -134,6 +135,7 @@ description: Program memory after executing neg_xz_plane.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XZ",
                 "origin": {
                   "x": 0.0,
@@ -179,6 +181,7 @@ description: Program memory after executing neg_xz_plane.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/parametric/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/parametric/program_memory.snap
@@ -44,6 +44,7 @@ description: Program memory after executing parametric.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -240,6 +241,7 @@ description: Program memory after executing parametric.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -285,6 +287,7 @@ description: Program memory after executing parametric.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/parametric_with_tan_arc/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/parametric_with_tan_arc/program_memory.snap
@@ -44,6 +44,7 @@ description: Program memory after executing parametric_with_tan_arc.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -312,6 +313,7 @@ description: Program memory after executing parametric_with_tan_arc.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -357,6 +359,7 @@ description: Program memory after executing parametric_with_tan_arc.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/pentagon_fillet_sugar/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/pentagon_fillet_sugar/program_memory.snap
@@ -333,6 +333,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
             "on": {
               "type": "face",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": "c",
               "xAxis": {
                 "x": 1.0,
@@ -352,6 +353,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
               "solid": {
                 "type": "Solid",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": [
                   {
                     "faceId": "[uuid]",
@@ -485,6 +487,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
                   "on": {
                     "type": "plane",
                     "id": "[uuid]",
+                    "artifactId": "[uuid]",
                     "value": "XY",
                     "origin": {
                       "x": 0.0,
@@ -709,6 +712,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
                       ]
                     }
                   },
+                  "artifactId": "[uuid]",
                   "units": {
                     "type": "Mm"
                   },
@@ -837,6 +841,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
                 ]
               }
             },
+            "artifactId": "[uuid]",
             "units": {
               "type": "Mm"
             },
@@ -912,6 +917,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
             "on": {
               "type": "face",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": "a",
               "xAxis": {
                 "x": 1.0,
@@ -931,6 +937,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
               "solid": {
                 "type": "Solid",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": [
                   {
                     "faceId": "[uuid]",
@@ -1064,6 +1071,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
                   "on": {
                     "type": "plane",
                     "id": "[uuid]",
+                    "artifactId": "[uuid]",
                     "value": "XY",
                     "origin": {
                       "x": 0.0,
@@ -1288,6 +1296,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
                       ]
                     }
                   },
+                  "artifactId": "[uuid]",
                   "units": {
                     "type": "Mm"
                   },
@@ -1416,6 +1425,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
                 ]
               }
             },
+            "artifactId": "[uuid]",
             "units": {
               "type": "Mm"
             },
@@ -1948,6 +1958,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
                     "value": {
                       "type": "Solid",
                       "id": "[uuid]",
+                      "artifactId": "[uuid]",
                       "value": [
                         {
                           "faceId": "[uuid]",
@@ -2081,6 +2092,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
                         "on": {
                           "type": "plane",
                           "id": "[uuid]",
+                          "artifactId": "[uuid]",
                           "value": "XY",
                           "origin": {
                             "x": 0.0,
@@ -2305,6 +2317,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
                             ]
                           }
                         },
+                        "artifactId": "[uuid]",
                         "units": {
                           "type": "Mm"
                         },
@@ -2409,6 +2422,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -2542,6 +2556,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -2766,6 +2781,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -2801,6 +2817,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -2878,6 +2895,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
               "on": {
                 "type": "face",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "a",
                 "xAxis": {
                   "x": 1.0,
@@ -2897,6 +2915,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
                 "solid": {
                   "type": "Solid",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": [
                     {
                       "faceId": "[uuid]",
@@ -3030,6 +3049,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
                     "on": {
                       "type": "plane",
                       "id": "[uuid]",
+                      "artifactId": "[uuid]",
                       "value": "XY",
                       "origin": {
                         "x": 0.0,
@@ -3254,6 +3274,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
                         ]
                       }
                     },
+                    "artifactId": "[uuid]",
                     "units": {
                       "type": "Mm"
                     },
@@ -3382,6 +3403,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -3433,6 +3455,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -3510,6 +3533,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
               "on": {
                 "type": "face",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "c",
                 "xAxis": {
                   "x": 1.0,
@@ -3529,6 +3553,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
                 "solid": {
                   "type": "Solid",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": [
                     {
                       "faceId": "[uuid]",
@@ -3662,6 +3687,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
                     "on": {
                       "type": "plane",
                       "id": "[uuid]",
+                      "artifactId": "[uuid]",
                       "value": "XY",
                       "origin": {
                         "x": 0.0,
@@ -3886,6 +3912,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
                         ]
                       }
                     },
+                    "artifactId": "[uuid]",
                     "units": {
                       "type": "Mm"
                     },
@@ -4014,6 +4041,7 @@ description: Program memory after executing pentagon_fillet_sugar.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/pipe_as_arg/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/pipe_as_arg/program_memory.snap
@@ -1563,6 +1563,7 @@ description: Program memory after executing pipe_as_arg.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -1717,6 +1718,7 @@ description: Program memory after executing pipe_as_arg.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -1762,6 +1764,7 @@ description: Program memory after executing pipe_as_arg.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/poop_chute/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/poop_chute/program_memory.snap
@@ -148,6 +148,7 @@ description: Program memory after executing poop_chute.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -571,6 +572,7 @@ description: Program memory after executing poop_chute.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "YZ",
                 "origin": {
                   "x": 0.0,
@@ -677,6 +679,7 @@ description: Program memory after executing poop_chute.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -1102,6 +1105,7 @@ description: Program memory after executing poop_chute.kcl
             "on": {
               "type": "plane",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": "YZ",
               "origin": {
                 "x": 0.0,
@@ -1208,6 +1212,7 @@ description: Program memory after executing poop_chute.kcl
                 ]
               }
             },
+            "artifactId": "[uuid]",
             "units": {
               "type": "Mm"
             },
@@ -1227,6 +1232,7 @@ description: Program memory after executing poop_chute.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -1650,6 +1656,7 @@ description: Program memory after executing poop_chute.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "YZ",
                 "origin": {
                   "x": 0.0,
@@ -1756,6 +1763,7 @@ description: Program memory after executing poop_chute.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/riddle_small/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/riddle_small/program_memory.snap
@@ -140,6 +140,7 @@ description: Program memory after executing riddle_small.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -274,6 +275,7 @@ description: Program memory after executing riddle_small.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XZ",
                 "origin": {
                   "x": 0.0,
@@ -319,6 +321,7 @@ description: Program memory after executing riddle_small.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/sketch-on-chamfer-two-times-different-order/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch-on-chamfer-two-times-different-order/program_memory.snap
@@ -31,6 +31,7 @@ description: Program memory after executing sketch-on-chamfer-two-times-differen
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -247,6 +248,7 @@ description: Program memory after executing sketch-on-chamfer-two-times-differen
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XZ",
                 "origin": {
                   "x": 0.0,
@@ -541,6 +543,7 @@ description: Program memory after executing sketch-on-chamfer-two-times-differen
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -609,6 +612,7 @@ description: Program memory after executing sketch-on-chamfer-two-times-differen
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -793,6 +797,7 @@ description: Program memory after executing sketch-on-chamfer-two-times-differen
               "on": {
                 "type": "face",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "seg03",
                 "xAxis": {
                   "x": 1.0,
@@ -812,6 +817,7 @@ description: Program memory after executing sketch-on-chamfer-two-times-differen
                 "solid": {
                   "type": "Solid",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": [
                     {
                       "faceId": "[uuid]",
@@ -1028,6 +1034,7 @@ description: Program memory after executing sketch-on-chamfer-two-times-differen
                     "on": {
                       "type": "plane",
                       "id": "[uuid]",
+                      "artifactId": "[uuid]",
                       "value": "XZ",
                       "origin": {
                         "x": 0.0,
@@ -1322,6 +1329,7 @@ description: Program memory after executing sketch-on-chamfer-two-times-differen
                         ]
                       }
                     },
+                    "artifactId": "[uuid]",
                     "units": {
                       "type": "Mm"
                     },
@@ -1595,6 +1603,7 @@ description: Program memory after executing sketch-on-chamfer-two-times-differen
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -2317,6 +2326,7 @@ description: Program memory after executing sketch-on-chamfer-two-times-differen
             "on": {
               "type": "plane",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": "XZ",
               "origin": {
                 "x": 0.0,
@@ -2611,6 +2621,7 @@ description: Program memory after executing sketch-on-chamfer-two-times-differen
                 ]
               }
             },
+            "artifactId": "[uuid]",
             "units": {
               "type": "Mm"
             },
@@ -2750,6 +2761,7 @@ description: Program memory after executing sketch-on-chamfer-two-times-differen
             "on": {
               "type": "face",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": "seg03",
               "xAxis": {
                 "x": 1.0,
@@ -2769,6 +2781,7 @@ description: Program memory after executing sketch-on-chamfer-two-times-differen
               "solid": {
                 "type": "Solid",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": [
                   {
                     "faceId": "[uuid]",
@@ -2985,6 +2998,7 @@ description: Program memory after executing sketch-on-chamfer-two-times-differen
                   "on": {
                     "type": "plane",
                     "id": "[uuid]",
+                    "artifactId": "[uuid]",
                     "value": "XZ",
                     "origin": {
                       "x": 0.0,
@@ -3279,6 +3293,7 @@ description: Program memory after executing sketch-on-chamfer-two-times-differen
                       ]
                     }
                   },
+                  "artifactId": "[uuid]",
                   "units": {
                     "type": "Mm"
                   },
@@ -3552,6 +3567,7 @@ description: Program memory after executing sketch-on-chamfer-two-times-differen
                 ]
               }
             },
+            "artifactId": "[uuid]",
             "units": {
               "type": "Mm"
             },
@@ -3691,6 +3707,7 @@ description: Program memory after executing sketch-on-chamfer-two-times-differen
             "on": {
               "type": "face",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": "seg04",
               "xAxis": {
                 "x": 1.0,
@@ -3710,6 +3727,7 @@ description: Program memory after executing sketch-on-chamfer-two-times-differen
               "solid": {
                 "type": "Solid",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": [
                   {
                     "faceId": "[uuid]",
@@ -3926,6 +3944,7 @@ description: Program memory after executing sketch-on-chamfer-two-times-differen
                   "on": {
                     "type": "plane",
                     "id": "[uuid]",
+                    "artifactId": "[uuid]",
                     "value": "XZ",
                     "origin": {
                       "x": 0.0,
@@ -4220,6 +4239,7 @@ description: Program memory after executing sketch-on-chamfer-two-times-differen
                       ]
                     }
                   },
+                  "artifactId": "[uuid]",
                   "units": {
                     "type": "Mm"
                   },
@@ -4448,6 +4468,7 @@ description: Program memory after executing sketch-on-chamfer-two-times-differen
                 ]
               }
             },
+            "artifactId": "[uuid]",
             "units": {
               "type": "Mm"
             },

--- a/src/wasm-lib/kcl/tests/sketch-on-chamfer-two-times/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch-on-chamfer-two-times/program_memory.snap
@@ -31,6 +31,7 @@ description: Program memory after executing sketch-on-chamfer-two-times.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -247,6 +248,7 @@ description: Program memory after executing sketch-on-chamfer-two-times.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XZ",
                 "origin": {
                   "x": 0.0,
@@ -541,6 +543,7 @@ description: Program memory after executing sketch-on-chamfer-two-times.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -609,6 +612,7 @@ description: Program memory after executing sketch-on-chamfer-two-times.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -793,6 +797,7 @@ description: Program memory after executing sketch-on-chamfer-two-times.kcl
               "on": {
                 "type": "face",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "seg03",
                 "xAxis": {
                   "x": 1.0,
@@ -812,6 +817,7 @@ description: Program memory after executing sketch-on-chamfer-two-times.kcl
                 "solid": {
                   "type": "Solid",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": [
                     {
                       "faceId": "[uuid]",
@@ -1028,6 +1034,7 @@ description: Program memory after executing sketch-on-chamfer-two-times.kcl
                     "on": {
                       "type": "plane",
                       "id": "[uuid]",
+                      "artifactId": "[uuid]",
                       "value": "XZ",
                       "origin": {
                         "x": 0.0,
@@ -1322,6 +1329,7 @@ description: Program memory after executing sketch-on-chamfer-two-times.kcl
                         ]
                       }
                     },
+                    "artifactId": "[uuid]",
                     "units": {
                       "type": "Mm"
                     },
@@ -1595,6 +1603,7 @@ description: Program memory after executing sketch-on-chamfer-two-times.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -2317,6 +2326,7 @@ description: Program memory after executing sketch-on-chamfer-two-times.kcl
             "on": {
               "type": "plane",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": "XZ",
               "origin": {
                 "x": 0.0,
@@ -2611,6 +2621,7 @@ description: Program memory after executing sketch-on-chamfer-two-times.kcl
                 ]
               }
             },
+            "artifactId": "[uuid]",
             "units": {
               "type": "Mm"
             },
@@ -2750,6 +2761,7 @@ description: Program memory after executing sketch-on-chamfer-two-times.kcl
             "on": {
               "type": "face",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": "seg03",
               "xAxis": {
                 "x": 1.0,
@@ -2769,6 +2781,7 @@ description: Program memory after executing sketch-on-chamfer-two-times.kcl
               "solid": {
                 "type": "Solid",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": [
                   {
                     "faceId": "[uuid]",
@@ -2985,6 +2998,7 @@ description: Program memory after executing sketch-on-chamfer-two-times.kcl
                   "on": {
                     "type": "plane",
                     "id": "[uuid]",
+                    "artifactId": "[uuid]",
                     "value": "XZ",
                     "origin": {
                       "x": 0.0,
@@ -3279,6 +3293,7 @@ description: Program memory after executing sketch-on-chamfer-two-times.kcl
                       ]
                     }
                   },
+                  "artifactId": "[uuid]",
                   "units": {
                     "type": "Mm"
                   },
@@ -3552,6 +3567,7 @@ description: Program memory after executing sketch-on-chamfer-two-times.kcl
                 ]
               }
             },
+            "artifactId": "[uuid]",
             "units": {
               "type": "Mm"
             },
@@ -3691,6 +3707,7 @@ description: Program memory after executing sketch-on-chamfer-two-times.kcl
             "on": {
               "type": "face",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": "seg04",
               "xAxis": {
                 "x": 1.0,
@@ -3710,6 +3727,7 @@ description: Program memory after executing sketch-on-chamfer-two-times.kcl
               "solid": {
                 "type": "Solid",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": [
                   {
                     "faceId": "[uuid]",
@@ -3926,6 +3944,7 @@ description: Program memory after executing sketch-on-chamfer-two-times.kcl
                   "on": {
                     "type": "plane",
                     "id": "[uuid]",
+                    "artifactId": "[uuid]",
                     "value": "XZ",
                     "origin": {
                       "x": 0.0,
@@ -4220,6 +4239,7 @@ description: Program memory after executing sketch-on-chamfer-two-times.kcl
                       ]
                     }
                   },
+                  "artifactId": "[uuid]",
                   "units": {
                     "type": "Mm"
                   },
@@ -4448,6 +4468,7 @@ description: Program memory after executing sketch-on-chamfer-two-times.kcl
                 ]
               }
             },
+            "artifactId": "[uuid]",
             "units": {
               "type": "Mm"
             },

--- a/src/wasm-lib/kcl/tests/sketch_in_object/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch_in_object/program_memory.snap
@@ -1126,6 +1126,7 @@ description: Program memory after executing sketch_in_object.kcl
             "on": {
               "type": "plane",
               "id": "[uuid]",
+              "artifactId": "[uuid]",
               "value": "XY",
               "origin": {
                 "x": 0.0,
@@ -1171,6 +1172,7 @@ description: Program memory after executing sketch_in_object.kcl
                 ]
               }
             },
+            "artifactId": "[uuid]",
             "units": {
               "type": "Mm"
             },
@@ -1281,6 +1283,7 @@ description: Program memory after executing sketch_in_object.kcl
                     "on": {
                       "type": "plane",
                       "id": "[uuid]",
+                      "artifactId": "[uuid]",
                       "value": "XY",
                       "origin": {
                         "x": 0.0,
@@ -1326,6 +1329,7 @@ description: Program memory after executing sketch_in_object.kcl
                         ]
                       }
                     },
+                    "artifactId": "[uuid]",
                     "units": {
                       "type": "Mm"
                     },

--- a/src/wasm-lib/kcl/tests/sketch_on_face/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face/program_memory.snap
@@ -91,6 +91,7 @@ description: Program memory after executing sketch_on_face.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -235,6 +236,7 @@ description: Program memory after executing sketch_on_face.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -341,6 +343,7 @@ description: Program memory after executing sketch_on_face.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -376,6 +379,7 @@ description: Program memory after executing sketch_on_face.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -510,6 +514,7 @@ description: Program memory after executing sketch_on_face.kcl
               "on": {
                 "type": "face",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "here",
                 "xAxis": {
                   "x": 1.0,
@@ -529,6 +534,7 @@ description: Program memory after executing sketch_on_face.kcl
                 "solid": {
                   "type": "Solid",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": [
                     {
                       "faceId": "[uuid]",
@@ -673,6 +679,7 @@ description: Program memory after executing sketch_on_face.kcl
                     "on": {
                       "type": "plane",
                       "id": "[uuid]",
+                      "artifactId": "[uuid]",
                       "value": "XY",
                       "origin": {
                         "x": 0.0,
@@ -779,6 +786,7 @@ description: Program memory after executing sketch_on_face.kcl
                         ]
                       }
                     },
+                    "artifactId": "[uuid]",
                     "units": {
                       "type": "Mm"
                     },
@@ -840,6 +848,7 @@ description: Program memory after executing sketch_on_face.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/sketch_on_face_after_fillets_referencing_face/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face_after_fillets_referencing_face/program_memory.snap
@@ -84,6 +84,7 @@ description: Program memory after executing sketch_on_face_after_fillets_referen
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -310,6 +311,7 @@ description: Program memory after executing sketch_on_face_after_fillets_referen
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -534,6 +536,7 @@ description: Program memory after executing sketch_on_face_after_fillets_referen
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -817,6 +820,7 @@ description: Program memory after executing sketch_on_face_after_fillets_referen
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -971,6 +975,7 @@ description: Program memory after executing sketch_on_face_after_fillets_referen
               "on": {
                 "type": "face",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "seg01",
                 "xAxis": {
                   "x": 1.0,
@@ -990,6 +995,7 @@ description: Program memory after executing sketch_on_face_after_fillets_referen
                 "solid": {
                   "type": "Solid",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": [
                     {
                       "faceId": "[uuid]",
@@ -1216,6 +1222,7 @@ description: Program memory after executing sketch_on_face_after_fillets_referen
                     "on": {
                       "type": "plane",
                       "id": "[uuid]",
+                      "artifactId": "[uuid]",
                       "value": "XY",
                       "origin": {
                         "x": 0.0,
@@ -1440,6 +1447,7 @@ description: Program memory after executing sketch_on_face_after_fillets_referen
                         ]
                       }
                     },
+                    "artifactId": "[uuid]",
                     "units": {
                       "type": "Mm"
                     },
@@ -1517,6 +1525,7 @@ description: Program memory after executing sketch_on_face_after_fillets_referen
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/sketch_on_face_circle_tagged/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face_circle_tagged/program_memory.snap
@@ -425,6 +425,7 @@ description: Program memory after executing sketch_on_face_circle_tagged.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -559,6 +560,7 @@ description: Program memory after executing sketch_on_face_circle_tagged.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -604,6 +606,7 @@ description: Program memory after executing sketch_on_face_circle_tagged.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -639,6 +642,7 @@ description: Program memory after executing sketch_on_face_circle_tagged.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -696,6 +700,7 @@ description: Program memory after executing sketch_on_face_circle_tagged.kcl
               "on": {
                 "type": "face",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "end",
                 "xAxis": {
                   "x": 1.0,
@@ -715,6 +720,7 @@ description: Program memory after executing sketch_on_face_circle_tagged.kcl
                 "solid": {
                   "type": "Solid",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": [
                     {
                       "faceId": "[uuid]",
@@ -849,6 +855,7 @@ description: Program memory after executing sketch_on_face_circle_tagged.kcl
                     "on": {
                       "type": "plane",
                       "id": "[uuid]",
+                      "artifactId": "[uuid]",
                       "value": "XY",
                       "origin": {
                         "x": 0.0,
@@ -894,6 +901,7 @@ description: Program memory after executing sketch_on_face_circle_tagged.kcl
                         ]
                       }
                     },
+                    "artifactId": "[uuid]",
                     "units": {
                       "type": "Mm"
                     },
@@ -1022,6 +1030,7 @@ description: Program memory after executing sketch_on_face_circle_tagged.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/sketch_on_face_end/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face_end/program_memory.snap
@@ -359,6 +359,7 @@ description: Program memory after executing sketch_on_face_end.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -493,6 +494,7 @@ description: Program memory after executing sketch_on_face_end.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -538,6 +540,7 @@ description: Program memory after executing sketch_on_face_end.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -573,6 +576,7 @@ description: Program memory after executing sketch_on_face_end.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -707,6 +711,7 @@ description: Program memory after executing sketch_on_face_end.kcl
               "on": {
                 "type": "face",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "end",
                 "xAxis": {
                   "x": 1.0,
@@ -726,6 +731,7 @@ description: Program memory after executing sketch_on_face_end.kcl
                 "solid": {
                   "type": "Solid",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": [
                     {
                       "faceId": "[uuid]",
@@ -860,6 +866,7 @@ description: Program memory after executing sketch_on_face_end.kcl
                     "on": {
                       "type": "plane",
                       "id": "[uuid]",
+                      "artifactId": "[uuid]",
                       "value": "XY",
                       "origin": {
                         "x": 0.0,
@@ -905,6 +912,7 @@ description: Program memory after executing sketch_on_face_end.kcl
                         ]
                       }
                     },
+                    "artifactId": "[uuid]",
                     "units": {
                       "type": "Mm"
                     },
@@ -966,6 +974,7 @@ description: Program memory after executing sketch_on_face_end.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/sketch_on_face_end_negative_extrude/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face_end_negative_extrude/program_memory.snap
@@ -359,6 +359,7 @@ description: Program memory after executing sketch_on_face_end_negative_extrude.
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -493,6 +494,7 @@ description: Program memory after executing sketch_on_face_end_negative_extrude.
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -538,6 +540,7 @@ description: Program memory after executing sketch_on_face_end_negative_extrude.
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -573,6 +576,7 @@ description: Program memory after executing sketch_on_face_end_negative_extrude.
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -707,6 +711,7 @@ description: Program memory after executing sketch_on_face_end_negative_extrude.
               "on": {
                 "type": "face",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "end",
                 "xAxis": {
                   "x": 1.0,
@@ -726,6 +731,7 @@ description: Program memory after executing sketch_on_face_end_negative_extrude.
                 "solid": {
                   "type": "Solid",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": [
                     {
                       "faceId": "[uuid]",
@@ -860,6 +866,7 @@ description: Program memory after executing sketch_on_face_end_negative_extrude.
                     "on": {
                       "type": "plane",
                       "id": "[uuid]",
+                      "artifactId": "[uuid]",
                       "value": "XY",
                       "origin": {
                         "x": 0.0,
@@ -905,6 +912,7 @@ description: Program memory after executing sketch_on_face_end_negative_extrude.
                         ]
                       }
                     },
+                    "artifactId": "[uuid]",
                     "units": {
                       "type": "Mm"
                     },
@@ -966,6 +974,7 @@ description: Program memory after executing sketch_on_face_end_negative_extrude.
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/sketch_on_face_start/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face_start/program_memory.snap
@@ -359,6 +359,7 @@ description: Program memory after executing sketch_on_face_start.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -493,6 +494,7 @@ description: Program memory after executing sketch_on_face_start.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -538,6 +540,7 @@ description: Program memory after executing sketch_on_face_start.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -573,6 +576,7 @@ description: Program memory after executing sketch_on_face_start.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -707,6 +711,7 @@ description: Program memory after executing sketch_on_face_start.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -752,6 +757,7 @@ description: Program memory after executing sketch_on_face_start.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },
@@ -787,6 +793,7 @@ description: Program memory after executing sketch_on_face_start.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -921,6 +928,7 @@ description: Program memory after executing sketch_on_face_start.kcl
               "on": {
                 "type": "face",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "start",
                 "xAxis": {
                   "x": 1.0,
@@ -940,6 +948,7 @@ description: Program memory after executing sketch_on_face_start.kcl
                 "solid": {
                   "type": "Solid",
                   "id": "[uuid]",
+                  "artifactId": "[uuid]",
                   "value": [
                     {
                       "faceId": "[uuid]",
@@ -1074,6 +1083,7 @@ description: Program memory after executing sketch_on_face_start.kcl
                     "on": {
                       "type": "plane",
                       "id": "[uuid]",
+                      "artifactId": "[uuid]",
                       "value": "XY",
                       "origin": {
                         "x": 0.0,
@@ -1119,6 +1129,7 @@ description: Program memory after executing sketch_on_face_start.kcl
                         ]
                       }
                     },
+                    "artifactId": "[uuid]",
                     "units": {
                       "type": "Mm"
                     },
@@ -1180,6 +1191,7 @@ description: Program memory after executing sketch_on_face_start.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/tangential_arc/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/tangential_arc/program_memory.snap
@@ -31,6 +31,7 @@ description: Program memory after executing tangential_arc.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -139,6 +140,7 @@ description: Program memory after executing tangential_arc.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XY",
                 "origin": {
                   "x": 0.0,
@@ -184,6 +186,7 @@ description: Program memory after executing tangential_arc.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },

--- a/src/wasm-lib/kcl/tests/xz_plane/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/xz_plane/program_memory.snap
@@ -31,6 +31,7 @@ description: Program memory after executing xz_plane.kcl
           "value": {
             "type": "Solid",
             "id": "[uuid]",
+            "artifactId": "[uuid]",
             "value": [
               {
                 "faceId": "[uuid]",
@@ -134,6 +135,7 @@ description: Program memory after executing xz_plane.kcl
               "on": {
                 "type": "plane",
                 "id": "[uuid]",
+                "artifactId": "[uuid]",
                 "value": "XZ",
                 "origin": {
                   "x": 0.0,
@@ -179,6 +181,7 @@ description: Program memory after executing xz_plane.kcl
                   ]
                 }
               },
+              "artifactId": "[uuid]",
               "units": {
                 "type": "Mm"
               },


### PR DESCRIPTION
Resolves #5186.

Weirdly, the `id` of Sketch and other core structs may get mutated. Sometimes the `id` value is the same as the artifact ID, but not always. We track and expose the stable artifact ID for everything that has it. This isn't used yet, but it will be in a follow-up PR.