### PR TITLE
Fix to invalidate execution cache when top-level annotations change

### DIFF
--- a/src/wasm-lib/kcl/Cargo.toml
+++ b/src/wasm-lib/kcl/Cargo.toml
@@ -32,6 +32,7 @@ gltf-json = "1.4.1"
 http = { workspace = true }
 image = { version = "0.25.5", default-features = false, features = ["png"] }
 indexmap = { version = "2.7.0", features = ["serde"] }
+itertools = "0.13.0"
 kittycad = { workspace = true }
 kittycad-modeling-cmds = { workspace = true }
 lazy_static = "1.5.0"
@@ -115,7 +116,6 @@ expectorate = "1.1.0"
 handlebars = "6.3.0"
 image = { version = "0.25.5", default-features = false, features = ["png"] }
 insta = { version = "1.41.1", features = ["json", "filters", "redactions"] }
-itertools = "0.13.0"
 miette = { version = "7.2.0", features = ["fancy"] }
 pretty_assertions = "1.4.1"
 tokio = { version = "1.41.1", features = ["rt-multi-thread", "macros", "time"] }

--- a/src/wasm-lib/kcl/src/parsing/ast/types/mod.rs
+++ b/src/wasm-lib/kcl/src/parsing/ast/types/mod.rs
@@ -254,15 +254,26 @@ impl Node<Program> {
         Ok(findings)
     }
 
