### PR TITLE
test: Fix to round floating point numbers in test output

### DIFF
--- a/src/wasm-lib/kcl/src/simulation_tests.rs
+++ b/src/wasm-lib/kcl/src/simulation_tests.rs
@@ -115,11 +115,14 @@ async fn execute(test_name: &str, render_to_png: bool) {
             );
             assert_snapshot(test_name, "Variables in memory after executing", || {
                 insta::assert_json_snapshot!("program_memory", outcome.variables, {
-                        ".**[].from[]" => rounded_redaction(4),
-                        ".**[].to[]" => rounded_redaction(4),
-                        ".**[].x[]" => rounded_redaction(4),
-                        ".**[].y[]" => rounded_redaction(4),
-                        ".**[].z[]" => rounded_redaction(4),
+                    ".**.value" => rounded_redaction(4),
+                    ".**[].value" => rounded_redaction(4),
+                    ".**.from[]" => rounded_redaction(4),
+                    ".**.to[]" => rounded_redaction(4),
+                    ".**.center[]" => rounded_redaction(4),
+                    ".**[].x[]" => rounded_redaction(4),
+                    ".**[].y[]" => rounded_redaction(4),
+                    ".**[].z[]" => rounded_redaction(4),
                 })
             });
         }

--- a/src/wasm-lib/kcl/tests/angled_line/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/angled_line/program_memory.snap
@@ -301,7 +301,7 @@ description: Variables in memory after executing angled_line.kcl
                 },
                 "from": [
                   19.93,
-                  15.040000000000001
+                  15.04
                 ],
                 "tag": {
                   "end": 141,
@@ -311,7 +311,7 @@ description: Variables in memory after executing angled_line.kcl
                 },
                 "to": [
                   23.08,
-                  5.190000000000001
+                  5.19
                 ],
                 "type": "ToPoint",
                 "units": {
@@ -397,7 +397,7 @@ description: Variables in memory after executing angled_line.kcl
         },
         "from": [
           19.93,
-          15.040000000000001
+          15.04
         ],
         "tag": {
           "end": 141,
@@ -407,7 +407,7 @@ description: Variables in memory after executing angled_line.kcl
         },
         "to": [
           23.08,
-          5.190000000000001
+          5.19
         ],
         "type": "ToPoint",
         "units": {

--- a/src/wasm-lib/kcl/tests/artifact_graph_example_code1/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/artifact_graph_example_code1/program_memory.snap
@@ -275,7 +275,7 @@ description: Variables in memory after executing artifact_graph_example_code1.kc
                   "value": "seg01"
                 },
                 "to": [
-                  5.550000000000001,
+                  5.55,
                   5.0
                 ],
                 "type": "ToPoint",
@@ -327,7 +327,7 @@ description: Variables in memory after executing artifact_graph_example_code1.kc
                   ]
                 },
                 "from": [
-                  5.550000000000001,
+                  5.55,
                   5.0
                 ],
                 "tag": {
@@ -337,7 +337,7 @@ description: Variables in memory after executing artifact_graph_example_code1.kc
                   "value": "seg02"
                 },
                 "to": [
-                  5.550000000000001,
+                  5.55,
                   -5.0
                 ],
                 "type": "ToPoint",
@@ -842,7 +842,7 @@ description: Variables in memory after executing artifact_graph_example_code1.kc
                         "value": "seg01"
                       },
                       "to": [
-                        5.550000000000001,
+                        5.55,
                         5.0
                       ],
                       "type": "ToPoint",
@@ -894,7 +894,7 @@ description: Variables in memory after executing artifact_graph_example_code1.kc
                         ]
                       },
                       "from": [
-                        5.550000000000001,
+                        5.55,
                         5.0
                       ],
                       "tag": {
@@ -904,7 +904,7 @@ description: Variables in memory after executing artifact_graph_example_code1.kc
                         "value": "seg02"
                       },
                       "to": [
-                        5.550000000000001,
+                        5.55,
                         -5.0
                       ],
                       "type": "ToPoint",
@@ -1075,7 +1075,7 @@ description: Variables in memory after executing artifact_graph_example_code1.kc
           "value": "seg01"
         },
         "to": [
-          5.550000000000001,
+          5.55,
           5.0
         ],
         "type": "ToPoint",
@@ -1128,7 +1128,7 @@ description: Variables in memory after executing artifact_graph_example_code1.kc
           ]
         },
         "from": [
-          5.550000000000001,
+          5.55,
           5.0
         ],
         "tag": {
@@ -1138,7 +1138,7 @@ description: Variables in memory after executing artifact_graph_example_code1.kc
           "value": "seg02"
         },
         "to": [
-          5.550000000000001,
+          5.55,
           -5.0
         ],
         "type": "ToPoint",
@@ -1385,7 +1385,7 @@ description: Variables in memory after executing artifact_graph_example_code1.kc
                 "value": "seg01"
               },
               "to": [
-                5.550000000000001,
+                5.55,
                 5.0
               ],
               "type": "ToPoint",
@@ -1437,7 +1437,7 @@ description: Variables in memory after executing artifact_graph_example_code1.kc
                 ]
               },
               "from": [
-                5.550000000000001,
+                5.55,
                 5.0
               ],
               "tag": {
@@ -1447,7 +1447,7 @@ description: Variables in memory after executing artifact_graph_example_code1.kc
                 "value": "seg02"
               },
               "to": [
-                5.550000000000001,
+                5.55,
                 -5.0
               ],
               "type": "ToPoint",
@@ -1888,7 +1888,7 @@ description: Variables in memory after executing artifact_graph_example_code1.kc
                       "value": "seg01"
                     },
                     "to": [
-                      5.550000000000001,
+                      5.55,
                       5.0
                     ],
                     "type": "ToPoint",
