### PR TITLE
Fix flaky e2e test with nondeterministic project list order

### DIFF
--- a/e2e/playwright/fixtures/homePageFixture.ts
+++ b/e2e/playwright/fixtures/homePageFixture.ts
@@ -89,18 +89,11 @@ export class HomePageFixture {
    * Maybe there a good sanity check we can do each time?
    */
   expectState = async (expectedState: HomePageState) => {
-    await expect
-      .poll(async () => {
-        const [projectCards, sortBy] = await Promise.all([
-          this._serialiseProjectCards(),
-          this._serialiseSortBy(),
-        ])
-        return {
-          projectCards,
-          sortBy,
-        }
-      })
-      .toEqual(expectedState)
+    await expect.poll(this._serialiseSortBy).toEqual(expectedState.sortBy)
+
+    for (const projectCard of expectedState.projectCards) {
+      await expect.poll(this._serialiseProjectCards).toContainEqual(projectCard)
+    }
   }
 
   createAndGoToProject = async (projectTitle = 'project-$nnn') => {

--- a/e2e/playwright/projects.spec.ts
+++ b/e2e/playwright/projects.spec.ts
@@ -1527,34 +1527,32 @@ test(
   { tag: '@electron' },
   async ({ context, page, cmdBar, homePage }, testInfo) => {
     await context.folderSetupFn(async (dir) => {
-      await Promise.all([
-        fsp.mkdir(path.join(dir, 'router-template-slate'), { recursive: true }),
-        fsp.mkdir(path.join(dir, 'bracket'), { recursive: true }),
-      ])
-      await Promise.all([
-        fsp.copyFile(
-          path.join(
-            'src',
-            'wasm-lib',
-            'tests',
-            'executor',
-            'inputs',
-            'router-template-slate.kcl'
-          ),
-          path.join(dir, 'router-template-slate', 'main.kcl')
+      await fsp.mkdir(path.join(dir, 'router-template-slate'), {
+        recursive: true,
+      })
+      await fsp.copyFile(
+        path.join(
+          'src',
+          'wasm-lib',
+          'tests',
+          'executor',
+          'inputs',
+          'router-template-slate.kcl'
         ),
-        fsp.copyFile(
-          path.join(
-            'src',
-            'wasm-lib',
-            'tests',
-            'executor',
-            'inputs',
-            'focusrite_scarlett_mounting_braket.kcl'
-          ),
-          path.join(dir, 'bracket', 'main.kcl')
+        path.join(dir, 'router-template-slate', 'main.kcl')
+      )
+      await fsp.mkdir(path.join(dir, 'bracket'), { recursive: true })
+      await fsp.copyFile(
+        path.join(
+          'src',
+          'wasm-lib',
+          'tests',
+          'executor',
+          'inputs',
+          'focusrite_scarlett_mounting_braket.kcl'
         ),
-      ])
+        path.join(dir, 'bracket', 'main.kcl')
+      )
     })
     const u = await getUtils(page)
     await page.setBodyDimensions({ width: 1200, height: 500 })

--- a/package.json
+++ b/package.json
@@ -209,5 +209,6 @@
     "wasm-pack": "^0.13.1",
     "ws": "^8.17.0",
     "yarn": "^1.22.22"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
The test "Opening a project should successfully load the stream" creates two projects. Then it queries the projects, checking both projects were created. However, the projects are returned in a nondeterministic order, which means the test flakes.

I think the nondeterminism is because they're created with a `Promise.all`, so I've instead changed it to create the projects in a specific order.

I've also _queried_ the projects in an order-insensitive way.