### PR TITLE
better track the root source code

### DIFF
--- a/src/wasm-lib/kcl/src/execution/state.rs
+++ b/src/wasm-lib/kcl/src/execution/state.rs
@@ -182,6 +182,26 @@ impl ExecState {
         self.global.path_to_source_id.insert(path.clone(), id);
     }
 
+    pub(crate) fn add_root_module_contents(&mut self, program: &crate::Program) {
+        let root_id = ModuleId::default();
+        // Get the path for the root module.
+        let path = self
+            .global
+            .path_to_source_id
+            .iter()
+            .find(|(_, v)| **v == root_id)
+            .unwrap()
+            .0
+            .clone();
+        self.add_id_to_source(
+            root_id,
+            ModuleSource {
+                path,
+                source: program.original_file_contents.to_string(),
+            },
+        );
+    }
+
     pub(super) fn add_id_to_source(&mut self, id: ModuleId, source: ModuleSource) {
         debug_assert!(!self.global.id_to_source.contains_key(&id));
         self.global.id_to_source.insert(id, source.clone());
@@ -251,8 +271,6 @@ impl GlobalState {
         global
             .path_to_source_id
             .insert(ModulePath::Local { value: root_path }, root_id);
-        // Ideally we'd have a way to set the root module's source here, but
-        // we don't have a way to get the source from the executor settings.
         global
     }
 }

--- a/src/wasm-lib/kcl/src/execution/state.rs
+++ b/src/wasm-lib/kcl/src/execution/state.rs
@@ -203,7 +203,6 @@ impl ExecState {
     }
 
     pub(super) fn add_id_to_source(&mut self, id: ModuleId, source: ModuleSource) {
-        debug_assert!(!self.global.id_to_source.contains_key(&id));
         self.global.id_to_source.insert(id, source.clone());
     }
 

--- a/src/wasm-lib/kcl/src/lib.rs
+++ b/src/wasm-lib/kcl/src/lib.rs
@@ -207,15 +207,6 @@ impl Program {
     }
 }
 
