### PR TITLE
Revert "Get rid of failing cache on build-apps' setup-node" and fix wasm copy on Windows

### DIFF
--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
+          cache: 'yarn'
 
       - run: yarn install
 
@@ -123,9 +124,11 @@ jobs:
           cp prepared-files/assets/icon.ico assets/icon.ico
           cp prepared-files/assets/icon.png assets/icon.png
 
-      - uses: actions/setup-node@v4
+      - name: Sync node version and setup cache
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
+          cache: 'yarn' # Set this to npm, yarn or pnpm.
 
       - name: yarn install
         # Windows is picky sometimes and fails on fetch. Step takes about ~30s

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "build:wasm-dev": "yarn wasm-prep && (cd src/wasm-lib && wasm-pack build --dev --target web --out-dir pkg && cargo test -p kcl-lib export_bindings) && yarn isomorphic-copy-wasm && yarn fmt",
     "build:wasm:nocopy": "yarn wasm-prep && cd src/wasm-lib && wasm-pack build --release --target web --out-dir pkg && cargo test -p kcl-lib export_bindings",
     "build:wasm": "yarn build:wasm:nocopy && cp src/wasm-lib/pkg/wasm_lib_bg.wasm public && yarn fmt",
-    "build:wasm:windows": "yarn install:wasm-pack:cargo && yarn build:wasm:nocopy && copy src\\wasm-lib\\pkg\\wasm_lib_bg.wasm public && yarn fmt",
+    "build:wasm:windows": "yarn install:wasm-pack:cargo && yarn build:wasm:nocopy && ./scripts/copy-wasm.ps1  && yarn fmt",
     "remove-importmeta": "sed -i 's/import.meta.url/window.location.origin/g' \"./src/wasm-lib/pkg/wasm_lib.js\"; sed -i '' 's/import.meta.url/window.location.origin/g' \"./src/wasm-lib/pkg/wasm_lib.js\" || echo \"sed for both mac and linux\"",
     "wasm-prep": "rimraf src/wasm-lib/pkg && mkdirp src/wasm-lib/pkg && rimraf src/wasm-lib/kcl/bindings",
     "lint-fix": "eslint --fix --ext .ts --ext .tsx src e2e packages/codemirror-lsp-client/src",

--- a/scripts/copy-wasm.ps1
+++ b/scripts/copy-wasm.ps1
@@ -1,0 +1,1 @@
+copy src\wasm-lib\pkg\wasm_lib_bg.wasm public


### PR DESCRIPTION
Reverts KittyCAD/modeling-app#5490 but fixes the copy without using escaped backslashes that were messing with `jq` since they might be invalid json.