### PR TITLE
KCL: Fix two cryptic error messages

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3097,15 +3097,14 @@ checksum = "e6cd655523701785087f69900df39892fb7b9b0721aa67682f571c38c32ac58a"
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -3559,12 +3558,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"


### PR DESCRIPTION
Firstly, before the code "{x = 1, y = }" would give the dreaded "unexpected token" error.

Now it says "This property has a label, but no value. Put some value after the equals sign". And points to the = symbol with no matching right-hand side value. Yay!

Second fix: before, in the code `f(1, x=)`, the error complained that an unlabeled arg was not permitted there.

Now it says "This argument has a label, but no value. Put some value after the equals sign".

Closes #5647 