-impl From<parsing::ast::types::Node<parsing::ast::types::Program>> for Program {
-    fn from(ast: parsing::ast::types::Node<parsing::ast::types::Program>) -> Program {
-        Self {
-            ast,
-            original_file_contents: String::new(),
-        }
-    }
-}
-
 #[inline]
 fn try_f64_to_usize(f: f64) -> Option<usize> {
     let i = f as usize;

--- a/src/wasm-lib/kcl/src/lib.rs
+++ b/src/wasm-lib/kcl/src/lib.rs
@@ -182,7 +182,7 @@ impl Program {
     }
 
     /// Change the meta settings for the kcl file.
-    pub fn change_meta_settings(&mut self, settings: crate::MetaSettings) -> Result<Self, KclError> {
+    pub fn change_meta_settings(&self, settings: crate::MetaSettings) -> Result<Self, KclError> {
         Ok(Self {
             ast: self.ast.change_meta_settings(settings)?,
             original_file_contents: self.original_file_contents.clone(),

--- a/src/wasm-lib/kcl/src/lsp/tests.rs
+++ b/src/wasm-lib/kcl/src/lsp/tests.rs
@@ -1138,7 +1138,7 @@ fn myFn = (param1) => {
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != Node::<Program>::default());
+    assert!(ast.ast != Node::<Program>::default());
 
     // Send semantic tokens request.
     let semantic_tokens = server
@@ -2251,7 +2251,7 @@ part001 = cube([0,0], 20)
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert_eq!(ast.body.len(), 2);
+    assert_eq!(ast.ast.body.len(), 2);
 
     // Send change file.
     server
@@ -2428,7 +2428,7 @@ async fn kcl_test_kcl_lsp_full_to_empty_file_updates_ast_and_memory() {
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != Node::<Program>::default());
+    assert!(ast.ast != Node::<Program>::default());
 
     // Send change file.
     server
@@ -2450,7 +2450,7 @@ async fn kcl_test_kcl_lsp_full_to_empty_file_updates_ast_and_memory() {
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert_eq!(ast, default_hashed);
+    assert_eq!(ast.ast, default_hashed);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -2479,7 +2479,7 @@ async fn kcl_test_kcl_lsp_code_unchanged_but_has_diagnostics_reexecute() {
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != Node::<Program>::default());
+    assert!(ast.ast != Node::<Program>::default());
 
     // Assure we have no diagnostics.
     assert_diagnostic_count(server.diagnostics_map.get("file:///test.kcl").as_deref(), 0);
@@ -2506,11 +2506,15 @@ async fn kcl_test_kcl_lsp_code_unchanged_but_has_diagnostics_reexecute() {
     assert_diagnostic_count(server.diagnostics_map.get("file:///test.kcl").as_deref(), 1);
 
     // Clear the ast and memory.
-    server
-        .ast_map
-        .insert("file:///test.kcl".to_string(), Node::<Program>::default());
+    server.ast_map.insert(
+        "file:///test.kcl".to_string(),
+        crate::Program {
+            ast: Default::default(),
+            original_file_contents: Default::default(),
+        },
+    );
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert_eq!(ast, Node::<Program>::default());
+    assert_eq!(ast.ast, Node::<Program>::default());
 
     // Send change file, but the code is the same.
     server
@@ -2529,7 +2533,7 @@ async fn kcl_test_kcl_lsp_code_unchanged_but_has_diagnostics_reexecute() {
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != Node::<Program>::default());
+    assert!(ast.ast != Node::<Program>::default());
 
     // Assure we have no diagnostics.
     assert_diagnostic_count(server.diagnostics_map.get("file:///test.kcl").as_deref(), 0);
@@ -2561,7 +2565,7 @@ async fn kcl_test_kcl_lsp_code_and_ast_unchanged_but_has_diagnostics_reexecute()
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != Node::<Program>::default());
+    assert!(ast.ast != Node::<Program>::default());
 
     // Assure we have no diagnostics.
     assert_diagnostic_count(server.diagnostics_map.get("file:///test.kcl").as_deref(), 0);
@@ -2604,7 +2608,7 @@ async fn kcl_test_kcl_lsp_code_and_ast_unchanged_but_has_diagnostics_reexecute()
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != Node::<Program>::default());
+    assert!(ast.ast != Node::<Program>::default());
 
     // Assure we have no diagnostics.
     assert_diagnostic_count(server.diagnostics_map.get("file:///test.kcl").as_deref(), 0);
@@ -2636,7 +2640,7 @@ async fn kcl_test_kcl_lsp_code_and_ast_units_unchanged_but_has_diagnostics_reexe
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != Node::<Program>::default());
+    assert!(ast.ast != Node::<Program>::default());
 
     // Assure we have no diagnostics.
     assert_diagnostic_count(server.diagnostics_map.get("file:///test.kcl").as_deref(), 0);
@@ -2682,7 +2686,7 @@ async fn kcl_test_kcl_lsp_code_and_ast_units_unchanged_but_has_diagnostics_reexe
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != Node::<Program>::default());
+    assert!(ast.ast != Node::<Program>::default());
 
     // Assure we have no diagnostics.
     assert_diagnostic_count(server.diagnostics_map.get("file:///test.kcl").as_deref(), 0);
@@ -2714,7 +2718,7 @@ async fn kcl_test_kcl_lsp_code_and_ast_units_unchanged_but_has_memory_reexecute_
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != Node::<Program>::default());
+    assert!(ast.ast != Node::<Program>::default());
 
     // Assure we have no diagnostics.
     assert_diagnostic_count(server.diagnostics_map.get("file:///test.kcl").as_deref(), 0);
@@ -2739,7 +2743,7 @@ async fn kcl_test_kcl_lsp_code_and_ast_units_unchanged_but_has_memory_reexecute_
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != Node::<Program>::default());
+    assert!(ast.ast != Node::<Program>::default());
 
     // Assure we have no diagnostics.
     assert_diagnostic_count(server.diagnostics_map.get("file:///test.kcl").as_deref(), 0);
@@ -2771,7 +2775,7 @@ async fn kcl_test_kcl_lsp_cant_execute_set() {
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != Node::<Program>::default());
+    assert!(ast.ast != Node::<Program>::default());
 
     // Assure we have no diagnostics.
     assert_diagnostic_count(server.diagnostics_map.get("file:///test.kcl").as_deref(), 0);
@@ -2795,7 +2799,7 @@ async fn kcl_test_kcl_lsp_cant_execute_set() {
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != Node::<Program>::default());
+    assert!(ast.ast != Node::<Program>::default());
 
     // Assure we have no diagnostics.
     assert_diagnostic_count(server.diagnostics_map.get("file:///test.kcl").as_deref(), 0);
@@ -2831,7 +2835,7 @@ async fn kcl_test_kcl_lsp_cant_execute_set() {
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != default_hashed);
+    assert!(ast.ast != default_hashed);
 
     // Assure we have no diagnostics.
     assert_diagnostic_count(server.diagnostics_map.get("file:///test.kcl").as_deref(), 0);
@@ -2862,7 +2866,7 @@ async fn kcl_test_kcl_lsp_cant_execute_set() {
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != Node::<Program>::default());
+    assert!(ast.ast != Node::<Program>::default());
 
     // Assure we have no diagnostics.
     assert_diagnostic_count(server.diagnostics_map.get("file:///test.kcl").as_deref(), 0);
@@ -2995,7 +2999,7 @@ part001 = startSketchOn('XY')
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != Node::<Program>::default());
+    assert!(ast.ast != Node::<Program>::default());
 
     // Assure we have one diagnostics.
     assert_diagnostic_count(server.diagnostics_map.get("file:///test.kcl").as_deref(), 1);
