### PR TITLE
Add warning when using a module with no return value

### DIFF
--- a/rust/kcl-lib/e2e/executor/main.rs
+++ b/rust/kcl-lib/e2e/executor/main.rs
@@ -857,7 +857,7 @@ part = rectShape([0, 0], 20, 20)
     };
     assert_eq!(
         err.error.message(),
-        "This function expected the unlabeled argument to be of type SketchOrSurface but it's actually of type string (text)"
+        "This function expected the input argument to be of type SketchOrSurface but it's actually of type string (text)"
     );
 }
 
@@ -2103,7 +2103,7 @@ async fn kcl_test_better_type_names() {
         },
         None => todo!(),
     };
-    assert_eq!(err, "This function expected the unlabeled argument to be of type SolidSet but it's actually of type Sketch. You can convert a sketch (2D) into a Solid (3D) by calling a function like `extrude` or `revolve`");
+    assert_eq!(err, "This function expected the input argument to be of type SolidSet but it's actually of type Sketch. You can convert a sketch (2D) into a Solid (3D) by calling a function like `extrude` or `revolve`");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/rust/kcl-lib/e2e/executor/main.rs
+++ b/rust/kcl-lib/e2e/executor/main.rs
@@ -857,7 +857,7 @@ part = rectShape([0, 0], 20, 20)
     };
     assert_eq!(
         err.error.message(),
-        "This function expected this argument to be of type SketchOrSurface but it's actually of type string (text)"
+        "This function expected the unlabeled argument to be of type SketchOrSurface but it's actually of type string (text)"
     );
 }
 
@@ -2103,7 +2103,7 @@ async fn kcl_test_better_type_names() {
         },
         None => todo!(),
     };
-    assert_eq!(err, "This function expected this argument to be of type SolidSet but it's actually of type Sketch. You can convert a sketch (2D) into a Solid (3D) by calling a function like `extrude` or `revolve`");
+    assert_eq!(err, "This function expected the unlabeled argument to be of type SolidSet but it's actually of type Sketch. You can convert a sketch (2D) into a Solid (3D) by calling a function like `extrude` or `revolve`");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/rust/kcl-lib/src/execution/kcl_value.rs
+++ b/rust/kcl-lib/src/execution/kcl_value.rs
@@ -659,7 +659,11 @@ impl KclValue {
                     args,
                     source_range,
                     ctx.clone(),
-                    exec_state.mod_local.pipe_value.clone().map(Arg::synthetic),
+                    exec_state
+                        .mod_local
+                        .pipe_value
+                        .clone()
+                        .map(|v| Arg::new(v, source_range)),
                 );
                 let result = func(exec_state, args).await.map(Some);
                 exec_state.mut_stack().pop_env();

--- a/rust/kcl-lib/src/std/args.rs
+++ b/rust/kcl-lib/src/std/args.rs
@@ -184,7 +184,7 @@ impl Args {
         T::from_kcl_val(&arg.value).ok_or_else(|| {
             let expected_type_name = tynm::type_name::<T>();
             let actual_type_name = arg.value.human_friendly_type();
-            let msg_base = format!("This function expected this argument to be of type {expected_type_name} but it's actually of type {actual_type_name}");
+            let msg_base = format!("This function expected the unlabeled argument to be of type {expected_type_name} but it's actually of type {actual_type_name}");
             let suggestion = match (expected_type_name.as_str(), actual_type_name) {
                 ("SolidSet", "Sketch") => Some(
                     "You can convert a sketch (2D) into a Solid (3D) by calling a function like `extrude` or `revolve`",

--- a/rust/kcl-lib/src/std/args.rs
+++ b/rust/kcl-lib/src/std/args.rs
@@ -184,7 +184,7 @@ impl Args {
         T::from_kcl_val(&arg.value).ok_or_else(|| {
             let expected_type_name = tynm::type_name::<T>();
             let actual_type_name = arg.value.human_friendly_type();
-            let msg_base = format!("This function expected the unlabeled argument to be of type {expected_type_name} but it's actually of type {actual_type_name}");
+            let msg_base = format!("This function expected the input argument to be of type {expected_type_name} but it's actually of type {actual_type_name}");
             let suggestion = match (expected_type_name.as_str(), actual_type_name) {
                 ("SolidSet", "Sketch") => Some(
                     "You can convert a sketch (2D) into a Solid (3D) by calling a function like `extrude` or `revolve`",

--- a/rust/kcl-lib/tests/angled_line/ops.snap
+++ b/rust/kcl-lib/tests/angled_line/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed angled_line.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed angled_line.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        270,
+        289,
         0
       ]
     }

--- a/rust/kcl-lib/tests/artifact_graph_example_code1/ops.snap
+++ b/rust/kcl-lib/tests/artifact_graph_example_code1/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed artifact_graph_example_code1.kcl
 ---
 [
@@ -125,8 +125,8 @@ description: Operations executed artifact_graph_example_code1.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        298,
+        332,
         0
       ]
     }

--- a/rust/kcl-lib/tests/basic_fillet_cube_close_opposite/ops.snap
+++ b/rust/kcl-lib/tests/basic_fillet_cube_close_opposite/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed basic_fillet_cube_close_opposite.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed basic_fillet_cube_close_opposite.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        197,
+        217,
         0
       ]
     }
@@ -129,8 +129,8 @@ description: Operations executed basic_fillet_cube_close_opposite.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        223,
+        283,
         0
       ]
     }

--- a/rust/kcl-lib/tests/basic_fillet_cube_end/ops.snap
+++ b/rust/kcl-lib/tests/basic_fillet_cube_end/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed basic_fillet_cube_end.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed basic_fillet_cube_end.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        185,
+        205,
         0
       ]
     }
@@ -129,8 +129,8 @@ description: Operations executed basic_fillet_cube_end.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        211,
+        269,
         0
       ]
     }

