### PR TITLE
Fix toolchain file copy to work on all platforms

### DIFF
--- a/.github/workflows/build-and-store-wasm.yml
+++ b/.github/workflows/build-and-store-wasm.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Use correct Rust toolchain
         shell: bash
         run: |
-          cp --update=none rust/rust-toolchain.toml ./ || true
+          [ -e rust-toolchain.toml ] || cp rust/rust-toolchain.toml ./
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Use correct Rust toolchain
         shell: bash
         run: |
-          cp --update=none rust/rust-toolchain.toml ./ || true
+          [ -e rust-toolchain.toml ] || cp rust/rust-toolchain.toml ./
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/cargo-check.yml
+++ b/.github/workflows/cargo-check.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Use correct Rust toolchain
         shell: bash
         run: |
-          cp --update=none rust/rust-toolchain.toml ./ || true
+          [ -e rust-toolchain.toml ] || cp rust/rust-toolchain.toml ./
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/cargo-clippy.yml
+++ b/.github/workflows/cargo-clippy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Use correct Rust toolchain
         shell: bash
         run: |
-          cp --update=none rust/rust-toolchain.toml ./ || true
+          [ -e rust-toolchain.toml ] || cp rust/rust-toolchain.toml ./
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/cargo-fmt.yml
+++ b/.github/workflows/cargo-fmt.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Use correct Rust toolchain
         shell: bash
         run: |
-          cp --update=none rust/rust-toolchain.toml ./ || true
+          [ -e rust-toolchain.toml ] || cp rust/rust-toolchain.toml ./
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Use correct Rust toolchain
         shell: bash
         run: |
-          cp --update=none rust/rust-toolchain.toml ./ || true
+          [ -e rust-toolchain.toml ] || cp rust/rust-toolchain.toml ./
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -152,7 +152,7 @@ jobs:
       if: ${{ needs.conditions.outputs.should-run == 'true' && steps.wasm.outputs.should-build-wasm == 'true' }}
       shell: bash
       run: |
-        cp --update=none rust/rust-toolchain.toml ./ || true
+        [ -e rust-toolchain.toml ] || cp rust/rust-toolchain.toml ./
     - name: Install rust
       if: ${{ needs.conditions.outputs.should-run == 'true' && steps.wasm.outputs.should-build-wasm == 'true' }}
       uses: actions-rust-lang/setup-rust-toolchain@v1


### PR DESCRIPTION
This also makes it so that it doesn't swallow the error if the copy fails for some reason. Follow-up to #5728.