### PR TITLE
Fix isomorphic-copy to work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "fmt-check": "prettier --check ./src *.ts *.json *.js ./e2e ./packages",
     "fetch:wasm": "./get-latest-wasm-bundle.sh",
     "fetch:samples": "echo \"Fetching latest KCL samples...\" && curl -o public/kcl-samples-manifest-fallback.json https://raw.githubusercontent.com/KittyCAD/kcl-samples/next/manifest.json",
-    "isomorphic-copy-wasm": "(copy src/wasm-lib/pkg/wasm_lib_bg.wasm public || cp src/wasm-lib/pkg/wasm_lib_bg.wasm public)",
+    "isomorphic-copy-wasm": "(copy src\\wasm-lib\\pkg\\wasm_lib_bg.wasm public || cp src/wasm-lib/pkg/wasm_lib_bg.wasm public)",
     "build:wasm-dev": "yarn wasm-prep && (cd src/wasm-lib && wasm-pack build --dev --target web --out-dir pkg && cargo test -p kcl-lib export_bindings) && yarn isomorphic-copy-wasm && yarn fmt",
     "build:wasm": "yarn wasm-prep && cd src/wasm-lib && wasm-pack build --release --target web --out-dir pkg && cargo test -p kcl-lib export_bindings && cd ../.. && yarn isomorphic-copy-wasm && yarn fmt",
     "remove-importmeta": "sed -i 's/import.meta.url/window.location.origin/g' \"./src/wasm-lib/pkg/wasm_lib.js\"; sed -i '' 's/import.meta.url/window.location.origin/g' \"./src/wasm-lib/pkg/wasm_lib.js\" || echo \"sed for both mac and linux\"",


### PR DESCRIPTION
The current command uses the proper `copy` command but does not use `\`'s, so it fails on my Windows machine.

Previous output of `yarn isomorphic-copy-wasm`:
```Powershell
 (copy src/wasm-lib/pkg/wasm_lib_bg.wasm public || cp src/wasm-lib/pkg/wasm_lib_bg.wasm public)
The syntax of the command is incorrect.
'cp' is not recognized as an internal or external command,
operable program or batch file.
error Command failed with exit code 1.
```

Now:
```Powershell
yarn isomorphic-copy-wasm
yarn run v1.22.22
$ (copy src\wasm-lib\pkg\wasm_lib_bg.wasm public || cp src/wasm-lib/pkg/wasm_lib_bg.wasm public)
        1 file(s) copied.
Done in 0.14s.
```