--- a/rust/kcl-lib/tests/basic_fillet_cube_next_adjacent/ops.snap
+++ b/rust/kcl-lib/tests/basic_fillet_cube_next_adjacent/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed basic_fillet_cube_next_adjacent.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed basic_fillet_cube_next_adjacent.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        212,
+        232,
         0
       ]
     }
@@ -124,8 +124,8 @@ description: Operations executed basic_fillet_cube_next_adjacent.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        238,
+        294,
         0
       ]
     }

--- a/rust/kcl-lib/tests/basic_fillet_cube_previous_adjacent/ops.snap
+++ b/rust/kcl-lib/tests/basic_fillet_cube_previous_adjacent/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed basic_fillet_cube_previous_adjacent.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed basic_fillet_cube_previous_adjacent.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        212,
+        232,
         0
       ]
     }
@@ -124,8 +124,8 @@ description: Operations executed basic_fillet_cube_previous_adjacent.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        238,
+        298,
         0
       ]
     }

--- a/rust/kcl-lib/tests/basic_fillet_cube_start/ops.snap
+++ b/rust/kcl-lib/tests/basic_fillet_cube_start/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed basic_fillet_cube_start.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed basic_fillet_cube_start.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        185,
+        205,
         0
       ]
     }
@@ -130,8 +130,8 @@ description: Operations executed basic_fillet_cube_start.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        211,
+        253,
         0
       ]
     }

--- a/rust/kcl-lib/tests/big_number_angle_to_match_length_x/ops.snap
+++ b/rust/kcl-lib/tests/big_number_angle_to_match_length_x/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed big_number_angle_to_match_length_x.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed big_number_angle_to_match_length_x.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        183,
+        203,
         0
       ]
     }

--- a/rust/kcl-lib/tests/big_number_angle_to_match_length_y/ops.snap
+++ b/rust/kcl-lib/tests/big_number_angle_to_match_length_y/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed big_number_angle_to_match_length_y.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed big_number_angle_to_match_length_y.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        183,
+        203,
         0
       ]
     }

--- a/rust/kcl-lib/tests/circle_three_point/ops.snap
+++ b/rust/kcl-lib/tests/circle_three_point/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed circle_three_point.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed circle_three_point.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        104,
+        124,
         0
       ]
     }

--- a/rust/kcl-lib/tests/circular_pattern3d_a_pattern/ops.snap
+++ b/rust/kcl-lib/tests/circular_pattern3d_a_pattern/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed circular_pattern3d_a_pattern.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed circular_pattern3d_a_pattern.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        159,
+        178,
         0
       ]
     }

--- a/rust/kcl-lib/tests/cube/ops.snap
+++ b/rust/kcl-lib/tests/cube/ops.snap
@@ -139,8 +139,8 @@ description: Operations executed cube.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        374,
+        402,
         0
       ]
     }

--- a/rust/kcl-lib/tests/cube_with_error/ops.snap
+++ b/rust/kcl-lib/tests/cube_with_error/ops.snap
@@ -80,8 +80,8 @@ description: Operations executed cube_with_error.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        366,
+        390,
         0
       ]
     }

--- a/rust/kcl-lib/tests/fillet-and-shell/ops.snap
+++ b/rust/kcl-lib/tests/fillet-and-shell/ops.snap
@@ -87,8 +87,8 @@ description: Operations executed fillet-and-shell.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1057,
+        1085,
         0
       ]
     }
@@ -159,8 +159,8 @@ description: Operations executed fillet-and-shell.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1091,
+        1297,
         0
       ]
     }
@@ -280,8 +280,8 @@ description: Operations executed fillet-and-shell.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1497,
+        1521,
         0
       ]
     }
@@ -404,8 +404,8 @@ description: Operations executed fillet-and-shell.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1497,
+        1521,
         0
       ]
     }
@@ -528,8 +528,8 @@ description: Operations executed fillet-and-shell.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1497,
+        1521,
         0
       ]
     }
@@ -652,8 +652,8 @@ description: Operations executed fillet-and-shell.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1497,
+        1521,
         0
       ]
     }

--- a/rust/kcl-lib/tests/function_sketch/ops.snap
+++ b/rust/kcl-lib/tests/function_sketch/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed function_sketch.kcl
 ---
 [
@@ -80,8 +80,8 @@ description: Operations executed function_sketch.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        183,
+        202,
         0
       ]
     }

--- a/rust/kcl-lib/tests/function_sketch_with_position/ops.snap
+++ b/rust/kcl-lib/tests/function_sketch_with_position/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed function_sketch_with_position.kcl
 ---
 [
@@ -80,8 +80,8 @@ description: Operations executed function_sketch_with_position.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        181,
+        200,
         0
       ]
     }

--- a/rust/kcl-lib/tests/helix_ccw/ops.snap
+++ b/rust/kcl-lib/tests/helix_ccw/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed helix_ccw.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed helix_ccw.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        77,
+        97,
         0
       ]
     }

--- a/rust/kcl-lib/tests/i_shape/ops.snap
+++ b/rust/kcl-lib/tests/i_shape/ops.snap
@@ -125,8 +125,8 @@ description: Operations executed i_shape.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2510,
+        2531,
         0
       ]
     }

--- a/rust/kcl-lib/tests/import_whole/ops.snap
+++ b/rust/kcl-lib/tests/import_whole/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed import_whole.kcl
 ---
 [
@@ -64,9 +64,9 @@ description: Operations executed import_whole.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        103,
+        123,
+        3
       ]
     }
   },
