### PR TITLE
Fix the fetch logic for the KCL samples after vendoring

### DIFF
--- a/src/lib/getKclSamplesManifest.ts
+++ b/src/lib/getKclSamplesManifest.ts
@@ -1,4 +1,5 @@
 import { KCL_SAMPLES_MANIFEST_URL } from './constants'
+import { isDesktop } from './isDesktop'
 
 export type KclSamplesManifestItem = {
   file: string
@@ -9,7 +10,9 @@ export type KclSamplesManifestItem = {
 }
 
 export async function getKclSamplesManifest() {
-  const response = await fetch(KCL_SAMPLES_MANIFEST_URL)
+  const response = await fetch(
+    (isDesktop() ? '.' : '') + KCL_SAMPLES_MANIFEST_URL
+  )
   if (!response.ok) {
     console.error(
       'Failed to fetch bundled KCL samples manifest:',

--- a/src/lib/kclCommands.ts
+++ b/src/lib/kclCommands.ts
@@ -64,9 +64,11 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
         const projectPathPart = pathParts[0]
         const primaryKclFile = pathParts[1]
         // local only
-        const sampleCodeUrl = `/kcl-samples/${encodeURIComponent(
-          projectPathPart
-        )}/${encodeURIComponent(primaryKclFile)}`
+        const sampleCodeUrl =
+          (isDesktop() ? '.' : '') +
+          `/kcl-samples/${encodeURIComponent(
+            projectPathPart
+          )}/${encodeURIComponent(primaryKclFile)}`
 
         fetch(sampleCodeUrl)
           .then(async (codeResponse): Promise<OnSubmitProps> => {


### PR DESCRIPTION
Fixes the last 2 E2E tests for #5460.