### PR TITLE
Fix kcl-lib derive-docs version

### DIFF
--- a/src/wasm-lib/kcl/Cargo.toml
+++ b/src/wasm-lib/kcl/Cargo.toml
@@ -22,7 +22,7 @@ clap = { version = "4.5.27", default-features = false, optional = true, features
 ] }
 convert_case = "0.6.0"
 dashmap = "6.1.0"
-derive-docs = { version = "0.1.34", path = "../derive-docs" }
+derive-docs = { version = "0.1.38", path = "../derive-docs" }
 dhat = { version = "0.3", optional = true }
 fnv = "1.0.7"
 form_urlencoded = "1.2.1"


### PR DESCRIPTION
Keeping this up to date would be nice for downstream repos like kcl-lsp. It always requires the latest version. We recently started making the patch version match between crates.