@@ -124,8 +124,8 @@ description: Operations executed import_whole.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        83,
+        123,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/3d-boaty/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/3d-boaty/ops.snap
@@ -93,9 +93,9 @@ description: Operations executed 3d-boaty.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        1379,
+        1417,
+        3
       ]
     }
   },
@@ -173,9 +173,9 @@ description: Operations executed 3d-boaty.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        1455,
+        1494,
+        3
       ]
     }
   },
@@ -428,9 +428,9 @@ description: Operations executed 3d-boaty.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        1379,
+        1417,
+        3
       ]
     }
   },
@@ -508,9 +508,9 @@ description: Operations executed 3d-boaty.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        1455,
+        1494,
+        3
       ]
     }
   },
@@ -763,9 +763,9 @@ description: Operations executed 3d-boaty.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        1379,
+        1417,
+        3
       ]
     }
   },
@@ -843,9 +843,9 @@ description: Operations executed 3d-boaty.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        1455,
+        1494,
+        3
       ]
     }
   },
@@ -1104,9 +1104,9 @@ description: Operations executed 3d-boaty.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        1949,
+        1973,
+        3
       ]
     }
   },
@@ -1190,9 +1190,9 @@ description: Operations executed 3d-boaty.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        2015,
+        2039,
+        3
       ]
     }
   },
@@ -1339,9 +1339,9 @@ description: Operations executed 3d-boaty.kcl
         ]
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        2523,
+        2547,
+        3
       ]
     }
   },
@@ -1485,9 +1485,9 @@ description: Operations executed 3d-boaty.kcl
         ]
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        3047,
+        3071,
+        3
       ]
     }
   },

--- a/rust/kcl-lib/tests/kcl_samples/80-20-rail/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/80-20-rail/ops.snap
@@ -118,8 +118,8 @@ description: Operations executed 80-20-rail.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        6006,
+        6034,
         0
       ]
     }
@@ -238,8 +238,8 @@ description: Operations executed 80-20-rail.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        6042,
+        6746,
         0
       ]
     }
@@ -358,8 +358,8 @@ description: Operations executed 80-20-rail.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        6754,
+        7457,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/a-parametric-bearing-pillow-block/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/a-parametric-bearing-pillow-block/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed a-parametric-bearing-pillow-block.kcl
 ---
 [
@@ -254,8 +254,8 @@ description: Operations executed a-parametric-bearing-pillow-block.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1902,
+        1936,
         0
       ]
     }
@@ -693,8 +693,8 @@ description: Operations executed a-parametric-bearing-pillow-block.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        3383,
+        3408,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/ball-bearing/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/ball-bearing/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed ball-bearing.kcl
 ---
 [
@@ -519,8 +519,8 @@ description: Operations executed ball-bearing.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1561,
+        1721,
         0
       ]
     }
@@ -779,8 +779,8 @@ description: Operations executed ball-bearing.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2214,
+        2374,
         0
       ]
     }
@@ -1027,8 +1027,8 @@ description: Operations executed ball-bearing.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2718,
+        2878,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/bracket/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/bracket/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed bracket.kcl
 ---
 [
@@ -274,8 +274,8 @@ description: Operations executed bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1903,
+        2052,
         0
       ]
     }
@@ -724,8 +724,8 @@ description: Operations executed bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        3306,
+        3455,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/car-wheel-assembly/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/car-wheel-assembly/ops.snap
@@ -1510,9 +1510,9 @@ description: Operations executed car-wheel-assembly.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        529,
+        562,
+        3
       ]
     }
   },
@@ -1622,9 +1622,9 @@ description: Operations executed car-wheel-assembly.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        859,
+        892,
+        3
       ]
     }
   },
@@ -1710,9 +1710,9 @@ description: Operations executed car-wheel-assembly.kcl
         ]
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        1214,
+        1248,
+        3
       ]
     }
   },
@@ -1798,9 +1798,9 @@ description: Operations executed car-wheel-assembly.kcl
         ]
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        1572,
+        1606,
+        3
       ]
     }
   },
@@ -2362,9 +2362,9 @@ description: Operations executed car-wheel-assembly.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        4067,
+        4247,
+        3
       ]
     }
   },
@@ -2801,9 +2801,9 @@ description: Operations executed car-wheel-assembly.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        4067,
+        4247,
+        3
       ]
     }
   },
@@ -3298,8 +3298,8 @@ description: Operations executed car-wheel-assembly.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        373,
+        524,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/enclosure/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/enclosure/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed enclosure.kcl
 ---
 [
@@ -130,8 +130,8 @@ description: Operations executed enclosure.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        740,
+        1021,
         0
       ]
     }
@@ -190,8 +190,8 @@ description: Operations executed enclosure.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1100,
+        1170,
         0
       ]
     }
@@ -1699,8 +1699,8 @@ description: Operations executed enclosure.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        3601,
+        3882,
         0
       ]
     }
@@ -1997,8 +1997,8 @@ description: Operations executed enclosure.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        5327,
+        5608,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/exhaust-manifold/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/exhaust-manifold/ops.snap
@@ -338,8 +338,8 @@ description: Operations executed exhaust-manifold.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1547,
+        1570,
         0
       ]
     }
@@ -682,8 +682,8 @@ description: Operations executed exhaust-manifold.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1547,
+        1570,
         0
       ]
     }
@@ -1026,8 +1026,8 @@ description: Operations executed exhaust-manifold.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1547,
+        1570,
         0
       ]
     }
@@ -1370,8 +1370,8 @@ description: Operations executed exhaust-manifold.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1547,
+        1570,
         0
       ]
     }
@@ -1744,8 +1744,8 @@ description: Operations executed exhaust-manifold.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        3933,
+        3962,
         0
       ]
     }
