### PR TITLE
Disable pw object.assign context

### DIFF
--- a/e2e/playwright/fixtures/fixtureSetup.ts
+++ b/e2e/playwright/fixtures/fixtureSetup.ts
@@ -101,7 +101,8 @@ export class AuthenticatedTronApp {
     // running against electron applications.
     // The timeline is still broken but failure screenshots work again.
     this.context = context
-    Object.assign(this.browserContext, this.context)
+    // TODO: try to get this to work again for screenshots, but it messed with test ends when enabled
+    // Object.assign(this.browserContext, this.context)
 
     this.electronApp = electronApp
     this.dir = dir


### PR DESCRIPTION
As discussed on Slack, commenting out the Object.assign call instead of reverting #5464.