### PR TITLE
refactor: Rename function to not have unneeded prefix

### DIFF
--- a/src/wasm-lib/kcl/src/lib.rs
+++ b/src/wasm-lib/kcl/src/lib.rs
@@ -160,7 +160,7 @@ impl Program {
 
     /// Get the meta settings for the kcl file from the annotations.
     pub fn meta_settings(&self) -> Result<Option<crate::MetaSettings>, KclError> {
-        self.ast.get_meta_settings()
+        self.ast.meta_settings()
     }
 
     /// Change the meta settings for the kcl file.

--- a/src/wasm-lib/kcl/src/parsing/ast/types/mod.rs
+++ b/src/wasm-lib/kcl/src/parsing/ast/types/mod.rs
@@ -269,7 +269,7 @@ impl Node<Program> {
     }
 
     /// Get the annotations for the meta settings from the kcl file.
-    pub fn get_meta_settings(&self) -> Result<Option<crate::execution::MetaSettings>, KclError> {
+    pub fn meta_settings(&self) -> Result<Option<crate::execution::MetaSettings>, KclError> {
         for annotation_node in self.annotations() {
             let annotation = &annotation_node.value;
             if annotation.annotation_name() == Some(annotations::SETTINGS) {
@@ -3881,7 +3881,7 @@ const cylinder = startSketchOn('-XZ')
 
 startSketchOn('XY')"#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
-        let result = program.get_meta_settings().unwrap();
+        let result = program.meta_settings().unwrap();
         assert!(result.is_some());
         let meta_settings = result.unwrap();
 
@@ -3897,7 +3897,7 @@ startSketchOn('XY')"#;
 
 startSketchOn('XY')"#;
         let mut program = crate::parsing::top_level_parse(some_program_string).unwrap();
-        let result = program.get_meta_settings().unwrap();
+        let result = program.meta_settings().unwrap();
         assert!(result.is_some());
         let meta_settings = result.unwrap();
 
@@ -3914,7 +3914,7 @@ startSketchOn('XY')"#;
             })
             .unwrap();
 
-        let result = new_program.get_meta_settings().unwrap();
+        let result = new_program.meta_settings().unwrap();
         assert!(result.is_some());
         let meta_settings = result.unwrap();
 
@@ -3939,7 +3939,7 @@ startSketchOn('XY')
     async fn test_parse_get_meta_settings_nothing_to_mm() {
         let some_program_string = r#"startSketchOn('XY')"#;
         let mut program = crate::parsing::top_level_parse(some_program_string).unwrap();
-        let result = program.get_meta_settings().unwrap();
+        let result = program.meta_settings().unwrap();
         assert!(result.is_none());
 
         // Edit the ast.
@@ -3950,7 +3950,7 @@ startSketchOn('XY')
             })
             .unwrap();
 
-        let result = new_program.get_meta_settings().unwrap();
+        let result = new_program.meta_settings().unwrap();
         assert!(result.is_some());
         let meta_settings = result.unwrap();
 


### PR DESCRIPTION
This is to match the other function names in #5212 and remove the unneeded `get_` prefix that isn't used [in Rust](https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter).