### PR TITLE
Make memory accessible from multiple threads/tasks

### DIFF
--- a/rust/kcl-lib/Cargo.toml
+++ b/rust/kcl-lib/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.2.45"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"
-rust-version = "1.73"
+rust-version = "1.83"
 authors = ["Jess Frazelle", "Adam Chalmers", "KittyCAD, Inc"]
 keywords = ["kcl", "KittyCAD", "CAD"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust/kcl-lib/src/execution/cache.rs
+++ b/rust/kcl-lib/src/execution/cache.rs
@@ -6,7 +6,7 @@ use itertools::{EitherOrBoth, Itertools};
 use tokio::sync::RwLock;
 
 use crate::{
-    execution::{annotations, memory::ProgramMemory, EnvironmentRef, ExecState, ExecutorSettings},
+    execution::{annotations, memory::Stack, EnvironmentRef, ExecState, ExecutorSettings},
     parsing::ast::types::{Annotation, Node, Program},
     walk::Node as WalkNode,
 };
@@ -15,7 +15,7 @@ lazy_static::lazy_static! {
     /// A static mutable lock for updating the last successful execution state for the cache.
     static ref OLD_AST: Arc<RwLock<Option<OldAstState>>> = Default::default();
     // The last successful run's memory. Not cleared after an unssuccessful run.
-    static ref PREV_MEMORY: Arc<RwLock<Option<ProgramMemory>>> = Default::default();
+    static ref PREV_MEMORY: Arc<RwLock<Option<Stack>>> = Default::default();
 }
 
 /// Read the old ast memory from the lock.
@@ -29,12 +29,12 @@ pub(super) async fn write_old_ast(old_state: OldAstState) {
     *old_ast = Some(old_state);
 }
 
-pub(crate) async fn read_old_memory() -> Option<ProgramMemory> {
+pub(crate) async fn read_old_memory() -> Option<Stack> {
     let old_mem = PREV_MEMORY.read().await;
     old_mem.clone()
 }
 
-pub(super) async fn write_old_memory(mem: ProgramMemory) {
+pub(super) async fn write_old_memory(mem: Stack) {
     let mut old_mem = PREV_MEMORY.write().await;
     *old_mem = Some(mem);
 }

--- a/rust/kcl-lib/src/execution/kcl_value.rs
+++ b/rust/kcl-lib/src/execution/kcl_value.rs
@@ -631,7 +631,7 @@ impl KclValue {
                         ),
                     ));
                 }
-                exec_state.mut_memory().push_new_env_for_rust_call();
+                exec_state.mut_stack().push_new_env_for_rust_call();
                 let args = crate::std::Args::new(
                     args,
                     source_range,
@@ -639,7 +639,7 @@ impl KclValue {
                     exec_state.mod_local.pipe_value.clone().map(Arg::synthetic),
                 );
                 let result = func(exec_state, args).await.map(Some);
-                exec_state.mut_memory().pop_env();
+                exec_state.mut_stack().pop_env();
                 result
             }
             KclValue::Function {

--- a/rust/kcl-lib/src/execution/memory.rs
+++ b/rust/kcl-lib/src/execution/memory.rs
@@ -9,13 +9,14 @@
 //! may change as code is executed and that mutates memory. Therefore,
 //! ProgramMemory supports mutability and does not rely on KCL's (mostly) immutable nature.
 //!
-//! ProgramMemory is observably monotonic, i.e., it only grows and even when we pop a stack frame the
-//! frame, it is retained. We remove some values which we know cannot be referenced, but we
-//! should in the future do better garbage collection (of values and envs).
+//! ProgramMemory is observably monotonic, i.e., it only grows and even when we pop a stack frame,
+//! the frame is retained unless we can prove it is unreferenced. We remove some values which we
+//! know cannot be referenced, but we should in the future do better garbage collection (of values
+//!  and envs).
 //!
 //! ## Concepts
 //!
-//! There are three main moving parts for ProgramMemory: environments, snapshots, and the call stack. I'll
+//! There are three main moving parts for ProgramMemory: environments, snapshots, and stacks. I'll
 //! cover environments (and the call stack) first as if snapshots didn't exist, then describe snapshots.
 //!
 //! An environment is a set of bindings (i.e., a map from names to values). Environments handle
@@ -45,6 +46,14 @@
 //! Note, however, that if a function is called from it's enclosing scope, then the outer env will
 //! be on the call stack and be the parent of the current env. Calling from a different scope will
 //! mean the call stack and parent env do not correspond.
+//!
+//! We use a new call stack for each module. When interpreting a module we start a new call stack
+//! with a new environment (though see below about std). Names imported from one module into another
+//! point into the envs from the exporting module's call stack (though once the module has been
+//! interpreted, those envs won't be on it's call stack any longer). A call stack is represented by
+//! a `Stack` object which references the global `ProgramMemory` object. Environments are stored in
+//! the global memory and the call stack is a stack of references. (See below on concurrent access
+//! using `Stack`s).
 //!
 //! When a function declaration is interpreted we create a value in memory (in the env in which it
 //! is declared) which contains the function's AST and a reference to the env where it is declared.
@@ -78,6 +87,17 @@
 //!
 //! Entering an inline scope (e.g., the body of an `if` statement) means pushing an env whose parent
 //! is the current env. We don't need to snapshot in this case.
+//!
+//! ### Std
+//!
+//! The standard library is implicitly imported into every module (unless it explicitly opts out).
+//! So that these implicitly imported names can be overridden, we want to import these names into a
+//! scope outside the implicitly importing module. Furthermore, for efficiency we'd like to share
+//! these imported names between all modules (because std is large and every module imports all
+//! those names). This is safe to do because everything in std is fully immutable.
+//!
+//! To make this work, every env has the std import (prelude) env as its root ancestor. So when an
+//! env is marked as a root env, it may still have the prelude env as its parent.
 //!
 //! ## Implementation
 //!
@@ -134,8 +154,87 @@
 //! - Therefore, an active env must either be on the call stack, have snapshots, or be a root env. This
 //!   is however a conservative approximation since snapshots may exist even if there are no live
 //!   references to an env.
+//!
+//! ## Concurrency and thread-safety
+//!
+//! `ProgramMemory` is a global singleton (technically one per program execution, if we handled multiple
+//! projects in a single interpreter process we'd need multiple `ProgramMemory`s, but that is currently
+//! not possible). `ProgramMemory` could be moved between threads, but there shouldn't be any need
+//! to do so. It can safely be referenced and accessed from multiple threads, but there are rules for
+//! doing so.
+//!
+//! `ProgramMemory` is mostly accessed via a `Stack` object, avoid accessing `ProgramMemory` directly
+//! where possible. `Stack`s can safely be moved to other threads and can access `ProgramMemory`
+//! from a different thread. There can be multiple `Stack`s on different threads or the same thread
+//! (either operating sequentially or using async tasks).
+//!
+//! The key requirement for users is that names from a `Stack` should never be exposed until the
+//! `Stack` itself is no longer needed. I.e., when interpreting a module, you would use a new `Stack`
+//! for the module and no other module can reference anything in the module until interpretation of
+//! it is complete (and the `Stack` object has been dropped).
+//!
+//! Using most of the `Stack` API is easy - you don't need to worry about thread safety and can treat
+//! it just like a self-contained object (though see the docs on `restore_env` and `squash_env` if
+//! you use that method). You shouldn't need to use `ProgramMemory` for much, other
+//! than creating new `Stack`s which is always safe (doesn't mutate `ProgramMemory`). After interpreting
+//! std, you'll need to call `set_std` and for this you must have a unique reference to `ProgramMemory`,
+//! but if you don't we'll just panic, not cause a safety issue. `get_from` and `find_all_in_env`
+//! take an owner parameter and follow the thread-safety invariants below.
+//!
+//! The rest of this section describes the implementation and thread-safety invariants, you should
+//! only need to understand it if you're modifying this file (or want to call a few, rarely used
+//! functions).
+//!
+//! The memory system is a lock-free, mostly wait-free structure. Safety is guaranteed by a few
+//! invariants which are maintained (mostly) internally. There are two areas of mutability which
+//! we need to think about: modifying, updating, or deleting items in memory, and adding or deleting
+//! environments. Other areas of mutation are maintaining the call stacks which is always trivially
+//! thread-local and collecting stats which is trivially atomic.
+//!
+//! A key invariant for modifying memory items is that each env is either uniquely owned by a single
+//! `Stack` (when it is active, i.e., part of a call stack) or is read-only (once interpretation of
+//! the scope backed by the env is complete and the env is no longer on any call stack). Being on a
+//! call stack means the env is owned by that `Stack`. Since the envs are all kept by the `ProgramMemory`
+//! singleton (so that env refs work), we can't rely on Rust ownership to enforce this. Instead, each
+//! `Stack` has an id (ordering of which is irrelevant) and each env has an owner id - if this is 0,
+//! the env is read-only, if not it is owned by the stack with that id. An env can be read or written
+//! by it's owning stack, or if read-only can be read by anyone but never written.
+//!
+//! We check this dynamically, but the checks are assertions and should never fail. The safety invariant
+//! is ensured by construction - memory in a `Stack` should not be referenced from another `Stack`,
+//! memory should only be referenced once interpretation related to it is finished. This is actually
+//! a stronger requirement than is strictly necessary but it is easy to reason about. To be precise,
+//! it is safe to reference a name in an env once it has been popped from a stack and as long as it
+//! doesn't again become active.
+//!
+//! Accessing an env is safe because they are stored on the heap and cannot be moved, even if the
+//! env storage is reorganised (which should only be due to reallocation, we can't move envs within
+//! storage since their indices must be kept consistent).
+//!
+//! Adding or removing an env from storage is protected by a 'lock' field in `ProgramMemory`. Modification
+//! of the env storage must only happen when holding this lock (use `with_envs`). `with_envs` uses a
+//! simple spin lock to wait (the only non-wait-free action) so don't hold the lock for long (currently
+//! the only time this might happen is if the env storage re-sizes and thus reallocates). Reading an
+//! env does not require any lock - an env can never be moved, access to the env must be either
+//! read-only or unique, and (importantly) modifying the environments cannot remove an env unless it
+//! is guaranteed there are no references to the env.
+//!
+//! Edge case: what if an env transitions ownership state at the same time as the env storage is
+//! modified? This shouldn't be a technical issue, because the owner field of an env is only used to
+//! check safety, it is not ever used for any decision. In any case, modifying the env storage is
+//! must be safe if the env is in either state, so even if the transition happens at the same time
+//! as the storage modification, it is ok.
 
-use std::{collections::HashMap, fmt};
+use std::{
+    cell::UnsafeCell,
+    collections::HashMap,
+    fmt,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc,
+    },
+};
 
 use anyhow::Result;
 use env::Environment;
