### PR TITLE
WIP: E2E tests failing on local ubuntu

### DIFF
--- a/e2e/playwright/code-pane-and-errors.spec.ts
+++ b/e2e/playwright/code-pane-and-errors.spec.ts
@@ -10,6 +10,7 @@ test.describe('Code pane and errors', () => {
   test('Typing KCL errors induces a badge on the code pane button', async ({
     page,
     homePage,
+    scene,
   }) => {
     const u = await getUtils(page)
 
@@ -30,11 +31,7 @@ test.describe('Code pane and errors', () => {
 
     await page.setBodyDimensions({ width: 1200, height: 500 })
     await homePage.goToModelingScene()
-
-    // wait for execution done
-    await u.openDebugPanel()
-    await u.expectCmdLog('[data-message-type="execution-done"]')
-    await u.closeDebugPanel()
+    await scene.waitForExecutionDone()
 
     // Ensure no badge is present
     const codePaneButtonHolder = page.locator('#code-button-holder')
@@ -175,7 +172,10 @@ test.describe('Code pane and errors', () => {
     await page.setBodyDimensions({ width: 1200, height: 500 })
     await homePage.goToModelingScene()
 
-    await page.waitForTimeout(1000)
+    // FIXME: await scene.waitForExecutionDone() does not work. It still fails.
+    // I needed to increase this timeout to get this to pass.
+    await page.waitForTimeout(10000)
+
 
     // Ensure badge is present
     const codePaneButtonHolder = page.locator('#code-button-holder')

--- a/e2e/playwright/desktop-export.spec.ts
+++ b/e2e/playwright/desktop-export.spec.ts
@@ -10,7 +10,7 @@ import fsp from 'fs/promises'
 test(
   'export works on the first try',
   { tag: '@electron' },
-  async ({ page, context }, testInfo) => {
+  async ({ page, context, scene }, testInfo) => {
     await context.folderSetupFn(async (dir) => {
       const bracketDir = path.join(dir, 'bracket')
       await Promise.all([fsp.mkdir(bracketDir, { recursive: true })])
@@ -118,8 +118,9 @@ test(
       // Close the file pane
       await u.closeFilePanel()
 
-      // wait for it to finish executing (todo: make this more robust)
-      await page.waitForTimeout(1000)
+      // FIXME: await scene.waitForExecutionDone() does not work. The modeling indicator stays in -receive-reliable and not execution done
+      await page.waitForTimeout(10000)
+
       // expect zero errors in guter
       await expect(page.locator('.cm-lint-marker-error')).not.toBeVisible()
 

--- a/e2e/playwright/editor-tests.spec.ts
+++ b/e2e/playwright/editor-tests.spec.ts
@@ -490,6 +490,11 @@ test.describe('Editor tests', () => {
     await page.keyboard.press('ArrowLeft')
     await page.keyboard.press('ArrowRight')
 
+    // FIXME: lsp errors do not propagate to the frontend until engine is connected and code is executed
+    // This timeout is to wait for engine connection. LSP and code execution errors should be handled differently
+    // LSP can emit errors as fast as it waits and show them in the editor
+    await page.waitForTimeout(10000)
+
     // error in guter
     await expect(page.locator('.cm-lint-marker-info').first()).toBeVisible()
 
@@ -641,7 +646,7 @@ test.describe('Editor tests', () => {
     width = 0.500
     height = 0.500
     dia = 4
-  
+
     fn squareHole = (l, w) => {
   squareHoleSketch = startSketchOn('XY')
   |> startProfileAt([-width / 2, -length / 2], %)
@@ -714,7 +719,7 @@ test.describe('Editor tests', () => {
     |> line(end = [0, -10], tag = $revolveAxis)
     |> close()
     |> extrude(length = 10)
-  
+
     sketch001 = startSketchOn(box, revolveAxis)
     |> startProfileAt([5, 10], %)
     |> line(end = [0, -10])

--- a/e2e/playwright/fixtures/cmdBarFixture.ts
+++ b/e2e/playwright/fixtures/cmdBarFixture.ts
@@ -121,6 +121,23 @@ export class CmdBarFixture {
     }
   }
 
+  // Added data-testid to the command bar buttons
+  // command-bar-continue are the buttons to go to the next step
+  // does not include the submit which is the final button press
+  // aka the right arrow button
+  continue = async () => {
+    const continueButton = this.page.getByTestId('command-bar-continue')
+    await continueButton.click()
+  }
+
+  // Added data-testid to the commad bar buttons
+  // command-bar-submit is the button for the final step to submit
+  // the command bar flow aka the checkmark button.
+  submit = async () => {
+    const submitButton = this.page.getByTestId('command-bar-submit')
+    await submitButton.click()
+  }
+
   openCmdBar = async (selectCmd?: 'promptToEdit') => {
     // TODO why does this button not work in electron tests?
     // await this.cmdBarOpenBtn.click()

--- a/e2e/playwright/point-click.spec.ts
+++ b/e2e/playwright/point-click.spec.ts
@@ -30,11 +30,13 @@ test('verify extruding circle works', async ({
     localStorage.setItem('persistCode', file)
   }, file)
   await homePage.goToModelingScene()
+  await scene.waitForExecutionDone()
 
   const [clickCircle, moveToCircle] = scene.makeMouseHelpers(582, 217)
 
   await test.step('because there is sweepable geometry, verify extrude is enable when nothing is selected', async () => {
-    await scene.clickNoWhere()
+    // FIXME: Do not click, clicking removes the activeLines in future checks
+    // await scene.clickNoWhere()
     await expect(toolbar.extrudeButton).toBeEnabled()
   })
 

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "test:playwright:electron:local": "yarn tronb:package:dev && NODE_ENV=development playwright test --config=playwright.electron.config.ts --grep-invert='@snapshot'",
     "test:playwright:electron:windows:local": "yarn tronb:package:dev && set NODE_ENV='development' && playwright test --config=playwright.electron.config.ts --grep-invert=\"@skipWin|@snapshot\"",
     "test:playwright:electron:macos:local": "yarn tronb:package:dev && NODE_ENV=development playwright test --config=playwright.electron.config.ts --grep-invert='@skipMacos|@snapshot'",
-    "test:playwright:electron:ubuntu:local": "yarn tronb:package:dev && NODE_ENV=development playwright test --config=playwright.electron.config.ts --grep-invert='@skipLinux|@snapshot'",
+    "test:playwright:electron:ubuntu:local": "yarn tronb:vite:dev && NODE_ENV=development playwright test --config=playwright.electron.config.ts --grep-invert='@skipLinux|@snapshot'",
     "test:unit:local": "yarn simpleserver:bg && yarn test:unit; kill-port 3000",
     "test:unit:kcl-samples:local": "yarn simpleserver:bg && yarn test:unit:kcl-samples; kill-port 3000"
   },

--- a/src/components/CommandBar/CommandBarHeader.tsx
+++ b/src/components/CommandBar/CommandBarHeader.tsx
@@ -195,6 +195,7 @@ function ReviewingButton() {
       type="submit"
       form="review-form"
       className="w-fit !p-0 rounded-sm hover:shadow"
+      data-testid="command-bar-submit"
       iconStart={{
         icon: 'checkmark',
         bgClassName: 'p-1 rounded-sm !bg-primary hover:brightness-110',
@@ -213,6 +214,7 @@ function GatheringArgsButton() {
       type="submit"
       form="arg-form"
       className="w-fit !p-0 rounded-sm hover:shadow"
+      data-testid="command-bar-continue"
       iconStart={{
         icon: 'arrowRight',
         bgClassName: 'p-1 rounded-sm !bg-primary hover:brightness-110',

--- a/src/components/CommandBar/CommandBarKclInput.tsx
+++ b/src/components/CommandBar/CommandBarKclInput.tsx
@@ -97,6 +97,7 @@ function CommandBarKclInput({
     value,
     initialVariableName,
   })
+
   const varMentionData: Completion[] = prevVariables.map((v) => ({
     label: v.key,
     detail: String(roundOff(v.value as number)),

--- a/src/editor/plugins/lsp/kcl/index.ts
+++ b/src/editor/plugins/lsp/kcl/index.ts
@@ -25,6 +25,18 @@ export class KclPlugin implements PluginValue {
 
   constructor(client: LanguageServerClient) {
     this.client = client
+
+    // Gotcha: Code can be written into the CodeMirror editor but not propagated to codeManager.code
+    // because the update function has not run. We need to initialize the codeManager.code when lsp initializes
+    // because new code could have been written into the editor before the update callback is initialized.
+    // There appears to be limited ways to safely get the current doc content. This appears to be sync and safe.
+    const kclLspPlugin = this.client.plugins.find((plugin) => {
+      return plugin.client.name === 'kcl'
+    })
+    if (kclLspPlugin) {
+      // @ts-ignore Ignoring this private dereference of .view on the plugin. I do not have another helper method that can give me doc string
+      codeManager.code = kclLspPlugin.view.state.doc.toString()
+    }
   }
 
   // When a doc update needs to be sent to the server, this holds the

--- a/src/lib/useCalculateKclExpression.ts
+++ b/src/lib/useCalculateKclExpression.ts
@@ -48,7 +48,16 @@ export function useCalculateKclExpression({
     bodyPath: [],
   })
   const [valueNode, setValueNode] = useState<Expr | null>(null)
-  const [calcResult, setCalcResult] = useState('NAN')
+  // If we pass in numeric literals, we should instantly parse them, they have nothing to do with application memory
+  const _code_value = `const __result__ = ${value}`
+  const codeValueParseResult = parse(_code_value)
+  let isValueParsable = true
+  if (err(codeValueParseResult) || !resultIsOk(codeValueParseResult)) {
+    isValueParsable = false
+  }
+  const initialCalcResult: number | string =
+    isNaN(Number(value)) || !isValueParsable ? 'NAN' : value
+  const [calcResult, setCalcResult] = useState(initialCalcResult)
   const [newVariableName, setNewVariableName] = useState('')
   const [isNewVariableNameUnique, setIsNewVariableNameUnique] = useState(true)
 


### PR DESCRIPTION
# Issue

On my machine a total of 19 when I run `yarn test:playwright:electron:ubuntu:local --workers 1` and spam `--last-failed` till I get a stable number of failures

# Implementation 

  19 failed

- [x] [chromium] › zoo-test.ts:86:10 › Code pane and errors › When error is not in view WITH LINTS you can click the badge to scroll to it
  - **Increased timeout because `await scene.waitForExecutionDone()` is missing and does not work**
- [x] [chromium] › zoo-test.ts:86:10 › export works on the first try @electron ───────────────────────
  - **Increased timeout because `await scene.waitForExecutionDone()` is missing and does not work**
- [x] [chromium] › zoo-test.ts:86:10 › Editor tests › if you write kcl with lint errors you get lints
  - **Race condition on initialization of LSP, CodeMirror, and onEngineConnectionOpened. We do not properly set `codeManager.code` on initialization of the application.**
- [x] [chromium] › zoo-test.ts:86:10 › verify extruding circle works 
  - **We have multiple react tics that the commandBarInputField has a value of `can't calculate` which means there is a race condition on when the commadBarInputField can be continued. E2E tests click the arrow to go forward but the application of the system says the value is invalid so the action is nullified.**
- [ ]     [chromium] › zoo-test.ts:86:10 › verify sketch on chamfer works › works on all edge selections and can break up multi edges in a chamfer array
- [ ]     [chromium] › zoo-test.ts:86:10 › verify sketch on chamfer works › Works on chamfers that are non in a pipeExpression can break up multi edges in a chamfer array
- [ ]     [chromium] › zoo-test.ts:86:10 › Loft and offset plane deletion via selection ──────────────────
- [ ]     [chromium] › zoo-test.ts:86:10 › Chamfer point-and-click ───────────────────────────────────────
- [ ]     [chromium] › zoo-test.ts:86:10 › Shell point-and-click cap (preselected sketches: false) ───────
- [ ]     [chromium] › zoo-test.ts:86:10 › Shell point-and-click wall ────────────────────────────────────
- [ ] Ignore, need text to cad release    [chromium] › zoo-test.ts:86:10 › Check the happy path, for basic changing color › User accepts change
- [ ] Ignore, need text to cad release    [chromium] › zoo-test.ts:86:10 › Check the happy path, for basic changing color › User rejects change
- [ ]     [chromium] › zoo-test.ts:86:10 › bad path › bad edit prompt ────────────────────────────────────
- [ ]     [chromium] › zoo-test.ts:86:10 › Testing segment overlays › Hover over a segment should show its overlay, hovering over the input overlays should show its popover, clicking the input overlay should constrain/unconstrain it:
- [ ] for the following segments › for segments [line, angledLine, xLineTo]
- [ ]     [chromium] › zoo-test.ts:86:10 › Testing selections › Selections work on fresh and edited sketch @skipWin
- [ ]     [chromium] › zoo-test.ts:86:10 › Testing selections › Solids should be select and deletable ────
- [ ]     [chromium] › zoo-test.ts:86:10 › Testing selections › Testing selections (and hovers) work on sketches when NOT in sketch mode
- [ ]     [chromium] › zoo-test.ts:86:10 › Testing selections › Hovering and selection of extruded faces works, and is not overridden shortly after user's click
- [ ]     [chromium] › zoo-test.ts:86:10 › Sketch on face ────────────────────────────────────────────────
