### PR TITLE
Show visible error when updater call fails

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -397,7 +397,7 @@ app.on('ready', () => {
 
   autoUpdater.on('error', (error) => {
     console.error('updater-error', error)
-    mainWindow?.webContents.send('updater-error', error)
+    mainWindow?.webContents.send('update-error', error)
   })
 
   autoUpdater.on('update-available', (info) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -396,7 +396,7 @@ app.on('ready', () => {
   }, fifteenMinutes)
 
   autoUpdater.on('error', (error) => {
-    console.error('updater-error', error)
+    console.error('update-error', error)
     mainWindow?.webContents.send('update-error', error)
   })
 


### PR DESCRIPTION
Not sure if it fixes #3696 fully but is a low-hanging fruit towards that.

Alright this was a TYPO and fixing it already helps a lot. Tested this by building a numbered dev build locally on mac (not codesign) which fails as it should. 

<img width="1800" alt="image" src="https://github.com/user-attachments/assets/90128987-f6f5-43c2-bb53-29bbd8c50182" />