@@ -156,58 +255,109 @@ pub(crate) const RETURN_NAME: &str = "__return";
 /// including other modules). Multiple interpretation runs should have fresh instances.
 ///
 /// See module docs.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct ProgramMemory {
-    environments: Vec<Environment>,
-    /// Invariant: current_env.1.is_none()
-    current_env: EnvironmentRef,
+    // Environments are boxed so they will never be moved if the `Vec` reallocates. We use `Pin`
+    // to help guarantee that.
+    environments: UnsafeCell<Vec<Pin<Box<Environment>>>>,
     /// Memory for the std prelude.
     std: Option<EnvironmentRef>,
-    /// Invariant: forall er in call_stack: er.1.is_none()
-    call_stack: Vec<EnvironmentRef>,
     /// Statistics about the memory, should not be used for anything other than meta-info.
     pub(crate) stats: MemoryStats,
+    next_stack_id: AtomicUsize,
+    write_lock: AtomicBool,
+}
+
+unsafe impl Sync for ProgramMemory {}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Stack {
+    pub(crate) memory: Arc<ProgramMemory>,
+    id: usize,
+    /// Invariant: current_env.1.is_none()
+    current_env: EnvironmentRef,
+    /// Invariant: forall er in call_stack: er.1.is_none()
+    call_stack: Vec<EnvironmentRef>,
 }
 
 // Intended for debugging. Do not rely on this output in any way!
 impl fmt::Display for ProgramMemory {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let envs: Vec<String> = self
-            .environments
+            .envs()
             .iter()
             .enumerate()
             .map(|(i, env)| format!("{i}: {env}"))
             .collect();
+        write!(
+            f,
+            "ProgramMemory (next stack: {})\nenvs:\n{}",
+            self.next_stack_id.load(Ordering::Relaxed),
+            envs.join("\n")
+        )
+    }
+}
+
+// Intended for debugging. Do not rely on this output in any way!
+impl fmt::Display for Stack {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let stack: Vec<String> = self
             .call_stack
             .iter()
             .chain(Some(&self.current_env))
             .map(|e| format!("EnvRef({}, {})", e.0, e.1 .0))
             .collect();
-        write!(
-            f,
-            "ProgramMemory\nenvs:\n{}\nstack:\n  {}",
-            envs.join("\n"),
-            stack.join("\n  ")
-        )
+        write!(f, "Stack {}\nstack frames:\n{}", self.id, stack.join("\n"))
     }
 }
 
 impl ProgramMemory {
     #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
-        Self {
-            environments: vec![],
-            current_env: EnvironmentRef::dummy(),
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            // Massively over-allocate here to try and avoid reallocating later.
+            environments: UnsafeCell::new(Vec::with_capacity(512)),
             std: None,
-            call_stack: Vec::new(),
             stats: MemoryStats::default(),
+            next_stack_id: AtomicUsize::new(1),
+            write_lock: AtomicBool::new(false),
+        })
+    }
+
+    /// Clone this ProgramMemory.
+    ///
+    /// This is deliberately not a `Clone` impl or called just `clone` since it requires the write
+    /// lock on the memory and so as to be totally unambiguous with cloning an `Arc` of the memory
+    /// (which you should usually prefer).
+    ///
+    /// This is a long-running operation and holds the write lock, which is bad. Callers must ensure
+    /// that no other task will need to use `self` while this runs.
+    fn deep_clone(&self) -> Self {
+        self.with_envs(|envs| Self {
+            environments: UnsafeCell::new(envs.clone()),
+            std: self.std,
+            stats: MemoryStats::default(),
+            next_stack_id: AtomicUsize::new(self.next_stack_id.load(Ordering::Relaxed)),
+            write_lock: AtomicBool::new(false),
+        })
+    }
+
+    pub fn new_stack(self: Arc<Self>) -> Stack {
+        let id = self.next_stack_id.fetch_add(1, Ordering::Relaxed);
+        assert!(id > 0);
+        Stack {
+            id,
+            memory: self,
+            current_env: EnvironmentRef::dummy(),
+            call_stack: Vec::new(),
         }
     }
 
     /// Set the env var used for the standard library prelude.
