### PR TITLE
Fix deep links on Linux .desktop files

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -94,7 +94,9 @@ const createWindow = (pathToOpen?: string, reuse?: boolean): BrowserWindow => {
   }
 
   // Deep Link: Case of a cold start from Windows or Linux
-  const zooProtocolArg = process.argv.find(a => a.startsWith(ZOO_STUDIO_PROTOCOL + '://'))
+  const zooProtocolArg = process.argv.find((a) =>
+    a.startsWith(ZOO_STUDIO_PROTOCOL + '://')
+  )
   if (!pathToOpen && zooProtocolArg) {
     pathToOpen = zooProtocolArg
     console.log('Retrieved deep link from argv', pathToOpen)

--- a/src/main.ts
+++ b/src/main.ts
@@ -94,12 +94,9 @@ const createWindow = (pathToOpen?: string, reuse?: boolean): BrowserWindow => {
   }
 
   // Deep Link: Case of a cold start from Windows or Linux
-  if (
-    !pathToOpen &&
-    process.argv.length > 1 &&
-    process.argv[1].indexOf(ZOO_STUDIO_PROTOCOL + '://') > -1
-  ) {
-    pathToOpen = process.argv[1]
+  const zooProtocolArg = process.argv.find(a => a.startsWith(ZOO_STUDIO_PROTOCOL + '://'))
+  if (!pathToOpen && zooProtocolArg) {
+    pathToOpen = zooProtocolArg
     console.log('Retrieved deep link from argv', pathToOpen)
   }
 


### PR DESCRIPTION
Fixes #5325

The `--no-sandbox` extra arg passed by the default .desktop file is causing the argv[1] lookup to be the wrong one. 
![image](https://github.com/user-attachments/assets/f5396b27-de6f-4bd4-b42b-48371172b395)
 