### PR TITLE
Hourly e2e tests only on Ubuntu

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -295,11 +295,16 @@ jobs:
         os: [namespace-profile-ubuntu-8-cores, namespace-profile-macos-8-cores, windows-16-cores]
         shardIndex: [1, 2, 3, 4, 5, 6, 7, 8]
         shardTotal: [8]
+        # Disable macos and windows tests on hourly e2e tests since we only care
+        # about server side changes.
+        # Technique from https://github.com/joaomcteixeira/python-project-skeleton/pull/31/files
+        isScheduled:
+          - ${{ github.event_name == 'schedule' }}
         exclude:
           - os: namespace-profile-macos-8-cores
-            if: github.event_name == 'schedule'
+            isScheduled: true
           - os: windows-16-cores
-            if: github.event_name == 'schedule'
+            isScheduled: true
         # TODO: add ref here for main and latest release tag
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,7 +1,7 @@
 name: E2E Tests
 on:
   push:
-    branches: [ main, pierremtb/adhoc/hourly-tests-on-ubuntu-only ]
+    branches: [ main ]
   pull_request:
   schedule:
     - cron: 0 * * * *  # hourly

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -291,15 +291,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: 
-          - key: namespace-profile-ubuntu-8-cores
-          - key: namespace-profile-macos-8-cores
-            if: github.event_name != 'schedule'
-          # TODO: enable namespace-profile-windows-8-cores once available
-          - key: windows-16-cores
-            if: github.event_name != 'schedule'
+        # TODO: enable namespace-profile-windows-8-cores once available
+        os: [namespace-profile-ubuntu-8-cores, namespace-profile-macos-8-cores, windows-16-cores]
         shardIndex: [1, 2, 3, 4, 5, 6, 7, 8]
         shardTotal: [8]
+        exclude:
+          - os: namespace-profile-macos-8-cores
+            if: github.event_name == 'schedule'
+          - os: windows-16-cores
+            if: github.event_name == 'schedule'
         # TODO: add ref here for main and latest release tag
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,7 +1,7 @@
 name: E2E Tests
 on:
   push:
-    branches: [ main ]
+    branches: [ main, pierremtb/adhoc/hourly-tests-on-ubuntu-only ]
   pull_request:
   schedule:
     - cron: 0 * * * *  # hourly
@@ -291,8 +291,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: enable self-hosted-windows-8-cores once available
-        os: [namespace-profile-ubuntu-8-cores, namespace-profile-macos-8-cores, windows-16-cores]
+        os: 
+          - key: namespace-profile-ubuntu-8-cores
+          - key: namespace-profile-macos-8-cores
+            if: github.event_name != 'schedule'
+          # TODO: enable namespace-profile-windows-8-cores once available
+          - key: windows-16-cores
+            if: github.event_name != 'schedule'
         shardIndex: [1, 2, 3, 4, 5, 6, 7, 8]
         shardTotal: [8]
         # TODO: add ref here for main and latest release tag


### PR DESCRIPTION
Since these are meant to ensure consistent behaviour of the upstream stack, there's little relevance in running these tests across all OSes.