@@ -1808,8 +1808,8 @@ description: Operations executed exhaust-manifold.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        3968,
+        4101,
         0
       ]
     }
@@ -1872,8 +1872,8 @@ description: Operations executed exhaust-manifold.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        4107,
+        4240,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/flange-with-patterns/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/flange-with-patterns/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed flange-with-patterns.kcl
 ---
 [
@@ -174,8 +174,8 @@ description: Operations executed flange-with-patterns.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1413,
+        1444,
         0
       ]
     }
@@ -461,8 +461,8 @@ description: Operations executed flange-with-patterns.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1928,
+        1963,
         0
       ]
     }
@@ -566,8 +566,8 @@ description: Operations executed flange-with-patterns.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2230,
+        2264,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/flange-xy/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/flange-xy/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed flange-xy.kcl
 ---
 [
@@ -254,8 +254,8 @@ description: Operations executed flange-xy.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1555,
+        1586,
         0
       ]
     }
@@ -552,8 +552,8 @@ description: Operations executed flange-xy.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2077,
+        2112,
         0
       ]
     }
@@ -657,8 +657,8 @@ description: Operations executed flange-xy.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2379,
+        2413,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/focusrite-scarlett-mounting-bracket/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/focusrite-scarlett-mounting-bracket/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed focusrite-scarlett-mounting-bracket.kcl
 ---
 [
@@ -253,8 +253,8 @@ description: Operations executed focusrite-scarlett-mounting-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1831,
+        1865,
         0
       ]
     }
@@ -325,8 +325,8 @@ description: Operations executed focusrite-scarlett-mounting-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1871,
+        2129,
         0
       ]
     }
@@ -612,8 +612,8 @@ description: Operations executed focusrite-scarlett-mounting-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2875,
+        2900,
         0
       ]
     }
@@ -670,8 +670,8 @@ description: Operations executed focusrite-scarlett-mounting-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2906,
+        3050,
         0
       ]
     }
@@ -779,8 +779,8 @@ description: Operations executed focusrite-scarlett-mounting-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        3056,
+        3184,
         0
       ]
     }
@@ -1066,8 +1066,8 @@ description: Operations executed focusrite-scarlett-mounting-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        3719,
+        3744,
         0
       ]
     }
@@ -1124,8 +1124,8 @@ description: Operations executed focusrite-scarlett-mounting-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        3750,
+        3894,
         0
       ]
     }
@@ -1233,8 +1233,8 @@ description: Operations executed focusrite-scarlett-mounting-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        3900,
+        4028,
         0
       ]
     }
@@ -1476,8 +1476,8 @@ description: Operations executed focusrite-scarlett-mounting-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        4458,
+        4486,
         0
       ]
     }
@@ -1719,8 +1719,8 @@ description: Operations executed focusrite-scarlett-mounting-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        4706,
+        4734,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/french-press/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/french-press/ops.snap
@@ -323,8 +323,8 @@ description: Operations executed french-press.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2157,
+        2179,
         0
       ]
     }
@@ -500,8 +500,8 @@ description: Operations executed french-press.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2185,
+        2340,
         0
       ]
     }
@@ -1293,8 +1293,8 @@ description: Operations executed french-press.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        5053,
+        5092,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/gear-rack/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/gear-rack/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed gear-rack.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed gear-rack.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        731,
+        754,
         0
       ]
     }
@@ -147,8 +147,8 @@ description: Operations executed gear-rack.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1279,
+        1302,
         0
       ]
     }
@@ -265,8 +265,8 @@ description: Operations executed gear-rack.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1409,
+        1508,
         0
       ]
     }
@@ -332,8 +332,8 @@ description: Operations executed gear-rack.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1820,
+        1843,
         0
       ]
     }
@@ -399,8 +399,8 @@ description: Operations executed gear-rack.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2157,
+        2180,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/gear/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/gear/ops.snap
@@ -5897,8 +5897,8 @@ description: Operations executed gear.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1405,
+        1433,
         0
       ]
     }
@@ -9802,8 +9802,8 @@ description: Operations executed gear.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2128,
+        2156,
         0
       ]
     }
@@ -9979,8 +9979,8 @@ description: Operations executed gear.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2162,
+        2322,
         0
       ]
     }
@@ -10097,8 +10097,8 @@ description: Operations executed gear.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        3058,
+        3087,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/gridfinity-baseplate-magnets/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/gridfinity-baseplate-magnets/ops.snap
@@ -919,8 +919,8 @@ description: Operations executed gridfinity-baseplate-magnets.kcl
         ]
       },
       "sourceRange": [
-        0,
-        0,
+        2243,
+        2360,
         0
       ]
     }
@@ -1183,8 +1183,8 @@ description: Operations executed gridfinity-baseplate-magnets.kcl
         ]
       },
       "sourceRange": [
-        0,
-        0,
+        2584,
+        2701,
         0
       ]
     }
@@ -2008,8 +2008,8 @@ description: Operations executed gridfinity-baseplate-magnets.kcl
         ]
       },
       "sourceRange": [
-        0,
-        0,
+        6613,
+        6730,
         0
       ]
     }
@@ -2243,8 +2243,8 @@ description: Operations executed gridfinity-baseplate-magnets.kcl
         ]
       },
       "sourceRange": [
-        0,
-        0,
+        6933,
+        7050,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/gridfinity-baseplate/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/gridfinity-baseplate/ops.snap
@@ -919,8 +919,8 @@ description: Operations executed gridfinity-baseplate.kcl
         ]
       },
       "sourceRange": [
-        0,
-        0,
+        2118,
+        2235,
         0
       ]
     }
