### PR TITLE
Improve sketch constraint test

### DIFF
--- a/e2e/playwright/testing-constraints.spec.ts
+++ b/e2e/playwright/testing-constraints.spec.ts
@@ -1127,7 +1127,6 @@ test.describe('Electron constraint tests', () => {
           path.join(bracketDir, 'main.kcl')
         )
       })
-      const [clickHandler] = scene.makeMouseHelpers(600, 300)
 
       await test.step('setup test', async () => {
         await homePage.expectState({
@@ -1144,8 +1143,12 @@ test.describe('Electron constraint tests', () => {
       })
 
       await test.step('Double click to constrain', async () => {
-        await clickHandler()
-        await page.getByRole('button', { name: 'Edit Sketch' }).click()
+        // Enter sketch edit mode via feature tree
+        await toolbar.openPane('feature-tree')
+        const op = await toolbar.getFeatureTreeOperation('Sketch', 0)
+        await op.dblclick()
+        await toolbar.closePane('feature-tree')
+
         const child = page
           .locator('.segment-length-label-text')
           .first()


### PR DESCRIPTION
Seen consistent failures of this test, example https://github.com/KittyCAD/modeling-app/actions/runs/13793844159/job/38580451541#step:27:3414

This PR changes the way we enter the sketch, through button clicks in the feature tree instead of stream coordinates.