@@ -1940,7 +1940,7 @@ description: Variables in memory after executing artifact_graph_example_code1.kc
                       ]
                     },
                     "from": [
-                      5.550000000000001,
+                      5.55,
                       5.0
                     ],
                     "tag": {
@@ -1950,7 +1950,7 @@ description: Variables in memory after executing artifact_graph_example_code1.kc
                       "value": "seg02"
                     },
                     "to": [
-                      5.550000000000001,
+                      5.55,
                       -5.0
                     ],
                     "type": "ToPoint",

--- a/src/wasm-lib/kcl/tests/artifact_graph_example_code_no_3d/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/artifact_graph_example_code_no_3d/program_memory.snap
@@ -31,8 +31,8 @@ description: Variables in memory after executing artifact_graph_example_code_no_
           "value": "rectangleSegmentA001"
         },
         "to": [
-          -5.719999999999999,
-          0.0000000000000014132424062160455
+          -5.72,
+          0.0
         ],
         "type": "ToPoint",
         "units": {
@@ -69,8 +69,8 @@ description: Variables in memory after executing artifact_graph_example_code_no_
           ]
         },
         "from": [
-          -5.719999999999999,
-          0.0000000000000014132424062160455
+          -5.72,
+          0.0
         ],
         "tag": {
           "end": 226,
@@ -79,8 +79,8 @@ description: Variables in memory after executing artifact_graph_example_code_no_
           "value": "rectangleSegmentB001"
         },
         "to": [
-          -5.719999999999998,
-          8.210000000000003
+          -5.72,
+          8.21
         ],
         "type": "ToPoint",
         "units": {
@@ -117,8 +117,8 @@ description: Variables in memory after executing artifact_graph_example_code_no_
           ]
         },
         "from": [
-          -5.719999999999998,
-          8.210000000000003
+          -5.72,
+          8.21
         ],
         "tag": {
           "end": 352,
@@ -127,7 +127,7 @@ description: Variables in memory after executing artifact_graph_example_code_no_
           "value": "rectangleSegmentC001"
         },
         "to": [
-          5.820000000000001,
+          5.82,
           8.21
         ],
         "type": "ToPoint",
@@ -364,8 +364,8 @@ description: Variables in memory after executing artifact_graph_example_code_no_
                 "value": "rectangleSegmentA001"
               },
               "to": [
-                -5.719999999999999,
-                0.0000000000000014132424062160455
+                -5.72,
+                0.0
               ],
               "type": "ToPoint",
               "units": {
@@ -401,8 +401,8 @@ description: Variables in memory after executing artifact_graph_example_code_no_
                 ]
               },
               "from": [
-                -5.719999999999999,
-                0.0000000000000014132424062160455
+                -5.72,
+                0.0
               ],
               "tag": {
                 "end": 226,
@@ -411,8 +411,8 @@ description: Variables in memory after executing artifact_graph_example_code_no_
                 "value": "rectangleSegmentB001"
               },
               "to": [
-                -5.719999999999998,
-                8.210000000000003
+                -5.72,
+                8.21
               ],
               "type": "ToPoint",
               "units": {
@@ -448,8 +448,8 @@ description: Variables in memory after executing artifact_graph_example_code_no_
                 ]
               },
               "from": [
-                -5.719999999999998,
-                8.210000000000003
+                -5.72,
+                8.21
               ],
               "tag": {
                 "end": 352,
@@ -458,7 +458,7 @@ description: Variables in memory after executing artifact_graph_example_code_no_
                 "value": "rectangleSegmentC001"
               },
               "to": [
-                5.820000000000001,
+                5.82,
                 8.21
               ],
               "type": "ToPoint",
@@ -535,8 +535,8 @@ description: Variables in memory after executing artifact_graph_example_code_no_
           },
           "ccw": false,
           "center": [
-            15.54030518835946,
-            -1.1745473537604454
+            15.5403,
+            -1.1745
           ],
           "from": [
             15.49,
@@ -563,8 +563,8 @@ description: Variables in memory after executing artifact_graph_example_code_no_
           },
           "ccw": true,
           "center": [
-            -7.6163791614610235,
-            0.5756513711217917
+            -7.6164,
+            0.5757
           ],
           "from": [
             0.0,

--- a/src/wasm-lib/kcl/tests/circle_three_point/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/circle_three_point/program_memory.snap
@@ -94,12 +94,12 @@ description: Variables in memory after executing circle_three_point.kcl
         },
         "start": {
           "from": [
-            30.00594901040716,
-            19.749999999999996
+            30.0059,
+            19.75
           ],
           "to": [
-            30.00594901040716,
-            19.749999999999996
+            30.0059,
+            19.75
           ],
           "units": {
             "type": "Mm"

--- a/src/wasm-lib/kcl/tests/fillet-and-shell/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/fillet-and-shell/program_memory.snap
@@ -1211,11 +1211,11 @@ description: Variables in memory after executing fillet-and-shell.kcl
       "start": {
         "from": [
           0.0,
-          10.799999999999999
+          10.8
         ],
         "to": [
           0.0,
-          10.799999999999999
+          10.8
         ],
         "units": {
           "type": "Mm"

--- a/src/wasm-lib/kcl/tests/flush_batch_on_end/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/flush_batch_on_end/program_memory.snap
@@ -26,7 +26,7 @@ description: Variables in memory after executing flush_batch_on_end.kcl
           0.0
         ],
         "from": [
-          0.2734375,
+          0.2734,
           0.0
         ],
         "radius": 0.2734375,
@@ -37,7 +37,7 @@ description: Variables in memory after executing flush_batch_on_end.kcl
           "value": "arc000"
         },
         "to": [
-          0.2734375,
+          0.2734,
           0.0
         ],
         "type": "Circle",
@@ -344,7 +344,7 @@ description: Variables in memory after executing flush_batch_on_end.kcl
   },
   "outerDiameter": {
     "type": "Number",
-    "value": 0.546875,
+    "value": 0.5469,
     "ty": {
       "type": "Unknown"
     },
@@ -438,11 +438,11 @@ description: Variables in memory after executing flush_batch_on_end.kcl
       },
       "start": {
         "from": [
-          0.2734375,
+          0.2734,
           0.0
         ],
         "to": [
-          0.2734375,
+          0.2734,
           0.0
         ],
         "units": {
@@ -481,7 +481,7 @@ description: Variables in memory after executing flush_batch_on_end.kcl
                 0.0
               ],
               "from": [
-                0.2734375,
+                0.2734,
                 0.0
               ],
               "radius": 0.2734375,
@@ -492,7 +492,7 @@ description: Variables in memory after executing flush_batch_on_end.kcl
                 "value": "arc000"
               },
               "to": [
-                0.2734375,
+                0.2734,
                 0.0
               ],
               "type": "Circle",
@@ -639,11 +639,11 @@ description: Variables in memory after executing flush_batch_on_end.kcl
         },
         "start": {
           "from": [
-            0.2734375,
+            0.2734,
             0.0
           ],
           "to": [
-            0.2734375,
+            0.2734,
             0.0
           ],
           "units": {
@@ -682,7 +682,7 @@ description: Variables in memory after executing flush_batch_on_end.kcl
                   0.0
                 ],
                 "from": [
-                  0.2734375,
+                  0.2734,
                   0.0
                 ],
                 "radius": 0.2734375,
@@ -693,7 +693,7 @@ description: Variables in memory after executing flush_batch_on_end.kcl
                   "value": "arc000"
                 },
                 "to": [
-                  0.2734375,
+                  0.2734,
                   0.0
                 ],
                 "type": "Circle",
