### PR TITLE
ci: Fix e2e workflow to install rust toolchain when needed

### DIFF
--- a/.github/workflows/build-and-store-wasm.yml
+++ b/.github/workflows/build-and-store-wasm.yml
@@ -16,15 +16,21 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies
         run: yarn
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-      - name: Cache wasm
-        uses: Swatinem/rust-cache@v2
+      - name: Use correct Rust toolchain
+        shell: bash
+        run: |
+          cp --update=none rust/rust-toolchain.toml ./ || true
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          workspaces: './rust'
+          cache: false # Configured below.
       - uses: taiki-e/install-action@955a6ff1416eae278c9f833008a9beb4b7f9afe3
         with:
           tool: wasm-pack
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
       - name: build wasm
         run: yarn build:wasm
 

--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -33,17 +33,24 @@ jobs:
 
       - run: yarn install
 
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
+      - name: Use correct Rust toolchain
+        shell: bash
+        run: |
+          cp --update=none rust/rust-toolchain.toml ./ || true
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          workspaces: './rust'
+          cache: false # Configured below.
 
       # TODO: see if we can fetch from main instead if no diff at rust
       - uses: taiki-e/install-action@955a6ff1416eae278c9f833008a9beb4b7f9afe3
         with:
           tool: wasm-pack
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
 
       - name: Run build:wasm
         run: "yarn build:wasm"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -135,22 +135,35 @@ jobs:
       shell: bash
       run: cp rust/kcl-wasm-lib/pkg/kcl_wasm_lib_bg.wasm public
       continue-on-error: true
+    - name: Build WASM condition
+      id: wasm
+      if: needs.conditions.outputs.should-run == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Build wasm if this is a scheduled run, there are Rust changes, or
+        # downloading from the wasm cache failed.
+        if [[ ${{github.event_name}} == 'schedule' || ${{steps.filter.outputs.rust}} == 'true' || ${{steps.download-wasm.outcome}} == 'failure' ]]; then
+          echo "should-build-wasm=true" >> $GITHUB_OUTPUT
+        else
+          echo "should-build-wasm=false" >> $GITHUB_OUTPUT
+        fi
     - name: Use correct Rust toolchain
-      if: ${{ needs.conditions.outputs.should-run == 'true' && (github.event_name == 'schedule' || steps.filter.outputs.rust == 'true' || steps.download-wasm.outcome == 'failure')  }}
+      if: ${{ needs.conditions.outputs.should-run == 'true' && steps.wasm.outputs.should-build-wasm == 'true' }}
       shell: bash
       run: |
         cp --update=none rust/rust-toolchain.toml ./ || true
     - name: Install rust
-      if: ${{ needs.conditions.outputs.should-run == 'true' && (github.event_name == 'schedule' || steps.filter.outputs.rust == 'true' || steps.download-wasm.outcome == 'failure') }}
+      if: ${{ needs.conditions.outputs.should-run == 'true' && steps.wasm.outputs.should-build-wasm == 'true' }}
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         cache: false # Configured below.
     - uses: taiki-e/install-action@955a6ff1416eae278c9f833008a9beb4b7f9afe3
-      if: ${{ needs.conditions.outputs.should-run == 'true' && (github.event_name == 'schedule' || steps.filter.outputs.rust == 'true' || steps.download-wasm.outcome == 'failure') }}
+      if: ${{ needs.conditions.outputs.should-run == 'true' && steps.wasm.outputs.should-build-wasm == 'true' }}
       with:
         tool: wasm-pack
     - name: Rust Cache
-      if: ${{ needs.conditions.outputs.should-run == 'true' && (github.event_name == 'schedule' || steps.filter.outputs.rust == 'true' || steps.download-wasm.outcome == 'failure') }}
+      if: ${{ needs.conditions.outputs.should-run == 'true' && steps.wasm.outputs.should-build-wasm == 'true' }}
       uses: Swatinem/rust-cache@v2
       with:
         workspaces: './rust'
@@ -178,7 +191,7 @@ jobs:
         cat /tmp/vector.toml
         ${HOME}/.vector/bin/vector --config /tmp/vector.toml &
     - name: Build Wasm
-      if: ${{ needs.conditions.outputs.should-run == 'true' && (github.event_name == 'schedule' || steps.filter.outputs.rust == 'true' || steps.download-wasm.outcome == 'failure') }}
+      if: ${{ needs.conditions.outputs.should-run == 'true' && steps.wasm.outputs.should-build-wasm == 'true' }}
       shell: bash
       run: yarn build:wasm
     - name: build web

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -140,7 +140,7 @@ jobs:
       if: needs.conditions.outputs.should-run == 'true'
       shell: bash
       run: |