@@ -1183,8 +1183,8 @@ description: Operations executed gridfinity-baseplate.kcl
         ]
       },
       "sourceRange": [
-        0,
-        0,
+        2459,
+        2576,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/gridfinity-bins-stacking-lip/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/gridfinity-bins-stacking-lip/ops.snap
@@ -722,8 +722,8 @@ description: Operations executed gridfinity-bins-stacking-lip.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2875,
+        2899,
         0
       ]
     }
@@ -794,8 +794,8 @@ description: Operations executed gridfinity-bins-stacking-lip.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2905,
+        3134,
         0
       ]
     }
@@ -885,8 +885,8 @@ description: Operations executed gridfinity-bins-stacking-lip.kcl
         ]
       },
       "sourceRange": [
-        0,
-        0,
+        3580,
+        3607,
         0
       ]
     }
@@ -1137,8 +1137,8 @@ description: Operations executed gridfinity-bins-stacking-lip.kcl
         ]
       },
       "sourceRange": [
-        0,
-        0,
+        3813,
+        3943,
         0
       ]
     }
@@ -1389,8 +1389,8 @@ description: Operations executed gridfinity-bins-stacking-lip.kcl
         ]
       },
       "sourceRange": [
-        0,
-        0,
+        4174,
+        4304,
         0
       ]
     }
@@ -1612,8 +1612,8 @@ description: Operations executed gridfinity-bins-stacking-lip.kcl
         ]
       },
       "sourceRange": [
-        0,
-        0,
+        4529,
+        4659,
         0
       ]
     }
@@ -1715,8 +1715,8 @@ description: Operations executed gridfinity-bins-stacking-lip.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        5002,
+        5046,
         0
       ]
     }
@@ -1787,8 +1787,8 @@ description: Operations executed gridfinity-bins-stacking-lip.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        5052,
+        5284,
         0
       ]
     }
@@ -1847,8 +1847,8 @@ description: Operations executed gridfinity-bins-stacking-lip.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        5290,
+        5332,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/gridfinity-bins/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/gridfinity-bins/ops.snap
@@ -722,8 +722,8 @@ description: Operations executed gridfinity-bins.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2618,
+        2642,
         0
       ]
     }
@@ -794,8 +794,8 @@ description: Operations executed gridfinity-bins.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2648,
+        2877,
         0
       ]
     }
@@ -885,8 +885,8 @@ description: Operations executed gridfinity-bins.kcl
         ]
       },
       "sourceRange": [
-        0,
-        0,
+        3323,
+        3350,
         0
       ]
     }
@@ -1137,8 +1137,8 @@ description: Operations executed gridfinity-bins.kcl
         ]
       },
       "sourceRange": [
-        0,
-        0,
+        3556,
+        3686,
         0
       ]
     }
@@ -1389,8 +1389,8 @@ description: Operations executed gridfinity-bins.kcl
         ]
       },
       "sourceRange": [
-        0,
-        0,
+        3917,
+        4047,
         0
       ]
     }
@@ -1612,8 +1612,8 @@ description: Operations executed gridfinity-bins.kcl
         ]
       },
       "sourceRange": [
-        0,
-        0,
+        4272,
+        4402,
         0
       ]
     }
@@ -1715,8 +1715,8 @@ description: Operations executed gridfinity-bins.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        4771,
+        4815,
         0
       ]
     }
@@ -1787,8 +1787,8 @@ description: Operations executed gridfinity-bins.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        4821,
+        5053,
         0
       ]
     }
@@ -1847,8 +1847,8 @@ description: Operations executed gridfinity-bins.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        5059,
+        5101,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/hex-nut/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/hex-nut/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed hex-nut.kcl
 ---
 [
@@ -118,8 +118,8 @@ description: Operations executed hex-nut.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1038,
+        1059,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/i-beam/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/i-beam/ops.snap
@@ -66,8 +66,8 @@ description: Operations executed i-beam.kcl
         ]
       },
       "sourceRange": [
-        0,
-        0,
+        652,
+        680,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/kitt/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/kitt/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed kitt.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        900,
+        930,
         0
       ]
     }
@@ -160,8 +160,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -243,8 +243,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2204,
+        2235,
         0
       ]
     }
@@ -339,8 +339,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -438,8 +438,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -537,8 +537,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -636,8 +636,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -719,8 +719,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        3485,
+        3514,
         0
       ]
     }
@@ -815,8 +815,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -914,8 +914,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -1013,8 +1013,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -1112,8 +1112,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -1211,8 +1211,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -1310,8 +1310,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -1409,8 +1409,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -1508,8 +1508,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -1607,8 +1607,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -1706,8 +1706,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -1805,8 +1805,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -1904,8 +1904,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -2003,8 +2003,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -2185,8 +2185,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -2370,8 +2370,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -2489,8 +2489,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -2588,8 +2588,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -2687,8 +2687,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -2786,8 +2786,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -2905,8 +2905,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -3004,8 +3004,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -3103,8 +3103,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -3202,8 +3202,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -3305,8 +3305,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -3405,8 +3405,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -3505,8 +3505,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -3605,8 +3605,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -3705,8 +3705,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -3805,8 +3805,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -3905,8 +3905,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -4005,8 +4005,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -4105,8 +4105,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }
@@ -4205,8 +4205,8 @@ description: Operations executed kitt.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        449,
+        472,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/lego/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/lego/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed lego.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed lego.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1780,
+        1804,
         0
       ]
     }
@@ -138,8 +138,8 @@ description: Operations executed lego.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2221,
+        2252,
         0
       ]
     }
@@ -262,8 +262,8 @@ description: Operations executed lego.kcl
         ]
       },
       "sourceRange": [
-        0,
-        0,
+        2687,
+        2715,
         0
       ]
     }