@@ -834,11 +834,11 @@ description: Variables in memory after executing flush_batch_on_end.kcl
       },
       "start": {
         "from": [
-          0.2734375,
+          0.2734,
           0.0
         ],
         "to": [
-          0.2734375,
+          0.2734,
           0.0
         ],
         "units": {
@@ -877,7 +877,7 @@ description: Variables in memory after executing flush_batch_on_end.kcl
                 0.0
               ],
               "from": [
-                0.2734375,
+                0.2734,
                 0.0
               ],
               "radius": 0.2734375,
@@ -888,7 +888,7 @@ description: Variables in memory after executing flush_batch_on_end.kcl
                 "value": "arc000"
               },
               "to": [
-                0.2734375,
+                0.2734,
                 0.0
               ],
               "type": "Circle",

--- a/src/wasm-lib/kcl/tests/i_shape/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/i_shape/program_memory.snap
@@ -145,7 +145,7 @@ description: Variables in memory after executing i_shape.kcl
           },
           "ccw": false,
           "center": [
-            55.60000000000001,
+            55.6,
             35.0
           ],
           "from": [
@@ -196,7 +196,7 @@ description: Variables in memory after executing i_shape.kcl
           },
           "ccw": false,
           "center": [
-            55.60000000000001,
+            55.6,
             97.0
           ],
           "from": [
@@ -247,7 +247,7 @@ description: Variables in memory after executing i_shape.kcl
           },
           "ccw": true,
           "center": [
-            60.60000000000001,
+            60.6,
             107.0
           ],
           "from": [
@@ -298,7 +298,7 @@ description: Variables in memory after executing i_shape.kcl
           },
           "ccw": true,
           "center": [
-            60.60000000000001,
+            60.6,
             125.0
           ],
           "from": [
@@ -349,7 +349,7 @@ description: Variables in memory after executing i_shape.kcl
           },
           "ccw": true,
           "center": [
-            16.60000000000001,
+            16.6,
             125.0
           ],
           "from": [
@@ -400,7 +400,7 @@ description: Variables in memory after executing i_shape.kcl
           },
           "ccw": true,
           "center": [
-            16.60000000000001,
+            16.6,
             107.0
           ],
           "from": [
@@ -451,7 +451,7 @@ description: Variables in memory after executing i_shape.kcl
           },
           "ccw": false,
           "center": [
-            21.60000000000001,
+            21.6,
             97.0
           ],
           "from": [
@@ -502,7 +502,7 @@ description: Variables in memory after executing i_shape.kcl
           },
           "ccw": false,
           "center": [
-            21.60000000000001,
+            21.6,
             35.0
           ],
           "from": [
@@ -553,7 +553,7 @@ description: Variables in memory after executing i_shape.kcl
           },
           "ccw": true,
           "center": [
-            5.000000000000014,
+            5.0,
             25.0
           ],
           "from": [
@@ -604,7 +604,7 @@ description: Variables in memory after executing i_shape.kcl
           },
           "ccw": true,
           "center": [
-            5.000000000000014,
+            5.0,
             5.0
           ],
           "from": [
@@ -1249,7 +1249,7 @@ description: Variables in memory after executing i_shape.kcl
             },
             "ccw": false,
             "center": [
-              55.60000000000001,
+              55.6,
               35.0
             ],
             "from": [
@@ -1300,7 +1300,7 @@ description: Variables in memory after executing i_shape.kcl
             },
             "ccw": false,
             "center": [
-              55.60000000000001,
+              55.6,
               97.0
             ],
             "from": [
@@ -1351,7 +1351,7 @@ description: Variables in memory after executing i_shape.kcl
             },
             "ccw": true,
             "center": [
-              60.60000000000001,
+              60.6,
               107.0
             ],
             "from": [
@@ -1402,7 +1402,7 @@ description: Variables in memory after executing i_shape.kcl
             },
             "ccw": true,
             "center": [
-              60.60000000000001,
+              60.6,
               125.0
             ],
             "from": [
@@ -1453,7 +1453,7 @@ description: Variables in memory after executing i_shape.kcl
             },
             "ccw": true,
             "center": [
-              16.60000000000001,
+              16.6,
               125.0
             ],
             "from": [
@@ -1504,7 +1504,7 @@ description: Variables in memory after executing i_shape.kcl
             },
             "ccw": true,
             "center": [
-              16.60000000000001,
+              16.6,
               107.0
             ],
             "from": [
@@ -1555,7 +1555,7 @@ description: Variables in memory after executing i_shape.kcl
             },
             "ccw": false,
             "center": [
-              21.60000000000001,
+              21.6,
               97.0
             ],
             "from": [
@@ -1606,7 +1606,7 @@ description: Variables in memory after executing i_shape.kcl
             },
             "ccw": false,
             "center": [
-              21.60000000000001,
+              21.6,
               35.0
             ],
             "from": [
@@ -1657,7 +1657,7 @@ description: Variables in memory after executing i_shape.kcl
             },
             "ccw": true,
             "center": [
-              5.000000000000014,
+              5.0,
               25.0
             ],
             "from": [
@@ -1708,7 +1708,7 @@ description: Variables in memory after executing i_shape.kcl
             },
             "ccw": true,
             "center": [
-              5.000000000000014,
+              5.0,
               5.0
             ],
             "from": [

--- a/src/wasm-lib/kcl/tests/parametric/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/parametric/program_memory.snap
@@ -438,7 +438,7 @@ description: Variables in memory after executing parametric.kcl
   },
   "thickness": {
     "type": "Number",
-    "value": 0.1851640199545103,
+    "value": 0.1852,
     "ty": {
       "type": "Unknown"
     },

--- a/src/wasm-lib/kcl/tests/parametric_with_tan_arc/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/parametric_with_tan_arc/program_memory.snap
@@ -159,7 +159,7 @@ description: Variables in memory after executing parametric_with_tan_arc.kcl
             },
             "ccw": true,
             "center": [
-              -0.7236272269866327,
+              -0.7236,
               8.0
             ],
             "from": [
@@ -256,7 +256,7 @@ description: Variables in memory after executing parametric_with_tan_arc.kcl
             },
             "ccw": false,
             "center": [
-              -0.7236272269866326,
+              -0.7236,
               8.0
             ],
             "from": [
@@ -428,7 +428,7 @@ description: Variables in memory after executing parametric_with_tan_arc.kcl
   },
   "filletR": {
     "type": "Number",
-    "value": 0.7236272269866327,
+    "value": 0.7236,
     "ty": {
       "type": "Unknown"
     },
@@ -517,7 +517,7 @@ description: Variables in memory after executing parametric_with_tan_arc.kcl
   },
   "thickness": {
     "type": "Number",
-    "value": 0.36181361349331637,
+    "value": 0.3618,
     "ty": {
       "type": "Unknown"
     },

--- a/src/wasm-lib/kcl/tests/pentagon_fillet_sugar/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/pentagon_fillet_sugar/program_memory.snap
@@ -31,8 +31,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
           "value": "a"
         },
         "to": [
-          250.00000000000006,
-          433.0127018922193
+          250.0,
+          433.0127
         ],
         "type": "ToPoint",
         "units": {
@@ -101,7 +101,7 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
         },
         "to": [
           280.0,
-          99.99999999999999
+          100.0
         ],
         "type": "Arc",
         "units": {
@@ -153,8 +153,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
           ]
         },
         "from": [
-          250.00000000000006,
-          433.0127018922193
+          250.0,
+          433.0127
         ],
         "tag": {
           "end": 310,
@@ -163,8 +163,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
           "value": "b"
         },
         "to": [
-          -249.99999999999994,
-          433.01270189221935
+          -250.0,
+          433.0127
         ],
         "type": "ToPoint",
         "units": {
@@ -216,8 +216,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
           ]
         },
         "from": [
-          -249.99999999999994,
-          433.01270189221935
+          -250.0,
+          433.0127
         ],
         "tag": {
           "end": 372,
@@ -226,8 +226,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
           "value": "c"
         },
         "to": [
-          0.00000000000011368683772161603,
-          0.00000000000005684341886080802
+          0.0,
+          0.0
         ],
         "type": "ToPoint",
         "units": {
@@ -568,8 +568,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                       "value": "a"
                     },
                     "to": [
-                      250.00000000000006,
-                      433.0127018922193
+                      250.0,
+                      433.0127
                     ],
                     "type": "ToPoint",
                     "units": {
@@ -620,8 +620,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                       ]
                     },
                     "from": [
-                      250.00000000000006,
-                      433.0127018922193
+                      250.0,
+                      433.0127
                     ],
                     "tag": {
                       "end": 310,
@@ -630,8 +630,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                       "value": "b"
                     },
                     "to": [
-                      -249.99999999999994,
-                      433.01270189221935
+                      -250.0,
+                      433.0127
                     ],
                     "type": "ToPoint",
                     "units": {
@@ -682,8 +682,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                       ]
                     },
                     "from": [
-                      -249.99999999999994,
-                      433.01270189221935
+                      -250.0,
+                      433.0127
                     ],
                     "tag": {
                       "end": 372,
@@ -692,8 +692,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                       "value": "c"
                     },
                     "to": [
-                      0.00000000000011368683772161603,
-                      0.00000000000005684341886080802
+                      0.0,
+                      0.0
                     ],
                     "type": "ToPoint",
                     "units": {
@@ -829,7 +829,7 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
               },
               "to": [
                 -120.0,
-                99.99999999999999
+                100.0
               ],
               "type": "Arc",
               "units": {
@@ -1187,8 +1187,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                       "value": "a"
                     },
                     "to": [
-                      250.00000000000006,
-                      433.0127018922193
+                      250.0,
+                      433.0127
                     ],
                     "type": "ToPoint",
                     "units": {
@@ -1239,8 +1239,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                       ]
                     },
                     "from": [
-                      250.00000000000006,
-                      433.0127018922193
+                      250.0,
+                      433.0127
                     ],
                     "tag": {
                       "end": 310,
@@ -1249,8 +1249,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                       "value": "b"
                     },
                     "to": [
-                      -249.99999999999994,
-                      433.01270189221935
+                      -250.0,
+                      433.0127
                     ],
                     "type": "ToPoint",
                     "units": {
@@ -1301,8 +1301,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                       ]
                     },
                     "from": [
-                      -249.99999999999994,
-                      433.01270189221935
+                      -250.0,
+                      433.0127
                     ],
                     "tag": {
                       "end": 372,
@@ -1311,8 +1311,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                       "value": "c"
                     },
                     "to": [
-                      0.00000000000011368683772161603,
-                      0.00000000000005684341886080802
+                      0.0,
+                      0.0
                     ],
                     "type": "ToPoint",
                     "units": {
@@ -1448,7 +1448,7 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
               },
               "to": [
                 280.0,
-                99.99999999999999
+                100.0
               ],
               "type": "Arc",
               "units": {
@@ -1816,8 +1816,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                   "value": "a"
                 },
                 "to": [
-                  250.00000000000006,
-                  433.0127018922193
+                  250.0,
+                  433.0127
                 ],
                 "type": "ToPoint",
                 "units": {
@@ -1868,8 +1868,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                   ]
                 },
                 "from": [
-                  250.00000000000006,
-                  433.0127018922193
+                  250.0,
+                  433.0127
                 ],
                 "tag": {
                   "end": 310,
@@ -1878,8 +1878,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                   "value": "b"
                 },
                 "to": [
-                  -249.99999999999994,
-                  433.01270189221935
+                  -250.0,
+                  433.0127
                 ],
                 "type": "ToPoint",
                 "units": {
@@ -1930,8 +1930,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                   ]
                 },
                 "from": [
-                  -249.99999999999994,
-                  433.01270189221935
+                  -250.0,
+                  433.0127
                 ],
                 "tag": {
                   "end": 372,
@@ -1940,8 +1940,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                   "value": "c"
                 },
                 "to": [
-                  0.00000000000011368683772161603,
-                  0.00000000000005684341886080802
+                  0.0,
+                  0.0
                 ],
                 "type": "ToPoint",
                 "units": {
@@ -2337,8 +2337,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                         "value": "a"
                       },
                       "to": [
-                        250.00000000000006,
-                        433.0127018922193
+                        250.0,
+                        433.0127
                       ],
                       "type": "ToPoint",
                       "units": {
@@ -2389,8 +2389,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                         ]
                       },
                       "from": [
-                        250.00000000000006,
-                        433.0127018922193
+                        250.0,
+                        433.0127
                       ],
                       "tag": {
                         "end": 310,
@@ -2399,8 +2399,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                         "value": "b"
                       },
                       "to": [
-                        -249.99999999999994,
-                        433.01270189221935
+                        -250.0,
+                        433.0127
                       ],
                       "type": "ToPoint",
                       "units": {
@@ -2451,8 +2451,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                         ]
                       },
                       "from": [
-                        -249.99999999999994,
-                        433.01270189221935
+                        -250.0,
+                        433.0127
                       ],
                       "tag": {
                         "end": 372,
@@ -2461,8 +2461,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                         "value": "c"
                       },
                       "to": [
-                        0.00000000000011368683772161603,
-                        0.00000000000005684341886080802
+                        0.0,
+                        0.0
                       ],
                       "type": "ToPoint",
                       "units": {
@@ -2598,7 +2598,7 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                 },
                 "to": [
                   280.0,
-                  99.99999999999999
+                  100.0
                 ],
                 "type": "Arc",
                 "units": {
@@ -3010,8 +3010,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                         "value": "a"
                       },
                       "to": [
-                        250.00000000000006,
-                        433.0127018922193
+                        250.0,
+                        433.0127
                       ],
                       "type": "ToPoint",
                       "units": {
@@ -3062,8 +3062,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                         ]
                       },
                       "from": [
-                        250.00000000000006,
-                        433.0127018922193
+                        250.0,
+                        433.0127
                       ],
                       "tag": {
                         "end": 310,
@@ -3072,8 +3072,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                         "value": "b"
                       },
                       "to": [
-                        -249.99999999999994,
-                        433.01270189221935
+                        -250.0,
+                        433.0127
                       ],
                       "type": "ToPoint",
                       "units": {
@@ -3124,8 +3124,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                         ]
                       },
                       "from": [
-                        -249.99999999999994,
-                        433.01270189221935
+                        -250.0,
+                        433.0127
                       ],
                       "tag": {
                         "end": 372,
@@ -3134,8 +3134,8 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                         "value": "c"
                       },
                       "to": [
-                        0.00000000000011368683772161603,
-                        0.00000000000005684341886080802
+                        0.0,
+                        0.0
                       ],
                       "type": "ToPoint",
                       "units": {
@@ -3271,7 +3271,7 @@ description: Variables in memory after executing pentagon_fillet_sugar.kcl
                 },
                 "to": [
                   -120.0,
-                  99.99999999999999
+                  100.0
                 ],
                 "type": "Arc",
                 "units": {

--- a/src/wasm-lib/kcl/tests/poop_chute/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/poop_chute/program_memory.snap
@@ -747,7 +747,7 @@ description: Variables in memory after executing poop_chute.kcl
                 },
                 "to": [
                   2.0,
-                  0.9374999999999999
+                  0.9375
                 ],
                 "type": "ToPoint",
                 "units": {
@@ -843,7 +843,7 @@ description: Variables in memory after executing poop_chute.kcl
         },
         "to": [
           2.0,
-          0.9374999999999999
+          0.9375
         ],
         "type": "ToPoint",
         "units": {
@@ -906,7 +906,7 @@ description: Variables in memory after executing poop_chute.kcl
         },
         "to": [
           2.0,
-          0.9374999999999999
+          0.9375
         ],
         "type": "ToPoint",
         "units": {
@@ -1332,7 +1332,7 @@ description: Variables in memory after executing poop_chute.kcl
               },
               "to": [
                 2.0,
-                0.9374999999999999
+                0.9375
               ],
               "type": "ToPoint",
               "units": {
@@ -1929,7 +1929,7 @@ description: Variables in memory after executing poop_chute.kcl
                 },
                 "to": [
                   2.0,
-                  0.9374999999999999
+                  0.9375
                 ],
                 "type": "ToPoint",
                 "units": {

--- a/src/wasm-lib/kcl/tests/sketch-on-chamfer-two-times-different-order/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch-on-chamfer-two-times-different-order/program_memory.snap
@@ -431,7 +431,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times-dif
                   ]
                 },
                 "from": [
-                  75.80000000000001,
+                  75.8,
                   99.94
                 ],
                 "tag": {
@@ -1260,7 +1260,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times-dif
                         ]
                       },
                       "from": [
-                        75.80000000000001,
+                        75.8,
                         99.94
                       ],
                       "tag": {
@@ -1849,7 +1849,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times-dif
           "value": "rectangleSegmentA003"
         },
         "to": [
-          -27.619999999999997,
+          -27.62,
           277.34
         ],
         "type": "ToPoint",
