### PR TITLE
Fix workflow to commit all generated kcl-samples files

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -100,9 +100,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cd rust
+          pushd rust
           just overwrite-sim-test kcl_samples
-          git add kcl-lib/tests
+          popd
+          git add \
+            rust/kcl-lib/tests \
+            public/kcl-samples/manifest.json \
+            public/kcl-samples/README.md \
+            public/kcl-samples/screenshots
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git remote set-url origin https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git

--- a/e2e/playwright/snapshots/prompt-to-edit/prompt-to-edit-snapshot-tests-spec-ts--edit-with-ai-example-snapshots--change-colour.snap.json
+++ b/e2e/playwright/snapshots/prompt-to-edit/prompt-to-edit-snapshot-tests-spec-ts--edit-with-ai-example-snapshots--change-colour.snap.json
@@ -29,5 +29,5 @@
       }
     }
   ],
-  "kcl_version": "0.2.51"
+  "kcl_version": "0.2.52"
 }


### PR DESCRIPTION
When only changing kcl-samples, it should generate all the files and push them. You can see this failing in the `cargo-test` workflow of #5876.