@@ -3016,7 +3020,7 @@ part001 = startSketchOn('XY')
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != Node::<Program>::default());
+    assert!(ast.ast != Node::<Program>::default());
 
     // Assure we have one diagnostics.
     assert_diagnostic_count(server.diagnostics_map.get("file:///test.kcl").as_deref(), 1);
@@ -3109,7 +3113,7 @@ part001 = startSketchOn('XY')
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != Node::<Program>::default());
+    assert!(ast.ast != Node::<Program>::default());
 
     // Send change file, but the code is the same.
     server
@@ -3128,7 +3132,7 @@ part001 = startSketchOn('XY')
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != Node::<Program>::default());
+    assert!(ast.ast != Node::<Program>::default());
 
     // Assure we have diagnostics.
 
@@ -3168,7 +3172,7 @@ part001 = startSketchOn('XY')
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != Node::<Program>::default());
+    assert!(ast.ast != Node::<Program>::default());
 
     // Send change file, but the code is the same.
     server
@@ -3195,7 +3199,7 @@ NEW_LINT = 1"#
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != Node::<Program>::default());
+    assert!(ast.ast != Node::<Program>::default());
 
     // Assure we have diagnostics.
 
@@ -3302,7 +3306,7 @@ part001 = startSketchOn('XY')
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != Node::<Program>::default());
+    assert!(ast.ast != Node::<Program>::default());
 
     // Get the symbols map.
     let symbols_map = server.symbols_map.get("file:///test.kcl").unwrap().clone();
@@ -3389,7 +3393,7 @@ part001 = startSketchOn('XY')
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != Node::<Program>::default());
+    assert!(ast.ast != Node::<Program>::default());
 
     // Get the symbols map.
     let symbols_map = server.symbols_map.get("file:///test.kcl").unwrap().clone();
@@ -3428,7 +3432,7 @@ part001 = startSketchOn('XY')
 
     // Get the ast.
     let ast = server.ast_map.get("file:///test.kcl").unwrap().clone();
-    assert!(ast != Node::<Program>::default());
+    assert!(ast.ast != Node::<Program>::default());
 
     // Get the symbols map.
     let symbols_map = server.symbols_map.get("file:///test.kcl").unwrap().clone();

--- a/src/wasm-lib/kcl/src/parsing/ast/modify.rs
+++ b/src/wasm-lib/kcl/src/parsing/ast/modify.rs
@@ -182,9 +182,7 @@ pub async fn modify_ast_for_sketch(
     let recasted = program.ast.recast(&FormatOptions::default(), 0);
 
     // Re-parse the ast so we get the correct source ranges.
-    *program = crate::parsing::parse_str(&recasted, module_id)
-        .parse_errs_as_err()?
-        .into();
+    program.ast = crate::parsing::parse_str(&recasted, module_id).parse_errs_as_err()?;
 
     Ok(recasted)
 }