-    pub fn set_std(&mut self, std: EnvironmentRef) {
-        self.std = Some(std);
+    ///
+    /// Precondition: `self` must be uniquely owned.
+    pub fn set_std(self: &mut Arc<Self>, std: EnvironmentRef) {
+        Arc::get_mut(self).unwrap().std = Some(std);
     }
 
     /// Whether this memory still needs to be initialised with its standard library prelude.
@@ -215,11 +365,181 @@ impl ProgramMemory {
         self.std.is_none()
     }
 
+    /// Get a value from a specific snapshot of the memory.
+    pub fn get_from(
+        &self,
+        var: &str,
+        mut env_ref: EnvironmentRef,
+        source_range: SourceRange,
+        owner: usize,
+    ) -> Result<&KclValue, KclError> {
+        loop {
+            let env = self.get_env(env_ref.index());
+            env_ref = match env.get(var, env_ref.1, owner) {
+                Ok(item) => return Ok(item),
+                Err(Some(parent)) => parent,
+                Err(None) => break,
+            };
+        }
+
+        Err(KclError::UndefinedValue(KclErrorDetails {
+            message: format!("memory item key `{}` is not defined", var),
+            source_ranges: vec![source_range],
+        }))
+    }
+
+    /// Iterate over all key/value pairs in the specified environment which satisfy the provided
+    /// predicate.
+    fn find_all_in_env<'a>(
+        &'a self,
+        env: EnvironmentRef,
+        pred: impl Fn(&KclValue) -> bool + 'a,
+        owner: usize,
+    ) -> impl Iterator<Item = (&'a String, &'a KclValue)> {
+        assert!(!env.skip_env());
+        self.get_env(env.index()).find_all_by(pred, owner)
+    }
+
+    fn envs(&self) -> &[Pin<Box<Environment>>] {
+        unsafe { self.environments.get().as_ref().unwrap() }
+    }
+
+    #[track_caller]
+    fn get_env(&self, index: usize) -> &Environment {
+        unsafe { &self.environments.get().as_ref().unwrap()[index] }
+    }
+
+    /// Mutable access to the environments. Prefer using higher-level methods if possible.
+    ///
+    /// Uses a spin lock to wait for write access, so `f` must not be even slightly long-running.
+    fn with_envs<T>(&self, f: impl FnOnce(&mut Vec<Pin<Box<Environment>>>) -> T) -> T {
+        // Spin lock
+        while self.write_lock.swap(true, Ordering::AcqRel) {
+            // Atomics wrap on overflow, so no chance of panicking here.
+            self.stats.lock_waits.fetch_add(1, Ordering::Relaxed);
+            std::hint::spin_loop();
+        }
+
+        let envs = unsafe { self.environments.get().as_mut().unwrap() };
+        let result = f(envs);
+
+        let locked = self.write_lock.fetch_not(Ordering::AcqRel);
+        assert!(locked);
+
+        result
+    }
+
+    /// Create a new environment, add it to the list of envs, and return it's ref.
+    fn new_env(&self, parent: Option<EnvironmentRef>, is_root_env: bool, owner: usize) -> EnvironmentRef {
+        assert!(owner > 0);
+        self.stats.env_count.fetch_add(1, Ordering::Relaxed);
+
+        let new_env = Environment::new(parent, is_root_env, owner);
+        self.with_envs(|envs| {
+            let result = EnvironmentRef(envs.len(), SnapshotRef::none());
+            // Note this might reallocate, which would hold the `with_envs` spin lock for way too long
+            // so somehow we should make sure we don't do that (though honestly the chance of that
+            // happening while another thread is waiting for the lock is pretty small).
+            envs.push(Box::pin(new_env));
+            result
+        })
+    }
+
+    /// Handle tidying up an env when it has been popped from the call stack.
+    ///
+    /// If the env must be preserved, it is. If not, then it will be removed or compacted.
+    fn pop_env(&self, old: EnvironmentRef, owner: usize) {
+        // If the env can't be referenced delete all it's bindings.
+        self.get_env(old.index()).compact(owner);
+
+        if self.get_env(old.index()).is_empty() {
+            self.with_envs(|envs| {
+                if old.index() == envs.len() - 1 {
+                    // We can pop the env from the vec.
+                    self.stats.env_gcs.fetch_add(1, Ordering::Relaxed);
+                    envs.pop();
+                } else {
+                    // The env is empty, but we can't pop it. Just leave it around (it can't be
+                    // referenced).
+                    self.stats.skipped_env_gcs.fetch_add(1, Ordering::Relaxed);
+                    envs[old.index()].read_only();
+                }
+            });
+        } else {
+            // Env is non-empty, so preserve it.
+            self.stats.preserved_envs.fetch_add(1, Ordering::Relaxed);
+            self.get_env(old.index()).read_only();
+        }
+    }
+
+    fn take_env(&self, old: EnvironmentRef) -> Pin<Box<Environment>> {
+        self.with_envs(|envs| {
+            if old.index() == envs.len() - 1 {
+                // We can pop the env from the vec.
+                self.stats.env_gcs.fetch_add(1, Ordering::Relaxed);
+                envs.pop().unwrap()
+            } else {
+                // We can't pop because the env is not at the end of the vec and we must maintain
+                // the indices. Replace the env with an empty one. It can no longer be referenced
+                // so we don't care about it.
+                self.stats.skipped_env_gcs.fetch_add(1, Ordering::Relaxed);
+                std::mem::replace(&mut envs[old.index()], Box::pin(Environment::new(None, false, 0)))
+            }
+        })
+    }
+
+    #[cfg(test)]
+    fn update_with_env(&self, key: &str, value: KclValue, env: usize, owner: usize) {
+        self.stats.mutation_count.fetch_add(1, Ordering::Relaxed);
+        self.get_env(env).insert_or_update(key.to_owned(), value, owner);
+    }
+
+    /// Get a value from memory without checking for ownership of the env.
+    ///
+    /// This is not safe to use in general and should only be used if you have unique access to
+    /// the `self` which is generally only true during testing.
+    #[cfg(test)]
+    pub fn get_from_unchecked(
+        &self,
+        var: &str,
+        mut env_ref: EnvironmentRef,
+        source_range: SourceRange,
+    ) -> Result<&KclValue, KclError> {
+        loop {
+            let env = self.get_env(env_ref.index());
+            env_ref = match env.get_unchecked(var, env_ref.1) {
+                Ok(item) => return Ok(item),
+                Err(Some(parent)) => parent,
+                Err(None) => break,
+            };
+        }
+
+        Err(KclError::UndefinedValue(KclErrorDetails {
+            message: format!("memory item key `{}` is not defined", var),
+            source_ranges: vec![source_range],
+        }))
+    }
+}
+
+impl Stack {
+    /// Clone this `Stack` and the underlying `ProgramMemory`.
+    ///
+    /// This is a long-running operation and holds the write lock, which is bad. Callers must ensure
+    /// that no other task will need to use the `ProgramMemory` while this runs.
+    pub fn deep_clone(&self) -> Stack {
+        let mem = self.memory.deep_clone();
+        let mut stack = self.clone();
+        stack.memory = Arc::new(mem);
+        stack
+    }
+
     #[cfg(test)]
     /// If you're using ProgramMemory directly for testing it must be initialized first.
-    pub fn init_for_tests(&mut self) {
-        self.push_new_root_env(false);
-        self.std = Some(self.current_env);
+    pub fn new_for_tests() -> Stack {
+        let mut stack = ProgramMemory::new().new_stack();
+        stack.push_new_root_env(false);
+        stack.memory.set_std(stack.current_env);
+        stack
     }
 
     /// Push a new (standard KCL) stack frame on to the call stack.
@@ -227,21 +547,15 @@ impl ProgramMemory {
     /// `parent` is the environment where the function being called is declared (not the caller's
     /// environment, which is probably `self.current_env`).
     pub fn push_new_env_for_call(&mut self, parent: EnvironmentRef) {
-        assert!(parent.1 .0 < usize::MAX);
-        self.stats.env_count += 1;
-
+        let env_ref = self.memory.new_env(Some(parent), false, self.id);
         self.call_stack.push(self.current_env);
-        let new_env = Environment::new(parent, false);
-        self.current_env = EnvironmentRef(self.environments.len(), SnapshotRef::none());
-        self.environments.push(new_env);
+        self.current_env = env_ref;
     }
 
     /// Push a stack frame for an inline scope.
     ///
     /// This should be used for blocks but is currently only used for mock execution.
     pub fn push_new_env_for_scope(&mut self) {
-        self.stats.env_count += 1;
-
         // We want to use the current env as the parent.
         // We need to snapshot in case there is a function decl in the new scope.
         let snapshot = self.snapshot();
@@ -267,24 +581,22 @@ impl ProgramMemory {
     /// Push a new stack frame on to the call stack with no connection to a parent environment.
     ///
     /// Suitable for executing a separate module.
-    /// Precondition: include_prelude -> !self.requires_std()
+    /// Precondition: include_prelude -> !self.memory.requires_std()
     pub fn push_new_root_env(&mut self, include_prelude: bool) {
-        self.stats.env_count += 1;
-
+        let parent = include_prelude.then(|| self.memory.std.unwrap());
+        let env_ref = self.memory.new_env(parent, true, self.id);
         self.call_stack.push(self.current_env);
-        let new_env = if include_prelude {
-            Environment::new(self.std.unwrap(), true)
-        } else {
-            Environment::new_no_prelude()
-        };
-        self.current_env = EnvironmentRef(self.environments.len(), SnapshotRef::none());
-        self.environments.push(new_env);
+        self.current_env = env_ref;
     }
 
     /// Push a previously used environment on to the call stack.
+    ///
+    /// SAFETY: the env must not be being used by another `Stack` since we'll move the env from
+    /// read-only to owned.
     pub fn restore_env(&mut self, env: EnvironmentRef) {
         assert!(env.1.is_none());
         self.call_stack.push(self.current_env);
+        self.memory.get_env(env.index()).restore_owner(self.id);
         self.current_env = env;
     }
 
@@ -298,18 +610,7 @@ impl ProgramMemory {
         self.current_env = self.call_stack.pop().unwrap();
 
         if !old.skip_env() {
-            self.environments[old.index()].compact();
-
-            if self.environments[old.index()].is_empty() {
-                if old.index() == self.environments.len() - 1 {
-                    self.environments.pop();
-                    self.stats.env_gcs += 1;
-                } else {
-                    self.stats.skipped_env_gcs += 1;
-                }
-            } else {
-                self.stats.preserved_envs += 1;
-            }
+            self.memory.pop_env(old, self.id);
         }
 
         old
@@ -320,29 +621,25 @@ impl ProgramMemory {
     pub fn pop_and_preserve_env(&mut self) -> EnvironmentRef {
         let old = self.current_env;
         self.current_env = self.call_stack.pop().unwrap();
+        if !old.skip_env() {
+            self.memory.get_env(old.index()).read_only();
+        }
         old
     }
 
     /// Merges the specified environment with the current environment, rewriting any environment refs
     /// taking snapshots into account. Deletes (if possible) or clears the squashed environment.
+    ///
+    /// Precondition: the caller must have unique access to the env pointed to by `old` and there must be
+    /// no extant references to it. If violated there may be dangling references to the old env once
+    /// it is removed from storage.
     pub fn squash_env(&mut self, old: EnvironmentRef) {
         assert!(!old.skip_env());
         if self.current_env.skip_env() {
             return;
         }
 
-        let mut old_env = if old.index() == self.environments.len() - 1 {
-            // Common case and efficient
-            self.stats.env_gcs += 1;
-            self.environments.pop().unwrap()
-        } else {
-            // Should basically never happen in normal usage.
-            self.stats.skipped_env_gcs += 1;
-            std::mem::replace(
-                &mut self.environments[old.index()],
-                Environment::new(self.current_env, false),
-            )
-        };
+        let mut old_env = self.memory.take_env(old);
 
         // Map of any old env refs to the current env.
         let snapshot_map: HashMap<_, _> = old_env
@@ -351,58 +648,55 @@ impl ProgramMemory {
             .collect();
 
         // Move the variables in the popped env into the current env.
-        for (k, v) in old_env.take_bindings() {
-            self.environments[self.current_env.index()].insert_or_update(k.clone(), v.map_env_ref(&snapshot_map));
+        let env = self.memory.get_env(self.current_env.index());
+        for (k, v) in old_env.as_mut().take_bindings() {
+            env.insert_or_update(k.clone(), v.map_env_ref(&snapshot_map), self.id);
         }
     }
 
     /// Snapshot the current state of the memory.
     pub fn snapshot(&mut self) -> EnvironmentRef {
-        self.stats.snapshot_count += 1;
-        let snapshot = env::snapshot(self, self.current_env);
+        self.memory.stats.snapshot_count.fetch_add(1, Ordering::Relaxed);
+        let snapshot = env::snapshot(&self.memory, self.current_env, self.id);
         EnvironmentRef(self.current_env.0, snapshot)
     }
 
     /// Add a value to the program memory (in the current scope). The value must not already exist.
     pub fn add(&mut self, key: String, value: KclValue, source_range: SourceRange) -> Result<(), KclError> {
-        if self.environments[self.current_env.index()].contains_key(&key) {
+        let env = self.memory.get_env(self.current_env.index());
+        if env.contains_key(&key) {
             return Err(KclError::ValueAlreadyDefined(KclErrorDetails {
                 message: format!("Cannot redefine `{}`", key),
                 source_ranges: vec![source_range],
             }));
         }
 
-        self.stats.mutation_count += 1;
+        self.memory.stats.mutation_count.fetch_add(1, Ordering::Relaxed);
 
-        self.environments[self.current_env.index()].insert(key, value);
+        env.insert(key, value, self.id);
 
         Ok(())
     }
 
     pub fn insert_or_update(&mut self, key: String, value: KclValue) {
-        self.stats.mutation_count += 1;
-        self.environments[self.current_env.index()].insert_or_update(key, value);
+        self.memory.stats.mutation_count.fetch_add(1, Ordering::Relaxed);
+        self.memory
+            .get_env(self.current_env.index())
+            .insert_or_update(key, value, self.id);
     }
 
     /// Delete an item from memory.
     ///
     /// Item will be preserved in any snapshots.
     pub fn clear(&mut self, key: String) {
-        self.stats.mutation_count += 1;
-        self.environments[self.current_env.index()].clear(key);
-    }
-
-    #[cfg(test)]
-    fn update_with_env(&mut self, key: &str, value: KclValue, env: Option<usize>) {
-        self.stats.mutation_count += 1;
-        let env = env.unwrap_or(self.current_env.index());
-        self.environments[env].insert_or_update(key.to_owned(), value);
+        self.memory.stats.mutation_count.fetch_add(1, Ordering::Relaxed);
+        self.memory.get_env(self.current_env.index()).clear(key, self.id);
     }
 
     /// Get a value from the program memory.
     /// Return Err if not found.
     pub fn get(&self, var: &str, source_range: SourceRange) -> Result<&KclValue, KclError> {
-        self.get_from(var, self.current_env, source_range)
+        self.memory.get_from(var, self.current_env, source_range, self.id)
     }
 
     /// Get a key from the first KCL (i.e., non-Rust) stack frame on the call stack.
@@ -413,33 +707,11 @@ impl ProgramMemory {
 
         for env in self.call_stack.iter().rev() {
             if !env.skip_env() {
-                return self.get_from(key, *env, source_range);
+                return self.memory.get_from(key, *env, source_range, self.id);
             }
         }
 
         unreachable!("It can't be Rust frames all the way down");
-    }
-
-    /// Get a value from a specific snapshot of the memory.
-    pub fn get_from(
-        &self,
-        var: &str,
-        mut env_ref: EnvironmentRef,
-        source_range: SourceRange,
-    ) -> Result<&KclValue, KclError> {
-        loop {
-            let env = &self.environments[env_ref.index()];
-            env_ref = match env.get(var, env_ref.1) {
-                Ok(item) => return Ok(item),
-                Err(Some(parent)) => parent,
-                Err(None) => break,
-            };
-        }
-
-        Err(KclError::UndefinedValue(KclErrorDetails {
-            message: format!("memory item key `{}` is not defined", var),
-            source_ranges: vec![source_range],
-        }))
     }
 
     /// Iterate over all key/value pairs in the current environment which satisfy the provided
@@ -448,18 +720,17 @@ impl ProgramMemory {
         &'a self,
         pred: impl Fn(&KclValue) -> bool + 'a,
     ) -> impl Iterator<Item = (&'a String, &'a KclValue)> {
-        self.find_all_in_env(self.current_env, pred)
+        self.memory.find_all_in_env(self.current_env, pred, self.id)
     }
 
     /// Iterate over all key/value pairs in the specified environment which satisfy the provided
-    /// predicate.
+    /// predicate. `env` must either be read-only or owned by `self`.
     pub fn find_all_in_env<'a>(
         &'a self,
         env: EnvironmentRef,
         pred: impl Fn(&KclValue) -> bool + 'a,
     ) -> impl Iterator<Item = (&'a String, &'a KclValue)> {
-        assert!(!env.skip_env());
-        self.environments[env.index()].find_all_by(pred)
+        self.memory.find_all_in_env(env, pred, self.id)
     }
 
     /// Walk all values accessible from any environment in the call stack.
@@ -478,7 +749,7 @@ impl ProgramMemory {
             cur_env,
             cur_values: None,
             stack_index,
-            mem: self,
+            stack: self,
         };
         result.init_iter();
         result
@@ -487,7 +758,7 @@ impl ProgramMemory {
 
 // See walk_call_stack.
 struct CallStackIterator<'a> {
-    mem: &'a ProgramMemory,
+    stack: &'a Stack,
     cur_env: EnvironmentRef,
     cur_values: Option<Box<dyn Iterator<Item = &'a KclValue> + 'a>>,
     stack_index: usize,
@@ -495,7 +766,7 @@ struct CallStackIterator<'a> {
 
 impl CallStackIterator<'_> {
     fn init_iter(&mut self) {
-        self.cur_values = Some(self.mem.environments[self.cur_env.index()].values(self.cur_env.1));
+        self.cur_values = Some(self.stack.memory.get_env(self.cur_env.index()).values(self.cur_env.1));
     }
 }
 
@@ -516,7 +787,7 @@ impl<'a> Iterator for CallStackIterator<'a> {
                     return next;
                 }
 
-                if let Some(env_ref) = self.mem.environments[self.cur_env.index()].parent(self.cur_env.1) {
+                if let Some(env_ref) = self.stack.memory.get_env(self.cur_env.index()).parent(self.cur_env.1) {
                     self.cur_env = env_ref;
                     self.init_iter();
                 } else {
@@ -528,7 +799,7 @@ impl<'a> Iterator for CallStackIterator<'a> {
                 // Loop to skip any non-KCL stack frames.
                 loop {
                     self.stack_index -= 1;
-                    let env_ref = self.mem.call_stack[self.stack_index];
+                    let env_ref = self.stack.call_stack[self.stack_index];
 
                     if !env_ref.skip_env() {
                         self.cur_env = env_ref;
@@ -549,9 +820,11 @@ impl<'a> Iterator for CallStackIterator<'a> {
 }
 
 #[cfg(test)]
-impl PartialEq for ProgramMemory {
+impl PartialEq for Stack {
     fn eq(&self, other: &Self) -> bool {
-        self.environments == other.environments && self.current_env == other.current_env
+        let vars: Vec<_> = self.find_all_in_current_env(|_| true).collect();
+        let vars_other: Vec<_> = other.find_all_in_current_env(|_| true).collect();
+        vars == vars_other
     }
 }
 
@@ -562,6 +835,10 @@ pub struct EnvironmentRef(usize, SnapshotRef);
 impl EnvironmentRef {
     fn dummy() -> Self {
         Self(usize::MAX, SnapshotRef(usize::MAX))
+    }
+
+    fn is_regular(&self) -> bool {
+        self.0 < usize::MAX && self.1 .0 < usize::MAX
     }
 
     fn index(&self) -> usize {
@@ -601,35 +878,59 @@ impl SnapshotRef {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+// TODO keep per-stack stats to avoid so many atomic updates
+#[derive(Debug, Default)]
 pub(crate) struct MemoryStats {
     // Total number of environments created.
-    env_count: usize,
+    env_count: AtomicUsize,
     // Total number of snapshots created.
-    snapshot_count: usize,
+    snapshot_count: AtomicUsize,
     // Total number of values inserted or updated.
-    mutation_count: usize,
+    mutation_count: AtomicUsize,
     // The number of envs we delete when popped from the call stack.
-    env_gcs: usize,
+    env_gcs: AtomicUsize,
     // The number of empty envs we can't delete when popped from the call stack.
-    skipped_env_gcs: usize,
+    skipped_env_gcs: AtomicUsize,
     // The number of envs we can't delete when popped from the call stack because they may be referenced.
-    preserved_envs: usize,
+    preserved_envs: AtomicUsize,
+    // The number of iterations waiting for a spin lock.
+    lock_waits: AtomicUsize,
 }
 
 // Use a sub-module to protect access to `Environment::bindings` and prevent unexpected mutatation
 // of stored values.
 mod env {
+    use std::marker::PhantomPinned;
+
     use super::*;
 
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug)]
     pub(super) struct Environment {
-        bindings: IndexMap<String, KclValue>,
+        bindings: UnsafeCell<IndexMap<String, KclValue>>,
         // invariant: self.parent.is_none() => forall s in self.snapshots: s.parent_snapshot.is_none()
-        snapshots: Vec<Snapshot>,
+        snapshots: UnsafeCell<Vec<Snapshot>>,
         // An outer scope, if one exists.
         parent: Option<EnvironmentRef>,
         is_root_env: bool,
+        // The id of the `Stack` if this `Environment` is on a call stack. If this is >0 then it may
+        // only be read or written by that `Stack`; if 0 then the env is read-only.
+        owner: AtomicUsize,
+        // Ensure Environment: !Unpin
+        _unpin: PhantomPinned,
+    }
+
+    impl Clone for Environment {
+        fn clone(&self) -> Self {
+            assert!(self.owner.load(Ordering::Acquire) == 0);
+            Self {
+                bindings: UnsafeCell::new(self.get_bindings().clone()),
+                snapshots: UnsafeCell::new(self.iter_snapshots().cloned().collect()),
+                parent: self.parent,
+                is_root_env: self.is_root_env,
+                owner: AtomicUsize::new(0),
+                _unpin: PhantomPinned,
+            }
+        }
     }
 
     impl fmt::Display for Environment {
@@ -639,14 +940,16 @@ mod env {
                 .map(|e| format!("EnvRef({}, {})", e.0, e.1 .0))
                 .unwrap_or("_".to_owned());
             let data: Vec<String> = self
-                .bindings
+                .get_bindings()
                 .iter()
                 .map(|(k, v)| format!("{k}: {}", v.human_friendly_type()))
                 .collect();
-            let snapshots: Vec<String> = self.snapshots.iter().map(|s| s.to_string()).collect();
+            let snapshots: Vec<String> = self.iter_snapshots().map(|s| s.to_string()).collect();
             write!(
                 f,
-                "Env {{\n  parent: {parent},\n  bindings:\n    {},\n  snapshots:\n    {}\n}}",
+                "Env {{\n  parent: {parent},\n  owner: {},\n  is root: {},\n  bindings:\n    {},\n  snapshots:\n    {}\n}}",
+                self.owner.load(Ordering::Relaxed),
+                self.is_root_env,
                 data.join("\n    "),
                 snapshots.join("\n    ")
             )
@@ -680,29 +983,80 @@ mod env {
     impl Environment {
         /// Create a new environment, parent points to it's surrounding lexical scope or the std
         /// env if it's a root scope.
-        pub(super) fn new(parent: EnvironmentRef, is_root_env: bool) -> Self {
-            assert!(!parent.skip_env());
+        pub(super) fn new(parent: Option<EnvironmentRef>, is_root_env: bool, owner: usize) -> Self {
+            assert!(parent.map(|p| p.is_regular()).unwrap_or(true));
             Self {
-                bindings: IndexMap::new(),
-                snapshots: Vec::new(),
-                parent: Some(parent),
+                bindings: UnsafeCell::new(IndexMap::new()),
+                snapshots: UnsafeCell::new(Vec::new()),
+                parent,
                 is_root_env,
+                owner: AtomicUsize::new(owner),
+                _unpin: PhantomPinned,
             }
         }
 
-        /// Create a new root environment with no prelude as parent.
-        pub(super) fn new_no_prelude() -> Self {
-            Self {
-                bindings: IndexMap::new(),
-                snapshots: Vec::new(),
-                parent: None,
-                is_root_env: true,
-            }
+        // Mark this env as read-only (see module docs).
+        pub(super) fn read_only(&self) {
+            self.owner.store(0, Ordering::Release);
+        }
+
+        // Mark this env as owned (see module docs).
+        pub(super) fn restore_owner(&self, owner: usize) {
+            self.owner.store(owner, Ordering::Release);
+        }
+
+        // SAFETY: either the owner of the env is on the Rust stack or the env is read-only.
+        fn snapshots_len(&self) -> usize {
+            unsafe { self.snapshots.get().as_ref().unwrap().len() }
+        }
+
+        // SAFETY: either the owner of the env is on the Rust stack or the env is read-only.
+        fn get_shapshot(&self, index: usize) -> &Snapshot {
+            unsafe { &self.snapshots.get().as_ref().unwrap()[index] }
+        }
+
+        // SAFETY: either the owner of the env is on the Rust stack or the env is read-only.
+        fn iter_snapshots(&self) -> impl Iterator<Item = &Snapshot> {
+            unsafe { self.snapshots.get().as_ref().unwrap().iter() }
+        }
+
+        fn cur_snapshot(&self, owner: usize) -> Option<&mut Snapshot> {
+            assert!(owner > 0 && self.owner.load(Ordering::Acquire) == owner);
+            unsafe { self.snapshots.get().as_mut().unwrap().last_mut() }
+        }
+
+        // SAFETY: either the owner of the env is on the Rust stack or the env is read-only.
+        fn get_bindings(&self) -> &IndexMap<String, KclValue> {
+            unsafe { self.bindings.get().as_ref().unwrap() }
+        }
+
+        // SAFETY do not call this function while a previous mutable reference is live
+        #[allow(clippy::mut_from_ref)]
+        fn get_mut_bindings(&self, owner: usize) -> &mut IndexMap<String, KclValue> {
+            assert!(owner > 0 && self.owner.load(Ordering::Acquire) == owner);
+            unsafe { self.bindings.get().as_mut().unwrap() }
         }
 
         // True if the env is empty and not a root env.
         pub(super) fn is_empty(&self) -> bool {
-            self.snapshots.is_empty() && self.bindings.is_empty() && !self.is_root_env
+            self.snapshots_len() == 0 && self.get_bindings().is_empty() && !self.is_root_env
+        }
+
+        fn push_snapshot(&self, parent: Option<SnapshotRef>, owner: usize) -> SnapshotRef {
+            let env_owner = self.owner.load(Ordering::Acquire);
+            // The env is read-only, no need to snapshot.
+            if env_owner == 0 {
+                return SnapshotRef::none();
+            }
+            assert!(
+                owner > 0 && env_owner == owner,
+                "mutating owner: {owner}, env: {self}({env_owner})"
+            );
+            unsafe {
+                let snapshots = self.snapshots.get().as_mut().unwrap();
+                snapshots.push(Snapshot::new(parent));
+                SnapshotRef(snapshots.len())
+            }
         }
 
         /// Possibly compress this environment by deleting the memory.
@@ -712,19 +1066,36 @@ mod env {
         /// in a new way it might be incorrect).
         ///
         /// See module docs for more details.
-        pub(super) fn compact(&mut self) {
+        pub(super) fn compact(&self, owner: usize) {
             // Don't compress if there might be a closure or import referencing us.
-            if !self.snapshots.is_empty() || self.is_root_env {
+            if self.snapshots_len() != 0 || self.is_root_env {
                 return;
             }
 
-            self.bindings = IndexMap::new();
+            *self.get_mut_bindings(owner) = IndexMap::new();
         }
 
-        pub(super) fn get(&self, key: &str, snapshot: SnapshotRef) -> Result<&KclValue, Option<EnvironmentRef>> {
+        pub(super) fn get(
+            &self,
+            key: &str,
+            snapshot: SnapshotRef,
+            owner: usize,
+        ) -> Result<&KclValue, Option<EnvironmentRef>> {
+            let env_owner = self.owner.load(Ordering::Acquire);
+            assert!(env_owner == 0 || env_owner == owner);
+
+            self.get_unchecked(key, snapshot)
+        }
+
+        /// Get a value from memory without checking the env's ownership invariant. Prefer to use `get`.
+        pub(super) fn get_unchecked(
+            &self,
+            key: &str,
+            snapshot: SnapshotRef,
+        ) -> Result<&KclValue, Option<EnvironmentRef>> {
             if snapshot.is_some() {
-                for i in snapshot.index()..self.snapshots.len() {
-                    match self.snapshots[i].data.get(key) {
+                for i in snapshot.index()..self.snapshots_len() {
+                    match self.get_shapshot(i).data.get(key) {
                         Some(KclValue::Tombstone { .. }) => return Err(self.parent(snapshot)),
                         Some(v) => return Ok(v),
                         None => {}
@@ -732,7 +1103,7 @@ mod env {
                 }
             }
 
-            self.bindings
+            self.get_bindings()
                 .get(key)
                 .and_then(|v| match v {
                     KclValue::Tombstone { .. } => None,
@@ -747,7 +1118,7 @@ mod env {
                 return self.parent;
             }
 
-            match self.snapshots[snapshot.index()].parent_snapshot {
+            match self.get_shapshot(snapshot.index()).parent_snapshot {
                 Some(sr) => Some(EnvironmentRef(self.parent.unwrap().0, sr)),
                 None => self.parent,
             }
@@ -756,19 +1127,18 @@ mod env {
         /// Iterate over all values in the environment at the specified snapshot.
         pub(super) fn values<'a>(&'a self, snapshot: SnapshotRef) -> Box<dyn Iterator<Item = &'a KclValue> + 'a> {
             if snapshot.is_none() {
-                return Box::new(self.bindings.values());
+                return Box::new(self.get_bindings().values());
             }
 
             Box::new(
-                self.bindings
+                self.get_bindings()
                     .iter()
                     .filter_map(move |(k, v)| {
                         (!self.snapshot_contains_key(k, snapshot) && !matches!(v, KclValue::Tombstone { .. }))
                             .then_some(v)
                     })
                     .chain(
-                        self.snapshots
-                            .iter()
+                        self.iter_snapshots()
                             .flat_map(|s| s.data.values().filter(|v| !matches!(v, KclValue::Tombstone { .. }))),
                     ),
             )
@@ -777,32 +1147,32 @@ mod env {
         /// Pure insert, panics if `key` is already in this environment.
         ///
         /// Precondition: !self.contains_key(key)
-        pub(super) fn insert(&mut self, key: String, value: KclValue) {
-            debug_assert!(!self.bindings.contains_key(&key));
-            if let Some(s) = self.snapshots.last_mut() {
+        pub(super) fn insert(&self, key: String, value: KclValue, owner: usize) {
+            debug_assert!(!self.get_bindings().contains_key(&key));
+            if let Some(s) = self.cur_snapshot(owner) {
                 s.data.insert(key.clone(), tombstone());
             }
-            self.bindings.insert(key, value);
+            self.get_mut_bindings(owner).insert(key, value);
         }
 
-        pub(super) fn insert_or_update(&mut self, key: String, value: KclValue) {
-            if let Some(s) = self.snapshots.last_mut() {
+        pub(super) fn insert_or_update(&self, key: String, value: KclValue, owner: usize) {
+            if let Some(s) = self.cur_snapshot(owner) {
                 if !s.data.contains_key(&key) {
-                    let old_value = self.bindings.get(&key).cloned().unwrap_or_else(tombstone);
+                    let old_value = self.get_bindings().get(&key).cloned().unwrap_or_else(tombstone);
                     s.data.insert(key.clone(), old_value);
                 }
             }
-            self.bindings.insert(key, value);
+            self.get_mut_bindings(owner).insert(key, value);
         }
 
         /// Delete a key/value.
         ///
         /// We want to preserve the snapshot, so we can't just remove the element. We copy the deleted
         /// value to the snapshot and replace the current value with a tombstone.
-        pub(super) fn clear(&mut self, key: String) {
-            if self.bindings.contains_key(&key) {
-                let old = self.bindings.insert(key.clone(), tombstone()).unwrap();
-                if let Some(s) = self.snapshots.last_mut() {
+        pub(super) fn clear(&self, key: String, owner: usize) {
+            if self.get_bindings().contains_key(&key) {
+                let old = self.get_mut_bindings(owner).insert(key.clone(), tombstone()).unwrap();
+                if let Some(s) = self.cur_snapshot(owner) {
                     s.data.insert(key, old);
                 }
             }
@@ -810,8 +1180,8 @@ mod env {
 
         /// Was the key contained in this environment at the specified point in time.
         fn snapshot_contains_key(&self, key: &str, snapshot: SnapshotRef) -> bool {
-            for i in snapshot.index()..self.snapshots.len() {
-                if self.snapshots[i].data.contains_key(key) {
+            for i in snapshot.index()..self.snapshots_len() {
+                if self.get_shapshot(i).data.contains_key(key) {
                     return true;
                 }
             }
@@ -820,7 +1190,7 @@ mod env {
 
         /// Is the key currently contained in this environment.
         pub(super) fn contains_key(&self, key: &str) -> bool {
-            !matches!(self.bindings.get(key), Some(KclValue::Tombstone { .. }) | None)
+            !matches!(self.get_bindings().get(key), Some(KclValue::Tombstone { .. }) | None)
         }
 
         /// Iterate over all key/value pairs currently in this environment where the value satisfies
@@ -828,15 +1198,20 @@ mod env {
         pub(super) fn find_all_by<'a>(
             &'a self,
             f: impl Fn(&KclValue) -> bool + 'a,
+            owner: usize,
         ) -> impl Iterator<Item = (&'a String, &'a KclValue)> {
-            self.bindings
+            let env_owner = self.owner.load(Ordering::Acquire);
+            assert!(env_owner == 0 || env_owner == owner);
+
+            self.get_bindings()
                 .iter()
                 .filter(move |(_, v)| f(v) && !matches!(v, KclValue::Tombstone { .. }))
         }
 
         /// Take all bindings from the environment.
-        pub(super) fn take_bindings(&mut self) -> impl Iterator<Item = (String, KclValue)> {
-            let bindings = std::mem::take(&mut self.bindings);
+        pub(super) fn take_bindings(self: Pin<&mut Self>) -> impl Iterator<Item = (String, KclValue)> {
+            // SAFETY: caller must have unique access since self is mut. We're not moving or invalidating `self`.
+            let bindings = std::mem::take(unsafe { self.bindings.get().as_mut().unwrap() });
             bindings
                 .into_iter()
                 .filter(move |(_, v)| !matches!(v, KclValue::Tombstone { .. }))
@@ -845,8 +1220,7 @@ mod env {
         /// Returns an iterator over any snapshots in this environment, returning the ref to the
         /// snapshot and its parent.
         pub(super) fn snapshot_parents(&self) -> impl Iterator<Item = (SnapshotRef, SnapshotRef)> + '_ {
-            self.snapshots
-                .iter()
+            self.iter_snapshots()
                 .enumerate()
                 .map(|(i, s)| (SnapshotRef(i + 1), s.parent_snapshot.unwrap()))
         }
@@ -864,24 +1238,22 @@ mod env {
     /// Build a new snapshot of the specified environment at the current moment.
     ///
     /// This is non-trival since we have to build the tree of parent snapshots.
-    pub(super) fn snapshot(mem: &mut ProgramMemory, env_ref: EnvironmentRef) -> SnapshotRef {
-        let env = &mem.environments[env_ref.index()];
-        let parent_snapshot = env.parent.map(|p| snapshot(mem, p));
+    pub(super) fn snapshot(mem: &ProgramMemory, env_ref: EnvironmentRef, owner: usize) -> SnapshotRef {
+        let env = mem.get_env(env_ref.index());
+        let parent_snapshot = env.parent.map(|p| snapshot(mem, p, owner));
 
-        let env = &mut mem.environments[env_ref.index()];
-        if env.snapshots.is_empty() {
-            env.snapshots.push(Snapshot::new(parent_snapshot));
-            return SnapshotRef(1);
+        let env = mem.get_env(env_ref.index());
+        if env.snapshots_len() == 0 {
+            return env.push_snapshot(parent_snapshot, owner);
         }
 
-        let prev_snapshot = env.snapshots.last().unwrap();
+        let prev_snapshot = env.cur_snapshot(owner).unwrap();
         if prev_snapshot.data.is_empty() && prev_snapshot.parent_snapshot == parent_snapshot {
             // If the prev snapshot is empty, reuse it.
-            return SnapshotRef(env.snapshots.len());
+            return SnapshotRef(env.snapshots_len());
         }
 
-        env.snapshots.push(Snapshot::new(parent_snapshot));
-        SnapshotRef(env.snapshots.len())
+        env.push_snapshot(parent_snapshot, owner)
     }
 
     fn tombstone() -> KclValue {
@@ -910,7 +1282,7 @@ mod test {
     }
 
     #[track_caller]
-    fn assert_get(mem: &ProgramMemory, key: &str, n: i64) {
+    fn assert_get(mem: &Stack, key: &str, n: i64) {
         match mem.get(key, sr()).unwrap() {
             KclValue::Number { value, .. } => assert_eq!(*value as i64, n),
             _ => unreachable!(),
@@ -925,8 +1297,8 @@ mod test {
     }
 
     #[track_caller]
-    fn assert_get_from(mem: &ProgramMemory, key: &str, n: i64, snapshot: EnvironmentRef) {
-        match mem.get_from(key, snapshot, sr()).unwrap() {
+    fn assert_get_from(mem: &Stack, key: &str, n: i64, snapshot: EnvironmentRef) {
+        match mem.memory.get_from_unchecked(key, snapshot, sr()).unwrap() {
             KclValue::Number { value, .. } => assert_eq!(*value as i64, n),
             _ => unreachable!(),
         }
@@ -936,8 +1308,7 @@ mod test {
     fn mem_smoke() {
         // Follows test_pattern_transform_function_cannot_access_future_definitions
 
-        let mem = &mut ProgramMemory::new();
-        mem.init_for_tests();
+        let mem = &mut Stack::new_for_tests();
         let transform = mem.snapshot();
         mem.add("transform".to_owned(), val(1), sr()).unwrap();
         let layer = mem.snapshot();
@@ -954,8 +1325,7 @@ mod test {
 
     #[test]
     fn simple_snapshot() {
-        let mem = &mut ProgramMemory::new();
-        mem.init_for_tests();
+        let mem = &mut Stack::new_for_tests();
         mem.add("a".to_owned(), val(1), sr()).unwrap();
         assert_get(mem, "a", 1);
         mem.add("a".to_owned(), val(2), sr()).unwrap_err();
@@ -967,13 +1337,12 @@ mod test {
         assert_get(mem, "a", 1);
         mem.add("b".to_owned(), val(3), sr()).unwrap();
         assert_get(mem, "b", 3);
-        mem.get_from("b", sn, sr()).unwrap_err();
+        mem.memory.get_from_unchecked("b", sn, sr()).unwrap_err();
     }
 
     #[test]
     fn multiple_snapshot() {
-        let mem = &mut ProgramMemory::new();
-        mem.init_for_tests();
+        let mem = &mut Stack::new_for_tests();
         mem.add("a".to_owned(), val(1), sr()).unwrap();
 
         let sn1 = mem.snapshot();
@@ -987,17 +1356,16 @@ mod test {
         assert_get(mem, "b", 3);
         assert_get(mem, "c", 6);
         assert_get_from(mem, "a", 1, sn1);
-        mem.get_from("b", sn1, sr()).unwrap_err();
-        mem.get_from("c", sn1, sr()).unwrap_err();
+        mem.memory.get_from_unchecked("b", sn1, sr()).unwrap_err();
+        mem.memory.get_from_unchecked("c", sn1, sr()).unwrap_err();
         assert_get_from(mem, "a", 1, sn2);
         assert_get_from(mem, "b", 3, sn2);
-        mem.get_from("c", sn2, sr()).unwrap_err();
+        mem.memory.get_from_unchecked("c", sn2, sr()).unwrap_err();
     }
 
     #[test]
     fn simple_call_env() {
-        let mem = &mut ProgramMemory::new();
-        mem.init_for_tests();
+        let mem = &mut Stack::new_for_tests();
         mem.add("a".to_owned(), val(1), sr()).unwrap();
         mem.add("b".to_owned(), val(3), sr()).unwrap();
 
@@ -1021,8 +1389,7 @@ mod test {
 
     #[test]
     fn multiple_call_env() {
-        let mem = &mut ProgramMemory::new();
-        mem.init_for_tests();
+        let mem = &mut Stack::new_for_tests();
         mem.add("a".to_owned(), val(1), sr()).unwrap();
         mem.add("b".to_owned(), val(3), sr()).unwrap();
 
@@ -1046,8 +1413,7 @@ mod test {
 
     #[test]
     fn root_env() {
-        let mem = &mut ProgramMemory::new();
-        mem.init_for_tests();
+        let mem = &mut Stack::new_for_tests();
         mem.add("a".to_owned(), val(1), sr()).unwrap();
         mem.add("b".to_owned(), val(3), sr()).unwrap();
 
@@ -1069,8 +1435,7 @@ mod test {
 
     #[test]
     fn rust_env() {
-        let mem = &mut ProgramMemory::new();
-        mem.init_for_tests();
+        let mem = &mut Stack::new_for_tests();
         mem.add("a".to_owned(), val(1), sr()).unwrap();
         mem.add("b".to_owned(), val(3), sr()).unwrap();
         let sn = mem.snapshot();
@@ -1088,8 +1453,7 @@ mod test {
 
     #[test]
     fn deep_call_env() {
-        let mem = &mut ProgramMemory::new();
-        mem.init_for_tests();
+        let mem = &mut Stack::new_for_tests();
         mem.add("a".to_owned(), val(1), sr()).unwrap();
         mem.add("b".to_owned(), val(3), sr()).unwrap();
 
@@ -1121,8 +1485,7 @@ mod test {
 
     #[test]
     fn snap_env() {
-        let mem = &mut ProgramMemory::new();
-        mem.init_for_tests();
+        let mem = &mut Stack::new_for_tests();
         mem.add("a".to_owned(), val(1), sr()).unwrap();
 
         let sn = mem.snapshot();
@@ -1137,13 +1500,12 @@ mod test {
 
         mem.pop_env();
         // old snapshot still untouched
-        mem.get_from("b", sn, sr()).unwrap_err();
+        mem.memory.get_from_unchecked("b", sn, sr()).unwrap_err();
     }
 
     #[test]
     fn snap_env2() {
-        let mem = &mut ProgramMemory::new();
-        mem.init_for_tests();
+        let mem = &mut Stack::new_for_tests();
         mem.add("a".to_owned(), val(1), sr()).unwrap();
 
         let sn1 = mem.snapshot();
@@ -1160,17 +1522,16 @@ mod test {
 
         mem.pop_env();
         // old snapshots still untouched
-        mem.get_from("b", sn1, sr()).unwrap_err();
+        mem.memory.get_from_unchecked("b", sn1, sr()).unwrap_err();
         assert_get_from(mem, "b", 3, sn2);
-        mem.get_from("c", sn2, sr()).unwrap_err();
+        mem.memory.get_from_unchecked("c", sn2, sr()).unwrap_err();
         assert_get_from(mem, "b", 4, sn3);
-        mem.get_from("c", sn3, sr()).unwrap_err();
+        mem.memory.get_from_unchecked("c", sn3, sr()).unwrap_err();
     }
 
     #[test]
     fn snap_env_two_updates() {
-        let mem = &mut ProgramMemory::new();
-        mem.init_for_tests();
+        let mem = &mut Stack::new_for_tests();
         mem.add("a".to_owned(), val(1), sr()).unwrap();
 
         let sn1 = mem.snapshot();
@@ -1182,8 +1543,8 @@ mod test {
         let sn3 = mem.snapshot();
         mem.add("b".to_owned(), val(4), sr()).unwrap();
         let sn4 = mem.snapshot();
-        mem.update_with_env("b", val(6), None);
-        mem.update_with_env("b", val(7), Some(callee_env));
+        mem.insert_or_update("b".to_owned(), val(6));
+        mem.memory.update_with_env("b", val(7), callee_env, mem.id);
 
         assert_get(mem, "b", 6);
         assert_get_from(mem, "b", 3, sn3);
@@ -1195,14 +1556,14 @@ mod test {
 
         let popped = mem.pop_env();
         assert_get(mem, "b", 7);
-        mem.get_from("b", sn1, sr()).unwrap_err();
+        mem.memory.get_from_unchecked("b", sn1, sr()).unwrap_err();
         assert_get_from(mem, "b", 3, sn2);
 
         let vals: Vec<_> = mem.walk_call_stack().filter_map(expect_small_number).collect();
         let expected = [1, 7];
         assert_eq!(vals, expected);
 
-        let popped_env = &mem.environments[popped.index()];
+        let popped_env = mem.memory.get_env(popped.index());
         let sp: Vec<_> = popped_env.snapshot_parents().collect();
         assert_eq!(
             sp,
@@ -1212,8 +1573,7 @@ mod test {
 
     #[test]
     fn snap_env_clear() {
-        let mem = &mut ProgramMemory::new();
-        mem.init_for_tests();
+        let mem = &mut Stack::new_for_tests();
         mem.add("a".to_owned(), val(1), sr()).unwrap();
 
         mem.add("b".to_owned(), val(3), sr()).unwrap();
@@ -1236,8 +1596,7 @@ mod test {
 
     #[test]
     fn snap_env_clear2() {
-        let mem = &mut ProgramMemory::new();
-        mem.init_for_tests();
+        let mem = &mut Stack::new_for_tests();
         mem.add("a".to_owned(), val(1), sr()).unwrap();
         mem.add("b".to_owned(), val(3), sr()).unwrap();
         let sn1 = mem.snapshot();
@@ -1261,14 +1620,15 @@ mod test {
 
         assert_get_from(mem, "a", 1, sn1);
         assert_get_from(mem, "b", 3, sn1);
-        mem.get_from("a", sn2, SourceRange::default()).unwrap_err();
+        mem.memory
+            .get_from_unchecked("a", sn2, SourceRange::default())
+            .unwrap_err();
         assert_get_from(mem, "b", 4, sn2);
     }
 
     #[test]
     fn squash_env() {
-        let mem = &mut ProgramMemory::new();
-        mem.init_for_tests();
+        let mem = &mut Stack::new_for_tests();
         mem.add("a".to_owned(), val(1), sr()).unwrap();
         let sn1 = mem.snapshot();
         mem.push_new_env_for_call(sn1);
@@ -1297,7 +1657,54 @@ mod test {
             } if memory == &sn1 => {}
             v => panic!("{v:#?}"),
         }
-        assert_eq!(mem.environments.len(), 1);
+        assert_eq!(mem.memory.envs().len(), 1);
         assert_eq!(mem.current_env, EnvironmentRef(0, SnapshotRef(0)));
+    }
+
+    #[test]
+    fn two_stacks() {
+        let stack1 = &mut Stack::new_for_tests();
+        let stack2 = &mut stack1.memory.clone().new_stack();
+        stack2.push_new_root_env(false);
+
+        stack1.add("a".to_owned(), val(1), sr()).unwrap();
+        stack1.push_new_env_for_call(stack1.current_env);
+
+        stack2.add("a".to_owned(), val(2), sr()).unwrap();
+        stack2.push_new_env_for_call(stack2.current_env);
+
+        stack2.add("a".to_owned(), val(4), sr()).unwrap();
+        stack2.push_new_env_for_call(stack2.current_env);
+
+        stack1.add("a".to_owned(), val(3), sr()).unwrap();
+        stack1.push_new_env_for_call(stack1.current_env);
+
+        stack1.add("a".to_owned(), val(5), sr()).unwrap();
+        stack1.push_new_env_for_call(stack1.current_env);
+
+        stack2.add("a".to_owned(), val(6), sr()).unwrap();
+        stack2.push_new_env_for_call(stack2.current_env);
+
+        stack1.add("a".to_owned(), val(7), sr()).unwrap();
+        stack2.add("a".to_owned(), val(8), sr()).unwrap();
+
+        assert_get(stack1, "a", 7);
+        assert_get(stack2, "a", 8);
+
+        stack1.pop_env();
+        assert_get(stack1, "a", 5);
+        assert_get(stack2, "a", 8);
+        stack2.pop_env();
+        assert_get(stack1, "a", 5);
+        assert_get(stack2, "a", 6);
+
+        stack2.pop_env();
+        assert_get(stack2, "a", 4);
+        stack2.pop_env();
+        assert_get(stack2, "a", 2);
+        stack1.pop_env();
+        assert_get(stack1, "a", 3);
+        stack1.pop_env();
+        assert_get(stack1, "a", 1);
     }
 }

--- a/rust/kcl-lib/src/lsp/kcl/mod.rs
+++ b/rust/kcl-lib/src/lsp/kcl/mod.rs
@@ -1606,9 +1606,8 @@ fn position_to_char_index(position: Position, code: &str) -> usize {
 }
 
 async fn with_cached_var<T>(name: &str, f: impl Fn(&KclValue) -> T) -> Option<T> {
-    let result_env = cache::read_old_ast().await?.result_env;
     let mem = cache::read_old_memory().await?;
-    let value = mem.get_from(name, result_env, SourceRange::default()).ok()?;
+    let value = mem.get(name, SourceRange::default()).ok()?;
 
     Some(f(value))
 }

--- a/rust/kcl-lib/src/std/args.rs
+++ b/rust/kcl-lib/src/std/args.rs
@@ -223,7 +223,7 @@ impl Args {
         exec_state: &'e mut ExecState,
         tag: &'a TagIdentifier,
     ) -> Result<&'e crate::execution::TagEngineInfo, KclError> {
-        if let KclValue::TagIdentifier(t) = exec_state.memory().get_from_call_stack(&tag.value, self.source_range)? {
+        if let KclValue::TagIdentifier(t) = exec_state.stack().get_from_call_stack(&tag.value, self.source_range)? {
             Ok(t.info.as_ref().ok_or_else(|| {
                 KclError::Type(KclErrorDetails {
                     message: format!("Tag `{}` does not have engine info", tag.value),
@@ -289,7 +289,7 @@ impl Args {
                 // Find all the solids on the same shared sketch.
                 ids.extend(
                     exec_state
-                        .memory()
+                        .stack()
                         .walk_call_stack()
                         .filter(|v| matches!(v, KclValue::Solid { value } if value.sketch.id == sketch_id))
                         .flat_map(|v| match v {


### PR DESCRIPTION
Factors out a `Stack` from `ProgramMemory` which encapsulates a call stack for a module. Multiple `Stack`s on different threads share a single `ProgramMemory` which means memory does not need to be reassembled after evaluating a module.