### PR TITLE
Change to not expose exec artifacts

### DIFF
--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -64,8 +64,6 @@ pub struct ExecOutcome {
     /// Operations that have been performed in execution order, for display in
     /// the Feature Tree.
     pub operations: Vec<Operation>,
-    /// Output map of UUIDs to artifacts.
-    pub artifacts: IndexMap<ArtifactId, Artifact>,
     /// Output commands to allow building the artifact graph by the caller.
     pub artifact_commands: Vec<ArtifactCommand>,
     /// Output artifact graph.

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -123,7 +123,6 @@ impl ExecState {
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect(),
             operations: self.global.operations,
-            artifacts: self.global.artifacts,
             artifact_commands: self.global.artifact_commands,
             artifact_graph: self.global.artifact_graph,
             errors: self.global.errors,
@@ -146,7 +145,6 @@ impl ExecState {
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect(),
             operations: Default::default(),
-            artifacts: Default::default(),
             artifact_commands: Default::default(),
             artifact_graph: Default::default(),
             errors: self.global.errors,

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -295,7 +295,6 @@ export const isPathToNodeNumber = (
 export interface ExecState {
   variables: { [key in string]?: KclValue }
   operations: Operation[]
-  artifacts: { [key in ArtifactId]?: RustArtifact }
   artifactCommands: ArtifactCommand[]
   artifactGraph: ArtifactGraph
   errors: CompilationError[]
@@ -310,7 +309,6 @@ export function emptyExecState(): ExecState {
   return {
     variables: {},
     operations: [],
-    artifacts: {},
     artifactCommands: [],
     artifactGraph: defaultArtifactGraph(),
     errors: [],
@@ -337,7 +335,6 @@ function execStateFromRust(
   return {
     variables: execOutcome.variables,
     operations: execOutcome.operations,
-    artifacts: execOutcome.artifacts,
     artifactCommands: execOutcome.artifactCommands,
     artifactGraph,
     errors: execOutcome.errors,
@@ -349,7 +346,6 @@ function mockExecStateFromRust(execOutcome: RustExecOutcome): ExecState {
   return {
     variables: execOutcome.variables,
     operations: execOutcome.operations,
-    artifacts: execOutcome.artifacts,
     artifactCommands: execOutcome.artifactCommands,
     artifactGraph: new Map<ArtifactId, Artifact>(),
     errors: execOutcome.errors,


### PR DESCRIPTION
Now that the artifact graph is built completely in Rust, these are an implementation detail that shouldn't be exposed to TS.