@@ -528,8 +528,8 @@ description: Operations executed lego.kcl
         ]
       },
       "sourceRange": [
-        0,
-        0,
+        3197,
+        3226,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/mounting-plate/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/mounting-plate/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed mounting-plate.kcl
 ---
 [
@@ -273,8 +273,8 @@ description: Operations executed mounting-plate.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1825,
+        1857,
         0
       ]
     }
@@ -345,8 +345,8 @@ description: Operations executed mounting-plate.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1863,
+        2127,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/multi-axis-robot/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/multi-axis-robot/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed multi-axis-robot.kcl
 ---
 [
@@ -212,9 +212,9 @@ description: Operations executed multi-axis-robot.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        769,
+        1045,
+        3
       ]
     }
   },
@@ -352,9 +352,9 @@ description: Operations executed multi-axis-robot.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        1280,
+        1362,
+        3
       ]
     }
   },
@@ -923,9 +923,9 @@ description: Operations executed multi-axis-robot.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        323,
+        406,
+        4
       ]
     }
   },
@@ -1340,9 +1340,9 @@ description: Operations executed multi-axis-robot.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        1143,
+        1226,
+        4
       ]
     }
   },
@@ -1685,9 +1685,9 @@ description: Operations executed multi-axis-robot.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        1996,
+        2079,
+        4
       ]
     }
   },
@@ -2341,9 +2341,9 @@ description: Operations executed multi-axis-robot.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        1033,
+        1116,
+        5
       ]
     }
   },
@@ -2519,9 +2519,9 @@ description: Operations executed multi-axis-robot.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        1415,
+        1498,
+        5
       ]
     }
   },
@@ -3400,9 +3400,9 @@ description: Operations executed multi-axis-robot.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        1299,
+        1382,
+        6
       ]
     }
   },

--- a/rust/kcl-lib/tests/kcl_samples/pipe-flange-assembly/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/pipe-flange-assembly/ops.snap
@@ -247,8 +247,8 @@ description: Operations executed pipe-flange-assembly.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        5504,
+        5535,
         0
       ]
     }
@@ -410,8 +410,8 @@ description: Operations executed pipe-flange-assembly.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        5838,
+        5872,
         0
       ]
     }
@@ -713,8 +713,8 @@ description: Operations executed pipe-flange-assembly.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        3177,
+        3198,
         0
       ]
     }
@@ -893,8 +893,8 @@ description: Operations executed pipe-flange-assembly.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        6049,
+        6204,
         0
       ]
     }
@@ -1431,8 +1431,8 @@ description: Operations executed pipe-flange-assembly.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        6407,
+        6562,
         0
       ]
     }
@@ -1857,8 +1857,8 @@ description: Operations executed pipe-flange-assembly.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        6781,
+        6936,
         0
       ]
     }
@@ -2160,8 +2160,8 @@ description: Operations executed pipe-flange-assembly.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        3177,
+        3198,
         0
       ]
     }
@@ -2340,8 +2340,8 @@ description: Operations executed pipe-flange-assembly.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        7426,
+        7581,
         0
       ]
     }
@@ -2643,8 +2643,8 @@ description: Operations executed pipe-flange-assembly.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        4236,
+        4258,
         0
       ]
     }
@@ -2823,8 +2823,8 @@ description: Operations executed pipe-flange-assembly.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        7778,
+        7933,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/poopy-shoe/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/poopy-shoe/ops.snap
@@ -209,8 +209,8 @@ description: Operations executed poopy-shoe.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1706,
+        1743,
         0
       ]
     }
@@ -452,8 +452,8 @@ description: Operations executed poopy-shoe.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2178,
+        2209,
         0
       ]
     }
@@ -532,8 +532,8 @@ description: Operations executed poopy-shoe.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2907,
+        2938,
         0
       ]
     }
@@ -775,8 +775,8 @@ description: Operations executed poopy-shoe.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        3566,
+        3597,
         0
       ]
     }
@@ -856,8 +856,8 @@ description: Operations executed poopy-shoe.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        3816,
+        3847,
         0
       ]
     }
@@ -930,8 +930,8 @@ description: Operations executed poopy-shoe.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        4043,
+        4093,
         0
       ]
     }
@@ -1173,8 +1173,8 @@ description: Operations executed poopy-shoe.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        4597,
+        4629,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/sheet-metal-bracket/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/sheet-metal-bracket/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed sheet-metal-bracket.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed sheet-metal-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1299,
+        1325,
         0
       ]
     }
@@ -124,8 +124,8 @@ description: Operations executed sheet-metal-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1331,
+        1410,
         0
       ]
     }
@@ -184,8 +184,8 @@ description: Operations executed sheet-metal-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1416,
+        1502,
         0
       ]
     }
@@ -244,8 +244,8 @@ description: Operations executed sheet-metal-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1508,
+        1594,
         0
       ]
     }
@@ -304,8 +304,8 @@ description: Operations executed sheet-metal-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1600,
+        1679,
         0
       ]
     }
@@ -364,8 +364,8 @@ description: Operations executed sheet-metal-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1685,
+        1771,
         0
       ]
     }
@@ -424,8 +424,8 @@ description: Operations executed sheet-metal-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1777,
+        1856,
         0
       ]
     }
@@ -484,8 +484,8 @@ description: Operations executed sheet-metal-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1862,
+        1942,
         0
       ]
     }
@@ -544,8 +544,8 @@ description: Operations executed sheet-metal-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1948,
+        2035,
         0
       ]
     }
@@ -687,8 +687,8 @@ description: Operations executed sheet-metal-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2446,
+        2473,
         0
       ]
     }
@@ -751,8 +751,8 @@ description: Operations executed sheet-metal-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2479,
+        2608,
         0
       ]
     }
@@ -894,8 +894,8 @@ description: Operations executed sheet-metal-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        2976,
+        3003,
         0
       ]
     }
