### PR TITLE
Prevent overwriting the commit status on main

### DIFF
--- a/.github/workflows/update-e2e-branch.yml
+++ b/.github/workflows/update-e2e-branch.yml
@@ -34,6 +34,8 @@ jobs:
           git fetch origin
           # reset to main
           git reset --hard origin/main
+          # get a new SHA to prevent overwriting the commit status on main
+          git commit --amend --message="[all-e2e] $(git log --max-count=1 --pretty=%B)"
           # force push it
           git remote set-url origin https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git
           git push --force origin all-e2e


### PR DESCRIPTION
The GitHub UI seems to only look at the commit SHA for status reporting, so even though the **E2E Tests** workflow runs on the `all-e2e` branch have a different run ID, it’s the same commit SHA as `main` so it overwrites the status indicator, making it look like `main` broken when it is not.