### PR TITLE
Bugfix: show proper error toast when user tries to rename project to conflicting name

### DIFF
--- a/e2e/playwright/projects.spec.ts
+++ b/e2e/playwright/projects.spec.ts
@@ -745,6 +745,23 @@ test(
       // expect the name not to have changed
       await expect(page.getByText('bracket')).toBeVisible()
     })
+
+    await test.step(`rename a project to a duplicate name should error toast`, async () => {
+      const routerTemplate = page.getByText('bracket')
+
+      await routerTemplate.hover()
+      await routerTemplate.focus()
+
+      await expect(page.getByLabel('sketch').last()).toBeVisible()
+      await page.getByLabel('sketch').last().click()
+
+      const inputField = page.getByTestId('project-rename-input')
+      await expect(inputField).toBeVisible()
+      await expect(inputField).toBeFocused()
+      await inputField.fill('lego')
+      await page.keyboard.press('Enter')
+      await expect(page.getByText('already exists')).toBeVisible()
+    })
   }
 )
 

--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -35,7 +35,9 @@ function ProjectCard({
 
   function handleSave(e: FormEvent<HTMLFormElement>) {
     e.preventDefault()
-    void handleRenameProject(e, project).then(() => setIsEditing(false))
+    handleRenameProject(e, project)
+      .then(() => setIsEditing(false))
+      .catch(reportRejection)
   }
 
   function getDisplayedTime(dateTimeMs: number) {

--- a/src/components/ProjectCard/ProjectCardRenameForm.tsx
+++ b/src/components/ProjectCard/ProjectCardRenameForm.tsx
@@ -18,6 +18,7 @@ export const ProjectCardRenameForm = forwardRef(
         <input
           className="min-w-0 dark:bg-chalkboard-80 dark:border-chalkboard-40 focus:outline-none"
           type="text"
+          data-testid="project-rename-input"
           id="newProjectName"
           onClickCapture={(e) => e.preventDefault()}
           name="newProjectName"

--- a/src/components/ProjectsContextProvider.tsx
+++ b/src/components/ProjectsContextProvider.tsx
@@ -306,6 +306,9 @@ const ProjectsContextDesktop = ({
               ('output' in event &&
                 typeof event.output === 'string' &&
                 event.output) ||
+              ('error' in event &&
+                event.error instanceof Error &&
+                event.error.message) ||
               ''
           ),
       },
@@ -338,6 +341,13 @@ const ProjectsContextDesktop = ({
           if (doesProjectNameNeedInterpolated(name)) {
             const nextIndex = getNextProjectIndex(name, projects)
             name = interpolateProjectNameWithIndex(name, nextIndex)
+          }
+
+          // Toast an error if the project name is taken
+          if (projects.find((p) => p.name === name)) {
+            return Promise.reject(
+              new Error(`Project with name "${name}" already exists`)
+            )
           }
 
           await renameProjectDirectory(


### PR DESCRIPTION
Closes #4113 and adds to the project renaming E2E test