### PR TITLE
Change playwright to always use env vars

### DIFF
--- a/e2e/playwright/secrets.ts
+++ b/e2e/playwright/secrets.ts
@@ -17,8 +17,7 @@ try {
 } catch (err) {
   // probably running in CI
   console.warn(
-    `Error reading ${secretsPath}; environment variables will be used`,
-    err
+    `Error reading ${secretsPath}; environment variables will be used`
   )
 }
 secrets.token = secrets.token || process.env.token || ''

--- a/e2e/playwright/secrets.ts
+++ b/e2e/playwright/secrets.ts
@@ -1,8 +1,9 @@
 import { readFileSync } from 'fs'
 
 const secrets: Record<string, string> = {}
+const secretsPath = './e2e/playwright/playwright-secrets.env'
 try {
-  const file = readFileSync('./e2e/playwright/playwright-secrets.env', 'utf8')
+  const file = readFileSync(secretsPath, 'utf8')
   file
     .split('\n')
     .filter((line) => line && line.length > 1)
@@ -15,9 +16,13 @@ try {
     })
 } catch (err) {
   // probably running in CI
-  secrets.token = process.env.token || ''
-  secrets.snapshottoken = process.env.snapshottoken || ''
-  // add more env vars here to make them available in CI
+  console.warn(
+    `Error reading ${secretsPath}; environment variables will be used`,
+    err
+  )
 }
+secrets.token = secrets.token || process.env.token || ''
+secrets.snapshottoken = secrets.snapshottoken || process.env.snapshottoken || ''
+// add more env vars here to make them available in CI
 
 export { secrets }


### PR DESCRIPTION
If the file exists but doesn't define the secrets, it should still use the environment variables. We want to move away from the file eventually.