### PR TITLE
CM KCL: add annotations

### DIFF
--- a/packages/codemirror-lang-kcl/src/kcl.grammar
+++ b/packages/codemirror-lang-kcl/src/kcl.grammar
@@ -115,7 +115,7 @@ commaSep1NoTrailingComma<term> { term ("," term)* }
   PipeSubstitution { "%" }
 
   identifier { (@asciiLetter | "_") (@asciiLetter | @digit | "_")* }
-  AnnotationName { "@" identifier }
+  AnnotationName { "@" identifier? }
   PropertyName { identifier }
   TagDeclarator { "$" identifier }
 

--- a/packages/codemirror-lang-kcl/src/kcl.grammar
+++ b/packages/codemirror-lang-kcl/src/kcl.grammar
@@ -1,4 +1,5 @@
 @precedence {
+  annotation
   member
   call
   exp @left
@@ -20,8 +21,11 @@ statement[@isGroup=Statement] {
   FunctionDeclaration { kw<"export">? kw<"fn"> VariableDefinition Equals? ParamList Arrow? Body } |
   VariableDeclaration { kw<"export">? (kw<"var"> | kw<"let"> | kw<"const">)? VariableDefinition Equals expression } |
   ReturnStatement { kw<"return"> expression } |
-  ExpressionStatement { expression }
+  ExpressionStatement { expression } |
+  Annotation { At AnnotationName AnnotationList? }
 }
+
+AnnotationList { !annotation "(" commaSep<AnnotationProperty> ")" }
 
 ParamList { "(" commaSep<Parameter { VariableDefinition "?"? (":" type)? }> ")" }
 
@@ -59,6 +63,12 @@ UnaryOp { AddOp | BangOp }
 
 ObjectProperty { PropertyName (":" | Equals) expression }
 
+AnnotationProperty {
+  PropertyName
+  ( AddOp | MultOp | ExpOp | LogicOp | BangOp | CompOp | Equals | Arrow | PipeOperator | PipeSubstitution )
+  expression
+}
+
 LabeledArgument { ArgumentLabel Equals expression }
 
 ArgumentList { "(" commaSep<LabeledArgument | expression> ")" }
@@ -78,6 +88,8 @@ VariableName { identifier }
 
 ArgumentLabel { identifier }
 
+AnnotationName { identifier }
+
 @skip { whitespace | LineComment | BlockComment }
 
 kw<term> { @specialize[@name={term}]<identifier, term> }
@@ -91,6 +103,8 @@ commaSep1NoTrailingComma<term> { term ("," term)* }
 
   Number { "." @digit+ | @digit+ ("." @digit+)? }
   @precedence { Number, "." }
+
+  At { "@" }
 
   AddOp { "+" | "-" }
   MultOp { "/" | "*" | "\\" }

--- a/packages/codemirror-lang-kcl/src/kcl.grammar
+++ b/packages/codemirror-lang-kcl/src/kcl.grammar
@@ -22,7 +22,7 @@ statement[@isGroup=Statement] {
   VariableDeclaration { kw<"export">? (kw<"var"> | kw<"let"> | kw<"const">)? VariableDefinition Equals expression } |
   ReturnStatement { kw<"return"> expression } |
   ExpressionStatement { expression } |
-  Annotation { At AnnotationName AnnotationList? }
+  Annotation { AnnotationName AnnotationList? }
 }
 
 AnnotationList { !annotation "(" commaSep<AnnotationProperty> ")" }
@@ -88,8 +88,6 @@ VariableName { identifier }
 
 ArgumentLabel { identifier }
 
-AnnotationName { identifier }
-
 @skip { whitespace | LineComment | BlockComment }
 
 kw<term> { @specialize[@name={term}]<identifier, term> }
@@ -104,8 +102,6 @@ commaSep1NoTrailingComma<term> { term ("," term)* }
   Number { "." @digit+ | @digit+ ("." @digit+)? }
   @precedence { Number, "." }
 
-  At { "@" }
-
   AddOp { "+" | "-" }
   MultOp { "/" | "*" | "\\" }
   ExpOp { "^" }
@@ -119,6 +115,7 @@ commaSep1NoTrailingComma<term> { term ("," term)* }
   PipeSubstitution { "%" }
 
   identifier { (@asciiLetter | "_") (@asciiLetter | @digit | "_")* }
+  AnnotationName { "@" identifier }
   PropertyName { identifier }
   TagDeclarator { "$" identifier }
 

--- a/packages/codemirror-lang-kcl/test/annotation.txt
+++ b/packages/codemirror-lang-kcl/test/annotation.txt
@@ -1,0 +1,140 @@
+# alone
+
+@a
+
+==>
+Program(Annotation(At,
+                   AnnotationName))
+
+# empty
+
+@ann()
+
+==>
+Program(Annotation(At,
+                   AnnotationName,
+                   AnnotationList))
+
+# equals
+
+@setting(a=1)
+
+==>
+Program(Annotation(At,
+                   AnnotationName,
+                   AnnotationList(AnnotationProperty(PropertyName,
+                                                     Equals,
+                                                     Number))))
+
+# operator
+
+@ann(a*1)
+
+==>
+Program(Annotation(At,
+                   AnnotationName,
+                   AnnotationList(AnnotationProperty(PropertyName,
+                                                     MultOp,
+                                                     Number))))
+
+# complex expr
+
+@ann(a=(1+2+f('yes')))
+
+==>
+Program(Annotation(At,
+                   AnnotationName,
+                   AnnotationList(AnnotationProperty(PropertyName,
+                                                     Equals,
+                                                     ParenthesizedExpression(BinaryExpression(BinaryExpression(Number,
+                                                                                                               AddOp,
+                                                                                                               Number),
+                                                                                              AddOp,
+                                                                                              CallExpression(VariableName,
+                                                                                                             ArgumentList(String))))))))
+
+# many args
+
+@ann(a=1, b=2)
+
+==>
+Program(Annotation(At,
+                   AnnotationName,
+                   AnnotationList(AnnotationProperty(PropertyName,
+                                                     Equals,
+                                                     Number),
+                                  AnnotationProperty(PropertyName,
+                                                     Equals,
+                                                     Number))))
+
+# space around op
+
+@ann(a / 1)
+
+==>
+Program(Annotation(At,
+                   AnnotationName,
+                   AnnotationList(AnnotationProperty(PropertyName,
+                                                     MultOp,
+                                                     Number))))
+
+# space around sep
+
+@ann(a/1 , b/2)
+
+==>
+Program(Annotation(At,
+                   AnnotationName,
+                   AnnotationList(AnnotationProperty(PropertyName,
+                                                     MultOp,
+                                                     Number),
+                                  AnnotationProperty(PropertyName,
+                                                     MultOp,
+                                                     Number))))
+
+# trailing sep
+
+@ann(a=1,)
+
+==>
+Program(Annotation(At,
+                   AnnotationName,
+                   AnnotationList(AnnotationProperty(PropertyName,
+                                                     Equals,
+                                                     Number))))
+
+# lone sep
+
+@ann(,)
+
+==>
+Program(Annotation(At,
+                   AnnotationName,
+                   AnnotationList))
+
+# inside fn
+
+fn f() {
+  @anno(b=2)
+}
+
+==>
+Program(FunctionDeclaration(fn,
+                            VariableDefinition,
+                            ParamList,
+                            Body(Annotation(At,
+                                            AnnotationName,
+                                            AnnotationList(AnnotationProperty(PropertyName,
+                                                                              Equals,
+                                                                              Number))))))
+
+# laxer with space than the language parser is
+
+@ anno (b=2)
+
+==>
+Program(Annotation(At,
+                   AnnotationName,
+                   AnnotationList(AnnotationProperty(PropertyName,
+                                                     Equals,
+                                                     Number))))

--- a/packages/codemirror-lang-kcl/test/annotation.txt
+++ b/packages/codemirror-lang-kcl/test/annotation.txt
@@ -5,9 +5,24 @@
 ==>
 Program(Annotation(AnnotationName))
 
+# alone and anonymous
+
+@
+
+==>
+Program(Annotation(AnnotationName))
+
 # empty
 
 @ann()
+
+==>
+Program(Annotation(AnnotationName,
+                   AnnotationList))
+
+# empty and anonymous
+
+@()
 
 ==>
 Program(Annotation(AnnotationName,
@@ -31,6 +46,16 @@ Program(Annotation(AnnotationName,
 Program(Annotation(AnnotationName,
                    AnnotationList(AnnotationProperty(PropertyName,
                                                      MultOp,
+                                                     Number))))
+
+# anonymous
+
+@(a=1)
+
+==>
+Program(Annotation(AnnotationName,
+                   AnnotationList(AnnotationProperty(PropertyName,
+                                                     Equals,
                                                      Number))))
 
 # complex expr

--- a/packages/codemirror-lang-kcl/test/annotation.txt
+++ b/packages/codemirror-lang-kcl/test/annotation.txt
@@ -3,16 +3,14 @@
 @a
 
 ==>
-Program(Annotation(At,
-                   AnnotationName))
+Program(Annotation(AnnotationName))
 
 # empty
 
 @ann()
 
 ==>
-Program(Annotation(At,
-                   AnnotationName,
+Program(Annotation(AnnotationName,
                    AnnotationList))
 
 # equals
@@ -20,8 +18,7 @@ Program(Annotation(At,
 @setting(a=1)
 
 ==>
-Program(Annotation(At,
-                   AnnotationName,
+Program(Annotation(AnnotationName,
                    AnnotationList(AnnotationProperty(PropertyName,
                                                      Equals,
                                                      Number))))
@@ -31,8 +28,7 @@ Program(Annotation(At,
 @ann(a*1)
 
 ==>
-Program(Annotation(At,
-                   AnnotationName,
+Program(Annotation(AnnotationName,
                    AnnotationList(AnnotationProperty(PropertyName,
                                                      MultOp,
                                                      Number))))
@@ -42,8 +38,7 @@ Program(Annotation(At,
 @ann(a=(1+2+f('yes')))
 
 ==>
-Program(Annotation(At,
-                   AnnotationName,
+Program(Annotation(AnnotationName,
                    AnnotationList(AnnotationProperty(PropertyName,
                                                      Equals,
                                                      ParenthesizedExpression(BinaryExpression(BinaryExpression(Number,
@@ -58,8 +53,7 @@ Program(Annotation(At,
 @ann(a=1, b=2)
 
 ==>
-Program(Annotation(At,
-                   AnnotationName,
+Program(Annotation(AnnotationName,
                    AnnotationList(AnnotationProperty(PropertyName,
                                                      Equals,
                                                      Number),
@@ -72,8 +66,7 @@ Program(Annotation(At,
 @ann(a / 1)
 
 ==>
-Program(Annotation(At,
-                   AnnotationName,
+Program(Annotation(AnnotationName,
                    AnnotationList(AnnotationProperty(PropertyName,
                                                      MultOp,
                                                      Number))))
@@ -83,8 +76,7 @@ Program(Annotation(At,
 @ann(a/1 , b/2)
 
 ==>
-Program(Annotation(At,
-                   AnnotationName,
+Program(Annotation(AnnotationName,
                    AnnotationList(AnnotationProperty(PropertyName,
                                                      MultOp,
                                                      Number),
@@ -97,8 +89,7 @@ Program(Annotation(At,
 @ann(a=1,)
 
 ==>
-Program(Annotation(At,
-                   AnnotationName,
+Program(Annotation(AnnotationName,
                    AnnotationList(AnnotationProperty(PropertyName,
                                                      Equals,
                                                      Number))))
@@ -108,8 +99,7 @@ Program(Annotation(At,
 @ann(,)
 
 ==>
-Program(Annotation(At,
-                   AnnotationName,
+Program(Annotation(AnnotationName,
                    AnnotationList))
 
 # inside fn
@@ -122,19 +112,17 @@ fn f() {
 Program(FunctionDeclaration(fn,
                             VariableDefinition,
                             ParamList,
-                            Body(Annotation(At,
-                                            AnnotationName,
+                            Body(Annotation(AnnotationName,
                                             AnnotationList(AnnotationProperty(PropertyName,
                                                                               Equals,
                                                                               Number))))))
 
 # laxer with space than the language parser is
 
-@ anno (b=2)
+@anno (b=2)
 
 ==>
-Program(Annotation(At,
-                   AnnotationName,
+Program(Annotation(AnnotationName,
                    AnnotationList(AnnotationProperty(PropertyName,
                                                      Equals,
                                                      Number))))


### PR DESCRIPTION
Authored by @mattmundell. Replaces/closes #5314.

## What

In `codemirror-lang-kcl`, add support for annotations to the Lezer parser.

~I've done this the simple way by treating the annotation as a statement and allowing space, eg between the `@` and `setting` and `(`. If it really needs to parse the spacing correctly in future it might need to use Lezer's external tokenizer feature.~

~Note that the `!annotation` forces the parser to choose the `AnnotationList`, because at that point the `(` could also be the start of a statement.~

## Why

Prepares for adding highlights to annotations.

## References

Related: /issues/5204.