--- a/src/wasm-lib/kcl/src/parsing/ast/types/mod.rs
+++ b/src/wasm-lib/kcl/src/parsing/ast/types/mod.rs
@@ -275,7 +275,7 @@ impl Node<Program> {
         Ok(None)
     }
 
-    pub fn change_meta_settings(&mut self, settings: crate::execution::MetaSettings) -> Result<Self, KclError> {
+    pub fn change_meta_settings(&self, settings: crate::execution::MetaSettings) -> Result<Self, KclError> {
         let mut new_program = self.clone();
         let mut found = false;
         for node in &mut new_program.inner_attrs {
@@ -4035,7 +4035,7 @@ startSketchOn('XY')"#;
         let some_program_string = r#"@settings(defaultLengthUnit = inch)
 
 startSketchOn('XY')"#;
-        let mut program = crate::parsing::top_level_parse(some_program_string).unwrap();
+        let program = crate::parsing::top_level_parse(some_program_string).unwrap();
         let result = program.meta_settings().unwrap();
         assert!(result.is_some());
         let meta_settings = result.unwrap();
@@ -4077,7 +4077,7 @@ startSketchOn('XY')
     #[tokio::test(flavor = "multi_thread")]
     async fn test_parse_get_meta_settings_nothing_to_mm() {
         let some_program_string = r#"startSketchOn('XY')"#;
-        let mut program = crate::parsing::top_level_parse(some_program_string).unwrap();
+        let program = crate::parsing::top_level_parse(some_program_string).unwrap();
         let result = program.meta_settings().unwrap();
         assert!(result.is_none());
 

--- a/src/wasm-lib/kcl/src/simulation_tests.rs
+++ b/src/wasm-lib/kcl/src/simulation_tests.rs
@@ -132,10 +132,7 @@ async fn execute(test_name: &str, render_to_png: bool) {
                         Box::new(miette::MietteHandlerOpts::new().show_related_errors_as_nested().build())
                     }))
                     .unwrap();
-                    let report = error
-                        .clone()
-                        .into_miette_report_with_outputs(&read("input.kcl", test_name))
-                        .unwrap();
+                    let report = error.clone().into_miette_report_with_outputs().unwrap();
                     let report = miette::Report::new(report);
                     if previously_passed {
                         eprintln!("This test case failed, but it previously passed. If this is intended, and the test should actually be failing now, please delete kcl/{ok_path_str} and other associated passing artifacts");

--- a/src/wasm-lib/kcl/src/simulation_tests.rs
+++ b/src/wasm-lib/kcl/src/simulation_tests.rs
@@ -84,10 +84,14 @@ async fn execute(test_name: &str, render_to_png: bool) {
     let Ok(ast) = ast_res else {
         return;
     };
+    let ast = crate::Program {
+        ast,
+        original_file_contents: read("input.kcl", test_name),
+    };
 
     // Run the program.
     let exec_res = crate::test_server::execute_and_snapshot_ast(
-        ast.into(),
+        ast,
         crate::settings::types::UnitLength::Mm,
         Some(Path::new("tests").join(test_name).join("input.kcl").to_owned()),
     )

--- a/src/wasm-lib/src/wasm.rs
+++ b/src/wasm-lib/src/wasm.rs
@@ -561,7 +561,7 @@ pub fn change_kcl_settings(code: &str, settings_str: &str) -> Result<String, Str
     console_error_panic_hook::set_once();
 
     let settings: kcl_lib::MetaSettings = serde_json::from_str(settings_str).map_err(|e| e.to_string())?;
-    let mut program = Program::parse_no_errs(code).map_err(|e| e.to_string())?;
+    let program = Program::parse_no_errs(code).map_err(|e| e.to_string())?;
 
     let new_program = program.change_meta_settings(settings).map_err(|e| e.to_string())?;
 


### PR DESCRIPTION
@nrc let me know what you think of this change, basically before we could store all the source code files for modules but getting the root was hard since we parse and read the file out of step