### PR TITLE
Refactor Edge Treatment Module to Break Cyclic Dependency

### DIFF
--- a/src/lang/modifyAst/addEdgeTreatment.test.ts
+++ b/src/lang/modifyAst/addEdgeTreatment.test.ts
@@ -27,7 +27,12 @@ import { getNodePathFromSourceRange } from 'lang/queryAstNodePathUtils'
 import { createLiteral } from 'lang/modifyAst'
 import { err } from 'lib/trap'
 import { Selection, Selections } from 'lib/selections'
-import { codeManager, editorManager, engineCommandManager, kclManager } from 'lib/singletons'
+import {
+  codeManager,
+  editorManager,
+  engineCommandManager,
+  kclManager,
+} from 'lib/singletons'
 import { VITE_KC_DEV_TOKEN } from 'env'
 import { isOverlap } from 'lib/utils'
 import { codeRefFromRange } from 'lang/std/artifactGraph'
@@ -297,7 +302,12 @@ const runModifyAstCloneWithEdgeTreatmentAndTag = async (
   }
 
   // apply edge treatment to selection
-  const result = modifyAstWithEdgeTreatmentAndTag(ast, selection, parameters, dependencies)
+  const result = modifyAstWithEdgeTreatmentAndTag(
+    ast,
+    selection,
+    parameters,
+    dependencies
+  )
   if (err(result)) {
     return result
   }

--- a/src/lang/modifyAst/addEdgeTreatment.test.ts
+++ b/src/lang/modifyAst/addEdgeTreatment.test.ts
@@ -27,7 +27,7 @@ import { getNodePathFromSourceRange } from 'lang/queryAstNodePathUtils'
 import { createLiteral } from 'lang/modifyAst'
 import { err } from 'lib/trap'
 import { Selection, Selections } from 'lib/selections'
-import { engineCommandManager, kclManager } from 'lib/singletons'
+import { codeManager, editorManager, engineCommandManager, kclManager } from 'lib/singletons'
 import { VITE_KC_DEV_TOKEN } from 'env'
 import { isOverlap } from 'lib/utils'
 import { codeRefFromRange } from 'lang/std/artifactGraph'
