### PR TITLE
Remove unused Zoo CLI step in e2e-tests.yml

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -50,7 +50,6 @@ jobs:
       with:
         node-version-file: '.nvmrc'
         cache: 'yarn'
-    - uses: KittyCAD/action-install-cli@main
     - name: Install dependencies
       shell: bash
       run: yarn


### PR DESCRIPTION
I've seen this step fail sometimes and I'm not even sure we need it?

I'd say let's remove first if the tests keep to green 🔪 