### PR TITLE
Add type to KclValue::Number

### DIFF
--- a/docs/kcl/types/KclValue.md
+++ b/docs/kcl/types/KclValue.md
@@ -59,6 +59,7 @@ Any KCL value.
 |----------|------|-------------|----------|
 | `type` |enum: `Number`|  | No |
 | `value` |`number`|  | No |
+| `ty` |[`NumericType`](/docs/kcl/types/NumericType)| Any KCL value. | No |
 | `__meta` |`[` [`Metadata`](/docs/kcl/types/Metadata) `]`|  | No |
 
 

--- a/docs/kcl/types/NumericType.md
+++ b/docs/kcl/types/NumericType.md
@@ -1,0 +1,250 @@
+---
+title: "NumericType"
+excerpt: ""
+layout: manual
+---
+
+
+
+
+
+
+**This schema accepts exactly one of the following:**
+
+
+**Type:** `object`
+
+
+
+**This schema accepts exactly one of the following:**
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Count`|  | No |
+
+
+----
+
+**Type:** `object`
+
+
+
+**This schema accepts exactly one of the following:**
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Mm`|  | No |
+
+
+----
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Cm`|  | No |
+
+
+----
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `M`|  | No |
+
+
+----
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Inches`|  | No |
+
+
+----
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Feet`|  | No |
+
+
+----
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Yards`|  | No |
+
+
+----
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Length`|  | No |
+
+
+----
+
+**Type:** `object`
+
+
+
+**This schema accepts exactly one of the following:**
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Degrees`|  | No |
+
+
+----
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Radians`|  | No |
+
+
+----
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Angle`|  | No |
+
+
+----
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Known`|  | No |
+
+
+----
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Default`|  | No |
+| `len` |[`UnitLen`](/docs/kcl/types/UnitLen)|  | No |
+| `angle` |[`UnitAngle`](/docs/kcl/types/UnitAngle)|  | No |
+
+
+----
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Unknown`|  | No |
+
+
+----
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Any`|  | No |
+
+
+----
+
+
+
+

--- a/docs/kcl/types/UnitAngle.md
+++ b/docs/kcl/types/UnitAngle.md
@@ -1,0 +1,47 @@
+---
+title: "UnitAngle"
+excerpt: ""
+layout: manual
+---
+
+
+
+
+
+
+**This schema accepts exactly one of the following:**
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Degrees`|  | No |
+
+
+----
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Radians`|  | No |
+
+
+----
+
+
+
+

