### PR TITLE
Fix a recast bug and don't delete the user's code if parsing fails

### DIFF
--- a/rust/kcl-lib/src/unparser.rs
+++ b/rust/kcl-lib/src/unparser.rs
@@ -426,7 +426,7 @@ impl Literal {
                 if self.raw.contains('.') && value.fract() == 0.0 {
                     format!("{value:?}{suffix}")
                 } else {
-                    format!("{}{suffix}", self.raw)
+                    self.raw.clone()
                 }
             }
             LiteralValue::String(ref s) => {
@@ -1516,7 +1516,7 @@ tabs_l = startSketchOn({
        radius = hole_diam / 2
      ), %)
   |> extrude(-thk, %)
-  |> patternLinear3d(axis = [0, -1, 0], repetitions = 1, distance = length - 10)
+  |> patternLinear3d(axis = [0, -1, 0], repetitions = 1, distance = length - 10ft)
 "#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
@@ -1633,7 +1633,7 @@ tabs_l = startSketchOn({
        radius = hole_diam / 2,
      ), %)
   |> extrude(-thk, %)
-  |> patternLinear3d(axis = [0, -1, 0], repetitions = 1, distance = length - 10)
+  |> patternLinear3d(axis = [0, -1, 0], repetitions = 1, distance = length - 10ft)
 "#
         );
     }

--- a/src/lang/KclSingleton.ts
+++ b/src/lang/KclSingleton.ts
@@ -452,7 +452,7 @@ export class KclManager {
 
   // NOTE: this always updates the code state and editor.
   // DO NOT CALL THIS from codemirror ever.
-  async executeAstMock(ast: Program = this._ast) {
+  async executeAstMock(ast: Program) {
     await this.ensureWasmInit()
 
     const newCode = recast(ast)
@@ -462,6 +462,8 @@ export class KclManager {
     }
     const newAst = await this.safeParse(newCode)
     if (!newAst) {
+      // By clearning the AST we indicate to our callers that there was an issue with execution and
+      // the pre-execution state should be restored.
       this.clearAst()
       return
     }
@@ -474,10 +476,6 @@ export class KclManager {
     })
 
     this._logs = logs
-    this.addDiagnostics(kclErrorsToDiagnostics(errors))
-    // Add warnings and non-fatal errors
-    this.addDiagnostics(complilationErrorsToDiagnostics(execState.errors))
-
     this._execState = execState
     this._variables = execState.variables
     if (!errors.length) {
@@ -494,6 +492,8 @@ export class KclManager {
     const ast = await this.safeParse(codeManager.code)
 
     if (!ast) {
+      // By clearning the AST we indicate to our callers that there was an issue with execution and
+      // the pre-execution state should be restored.
       this.clearAst()
       return
     }

--- a/src/lang/codeManager.ts
+++ b/src/lang/codeManager.ts
@@ -174,7 +174,7 @@ export default class CodeManager {
     if (err(newCode)) return
     // Test to see if we can parse the recast code, and never update the editor with bad code.
     // This should never happen ideally and should mean there is a bug in recast.
-    const result = await parse(newCode)
+    const result = parse(newCode)
     if (err(result)) {
       console.log('Recast code could not be parsed:', result, ast)
       return


### PR DESCRIPTION
There's a couple of weird bugs here, apologies in advance for rambling. The simplest one with the simplest fix is that numbers with a units suffix (e.g., `5ft`) were not being recast properly - it's a one line fix with a small change to test it (before the PR, that would be recast as `5ftft` which is a parse error).

On the frontend, that recast bug exposed another where if recasting produced code which in turn generated a parse error, then entering sketch mode would either fail, get into a weird state where sketching couldn't happen, or sometimes delete all the user's code(!). There was a couple of things going on here: if the UI generated code with an error or warning, then mock-executing that would try and report the error but because mock execution works over different code to that in the editor, trying to get codemirror to render those diagnostics caused a range-out-of-bounds error. That happened deep in some mess of React and JS callbacks such that the error was not reported or logged and instead the app would just get into weird states. The fix for this is to simply not report diagnostics from mock executions.

Finally, there is some weirdness which is not fully resolved about how state and invariants are managed in the front end. We often set the text in the editor to a recast of the AST we have either in the manager or which has been modified. However, when executing or parsing, if there is an error, then the app signals this my clearing the stored AST, presumably indicating that the AST should not be trusted as the source of truth and we should reinstate the previous source text. However, this isn't documented and that is not followed by some caller code and so if we hit this state, then we might occasionally update the source code from the AST anyway, which clears the editor. However, the simple change to not clear the AST means that cancelling sketch mode doesn't work properly and we sometimes lose changes to the source text made while in sketch mode (thankfully there is a test for this!). I've added some hacky checks to avoid clearing the editor based on an empty AST and to avoid writing an AST to the editor if the recast text doesn't parse. Unfortunately, in either case the app is going to get into a shitty state where weird things happen, but at least we don't delete all the code in the editor and then save it to disk. I'm not even sure what a proper fix is, and the call graph is abstracted by the state machine and there's lots of callers who can modify the code in the editor/on disk, so fixing this seems like a big job, even for someone who knows this code, which I clearly don't.