### PR TITLE
Fix overflow in KCL command palette input

### DIFF
--- a/src/components/CommandBar/CommandBarKclInput.module.css
+++ b/src/components/CommandBar/CommandBarKclInput.module.css
@@ -1,5 +1,6 @@
 .editor {
-  @apply text-base flex-1;
+  @apply text-base flex-1 overflow-auto;
+  scrollbar-width: thin;
 }
 
 .editor :global(.cm-editor) {


### PR DESCRIPTION
Closes #4719.

Looks much better now I think, yeah?

https://github.com/user-attachments/assets/5f1aa958-3c9d-4446-a175-9991fa8d06aa

