### PR TITLE
Fix so that only comments doesn't format to empty

### DIFF
--- a/rust/kcl-lib/src/parsing/mod.rs
+++ b/rust/kcl-lib/src/parsing/mod.rs
@@ -60,11 +60,8 @@ pub fn parse_tokens(mut tokens: TokenStream) -> ParseResult {
         return Node::<Program>::default().into();
     }
 
-    // Check all the tokens are whitespace or comments.
-    if tokens
-        .iter()
-        .all(|t| t.token_type.is_whitespace() || t.token_type.is_comment())
-    {
+    // Check all the tokens are whitespace.
+    if tokens.iter().all(|t| t.token_type.is_whitespace()) {
         return Node::<Program>::default().into();
     }
 

--- a/rust/kcl-lib/src/unparser.rs
+++ b/rust/kcl-lib/src/unparser.rs
@@ -2040,6 +2040,15 @@ thing = 'foo'
     }
 
     #[test]
+    fn test_recast_only_line_comments() {
+        let code = r#"// comment at start
+"#;
+        let program = crate::parsing::top_level_parse(code).unwrap();
+
+        assert_eq!(program.recast(&Default::default(), 0), code);
+    }
+
+    #[test]
     fn test_recast_comment_at_start() {
         let test_program = r#"
 /* comment at start */


### PR DESCRIPTION
If you had a KCL file with only comments, it would get formatted away to an empty file.

For #5808, parsing a file with only comments needs to have a non-empty result so that we don't blow away significant files when replacing the current buffer.