### PR TITLE
Fix settings loading actions

### DIFF
--- a/src/machines/settingsMachine.ts
+++ b/src/machines/settingsMachine.ts
@@ -538,7 +538,16 @@ export const settingsMachine = setup({
         src: 'loadUserSettings',
         onDone: {
           target: 'idle',
-          actions: 'setAllSettings',
+          actions: [
+            'setAllSettings',
+            'setThemeClass',
+            'setEngineTheme',
+            'setClientSideSceneUnits',
+            'setThemeColor',
+            'setClientTheme',
+            'setAllowOrbitInSketchMode',
+            'sendThemeToWatcher',
+          ],
         },
         onError: {
           target: 'idle',
@@ -561,8 +570,14 @@ export const settingsMachine = setup({
           target: 'idle',
           actions: [
             'setAllSettings',
+            'setThemeClass',
+            'setEngineTheme',
+            'setClientSideSceneUnits',
             'setThemeColor',
             'Execute AST',
+            'setClientTheme',
+            'setAllowOrbitInSketchMode',
+            'sendThemeToWatcher',
             sendTo('registerCommands', { type: 'update' }),
           ],
         },


### PR DESCRIPTION
Fixes a bug found by @Irev-Dev that was introduced with #5142.

Due to a lapse in understanding between `Set all settings` event and `setAllSettings` action, these were missing from slots where user and project settings are loaded. We want to fire off these effectful actions when those settings are updated so that we can, for example, get the opposite theme for sketch mode properly.