### PR TITLE
pass thru the kcl version

### DIFF
--- a/src/lang/KclSingleton.ts
+++ b/src/lang/KclSingleton.ts
@@ -16,6 +16,7 @@ import {
   clearSceneAndBustCache,
   emptyExecState,
   ExecState,
+  getKclVersion,
   initPromise,
   KclValue,
   parse,
@@ -74,6 +75,7 @@ export class KclManager {
   private _hasErrors = false
   private _switchedFiles = false
   private _fileSettings: KclSettingsAnnotation = {}
+  private _kclVersion: string | undefined = undefined
 
   engineCommandManager: EngineCommandManager
 
@@ -116,6 +118,16 @@ export class KclManager {
 
   get execState() {
     return this._execState
+  }
+
+  // Get the kcl version from the wasm module
+  // and store it in the singleton
+  // so we don't waste time getting it multiple times
+  get kclVersion() {
+    if (this._kclVersion === undefined) {
+      this._kclVersion = getKclVersion()
+    }
+    return this._kclVersion
   }
 
   get errors() {

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -9,6 +9,7 @@ import {
   modify_ast_for_sketch_wasm,
   is_points_ccw,
   get_tangential_arc_to_info,
+  get_kcl_version,
   make_default_planes,
   coredump,
   toml_stringify,
@@ -765,4 +766,11 @@ export function unitAngToUnitAngle(input: UnitAng): UnitAngle {
     default:
       return 'degrees'
   }
+}
+
+/**
+ * Get the KCL version currently being used.
+ */
+export function getKclVersion(): string {
+  return get_kcl_version()
 }

--- a/src/lib/promptToEdit.ts
+++ b/src/lib/promptToEdit.ts
@@ -161,6 +161,7 @@ See later source ranges for more context. about the sweep`,
     source_ranges: ranges,
     project_name:
       projectName !== '' && projectName !== 'browser' ? projectName : undefined,
+    kcl_version: kclManager.kclVersion,
   }
   const url = VITE_KC_API_BASE_URL + '/ml/text-to-cad/iteration'
   const data: Models['TextToCadIteration_type'] | Error =

--- a/src/lib/textToCad.ts
+++ b/src/lib/textToCad.ts
@@ -16,6 +16,7 @@ import { commandBarMachine } from 'machines/commandBarMachine'
 import { getNextFileName } from './desktopFS'
 import { reportRejection } from './trap'
 import { toSync } from './utils'
+import { kclManager } from './singletons'
 
 async function submitTextToCadPrompt(
   prompt: string,
@@ -26,6 +27,7 @@ async function submitTextToCadPrompt(
     prompt,
     project_name:
       projectName !== '' && projectName !== 'browser' ? projectName : undefined,
+    kcl_version: kclManager.kclVersion,
   }
   // Glb has a smaller footprint than gltf, should we want to render it.
   const url = VITE_KC_API_BASE_URL + '/ai/text-to-cad/glb?kcl=true'

--- a/src/lib/wasm_lib_wrapper.ts
+++ b/src/lib/wasm_lib_wrapper.ts
@@ -28,6 +28,7 @@ import {
   clear_scene_and_bust_cache as ClearSceneAndBustCache,
   kcl_settings as KclSettings,
   change_kcl_settings as ChangeKclSettings,
+  get_kcl_version as GetKclVersion,
 } from '../wasm-lib/pkg/wasm_lib'
 
 type ModuleType = typeof import('../wasm-lib/pkg/wasm_lib')
@@ -117,4 +118,7 @@ export const kcl_settings: typeof KclSettings = (...args) => {
 }
 export const change_kcl_settings: typeof ChangeKclSettings = (...args) => {
   return getModule().change_kcl_settings(...args)
+}
+export const get_kcl_version: typeof GetKclVersion = () => {
+  return getModule().get_kcl_version()
 }

--- a/src/wasm-lib/kcl/src/lib.rs
+++ b/src/wasm-lib/kcl/src/lib.rs
@@ -236,6 +236,11 @@ fn try_f64_to_i64(f: f64) -> Option<i64> {
     }
 }
 
+/// Get the version of the KCL library.
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/wasm-lib/src/wasm.rs
+++ b/src/wasm-lib/src/wasm.rs
@@ -569,3 +569,11 @@ pub fn change_kcl_settings(code: &str, settings_str: &str) -> Result<String, Str
 
     Ok(formatted)
 }
+
+/// Get the version of the kcl library.
+#[wasm_bindgen]
+pub fn get_kcl_version() -> String {
+    console_error_panic_hook::set_once();
+
+    kcl_lib::version().to_string()
+}


### PR DESCRIPTION
one thing to keep in mind, is we'd need to be sure to bump the `kcl/Cargo.toml` _before_ the ZMA release as opposed to after in order for this to work currently.