### PR TITLE
Don't close the command palette on backspace

### DIFF
--- a/src/components/CommandComboBox.tsx
+++ b/src/components/CommandComboBox.tsx
@@ -57,7 +57,7 @@ function CommandComboBox({
           onKeyDown={(event) => {
             if (
               (event.metaKey && event.key === 'k') ||
-              (event.key === 'Backspace' && !event.currentTarget.value)
+              (event.key === 'Escape')
             ) {
               event.preventDefault()
               commandBarActor.send({ type: 'Close' })

--- a/src/components/CommandComboBox.tsx
+++ b/src/components/CommandComboBox.tsx
@@ -57,7 +57,7 @@ function CommandComboBox({
           onKeyDown={(event) => {
             if (
               (event.metaKey && event.key === 'k') ||
-              (event.key === 'Escape')
+              event.key === 'Escape'
             ) {
               event.preventDefault()
               commandBarActor.send({ type: 'Close' })


### PR DESCRIPTION
It leads to awkward UX like the one reported in #5007. Users can still go back between arguments using <kbd>Backspace</kbd> on an empty argument, but to close it they have to hit <kbd>Escape</kbd>, <kbd>Cmd+K</kbd>, or click the close button.