### PR TITLE
Rename AI-related buttons to reduce confusion

### DIFF
--- a/src/lib/toolbar.ts
+++ b/src/lib/toolbar.ts
@@ -312,7 +312,7 @@ export const toolbarConfig: Record<ToolbarModeName, ToolbarMode> = {
             }),
           icon: 'sparkles',
           status: 'available',
-          title: 'Text-to-CAD',
+          title: 'Create with AI',
           description: 'Generate geometry from a text prompt.',
           links: [
             {
@@ -330,7 +330,7 @@ export const toolbarConfig: Record<ToolbarModeName, ToolbarMode> = {
             }),
           icon: 'sparkles',
           status: 'available',
-          title: 'Prompt-to-Edit',
+          title: 'Edit with AI',
           description: 'Edit geometry based on a text prompt.',
           links: [],
         },


### PR DESCRIPTION
Just renaming the titles for now; there are lots of other places we refer to "text-to-cad" and "prompt-to-edit" that we will will want to follow up on eventually I'm sure. This is a user fix with the least chance of introducing bugs.