### PR TITLE
Skip text-to-cad playwright tests on windows

### DIFF
--- a/e2e/playwright/text-to-cad-tests.spec.ts
+++ b/e2e/playwright/text-to-cad-tests.spec.ts
@@ -3,7 +3,7 @@ import { getUtils, createProject } from './test-utils'
 import { join } from 'path'
 import fs from 'fs'
 
-test.describe('Text-to-CAD tests', () => {
+test.describe('Text-to-CAD tests', { tag: ['@skipWin'] }, () => {
   test('basic lego happy case', async ({ page, homePage }) => {
     const u = await getUtils(page)
 

--- a/public/kcl-samples-manifest-fallback.json
+++ b/public/kcl-samples-manifest-fallback.json
@@ -1,1 +1,212 @@
-404: Not Found
+[
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "80-20-rail/main.kcl",
+    "multipleFiles": false,
+    "title": "80/20 Rail",
+    "description": "An 80/20 extruded aluminum linear rail. T-slot profile adjustable by profile height, rail length, and origin position"
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "a-parametric-bearing-pillow-block/main.kcl",
+    "multipleFiles": false,
+    "title": "A Parametric Bearing Pillow Block",
+    "description": "A bearing pillow block, also known as a plummer block or pillow block bearing, is a pedestal used to provide support for a rotating shaft with the help of compatible bearings and various accessories. Housing a bearing, the pillow block provides a secure and stable foundation that allows the shaft to rotate smoothly within its machinery setup. These components are essential in a wide range of mechanical systems and machinery, playing a key role in reducing friction and supporting radial and axial loads."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "ball-bearing/main.kcl",
+    "multipleFiles": false,
+    "title": "Ball Bearing",
+    "description": "A ball bearing is a type of rolling-element bearing that uses balls to maintain the separation between the bearing races. The primary purpose of a ball bearing is to reduce rotational friction and support radial and axial loads."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "bracket/main.kcl",
+    "multipleFiles": false,
+    "title": "Shelf Bracket",
+    "description": "This is a bracket that holds a shelf. It is made of aluminum and is designed to hold a force of 300 lbs. The bracket is 6 inches wide and the force is applied at the end of the shelf, 12 inches from the wall. The bracket has a factor of safety of 1.2. The legs of the bracket are 5 inches and 2 inches long. The thickness of the bracket is calculated from the constraints provided."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "car-wheel-assembly/main.kcl",
+    "multipleFiles": true,
+    "title": "Car Wheel Assembly",
+    "description": "A car wheel assembly with a rotor, tire, and lug nuts."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "dodecahedron/main.kcl",
+    "multipleFiles": false,
+    "title": "Hollow Dodecahedron",
+    "description": "A regular dodecahedron or pentagonal dodecahedron is a dodecahedron composed of regular pentagonal faces, three meeting at each vertex. This example shows constructing the individual faces of the dodecahedron and extruding inwards."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "enclosure/main.kcl",
+    "multipleFiles": false,
+    "title": "Enclosure",
+    "description": "An enclosure body and sealing lid for storing items"
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "flange-with-patterns/main.kcl",
+    "multipleFiles": false,
+    "title": "Flange",
+    "description": "A flange is a flat rim, collar, or rib, typically forged or cast, that is used to strengthen an object, guide it, or attach it to another object. Flanges are known for their use in various applications, including piping, plumbing, and mechanical engineering, among others."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "flange-xy/main.kcl",
+    "multipleFiles": false,
+    "title": "Flange with XY coordinates",
+    "description": "A flange is a flat rim, collar, or rib, typically forged or cast, that is used to strengthen an object, guide it, or attach it to another object. Flanges are known for their use in various applications, including piping, plumbing, and mechanical engineering, among others."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "focusrite-scarlett-mounting-bracket/main.kcl",
+    "multipleFiles": false,
+    "title": "A mounting bracket for the Focusrite Scarlett Solo audio interface",
+    "description": "This is a bracket that holds an audio device underneath a desk or shelf. The audio device has dimensions of 144mm wide, 80mm length and 45mm depth with fillets of 6mm. This mounting bracket is designed to be 3D printed with PLA material"
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "food-service-spatula/main.kcl",
+    "multipleFiles": false,
+    "title": "Food Service Spatula",
+    "description": "Use these spatulas for mixing, flipping, and scraping."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "french-press/main.kcl",
+    "multipleFiles": false,
+    "title": "French Press",
+    "description": "A french press immersion coffee maker"
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "gear/main.kcl",
+    "multipleFiles": false,
+    "title": "Spur Gear",
+    "description": "A rotating machine part having cut teeth or, in the case of a cogwheel, inserted teeth (called cogs), which mesh with another toothed part to transmit torque. Geared devices can change the speed, torque, and direction of a power source. The two elements that define a gear are its circular shape and the teeth that are integrated into its outer edge, which are designed to fit into the teeth of another gear."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "gear-rack/main.kcl",
+    "multipleFiles": false,
+    "title": "100mm Gear Rack",
+    "description": "A flat bar or rail that is engraved with teeth along its length. These teeth are designed to mesh with the teeth of a gear, known as a pinion. When the pinion, a small cylindrical gear, rotates, its teeth engage with the teeth on the rack, causing the rack to move linearly. Conversely, linear motion applied to the rack will cause the pinion to rotate."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "hex-nut/main.kcl",
+    "multipleFiles": false,
+    "title": "Hex nut",
+    "description": "A hex nut is a type of fastener with a threaded hole and a hexagonal outer shape, used in a wide variety of applications to secure parts together. The hexagonal shape allows for a greater torque to be applied with wrenches or tools, making it one of the most common nut types in hardware."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "i-beam/main.kcl",
+    "multipleFiles": false,
+    "title": "I-beam",
+    "description": "A structural metal beam with an I shaped cross section. Often used in construction"
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "kitt/main.kcl",
+    "multipleFiles": false,
+    "title": "Kitt",
+    "description": "The beloved KittyCAD mascot in a voxelized style."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "lego/main.kcl",
+    "multipleFiles": false,
+    "title": "Lego Brick",
+    "description": "A standard Lego brick. This is a small, plastic construction block toy that can be interlocked with other blocks to build various structures, models, and figures. There are a lot of hacks used in this code."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "mounting-plate/main.kcl",
+    "multipleFiles": false,
+    "title": "Mounting Plate",
+    "description": "A flat piece of material, often metal or plastic, that serves as a support or base for attaching, securing, or mounting various types of equipment, devices, or components."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "multi-axis-robot/main.kcl",
+    "multipleFiles": true,
+    "title": "Robot Arm",
+    "description": "A 4 axis robotic arm for industrial use. These machines can be used for assembly, packaging, organization of goods, and quality inspection processes"
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "pipe/main.kcl",
+    "multipleFiles": false,
+    "title": "Pipe",
+    "description": "A tubular section or hollow cylinder, usually but not necessarily of circular cross-section, used mainly to convey substances that can flow."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "pipe-flange-assembly/main.kcl",
+    "multipleFiles": false,
+    "title": "Pipe and Flange Assembly",
+    "description": "A crucial component in various piping systems, designed to facilitate the connection, disconnection, and access to piping for inspection, cleaning, and modifications. This assembly combines pipes (long cylindrical conduits) with flanges (plate-like fittings) to create a secure yet detachable joint."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "pipe-with-bend/main.kcl",
+    "multipleFiles": false,
+    "title": "Pipe with bend",
+    "description": "A tubular section or hollow cylinder, usually but not necessarily of circular cross-section, used mainly to convey substances that can flow."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "poopy-shoe/main.kcl",
+    "multipleFiles": false,
+    "title": "Poopy Shoe",
+    "description": "poop shute for bambu labs printer - optimized for printing."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "router-template-cross-bar/main.kcl",
+    "multipleFiles": false,
+    "title": "Router template for a cross bar",
+    "description": "A guide for routing a notch into a cross bar."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "router-template-slate/main.kcl",
+    "multipleFiles": false,
+    "title": "Router template for a slate",
+    "description": "A guide for routing a slate for a cross bar."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "sheet-metal-bracket/main.kcl",
+    "multipleFiles": false,
+    "title": "Sheet Metal Bracket",
+    "description": "A component typically made from flat sheet metal through various manufacturing processes such as bending, punching, cutting, and forming. These brackets are used to support, attach, or mount other hardware components, often providing a structural or functional base for assembly."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "socket-head-cap-screw/main.kcl",
+    "multipleFiles": false,
+    "title": "Socket Head Cap Screw",
+    "description": "This is for a #10-24 screw that is 1.00 inches long. A socket head cap screw is a type of fastener that is widely used in a variety of applications requiring a high strength fastening solution. It is characterized by its cylindrical head and internal hexagonal drive, which allows for tightening with an Allen wrench or hex key."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "walkie-talkie/main.kcl",
+    "multipleFiles": true,
+    "title": "Walkie Talkie",
+    "description": "A portable, handheld two-way radio device that allows users to communicate wirelessly over short to medium distances. It operates on specific radio frequencies and features a push-to-talk button for transmitting messages, making it ideal for quick and reliable communication in outdoor, work, or emergency settings."
+  },
+  {
+    "file": "main.kcl",
+    "pathFromProjectDirectoryToFirstFile": "washer/main.kcl",
+    "multipleFiles": false,
+    "title": "Washer",
+    "description": "A small, typically disk-shaped component with a hole in the middle, used in a wide range of applications, primarily in conjunction with fasteners like bolts and screws. Washers distribute the load of a fastener across a broader area. This is especially important when the fastening surface is soft or uneven, as it helps to prevent damage to the surface and ensures the load is evenly distributed, reducing the risk of the fastener becoming loose over time."
+  }
+]


### PR DESCRIPTION
Too flaky and there's no need to have then run on all three OSes from a coverage perspective.