### PR TITLE
Fix to have deterministic order of commands

### DIFF
--- a/src/wasm-lib/kcl/src/std/chamfer.rs
+++ b/src/wasm-lib/kcl/src/std/chamfer.rs
@@ -5,6 +5,7 @@ use derive_docs::stdlib;
 use kcmc::{each_cmd as mcmd, length_unit::LengthUnit, shared::CutType, ModelingCmd};
 use kittycad_modeling_cmds as kcmc;
 
+use super::utils::dedup_vec;
 use crate::{
     errors::{KclError, KclErrorDetails},
     execution::{ChamferSurface, EdgeCut, ExecState, ExtrudeSurface, GeoMeta, KclValue, Solid},
@@ -109,9 +110,7 @@ async fn inner_chamfer(
     args: Args,
 ) -> Result<Box<Solid>, KclError> {
     // Check if tags contains any duplicate values.
-    let mut tags = tags.clone();
-    tags.sort();
-    tags.dedup();
+    let tags = dedup_vec(tags.clone());
     if tags.len() != tags.len() {
         return Err(KclError::Type(KclErrorDetails {
             message: "Duplicate tags are not allowed.".to_string(),

--- a/src/wasm-lib/kcl/src/std/chamfer.rs
+++ b/src/wasm-lib/kcl/src/std/chamfer.rs
@@ -110,8 +110,8 @@ async fn inner_chamfer(
     args: Args,
 ) -> Result<Box<Solid>, KclError> {
     // Check if tags contains any duplicate values.
-    let tags = dedup_vec(tags.clone());
-    if tags.len() != tags.len() {
+    let unique_tags = dedup_vec(tags.clone());
+    if unique_tags.len() != tags.len() {
         return Err(KclError::Type(KclErrorDetails {
             message: "Duplicate tags are not allowed.".to_string(),
             source_ranges: vec![args.source_range],

--- a/src/wasm-lib/kcl/src/std/chamfer.rs
+++ b/src/wasm-lib/kcl/src/std/chamfer.rs
@@ -5,7 +5,7 @@ use derive_docs::stdlib;
 use kcmc::{each_cmd as mcmd, length_unit::LengthUnit, shared::CutType, ModelingCmd};
 use kittycad_modeling_cmds as kcmc;
 
-use super::utils::dedup_vec;
+use super::utils::unique_count;
 use crate::{
     errors::{KclError, KclErrorDetails},
     execution::{ChamferSurface, EdgeCut, ExecState, ExtrudeSurface, GeoMeta, KclValue, Solid},
@@ -110,8 +110,8 @@ async fn inner_chamfer(
     args: Args,
 ) -> Result<Box<Solid>, KclError> {
     // Check if tags contains any duplicate values.
-    let unique_tags = dedup_vec(tags.clone());
-    if unique_tags.len() != tags.len() {
+    let unique_tags = unique_count(tags.clone());
+    if unique_tags != tags.len() {
         return Err(KclError::Type(KclErrorDetails {
             message: "Duplicate tags are not allowed.".to_string(),
             source_ranges: vec![args.source_range],

--- a/src/wasm-lib/kcl/src/std/fillet.rs
+++ b/src/wasm-lib/kcl/src/std/fillet.rs
@@ -11,6 +11,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use super::utils::dedup_vec;
 use crate::{
     errors::{KclError, KclErrorDetails},
     execution::{EdgeCut, ExecState, ExtrudeSurface, FilletSurface, GeoMeta, KclValue, Solid, TagIdentifier},
@@ -20,7 +21,7 @@ use crate::{
 };
 
 /// A tag or a uuid of an edge.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Eq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, Eq, Hash)]
 #[ts(export)]
 #[serde(untagged)]
 pub enum EdgeReference {
@@ -129,9 +130,7 @@ async fn inner_fillet(
     args: Args,
 ) -> Result<Box<Solid>, KclError> {
     // Check if tags contains any duplicate values.
-    let mut unique_tags = tags.clone();
-    unique_tags.sort();
-    unique_tags.dedup();
+    let unique_tags = dedup_vec(tags.clone());
     if unique_tags.len() != tags.len() {
         return Err(KclError::Type(KclErrorDetails {
             message: "Duplicate tags are not allowed.".to_string(),

--- a/src/wasm-lib/kcl/src/std/fillet.rs
+++ b/src/wasm-lib/kcl/src/std/fillet.rs
@@ -11,7 +11,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use super::utils::dedup_vec;
+use super::utils::unique_count;
 use crate::{
     errors::{KclError, KclErrorDetails},
     execution::{EdgeCut, ExecState, ExtrudeSurface, FilletSurface, GeoMeta, KclValue, Solid, TagIdentifier},
@@ -130,8 +130,8 @@ async fn inner_fillet(
     args: Args,
 ) -> Result<Box<Solid>, KclError> {
     // Check if tags contains any duplicate values.
-    let unique_tags = dedup_vec(tags.clone());
-    if unique_tags.len() != tags.len() {
+    let unique_tags = unique_count(tags.clone());
+    if unique_tags != tags.len() {
         return Err(KclError::Type(KclErrorDetails {
             message: "Duplicate tags are not allowed.".to_string(),
             source_ranges: vec![args.source_range],

--- a/src/wasm-lib/kcl/src/std/utils.rs
+++ b/src/wasm-lib/kcl/src/std/utils.rs
@@ -1,5 +1,6 @@
 use std::f64::consts::PI;
 
+use indexmap::IndexSet;
 use kittycad_modeling_cmds::shared::Angle;
 
 use crate::{
@@ -7,6 +8,18 @@ use crate::{
     execution::Point2d,
     source_range::SourceRange,
 };
+
+/// Deduplicate items in a `Vec` in O(n) time.  If there are multiple instances
+/// that compare equal, the last one will be kept.
+#[must_use]
+pub(crate) fn dedup_vec<T: Eq + std::hash::Hash>(vec: Vec<T>) -> Vec<T> {
+    // Add to a set, preserving order.
+    let mut set = IndexSet::with_capacity(vec.len());
+    for item in vec {
+        set.insert(item);
+    }
+    set.into_iter().collect()
+}
 
 /// Get the distance between two points.
 pub fn distance(a: Point2d, b: Point2d) -> f64 {
@@ -674,6 +687,11 @@ mod get_tangential_arc_to_info_tests {
 
     fn round_to_three_decimals(num: f64) -> f64 {
         (num * 1000.0).round() / 1000.0
+    }
+
+    #[test]
+    fn test_dedup_vec() {
+        assert_eq!(dedup_vec(vec![1, 2, 2, 3, 2]), vec![1, 2, 3]);
     }
 
     #[test]

--- a/src/wasm-lib/kcl/src/std/utils.rs
+++ b/src/wasm-lib/kcl/src/std/utils.rs
@@ -1,6 +1,5 @@
-use std::f64::consts::PI;
+use std::{collections::HashSet, f64::consts::PI};
 
-use indexmap::IndexSet;
 use kittycad_modeling_cmds::shared::Angle;
 
 use crate::{
@@ -9,16 +8,14 @@ use crate::{
     source_range::SourceRange,
 };
 
-/// Deduplicate items in a `Vec` in O(n) time.  If there are multiple instances
-/// that compare equal, the last one will be kept.
-#[must_use]
-pub(crate) fn dedup_vec<T: Eq + std::hash::Hash>(vec: Vec<T>) -> Vec<T> {
-    // Add to a set, preserving order.
-    let mut set = IndexSet::with_capacity(vec.len());
+/// Count the number of unique items in a `Vec` in O(n) time.
+pub(crate) fn unique_count<T: Eq + std::hash::Hash>(vec: Vec<T>) -> usize {
+    // Add to a set.
+    let mut set = HashSet::with_capacity(vec.len());
     for item in vec {
         set.insert(item);
     }
-    set.into_iter().collect()
+    set.len()
 }
 
 /// Get the distance between two points.
@@ -690,8 +687,8 @@ mod get_tangential_arc_to_info_tests {
     }
 
     #[test]
-    fn test_dedup_vec() {
-        assert_eq!(dedup_vec(vec![1, 2, 2, 3, 2]), vec![1, 2, 3]);
+    fn test_unique_count() {
+        assert_eq!(unique_count(vec![1, 2, 2, 3, 2]), 3);
     }
 
     #[test]


### PR DESCRIPTION
Extracted from #5460. Order of engine commands wasn't deterministic because we were sorting by UUID. Also, the error on duplicate tags wasn't working. This was caused by a recent PR:

- #5389

The PR that this was extracted from has a lot more tests that depend on this change.