### PR TITLE
Add Dry Run and Multi-Edge Fillet Validation

### DIFF
--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -14,6 +14,7 @@ import { kclManager } from 'lib/singletons'
 import { err } from 'lib/trap'
 import { modelingMachine, SketchTool } from 'machines/modelingMachine'
 import {
+  filletValidator,
   loftValidator,
   revolveAxisValidator,
   shellValidator,
@@ -537,6 +538,11 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         multiple: true,
         required: true,
         skip: false,
+        /**
+         * You can't validate this step since even valid selection
+         * might fail on the engine side with the bad radius.
+         * you have to validate selection and radius together.
+         */
         warningMessage:
           'Fillets cannot touch other fillets yet. This is under development.',
       },
@@ -544,6 +550,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         inputType: 'kcl',
         defaultValue: KCL_DEFAULT_LENGTH,
         required: true,
+        validation: filletValidator,
       },
     },
   },

--- a/src/lib/commandTypes.ts
+++ b/src/lib/commandTypes.ts
@@ -189,6 +189,13 @@ export type CommandArgumentConfig<
             commandBarContext: ContextFrom<typeof commandBarMachine>,
             machineContext?: C
           ) => string)
+      validation?: ({
+        data,
+        context,
+      }: {
+        data: any
+        context: CommandBarContext
+      }) => Promise<boolean | string>
     }
   | {
       inputType: 'string'
@@ -302,6 +309,13 @@ export type CommandArgument<
             commandBarContext: ContextFrom<typeof commandBarMachine>,
             machineContext?: ContextFrom<T>
           ) => string)
+      validation?: ({
+        data,
+        context,
+      }: {
+        data: any
+        context: CommandBarContext
+      }) => Promise<boolean | string>
     }
   | {
       inputType: 'string'

--- a/src/lib/createMachineCommand.ts
+++ b/src/lib/createMachineCommand.ts
@@ -203,6 +203,7 @@ export function buildCommandArgument<
       createVariableByDefault: arg.createVariableByDefault,
       variableName: arg.variableName,
       defaultValue: arg.defaultValue,
+      validation: arg.validation,
       ...baseCommandArgument,
     } satisfies CommandArgument<O, T> & { inputType: 'kcl' }
   } else {

--- a/src/machines/commandBarMachine.ts
+++ b/src/machines/commandBarMachine.ts
@@ -296,7 +296,8 @@ export const commandBarMachine = setup({
             context.currentArgument &&
             context.selectedCommand &&
             (argConfig?.inputType === 'selection' ||
-              argConfig?.inputType === 'selectionMixed') &&
+              argConfig?.inputType === 'selectionMixed' ||
+              argConfig?.inputType === 'kcl') &&
             argConfig?.validation
           ) {
             argConfig


### PR DESCRIPTION
Implements a new `filletValidator` that handles multiple edges across different solids, and uses a dry run to catch errors early. This prevents discrepancies between the visual model and underlying code.

## Status:
We’re pausing the multi-edge fillet “dry run” feature for now.

## Reason:
The engine does not currently support a true, single-operation dry run when filleting multiple edges at once – it either only handles one edge at a time or applies each edge in sequence to original body, leading to inadequate validation. Also, typical CAD workflows let a user apply a potentially “broken” feature so it can be corrected later – we don’t necessarily want to block them entirely.

## Next Steps:
We will do a separate PR to fix the bug where if the engine applies valid fillets but fails invalid once, app gets stuck, leaving the AST/code pane out of sync with the 3D viewport. That fix will ensure the AST (and thus the code pane) always reflects what the engine actually does, even in cases of partial or failed features. This keeps code and viewport consistent, even without a “dry run” step.

related issues:

- https://github.com/KittyCAD/modeling-app/issues/4748
- https://github.com/KittyCAD/modeling-app/issues/5111