-        set -euo pipefail
+        set -euox pipefail
         # Build wasm if this is a scheduled run, there are Rust changes, or
         # downloading from the wasm cache failed.
         if [[ ${{github.event_name}} == 'schedule' || ${{steps.filter.outputs.rust}} == 'true' || ${{steps.download-wasm.outcome}} == 'failure' ]]; then

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -136,25 +136,21 @@ jobs:
       run: cp rust/kcl-wasm-lib/pkg/kcl_wasm_lib_bg.wasm public
       continue-on-error: true
     - name: Use correct Rust toolchain
-      if: ${{ needs.conditions.outputs.should-run == 'true' && (github.event_name == 'schedule' || steps.filter.outputs.rust == 'true')  }}
+      if: ${{ needs.conditions.outputs.should-run == 'true' && (github.event_name == 'schedule' || steps.filter.outputs.rust == 'true' || steps.download-wasm.outcome == 'failure')  }}
       shell: bash
       run: |
         cp --update=none rust/rust-toolchain.toml ./ || true
     - name: Install rust
-      if: ${{ needs.conditions.outputs.should-run == 'true' && (github.event_name == 'schedule' || steps.filter.outputs.rust == 'true')  }}
+      if: ${{ needs.conditions.outputs.should-run == 'true' && (github.event_name == 'schedule' || steps.filter.outputs.rust == 'true' || steps.download-wasm.outcome == 'failure') }}
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         cache: false # Configured below.
     - uses: taiki-e/install-action@955a6ff1416eae278c9f833008a9beb4b7f9afe3
+      if: ${{ needs.conditions.outputs.should-run == 'true' && (github.event_name == 'schedule' || steps.filter.outputs.rust == 'true' || steps.download-wasm.outcome == 'failure') }}
       with:
         tool: wasm-pack
-    - name: Cache Wasm (because rust diff)
-      if: ${{ needs.conditions.outputs.should-run == 'true' && (github.event_name == 'schedule' || steps.filter.outputs.rust == 'true') }}
-      uses: Swatinem/rust-cache@v2
-      with:
-        workspaces: './rust'
-    - name: OR Cache Wasm (because wasm cache failed)
-      if: ${{ needs.conditions.outputs.should-run == 'true' && steps.download-wasm.outcome == 'failure' }}
+    - name: Rust Cache
+      if: ${{ needs.conditions.outputs.should-run == 'true' && (github.event_name == 'schedule' || steps.filter.outputs.rust == 'true' || steps.download-wasm.outcome == 'failure') }}
       uses: Swatinem/rust-cache@v2
       with:
         workspaces: './rust'
@@ -181,12 +177,8 @@ jobs:
         sed -i "s#GH_ACTIONS_AXIOM_TOKEN#${{secrets.GH_ACTIONS_AXIOM_TOKEN}}#g" /tmp/vector.toml
         cat /tmp/vector.toml
         ${HOME}/.vector/bin/vector --config /tmp/vector.toml &
-    - name: Build Wasm (because rust diff)
-      if: ${{ needs.conditions.outputs.should-run == 'true' && (github.event_name == 'schedule' || steps.filter.outputs.rust == 'true') }}
-      shell: bash
-      run: yarn build:wasm
-    - name: OR Build Wasm (because wasm cache failed)
-      if: ${{ needs.conditions.outputs.should-run == 'true' && steps.download-wasm.outcome == 'failure' }}
+    - name: Build Wasm
+      if: ${{ needs.conditions.outputs.should-run == 'true' && (github.event_name == 'schedule' || steps.filter.outputs.rust == 'true' || steps.download-wasm.outcome == 'failure') }}
       shell: bash
       run: yarn build:wasm
     - name: build web

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -135,9 +135,16 @@ jobs:
       shell: bash
       run: cp rust/kcl-wasm-lib/pkg/kcl_wasm_lib_bg.wasm public
       continue-on-error: true
-    - name: Setup Rust
-      if: ${{ needs.conditions.outputs.should-run == 'true' }}
-      uses: dtolnay/rust-toolchain@stable
+    - name: Use correct Rust toolchain
+      if: ${{ needs.conditions.outputs.should-run == 'true' && (github.event_name == 'schedule' || steps.filter.outputs.rust == 'true')  }}
+      shell: bash
+      run: |
+        cp --update=none rust/rust-toolchain.toml ./ || true
+    - name: Install rust
+      if: ${{ needs.conditions.outputs.should-run == 'true' && (github.event_name == 'schedule' || steps.filter.outputs.rust == 'true')  }}
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        cache: false # Configured below.
     - uses: taiki-e/install-action@955a6ff1416eae278c9f833008a9beb4b7f9afe3
       with:
         tool: wasm-pack


### PR DESCRIPTION
This also migrates more uses of Rust toolchain installation actions to use the same one as in #5614.