@@ -1950,7 +1950,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times-dif
           ]
         },
         "from": [
-          -27.619999999999997,
+          -27.62,
           277.34
         ],
         "tag": {
@@ -1960,8 +1960,8 @@ description: Variables in memory after executing sketch-on-chamfer-two-times-dif
           "value": "rectangleSegmentB002"
         },
         "to": [
-          -27.61999999999999,
-          172.53999999999996
+          -27.62,
+          172.54
         ],
         "type": "ToPoint",
         "units": {
@@ -2061,8 +2061,8 @@ description: Variables in memory after executing sketch-on-chamfer-two-times-dif
           ]
         },
         "from": [
-          -27.61999999999999,
-          172.53999999999996
+          -27.62,
+          172.54
         ],
         "tag": {
           "end": 1028,
@@ -2072,7 +2072,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times-dif
         },
         "to": [
           -69.1,
-          172.53999999999996
+          172.54
         ],
         "type": "ToPoint",
         "units": {
@@ -2172,7 +2172,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times-dif
           ]
         },
         "from": [
-          75.80000000000001,
+          75.8,
           99.94
         ],
         "tag": {
@@ -2620,7 +2620,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times-dif
                 ]
               },
               "from": [
-                75.80000000000001,
+                75.8,
                 99.94
               ],
               "tag": {
@@ -3335,7 +3335,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times-dif
                       ]
                     },
                     "from": [
-                      75.80000000000001,
+                      75.8,
                       99.94
                     ],
                     "tag": {
@@ -4337,7 +4337,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times-dif
                       ]
                     },
                     "from": [
-                      75.80000000000001,
+                      75.8,
                       99.94
                     ],
                     "tag": {
@@ -4580,7 +4580,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times-dif
                 "value": "rectangleSegmentA003"
               },
               "to": [
-                -27.619999999999997,
+                -27.62,
                 277.34
               ],
               "type": "ToPoint",
