### PR TITLE
Only one playwright worker and less retries. Plus auto-retries on snapshots

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,7 +1,7 @@
 name: E2E Tests
 on:
   push:
-    branches: [ main ]
+    branches: [ main, pierremtb/adhoc/less-pw-workers-and-retries ]
   pull_request:
   schedule:
     - cron: 0 * * * *  # hourly
@@ -289,8 +289,8 @@ jobs:
       matrix:
         # TODO: enable self-hosted-windows-8-cores once available
         os: [namespace-profile-ubuntu-8-cores, namespace-profile-macos-8-cores, windows-16-cores]
-        shardIndex: [1, 2, 3, 4]
-        shardTotal: [4]
+        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8]
+        shardTotal: [8]
         # TODO: add ref here for main and latest release tag
     runs-on: ${{ matrix.os }}
     steps:
@@ -358,7 +358,7 @@ jobs:
           shell: bash
           command: .github/ci-cd-scripts/playwright-electron.sh ${{matrix.shardIndex}} ${{matrix.shardTotal}} ${{matrix.os}}
           timeout_minutes: 30
-          max_attempts: 25
+          max_attempts: 10
         env:
           CI: true
           FAIL_ON_CONSOLE_ERRORS: true

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,7 +1,7 @@
 name: E2E Tests
 on:
   push:
-    branches: [ main, pierremtb/adhoc/less-pw-workers-and-retries ]
+    branches: [ main ]
   pull_request:
   schedule:
     - cron: 0 * * * *  # hourly
@@ -362,7 +362,7 @@ jobs:
           shell: bash
           command: .github/ci-cd-scripts/playwright-electron.sh ${{matrix.shardIndex}} ${{matrix.shardTotal}} ${{matrix.os}}
           timeout_minutes: 30
-          max_attempts: 10
+          max_attempts: 15
         env:
           CI: true
           FAIL_ON_CONSOLE_ERRORS: true

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -293,8 +293,8 @@ jobs:
       matrix:
         # TODO: enable self-hosted-windows-8-cores once available
         os: [namespace-profile-ubuntu-8-cores, namespace-profile-macos-8-cores, windows-16-cores]
-        shardIndex: [1, 2, 3, 4]
-        shardTotal: [4]
+        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8]
+        shardTotal: [8]
         # TODO: add ref here for main and latest release tag
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -220,8 +220,12 @@ jobs:
 
       - name: Run ubuntu/chrome snapshots
         if: needs.conditions.outputs.should-run == 'true'
-        run: |
-          yarn test:snapshots
+        uses: nick-fields/retry@v3.0.2
+        with:
+          shell: bash
+          command: yarn test:snapshots
+          timeout_minutes: 30
+          max_attempts: 3
         env:
           CI: true
           NODE_ENV: development

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -293,8 +293,8 @@ jobs:
       matrix:
         # TODO: enable self-hosted-windows-8-cores once available
         os: [namespace-profile-ubuntu-8-cores, namespace-profile-macos-8-cores, windows-16-cores]
-        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8]
-        shardTotal: [8]
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
         # TODO: add ref here for main and latest release tag
     runs-on: ${{ matrix.os }}
     steps:

--- a/playwright.electron.config.ts
+++ b/playwright.electron.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   /* Do not retry */
   retries: 0,
   /* Different amount of parallelism on CI and local. */
-  workers: 8,
+  workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ['dot'],


### PR DESCRIPTION
Based on recent tests this seems to work better:
- reduced flow workers from 8 per machine to 1 (so only one app)
- doubled the amount of shards from 4 to 8
- reduced the amount of auto step retries to 15 from 25

Unrelated to flow but useful with what we've seen lately: added auto step retries to snapshot tests that have gone flakey.