@@ -958,8 +958,8 @@ description: Operations executed sheet-metal-bracket.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        3009,
+        3139,
         0
       ]
     }

--- a/rust/kcl-lib/tests/kcl_samples/walkie-talkie/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/walkie-talkie/ops.snap
@@ -136,9 +136,9 @@ description: Operations executed walkie-talkie.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        564,
+        794,
+        3
       ]
     }
   },
@@ -2035,9 +2035,9 @@ description: Operations executed walkie-talkie.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        745,
+        890,
+        8
       ]
     }
   },
@@ -2227,9 +2227,9 @@ description: Operations executed walkie-talkie.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        745,
+        890,
+        8
       ]
     }
   },
@@ -2419,9 +2419,9 @@ description: Operations executed walkie-talkie.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        745,
+        890,
+        8
       ]
     }
   },
@@ -2611,9 +2611,9 @@ description: Operations executed walkie-talkie.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        745,
+        890,
+        8
       ]
     }
   },
@@ -2923,9 +2923,9 @@ description: Operations executed walkie-talkie.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
-        0
+        891,
+        1096,
+        6
       ]
     }
   },

--- a/rust/kcl-lib/tests/kittycad_svg/ops.snap
+++ b/rust/kcl-lib/tests/kittycad_svg/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed kittycad_svg.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed kittycad_svg.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        18347,
+        18366,
         0
       ]
     }

--- a/rust/kcl-lib/tests/linear_pattern3d_a_pattern/ops.snap
+++ b/rust/kcl-lib/tests/linear_pattern3d_a_pattern/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed linear_pattern3d_a_pattern.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed linear_pattern3d_a_pattern.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        159,
+        178,
         0
       ]
     }

--- a/rust/kcl-lib/tests/mike_stress_test/ops.snap
+++ b/rust/kcl-lib/tests/mike_stress_test/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed mike_stress_test.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed mike_stress_test.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        77102,
+        77121,
         0
       ]
     }

--- a/rust/kcl-lib/tests/neg_xz_plane/ops.snap
+++ b/rust/kcl-lib/tests/neg_xz_plane/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed neg_xz_plane.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed neg_xz_plane.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        151,
+        174,
         0
       ]
     }

--- a/rust/kcl-lib/tests/parametric/ops.snap
+++ b/rust/kcl-lib/tests/parametric/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed parametric.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed parametric.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        465,
+        488,
         0
       ]
     }

--- a/rust/kcl-lib/tests/parametric_with_tan_arc/ops.snap
+++ b/rust/kcl-lib/tests/parametric_with_tan_arc/ops.snap
@@ -64,8 +64,8 @@ description: Operations executed parametric_with_tan_arc.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        622,
+        645,
         0
       ]
     }

--- a/rust/kcl-lib/tests/pentagon_fillet_sugar/ops.snap
+++ b/rust/kcl-lib/tests/pentagon_fillet_sugar/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed pentagon_fillet_sugar.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed pentagon_fillet_sugar.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        379,
+        411,
         0
       ]
     }
@@ -164,8 +164,8 @@ description: Operations executed pentagon_fillet_sugar.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        612,
+        640,
         0
       ]
     }
@@ -229,8 +229,8 @@ description: Operations executed pentagon_fillet_sugar.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        646,
+        773,
         0
       ]
     }
@@ -329,8 +329,8 @@ description: Operations executed pentagon_fillet_sugar.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        812,
+        840,
         0
       ]
     }
@@ -394,8 +394,8 @@ description: Operations executed pentagon_fillet_sugar.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        846,
+        973,
         0
       ]
     }

--- a/rust/kcl-lib/tests/pipe_as_arg/ops.snap
+++ b/rust/kcl-lib/tests/pipe_as_arg/ops.snap
@@ -93,8 +93,8 @@ description: Operations executed pipe_as_arg.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        367,
+        391,
         0
       ]
     }

--- a/rust/kcl-lib/tests/poop_chute/ops.snap
+++ b/rust/kcl-lib/tests/poop_chute/ops.snap
@@ -209,8 +209,8 @@ description: Operations executed poop_chute.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1719,
+        1757,
         0
       ]
     }

--- a/rust/kcl-lib/tests/riddle_small/ops.snap
+++ b/rust/kcl-lib/tests/riddle_small/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed riddle_small.kcl
 ---
 [
@@ -102,8 +102,8 @@ description: Operations executed riddle_small.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        287,
+        306,
         0
       ]
     }

--- a/rust/kcl-lib/tests/sketch-on-chamfer-two-times-different-order/ops.snap
+++ b/rust/kcl-lib/tests/sketch-on-chamfer-two-times-different-order/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed sketch-on-chamfer-two-times-different-order.kcl
 ---
 [
@@ -125,8 +125,8 @@ description: Operations executed sketch-on-chamfer-two-times-different-order.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        492,
+        527,
         0
       ]
     }
@@ -196,8 +196,8 @@ description: Operations executed sketch-on-chamfer-two-times-different-order.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        533,
+        600,
         0
       ]
     }
@@ -268,8 +268,8 @@ description: Operations executed sketch-on-chamfer-two-times-different-order.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        606,
+        656,
         0
       ]
     }

--- a/rust/kcl-lib/tests/sketch-on-chamfer-two-times/ops.snap
+++ b/rust/kcl-lib/tests/sketch-on-chamfer-two-times/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed sketch-on-chamfer-two-times.kcl
 ---
 [
@@ -125,8 +125,8 @@ description: Operations executed sketch-on-chamfer-two-times.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        492,
+        527,
         0
       ]
     }
@@ -197,8 +197,8 @@ description: Operations executed sketch-on-chamfer-two-times.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        533,
+        583,
         0
       ]
     }
