### PR TITLE
better testing for making sure we update the cache state on just settings changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,9 +41,12 @@ e2e/playwright/playwright-secrets.env
 e2e/playwright/temp1.png
 e2e/playwright/temp2.png
 e2e/playwright/temp3.png
+# this will be overridden for specific directories
+e2e/playwright/**/*.png
 # exports from snapshot-tests.spec.ts "exports of each format should work"
 e2e/playwright/export-snapshots/*
 !e2e/playwright/export-snapshots/*.png
+!e2e/playwright/snapshot-tests.spec.ts-snapshots/*.png
 
 /kcl-samples
 /test-results/

--- a/e2e/playwright/testing-settings.spec.ts
+++ b/e2e/playwright/testing-settings.spec.ts
@@ -945,4 +945,76 @@ fn cube`
       ).toBeVisible()
     })
   })
+
+  /**
+   * This test assumes that the default value of the "highlight edges" setting is "on".
+   */
+  test(`Toggle stream settings multiple times`, async ({
+    page,
+    scene,
+    homePage,
+    context,
+    toolbar,
+    cmdBar,
+  }, testInfo) => {
+    await context.folderSetupFn(async (dir) => {
+      const projectDir = join(dir, 'project-000')
+      await fsp.mkdir(projectDir, { recursive: true })
+      await fsp.copyFile(
+        executorInputPath('cube.kcl'),
+        join(projectDir, 'main.kcl')
+      )
+    })
+
+    await test.step(`First snapshot`, async () => {
+      await homePage.openProject('project-000')
+      await toolbar.closePane('code')
+      await expect(toolbar.startSketchBtn).toBeEnabled({ timeout: 20_000 })
+      await scene.clickNoWhere()
+    })
+
+    const toast = (value: boolean) =>
+      page.getByText(
+        `Set highlight edges to "${String(value)}" as a user default`
+      )
+    const initialPath = testInfo.snapshotPath('toggle-settings-initial.png')
+    const initialScreenshot = await scene.streamWrapper.screenshot({
+      path: initialPath,
+      mask: [page.getByTestId('model-state-indicator')],
+    })
+
+    await test.step(`Toggle highlightEdges off`, async () => {
+      await cmdBar.openCmdBar()
+      await cmdBar.chooseCommand('Settings · modeling · highlight edges')
+      await cmdBar.selectOption({ name: 'off' }).click()
+      const falseToast = toast(false)
+      await expect(falseToast).toBeVisible()
+      await falseToast.waitFor({ state: 'detached' })
+    })
+
+    await expect(scene.streamWrapper).not.toHaveScreenshot(
+      'toggle-settings-initial.png',
+      {
+        maxDiffPixels: 15,
+        mask: [page.getByTestId('model-state-indicator')],
+      }
+    )
+
+    await test.step(`Toggle highlightEdges on`, async () => {
+      await cmdBar.openCmdBar()
+      await cmdBar.chooseCommand('Settings · modeling · highlight edges')
+      await cmdBar.selectOption({ name: 'on' }).click()
+      const trueToast = toast(true)
+      await expect(trueToast).toBeVisible()
+      await trueToast.waitFor({ state: 'detached' })
+    })
+
+    await expect(scene.streamWrapper).toHaveScreenshot(
+      'toggle-settings-initial.png',
+      {
+        maxDiffPixels: 15,
+        mask: [page.getByTestId('model-state-indicator')],
+      }
+    )
+  })
 })

--- a/src/wasm-lib/kcl/src/execution/cache.rs
+++ b/src/wasm-lib/kcl/src/execution/cache.rs
@@ -533,6 +533,42 @@ shell(firstSketch, faces = ['end'], thickness = 0.25)"#;
         .await;
 
         assert_eq!(result, CacheResult::NoAction(true));
