### PR TITLE
Only save the themeColor setting on end of input

### DIFF
--- a/src/lib/settings/initialSettings.tsx
+++ b/src/lib/settings/initialSettings.tsx
@@ -155,32 +155,39 @@ export function createSettings() {
         description: 'The hue of the primary theme color for the app',
         validate: (v) => Number(v) >= 0 && Number(v) < 360,
         Component: ({ value, updateValue }) => {
-          const preview = (e: React.SyntheticEvent) => e.isTrusted && 'value' in e.currentTarget && document.documentElement.style.setProperty(
-            `--primary-hue`,
-            String(e.currentTarget.value
+          const preview = (e: React.SyntheticEvent) =>
+            e.isTrusted &&
+            'value' in e.currentTarget &&
+            document.documentElement.style.setProperty(
+              `--primary-hue`,
+              String(e.currentTarget.value)
             )
-          )
-          const save = (e: React.SyntheticEvent) => e.isTrusted && 'value' in e.currentTarget && e.currentTarget.value && updateValue(String(e.currentTarget.value))
-          return (<div className="flex item-center gap-4 px-2 m-0 py-0">
-            <div
-              className="w-4 h-4 rounded-full bg-primary border border-solid border-chalkboard-100 dark:border-chalkboard-30"
-              style={{
-                backgroundColor: `oklch(var(--primary-lightness) var(--primary-chroma) var(--primary-hue))`,
-              }}
-            />
-            <input
-              type="range"
-              onInput={preview}
-              onMouseUp={save}
-              onKeyUp={save}
-              onPointerUp={save}
-              defaultValue={value}
-              min={0}
-              max={259}
-              step={1}
-              className="block flex-1"
-            />
-          </div>
+          const save = (e: React.SyntheticEvent) =>
+            e.isTrusted &&
+            'value' in e.currentTarget &&
+            e.currentTarget.value &&
+            updateValue(String(e.currentTarget.value))
+          return (
+            <div className="flex item-center gap-4 px-2 m-0 py-0">
+              <div
+                className="w-4 h-4 rounded-full bg-primary border border-solid border-chalkboard-100 dark:border-chalkboard-30"
+                style={{
+                  backgroundColor: `oklch(var(--primary-lightness) var(--primary-chroma) var(--primary-hue))`,
+                }}
+              />
+              <input
+                type="range"
+                onInput={preview}
+                onMouseUp={save}
+                onKeyUp={save}
+                onPointerUp={save}
+                defaultValue={value}
+                min={0}
+                max={259}
+                step={1}
+                className="block flex-1"
+              />
+            </div>
           )
         },
       }),

--- a/src/lib/settings/initialSettings.tsx
+++ b/src/lib/settings/initialSettings.tsx
@@ -154,25 +154,35 @@ export function createSettings() {
         defaultValue: '264.5',
         description: 'The hue of the primary theme color for the app',
         validate: (v) => Number(v) >= 0 && Number(v) < 360,
-        Component: ({ value, updateValue }) => (
-          <div className="flex item-center gap-4 px-2 m-0 py-0">
+        Component: ({ value, updateValue }) => {
+          const preview = (e: React.SyntheticEvent) => e.isTrusted && 'value' in e.currentTarget && document.documentElement.style.setProperty(
+            `--primary-hue`,
+            String(e.currentTarget.value
+            )
+          )
+          const save = (e: React.SyntheticEvent) => e.isTrusted && 'value' in e.currentTarget && e.currentTarget.value && updateValue(String(e.currentTarget.value))
+          return (<div className="flex item-center gap-4 px-2 m-0 py-0">
             <div
               className="w-4 h-4 rounded-full bg-primary border border-solid border-chalkboard-100 dark:border-chalkboard-30"
               style={{
-                backgroundColor: `oklch(var(--primary-lightness) var(--primary-chroma) ${value})`,
+                backgroundColor: `oklch(var(--primary-lightness) var(--primary-chroma) var(--primary-hue))`,
               }}
             />
             <input
               type="range"
-              onChange={(e) => updateValue(e.currentTarget.value)}
-              value={value}
+              onInput={preview}
+              onMouseUp={save}
+              onKeyUp={save}
+              onPointerUp={save}
+              defaultValue={value}
               min={0}
               max={259}
               step={1}
               className="block flex-1"
             />
           </div>
-        ),
+          )
+        },
       }),
       /**
        * Whether to show the debug panel, which lets you see


### PR DESCRIPTION
Closes #4463 by making this input sliders less eager to write to disk, which was gumming up the works. Now it updates the CSS variable to "preview" the change on input, and only triggers the permanent save on `mouseUp`, `pointerUp`, or keyUp`, when the user is done. Shoutout to @tmcw for [this helpful Observable notebook from back in the day](https://observablehq.com/@tmcw/inputs/2#slider); I owe you a tea.

## Demo

https://github.com/user-attachments/assets/89e0e6db-47e6-4874-b5cb-5c2d546ca5e0

