### PR TITLE
Make z-index relation between sketch scene items explicit and colocated

### DIFF
--- a/src/clientSideScene/ClientSideSceneComp.tsx
+++ b/src/clientSideScene/ClientSideSceneComp.tsx
@@ -179,10 +179,7 @@ const Overlays = () => {
   // Set a large zIndex, the overlay for hover dropdown menu on line segments needs to render
   // over the length labels on the line segments
   return (
-    <div
-      className="absolute inset-0 pointer-events-none"
-      style={{ zIndex: '99999999' }}
-    >
+    <div className="absolute inset-0 pointer-events-none z-sketchOverlayDropdown">
       {Object.entries(context.segmentOverlays)
         .flatMap((a) =>
           a[1].map((b) => ({ pathToNodeString: a[0], overlay: b }))

--- a/src/clientSideScene/sceneInfra.ts
+++ b/src/clientSideScene/sceneInfra.ts
@@ -291,6 +291,7 @@ export class SceneInfra {
     this.labelRenderer.domElement.style.position = 'absolute'
     this.labelRenderer.domElement.style.top = '0px'
     this.labelRenderer.domElement.style.pointerEvents = 'none'
+    this.labelRenderer.domElement.className = 'z-sketchSegmentIndicators'
     window.addEventListener('resize', this.onWindowResize)
 
     this.camControls = new CameraControls(

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -43,6 +43,21 @@ module.exports = {
         'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
         sans-serif`,
       },
+      /**
+       * We want the z-index of major UI areas
+       * to be consolidated in this one spot,
+       * so we can make sure they coordinate.
+       */
+      zIndex: {
+        // TODO change use of `z-<number>` to use these instead
+        // underlay: '-1',
+        // tooltip: '1',
+        // commandBar: '2',
+        // modal: '3',
+        sketchSegmentIndicators: '5',
+        sketchOverlayDropdown: '6',
+        // top: '99',
+      },
     },
   },
   darkMode: 'class',


### PR DESCRIPTION
Closes #3946, which then closes #3974 since it was the only reason that issue was reopened.

Following @nadr0's good idea about using `tailwind.config.js` to set up named z-index layers that we can see all in one place in the app. There are still many places in the code base that use `z-<number>` classes from the default Tailwind config, so I left a TODO that we should enable more layers in that file, and replace all instances of numbered classes with named ones. That seemed beyond the scope of this fix.

It turns out that #3946 was actually fixed in #4816. This PR gets rid of the `zIndex: '99999999'` fix that @nadr0 had to implement, instead making the z-index of the CSS2DRenderer lower than the Overlays component.