### PR TITLE
Make Helix available in numbered releases

### DIFF
--- a/e2e/playwright/point-click.spec.ts
+++ b/e2e/playwright/point-click.spec.ts
@@ -1097,7 +1097,6 @@ openSketch = startSketchOn(XY)
           Mode: '',
           AngleStart: '',
           Revolutions: '',
-          Length: '',
           Radius: '',
           CounterClockWise: '',
         },
@@ -1194,14 +1193,14 @@ openSketch = startSketchOn(XY)
     {
       selectionType: 'segment',
       testPoint: { x: 513, y: 221 },
-      expectedOutput: `helix001 = helix(  axis = seg01,  radius = 1,  length = 100,  revolutions = 20,  angleStart = 0,  ccw = false,)`,
-      expectedEditedOutput: `helix001 = helix(  axis = seg01,  radius = 1,  length = 50,  revolutions = 20,  angleStart = 0,  ccw = false,)`,
+      expectedOutput: `helix001 = helix(  axis = seg01,  radius = 1,  revolutions = 20,  angleStart = 0,  ccw = false,)`,
+      expectedEditedOutput: `helix001 = helix(  axis = seg01,  radius = 5,  revolutions = 20,  angleStart = 0,  ccw = false,)`,
     },
     {
       selectionType: 'sweepEdge',
       testPoint: { x: 564, y: 364 },
-      expectedOutput: `helix001 = helix(  axis =   getOppositeEdge(seg01),  radius = 1,  length = 100,  revolutions = 20,  angleStart = 0,  ccw = false,)`,
-      expectedEditedOutput: `helix001 = helix(  axis =   getOppositeEdge(seg01),  radius = 1,  length = 50,  revolutions = 20,  angleStart = 0,  ccw = false,)`,
+      expectedOutput: `helix001 = helix(  axis =   getOppositeEdge(seg01),  radius = 1,  revolutions = 20,  angleStart = 0,  ccw = false,)`,
+      expectedEditedOutput: `helix001 = helix(  axis =   getOppositeEdge(seg01),  radius = 5,  revolutions = 20,  angleStart = 0,  ccw = false,)`,
     },
   ]
   helixCases.map(
@@ -1244,7 +1243,6 @@ openSketch = startSketchOn(XY)
               AngleStart: '',
               Mode: '',
               CounterClockWise: '',
-              Length: '',
               Radius: '',
               Revolutions: '',
             },
@@ -1261,8 +1259,6 @@ openSketch = startSketchOn(XY)
           await cmdBar.progressCmdBar()
           await page.keyboard.insertText('1')
           await cmdBar.progressCmdBar()
-          await page.keyboard.insertText('100')
-          await cmdBar.progressCmdBar()
           await cmdBar.expectState({
             stage: 'review',
             headerArguments: {
@@ -1271,7 +1267,6 @@ openSketch = startSketchOn(XY)
               AngleStart: '0',
               Revolutions: '20',
               Radius: '1',
-              Length: '100',
               CounterClockWise: '',
             },
             commandName: 'Helix',
@@ -1292,8 +1287,8 @@ openSketch = startSketchOn(XY)
             0
           )
           await operationButton.dblclick()
-          const initialInput = '100'
-          const newInput = '50'
+          const initialInput = '1'
+          const newInput = '5'
           await cmdBar.expectState({
             commandName: 'Helix',
             stage: 'arguments',
@@ -1302,13 +1297,14 @@ openSketch = startSketchOn(XY)
             headerArguments: {
               AngleStart: '0',
               Revolutions: '20',
-              Radius: '1',
-              Length: initialInput,
+              Radius: initialInput,
               CounterClockWise: '',
             },
             highlightedHeaderArg: 'CounterClockWise',
           })
-          await page.keyboard.press('Shift+Backspace')
+          await page
+            .getByRole('button', { name: 'radius', exact: false })
+            .click()
           await expect(cmdBar.currentArgumentInput).toBeVisible()
           await cmdBar.currentArgumentInput
             .locator('.cm-content')
@@ -1319,8 +1315,7 @@ openSketch = startSketchOn(XY)
             headerArguments: {
               AngleStart: '0',
               Revolutions: '20',
-              Radius: '1',
-              Length: newInput,
+              Radius: newInput,
               CounterClockWise: '',
             },
             commandName: 'Helix',
@@ -1391,7 +1386,6 @@ extrude001 = extrude(profile001, length = 100)
           Mode: '',
           AngleStart: '',
           Revolutions: '',
-          Length: '',
           Radius: '',
           CounterClockWise: '',
         },

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -606,9 +606,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         inputType: 'kcl',
         defaultValue: KCL_DEFAULT_LENGTH,
         required: (commandContext) =>
-          !['Cylinder'].includes(
-            commandContext.argumentsToSubmit.mode as string
-          ),
+          ['Axis'].includes(commandContext.argumentsToSubmit.mode as string),
       },
       ccw: {
         inputType: 'options',

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -757,7 +757,9 @@ const prepareToEditHelix: PrepareToEditCallback = async ({ operation }) => {
     } else {
       return { reason: "Couldn't find radius argument" }
     }
+  }
 
+  if (mode === 'Axis') {
     if ('length' in operation.labeledArgs && operation.labeledArgs.length) {
       const r = await stringToKclExpression(
         codeManager.code.slice(

--- a/src/lib/toolbar.ts
+++ b/src/lib/toolbar.ts
@@ -295,7 +295,7 @@ export const toolbarConfig: Record<ToolbarModeName, ToolbarMode> = {
         },
         hotkey: 'H',
         icon: 'helix',
-        status: DEV || IS_NIGHTLY_OR_DEBUG ? 'available' : 'kcl-only',
+        status: 'available',
         title: 'Helix',
         description: 'Create a helix or spiral in 3D about an axis.',
         links: [{ label: 'KCL docs', url: 'https://zoo.dev/docs/kcl/helix' }],


### PR DESCRIPTION
Fixes #5059 (meta issue!)

Taking the chance to add a little consistency edit by making length non-required for edge mode, since length is pretty pointless for edge mode if offset doesn't exist. If we want to provide control on the length it needs to be on both way. So I think it should remain part of the extra things for later—likely post v1—just like extrude until or offset from sketch would come in later. 