### PR TITLE
Don't crash when trying to apply `lastSelectionEvent` selection that is out-of-range

### DIFF
--- a/e2e/playwright/regression-tests.spec.ts
+++ b/e2e/playwright/regression-tests.spec.ts
@@ -654,6 +654,50 @@ extrude001 = extrude(sketch001, length = 50)
       await expect.poll(toolBarMode).toEqual('sketching')
     })
   })
+
+  test(`Delete via feature tree then open code pane, never crash`, async ({
+    homePage,
+    toolbar,
+    editor,
+    context,
+    page,
+    scene,
+    cmdBar,
+  }) => {
+    await context.folderSetupFn(async (dir) => {
+      const bracketDir = path.join(dir, 'test-sample')
+      await fsp.mkdir(bracketDir, { recursive: true })
+      await fsp.writeFile(
+        path.join(bracketDir, 'main.kcl'),
+        `x = 5
+plane001 = offsetPlane(XZ, offset = x)
+plane002 = offsetPlane(XZ, offset = -2 * x)`
+      )
+    })
+    await homePage.openProject('test-sample')
+    await scene.waitForExecutionDone()
+    await expect(toolbar.startSketchBtn).toBeEnabled({ timeout: 20_000 })
+    const operationButton = await toolbar.getFeatureTreeOperation(
+      'Offset Plane',
+      1
+    )
+
+    await test.step('Delete offset plane via feature tree selection', async () => {
+      await expect(operationButton.last()).toBeVisible({ timeout: 10_000 })
+      await editor.closePane()
+      await operationButton.first().click({ button: 'left' })
+      await page.keyboard.press('Delete')
+      await scene.settled(cmdBar)
+    })
+
+    await test.step(`Open the code pane, don't crash`, async () => {
+      await editor.openPane()
+      expect(page.getByText('unexpected error')).not.toBeVisible()
+      await editor.expectEditor.toContain(`x = 5`)
+      await editor.expectEditor.toContain(`plane001`)
+      await editor.expectEditor.not.toContain(`plane002`)
+    })
+  })
 })
 
 async function clickExportButton(page: Page) {

--- a/src/components/ModelingSidebar/ModelingPanes/KclEditorPane.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/KclEditorPane.tsx
@@ -96,11 +96,15 @@ export const KclEditorPane = () => {
       return
     }
 
-    editorManager.editorView.dispatch({
-      selection: lastSelectionEvent.codeMirrorSelection,
-      annotations: [modelingMachineEvent, Transaction.addToHistory.of(false)],
-      scrollIntoView: lastSelectionEvent.scrollIntoView,
-    })
+    try {
+      editorManager.editorView.dispatch({
+        selection: lastSelectionEvent.codeMirrorSelection,
+        annotations: [modelingMachineEvent, Transaction.addToHistory.of(false)],
+        scrollIntoView: lastSelectionEvent.scrollIntoView,
+      })
+    } catch (e) {
+      console.error('Error setting selection', e)
+    }
   }, [editorIsMounted, lastSelectionEvent])
 
   const textWrapping = context.textEditor.textWrapping


### PR DESCRIPTION
Deleting an object near the end of your feature tree with the code pane closed and opening the app will crash it today. This is because on opening, we try to apply the `lastSelectionEvent`, which in this case points to a part of the document that is now gone. This category of issue was addressed in #4931, but the useEffect where this error occurs was added after that work to accommodate the feature tree's selection coordination with the modelingMachine and editorManager.

I'm fixing in the lightest way I can, a try/catch, just to stick to the "don't throw on the frontend" rule we have that CodeMirror doesn't adhere to.

Adds a regression E2E test for this crash.