### PR TITLE
Fix electron renderer topLevelAwait in electron-forge

### DIFF
--- a/vite.renderer.config.ts
+++ b/vite.renderer.config.ts
@@ -2,6 +2,7 @@ import type { ConfigEnv, UserConfig } from 'vite'
 import { defineConfig } from 'vite'
 import { pluginExposeRenderer } from './vite.base.config'
 import viteTsconfigPaths from 'vite-tsconfig-paths'
+import topLevelAwait from 'vite-plugin-top-level-await'
 // @ts-ignore: No types available
 import { lezer } from '@lezer/generator/rollup'
 
@@ -18,8 +19,20 @@ export default defineConfig((env) => {
     build: {
       outDir: `.vite/renderer/${name}`,
     },
+    // Needed for electron-forge (in yarn tron:start)
     optimizeDeps: { esbuildOptions: { target: 'es2022' } },
-    plugins: [pluginExposeRenderer(name), viteTsconfigPaths(), lezer()],
+    plugins: [
+      pluginExposeRenderer(name),
+      viteTsconfigPaths(),
+      lezer(),
+      // Needed for electron-builder (in yarn tronb:vite scripts)
+      topLevelAwait({
+        // The export name of top-level await promise for each chunk module
+        promiseExportName: '__tla',
+        // The function to generate import names of top-level await promise in each chunk module
+        promiseImportName: (i) => `__tla_${i}`,
+      }),
+    ],
     worker: {
       plugins: () => [viteTsconfigPaths()],
     },

--- a/vite.renderer.config.ts
+++ b/vite.renderer.config.ts
@@ -2,7 +2,6 @@ import type { ConfigEnv, UserConfig } from 'vite'
 import { defineConfig } from 'vite'
 import { pluginExposeRenderer } from './vite.base.config'
 import viteTsconfigPaths from 'vite-tsconfig-paths'
-import topLevelAwait from 'vite-plugin-top-level-await'
 // @ts-ignore: No types available
 import { lezer } from '@lezer/generator/rollup'
 
@@ -19,17 +18,8 @@ export default defineConfig((env) => {
     build: {
       outDir: `.vite/renderer/${name}`,
     },
-    plugins: [
-      pluginExposeRenderer(name),
-      viteTsconfigPaths(),
-      lezer(),
-      topLevelAwait({
-        // The export name of top-level await promise for each chunk module
-        promiseExportName: '__tla',
-        // The function to generate import names of top-level await promise in each chunk module
-        promiseImportName: (i) => `__tla_${i}`,
-      }),
-    ],
+    optimizeDeps: { esbuildOptions: { target: 'es2022' } },
+    plugins: [pluginExposeRenderer(name), viteTsconfigPaths(), lezer()],
     worker: {
       plugins: () => [viteTsconfigPaths()],
     },


### PR DESCRIPTION
We need to keep both `vite-plugin-top-level-await` and the `es2022` build target for the renderer layer of electron as this was causing issues with `electron-forge start` that the team relies on for local development with convenient hot reload of all layers.

A better long term approach was started at #5881, removing the dependencies on electron-forge completely, but it wasn't successful in terms of functionality parity. More to come on that