@@ -268,8 +268,8 @@ description: Operations executed sketch-on-chamfer-two-times.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        589,
+        656,
         0
       ]
     }

--- a/rust/kcl-lib/tests/sketch_in_object/ops.snap
+++ b/rust/kcl-lib/tests/sketch_in_object/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed sketch_in_object.kcl
 ---
 [
@@ -83,8 +83,8 @@ description: Operations executed sketch_in_object.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        425,
+        446,
         0
       ]
     }
@@ -169,8 +169,8 @@ description: Operations executed sketch_in_object.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        483,
+        503,
         0
       ]
     }

--- a/rust/kcl-lib/tests/sketch_on_face/ops.snap
+++ b/rust/kcl-lib/tests/sketch_on_face/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed sketch_on_face.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed sketch_on_face.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        200,
+        219,
         0
       ]
     }
@@ -145,8 +145,8 @@ description: Operations executed sketch_on_face.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        386,
+        405,
         0
       ]
     }

--- a/rust/kcl-lib/tests/sketch_on_face_after_fillets_referencing_face/ops.snap
+++ b/rust/kcl-lib/tests/sketch_on_face_after_fillets_referencing_face/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed sketch_on_face_after_fillets_referencing_face.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed sketch_on_face_after_fillets_referencing_face.k
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1305,
+        1328,
         0
       ]
     }
@@ -124,8 +124,8 @@ description: Operations executed sketch_on_face_after_fillets_referencing_face.k
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1334,
+        1399,
         0
       ]
     }
@@ -178,8 +178,8 @@ description: Operations executed sketch_on_face_after_fillets_referencing_face.k
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1405,
+        1482,
         0
       ]
     }
@@ -259,8 +259,8 @@ description: Operations executed sketch_on_face_after_fillets_referencing_face.k
         }
       },
       "sourceRange": [
-        0,
-        0,
+        1737,
+        1757,
         0
       ]
     }

--- a/rust/kcl-lib/tests/sketch_on_face_circle_tagged/ops.snap
+++ b/rust/kcl-lib/tests/sketch_on_face_circle_tagged/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed sketch_on_face_circle_tagged.kcl
 ---
 [
@@ -83,8 +83,8 @@ description: Operations executed sketch_on_face_circle_tagged.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        231,
+        251,
         0
       ]
     }
@@ -163,8 +163,8 @@ description: Operations executed sketch_on_face_circle_tagged.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        356,
+        375,
         0
       ]
     }

--- a/rust/kcl-lib/tests/sketch_on_face_end/ops.snap
+++ b/rust/kcl-lib/tests/sketch_on_face_end/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed sketch_on_face_end.kcl
 ---
 [
@@ -83,8 +83,8 @@ description: Operations executed sketch_on_face_end.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        231,
+        251,
         0
       ]
     }
@@ -163,8 +163,8 @@ description: Operations executed sketch_on_face_end.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        419,
+        438,
         0
       ]
     }

--- a/rust/kcl-lib/tests/sketch_on_face_end_negative_extrude/ops.snap
+++ b/rust/kcl-lib/tests/sketch_on_face_end_negative_extrude/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed sketch_on_face_end_negative_extrude.kcl
 ---
 [
@@ -83,8 +83,8 @@ description: Operations executed sketch_on_face_end_negative_extrude.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        231,
+        251,
         0
       ]
     }
@@ -163,8 +163,8 @@ description: Operations executed sketch_on_face_end_negative_extrude.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        419,
+        439,
         0
       ]
     }

--- a/rust/kcl-lib/tests/sketch_on_face_start/ops.snap
+++ b/rust/kcl-lib/tests/sketch_on_face_start/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed sketch_on_face_start.kcl
 ---
 [
@@ -83,8 +83,8 @@ description: Operations executed sketch_on_face_start.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        231,
+        251,
         0
       ]
     }
@@ -163,8 +163,8 @@ description: Operations executed sketch_on_face_start.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        424,
+        443,
         0
       ]
     }

--- a/rust/kcl-lib/tests/ssi_pattern/ops.snap
+++ b/rust/kcl-lib/tests/ssi_pattern/ops.snap
@@ -234,8 +234,8 @@ description: Operations executed ssi_pattern.kcl
         ]
       },
       "sourceRange": [
-        0,
-        0,
+        616,
+        637,
         0
       ]
     }

--- a/rust/kcl-lib/tests/tangential_arc/ops.snap
+++ b/rust/kcl-lib/tests/tangential_arc/ops.snap
@@ -64,8 +64,8 @@ description: Operations executed tangential_arc.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        168,
+        188,
         0
       ]
     }

--- a/rust/kcl-lib/tests/xz_plane/ops.snap
+++ b/rust/kcl-lib/tests/xz_plane/ops.snap
@@ -1,5 +1,5 @@
 ---
-source: kcl/src/simulation_tests.rs
+source: kcl-lib/src/simulation_tests.rs
 description: Operations executed xz_plane.kcl
 ---
 [
@@ -64,8 +64,8 @@ description: Operations executed xz_plane.kcl
         }
       },
       "sourceRange": [
-        0,
-        0,
+        150,
+        173,
         0
       ]
     }


### PR DESCRIPTION
Follow up to #5161 now that runtime warnings are implemented.

This also changes the pipeline value's source range to point to the entire call expression, even though the implied `%` isn't actually in the source text. This way, when an error or warning does use it, it points to the call site, instead of the beginning of the file, which isn't very helpful.

Related to https://github.com/KittyCAD/modeling-app/issues/5611 and [Slack thread](https://kittycadworkspace.slack.com/archives/C06L2RHP9SL/p1741739873996509). Not sure if it resolves the issue since the warning doesn't show up when there's also an error.