### PR TITLE
Add button in settings menu to manually check for updates

### DIFF
--- a/interface.d.ts
+++ b/interface.d.ts
@@ -88,6 +88,7 @@ export interface IElectronAPI {
   ) => Electron.IpcRenderer
   onUpdateError: (callback: (value: { error: Error }) => void) => Electron
   appRestart: () => void
+  appCheckForUpdates: () => Promise<unknown>
   getArgvParsed: () => any
   getAppTestProperty: (propertyName: string) => any
 }

--- a/src/components/Settings/AllSettingsFields.tsx
+++ b/src/components/Settings/AllSettingsFields.tsx
@@ -252,15 +252,29 @@ export const AllSettingsFields = forwardRef(
               {/* This uses a Vite plugin, set in vite.config.ts
                   to inject the version from package.json */}
               App version {APP_VERSION}.{' '}
-              <a
-                onClick={openExternalBrowserIfDesktop(getReleaseUrl())}
-                href={getReleaseUrl()}
-                target="_blank"
-                rel="noopener noreferrer"
+            </p>
+            <div className="flex gap-2 flex-wrap my-4">
+              <ActionButton
+                Element="externalLink"
+                to={getReleaseUrl()}
+                iconStart={{ icon: 'file', className: 'p-1' }}
               >
                 View release on GitHub
-              </a>
-            </p>
+              </ActionButton>
+              <ActionButton
+                Element="button"
+                onClick={() => {
+                  window.electron.appCheckForUpdates().catch(reportRejection)
+                }}
+                iconStart={{
+                  icon: 'refresh',
+                  size: 'sm',
+                  className: 'p-1',
+                }}
+              >
+                Check for updates
+              </ActionButton>
+            </div>
             <p className="max-w-2xl mt-6">
               Don't see the feature you want? Check to see if it's on{' '}
               <a

--- a/src/main.ts
+++ b/src/main.ts
@@ -430,6 +430,9 @@ app.on('ready', () => {
   ipcMain.handle('app.restart', () => {
     autoUpdater.quitAndInstall()
   })
+  ipcMain.handle('app.checkForUpdates', () => {
+    return autoUpdater.checkForUpdates()
+  })
 })
 
 const getProjectPathAtStartup = async (

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -38,6 +38,7 @@ const onUpdateDownloadStart = (
 const onUpdateError = (callback: (value: Error) => void) =>
   ipcRenderer.on('update-error', (_event: any, value) => callback(value))
 const appRestart = () => ipcRenderer.invoke('app.restart')
+const appCheckForUpdates = () => ipcRenderer.invoke('app.checkForUpdates')
 const getAppTestProperty = (propertyName: string) =>
   ipcRenderer.invoke('app.testProperty', propertyName)
 
@@ -207,6 +208,7 @@ contextBridge.exposeInMainWorld('electron', {
   onUpdateDownloaded,
   onUpdateError,
   appRestart,
+  appCheckForUpdates,
   getArgvParsed,
   resizeWindow,
 })


### PR DESCRIPTION
Closes #3886 by providing users with a way to manually check for app updates from the bottom of the settings.

## Demo

(Edit: I had the wrong demo vid thanks @lf94)

https://github.com/user-attachments/assets/57072927-a0ff-40e5-a24a-74d191a75f7d




