### PR TITLE
Fix a couple of panics

### DIFF
--- a/rust/kcl-lib/src/engine/mod.rs
+++ b/rust/kcl-lib/src/engine/mod.rs
@@ -147,6 +147,11 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
         source_range: SourceRange,
     ) -> Result<(), crate::errors::KclError>;
 
+    async fn clear_queues(&self) {
+        self.batch().write().await.clear();
+        self.batch_end().write().await.clear();
+    }
+
     /// Send a modeling command and wait for the response message.
     async fn inner_send_modeling_cmd(
         &self,
@@ -161,6 +166,9 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
         id_generator: &mut IdGenerator,
         source_range: SourceRange,
     ) -> Result<(), crate::errors::KclError> {
+        // Clear any batched commands leftover from previous scenes.
+        self.clear_queues().await;
+
         self.batch_modeling_cmd(
             uuid::Uuid::new_v4(),
             source_range,

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -96,7 +96,7 @@ impl ExecutorContext {
         module_id: ModuleId,
         path: &ModulePath,
     ) -> Result<(Option<KclValue>, EnvironmentRef, Vec<String>), KclError> {
-        crate::log::log(format!("enter module {path} {}", exec_state.stack()));
+        crate::log::log(format!("enter module {path} {} {exec_kind:?}", exec_state.stack()));
 
         let old_units = exec_state.length_unit();
         let original_execution = self.engine.replace_execution_kind(exec_kind).await;

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1192,6 +1192,7 @@ impl Node<CallExpression> {
                         format!("`{fn_name}` is deprecated, see the docs for a recommended replacement"),
                     ));
                 }
+
                 let op = if func.feature_tree_operation() {
                     let op_labeled_args = func
                         .args(false)

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -1595,6 +1595,18 @@ const bracket = startSketchOn(XY)
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_bad_arg_count_std() {
+        let ast = "startSketchOn(XY)
+  |> startProfileAt([0, 0], %)
+  |> profileStartX()";
+        assert!(parse_execute(ast)
+            .await
+            .unwrap_err()
+            .message()
+            .contains("Expected a sketch argument"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_unary_operator_not_succeeds() {
         let ast = r#"
 fn returnTrue = () => { return !false }

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -724,33 +724,34 @@ impl ExecutorContext {
             .map_err(KclErrorWithOutputs::no_outputs)?;
 
         let default_planes = self.engine.get_default_planes().read().await.clone();
-        let env_ref = self
+        let result = self
             .execute_and_build_graph(&program.ast, exec_state, preserve_mem)
-            .await
-            .map_err(|e| {
-                let module_id_to_module_path: IndexMap<ModuleId, ModulePath> = exec_state
-                    .global
-                    .path_to_source_id
-                    .iter()
-                    .map(|(k, v)| ((*v), k.clone()))
-                    .collect();
-
-                KclErrorWithOutputs::new(
-                    e,
-                    exec_state.global.operations.clone(),
-                    exec_state.global.artifact_commands.clone(),
-                    exec_state.global.artifact_graph.clone(),
-                    module_id_to_module_path,
-                    exec_state.global.id_to_source.clone(),
-                    default_planes,
-                )
-            })?;
+            .await;
 
         crate::log::log(format!(
             "Post interpretation KCL memory stats: {:#?}",
             exec_state.stack().memory.stats
         ));
         crate::log::log(format!("Engine stats: {:?}", self.engine.stats()));
+
+        let env_ref = result.map_err(|e| {
+            let module_id_to_module_path: IndexMap<ModuleId, ModulePath> = exec_state
+                .global
+                .path_to_source_id
+                .iter()
+                .map(|(k, v)| ((*v), k.clone()))
+                .collect();
+
+            KclErrorWithOutputs::new(
+                e,
+                exec_state.global.operations.clone(),
+                exec_state.global.artifact_commands.clone(),
+                exec_state.global.artifact_graph.clone(),
+                module_id_to_module_path,
+                exec_state.global.id_to_source.clone(),
+                default_planes,
+            )
+        })?;
 
         if !self.is_mock() {
             let mut mem = exec_state.stack().deep_clone();
@@ -785,6 +786,10 @@ impl ExecutorContext {
                 &ModulePath::Main,
             )
             .await;
+
+        // If we errored out and early-returned, there might be commands which haven't been executed
+        // and should be dropped.
+        self.engine.clear_queues().await;
 
         // Move the artifact commands and responses to simplify cache management
         // and error creation.

--- a/rust/kcl-lib/src/std/args.rs
+++ b/rust/kcl-lib/src/std/args.rs
@@ -546,13 +546,19 @@ impl Args {
     }
 
     pub(crate) fn get_sketches(&self, exec_state: &mut ExecState) -> Result<(Vec<Sketch>, Sketch), KclError> {
-        let sarg = self.args[0]
+        let Some(arg0) = self.args.first() else {
+            return Err(KclError::Semantic(KclErrorDetails {
+                message: "Expected a sketch argument".to_owned(),
+                source_ranges: vec![self.source_range],
+            }));
+        };
+        let sarg = arg0
             .value
             .coerce(&RuntimeType::Array(PrimitiveType::Sketch, ArrayLen::None), exec_state)
             .ok_or(KclError::Type(KclErrorDetails {
                 message: format!(
                     "Expected an array of sketches, found {}",
-                    self.args[0].value.human_friendly_type()
+                    arg0.value.human_friendly_type()
                 ),
                 source_ranges: vec![self.source_range],
             }))?;
@@ -560,11 +566,18 @@ impl Args {
             KclValue::HomArray { value, .. } => value.iter().map(|v| v.as_sketch().unwrap().clone()).collect(),
             _ => unreachable!(),
         };
-        let sarg = self.args[1]
+
+        let Some(arg1) = self.args.get(1) else {
+            return Err(KclError::Semantic(KclErrorDetails {
+                message: "Expected a second sketch argument".to_owned(),
+                source_ranges: vec![self.source_range],
+            }));
+        };
+        let sarg = arg1
             .value
             .coerce(&RuntimeType::Primitive(PrimitiveType::Sketch), exec_state)
             .ok_or(KclError::Type(KclErrorDetails {
-                message: format!("Expected a sketch, found {}", self.args[1].value.human_friendly_type()),
+                message: format!("Expected a sketch, found {}", arg1.value.human_friendly_type()),
                 source_ranges: vec![self.source_range],
             }))?;
         let sketch = match sarg {
@@ -576,11 +589,17 @@ impl Args {
     }
 
     pub(crate) fn get_sketch(&self, exec_state: &mut ExecState) -> Result<Sketch, KclError> {
-        let sarg = self.args[0]
+        let Some(arg0) = self.args.first() else {
+            return Err(KclError::Semantic(KclErrorDetails {
+                message: "Expected a sketch argument".to_owned(),
+                source_ranges: vec![self.source_range],
+            }));
+        };
+        let sarg = arg0
             .value
             .coerce(&RuntimeType::Primitive(PrimitiveType::Sketch), exec_state)
             .ok_or(KclError::Type(KclErrorDetails {
-                message: format!("Expected a sketch, found {}", self.args[0].value.human_friendly_type()),
+                message: format!("Expected a sketch, found {}", arg0.value.human_friendly_type()),
                 source_ranges: vec![self.source_range],
             }))?;
         match sarg {
@@ -615,13 +634,19 @@ impl Args {
         T: serde::de::DeserializeOwned + FromArgs<'a>,
     {
         let data: T = FromArgs::from_args(self, 0)?;
-        let sarg = self.args[1]
+        let Some(arg1) = self.args.get(1) else {
+            return Err(KclError::Semantic(KclErrorDetails {
+                message: "Expected one or more sketches for second argument".to_owned(),
+                source_ranges: vec![self.source_range],
+            }));
+        };
+        let sarg = arg1
             .value
             .coerce(&RuntimeType::Array(PrimitiveType::Sketch, ArrayLen::None), exec_state)
             .ok_or(KclError::Type(KclErrorDetails {
                 message: format!(
-                    "Expected an array of sketches for second argument, found {}",
-                    self.args[1].value.human_friendly_type()
+                    "Expected one or more sketches for second argument, found {}",
+                    arg1.value.human_friendly_type()
                 ),
                 source_ranges: vec![self.source_range],
             }))?;
@@ -640,13 +665,19 @@ impl Args {
         T: serde::de::DeserializeOwned + FromKclValue<'a> + Sized,
     {
         let data: T = FromArgs::from_args(self, 0)?;
-        let sarg = self.args[1]
+        let Some(arg1) = self.args.get(1) else {
+            return Err(KclError::Semantic(KclErrorDetails {
+                message: "Expected a sketch for second argument".to_owned(),
+                source_ranges: vec![self.source_range],
+            }));
+        };
+        let sarg = arg1
             .value
             .coerce(&RuntimeType::Primitive(PrimitiveType::Sketch), exec_state)
             .ok_or(KclError::Type(KclErrorDetails {
                 message: format!(
                     "Expected a sketch for second argument, found {}",
-                    self.args[1].value.human_friendly_type()
+                    arg1.value.human_friendly_type()
                 ),
                 source_ranges: vec![self.source_range],
             }))?;
@@ -670,13 +701,19 @@ impl Args {
         T: serde::de::DeserializeOwned + FromKclValue<'a> + Sized,
     {
         let data: T = FromArgs::from_args(self, 0)?;
-        let sarg = self.args[1]
+        let Some(arg1) = self.args.get(1) else {
+            return Err(KclError::Semantic(KclErrorDetails {
+                message: "Expected a solid for second argument".to_owned(),
+                source_ranges: vec![self.source_range],
+            }));
+        };
+        let sarg = arg1
             .value
             .coerce(&RuntimeType::Primitive(PrimitiveType::Solid), exec_state)
             .ok_or(KclError::Type(KclErrorDetails {
                 message: format!(
                     "Expected a solid for second argument, found {}",
-                    self.args[1].value.human_friendly_type()
+                    arg1.value.human_friendly_type()
                 ),
                 source_ranges: vec![self.source_range],
             }))?;


### PR DESCRIPTION
One rare panic where an engine error persists to the next scene manifesting as an error in std::prelude, and one due to not enough arguments to some standard library functions.