@@ -54,6 +54,13 @@ beforeAll(async () => {
 afterAll(() => {
   engineCommandManager.tearDown()
 })
+
+const dependencies = {
+  kclManager,
+  engineCommandManager,
+  editorManager,
+  codeManager,
+}
 
 const runGetPathToExtrudeForSegmentSelectionTest = async (
   code: string,
@@ -131,7 +138,8 @@ const runGetPathToExtrudeForSegmentSelectionTest = async (
   const pathResult = getPathToExtrudeForSegmentSelection(
     ast,
     selection,
-    artifactGraph
+    artifactGraph,
+    dependencies
   )
   if (err(pathResult)) return pathResult
   const { pathToExtrudeNode } = pathResult
@@ -289,7 +297,7 @@ const runModifyAstCloneWithEdgeTreatmentAndTag = async (
   }
 
   // apply edge treatment to selection
-  const result = modifyAstWithEdgeTreatmentAndTag(ast, selection, parameters)
+  const result = modifyAstWithEdgeTreatmentAndTag(ast, selection, parameters, dependencies)
   if (err(result)) {
     return result
   }

--- a/src/lang/modifyAst/addEdgeTreatment.ts
+++ b/src/lang/modifyAst/addEdgeTreatment.ts
@@ -69,7 +69,12 @@ export async function applyEdgeTreatmentToSelection(
   }
 ): Promise<void | Error> {
   // 1. clone and modify with edge treatment and tag
-  const result = modifyAstWithEdgeTreatmentAndTag(ast, selection, parameters, dependencies)
+  const result = modifyAstWithEdgeTreatmentAndTag(
+    ast,
+    selection,
+    parameters,
+    dependencies
+  )
   if (err(result)) return result
   const { modifiedAst, pathToEdgeTreatmentNode } = result
 
@@ -312,11 +317,17 @@ async function updateAstAndFocus(
     codeManager: CodeManager
   }
 ): Promise<void> {
-  const updatedAst = await dependencies.kclManager.updateAst(modifiedAst, true, {
-    focusPath: pathToEdgeTreatmentNode,
-  })
+  const updatedAst = await dependencies.kclManager.updateAst(
+    modifiedAst,
+    true,
+    {
+      focusPath: pathToEdgeTreatmentNode,
+    }
+  )
 
-  await dependencies.codeManager.updateEditorWithAstAndWriteToFile(updatedAst.newAst)
+  await dependencies.codeManager.updateEditorWithAstAndWriteToFile(
+    updatedAst.newAst
+  )
 
   if (updatedAst?.selections) {
     dependencies.editorManager.selectRange(updatedAst?.selections)

--- a/src/lang/modifyAst/addEdgeTreatment.ts
+++ b/src/lang/modifyAst/addEdgeTreatment.ts
@@ -34,13 +34,11 @@ import { err, trap } from 'lib/trap'
 import { Selection, Selections } from 'lib/selections'
 import { KclCommandValue } from 'lib/commandTypes'
 import { Artifact, getSweepFromSuspectedPath } from 'lang/std/artifactGraph'
-import {
-  kclManager,
-  engineCommandManager,
-  editorManager,
-  codeManager,
-} from 'lib/singletons'
 import { Node } from 'wasm-lib/kcl/bindings/Node'
+import { KclManager } from 'lang/KclSingleton'
+import { EngineCommandManager } from 'lang/std/engineConnection'
+import EditorManager from 'editor/manager'
+import CodeManager from 'lang/codeManager'
 
 // Edge Treatment Types
 export enum EdgeTreatmentType {
@@ -62,21 +60,33 @@ export type EdgeTreatmentParameters = ChamferParameters | FilletParameters
 export async function applyEdgeTreatmentToSelection(
   ast: Node<Program>,
   selection: Selections,
-  parameters: EdgeTreatmentParameters
+  parameters: EdgeTreatmentParameters,
+  dependencies: {
+    kclManager: KclManager
+    engineCommandManager: EngineCommandManager
+    editorManager: EditorManager
+    codeManager: CodeManager
+  }
 ): Promise<void | Error> {
   // 1. clone and modify with edge treatment and tag
-  const result = modifyAstWithEdgeTreatmentAndTag(ast, selection, parameters)
+  const result = modifyAstWithEdgeTreatmentAndTag(ast, selection, parameters, dependencies)
   if (err(result)) return result
   const { modifiedAst, pathToEdgeTreatmentNode } = result
 
   // 2. update ast
-  await updateAstAndFocus(modifiedAst, pathToEdgeTreatmentNode)
+  await updateAstAndFocus(modifiedAst, pathToEdgeTreatmentNode, dependencies)
 }
 
 export function modifyAstWithEdgeTreatmentAndTag(
   ast: Node<Program>,
   selections: Selections,
-  parameters: EdgeTreatmentParameters
+  parameters: EdgeTreatmentParameters,
+  dependencies: {
+    kclManager: KclManager
+    engineCommandManager: EngineCommandManager
+    editorManager: EditorManager
+    codeManager: CodeManager
+  }
 ):
   | { modifiedAst: Node<Program>; pathToEdgeTreatmentNode: Array<PathToNode> }
   | Error {
@@ -86,7 +96,7 @@ export function modifyAstWithEdgeTreatmentAndTag(
   const astResult = insertParametersIntoAst(clonedAst, parameters)
   if (err(astResult)) return astResult
 
-  const artifactGraph = engineCommandManager.artifactGraph
+  const artifactGraph = dependencies.engineCommandManager.artifactGraph
 
   // Step 1: modify ast with tags and group them by extrude nodes (bodies)
   const extrudeToTagsMap: Map<
@@ -99,7 +109,8 @@ export function modifyAstWithEdgeTreatmentAndTag(
     const result = getPathToExtrudeForSegmentSelection(
       clonedAstForGetExtrude,
       selection,
-      artifactGraph
+      artifactGraph,
+      dependencies
     )
     if (err(result)) return result
     const { pathToSegmentNode, pathToExtrudeNode } = result
@@ -252,7 +263,13 @@ function insertParametersIntoAst(
 export function getPathToExtrudeForSegmentSelection(
   ast: Program,
   selection: Selection,
-  artifactGraph: ArtifactGraph
+  artifactGraph: ArtifactGraph,
+  dependencies: {
+    kclManager: KclManager
+    engineCommandManager: EngineCommandManager
+    editorManager: EditorManager
+    codeManager: CodeManager
+  }
 ): { pathToSegmentNode: PathToNode; pathToExtrudeNode: PathToNode } | Error {
   const pathToSegmentNode = getNodePathFromSourceRange(
     ast,
@@ -268,7 +285,7 @@ export function getPathToExtrudeForSegmentSelection(
   const sketchVar = varDecNode.node.declaration.id.name
 
   const sketch = sketchFromKclValue(
-    kclManager.programMemory.get(sketchVar),
+    dependencies.kclManager.programMemory.get(sketchVar),
     sketchVar
   )
   if (trap(sketch)) return sketch
@@ -287,16 +304,22 @@ export function getPathToExtrudeForSegmentSelection(
 
 async function updateAstAndFocus(
   modifiedAst: Node<Program>,
-  pathToEdgeTreatmentNode: Array<PathToNode>
+  pathToEdgeTreatmentNode: Array<PathToNode>,
+  dependencies: {
+    kclManager: KclManager
+    engineCommandManager: EngineCommandManager
+    editorManager: EditorManager
+    codeManager: CodeManager
+  }
 ): Promise<void> {
-  const updatedAst = await kclManager.updateAst(modifiedAst, true, {
+  const updatedAst = await dependencies.kclManager.updateAst(modifiedAst, true, {
     focusPath: pathToEdgeTreatmentNode,
   })
 
-  await codeManager.updateEditorWithAstAndWriteToFile(updatedAst.newAst)
+  await dependencies.codeManager.updateEditorWithAstAndWriteToFile(updatedAst.newAst)
 
   if (updatedAst?.selections) {
-    editorManager.selectRange(updatedAst?.selections)
+    dependencies.editorManager.selectRange(updatedAst?.selections)
   }
 }
 

--- a/src/lang/modifyAst/addShell.ts
+++ b/src/lang/modifyAst/addShell.ts
@@ -19,17 +19,29 @@ import {
   createVariableDeclaration,
 } from 'lang/modifyAst'
 import { KCL_DEFAULT_CONSTANT_PREFIXES } from 'lib/constants'
+import { KclManager } from 'lang/KclSingleton'
+import { EngineCommandManager } from 'lang/std/engineConnection'
+import EditorManager from 'editor/manager'
+import CodeManager from 'lang/codeManager'
+
 
 export function addShell({
   node,
   selection,
   artifactGraph,
   thickness,
+  dependencies
 }: {
   node: Node<Program>
   selection: Selections
   artifactGraph: ArtifactGraph
   thickness: Expr
+  dependencies: {
+      kclManager: KclManager
+      engineCommandManager: EngineCommandManager
+      editorManager: EditorManager
+      codeManager: CodeManager
+    }
 }): Error | { modifiedAst: Node<Program>; pathToNode: PathToNode } {
   const modifiedAst = structuredClone(node)
 
@@ -42,7 +54,8 @@ export function addShell({
     const extrudeLookupResult = getPathToExtrudeForSegmentSelection(
       clonedAstForGetExtrude,
       graphSelection,
-      artifactGraph
+      artifactGraph,
+      dependencies
     )
     if (err(extrudeLookupResult)) {
       return new Error("Couldn't find extrude")

--- a/src/lang/modifyAst/addShell.ts
+++ b/src/lang/modifyAst/addShell.ts
@@ -24,24 +24,23 @@ import { EngineCommandManager } from 'lang/std/engineConnection'
 import EditorManager from 'editor/manager'
 import CodeManager from 'lang/codeManager'
 
-
 export function addShell({
   node,
   selection,
   artifactGraph,
   thickness,
-  dependencies
+  dependencies,
 }: {
   node: Node<Program>
   selection: Selections
   artifactGraph: ArtifactGraph
   thickness: Expr
   dependencies: {
-      kclManager: KclManager
-      engineCommandManager: EngineCommandManager
-      editorManager: EditorManager
-      codeManager: CodeManager
-    }
+    kclManager: KclManager
+    engineCommandManager: EngineCommandManager
+    editorManager: EditorManager
+    codeManager: CodeManager
+  }
 }): Error | { modifiedAst: Node<Program>; pathToNode: PathToNode } {
   const modifiedAst = structuredClone(node)
 

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -1681,7 +1681,7 @@ export const modelingMachine = setup({
         // Extract inputs
         const ast = kclManager.ast
         const { selection, thickness } = input
-        const dependencies = { 
+        const dependencies = {
           kclManager,
           engineCommandManager,
           editorManager,
@@ -1712,7 +1712,7 @@ export const modelingMachine = setup({
             'variableName' in thickness
               ? thickness.variableIdentifierAst
               : thickness.valueAst,
-          dependencies
+          dependencies,
         })
         if (err(shellResult)) {
           return err(shellResult)

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -1681,6 +1681,12 @@ export const modelingMachine = setup({
         // Extract inputs
         const ast = kclManager.ast
         const { selection, thickness } = input
+        const dependencies = { 
+          kclManager,
+          engineCommandManager,
+          editorManager,
+          codeManager,
+        }
 
         // Insert the thickness variable if it exists
         if (
@@ -1706,6 +1712,7 @@ export const modelingMachine = setup({
             'variableName' in thickness
               ? thickness.variableIdentifierAst
               : thickness.valueAst,
+          dependencies
         })
         if (err(shellResult)) {
           return err(shellResult)
@@ -1745,12 +1752,19 @@ export const modelingMachine = setup({
           type: EdgeTreatmentType.Fillet,
           radius,
         }
+        const dependencies = {
+          kclManager,
+          engineCommandManager,
+          editorManager,
+          codeManager,
+        }
 
         // Apply fillet to selection
         const filletResult = await applyEdgeTreatmentToSelection(
           ast,
           selection,
-          parameters
+          parameters,
+          dependencies
         )
         if (err(filletResult)) return filletResult
       }
@@ -1772,12 +1786,19 @@ export const modelingMachine = setup({
           type: EdgeTreatmentType.Chamfer,
           length,
         }
+        const dependencies = {
+          kclManager,
+          engineCommandManager,
+          editorManager,
+          codeManager,
+        }
 
         // Apply chamfer to selection
         const chamferResult = await applyEdgeTreatmentToSelection(
           ast,
           selection,
-          parameters
+          parameters,
+          dependencies
         )
         if (err(chamferResult)) return chamferResult
       }


### PR DESCRIPTION
## Problem: 
`addEdgeTreatment.ts` directly imported singletons (e.g. `kclManager`), creating a cycle with `KclSingleton.ts`.
## Solution: 
Removed direct singleton imports and refactored functions to accept a dependency object (containing `kclManager`, `engineCommandManager`, `editorManager`, and `codeManager`). These dependencies are now injected from the higher-level module.

This change breaks the cyclic dependency.

Closes: #5239