### PR TITLE
Strip ANSI control sequences to clean up Axiom dashboard

### DIFF
--- a/playwrightProcess.mjs
+++ b/playwrightProcess.mjs
@@ -2,6 +2,13 @@ import { readFileSync } from 'fs'
 
 const data = readFileSync('./test-results/report.json', 'utf8')
 
+// We need this until Playwright's JSON reporter supports `stripANSIControlSequences`
+// https://github.com/microsoft/playwright/issues/33670#issuecomment-2487941649
+const ansiRegex = new RegExp('([\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~])))', 'g');
+export function stripAnsiEscapes(str) {
+  return str ? str.replace(ansiRegex, '') : '';
+}
+
 // types, but was easier to store and run as normal js
 // interface FailedTest {
 //     name: string;
@@ -47,7 +54,7 @@ const processReport = (suites) => {
                 name: (name + ' -- ' + spec.title) + (test.title ? ` -- ${test.title}` : ''),
                 status: result.status,
                 projectName: test.projectName,
-                error: result.error?.stack,
+                error: stripAnsiEscapes(result.error?.stack),
               })
             }
           }


### PR DESCRIPTION
This is making it difficult to see common prefixes and query within messages in [this](https://app.axiom.co/kittycad-xx0p/dashboards/idQcOOMOsGMHFuZyqe) dashboard:

<img width="1263" alt="Screenshot 2025-03-21 at 12 43 15 PM" src="https://github.com/user-attachments/assets/4d0c8bb8-b59a-4f9e-b801-3a12f1e9171a" />