-    /// Get the annotations for the meta settings from the kcl file.
-    pub fn get_meta_settings(&self) -> Result<Option<crate::execution::MetaSettings>, KclError> {
-        let annotations = self
-            .non_code_meta
+    pub fn annotations(&self) -> impl Iterator<Item = &Node<NonCodeNode>> {
+        self.non_code_meta
             .start_nodes
             .iter()
-            .filter_map(|n| n.annotation().map(|result| (result, n.as_source_range())));
-        for (annotation, source_range) in annotations {
+            .filter(|n| n.value_is_annotation())
+    }
+
+    pub fn annotations_mut(&mut self) -> impl Iterator<Item = &mut Node<NonCodeNode>> {
+        self.non_code_meta
+            .start_nodes
+            .iter_mut()
+            .filter(|n| n.value_is_annotation())
+    }
+
+    /// Get the annotations for the meta settings from the kcl file.
+    pub fn get_meta_settings(&self) -> Result<Option<crate::execution::MetaSettings>, KclError> {
+        for annotation_node in self.annotations() {
+            let annotation = &annotation_node.value;
             if annotation.annotation_name() == Some(annotations::SETTINGS) {
+                let source_range = annotation_node.as_source_range();
                 let mut meta_settings = crate::execution::MetaSettings::default();
                 meta_settings.update_from_annotation(annotation, source_range)?;
                 return Ok(Some(meta_settings));
@@ -275,17 +286,15 @@ impl Node<Program> {
     pub fn change_meta_settings(&mut self, settings: crate::execution::MetaSettings) -> Result<Self, KclError> {
         let mut new_program = self.clone();
         let mut found = false;
-        for node in &mut new_program.non_code_meta.start_nodes {
-            if let Some(annotation) = node.annotation() {
-                if annotation.annotation_name() == Some(annotations::SETTINGS) {
-                    let annotation = NonCodeValue::new_from_meta_settings(&settings);
-                    *node = Node::no_src(NonCodeNode {
-                        value: annotation,
-                        digest: None,
-                    });
-                    found = true;
-                    break;
-                }
+        for node in new_program.annotations_mut() {
+            if node.value.annotation_name() == Some(annotations::SETTINGS) {
+                let annotation = NonCodeValue::new_from_meta_settings(&settings);
+                *node = Node::no_src(NonCodeNode {
+                    value: annotation,
+                    digest: None,
+                });
+                found = true;
+                break;
             }
         }
 
@@ -1088,6 +1097,16 @@ impl NonCodeNode {
         match &self.value {
             a @ NonCodeValue::Annotation { .. } => Some(a),
             _ => None,
+        }
+    }
+
+    pub fn value_is_annotation(&self) -> bool {
+        match self.value {
+            NonCodeValue::InlineComment { .. }
+            | NonCodeValue::BlockComment { .. }
+            | NonCodeValue::NewLineBlockComment { .. }
+            | NonCodeValue::NewLine => false,
+            NonCodeValue::Annotation { .. } => true,
         }
     }
 }

--- a/src/wasm-lib/kcl/src/parsing/ast/types/mod.rs
+++ b/src/wasm-lib/kcl/src/parsing/ast/types/mod.rs
@@ -2,7 +2,7 @@
 
 use std::{
     cell::RefCell,
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     fmt,
     ops::{Deref, DerefMut, RangeInclusive},
     rc::Rc,
@@ -1175,7 +1175,7 @@ impl NonCodeValue {
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct NonCodeMeta {
-    pub non_code_nodes: HashMap<usize, NodeList<NonCodeNode>>,
+    pub non_code_nodes: BTreeMap<usize, NodeList<NonCodeNode>>,
     pub start_nodes: NodeList<NonCodeNode>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1214,7 +1214,7 @@ impl<'de> Deserialize<'de> for NonCodeMeta {
             .non_code_nodes
             .into_iter()
             .map(|(key, value)| Ok((key.parse().map_err(serde::de::Error::custom)?, value)))
-            .collect::<Result<HashMap<_, _>, _>>()?;
+            .collect::<Result<BTreeMap<_, _>, _>>()?;
         Ok(NonCodeMeta {
             non_code_nodes,
             start_nodes: helper.start_nodes,

--- a/src/wasm-lib/kcl/src/parsing/parser.rs
+++ b/src/wasm-lib/kcl/src/parsing/parser.rs
@@ -1,7 +1,7 @@
 // TODO optimise size of CompilationError
 #![allow(clippy::result_large_err)]
 
-use std::{cell::RefCell, collections::HashMap, str::FromStr};
+use std::{cell::RefCell, collections::BTreeMap, str::FromStr};
 
 use winnow::{
     combinator::{alt, delimited, opt, peek, preceded, repeat, separated, separated_pair, terminated},
@@ -755,8 +755,8 @@ pub(crate) fn array_elem_by_elem(i: &mut TokenSlice) -> PResult<Node<ArrayExpres
         .end;
 
     // Sort the array's elements (i.e. expression nodes) from the noncode nodes.
-    let (elements, non_code_nodes): (Vec<_>, HashMap<usize, _>) = elements.into_iter().enumerate().fold(
-        (Vec::new(), HashMap::new()),
+    let (elements, non_code_nodes): (Vec<_>, BTreeMap<usize, _>) = elements.into_iter().enumerate().fold(
+        (Vec::new(), BTreeMap::new()),
         |(mut elements, mut non_code_nodes), (i, e)| {
             match e {
                 NonCodeOr::NonCode(x) => {
@@ -898,8 +898,8 @@ pub(crate) fn object(i: &mut TokenSlice) -> PResult<Node<ObjectExpression>> {
     .parse_next(i)?;
 
     // Sort the object's properties from the noncode nodes.
-    let (properties, non_code_nodes): (Vec<_>, HashMap<usize, _>) = properties.into_iter().enumerate().fold(
-        (Vec::new(), HashMap::new()),
+    let (properties, non_code_nodes): (Vec<_>, BTreeMap<usize, _>) = properties.into_iter().enumerate().fold(
+        (Vec::new(), BTreeMap::new()),
         |(mut properties, mut non_code_nodes), (i, e)| {
             match e {
                 NonCodeOr::NonCode(x) => {


### PR DESCRIPTION
The symptoms observed were that changing only units in a file didn't change what was exported. This was discovered in #5212.