@@ -4617,7 +4617,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times-dif
                 ]
               },
               "from": [
-                -27.619999999999997,
+                -27.62,
                 277.34
               ],
               "tag": {
@@ -4627,8 +4627,8 @@ description: Variables in memory after executing sketch-on-chamfer-two-times-dif
                 "value": "rectangleSegmentB002"
               },
               "to": [
-                -27.61999999999999,
-                172.53999999999996
+                -27.62,
+                172.54
               ],
               "type": "ToPoint",
               "units": {
@@ -4664,8 +4664,8 @@ description: Variables in memory after executing sketch-on-chamfer-two-times-dif
                 ]
               },
               "from": [
-                -27.61999999999999,
-                172.53999999999996
+                -27.62,
+                172.54
               ],
               "tag": {
                 "end": 1028,
@@ -4675,7 +4675,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times-dif
               },
               "to": [
                 -69.1,
-                172.53999999999996
+                172.54
               ],
               "type": "ToPoint",
               "units": {

--- a/src/wasm-lib/kcl/tests/sketch-on-chamfer-two-times/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch-on-chamfer-two-times/program_memory.snap
@@ -431,7 +431,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times.kcl
                   ]
                 },
                 "from": [
-                  75.80000000000001,
+                  75.8,
                   99.94
                 ],
                 "tag": {
@@ -1260,7 +1260,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times.kcl
                         ]
                       },
                       "from": [
-                        75.80000000000001,
+                        75.8,
                         99.94
                       ],
                       "tag": {
@@ -1849,7 +1849,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times.kcl
           "value": "rectangleSegmentA003"
         },
         "to": [
-          -27.619999999999997,
+          -27.62,
           277.34
         ],
         "type": "ToPoint",
