### PR TITLE
Remove all tooltip delays throughout the app

### DIFF
--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -405,7 +405,6 @@ const ToolbarItemTooltip = memo(function ToolbarItemContents({
       position="bottom"
       wrapperClassName={'!p-4 !pointer-events-auto ' + wrapperClassName}
       contentClassName={contentClassName}
-      delay={0}
     >
       {children}
     </Tooltip>

--- a/src/components/ActionButtonDropdown.tsx
+++ b/src/components/ActionButtonDropdown.tsx
@@ -48,7 +48,6 @@ export function ActionButtonDropdown({
               {props.name ? props.name + ': ' : ''}open menu
             </span>
             <Tooltip
-              delay={0}
               position="bottom"
               hoverOnly
               wrapperClassName="ui-open:!hidden"

--- a/src/components/CommandBar/CommandBar.tsx
+++ b/src/components/CommandBar/CommandBar.tsx
@@ -136,7 +136,7 @@ export const CommandBar = () => {
                   name="close"
                   className="w-5 h-5 rounded-sm bg-destroy-10 text-destroy-80 dark:bg-destroy-80 dark:text-destroy-10 group-hover:brightness-110"
                 />
-                <Tooltip position="bottom" delay={500}>
+                <Tooltip position="bottom">
                   Cancel{' '}
                   <kbd className="hotkey ml-4 dark:!bg-chalkboard-80">esc</kbd>
                 </Tooltip>
@@ -144,7 +144,7 @@ export const CommandBar = () => {
               {!commandBarState.matches('Selecting command') && (
                 <button onClick={stepBack} className="m-0 p-0 border-none">
                   <CustomIcon name="arrowLeft" className="w-5 h-5 rounded-sm" />
-                  <Tooltip position="bottom" delay={500}>
+                  <Tooltip position="bottom">
                     Step back{' '}
                     <kbd className="hotkey ml-4 dark:!bg-chalkboard-80">
                       Shift

--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -547,9 +547,7 @@ export const FileTreeMenu = ({
         className="!p-0 !bg-transparent hover:text-primary border-transparent hover:border-primary !outline-none"
         onClick={onCreateFile}
       >
-        <Tooltip position="bottom-right" delay={750}>
-          Create file
-        </Tooltip>
+        <Tooltip position="bottom-right">Create file</Tooltip>
       </ActionButton>
 
       <ActionButton
@@ -563,9 +561,7 @@ export const FileTreeMenu = ({
         className="!p-0 !bg-transparent hover:text-primary border-transparent hover:border-primary !outline-none"
         onClick={onCreateFolder}
       >
-        <Tooltip position="bottom-right" delay={750}>
-          Create folder
-        </Tooltip>
+        <Tooltip position="bottom-right">Create folder</Tooltip>
       </ActionButton>
     </>
   )

--- a/src/components/ModelingSidebar/ModelingPane.tsx
+++ b/src/components/ModelingSidebar/ModelingPane.tsx
@@ -51,9 +51,7 @@ export const ModelingPaneHeader = ({
         className="!p-0 !bg-transparent hover:text-primary border-transparent dark:!border-transparent hover:!border-primary dark:hover:!border-chalkboard-70 !outline-none"
         onClick={() => onClose()}
       >
-        <Tooltip position="bottom-right" delay={750}>
-          Close
-        </Tooltip>
+        <Tooltip position="bottom-right">Close</Tooltip>
       </ActionButton>
     </div>
   )

--- a/src/components/ModelingSidebar/ModelingPanes/MemoryPane.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/MemoryPane.tsx
@@ -40,9 +40,7 @@ export const MemoryPaneMenu = () => {
         className="!p-0 !bg-transparent hover:text-primary border-transparent hover:border-primary !outline-none"
         onClick={copyProgramMemoryToClipboard}
       >
-        <Tooltip position="bottom-right" delay={750}>
-          Copy to clipboard
-        </Tooltip>
+        <Tooltip position="bottom-right">Copy to clipboard</Tooltip>
       </ActionButton>
     </>
   )

--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -158,9 +158,7 @@ function ProjectCard({
             }}
             className="!p-0"
           >
-            <Tooltip position="top-right" delay={1000}>
-              Rename project
-            </Tooltip>
+            <Tooltip position="top-right">Rename project</Tooltip>
           </ActionButton>
           <ActionButton
             Element="button"
@@ -176,9 +174,7 @@ function ProjectCard({
               setIsConfirmingDelete(true)
             }}
           >
-            <Tooltip position="top-right" delay={1000}>
-              Delete project
-            </Tooltip>
+            <Tooltip position="top-right">Delete project</Tooltip>
           </ActionButton>
         </div>
       )}

--- a/src/components/ProjectCard/ProjectCardRenameForm.tsx
+++ b/src/components/ProjectCard/ProjectCardRenameForm.tsx
@@ -43,9 +43,7 @@ export const ProjectCardRenameForm = forwardRef(
             }}
             className="!p-0"
           >
-            <Tooltip position="left" delay={1000}>
-              Rename project
-            </Tooltip>
+            <Tooltip position="left">Rename project</Tooltip>
           </ActionButton>
           <ActionButton
             Element="button"
@@ -57,9 +55,7 @@ export const ProjectCardRenameForm = forwardRef(
             className="!p-0"
             onClick={onDismiss}
           >
-            <Tooltip position="left" delay={1000}>
-              Cancel
-            </Tooltip>
+            <Tooltip position="left">Cancel</Tooltip>
           </ActionButton>
         </div>
       </form>

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -24,7 +24,7 @@ export default function Tooltip({
   wrapperClassName: className,
   contentClassName,
   wrapperStyle = {},
-  delay = 200,
+  delay = 0,
   hoverOnly = false,
   inert = true,
 }: TooltipProps) {

--- a/src/components/UserSidebarMenu.tsx
+++ b/src/components/UserSidebarMenu.tsx
@@ -193,7 +193,7 @@ const UserSidebarMenu = ({ user }: { user?: User }) => {
             className="w-4 h-4 text-chalkboard-70 dark:text-chalkboard-40 ui-open:rotate-180"
           />
         </div>
-        <Tooltip position="bottom-right" delay={1000} hoverOnly>
+        <Tooltip position="bottom-right" hoverOnly>
           User menu
         </Tooltip>
       </Popover.Button>

--- a/src/routes/Onboarding/index.tsx
+++ b/src/routes/Onboarding/index.tsx
@@ -193,7 +193,7 @@ export function OnboardingButtons({
           name="close"
           className="w-5 h-5 rounded-sm bg-destroy-10 text-destroy-80 dark:bg-destroy-80 dark:text-destroy-10 group-hover:brightness-110"
         />
-        <Tooltip position="bottom" delay={500}>
+        <Tooltip position="bottom">
           Dismiss <kbd className="hotkey ml-4 dark:!bg-chalkboard-80">esc</kbd>
         </Tooltip>
       </button>


### PR DESCRIPTION
They make things feel slow, so we should remove all of them and only add them back where they feel very critical. A good example of a tooltip "delay" we have that doesn't use this property directly is the more detailed version of the toolbar tooltips, which show essential info immediately and expand after lingering.

Reported as a polish point by @nickmccleery during our first "final appearance tweaks" meeting, and it took no time to do so I'm sneaking it in while I wait for CI elsewhere.

## Demo

https://github.com/user-attachments/assets/03c894ae-2a8f-4045-8b56-c089cf28a827


