### PR TITLE
WIP: Start synchronizing the enableSketchMode call

### DIFF
--- a/src/clientSideScene/CameraControls.ts
+++ b/src/clientSideScene/CameraControls.ts
@@ -1335,21 +1335,34 @@ export async function letEngineAnimateAndSyncCamAfter(
   engineCommandManager: EngineCommandManager,
   entityId: string
 ) {
-  await engineCommandManager.sendSceneCommand({
-    type: 'modeling_cmd_req',
-    cmd_id: uuidv4(),
-    cmd: {
-      type: 'enable_sketch_mode',
-      adjust_camera: true,
-      animated: !isReducedMotion(),
-      ortho: true,
-      entity_id: entityId,
+  const enableSketchCmdId = uuidv4()
+  console.warn('ADAM: enableSketchMode promise has ID', enableSketchCmdId)
+  await engineCommandManager.sendSceneCommand(
+    {
+      type: 'modeling_cmd_req',
+      cmd_id: enableSketchCmdId,
+      cmd: {
+        type: 'enable_sketch_mode',
+        adjust_camera: true,
+        animated: !isReducedMotion(),
+        ortho: true,
+        entity_id: entityId,
+      },
     },
-  })
-  // wait 600ms (animation takes 500, + 100 for safety)
-  await new Promise((resolve) =>
-    setTimeout(resolve, isReducedMotion() ? 100 : 600)
+    false,
+    // Callback triggers when the enable_sketch_mode finishes successfully.
+    (_whatever) => {
+      console.error('ADAM: Hello from the resolvedCb')
+      window.alert("G'day ADAM and Frank, enable_sketch_mode is done")
+    },
+    // Callback triggers when the enable_sketch_mode fails.
+    (_whatever) => {
+      console.error('ADAM: Hello from the rejectCb')
+      window.alert("G'day ADAM and Frank, enable_sketch_mode is FUCKING TOAST")
+    }
   )
+  // TODO: Wait for one of the two callbacks above to finish.
+
   await engineCommandManager.sendSceneCommand({
     // CameraControls subscribes to default_camera_get_settings response events
     // firing this at connection ensure the camera's are synced initially


### PR DESCRIPTION
One of the pain points in testing and possibly in rare user experiences is that we have no signal that the user has completed the engine-side animation into sketch mode, and is now ready to begin sketching. @Irev-Dev has opened an issue on the engine repo (see https://github.com/KittyCAD/engine/issues/1453), but @adamchalmers mentioned during discussion that there is nothing stopping the frontend from awaiting the command responses properly to get notified of when they are completed, including this animation.

This WIP PR is the progress we made toward that goal while pairing back on Feb 22. We reached a point where we got a little stuck carrying the Promise all the way through the system, but we think we've proved out the principle. We need to check in with @Irev-Dev to fill the gaps in our knowledge.