### PR TITLE
Hide selection-type args from command palette while in an edit flow

### DIFF
--- a/e2e/playwright/feature-tree-pane.spec.ts
+++ b/e2e/playwright/feature-tree-pane.spec.ts
@@ -274,7 +274,6 @@ test.describe('Feature Tree pane', () => {
         currentArgKey: 'distance',
         currentArgValue: initialInput,
         headerArguments: {
-          Selection: '1 face',
           Distance: initialInput,
         },
         highlightedHeaderArg: 'distance',
@@ -291,7 +290,6 @@ test.describe('Feature Tree pane', () => {
       await cmdBar.expectState({
         stage: 'review',
         headerArguments: {
-          Selection: '1 face',
           // The calculated value is shown in the argument summary
           Distance: initialInput,
         },

--- a/src/components/CommandBar/CommandBarHeader.tsx
+++ b/src/components/CommandBar/CommandBarHeader.tsx
@@ -17,7 +17,12 @@ function CommandBarHeader({ children }: React.PropsWithChildren<{}>) {
     if (!selectedCommand?.args) return undefined
     const s = { ...selectedCommand.args }
     for (const [name, arg] of Object.entries(s)) {
-      if (arg.hidden) delete s[name]
+      if (
+        typeof arg.hidden === 'function'
+          ? arg.hidden(commandBarState.context)
+          : arg.hidden
+      )
+        delete s[name]
     }
     return s
   }, [selectedCommand])

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -319,6 +319,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         multiple: false, // TODO: multiple selection
         required: true,
         skip: true,
+        hidden: (context) => Boolean(context.argumentsToSubmit.nodeToEdit),
       },
       // result: {
       //   inputType: 'options',
@@ -407,6 +408,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         multiple: false, // TODO: multiple selection
         required: true,
         skip: true,
+        hidden: (context) => Boolean(context.argumentsToSubmit.nodeToEdit),
       },
       axisOrEdge: {
         inputType: 'options',
@@ -416,6 +418,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
           { name: 'Axis', isCurrent: true, value: 'Axis' },
           { name: 'Edge', isCurrent: false, value: 'Edge' },
         ],
+        hidden: (context) => Boolean(context.argumentsToSubmit.nodeToEdit),
       },
       axis: {
         required: (commandContext) =>
@@ -437,6 +440,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         selectionTypes: ['segment', 'sweepEdge', 'edgeCutEdge'],
         multiple: false,
         validation: revolveAxisValidator,
+        hidden: (context) => Boolean(context.argumentsToSubmit.nodeToEdit),
       },
       angle: {
         inputType: 'kcl',

--- a/src/lib/commandTypes.ts
+++ b/src/lib/commandTypes.ts
@@ -120,7 +120,12 @@ export type CommandArgumentConfig<
       ) => boolean)
   warningMessage?: string
   /** If `true`, arg is used as passed-through data, never for user input */
-  hidden?: boolean
+  hidden?:
+    | boolean
+    | ((
+        commandBarContext: { argumentsToSubmit: Record<string, unknown> }, // Should be the commandbarMachine's context, but it creates a circular dependency
+        machineContext?: C
+      ) => boolean)
   skip?: boolean
   /** For showing a summary display of the current value, such as in
    *  the command bar's header
@@ -236,7 +241,12 @@ export type CommandArgument<
         machineContext?: ContextFrom<T>
       ) => boolean)
   /** If `true`, arg is used as passed-through data, never for user input */
-  hidden?: boolean
+  hidden?:
+    | boolean
+    | ((
+        commandBarContext: { argumentsToSubmit: Record<string, unknown> }, // Should be the commandbarMachine's context, but it creates a circular dependency
+        machineContext?: ContextFrom<T>
+      ) => boolean)
   skip?: boolean
   machineActor?: Actor<T>
   warningMessage?: string

--- a/src/machines/commandBarMachine.ts
+++ b/src/machines/commandBarMachine.ts
@@ -134,8 +134,10 @@ export const commandBarMachine = setup({
         // that is, the first argument that is not already in the argumentsToSubmit
         // or hidden, or that is not undefined, or that is not marked as "skippable".
         // TODO validate the type of the existing arguments
-        const nonHiddenArgs = Object.entries(selectedCommand.args).filter(
-          (a) => !a[1].hidden
+        const nonHiddenArgs = Object.entries(selectedCommand.args).filter((a) =>
+          a[1].hidden && typeof a[1].hidden === 'function'
+            ? !a[1].hidden(context)
+            : !a[1].hidden
         )
         let argIndex = 0
 
@@ -260,7 +262,11 @@ export const commandBarMachine = setup({
     },
     'All arguments are skippable': ({ context }) => {
       return Object.values(context.selectedCommand!.args!).every(
-        (argConfig) => argConfig.skip || argConfig.hidden
+        (argConfig) =>
+          argConfig.skip ||
+          (typeof argConfig.hidden === 'function'
+            ? argConfig.hidden(context)
+            : argConfig.hidden)
       )
     },
     'Has selected command': ({ context }) => !!context.selectedCommand,


### PR DESCRIPTION
As a workaround until we have time for https://github.com/KittyCAD/modeling-app/issues/5190, we will hide any selection type arguments from the command palette while the user is in an edit flow, so that they do not run the risk of selecting items that are in the scene but were generated after the operation being edited. This can be detected by the presence of a `nodeToEdit` in the command palettes arguments (which is also hidden).

This PR:
1. refactors the `hidden` argument config to be able to be a function that takes the current command palette context.
2. configures all the selection-based arguments for modeling commands we have edit flows for to be hidden if `nodeToEdit` is present
3. updates the existing E2E tests to expect the selection-based arguments to _not_ be present in edit flow tests