### PR TITLE
Don't auto-hide menu bar on Windows and Linux

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -82,7 +82,7 @@ const createWindow = (pathToOpen?: string, reuse?: boolean): BrowserWindow => {
   }
   if (!newWindow) {
     newWindow = new BrowserWindow({
-      autoHideMenuBar: true,
+      autoHideMenuBar: false,
       show: false,
       width: 1800,
       height: 1200,


### PR DESCRIPTION
This auto-hide behavior causes the bar to toggle visible and hidden when the user hits the <kbd>Alt</kbd> key, which can be quite often especially with Trackpad Friendly controls enabled.

Behavior in Nightly v25.2.18
https://github.com/user-attachments/assets/cbf6139d-afe0-4dfd-b876-cafc1007907e

New behavior from this branch
https://github.com/user-attachments/assets/225915d3-35ae-4cd9-aefa-b7a858d36ae1

