### PR TITLE
Get rid of failing cache on build-apps' setup-node

### DIFF
--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -32,7 +32,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          cache: 'yarn'
 
       - run: yarn install
 
@@ -124,11 +123,9 @@ jobs:
           cp prepared-files/assets/icon.ico assets/icon.ico
           cp prepared-files/assets/icon.png assets/icon.png
 
-      - name: Sync node version and setup cache
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          cache: 'yarn' # Set this to npm, yarn or pnpm.
 
       - name: yarn install
         # Windows is picky sometimes and fails on fetch. Step takes about ~30s


### PR DESCRIPTION
I'm guilty of making a non-new mistake https://github.com/KittyCAD/modeling-app/actions/runs/13513410617
Went back to the double backslash at https://github.com/KittyCAD/modeling-app/pull/5335/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R98 and that got me on nightly yesterday.

I'm tempted to say that if we don't resolve this in a different way we're bound to repeat it. So my vote is it's time to cache out!