+
+        // Change the settings back.
+        let old_settings = ctx.settings.clone();
+        ctx.settings.highlight_edges = !ctx.settings.highlight_edges;
+
+        let result = get_changed_program(
+            CacheInformation {
+                ast: &program.ast,
+                settings: &old_settings,
+            },
+            CacheInformation {
+                ast: &program.ast,
+                settings: &ctx.settings,
+            },
+        )
+        .await;
+
+        assert_eq!(result, CacheResult::NoAction(true));
+
+        // Change the settings back.
+        let old_settings = ctx.settings.clone();
+        ctx.settings.highlight_edges = !ctx.settings.highlight_edges;
+
+        let result = get_changed_program(
+            CacheInformation {
+                ast: &program.ast,
+                settings: &old_settings,
+            },
+            CacheInformation {
+                ast: &program.ast,
+                settings: &ctx.settings,
+            },
+        )
+        .await;
+
+        assert_eq!(result, CacheResult::NoAction(true));
     }
 
     // Changing the units settings using an annotation with the exact same file

--- a/src/wasm-lib/kcl/src/execution/mod.rs
+++ b/src/wasm-lib/kcl/src/execution/mod.rs
@@ -587,6 +587,14 @@ impl ExecutorContext {
                         .await
                         .is_ok()
                     {
+                        // We need to update the old ast state with the new settings!!
+                        cache::write_old_ast(OldAstState {
+                            ast: old_ast,
+                            exec_state: old_state.clone(),
+                            settings: self.settings.clone(),
+                        })
+                        .await;
+
                         return Ok(old_state.to_wasm_outcome());
                     }
                     (true, program.ast)
@@ -1671,5 +1679,60 @@ let w = f() + f()
         let new_id_generator = cache::read_old_ast().await.unwrap().exec_state.global.id_generator;
 
         assert_eq!(id_generator, new_id_generator);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn kcl_test_changing_a_setting_updates_the_cached_state() {
+        let code = r#"sketch001 = startSketchOn('XZ')
+|> startProfileAt([61.74, 206.13], %)
+|> xLine(305.11, %, $seg01)
+|> yLine(-291.85, %)
+|> xLine(-segLen(seg01), %)
+|> line(endAbsolute = [profileStartX(%), profileStartY(%)])
+|> close()
+|> extrude(length = 40.14)
+|> shell(
+    thickness = 3.14,
+    faces = [seg01]
+)
+"#;
+
+        let mut ctx = crate::test_server::new_context(UnitLength::Mm, true, None)
+            .await
+            .unwrap();
+        let old_program = crate::Program::parse_no_errs(code).unwrap();
+
+        // Execute the program.
+        ctx.run_with_caching(old_program.clone()).await.unwrap();
+
+        // Get the id_generator from the first execution.
+        let settings_state = cache::read_old_ast().await.unwrap().settings;
+
+        // Ensure the settings are as expected.
+        assert_eq!(settings_state, ctx.settings);
+
+        // Change a setting.
+        ctx.settings.highlight_edges = !ctx.settings.highlight_edges;
+
+        // Execute the program.
+        ctx.run_with_caching(old_program.clone()).await.unwrap();
+
+        // Get the id_generator from the first execution.
+        let settings_state = cache::read_old_ast().await.unwrap().settings;
+
+        // Ensure the settings are as expected.
+        assert_eq!(settings_state, ctx.settings);
+
+        // Change a setting.
+        ctx.settings.highlight_edges = !ctx.settings.highlight_edges;
+
+        // Execute the program.
+        ctx.run_with_caching(old_program).await.unwrap();
+
+        // Get the id_generator from the first execution.
+        let settings_state = cache::read_old_ast().await.unwrap().settings;
+
+        // Ensure the settings are as expected.
+        assert_eq!(settings_state, ctx.settings);
     }
 }


### PR DESCRIPTION
closes #5443
fixes https://github.com/KittyCAD/modeling-app/issues/5283

EDIT: yes it fixes both, sorry for putting blame on yall this was a place where the caching was not testing e2e and only unit :) I added a test
