### PR TITLE
Remove annotations from non-code-meta and store them in nodes

### DIFF
--- a/src/lang/KclSingleton.ts
+++ b/src/lang/KclSingleton.ts
@@ -60,7 +60,8 @@ export class KclManager {
       nonCodeNodes: {},
       startNodes: [],
     },
-    trivia: [],
+    innerAttrs: [],
+    outerAttrs: [],
   }
   private _execState: ExecState = emptyExecState()
   private _variables: VariableMap = {}
@@ -255,7 +256,8 @@ export class KclManager {
         nonCodeNodes: {},
         startNodes: [],
       },
-      trivia: [],
+      innerAttrs: [],
+      outerAttrs: [],
     }
   }
 

--- a/src/lang/modifyAst.test.ts
+++ b/src/lang/modifyAst.test.ts
@@ -134,7 +134,7 @@ describe('Testing findUniqueName', () => {
           start: 0,
           end: 0,
           moduleId: 0,
-          trivia: [],
+          outerAttrs: [],
         },
         {
           type: 'Identifier',
@@ -142,7 +142,7 @@ describe('Testing findUniqueName', () => {
           start: 0,
           end: 0,
           moduleId: 0,
-          trivia: [],
+          outerAttrs: [],
         },
         {
           type: 'Identifier',
@@ -150,7 +150,7 @@ describe('Testing findUniqueName', () => {
           start: 0,
           end: 0,
           moduleId: 0,
-          trivia: [],
+          outerAttrs: [],
         },
         {
           type: 'Identifier',
@@ -158,7 +158,7 @@ describe('Testing findUniqueName', () => {
           start: 0,
           end: 0,
           moduleId: 0,
-          trivia: [],
+          outerAttrs: [],
         },
         {
           type: 'Identifier',
@@ -166,7 +166,7 @@ describe('Testing findUniqueName', () => {
           start: 0,
           end: 0,
           moduleId: 0,
-          trivia: [],
+          outerAttrs: [],
         },
         {
           type: 'Identifier',
@@ -174,7 +174,7 @@ describe('Testing findUniqueName', () => {
           start: 0,
           end: 0,
           moduleId: 0,
-          trivia: [],
+          outerAttrs: [],
         },
         {
           type: 'Identifier',
@@ -182,7 +182,7 @@ describe('Testing findUniqueName', () => {
           start: 0,
           end: 0,
           moduleId: 0,
-          trivia: [],
+          outerAttrs: [],
         },
         {
           type: 'Identifier',
@@ -190,7 +190,7 @@ describe('Testing findUniqueName', () => {
           start: 0,
           end: 0,
           moduleId: 0,
-          trivia: [],
+          outerAttrs: [],
         },
         {
           type: 'Identifier',
@@ -198,7 +198,7 @@ describe('Testing findUniqueName', () => {
           start: 0,
           end: 0,
           moduleId: 0,
-          trivia: [],
+          outerAttrs: [],
         },
       ] satisfies Node<Identifier>[]),
       'yo',
@@ -217,7 +217,8 @@ describe('Testing addSketchTo', () => {
         end: 0,
         moduleId: 0,
         nonCodeMeta: { nonCodeNodes: {}, startNodes: [] },
-        trivia: [],
+        innerAttrs: [],
+        outerAttrs: [],
       },
       'yz'
     )

--- a/src/lang/modifyAst.ts
+++ b/src/lang/modifyAst.ts
@@ -278,7 +278,7 @@ export function mutateObjExpProp(
         start: 0,
         end: 0,
         moduleId: 0,
-        trivia: [],
+        outerAttrs: [],
       })
     }
   }
@@ -891,7 +891,7 @@ export function createLiteral(value: LiteralValue | number): Node<Literal> {
     moduleId: 0,
     value,
     raw,
-    trivia: [],
+    outerAttrs: [],
   }
 }
 
@@ -901,7 +901,7 @@ export function createTagDeclarator(value: string): Node<TagDeclarator> {
     start: 0,
     end: 0,
     moduleId: 0,
-    trivia: [],
+    outerAttrs: [],
 
     value,
   }
@@ -913,7 +913,7 @@ export function createIdentifier(name: string): Node<Identifier> {
     start: 0,
     end: 0,
     moduleId: 0,
-    trivia: [],
+    outerAttrs: [],
 
     name,
   }
@@ -925,7 +925,7 @@ export function createPipeSubstitution(): Node<PipeSubstitution> {
     start: 0,
     end: 0,
     moduleId: 0,
-    trivia: [],
+    outerAttrs: [],
   }
 }
 
@@ -938,13 +938,13 @@ export function createCallExpressionStdLib(
     start: 0,
     end: 0,
     moduleId: 0,
-    trivia: [],
+    outerAttrs: [],
     callee: {
       type: 'Identifier',
       start: 0,
       end: 0,
       moduleId: 0,
-      trivia: [],
+      outerAttrs: [],
 
       name,
     },
@@ -962,13 +962,13 @@ export function createCallExpressionStdLibKw(
     start: 0,
     end: 0,
     moduleId: 0,
-    trivia: [],
+    outerAttrs: [],
     callee: {
       type: 'Identifier',
       start: 0,
       end: 0,
       moduleId: 0,
-      trivia: [],
+      outerAttrs: [],
 
       name,
     },
@@ -986,13 +986,13 @@ export function createCallExpression(
     start: 0,
     end: 0,
     moduleId: 0,
-    trivia: [],
+    outerAttrs: [],
     callee: {
       type: 'Identifier',
       start: 0,
       end: 0,
       moduleId: 0,
-      trivia: [],
+      outerAttrs: [],
 
       name,
     },
@@ -1008,7 +1008,7 @@ export function createArrayExpression(
     start: 0,
     end: 0,
     moduleId: 0,
-    trivia: [],
+    outerAttrs: [],
 
     nonCodeMeta: nonCodeMetaEmpty(),
     elements,
@@ -1023,7 +1023,7 @@ export function createPipeExpression(
     start: 0,
     end: 0,
     moduleId: 0,
-    trivia: [],
+    outerAttrs: [],
 
     body,
     nonCodeMeta: nonCodeMetaEmpty(),
@@ -1041,14 +1041,14 @@ export function createVariableDeclaration(
     start: 0,
     end: 0,
     moduleId: 0,
-    trivia: [],
+    outerAttrs: [],
 
     declaration: {
       type: 'VariableDeclarator',
       start: 0,
       end: 0,
       moduleId: 0,
-      trivia: [],
+      outerAttrs: [],
 
       id: createIdentifier(varName),
       init,
@@ -1066,7 +1066,7 @@ export function createObjectExpression(properties: {
     start: 0,
     end: 0,
     moduleId: 0,
-    trivia: [],
+    outerAttrs: [],
 
     nonCodeMeta: nonCodeMetaEmpty(),
     properties: Object.entries(properties).map(([key, value]) => ({
@@ -1074,7 +1074,7 @@ export function createObjectExpression(properties: {
       start: 0,
       end: 0,
       moduleId: 0,
-      trivia: [],
+      outerAttrs: [],
       key: createIdentifier(key),
 
       value,
@@ -1091,7 +1091,7 @@ export function createUnaryExpression(
     start: 0,
     end: 0,
     moduleId: 0,
-    trivia: [],
+    outerAttrs: [],
 
     operator,
     argument,
@@ -1108,7 +1108,7 @@ export function createBinaryExpression([left, operator, right]: [
     start: 0,
     end: 0,
     moduleId: 0,
-    trivia: [],
+    outerAttrs: [],
 
     operator,
     left,

--- a/src/lang/std/sketch.ts
+++ b/src/lang/std/sketch.ts
@@ -1945,7 +1945,8 @@ export const updateStartProfileAtArgs: SketchLineHelper['updateArgs'] = ({
           startNodes: [],
           nonCodeNodes: [],
         },
-        trivia: [],
+        innerAttrs: [],
+        outerAttrs: [],
       },
       pathToNode,
     }
@@ -2527,7 +2528,7 @@ function addTagKw(): addTagFn {
         start: callExpr.node.start,
         end: callExpr.node.end,
         moduleId: callExpr.node.moduleId,
-        trivia: callExpr.node.trivia,
+        outerAttrs: callExpr.node.outerAttrs,
       })
     }
 

--- a/src/wasm-lib/kcl/src/execution/exec_ast.rs
+++ b/src/wasm-lib/kcl/src/execution/exec_ast.rs
@@ -17,9 +17,9 @@ use crate::{
     },
     modules::{ModuleId, ModulePath, ModuleRepr},
     parsing::ast::types::{
-        ArrayExpression, ArrayRangeExpression, BinaryExpression, BinaryOperator, BinaryPart, BodyItem, CallExpression,
-        CallExpressionKw, Expr, FunctionExpression, IfExpression, ImportPath, ImportSelector, ItemVisibility,
-        LiteralIdentifier, LiteralValue, MemberExpression, MemberObject, Node, NodeRef, NonCodeNode, NonCodeValue,
+        Annotation, ArrayExpression, ArrayRangeExpression, BinaryExpression, BinaryOperator, BinaryPart, BodyItem,
+        CallExpression, CallExpressionKw, Expr, FunctionExpression, IfExpression, ImportPath, ImportSelector,
+        ItemVisibility, LiteralIdentifier, LiteralValue, MemberExpression, MemberObject, Node, NodeRef,
         ObjectExpression, PipeExpression, Program, TagDeclarator, UnaryExpression, UnaryOperator,
     },
     source_range::SourceRange,
@@ -37,37 +37,36 @@ enum StatementKind<'a> {
 impl ExecutorContext {
     async fn handle_annotations(
         &self,
-        annotations: impl Iterator<Item = (&NonCodeValue, SourceRange)>,
+        annotations: impl Iterator<Item = &Node<Annotation>>,
         scope: annotations::AnnotationScope,
         exec_state: &mut ExecState,
     ) -> Result<bool, KclError> {
         let mut no_prelude = false;
-        for (annotation, source_range) in annotations {
-            if annotation.annotation_name() == Some(annotations::SETTINGS) {
+        for annotation in annotations {
+            if annotation.name() == Some(annotations::SETTINGS) {
                 if scope == annotations::AnnotationScope::Module {
                     let old_units = exec_state.length_unit();
-                    exec_state
-                        .mod_local
-                        .settings
-                        .update_from_annotation(annotation, source_range)?;
+                    exec_state.mod_local.settings.update_from_annotation(annotation)?;
                     let new_units = exec_state.length_unit();
                     if !self.engine.execution_kind().is_isolated() && old_units != new_units {
-                        self.engine.set_units(new_units.into(), source_range).await?;
+                        self.engine
+                            .set_units(new_units.into(), annotation.as_source_range())
+                            .await?;
                     }
                 } else {
                     return Err(KclError::Semantic(KclErrorDetails {
                         message: "Settings can only be modified at the top level scope of a file".to_owned(),
-                        source_ranges: vec![source_range],
+                        source_ranges: vec![annotation.as_source_range()],
                     }));
                 }
             }
-            if annotation.annotation_name() == Some(annotations::NO_PRELUDE) {
+            if annotation.name() == Some(annotations::NO_PRELUDE) {
                 if scope == annotations::AnnotationScope::Module {
                     no_prelude = true;
                 } else {
                     return Err(KclError::Semantic(KclErrorDetails {
                         message: "Prelude can only be skipped at the top level scope of a file".to_owned(),
-                        source_ranges: vec![source_range],
+                        source_ranges: vec![annotation.as_source_range()],
                     }));
                 }
             }
@@ -87,11 +86,7 @@ impl ExecutorContext {
         if body_type == BodyType::Root {
             let _no_prelude = self
                 .handle_annotations(
-                    program
-                        .non_code_meta
-                        .start_nodes
-                        .iter()
-                        .filter_map(|n| n.annotation().map(|result| (result, n.as_source_range()))),
+                    program.inner_attrs.iter(),
                     annotations::AnnotationScope::Module,
                     exec_state,
                 )
@@ -100,7 +95,7 @@ impl ExecutorContext {
 
         let mut last_expr = None;
         // Iterate over the body of the program.
-        for (i, statement) in program.body.iter().enumerate() {
+        for statement in &program.body {
             match statement {
                 BodyItem::ImportStatement(import_stmt) => {
                     if body_type != BodyType::Root {
@@ -111,9 +106,9 @@ impl ExecutorContext {
                     }
 
                     let source_range = SourceRange::from(import_stmt);
-                    let meta_nodes = program.non_code_meta.get(i);
+                    let attrs = &import_stmt.outer_attrs;
                     let module_id = self
-                        .open_module(&import_stmt.path, meta_nodes, exec_state, source_range)
+                        .open_module(&import_stmt.path, attrs, exec_state, source_range)
                         .await?;
 
                     match &import_stmt.selector {
@@ -209,7 +204,7 @@ impl ExecutorContext {
                     let source_range = SourceRange::from(&variable_declaration.declaration.init);
                     let metadata = Metadata { source_range };
 
-                    let _meta_nodes = program.non_code_meta.get(i);
+                    let _annotations = &variable_declaration.outer_attrs;
 
                     let memory_item = self
                         .execute_expr(
@@ -279,7 +274,7 @@ impl ExecutorContext {
     async fn open_module(
         &self,
         path: &ImportPath,
-        non_code_meta: &[Node<NonCodeNode>],
+        attrs: &[Node<Annotation>],
         exec_state: &mut ExecState,
         source_range: SourceRange,
     ) -> Result<ModuleId, KclError> {
@@ -307,7 +302,7 @@ impl ExecutorContext {
 
                 let id = exec_state.next_module_id();
                 let path = resolved_path.expect_path();
-                let format = super::import::format_from_annotations(non_code_meta, path, source_range)?;
+                let format = super::import::format_from_annotations(attrs, path, source_range)?;
                 let geom = super::import::import_foreign(path, format, exec_state, self, source_range).await?;
                 exec_state.add_module(id, resolved_path, ModuleRepr::Foreign(geom));
                 Ok(id)
@@ -1838,18 +1833,7 @@ mod test {
             // Run each test.
             let func_expr = &Node::no_src(FunctionExpression {
                 params,
-                body: Node {
-                    inner: crate::parsing::ast::types::Program {
-                        body: Vec::new(),
-                        non_code_meta: Default::default(),
-                        shebang: None,
-                        digest: None,
-                    },
-                    start: 0,
-                    end: 0,
-                    module_id: ModuleId::default(),
-                    trivia: Vec::new(),
-                },
+                body: crate::parsing::ast::types::Program::empty(),
                 return_type: None,
                 digest: None,
             });

--- a/src/wasm-lib/kcl/src/execution/import.rs
+++ b/src/wasm-lib/kcl/src/execution/import.rs
@@ -19,7 +19,7 @@ use crate::{
     errors::{KclError, KclErrorDetails},
     execution::{annotations, kcl_value::UnitLen, ExecState, ExecutorContext, ImportedGeometry},
     fs::FileSystem,
-    parsing::ast::types::{Node, NonCodeNode},
+    parsing::ast::types::{Annotation, Node},
     source_range::SourceRange,
 };
 
@@ -155,16 +155,18 @@ pub async fn import_foreign(
 }
 
 pub(super) fn format_from_annotations(
-    non_code_meta: &[Node<NonCodeNode>],
+    annotations: &[Node<Annotation>],
     path: &Path,
     import_source_range: SourceRange,
 ) -> Result<Option<InputFormat>, KclError> {
-    let Some(props) = annotations::unnamed_properties(non_code_meta.iter().map(|n| &n.value)) else {
+    if annotations.is_empty() {
         return Ok(None);
-    };
+    }
+
+    let props = annotations.iter().flat_map(|a| a.properties.as_deref().unwrap_or(&[]));
 
     let mut result = None;
-    for p in props {
+    for p in props.clone() {
         if p.key.name == annotations::IMPORT_FORMAT {
             result = Some(
                 get_import_format_from_extension(annotations::expect_ident(&p.value)?).map_err(|_| {
@@ -422,8 +424,8 @@ mod test {
         // no format, no options
         let text = "@()\nimport '../foo.gltf' as foo";
         let parsed = crate::Program::parse_no_errs(text).unwrap().ast;
-        let non_code_meta = parsed.non_code_meta.get(0);
-        let fmt = format_from_annotations(non_code_meta, Path::new("../foo.gltf"), SourceRange::default())
+        let attrs = parsed.body[0].get_attrs();
+        let fmt = format_from_annotations(attrs, Path::new("../foo.gltf"), SourceRange::default())
             .unwrap()
             .unwrap();
         assert_eq!(
@@ -434,8 +436,8 @@ mod test {
         // format, no options
         let text = "@(format = gltf)\nimport '../foo.txt' as foo";
         let parsed = crate::Program::parse_no_errs(text).unwrap().ast;
-        let non_code_meta = parsed.non_code_meta.get(0);
-        let fmt = format_from_annotations(non_code_meta, Path::new("../foo.txt"), SourceRange::default())
+        let attrs = parsed.body[0].get_attrs();
+        let fmt = format_from_annotations(attrs, Path::new("../foo.txt"), SourceRange::default())
             .unwrap()
             .unwrap();
         assert_eq!(
@@ -444,7 +446,7 @@ mod test {
         );
 
         // format, no extension (wouldn't parse but might some day)
-        let fmt = format_from_annotations(non_code_meta, Path::new("../foo"), SourceRange::default())
+        let fmt = format_from_annotations(attrs, Path::new("../foo"), SourceRange::default())
             .unwrap()
             .unwrap();
         assert_eq!(
@@ -455,8 +457,8 @@ mod test {
         // format, options
         let text = "@(format = obj, coords = vulkan, lengthUnit = ft)\nimport '../foo.txt' as foo";
         let parsed = crate::Program::parse_no_errs(text).unwrap().ast;
-        let non_code_meta = parsed.non_code_meta.get(0);
-        let fmt = format_from_annotations(non_code_meta, Path::new("../foo.txt"), SourceRange::default())
+        let attrs = parsed.body[0].get_attrs();
+        let fmt = format_from_annotations(attrs, Path::new("../foo.txt"), SourceRange::default())
             .unwrap()
             .unwrap();
         assert_eq!(
@@ -470,8 +472,8 @@ mod test {
         // no format, options
         let text = "@(coords = vulkan, lengthUnit = ft)\nimport '../foo.obj' as foo";
         let parsed = crate::Program::parse_no_errs(text).unwrap().ast;
-        let non_code_meta = parsed.non_code_meta.get(0);
-        let fmt = format_from_annotations(non_code_meta, Path::new("../foo.obj"), SourceRange::default())
+        let attrs = parsed.body[0].get_attrs();
+        let fmt = format_from_annotations(attrs, Path::new("../foo.obj"), SourceRange::default())
             .unwrap()
             .unwrap();
         assert_eq!(
@@ -523,8 +525,8 @@ mod test {
     #[track_caller]
     fn assert_annotation_error(src: &str, path: &str, expected: &str) {
         let parsed = crate::Program::parse_no_errs(src).unwrap().ast;
-        let non_code_meta = parsed.non_code_meta.get(0);
-        let err = format_from_annotations(non_code_meta, Path::new(path), SourceRange::default()).unwrap_err();
+        let attrs = parsed.body[0].get_attrs();
+        let err = format_from_annotations(attrs, Path::new(path), SourceRange::default()).unwrap_err();
         assert!(
             err.message().contains(expected),
             "Expected: `{expected}`, found `{}`",

--- a/src/wasm-lib/kcl/src/execution/state.rs
+++ b/src/wasm-lib/kcl/src/execution/state.rs
@@ -12,7 +12,7 @@ use crate::{
         ExecOutcome, ExecutorSettings, KclValue, Operation, UnitAngle, UnitLen,
     },
     modules::{ModuleId, ModuleInfo, ModuleLoader, ModulePath, ModuleRepr},
-    parsing::ast::types::NonCodeValue,
+    parsing::ast::types::Annotation,
     source_range::SourceRange,
 };
 
@@ -236,21 +236,20 @@ pub struct MetaSettings {
 impl MetaSettings {
     pub(crate) fn update_from_annotation(
         &mut self,
-        annotation: &NonCodeValue,
-        source_range: SourceRange,
+        annotation: &crate::parsing::ast::types::Node<Annotation>,
     ) -> Result<(), KclError> {
-        let properties = annotations::expect_properties(annotations::SETTINGS, annotation, source_range)?;
+        let properties = annotations::expect_properties(annotations::SETTINGS, annotation)?;
 
         for p in properties {
             match &*p.inner.key.name {
                 annotations::SETTINGS_UNIT_LENGTH => {
                     let value = annotations::expect_ident(&p.inner.value)?;
-                    let value = kcl_value::UnitLen::from_str(value, source_range)?;
+                    let value = kcl_value::UnitLen::from_str(value, annotation.as_source_range())?;
                     self.default_length_units = value;
                 }
                 annotations::SETTINGS_UNIT_ANGLE => {
                     let value = annotations::expect_ident(&p.inner.value)?;
-                    let value = kcl_value::UnitAngle::from_str(value, source_range)?;
+                    let value = kcl_value::UnitAngle::from_str(value, annotation.as_source_range())?;
                     self.default_angle_units = value;
                 }
                 name => {
@@ -260,7 +259,7 @@ impl MetaSettings {
                             annotations::SETTINGS_UNIT_LENGTH,
                             annotations::SETTINGS_UNIT_ANGLE
                         ),
-                        source_ranges: vec![source_range],
+                        source_ranges: vec![annotation.as_source_range()],
                     }))
                 }
             }

--- a/src/wasm-lib/kcl/tests/import_cycle1/ast.snap
+++ b/src/wasm-lib/kcl/tests/import_cycle1/ast.snap
@@ -103,6 +103,39 @@ description: Result of parsing import_cycle1.kcl
       }
     ],
     "end": 110,
+    "innerAttrs": [
+      {
+        "end": 33,
+        "name": {
+          "end": 9,
+          "name": "settings",
+          "start": 1,
+          "type": "Identifier"
+        },
+        "properties": [
+          {
+            "end": 32,
+            "key": {
+              "end": 27,
+              "name": "defaultLengthUnit",
+              "start": 10,
+              "type": "Identifier"
+            },
+            "start": 10,
+            "type": "ObjectProperty",
+            "value": {
+              "end": 32,
+              "name": "in",
+              "start": 30,
+              "type": "Identifier",
+              "type": "Identifier"
+            }
+          }
+        ],
+        "start": 0,
+        "type": "Annotation"
+      }
+    ],
     "nonCodeMeta": {
       "nonCodeNodes": {
         "0": [
@@ -116,42 +149,7 @@ description: Result of parsing import_cycle1.kcl
           }
         ]
       },
-      "startNodes": [
-        {
-          "end": 33,
-          "start": 0,
-          "type": "NonCodeNode",
-          "value": {
-            "type": "annotation",
-            "name": {
-              "end": 9,
-              "name": "settings",
-              "start": 1,
-              "type": "Identifier"
-            },
-            "properties": [
-              {
-                "end": 32,
-                "key": {
-                  "end": 27,
-                  "name": "defaultLengthUnit",
-                  "start": 10,
-                  "type": "Identifier"
-                },
-                "start": 10,
-                "type": "ObjectProperty",
-                "value": {
-                  "end": 32,
-                  "name": "in",
-                  "start": 30,
-                  "type": "Identifier",
-                  "type": "Identifier"
-                }
-              }
-            ]
-          }
-        }
-      ]
+      "startNodes": []
     },
     "start": 0
   }

--- a/src/wasm-lib/kcl/tests/import_function_not_sketch/ast.snap
+++ b/src/wasm-lib/kcl/tests/import_function_not_sketch/ast.snap
@@ -103,6 +103,39 @@ description: Result of parsing import_function_not_sketch.kcl
       }
     ],
     "end": 109,
+    "innerAttrs": [
+      {
+        "end": 33,
+        "name": {
+          "end": 9,
+          "name": "settings",
+          "start": 1,
+          "type": "Identifier"
+        },
+        "properties": [
+          {
+            "end": 32,
+            "key": {
+              "end": 27,
+              "name": "defaultLengthUnit",
+              "start": 10,
+              "type": "Identifier"
+            },
+            "start": 10,
+            "type": "ObjectProperty",
+            "value": {
+              "end": 32,
+              "name": "in",
+              "start": 30,
+              "type": "Identifier",
+              "type": "Identifier"
+            }
+          }
+        ],
+        "start": 0,
+        "type": "Annotation"
+      }
+    ],
     "nonCodeMeta": {
       "nonCodeNodes": {
         "0": [
@@ -116,42 +149,7 @@ description: Result of parsing import_function_not_sketch.kcl
           }
         ]
       },
-      "startNodes": [
-        {
-          "end": 33,
-          "start": 0,
-          "type": "NonCodeNode",
-          "value": {
-            "type": "annotation",
-            "name": {
-              "end": 9,
-              "name": "settings",
-              "start": 1,
-              "type": "Identifier"
-            },
-            "properties": [
-              {
-                "end": 32,
-                "key": {
-                  "end": 27,
-                  "name": "defaultLengthUnit",
-                  "start": 10,
-                  "type": "Identifier"
-                },
-                "start": 10,
-                "type": "ObjectProperty",
-                "value": {
-                  "end": 32,
-                  "name": "in",
-                  "start": 30,
-                  "type": "Identifier",
-                  "type": "Identifier"
-                }
-              }
-            ]
-          }
-        }
-      ]
+      "startNodes": []
     },
     "start": 0
   }

--- a/src/wasm-lib/kcl/tests/import_whole/ast.snap
+++ b/src/wasm-lib/kcl/tests/import_whole/ast.snap
@@ -115,6 +115,39 @@ description: Result of parsing import_whole.kcl
       }
     ],
     "end": 124,
+    "innerAttrs": [
+      {
+        "end": 33,
+        "name": {
+          "end": 9,
+          "name": "settings",
+          "start": 1,
+          "type": "Identifier"
+        },
+        "properties": [
+          {
+            "end": 32,
+            "key": {
+              "end": 27,
+              "name": "defaultLengthUnit",
+              "start": 10,
+              "type": "Identifier"
+            },
+            "start": 10,
+            "type": "ObjectProperty",
+            "value": {
+              "end": 32,
+              "name": "mm",
+              "start": 30,
+              "type": "Identifier",
+              "type": "Identifier"
+            }
+          }
+        ],
+        "start": 0,
+        "type": "Annotation"
+      }
+    ],
     "nonCodeMeta": {
       "nonCodeNodes": {
         "0": [
@@ -128,42 +161,7 @@ description: Result of parsing import_whole.kcl
           }
         ]
       },
-      "startNodes": [
-        {
-          "end": 33,
-          "start": 0,
-          "type": "NonCodeNode",
-          "value": {
-            "type": "annotation",
-            "name": {
-              "end": 9,
-              "name": "settings",
-              "start": 1,
-              "type": "Identifier"
-            },
-            "properties": [
-              {
-                "end": 32,
-                "key": {
-                  "end": 27,
-                  "name": "defaultLengthUnit",
-                  "start": 10,
-                  "type": "Identifier"
-                },
-                "start": 10,
-                "type": "ObjectProperty",
-                "value": {
-                  "end": 32,
-                  "name": "mm",
-                  "start": 30,
-                  "type": "Identifier",
-                  "type": "Identifier"
-                }
-              }
-            ]
-          }
-        }
-      ]
+      "startNodes": []
     },
     "start": 0
   }


### PR DESCRIPTION
This makes things a bit easier since we don't have to treat annotations as a kind of comment and also lets us have annotations on any node.