### PR TITLE
fix: E2E test assumes codemirror error is present when it is lazy loaded

### DIFF
--- a/e2e/playwright/projects.spec.ts
+++ b/e2e/playwright/projects.spec.ts
@@ -117,7 +117,7 @@ test(
 test(
   'open a file in a project works and renders, open another file in different project with errors, it should clear the scene',
   { tag: '@electron' },
-  async ({ context, page }, testInfo) => {
+  async ({ context, page, editor }, testInfo) => {
     await context.folderSetupFn(async (dir) => {
       const bracketDir = path.join(dir, 'bracket')
       await fsp.mkdir(bracketDir, { recursive: true })
@@ -179,6 +179,9 @@ test(
       await expect(page.getByText('broken-code')).toBeVisible()
 
       await page.getByText('broken-code').click()
+
+      await page.waitForTimeout(2000)
+      await editor.scrollToText('|> line(end = [0, wallMountL], tag = \'outerEdge\')')
 
       // error in guter
       await expect(page.locator('.cm-lint-marker-error')).toBeVisible()

--- a/e2e/playwright/projects.spec.ts
+++ b/e2e/playwright/projects.spec.ts
@@ -181,7 +181,9 @@ test(
       await page.getByText('broken-code').click()
 
       await page.waitForTimeout(2000)
-      await editor.scrollToText('|> line(end = [0, wallMountL], tag = \'outerEdge\')')
+      await editor.scrollToText(
+        "|> line(end = [0, wallMountL], tag = 'outerEdge')"
+      )
 
       // error in guter
       await expect(page.locator('.cm-lint-marker-error')).toBeVisible()


### PR DESCRIPTION
# Issue

E2E tests pass when it really shouldn't. It fails if you manually test the step yourself.

# Implementation 

CodeMirror does not always put the error into the DOM. The test assumes the error is in the DOM but that is not always true. CodeMirror lazy loads the text.

I fixed this by scrolling to the text to see that there is an error.

by the way this passes in main already but it passes for the wrong reason, this should pass again but be more robust. 