### PR TITLE
External retry of the playwright step instead of --last-failed

### DIFF
--- a/.github/ci-cd-scripts/playwright-electron.sh
+++ b/.github/ci-cd-scripts/playwright-electron.sh
@@ -21,7 +21,7 @@ if [[ ! -f "test-results/.last-run.json" ]]; then
 fi
 
 retry=1
-max_retrys=3
+max_retrys=1
 
 # retry failed tests, doing our own retries because using inbuilt playwright retries causes connection issues
 while [[ $retry -le $max_retrys ]]; do

--- a/.github/ci-cd-scripts/playwright-electron.sh
+++ b/.github/ci-cd-scripts/playwright-electron.sh
@@ -21,7 +21,7 @@ if [[ ! -f "test-results/.last-run.json" ]]; then
 fi
 
 retry=1
-max_retrys=5
+max_retrys=3
 
 # retry failed tests, doing our own retries because using inbuilt playwright retries causes connection issues
 while [[ $retry -le $max_retrys ]]; do

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -46,7 +46,7 @@ jobs:
         shell: bash
         run: |-
           cd "${{ matrix.dir }}"
-          cargo llvm-cov nextest --workspace --lcov --output-path lcov.info --test-threads=1 --no-fail-fast -P ci 2>&1 | tee /tmp/github-actions.log
+          cargo llvm-cov nextest --workspace --lcov --output-path lcov.info --test-threads=1 --retries=2 --no-fail-fast -P ci 2>&1 | tee /tmp/github-actions.log
         env:
           KITTYCAD_API_TOKEN: ${{secrets.KITTYCAD_API_TOKEN}}
           RUST_MIN_STACK: 10485760000

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,7 +1,7 @@
 name: E2E Tests
 on:
   push:
-    branches: [ main, pierremtb/adhoc/e2e-external-retry ]
+    branches: [ main ]
   pull_request:
 
 concurrency:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -204,7 +204,7 @@ jobs:
       with:
         command: .github/ci-cd-scripts/playwright-electron.sh ${{matrix.shardIndex}} ${{matrix.shardTotal}} ${{matrix.os}}
         timeout_minutes: 30
-        max_attempts: 10
+        max_attempts: 25
       env:
         CI: true
         FAIL_ON_CONSOLE_ERRORS: true

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,7 +1,7 @@
 name: E2E Tests
 on:
   push:
-    branches: [ main ]
+    branches: [ main, pierremtb/adhoc/e2e-external-retry ]
   pull_request:
 
 concurrency:
@@ -200,9 +200,11 @@ jobs:
     - name: Run playwright/electron flow (with retries)
       id: retry
       if: ${{ !cancelled() && (success() || failure()) }}
-      shell: bash
-      run: |
-        .github/ci-cd-scripts/playwright-electron.sh ${{matrix.shardIndex}} ${{matrix.shardTotal}} ${{matrix.os}}
+      uses: nick-fields/retry@v3.0.0
+      with:
+        command: .github/ci-cd-scripts/playwright-electron.sh ${{matrix.shardIndex}} ${{matrix.shardTotal}} ${{matrix.os}}
+        timeout_minutes: 30
+        max_attempts: 10
       env:
         CI: true
         FAIL_ON_CONSOLE_ERRORS: true


### PR DESCRIPTION
I hit a straight green first attempt three times on a row on this branch https://github.com/KittyCAD/modeling-app/compare/main...pierremtb/adhoc/e2e-external-retry
This is about retrying the whole workflow step with nick-fields/retry@v3.0.0 instead of rerunning playwright --last-failed in the script. And seems to give me much better results?? It's the first time that I brute force in one direction and I actually see tangible improvements.

Link to the three times:
https://github.com/KittyCAD/modeling-app/actions/runs/13474280984/job/37651492175
https://github.com/KittyCAD/modeling-app/actions/runs/13474388068/job/37651720678
https://github.com/KittyCAD/modeling-app/actions/runs/13474516441/job/37652011524