### PR TITLE
Add step to E2E test to verify `Backspace` doesn't dismiss command palette

### DIFF
--- a/e2e/playwright/command-bar-tests.spec.ts
+++ b/e2e/playwright/command-bar-tests.spec.ts
@@ -125,6 +125,12 @@ test.describe('Command bar tests', { tag: ['@skipWin'] }, () => {
     await expect(cmdSearchBar).toBeVisible()
     await expect(cmdSearchBar).toBeFocused()
 
+    await test.step(`Pressing backspace in the command selection step does not dismiss`, async () => {
+      await page.keyboard.press('Backspace')
+      await expect(cmdSearchBar).toBeVisible()
+      await expect(cmdSearchBar).toBeFocused()
+    })
+
     // Try typing in the command bar
     await cmdSearchBar.fill(commandName)
     await expect(commandOption).toBeVisible()


### PR DESCRIPTION
Closes #5007.