@@ -1950,7 +1950,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times.kcl
           ]
         },
         "from": [
-          -27.619999999999997,
+          -27.62,
           277.34
         ],
         "tag": {
@@ -1960,8 +1960,8 @@ description: Variables in memory after executing sketch-on-chamfer-two-times.kcl
           "value": "rectangleSegmentB002"
         },
         "to": [
-          -27.61999999999999,
-          172.53999999999996
+          -27.62,
+          172.54
         ],
         "type": "ToPoint",
         "units": {
@@ -2061,8 +2061,8 @@ description: Variables in memory after executing sketch-on-chamfer-two-times.kcl
           ]
         },
         "from": [
-          -27.61999999999999,
-          172.53999999999996
+          -27.62,
+          172.54
         ],
         "tag": {
           "end": 1028,
@@ -2072,7 +2072,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times.kcl
         },
         "to": [
           -69.1,
-          172.53999999999996
+          172.54
         ],
         "type": "ToPoint",
         "units": {
@@ -2172,7 +2172,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times.kcl
           ]
         },
         "from": [
-          75.80000000000001,
+          75.8,
           99.94
         ],
         "tag": {
@@ -2620,7 +2620,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times.kcl
                 ]
               },
               "from": [
-                75.80000000000001,
+                75.8,
                 99.94
               ],
               "tag": {
@@ -3335,7 +3335,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times.kcl
                       ]
                     },
                     "from": [
-                      75.80000000000001,
+                      75.8,
                       99.94
                     ],
                     "tag": {
@@ -4337,7 +4337,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times.kcl
                       ]
                     },
                     "from": [
-                      75.80000000000001,
+                      75.8,
                       99.94
                     ],
                     "tag": {
@@ -4580,7 +4580,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times.kcl
                 "value": "rectangleSegmentA003"
               },
               "to": [
-                -27.619999999999997,
+                -27.62,
                 277.34
               ],
               "type": "ToPoint",