--- a/docs/kcl/types/UnitType.md
+++ b/docs/kcl/types/UnitType.md
@@ -1,0 +1,186 @@
+---
+title: "UnitType"
+excerpt: ""
+layout: manual
+---
+
+
+
+
+
+
+**This schema accepts exactly one of the following:**
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Count`|  | No |
+
+
+----
+
+**Type:** `object`
+
+
+
+**This schema accepts exactly one of the following:**
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Mm`|  | No |
+
+
+----
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Cm`|  | No |
+
+
+----
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `M`|  | No |
+
+
+----
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Inches`|  | No |
+
+
+----
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Feet`|  | No |
+
+
+----
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Yards`|  | No |
+
+
+----
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Length`|  | No |
+
+
+----
+
+**Type:** `object`
+
+
+
+**This schema accepts exactly one of the following:**
+
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Degrees`|  | No |
+
+
+----
+
+**Type:** `object`
+
+
+
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Radians`|  | No |
+
+
+----
+
+
+## Properties
+
+| Property | Type | Description | Required |
+|----------|------|-------------|----------|
+| `type` |enum: `Angle`|  | No |
+
+
+----
+
+
+
+

--- a/src/lang/executor.test.ts
+++ b/src/lang/executor.test.ts
@@ -239,6 +239,7 @@ const newVar = myVar + 1`
     expect(mem['three']).toEqual({
       type: 'Number',
       value: 3,
+      ty: expect.any(Object),
       __meta: [
         {
           sourceRange: [14, 15, 0],
@@ -248,12 +249,23 @@ const newVar = myVar + 1`
     expect(mem['yo']).toEqual({
       type: 'Array',
       value: [
-        { type: 'Number', value: 1, __meta: [{ sourceRange: [28, 29, 0] }] },
+        {
+          type: 'Number',
+          value: 1,
+          ty: expect.any(Object),
+          __meta: [{ sourceRange: [28, 29, 0] }],
+        },
         { type: 'String', value: '2', __meta: [{ sourceRange: [31, 34, 0] }] },
-        { type: 'Number', value: 3, __meta: [{ sourceRange: [14, 15, 0] }] },
+        {
+          type: 'Number',
+          value: 3,
+          ty: expect.any(Object),
+          __meta: [{ sourceRange: [14, 15, 0] }],
+        },
         {
           type: 'Number',
           value: 9,
+          ty: expect.any(Object),
           __meta: [{ sourceRange: [43, 44, 0] }, { sourceRange: [47, 48, 0] }],
         },
       ],
@@ -281,16 +293,19 @@ const newVar = myVar + 1`
         anum: {
           type: 'Number',
           value: 2,
+          ty: expect.any(Object),
           __meta: [{ sourceRange: [47, 48, 0] }],
         },
         identifier: {
           type: 'Number',
           value: 3,
+          ty: expect.any(Object),
           __meta: [{ sourceRange: [14, 15, 0] }],
         },
         binExp: {
           type: 'Number',
           value: 9,
+          ty: expect.any(Object),
           __meta: [{ sourceRange: [77, 78, 0] }, { sourceRange: [81, 82, 0] }],
         },
       },
@@ -404,6 +419,7 @@ describe('testing math operators', () => {
         ],
         type: 'Number',
         value: 1,
+        ty: expect.any(Object),
       },
       {
         __meta: [
@@ -413,6 +429,7 @@ describe('testing math operators', () => {
         ],
         type: 'Number',
         value: -3,
+        ty: expect.any(Object),
       },
     ])
   })

--- a/src/lib/kclHelpers.test.ts
+++ b/src/lib/kclHelpers.test.ts
@@ -14,6 +14,7 @@ describe('KCL expression calculations', () => {
     variables['x'] = {
       type: 'Number',
       value: 2,
+      ty: { type: 'Any' },
       __meta: [],
     }
     const actual = await getCalculatedKclExpressionValue('1 + x', variables)
@@ -32,6 +33,7 @@ describe('KCL expression calculations', () => {
     variables['y'] = {
       type: 'Number',
       value: 2,
+      ty: { type: 'Any' },
       __meta: [],
     }
     const actual = await getCalculatedKclExpressionValue('1 + x', variables)
@@ -44,6 +46,7 @@ describe('KCL expression calculations', () => {
     variables['x'] = {
       type: 'Number',
       value: 2,
+      ty: { type: 'Any' },
       __meta: [],
     }
     const actual = await getCalculatedKclExpressionValue(

--- a/src/wasm-lib/kcl/src/execution/exec_ast.rs
+++ b/src/wasm-lib/kcl/src/execution/exec_ast.rs
@@ -9,8 +9,8 @@ use crate::{
     execution::{
         annotations,
         cad_op::{OpArg, Operation},
+        kcl_value::NumericType,
         memory,
-        memory::ProgramMemory,
         state::ModuleState,
         BodyType, EnvironmentRef, ExecState, ExecutorContext, KclValue, MemoryFunction, Metadata, TagEngineInfo,
         TagIdentifier,
@@ -437,7 +437,7 @@ impl ExecutorContext {
     ) -> Result<KclValue, KclError> {
         let item = match init {
             Expr::None(none) => KclValue::from(none),
-            Expr::Literal(literal) => KclValue::from(literal),
+            Expr::Literal(literal) => KclValue::from_literal((**literal).clone(), &exec_state.mod_local.settings),
             Expr::TagDeclarator(tag) => tag.execute(exec_state).await?,
             Expr::Identifier(identifier) => {
                 let value = exec_state.memory().get(&identifier.name, identifier.into())?.clone();
@@ -518,7 +518,10 @@ impl BinaryPart {
     #[async_recursion]
     pub async fn get_result(&self, exec_state: &mut ExecState, ctx: &ExecutorContext) -> Result<KclValue, KclError> {
         match self {
-            BinaryPart::Literal(literal) => Ok(literal.into()),
+            BinaryPart::Literal(literal) => Ok(KclValue::from_literal(
+                (**literal).clone(),
+                &exec_state.mod_local.settings,
+            )),
             BinaryPart::Identifier(identifier) => {
                 let value = exec_state.memory().get(&identifier.name, identifier.into())?;
                 Ok(value.clone())
@@ -704,26 +707,32 @@ impl Node<BinaryExpression> {
             BinaryOperator::Add => KclValue::Number {
                 value: left + right,
                 meta,
+                ty: NumericType::Unknown,
             },
             BinaryOperator::Sub => KclValue::Number {
                 value: left - right,
                 meta,
+                ty: NumericType::Unknown,
             },
             BinaryOperator::Mul => KclValue::Number {
                 value: left * right,
                 meta,
+                ty: NumericType::Unknown,
             },
             BinaryOperator::Div => KclValue::Number {
                 value: left / right,
                 meta,
+                ty: NumericType::Unknown,
             },
             BinaryOperator::Mod => KclValue::Number {
                 value: left % right,
                 meta,
+                ty: NumericType::Unknown,
             },
             BinaryOperator::Pow => KclValue::Number {
                 value: left.powf(right),
                 meta,
+                ty: NumericType::Unknown,
             },
             BinaryOperator::Neq => KclValue::Bool {
                 value: left != right,
@@ -786,11 +795,15 @@ impl Node<UnaryExpression> {
 
         let value = &self.argument.get_result(exec_state, ctx).await?;
         match value {
-            KclValue::Number { value, meta: _ } => {
+            KclValue::Number { value, ty, .. } => {
                 let meta = vec![Metadata {
                     source_range: self.into(),
                 }];
-                Ok(KclValue::Number { value: -value, meta })
+                Ok(KclValue::Number {
+                    value: -value,
+                    meta,
+                    ty: ty.clone(),
+                })
             }
             _ => Err(KclError::Semantic(KclErrorDetails {
                 message: format!(
@@ -1292,6 +1305,7 @@ impl Node<ArrayRangeExpression> {
                 .into_iter()
                 .map(|num| KclValue::Number {
                     value: num as f64,
+                    ty: NumericType::Unknown,
                     meta: meta.clone(),
                 })
                 .collect(),
@@ -1449,7 +1463,7 @@ fn jvalue_to_prop(value: &KclValue, property_sr: Vec<SourceRange>, name: &str) -
         }))
     };
     match value {
-        KclValue::Number{value: num, meta:_} => {
+        KclValue::Number{value: num, .. } => {
             let num = *num;
             if num < 0.0 {
                 return make_err(format!("'{num}' is negative, so you can't index an array with it"))
@@ -1490,7 +1504,7 @@ impl Node<PipeExpression> {
 fn assign_args_to_params(
     function_expression: NodeRef<'_, FunctionExpression>,
     args: Vec<Arg>,
-    fn_memory: &mut ProgramMemory,
+    exec_state: &mut ExecState,
 ) -> Result<(), KclError> {
     let num_args = function_expression.number_of_args();
     let (min_params, max_params) = num_args.into_inner();
@@ -1510,12 +1524,15 @@ fn assign_args_to_params(
         return Err(err_wrong_number_args);
     }
 
+    let mem = &mut exec_state.global.memory;
+    let settings = &exec_state.mod_local.settings;
+
     // Add the arguments to the memory.  A new call frame should have already
     // been created.
     for (index, param) in function_expression.params.iter().enumerate() {
         if let Some(arg) = args.get(index) {
             // Argument was provided.
-            fn_memory.add(
+            mem.add(
                 param.identifier.name.clone(),
                 arg.value.clone(),
                 (&param.identifier).into(),
@@ -1525,9 +1542,9 @@ fn assign_args_to_params(
             if let Some(ref default_val) = param.default_value {
                 // If the corresponding parameter is optional,
                 // then it's fine, the user doesn't need to supply it.
-                fn_memory.add(
+                mem.add(
                     param.identifier.name.clone(),
-                    default_val.clone().into(),
+                    KclValue::from_default_param(default_val.clone(), settings),
                     (&param.identifier).into(),
                 )?;
             } else {
@@ -1543,18 +1560,21 @@ fn assign_args_to_params(
 fn assign_args_to_params_kw(
     function_expression: NodeRef<'_, FunctionExpression>,
     mut args: crate::std::args::KwArgs,
-    fn_memory: &mut ProgramMemory,
+    exec_state: &mut ExecState,
 ) -> Result<(), KclError> {
     // Add the arguments to the memory.  A new call frame should have already
     // been created.
     let source_ranges = vec![function_expression.into()];
+    let mem = &mut exec_state.global.memory;
+    let settings = &exec_state.mod_local.settings;
+
     for param in function_expression.params.iter() {
         if param.labeled {
             let arg = args.labeled.get(&param.identifier.name);
             let arg_val = match arg {
                 Some(arg) => arg.value.clone(),
                 None => match param.default_value {
-                    Some(ref default_val) => KclValue::from(default_val.clone()),
+                    Some(ref default_val) => KclValue::from_default_param(default_val.clone(), settings),
                     None => {
                         return Err(KclError::Semantic(KclErrorDetails {
                             source_ranges,
@@ -1566,7 +1586,7 @@ fn assign_args_to_params_kw(
                     }
                 },
             };
-            fn_memory.add(param.identifier.name.clone(), arg_val, (&param.identifier).into())?;
+            mem.add(param.identifier.name.clone(), arg_val, (&param.identifier).into())?;
         } else {
             let Some(unlabeled) = args.unlabeled.take() else {
                 let param_name = &param.identifier.name;
@@ -1583,7 +1603,7 @@ fn assign_args_to_params_kw(
                     })
                 });
             };
-            fn_memory.add(
+            mem.add(
                 param.identifier.name.clone(),
                 unlabeled.value.clone(),
                 (&param.identifier).into(),
@@ -1604,7 +1624,7 @@ pub(crate) async fn call_user_defined_function(
     // variables shadow variables in the parent scope.  The new environment's
     // parent should be the environment of the closure.
     exec_state.mut_memory().push_new_env_for_call(memory);
-    if let Err(e) = assign_args_to_params(function_expression, args, exec_state.mut_memory()) {
+    if let Err(e) = assign_args_to_params(function_expression, args, exec_state) {
         exec_state.mut_memory().pop_env();
         return Err(e);
     }
@@ -1637,7 +1657,7 @@ pub(crate) async fn call_user_defined_function_kw(
     // variables shadow variables in the parent scope.  The new environment's
     // parent should be the environment of the closure.
     exec_state.mut_memory().push_new_env_for_call(memory);
-    if let Err(e) = assign_args_to_params_kw(function_expression, args, exec_state.mut_memory()) {
+    if let Err(e) = assign_args_to_params_kw(function_expression, args, exec_state) {
         exec_state.mut_memory().pop_env();
         return Err(e);
     }
@@ -1701,7 +1721,7 @@ impl JsonSchema for FunctionParam<'_> {
 #[cfg(test)]
 mod test {
     use crate::{
-        execution::parse_execute,
+        execution::{memory::ProgramMemory, parse_execute},
         parsing::ast::types::{DefaultParamVal, Identifier, Parameter},
     };
 
@@ -1713,6 +1733,7 @@ mod test {
         fn mem(number: usize) -> KclValue {
             KclValue::Number {
                 value: number as f64,
+                ty: NumericType::count(),
                 meta: Default::default(),
             }
         }
@@ -1818,8 +1839,8 @@ mod test {
                 digest: None,
             });
             let args = args.into_iter().map(Arg::synthetic).collect();
-            let mut actual = ProgramMemory::new();
-            let actual = assign_args_to_params(func_expr, args, &mut actual).map(|_| actual);
+            let mut exec_state = ExecState::new(&Default::default());
+            let actual = assign_args_to_params(func_expr, args, &mut exec_state).map(|_| exec_state.global.memory);
             assert_eq!(
                 actual, expected,
                 "failed test '{test_name}':\ngot {actual:?}\nbut expected\n{expected:?}"

--- a/src/wasm-lib/kcl/src/execution/memory.rs
+++ b/src/wasm-lib/kcl/src/execution/memory.rs
@@ -845,6 +845,8 @@ mod env {
 
 #[cfg(test)]
 mod test {
+    use crate::execution::kcl_value::NumericType;
+
     use super::*;
 
     fn sr() -> SourceRange {
@@ -854,6 +856,7 @@ mod test {
     fn val(value: i64) -> KclValue {
         KclValue::Number {
             value: value as f64,
+            ty: NumericType::count(),
             meta: Vec::new(),
         }
     }

--- a/src/wasm-lib/kcl/src/parsing/ast/types/mod.rs
+++ b/src/wasm-lib/kcl/src/parsing/ast/types/mod.rs
@@ -2080,30 +2080,6 @@ impl Literal {
     }
 }
 
-impl From<Node<Literal>> for KclValue {
-    fn from(literal: Node<Literal>) -> Self {
-        let meta = vec![literal.metadata()];
-        match literal.inner.value {
-            LiteralValue::Number { value, .. } => KclValue::Number { value, meta },
-            LiteralValue::String(value) => KclValue::String { value, meta },
-            LiteralValue::Bool(value) => KclValue::Bool { value, meta },
-        }
-    }
-}
-
-impl From<&Node<Literal>> for KclValue {
-    fn from(literal: &Node<Literal>) -> Self {
-        Self::from(literal.to_owned())
-    }
-}
-
-impl From<&BoxNode<Literal>> for KclValue {
-    fn from(literal: &BoxNode<Literal>) -> Self {
-        let b: &Node<Literal> = literal;
-        Self::from(b)
-    }
-}
-
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Eq)]
 #[ts(export)]
 #[serde(tag = "type")]
@@ -3088,20 +3064,7 @@ pub enum FnArgType {
 #[allow(clippy::large_enum_variant)]
 pub enum DefaultParamVal {
     KclNone(KclNone),
-    Literal(Literal),
-}
-
-// TODO: This should actually take metadata.
-impl From<DefaultParamVal> for KclValue {
-    fn from(v: DefaultParamVal) -> Self {
-        match v {
-            DefaultParamVal::KclNone(kcl_none) => Self::KclNone {
-                value: kcl_none,
-                meta: Default::default(),
-            },
-            DefaultParamVal::Literal(literal) => Self::from_literal(literal.value, Vec::new()),
-        }
-    }
+    Literal(Node<Literal>),
 }
 
 impl DefaultParamVal {

--- a/src/wasm-lib/kcl/src/parsing/parser.rs
+++ b/src/wasm-lib/kcl/src/parsing/parser.rs
@@ -2579,7 +2579,7 @@ fn parameter(i: &mut TokenSlice) -> PResult<ParamDescription> {
         arg_name,
         type_,
         default_value: match (question_mark.is_some(), default_literal) {
-            (true, Some(lit)) => Some(DefaultParamVal::Literal(lit.inner)),
+            (true, Some(lit)) => Some(DefaultParamVal::Literal(*lit)),
             (true, None) => Some(DefaultParamVal::none()),
             (false, None) => None,
             (false, Some(lit)) => {

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__kw_function_decl_with_default_and_type.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__kw_function_decl_with_default_and_type.snap
@@ -48,13 +48,15 @@ expression: actual
                 "type": "Identifier"
               },
               "default_value": {
+                "end": 21,
+                "raw": "2",
+                "start": 20,
                 "type": "Literal",
                 "type": "Literal",
                 "value": {
                   "value": 2.0,
                   "suffix": "None"
-                },
-                "raw": "2"
+                }
               }
             }
           ],

--- a/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__kw_function_decl_with_default_no_type.snap
+++ b/src/wasm-lib/kcl/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__kw_function_decl_with_default_no_type.snap
@@ -48,13 +48,15 @@ expression: actual
                 "type": "Identifier"
               },
               "default_value": {
+                "end": 13,
+                "raw": "2",
+                "start": 12,
                 "type": "Literal",
                 "type": "Literal",
                 "value": {
                   "value": 2.0,
                   "suffix": "None"
-                },
-                "raw": "2"
+                }
               }
             }
           ],

--- a/src/wasm-lib/kcl/src/std/args.rs
+++ b/src/wasm-lib/kcl/src/std/args.rs
@@ -8,8 +8,8 @@ use super::shapes::PolygonType;
 use crate::{
     errors::{KclError, KclErrorDetails},
     execution::{
-        ExecState, ExecutorContext, ExtrudeSurface, Helix, KclObjectFields, KclValue, Metadata, Sketch, SketchSet,
-        SketchSurface, Solid, SolidSet, TagIdentifier,
+        kcl_value::NumericType, ExecState, ExecutorContext, ExtrudeSurface, Helix, KclObjectFields, KclValue, Metadata,
+        Sketch, SketchSet, SketchSurface, Solid, SolidSet, TagIdentifier,
     },
     parsing::ast::types::TagNode,
     source_range::SourceRange,
@@ -299,10 +299,12 @@ impl Args {
         let x = KclValue::Number {
             value: p[0],
             meta: vec![meta],
+            ty: NumericType::Unknown,
         };
         let y = KclValue::Number {
             value: p[1],
             meta: vec![meta],
+            ty: NumericType::Unknown,
         };
         Ok(KclValue::Array {
             value: vec![x, y],
@@ -319,6 +321,16 @@ impl Args {
         )
     }
 
+    pub(crate) fn make_user_val_from_f64_with_type(&self, f: f64, ty: NumericType) -> KclValue {
+        KclValue::from_number_with_type(
+            f,
+            ty,
+            vec![Metadata {
+                source_range: self.source_range,
+            }],
+        )
+    }
+
     pub(crate) fn make_user_val_from_f64_array(&self, f: Vec<f64>) -> Result<KclValue, KclError> {
         let array = f
             .into_iter()
@@ -327,6 +339,7 @@ impl Args {
                 meta: vec![Metadata {
                     source_range: self.source_range,
                 }],
+                ty: NumericType::Unknown,
             })
             .collect::<Vec<_>>();
         Ok(KclValue::Array {
@@ -338,6 +351,10 @@ impl Args {
     }
 
     pub(crate) fn get_number(&self) -> Result<f64, KclError> {
+        FromArgs::from_args(self, 0)
+    }
+
+    pub(crate) fn get_number_with_type(&self) -> Result<(f64, NumericType), KclError> {
         FromArgs::from_args(self, 0)
     }
 
@@ -358,8 +375,25 @@ impl Args {
         Ok(numbers)
     }
 
-    pub(crate) fn get_hypotenuse_leg(&self) -> Result<(f64, f64), KclError> {
-        let numbers = self.get_number_array()?;
+    pub(crate) fn get_number_array_with_types(&self) -> Result<Vec<(f64, NumericType)>, KclError> {
+        let numbers = self
+            .args
+            .iter()
+            .map(|arg| {
+                let Some(num) = <(f64, NumericType)>::from_kcl_val(&arg.value) else {
+                    return Err(KclError::Semantic(KclErrorDetails {
+                        source_ranges: arg.source_ranges(),
+                        message: format!("Expected a number but found {}", arg.value.human_friendly_type()),
+                    }));
+                };
+                Ok(num)
+            })
+            .collect::<Result<_, _>>()?;
+        Ok(numbers)
+    }
+
+    pub(crate) fn get_hypotenuse_leg(&self) -> Result<(f64, f64, NumericType), KclError> {
+        let numbers = self.get_number_array_with_types()?;
 
         if numbers.len() != 2 {
             return Err(KclError::Type(KclErrorDetails {
@@ -368,7 +402,11 @@ impl Args {
             }));
         }
 
-        Ok((numbers[0], numbers[1]))
+        let mut numbers = numbers.into_iter();
+        let (a, ta) = numbers.next().unwrap();
+        let (b, tb) = numbers.next().unwrap();
+        let ty = ta.combine(&tb);
+        Ok((a, b, ty))
     }
 
     pub(crate) fn get_circle_args(
@@ -1383,7 +1421,7 @@ impl<'a> FromKclValue<'a> for super::sketch::AngledLineData {
 impl<'a> FromKclValue<'a> for i64 {
     fn from_kcl_val(arg: &'a KclValue) -> Option<Self> {
         match arg {
-            KclValue::Number { value, meta: _ } => crate::try_f64_to_i64(*value),
+            KclValue::Number { value, .. } => crate::try_f64_to_i64(*value),
             _ => None,
         }
     }
@@ -1419,7 +1457,7 @@ impl<'a> FromKclValue<'a> for uuid::Uuid {
 impl<'a> FromKclValue<'a> for u32 {
     fn from_kcl_val(arg: &'a KclValue) -> Option<Self> {
         match arg {
-            KclValue::Number { value, meta: _ } => crate::try_f64_to_u32(*value),
+            KclValue::Number { value, .. } => crate::try_f64_to_u32(*value),
             _ => None,
         }
     }
@@ -1434,7 +1472,7 @@ impl<'a> FromKclValue<'a> for NonZeroU32 {
 impl<'a> FromKclValue<'a> for u64 {
     fn from_kcl_val(arg: &'a KclValue) -> Option<Self> {
         match arg {
-            KclValue::Number { value, meta: _ } => crate::try_f64_to_u64(*value),
+            KclValue::Number { value, .. } => crate::try_f64_to_u64(*value),
             _ => None,
         }
     }
@@ -1442,7 +1480,15 @@ impl<'a> FromKclValue<'a> for u64 {
 impl<'a> FromKclValue<'a> for f64 {
     fn from_kcl_val(arg: &'a KclValue) -> Option<Self> {
         match arg {
-            KclValue::Number { value, meta: _ } => Some(*value),
+            KclValue::Number { value, .. } => Some(*value),
+            _ => None,
+        }
+    }
+}
+impl<'a> FromKclValue<'a> for (f64, NumericType) {
+    fn from_kcl_val(arg: &'a KclValue) -> Option<Self> {
+        match arg {
+            KclValue::Number { value, ty, .. } => Some((*value, ty.clone())),
             _ => None,
         }
     }

--- a/src/wasm-lib/kcl/src/std/assert.rs
+++ b/src/wasm-lib/kcl/src/std/assert.rs
@@ -5,7 +5,7 @@ use derive_docs::stdlib;
 
 use crate::{
     errors::{KclError, KclErrorDetails},
-    execution::{ExecState, KclValue},
+    execution::{kcl_value::NumericType, ExecState, KclValue},
     std::Args,
 };
 
@@ -24,7 +24,7 @@ async fn _assert(value: bool, message: &str, args: &Args) -> Result<(), KclError
 pub async fn assert(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let (data, description): (bool, String) = args.get_data()?;
     inner_assert(data, &description, &args).await?;
-    Ok(args.make_user_val_from_f64(0.0)) // TODO: Add a new Void enum for fns that don't return anything.
+    Ok(args.make_user_val_from_f64_with_type(0.0, NumericType::count())) // TODO: Add a new Void enum for fns that don't return anything.
 }
 
 /// Check a value at runtime, and raise an error if the argument provided
@@ -44,7 +44,7 @@ async fn inner_assert(data: bool, message: &str, args: &Args) -> Result<(), KclE
 pub async fn assert_lt(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let (left, right, description): (f64, f64, String) = args.get_data()?;
     inner_assert_lt(left, right, &description, &args).await?;
-    Ok(args.make_user_val_from_f64(0.0)) // TODO: Add a new Void enum for fns that don't return anything.
+    Ok(args.make_user_val_from_f64_with_type(0.0, NumericType::count())) // TODO: Add a new Void enum for fns that don't return anything.
 }
 
 /// Check that a numerical value is less than to another at runtime,
@@ -63,7 +63,7 @@ async fn inner_assert_lt(left: f64, right: f64, message: &str, args: &Args) -> R
 pub async fn assert_gt(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let (left, right, description): (f64, f64, String) = args.get_data()?;
     inner_assert_gt(left, right, &description, &args).await?;
-    Ok(args.make_user_val_from_f64(0.0)) // TODO: Add a new Void enum for fns that don't return anything.
+    Ok(args.make_user_val_from_f64_with_type(0.0, NumericType::count())) // TODO: Add a new Void enum for fns that don't return anything.
 }
 
 /// Check that a numerical value equals another at runtime,
@@ -96,7 +96,7 @@ async fn inner_assert_equal(left: f64, right: f64, epsilon: f64, message: &str, 
 pub async fn assert_equal(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let (left, right, epsilon, description): (f64, f64, f64, String) = args.get_data()?;
     inner_assert_equal(left, right, epsilon, &description, &args).await?;
-    Ok(args.make_user_val_from_f64(0.0)) // TODO: Add a new Void enum for fns that don't return anything.
+    Ok(args.make_user_val_from_f64_with_type(0.0, NumericType::count())) // TODO: Add a new Void enum for fns that don't return anything.
 }
 
 /// Check that a numerical value is greater than another at runtime,
@@ -115,7 +115,7 @@ async fn inner_assert_gt(left: f64, right: f64, message: &str, args: &Args) -> R
 pub async fn assert_lte(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let (left, right, description): (f64, f64, String) = args.get_data()?;
     inner_assert_lte(left, right, &description, &args).await?;
-    Ok(args.make_user_val_from_f64(0.0)) // TODO: Add a new Void enum for fns that don't return anything.
+    Ok(args.make_user_val_from_f64_with_type(0.0, NumericType::count())) // TODO: Add a new Void enum for fns that don't return anything.
 }
 
 /// Check that a numerical value is less than or equal to another at runtime,
@@ -135,7 +135,7 @@ async fn inner_assert_lte(left: f64, right: f64, message: &str, args: &Args) -> 
 pub async fn assert_gte(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let (left, right, description): (f64, f64, String) = args.get_data()?;
     inner_assert_gte(left, right, &description, &args).await?;
-    Ok(args.make_user_val_from_f64(0.0)) // TODO: Add a new Void enum for fns that don't return anything.
+    Ok(args.make_user_val_from_f64_with_type(0.0, NumericType::count())) // TODO: Add a new Void enum for fns that don't return anything.
 }
 
 /// Check that a numerical value is greater than or equal to another at runtime,

--- a/src/wasm-lib/kcl/src/std/convert.rs
+++ b/src/wasm-lib/kcl/src/std/convert.rs
@@ -10,10 +10,10 @@ use crate::{
 
 /// Converts a number to integer.
 pub async fn int(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
-    let num = args.get_number()?;
+    let (num, ty) = args.get_number_with_type()?;
     let converted = inner_int(num)?;
 
-    Ok(args.make_user_val_from_f64(converted))
+    Ok(args.make_user_val_from_f64_with_type(converted, ty))
 }
 
 /// Convert a number to an integer.

--- a/src/wasm-lib/kcl/src/std/math.rs
+++ b/src/wasm-lib/kcl/src/std/math.rs
@@ -6,7 +6,7 @@ use derive_docs::stdlib;
 use super::args::FromArgs;
 use crate::{
     errors::{KclError, KclErrorDetails},
-    execution::{ExecState, KclValue},
+    execution::{kcl_value::NumericType, ExecState, KclValue},
     std::Args,
 };
 
@@ -50,7 +50,7 @@ pub async fn cos(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
     let num = args.get_number()?;
     let result = inner_cos(num)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(result, NumericType::count()))
 }
 
 /// Compute the cosine of a number (in radians).
@@ -80,7 +80,7 @@ pub async fn sin(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
     let num = args.get_number()?;
     let result = inner_sin(num)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(result, NumericType::count()))
 }
 
 /// Compute the sine of a number (in radians).
@@ -110,7 +110,7 @@ pub async fn tan(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
     let num = args.get_number()?;
     let result = inner_tan(num)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(result, NumericType::count()))
 }
 
 /// Compute the tangent of a number (in radians).

--- a/src/wasm-lib/kcl/src/std/mod.rs
+++ b/src/wasm-lib/kcl/src/std/mod.rs
@@ -228,9 +228,9 @@ pub enum FunctionKind {
 
 /// Compute the length of the given leg.
 pub async fn leg_length(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
-    let (hypotenuse, leg) = args.get_hypotenuse_leg()?;
+    let (hypotenuse, leg, ty) = args.get_hypotenuse_leg()?;
     let result = inner_leg_length(hypotenuse, leg);
-    Ok(KclValue::from_number(result, vec![args.into()]))
+    Ok(KclValue::from_number_with_type(result, ty, vec![args.into()]))
 }
 
 /// Compute the length of the given leg.
@@ -248,9 +248,9 @@ fn inner_leg_length(hypotenuse: f64, leg: f64) -> f64 {
 
 /// Compute the angle of the given leg for x.
 pub async fn leg_angle_x(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
-    let (hypotenuse, leg) = args.get_hypotenuse_leg()?;
+    let (hypotenuse, leg, ty) = args.get_hypotenuse_leg()?;
     let result = inner_leg_angle_x(hypotenuse, leg);
-    Ok(KclValue::from_number(result, vec![args.into()]))
+    Ok(KclValue::from_number_with_type(result, ty, vec![args.into()]))
 }
 
 /// Compute the angle of the given leg for x.
@@ -268,9 +268,9 @@ fn inner_leg_angle_x(hypotenuse: f64, leg: f64) -> f64 {
 
 /// Compute the angle of the given leg for y.
 pub async fn leg_angle_y(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
-    let (hypotenuse, leg) = args.get_hypotenuse_leg()?;
+    let (hypotenuse, leg, ty) = args.get_hypotenuse_leg()?;
     let result = inner_leg_angle_y(hypotenuse, leg);
-    Ok(KclValue::from_number(result, vec![args.into()]))
+    Ok(KclValue::from_number_with_type(result, ty, vec![args.into()]))
 }
 
 /// Compute the angle of the given leg for y.

--- a/src/wasm-lib/kcl/src/std/patterns.rs
+++ b/src/wasm-lib/kcl/src/std/patterns.rs
@@ -20,8 +20,8 @@ use super::{args::Arg, FnAsArg};
 use crate::{
     errors::{KclError, KclErrorDetails},
     execution::{
-        ExecState, FunctionParam, Geometries, Geometry, KclObjectFields, KclValue, Point2d, Point3d, Sketch, SketchSet,
-        Solid, SolidSet,
+        kcl_value::NumericType, ExecState, FunctionParam, Geometries, Geometry, KclObjectFields, KclValue, Point2d,
+        Point3d, Sketch, SketchSet, Solid, SolidSet,
     },
     std::Args,
     SourceRange,
@@ -448,6 +448,7 @@ async fn make_transform<T: GeometryTrait>(
     // Call the transform fn for this repetition.
     let repetition_num = KclValue::Number {
         value: i.into(),
+        ty: NumericType::count(),
         meta: vec![source_range.into()],
     };
     let transform_fn_args = vec![Arg::synthetic(repetition_num)];
@@ -530,7 +531,7 @@ fn transform_from_obj_fields<T: GeometryTrait>(
         }
         if let Some(angle) = rot.get("angle") {
             match angle {
-                KclValue::Number { value: number, meta: _ } => {
+                KclValue::Number { value: number, .. } => {
                     rotation.angle = Angle::from_degrees(*number);
                 }
                 _ => {
@@ -679,6 +680,8 @@ impl GeometryTrait for Box<Solid> {
 
 #[cfg(test)]
 mod tests {
+    use crate::execution::kcl_value::NumericType;
+
     use super::*;
 
     #[test]
@@ -688,14 +691,17 @@ mod tests {
                 KclValue::Number {
                     value: 1.1,
                     meta: Default::default(),
+                    ty: NumericType::Unknown,
                 },
                 KclValue::Number {
                     value: 2.2,
                     meta: Default::default(),
+                    ty: NumericType::Unknown,
                 },
                 KclValue::Number {
                     value: 3.3,
                     meta: Default::default(),
+                    ty: NumericType::Unknown,
                 },
             ],
             meta: Default::default(),

--- a/src/wasm-lib/kcl/src/std/sketch.rs
+++ b/src/wasm-lib/kcl/src/std/sketch.rs
@@ -1388,8 +1388,9 @@ pub(crate) async fn inner_start_profile_at(
 /// Returns the X component of the sketch profile start point.
 pub async fn profile_start_x(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let sketch: Sketch = args.get_sketch()?;
+    let ty = sketch.units.into();
     let x = inner_profile_start_x(sketch)?;
-    Ok(args.make_user_val_from_f64(x))
+    Ok(args.make_user_val_from_f64_with_type(x, ty))
 }
 
 /// Extract the provided 2-dimensional sketch's profile's origin's 'x'
@@ -1412,8 +1413,9 @@ pub(crate) fn inner_profile_start_x(sketch: Sketch) -> Result<f64, KclError> {
 /// Returns the Y component of the sketch profile start point.
 pub async fn profile_start_y(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let sketch: Sketch = args.get_sketch()?;
+    let ty = sketch.units.into();
     let x = inner_profile_start_y(sketch)?;
-    Ok(args.make_user_val_from_f64(x))
+    Ok(args.make_user_val_from_f64_with_type(x, ty))
 }
 
 /// Extract the provided 2-dimensional sketch's profile's origin's 'y'
@@ -1435,8 +1437,9 @@ pub(crate) fn inner_profile_start_y(sketch: Sketch) -> Result<f64, KclError> {
 /// Returns the sketch profile start point.
 pub async fn profile_start(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let sketch: Sketch = args.get_sketch()?;
+    let ty = sketch.units.into();
     let point = inner_profile_start(sketch)?;
-    Ok(KclValue::from_point2d(point, args.into()))
+    Ok(KclValue::from_point2d(point, ty, args.into()))
 }
 
 /// Extract the provided 2-dimensional sketch's profile's origin

--- a/src/wasm-lib/kcl/tests/add_lots/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/add_lots/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing add_lots.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "f": {
@@ -95,6 +107,9 @@ description: Variables in memory after executing add_lots.kcl
   "x": {
     "type": "Number",
     "value": 10100.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": [
       {
         "sourceRange": [

--- a/src/wasm-lib/kcl/tests/angled_line/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/angled_line/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing angled_line.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "part001": {

--- a/src/wasm-lib/kcl/tests/array_elem_pop/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/array_elem_pop/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing array_elem_pop.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "arr": {
@@ -29,6 +41,15 @@ description: Variables in memory after executing array_elem_pop.kcl
       {
         "type": "Number",
         "value": 1.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -42,6 +63,15 @@ description: Variables in memory after executing array_elem_pop.kcl
       {
         "type": "Number",
         "value": 2.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -55,6 +85,15 @@ description: Variables in memory after executing array_elem_pop.kcl
       {
         "type": "Number",
         "value": 3.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -82,6 +121,15 @@ description: Variables in memory after executing array_elem_pop.kcl
       {
         "type": "Number",
         "value": 1.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -95,6 +143,15 @@ description: Variables in memory after executing array_elem_pop.kcl
       {
         "type": "Number",
         "value": 2.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -122,6 +179,15 @@ description: Variables in memory after executing array_elem_pop.kcl
       {
         "type": "Number",
         "value": 1.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [

--- a/src/wasm-lib/kcl/tests/array_elem_push/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/array_elem_push/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing array_elem_push.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "arr": {
@@ -29,6 +41,15 @@ description: Variables in memory after executing array_elem_push.kcl
       {
         "type": "Number",
         "value": 1.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -42,6 +63,15 @@ description: Variables in memory after executing array_elem_push.kcl
       {
         "type": "Number",
         "value": 2.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -55,6 +85,15 @@ description: Variables in memory after executing array_elem_push.kcl
       {
         "type": "Number",
         "value": 3.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -82,6 +121,15 @@ description: Variables in memory after executing array_elem_push.kcl
       {
         "type": "Number",
         "value": 1.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -95,6 +143,15 @@ description: Variables in memory after executing array_elem_push.kcl
       {
         "type": "Number",
         "value": 2.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -108,6 +165,15 @@ description: Variables in memory after executing array_elem_push.kcl
       {
         "type": "Number",
         "value": 3.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -121,6 +187,15 @@ description: Variables in memory after executing array_elem_push.kcl
       {
         "type": "Number",
         "value": 4.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -148,6 +223,15 @@ description: Variables in memory after executing array_elem_push.kcl
       {
         "type": "Number",
         "value": 1.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -161,6 +245,15 @@ description: Variables in memory after executing array_elem_push.kcl
       {
         "type": "Number",
         "value": 2.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -174,6 +267,15 @@ description: Variables in memory after executing array_elem_push.kcl
       {
         "type": "Number",
         "value": 3.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -187,6 +289,15 @@ description: Variables in memory after executing array_elem_push.kcl
       {
         "type": "Number",
         "value": 4.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -200,6 +311,15 @@ description: Variables in memory after executing array_elem_push.kcl
       {
         "type": "Number",
         "value": 5.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [

--- a/src/wasm-lib/kcl/tests/array_range_expr/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/array_range_expr/program_memory.snap
@@ -6,26 +6,41 @@ description: Variables in memory after executing array_range_expr.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "five": {
     "type": "Number",
     "value": 5.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -39,6 +54,15 @@ description: Variables in memory after executing array_range_expr.kcl
   "four": {
     "type": "Number",
     "value": 4.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -55,6 +79,9 @@ description: Variables in memory after executing array_range_expr.kcl
       {
         "type": "Number",
         "value": 0.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -68,6 +95,9 @@ description: Variables in memory after executing array_range_expr.kcl
       {
         "type": "Number",
         "value": 1.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -81,6 +111,9 @@ description: Variables in memory after executing array_range_expr.kcl
       {
         "type": "Number",
         "value": 2.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -94,6 +127,9 @@ description: Variables in memory after executing array_range_expr.kcl
       {
         "type": "Number",
         "value": 3.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -107,6 +143,9 @@ description: Variables in memory after executing array_range_expr.kcl
       {
         "type": "Number",
         "value": 4.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -134,6 +173,9 @@ description: Variables in memory after executing array_range_expr.kcl
       {
         "type": "Number",
         "value": 0.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -147,6 +189,9 @@ description: Variables in memory after executing array_range_expr.kcl
       {
         "type": "Number",
         "value": 1.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -160,6 +205,9 @@ description: Variables in memory after executing array_range_expr.kcl
       {
         "type": "Number",
         "value": 2.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -173,6 +221,9 @@ description: Variables in memory after executing array_range_expr.kcl
       {
         "type": "Number",
         "value": 3.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -186,6 +237,9 @@ description: Variables in memory after executing array_range_expr.kcl
       {
         "type": "Number",
         "value": 4.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -213,6 +267,9 @@ description: Variables in memory after executing array_range_expr.kcl
       {
         "type": "Number",
         "value": 0.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -226,6 +283,9 @@ description: Variables in memory after executing array_range_expr.kcl
       {
         "type": "Number",
         "value": 1.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -239,6 +299,9 @@ description: Variables in memory after executing array_range_expr.kcl
       {
         "type": "Number",
         "value": 2.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -252,6 +315,9 @@ description: Variables in memory after executing array_range_expr.kcl
       {
         "type": "Number",
         "value": 3.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -265,6 +331,9 @@ description: Variables in memory after executing array_range_expr.kcl
       {
         "type": "Number",
         "value": 4.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -278,6 +347,9 @@ description: Variables in memory after executing array_range_expr.kcl
       {
         "type": "Number",
         "value": 5.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -305,6 +377,9 @@ description: Variables in memory after executing array_range_expr.kcl
       {
         "type": "Number",
         "value": 1.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -318,6 +393,9 @@ description: Variables in memory after executing array_range_expr.kcl
       {
         "type": "Number",
         "value": 2.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -331,6 +409,9 @@ description: Variables in memory after executing array_range_expr.kcl
       {
         "type": "Number",
         "value": 3.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -344,6 +425,9 @@ description: Variables in memory after executing array_range_expr.kcl
       {
         "type": "Number",
         "value": 4.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -368,6 +452,15 @@ description: Variables in memory after executing array_range_expr.kcl
   "zero": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [

--- a/src/wasm-lib/kcl/tests/array_range_negative_expr/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/array_range_negative_expr/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing array_range_negative_expr.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "xs": {
@@ -29,6 +41,9 @@ description: Variables in memory after executing array_range_negative_expr.kcl
       {
         "type": "Number",
         "value": -5.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -42,6 +57,9 @@ description: Variables in memory after executing array_range_negative_expr.kcl
       {
         "type": "Number",
         "value": -4.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -55,6 +73,9 @@ description: Variables in memory after executing array_range_negative_expr.kcl
       {
         "type": "Number",
         "value": -3.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -68,6 +89,9 @@ description: Variables in memory after executing array_range_negative_expr.kcl
       {
         "type": "Number",
         "value": -2.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -81,6 +105,9 @@ description: Variables in memory after executing array_range_negative_expr.kcl
       {
         "type": "Number",
         "value": -1.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -94,6 +121,9 @@ description: Variables in memory after executing array_range_negative_expr.kcl
       {
         "type": "Number",
         "value": 0.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -107,6 +137,9 @@ description: Variables in memory after executing array_range_negative_expr.kcl
       {
         "type": "Number",
         "value": 1.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -120,6 +153,9 @@ description: Variables in memory after executing array_range_negative_expr.kcl
       {
         "type": "Number",
         "value": 2.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -133,6 +169,9 @@ description: Variables in memory after executing array_range_negative_expr.kcl
       {
         "type": "Number",
         "value": 3.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -146,6 +185,9 @@ description: Variables in memory after executing array_range_negative_expr.kcl
       {
         "type": "Number",
         "value": 4.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -159,6 +201,9 @@ description: Variables in memory after executing array_range_negative_expr.kcl
       {
         "type": "Number",
         "value": 5.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [

--- a/src/wasm-lib/kcl/tests/artifact_graph_example_code1/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/artifact_graph_example_code1/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing artifact_graph_example_code1.kc
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "extrude001": {

--- a/src/wasm-lib/kcl/tests/artifact_graph_example_code_no_3d/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/artifact_graph_example_code_no_3d/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing artifact_graph_example_code_no_
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "rectangleSegmentA001": {

--- a/src/wasm-lib/kcl/tests/artifact_graph_example_code_offset_planes/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/artifact_graph_example_code_offset_planes/program_memory.snap
@@ -7,21 +7,33 @@ snapshot_kind: text
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "offsetPlane001": {

--- a/src/wasm-lib/kcl/tests/artifact_graph_sketch_on_face_etc/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/artifact_graph_sketch_on_face_etc/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing artifact_graph_sketch_on_face_e
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "extrude001": {

--- a/src/wasm-lib/kcl/tests/basic_fillet_cube_close_opposite/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/basic_fillet_cube_close_opposite/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing basic_fillet_cube_close_opposit
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "part001": {

--- a/src/wasm-lib/kcl/tests/basic_fillet_cube_end/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/basic_fillet_cube_end/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing basic_fillet_cube_end.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "part001": {

--- a/src/wasm-lib/kcl/tests/basic_fillet_cube_next_adjacent/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/basic_fillet_cube_next_adjacent/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing basic_fillet_cube_next_adjacent
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "part001": {

--- a/src/wasm-lib/kcl/tests/basic_fillet_cube_previous_adjacent/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/basic_fillet_cube_previous_adjacent/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing basic_fillet_cube_previous_adja
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "part001": {

--- a/src/wasm-lib/kcl/tests/basic_fillet_cube_start/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/basic_fillet_cube_start/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing basic_fillet_cube_start.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "part001": {

--- a/src/wasm-lib/kcl/tests/big_number_angle_to_match_length_x/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/big_number_angle_to_match_length_x/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing big_number_angle_to_match_lengt
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "part001": {

--- a/src/wasm-lib/kcl/tests/big_number_angle_to_match_length_y/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/big_number_angle_to_match_length_y/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing big_number_angle_to_match_lengt
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "part001": {

--- a/src/wasm-lib/kcl/tests/boolean_logical_and/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/boolean_logical_and/program_memory.snap
@@ -6,26 +6,47 @@ description: Variables in memory after executing boolean_logical_and.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "a": {
     "type": "Number",
     "value": 2.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -59,6 +80,15 @@ description: Variables in memory after executing boolean_logical_and.kcl
   "b": {
     "type": "Number",
     "value": 2.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -92,6 +122,15 @@ description: Variables in memory after executing boolean_logical_and.kcl
   "c": {
     "type": "Number",
     "value": 1.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -125,6 +164,15 @@ description: Variables in memory after executing boolean_logical_and.kcl
   "d": {
     "type": "Number",
     "value": 2.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [

--- a/src/wasm-lib/kcl/tests/boolean_logical_multiple/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/boolean_logical_multiple/program_memory.snap
@@ -6,26 +6,47 @@ description: Variables in memory after executing boolean_logical_multiple.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "i": {
     "type": "Number",
     "value": 1.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -66,6 +87,15 @@ description: Variables in memory after executing boolean_logical_multiple.kcl
   "j": {
     "type": "Number",
     "value": 1.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [

--- a/src/wasm-lib/kcl/tests/boolean_logical_or/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/boolean_logical_or/program_memory.snap
@@ -6,26 +6,47 @@ description: Variables in memory after executing boolean_logical_or.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "a": {
     "type": "Number",
     "value": 1.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -59,6 +80,15 @@ description: Variables in memory after executing boolean_logical_or.kcl
   "b": {
     "type": "Number",
     "value": 1.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -92,6 +122,15 @@ description: Variables in memory after executing boolean_logical_or.kcl
   "c": {
     "type": "Number",
     "value": 1.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -125,6 +164,15 @@ description: Variables in memory after executing boolean_logical_or.kcl
   "d": {
     "type": "Number",
     "value": 2.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [

--- a/src/wasm-lib/kcl/tests/circle_three_point/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/circle_three_point/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing circle_three_point.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "sketch001": {

--- a/src/wasm-lib/kcl/tests/circular_pattern3d_a_pattern/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/circular_pattern3d_a_pattern/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing circular_pattern3d_a_pattern.kc
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "exampleSketch": {

--- a/src/wasm-lib/kcl/tests/comparisons/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/comparisons/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing comparisons.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   }
 }

--- a/src/wasm-lib/kcl/tests/computed_var/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/computed_var/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing computed_var.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "arr": {
@@ -29,6 +41,15 @@ description: Variables in memory after executing computed_var.kcl
       {
         "type": "Number",
         "value": 0.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -42,6 +63,15 @@ description: Variables in memory after executing computed_var.kcl
       {
         "type": "Number",
         "value": 0.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -55,6 +85,15 @@ description: Variables in memory after executing computed_var.kcl
       {
         "type": "Number",
         "value": 0.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -68,6 +107,15 @@ description: Variables in memory after executing computed_var.kcl
       {
         "type": "Number",
         "value": 10.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -92,6 +140,15 @@ description: Variables in memory after executing computed_var.kcl
   "i": {
     "type": "Number",
     "value": 3.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -108,6 +165,15 @@ description: Variables in memory after executing computed_var.kcl
       "bar": {
         "type": "Number",
         "value": 0.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -121,6 +187,15 @@ description: Variables in memory after executing computed_var.kcl
       "foo": {
         "type": "Number",
         "value": 1.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -145,6 +220,15 @@ description: Variables in memory after executing computed_var.kcl
   "one": {
     "type": "Number",
     "value": 1.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -171,6 +255,15 @@ description: Variables in memory after executing computed_var.kcl
   "ten": {
     "type": "Number",
     "value": 10.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [

--- a/src/wasm-lib/kcl/tests/cube/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/cube/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing cube.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "cube": {

--- a/src/wasm-lib/kcl/tests/double_map_fn/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/double_map_fn/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing double_map_fn.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "increment": {
@@ -98,6 +110,9 @@ description: Variables in memory after executing double_map_fn.kcl
       {
         "type": "Number",
         "value": 0.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -111,6 +126,9 @@ description: Variables in memory after executing double_map_fn.kcl
       {
         "type": "Number",
         "value": 1.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -124,6 +142,9 @@ description: Variables in memory after executing double_map_fn.kcl
       {
         "type": "Number",
         "value": 2.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -151,6 +172,9 @@ description: Variables in memory after executing double_map_fn.kcl
       {
         "type": "Number",
         "value": 2.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -178,6 +202,9 @@ description: Variables in memory after executing double_map_fn.kcl
       {
         "type": "Number",
         "value": 3.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -205,6 +232,9 @@ description: Variables in memory after executing double_map_fn.kcl
       {
         "type": "Number",
         "value": 4.0,
+        "ty": {
+          "type": "Unknown"
+        },
         "__meta": [
           {
             "sourceRange": [

--- a/src/wasm-lib/kcl/tests/fillet-and-shell/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/fillet-and-shell/program_memory.snap
@@ -6,26 +6,47 @@ description: Variables in memory after executing fillet-and-shell.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "border": {
     "type": "Number",
     "value": 4.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -565,6 +586,15 @@ description: Variables in memory after executing fillet-and-shell.kcl
   "caseHeight": {
     "type": "Number",
     "value": 8.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -578,6 +608,9 @@ description: Variables in memory after executing fillet-and-shell.kcl
   "caseLength": {
     "type": "Number",
     "value": 73.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -605,6 +638,15 @@ description: Variables in memory after executing fillet-and-shell.kcl
   "caseThickness": {
     "type": "Number",
     "value": 1.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -618,6 +660,9 @@ description: Variables in memory after executing fillet-and-shell.kcl
   "caseWidth": {
     "type": "Number",
     "value": 38.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -645,6 +690,15 @@ description: Variables in memory after executing fillet-and-shell.kcl
   "connectorPadding": {
     "type": "Number",
     "value": 4.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -898,6 +952,9 @@ description: Variables in memory after executing fillet-and-shell.kcl
   "lengthBetweenScrews": {
     "type": "Number",
     "value": 58.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -1300,6 +1357,15 @@ description: Variables in memory after executing fillet-and-shell.kcl
   "microUsb1Distance": {
     "type": "Number",
     "value": 41.4,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -1313,6 +1379,15 @@ description: Variables in memory after executing fillet-and-shell.kcl
   "microUsb2Distance": {
     "type": "Number",
     "value": 54.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -1326,6 +1401,15 @@ description: Variables in memory after executing fillet-and-shell.kcl
   "microUsbWidth": {
     "type": "Number",
     "value": 7.4,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -1339,6 +1423,15 @@ description: Variables in memory after executing fillet-and-shell.kcl
   "miniHdmiDistance": {
     "type": "Number",
     "value": 12.4,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -1504,6 +1597,15 @@ description: Variables in memory after executing fillet-and-shell.kcl
   "miniHdmiWidth": {
     "type": "Number",
     "value": 11.2,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -1517,6 +1619,15 @@ description: Variables in memory after executing fillet-and-shell.kcl
   "rpizLength": {
     "type": "Number",
     "value": 65.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -1530,6 +1641,15 @@ description: Variables in memory after executing fillet-and-shell.kcl
   "rpizWidth": {
     "type": "Number",
     "value": 30.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -1543,6 +1663,15 @@ description: Variables in memory after executing fillet-and-shell.kcl
   "screwHeight": {
     "type": "Number",
     "value": 4.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -1556,6 +1685,15 @@ description: Variables in memory after executing fillet-and-shell.kcl
   "widthBetweenScrews": {
     "type": "Number",
     "value": 23.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [

--- a/src/wasm-lib/kcl/tests/function_sketch/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/function_sketch/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing function_sketch.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "box": {

--- a/src/wasm-lib/kcl/tests/function_sketch_with_position/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/function_sketch_with_position/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing function_sketch_with_position.k
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "box": {

--- a/src/wasm-lib/kcl/tests/helix_ccw/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/helix_ccw/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing helix_ccw.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "part001": {

--- a/src/wasm-lib/kcl/tests/helix_simple/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/helix_simple/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing helix_simple.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "edge001": {

--- a/src/wasm-lib/kcl/tests/i_shape/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/i_shape/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing i_shape.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "brace_base": {
@@ -658,6 +670,15 @@ description: Variables in memory after executing i_shape.kcl
   "corner_radius": {
     "type": "Number",
     "value": 5.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -674,6 +695,15 @@ description: Variables in memory after executing i_shape.kcl
       {
         "type": "Number",
         "value": 22.8,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -687,6 +717,15 @@ description: Variables in memory after executing i_shape.kcl
       {
         "type": "Number",
         "value": 10.7,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -700,6 +739,15 @@ description: Variables in memory after executing i_shape.kcl
       {
         "type": "Number",
         "value": 16.4,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -713,6 +761,15 @@ description: Variables in memory after executing i_shape.kcl
       {
         "type": "Number",
         "value": 18.5,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -1655,6 +1712,15 @@ description: Variables in memory after executing i_shape.kcl
   "hand_thickness": {
     "type": "Number",
     "value": 24.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -1940,6 +2006,15 @@ description: Variables in memory after executing i_shape.kcl
   "length": {
     "type": "Number",
     "value": 120.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -1953,6 +2028,9 @@ description: Variables in memory after executing i_shape.kcl
   "width": {
     "type": "Number",
     "value": 68.4,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": [
       {
         "sourceRange": [

--- a/src/wasm-lib/kcl/tests/if_else/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/if_else/program_memory.snap
@@ -6,26 +6,47 @@ description: Variables in memory after executing if_else.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "a": {
     "type": "Number",
     "value": 3.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -39,6 +60,15 @@ description: Variables in memory after executing if_else.kcl
   "b": {
     "type": "Number",
     "value": 4.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -52,6 +82,15 @@ description: Variables in memory after executing if_else.kcl
   "c": {
     "type": "Number",
     "value": 5.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [

--- a/src/wasm-lib/kcl/tests/import_constant/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/import_constant/program_memory.snap
@@ -6,26 +6,47 @@ description: Variables in memory after executing import_constant.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "three": {
     "type": "Number",
     "value": 3.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [

--- a/src/wasm-lib/kcl/tests/import_export/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/import_export/program_memory.snap
@@ -6,26 +6,47 @@ description: Variables in memory after executing import_export.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "three": {
     "type": "Number",
     "value": 3.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [

--- a/src/wasm-lib/kcl/tests/import_foreign/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/import_foreign/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing import_foreign.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "cube": {

--- a/src/wasm-lib/kcl/tests/import_function_not_sketch/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/import_function_not_sketch/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing import_function_not_sketch.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "one": {

--- a/src/wasm-lib/kcl/tests/import_glob/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/import_glob/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing import_glob.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "foo": {
@@ -75,6 +87,15 @@ description: Variables in memory after executing import_glob.kcl
   "three": {
     "type": "Number",
     "value": 3.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [

--- a/src/wasm-lib/kcl/tests/import_side_effect/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/import_side_effect/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing import_side_effect.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "foo": {

--- a/src/wasm-lib/kcl/tests/import_whole/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/import_whole/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing import_whole.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "bar": {

--- a/src/wasm-lib/kcl/tests/index_of_array/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/index_of_array/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing index_of_array.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "arr": {
@@ -29,6 +41,15 @@ description: Variables in memory after executing index_of_array.kcl
       {
         "type": "Number",
         "value": 90.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -42,6 +63,15 @@ description: Variables in memory after executing index_of_array.kcl
       {
         "type": "Number",
         "value": 91.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -55,6 +85,15 @@ description: Variables in memory after executing index_of_array.kcl
       {
         "type": "Number",
         "value": 92.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -79,6 +118,9 @@ description: Variables in memory after executing index_of_array.kcl
   "i": {
     "type": "Number",
     "value": 1.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -92,6 +134,15 @@ description: Variables in memory after executing index_of_array.kcl
   "result0": {
     "type": "Number",
     "value": 91.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -105,6 +156,15 @@ description: Variables in memory after executing index_of_array.kcl
   "result1": {
     "type": "Number",
     "value": 91.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [

--- a/src/wasm-lib/kcl/tests/kittycad_svg/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/kittycad_svg/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing kittycad_svg.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "svg": {

--- a/src/wasm-lib/kcl/tests/kw_fn/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/kw_fn/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing kw_fn.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "add": {
@@ -171,6 +183,9 @@ description: Variables in memory after executing kw_fn.kcl
   "three": {
     "type": "Number",
     "value": 3.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -191,6 +206,9 @@ description: Variables in memory after executing kw_fn.kcl
   "two": {
     "type": "Number",
     "value": 2.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": [
       {
         "sourceRange": [

--- a/src/wasm-lib/kcl/tests/kw_fn_with_defaults/ast.snap
+++ b/src/wasm-lib/kcl/tests/kw_fn_with_defaults/ast.snap
@@ -69,13 +69,15 @@ description: Result of parsing kw_fn_with_defaults.kcl
                   "type": "Identifier"
                 },
                 "default_value": {
+                  "end": 24,
+                  "raw": "1",
+                  "start": 23,
                   "type": "Literal",
                   "type": "Literal",
                   "value": {
                     "value": 1.0,
                     "suffix": "None"
-                  },
-                  "raw": "1"
+                  }
                 }
               }
             ],

--- a/src/wasm-lib/kcl/tests/kw_fn_with_defaults/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/kw_fn_with_defaults/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing kw_fn_with_defaults.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "increment": {
@@ -80,13 +92,15 @@ description: Variables in memory after executing kw_fn_with_defaults.kcl
             "type": "Identifier"
           },
           "default_value": {
+            "end": 24,
+            "raw": "1",
+            "start": 23,
             "type": "Literal",
             "type": "Literal",
             "value": {
               "value": 1.0,
               "suffix": "None"
-            },
-            "raw": "1"
+            }
           }
         }
       ],
@@ -110,6 +124,9 @@ description: Variables in memory after executing kw_fn_with_defaults.kcl
   "twentyOne": {
     "type": "Number",
     "value": 21.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -130,11 +147,21 @@ description: Variables in memory after executing kw_fn_with_defaults.kcl
   "two": {
     "type": "Number",
     "value": 2.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": [
       {
         "sourceRange": [
           63,
           64,
+          0
+        ]
+      },
+      {
+        "sourceRange": [
+          23,
+          24,
           0
         ]
       }

--- a/src/wasm-lib/kcl/tests/linear_pattern3d_a_pattern/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/linear_pattern3d_a_pattern/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing linear_pattern3d_a_pattern.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "exampleSketch": {

--- a/src/wasm-lib/kcl/tests/mike_stress_test/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/mike_stress_test/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing mike_stress_test.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "part001": {

--- a/src/wasm-lib/kcl/tests/neg_xz_plane/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/neg_xz_plane/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing neg_xz_plane.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "part001": {

--- a/src/wasm-lib/kcl/tests/parametric/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/parametric/program_memory.snap
@@ -6,6 +6,15 @@ description: Variables in memory after executing parametric.kcl
   "FOS": {
     "type": "Number",
     "value": 2.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -19,21 +28,33 @@ description: Variables in memory after executing parametric.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "bracket": {
@@ -319,6 +340,15 @@ description: Variables in memory after executing parametric.kcl
   "distance": {
     "type": "Number",
     "value": 6.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -332,6 +362,15 @@ description: Variables in memory after executing parametric.kcl
   "leg1": {
     "type": "Number",
     "value": 5.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -345,6 +384,15 @@ description: Variables in memory after executing parametric.kcl
   "leg2": {
     "type": "Number",
     "value": 8.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -358,6 +406,15 @@ description: Variables in memory after executing parametric.kcl
   "p": {
     "type": "Number",
     "value": 150.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -371,6 +428,15 @@ description: Variables in memory after executing parametric.kcl
   "sigmaAllow": {
     "type": "Number",
     "value": 35000.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -384,6 +450,9 @@ description: Variables in memory after executing parametric.kcl
   "thickness": {
     "type": "Number",
     "value": 0.1851640199545103,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -397,6 +466,15 @@ description: Variables in memory after executing parametric.kcl
   "width": {
     "type": "Number",
     "value": 9.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [

--- a/src/wasm-lib/kcl/tests/parametric_with_tan_arc/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/parametric_with_tan_arc/program_memory.snap
@@ -6,6 +6,15 @@ description: Variables in memory after executing parametric_with_tan_arc.kcl
   "FOS": {
     "type": "Number",
     "value": 2.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -19,21 +28,33 @@ description: Variables in memory after executing parametric_with_tan_arc.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "bracket": {
@@ -391,6 +412,15 @@ description: Variables in memory after executing parametric_with_tan_arc.kcl
   "distance": {
     "type": "Number",
     "value": 12.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -404,6 +434,9 @@ description: Variables in memory after executing parametric_with_tan_arc.kcl
   "filletR": {
     "type": "Number",
     "value": 0.7236272269866327,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -424,6 +457,15 @@ description: Variables in memory after executing parametric_with_tan_arc.kcl
   "p": {
     "type": "Number",
     "value": 150.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -437,6 +479,15 @@ description: Variables in memory after executing parametric_with_tan_arc.kcl
   "shelfMountL": {
     "type": "Number",
     "value": 9.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -450,6 +501,15 @@ description: Variables in memory after executing parametric_with_tan_arc.kcl
   "sigmaAllow": {
     "type": "Number",
     "value": 15000.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -463,6 +523,9 @@ description: Variables in memory after executing parametric_with_tan_arc.kcl
   "thickness": {
     "type": "Number",
     "value": 0.36181361349331637,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -476,6 +539,15 @@ description: Variables in memory after executing parametric_with_tan_arc.kcl
   "wallMountL": {
     "type": "Number",
     "value": 8.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -489,6 +561,15 @@ description: Variables in memory after executing parametric_with_tan_arc.kcl
   "width": {
     "type": "Number",
     "value": 11.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [

--- a/src/wasm-lib/kcl/tests/pentagon_fillet_sugar/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/pentagon_fillet_sugar/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "a": {
@@ -1447,6 +1459,15 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
       "angleEnd": {
         "type": "Number",
         "value": 360.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -1460,6 +1481,15 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
       "angleStart": {
         "type": "Number",
         "value": 0.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -1473,6 +1503,15 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
       "radius": {
         "type": "Number",
         "value": 80.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -3390,6 +3429,15 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
   "plumbusLen": {
     "type": "Number",
     "value": 100.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -3403,6 +3451,15 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
   "radius": {
     "type": "Number",
     "value": 80.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -3416,6 +3473,15 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
   "triangleHeight": {
     "type": "Number",
     "value": 200.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -3429,6 +3495,15 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
   "triangleLen": {
     "type": "Number",
     "value": 500.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [

--- a/src/wasm-lib/kcl/tests/pipe_as_arg/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/pipe_as_arg/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing pipe_as_arg.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "cube": {

--- a/src/wasm-lib/kcl/tests/poop_chute/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/poop_chute/program_memory.snap
@@ -6,6 +6,15 @@ description: Variables in memory after executing poop_chute.kcl
   "Fx": {
     "type": "Number",
     "value": 0.5,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -19,6 +28,15 @@ description: Variables in memory after executing poop_chute.kcl
   "Fy": {
     "type": "Number",
     "value": 0.5,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -32,26 +50,47 @@ description: Variables in memory after executing poop_chute.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "back_length": {
     "type": "Number",
     "value": 7.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -65,6 +104,15 @@ description: Variables in memory after executing poop_chute.kcl
   "back_walls_width": {
     "type": "Number",
     "value": 2.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -78,6 +126,15 @@ description: Variables in memory after executing poop_chute.kcl
   "exit_height": {
     "type": "Number",
     "value": 1.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -91,6 +148,15 @@ description: Variables in memory after executing poop_chute.kcl
   "filletRadius": {
     "type": "Number",
     "value": 0.05,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -104,6 +170,15 @@ description: Variables in memory after executing poop_chute.kcl
   "front_length": {
     "type": "Number",
     "value": 6.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -117,6 +192,15 @@ description: Variables in memory after executing poop_chute.kcl
   "front_walls_width": {
     "type": "Number",
     "value": 2.5,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -130,6 +214,15 @@ description: Variables in memory after executing poop_chute.kcl
   "height": {
     "type": "Number",
     "value": 5.5,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -1797,6 +1890,15 @@ description: Variables in memory after executing poop_chute.kcl
   "wall_thickness": {
     "type": "Number",
     "value": 0.125,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [

--- a/src/wasm-lib/kcl/tests/property_of_object/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/property_of_object/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing property_of_object.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "obj": {
@@ -29,6 +41,15 @@ description: Variables in memory after executing property_of_object.kcl
       "bar": {
         "type": "Number",
         "value": 0.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -42,6 +63,15 @@ description: Variables in memory after executing property_of_object.kcl
       "foo": {
         "type": "Number",
         "value": 1.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
+        },
         "__meta": [
           {
             "sourceRange": [
@@ -72,6 +102,15 @@ description: Variables in memory after executing property_of_object.kcl
           "bar": {
             "type": "Number",
             "value": 0.0,
+            "ty": {
+              "type": "Default",
+              "len": {
+                "type": "Mm"
+              },
+              "angle": {
+                "type": "Degrees"
+              }
+            },
             "__meta": [
               {
                 "sourceRange": [
@@ -85,6 +124,15 @@ description: Variables in memory after executing property_of_object.kcl
           "foo": {
             "type": "Number",
             "value": 1.0,
+            "ty": {
+              "type": "Default",
+              "len": {
+                "type": "Mm"
+              },
+              "angle": {
+                "type": "Degrees"
+              }
+            },
             "__meta": [
               {
                 "sourceRange": [
@@ -120,6 +168,15 @@ description: Variables in memory after executing property_of_object.kcl
   "one_a": {
     "type": "Number",
     "value": 1.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -133,6 +190,15 @@ description: Variables in memory after executing property_of_object.kcl
   "one_b": {
     "type": "Number",
     "value": 1.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -146,6 +212,15 @@ description: Variables in memory after executing property_of_object.kcl
   "one_c": {
     "type": "Number",
     "value": 1.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -159,6 +234,15 @@ description: Variables in memory after executing property_of_object.kcl
   "one_d": {
     "type": "Number",
     "value": 1.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [

--- a/src/wasm-lib/kcl/tests/riddle_small/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/riddle_small/program_memory.snap
@@ -6,6 +6,15 @@ description: Variables in memory after executing riddle_small.kcl
   "ANSWER": {
     "type": "Number",
     "value": 41803.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -19,26 +28,41 @@ description: Variables in memory after executing riddle_small.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ox": {
     "type": "Number",
     "value": -26.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -87,6 +111,9 @@ description: Variables in memory after executing riddle_small.kcl
   "oy": {
     "type": "Number",
     "value": 34.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -454,6 +481,15 @@ description: Variables in memory after executing riddle_small.kcl
   "xs": {
     "type": "Number",
     "value": 205804.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -467,6 +503,15 @@ description: Variables in memory after executing riddle_small.kcl
   "ys": {
     "type": "Number",
     "value": 71816.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [

--- a/src/wasm-lib/kcl/tests/sketch-on-chamfer-two-times-different-order/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch-on-chamfer-two-times-different-order/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing sketch-on-chamfer-two-times-dif
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "extrude001": {

--- a/src/wasm-lib/kcl/tests/sketch-on-chamfer-two-times/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch-on-chamfer-two-times/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing sketch-on-chamfer-two-times.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "extrude001": {

--- a/src/wasm-lib/kcl/tests/sketch_in_object/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch_in_object/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing sketch_in_object.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "test": {

--- a/src/wasm-lib/kcl/tests/sketch_on_face/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing sketch_on_face.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "here": {

--- a/src/wasm-lib/kcl/tests/sketch_on_face_after_fillets_referencing_face/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face_after_fillets_referencing_face/program_memory.snap
@@ -6,6 +6,15 @@ description: Variables in memory after executing sketch_on_face_after_fillets_re
   "FOS": {
     "type": "Number",
     "value": 2.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -19,11 +28,23 @@ description: Variables in memory after executing sketch_on_face_after_fillets_re
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "L": {
     "type": "Number",
     "value": 12.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -37,6 +58,9 @@ description: Variables in memory after executing sketch_on_face_after_fillets_re
   "M": {
     "type": "Number",
     "value": 1800.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -64,16 +88,25 @@ description: Variables in memory after executing sketch_on_face_after_fillets_re
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "bracket": {
@@ -584,6 +617,15 @@ description: Variables in memory after executing sketch_on_face_after_fillets_re
   "filletR": {
     "type": "Number",
     "value": 0.25,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -717,6 +759,15 @@ description: Variables in memory after executing sketch_on_face_after_fillets_re
   "p": {
     "type": "Number",
     "value": 300.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -790,6 +841,15 @@ description: Variables in memory after executing sketch_on_face_after_fillets_re
   "shelfMountL": {
     "type": "Number",
     "value": 8.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -803,6 +863,15 @@ description: Variables in memory after executing sketch_on_face_after_fillets_re
   "sigmaAllow": {
     "type": "Number",
     "value": 35000.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -1559,6 +1628,9 @@ description: Variables in memory after executing sketch_on_face_after_fillets_re
   "thickness": {
     "type": "Number",
     "value": 0.32071349029490925,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -1572,6 +1644,15 @@ description: Variables in memory after executing sketch_on_face_after_fillets_re
   "wallMountL": {
     "type": "Number",
     "value": 6.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -1585,6 +1666,15 @@ description: Variables in memory after executing sketch_on_face_after_fillets_re
   "width": {
     "type": "Number",
     "value": 6.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [

--- a/src/wasm-lib/kcl/tests/sketch_on_face_circle_tagged/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face_circle_tagged/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing sketch_on_face_circle_tagged.kc
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "cube": {

--- a/src/wasm-lib/kcl/tests/sketch_on_face_end/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face_end/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing sketch_on_face_end.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "cube": {

--- a/src/wasm-lib/kcl/tests/sketch_on_face_end_negative_extrude/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face_end_negative_extrude/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing sketch_on_face_end_negative_ext
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "cube": {

--- a/src/wasm-lib/kcl/tests/sketch_on_face_start/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face_start/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing sketch_on_face_start.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "cube": {

--- a/src/wasm-lib/kcl/tests/ssi_pattern/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/ssi_pattern/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing ssi_pattern.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "extrude001": {

--- a/src/wasm-lib/kcl/tests/tan_arc_x_line/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/tan_arc_x_line/program_memory.snap
@@ -6,26 +6,47 @@ description: Variables in memory after executing tan_arc_x_line.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "angleOffset": {
     "type": "Number",
     "value": 135.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -39,6 +60,15 @@ description: Variables in memory after executing tan_arc_x_line.kcl
   "angleStart": {
     "type": "Number",
     "value": 110.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -202,6 +232,15 @@ description: Variables in memory after executing tan_arc_x_line.kcl
   "r": {
     "type": "Number",
     "value": 1.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -215,6 +254,15 @@ description: Variables in memory after executing tan_arc_x_line.kcl
   "startX": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [
@@ -228,6 +276,15 @@ description: Variables in memory after executing tan_arc_x_line.kcl
   "startY": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
+    },
     "__meta": [
       {
         "sourceRange": [

--- a/src/wasm-lib/kcl/tests/tangential_arc/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/tangential_arc/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing tangential_arc.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "boxSketch": {

--- a/src/wasm-lib/kcl/tests/xz_plane/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/xz_plane/program_memory.snap
@@ -6,21 +6,33 @@ description: Variables in memory after executing xz_plane.kcl
   "HALF_TURN": {
     "type": "Number",
     "value": 180.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "QUARTER_TURN": {
     "type": "Number",
     "value": 90.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "THREE_QUARTER_TURN": {
     "type": "Number",
     "value": 270.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "ZERO": {
     "type": "Number",
     "value": 0.0,
+    "ty": {
+      "type": "Unknown"
+    },
     "__meta": []
   },
   "part001": {


### PR DESCRIPTION
Another step towards UoM types. Again, there are no user-visible changes here.

This PR adds a type to `KclValue::Number`. It initialises this for literals with either the specified of default units, but doesn't use it for any checking or conversion. I've done some of the low-hanging fruit of propagating the types, but mostly that is left for future work (as shown by the prevalence of `Unknown`).