@@ -4617,7 +4617,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times.kcl
                 ]
               },
               "from": [
-                -27.619999999999997,
+                -27.62,
                 277.34
               ],
               "tag": {
@@ -4627,8 +4627,8 @@ description: Variables in memory after executing sketch-on-chamfer-two-times.kcl
                 "value": "rectangleSegmentB002"
               },
               "to": [
-                -27.61999999999999,
-                172.53999999999996
+                -27.62,
+                172.54
               ],
               "type": "ToPoint",
               "units": {
@@ -4664,8 +4664,8 @@ description: Variables in memory after executing sketch-on-chamfer-two-times.kcl
                 ]
               },
               "from": [
-                -27.61999999999999,
-                172.53999999999996
+                -27.62,
+                172.54
               ],
               "tag": {
                 "end": 1028,
@@ -4675,7 +4675,7 @@ description: Variables in memory after executing sketch-on-chamfer-two-times.kcl
               },
               "to": [
                 -69.1,
-                172.53999999999996
+                172.54
               ],
               "type": "ToPoint",
               "units": {

--- a/src/wasm-lib/kcl/tests/sketch_on_face/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face/program_memory.snap
@@ -32,7 +32,7 @@ description: Variables in memory after executing sketch_on_face.kcl
         },
         "to": [
           39.86,
-          15.100000000000001
+          15.1
         ],
         "type": "ToPoint",
         "units": {
@@ -306,7 +306,7 @@ description: Variables in memory after executing sketch_on_face.kcl
                 },
                 "to": [
                   39.86,
-                  15.100000000000001
+                  15.1
                 ],
                 "type": "ToPoint",
                 "units": {
@@ -780,7 +780,7 @@ description: Variables in memory after executing sketch_on_face.kcl
                       },
                       "to": [
                         39.86,
-                        15.100000000000001
+                        15.1
                       ],
                       "type": "ToPoint",
                       "units": {

--- a/src/wasm-lib/kcl/tests/sketch_on_face_after_fillets_referencing_face/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/sketch_on_face_after_fillets_referencing_face/program_memory.snap
@@ -395,7 +395,7 @@ description: Variables in memory after executing sketch_on_face_after_fillets_re
                 },
                 "from": [
                   -8.0,
-                  5.679286509705091
+                  5.6793
                 ],
                 "tag": {
                   "end": 1238,
@@ -404,8 +404,8 @@ description: Variables in memory after executing sketch_on_face_after_fillets_re
                   "value": "innerEdge"
                 },
                 "to": [
-                  -0.32071349029490914,
-                  5.679286509705091
+                  -0.3207,
+                  5.6793
                 ],
                 "type": "ToPoint",
                 "units": {
@@ -653,7 +653,7 @@ description: Variables in memory after executing sketch_on_face_after_fillets_re
         },
         "from": [
           -8.0,
-          5.679286509705091
+          5.6793
         ],
         "tag": {
           "end": 1238,
@@ -662,8 +662,8 @@ description: Variables in memory after executing sketch_on_face_after_fillets_re
           "value": "innerEdge"
         },
         "to": [
-          -0.32071349029490914,
-          5.679286509705091
+          -0.3207,
+          5.6793
         ],
         "type": "ToPoint",
         "units": {
@@ -1397,7 +1397,7 @@ description: Variables in memory after executing sketch_on_face_after_fillets_re
                       },
                       "from": [
                         -8.0,
-                        5.679286509705091
+                        5.6793
                       ],
                       "tag": {
                         "end": 1238,
@@ -1406,8 +1406,8 @@ description: Variables in memory after executing sketch_on_face_after_fillets_re
                         "value": "innerEdge"
                       },
                       "to": [
-                        -0.32071349029490914,
-                        5.679286509705091
+                        -0.3207,
+                        5.6793
                       ],
                       "type": "ToPoint",
                       "units": {
@@ -1682,7 +1682,7 @@ description: Variables in memory after executing sketch_on_face_after_fillets_re
   },
   "thickness": {
     "type": "Number",
-    "value": 0.32071349029490925,
+    "value": 0.3207,
     "ty": {
       "type": "Unknown"
     },

--- a/src/wasm-lib/kcl/tests/ssi_pattern/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/ssi_pattern/program_memory.snap
@@ -132,8 +132,8 @@ description: Variables in memory after executing ssi_pattern.kcl
             },
             "ccw": true,
             "center": [
-              -2.478430620978426,
-              21.878248822388485
+              -2.4784,
+              21.8782
             ],
             "from": [
               -3.81,
@@ -295,7 +295,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                 },
                 "from": [
                   20.4,
-                  -12.150000000000002
+                  -12.15
                 ],
                 "tag": {
                   "end": 258,
@@ -391,7 +391,7 @@ description: Variables in memory after executing ssi_pattern.kcl
         },
         "from": [
           20.4,
-          -12.150000000000002
+          -12.15
         ],
         "tag": {
           "end": 258,
@@ -498,8 +498,8 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "ccw": true,
           "center": [
-            -2.478430620978426,
-            21.878248822388485
+            -2.4784,
+            21.8782
           ],
           "from": [
             -3.81,
@@ -661,7 +661,7 @@ description: Variables in memory after executing ssi_pattern.kcl
               },
               "from": [
                 20.4,
-                -12.150000000000002
+                -12.15
               ],
               "tag": {
                 "end": 258,
@@ -923,8 +923,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -1086,7 +1086,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -1177,11 +1177,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -1426,8 +1426,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -1589,7 +1589,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -1680,11 +1680,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -1929,8 +1929,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -2092,7 +2092,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -2183,11 +2183,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -2432,8 +2432,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -2595,7 +2595,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -2686,11 +2686,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -2935,8 +2935,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -3098,7 +3098,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -3189,11 +3189,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -3438,8 +3438,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -3601,7 +3601,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -3692,11 +3692,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -3941,8 +3941,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -4104,7 +4104,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -4195,11 +4195,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -4444,8 +4444,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -4607,7 +4607,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -4698,11 +4698,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -4947,8 +4947,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -5110,7 +5110,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -5201,11 +5201,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -5450,8 +5450,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -5613,7 +5613,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -5704,11 +5704,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -5953,8 +5953,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -6116,7 +6116,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -6207,11 +6207,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -6456,8 +6456,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -6619,7 +6619,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -6710,11 +6710,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -6959,8 +6959,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -7122,7 +7122,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -7213,11 +7213,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -7462,8 +7462,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -7625,7 +7625,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -7716,11 +7716,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -7965,8 +7965,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -8128,7 +8128,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -8219,11 +8219,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -8468,8 +8468,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -8631,7 +8631,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -8722,11 +8722,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -8971,8 +8971,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -9134,7 +9134,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -9225,11 +9225,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -9474,8 +9474,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -9637,7 +9637,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -9728,11 +9728,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -9977,8 +9977,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -10140,7 +10140,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -10231,11 +10231,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -10480,8 +10480,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -10643,7 +10643,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -10734,11 +10734,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -10983,8 +10983,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -11146,7 +11146,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -11237,11 +11237,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -11486,8 +11486,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -11649,7 +11649,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -11740,11 +11740,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -11989,8 +11989,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -12152,7 +12152,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -12243,11 +12243,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -12492,8 +12492,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -12655,7 +12655,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -12746,11 +12746,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -12995,8 +12995,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -13158,7 +13158,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -13249,11 +13249,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -13498,8 +13498,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -13661,7 +13661,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -13752,11 +13752,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -14001,8 +14001,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -14164,7 +14164,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -14255,11 +14255,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -14504,8 +14504,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -14667,7 +14667,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -14758,11 +14758,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -15007,8 +15007,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -15170,7 +15170,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -15261,11 +15261,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {
@@ -15510,8 +15510,8 @@ description: Variables in memory after executing ssi_pattern.kcl
                     },
                     "ccw": true,
                     "center": [
-                      -2.478430620978426,
-                      21.878248822388485
+                      -2.4784,
+                      21.8782
                     ],
                     "from": [
                       -3.81,
@@ -15673,7 +15673,7 @@ description: Variables in memory after executing ssi_pattern.kcl
                         },
                         "from": [
                           20.4,
-                          -12.150000000000002
+                          -12.15
                         ],
                         "tag": {
                           "end": 258,
@@ -15764,11 +15764,11 @@ description: Variables in memory after executing ssi_pattern.kcl
           },
           "start": {
             "from": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "to": [
-              -0.6800000000000002,
+              -0.68,
               47.7
             ],
             "units": {

--- a/src/wasm-lib/kcl/tests/tan_arc_x_line/program_memory.snap
+++ b/src/wasm-lib/kcl/tests/tan_arc_x_line/program_memory.snap
@@ -66,12 +66,12 @@ description: Variables in memory after executing tan_arc_x_line.kcl
         },
         "ccw": true,
         "center": [
-          -0.9396929628060517,
-          -0.34201920363304794
+          -0.9397,
+          -0.342
         ],
         "from": [
-          -0.0000003420201433256687,
-          0.0000009396926207859084
+          -0.0,
+          0.0
         ],
         "tag": {
           "end": 251,
@@ -80,8 +80,8 @@ description: Variables in memory after executing tan_arc_x_line.kcl
           "value": "arc1"
         },
         "to": [
-          -1.8460007498427018,
-          0.08059905810765156
+          -1.846,
+          0.0806
         ],
         "type": "TangentialArc",
         "units": {
@@ -119,12 +119,12 @@ description: Variables in memory after executing tan_arc_x_line.kcl
         },
         "ccw": true,
         "center": [
-          -1.3928468563243768,
-          -0.13071007276269808
+          -1.3928,
+          -0.1307
         ],
         "from": [
-          -1.8460007498427018,
-          0.08059905810765156
+          -1.846,
+          0.0806
         ],
         "tag": {
           "end": 343,
@@ -133,8 +133,8 @@ description: Variables in memory after executing tan_arc_x_line.kcl
           "value": "arc2"
         },
         "to": [
-          -1.2218367846615423,
-          -0.6005563831556522
+          -1.2218,
+          -0.6006
         ],
         "type": "TangentialArc",
         "units": {
@@ -172,12 +172,12 @@ description: Variables in memory after executing tan_arc_x_line.kcl
         },
         "ccw": false,
         "center": [
-          -1.050826712998708,
-          -1.0704026935486064
+          -1.0508,
+          -1.0704
         ],
         "from": [
-          -1.2218367846615423,
-          -0.6005563831556522
+          -1.2218,
+          -0.6006
         ],
         "tag": {
           "end": 436,
@@ -186,8 +186,8 @@ description: Variables in memory after executing tan_arc_x_line.kcl
           "value": "arc3"
         },
         "to": [
-          -0.5976728194803829,
-          -1.281711824418956
+          -0.5977,
+          -1.2817
         ],
         "type": "TangentialArc",
         "units": {


### PR DESCRIPTION
Extracted from #5460. Floating point numbers were not being rounded thoroughly. The PR that this was extracted from has a lot more tests that were failing because of this.