### PR TITLE
Fix 'originalCode' undefined in a test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ build-web: public/kcl_wasm_lib_bg.wasm build/index.html
 build-desktop: public/kcl_wasm_lib_bg.wasm .vite/build/main.js
 
 public/kcl_wasm_lib_bg.wasm: $(CARGO_SOURCES)$(RUST_SOURCES)
-	yarn build:wasm
+	yarn build:wasm:dev
 
 build/index.html: $(REACT_SOURCES) $(TYPESCRIPT_SOURCES) $(VITE_SOURCES)
 	yarn build:local
@@ -99,7 +99,7 @@ test-e2e-web: install build-web ## Run the web e2e tests
 
 .PHONY: test-e2e-desktop
 test-e2e-desktop: install build-desktop ## Run the desktop e2e tests
-	yarn test:playwright:electron --workers=$(E2E_WORKERS) --max-failures=$(E2E_FAILURES) --grep=$(E2E_GREP)
+	yarn test:playwright:electron --workers=$(E2E_WORKERS) --max-failures=$(E2E_FAILURES) --grep="$(E2E_GREP)"
 
 ###############################################################################
 # CLEAN

--- a/e2e/playwright/lib/console-error-whitelist.ts
+++ b/e2e/playwright/lib/console-error-whitelist.ts
@@ -273,21 +273,12 @@ export const isErrorWhitelisted = (exception: Error) => {
       project: 'Google Chrome',
       foundInSpec: 'e2e/playwright/snapshot-tests.spec.ts',
     },
-    // TODO: fix this error in the code
     {
       name: 'TypeError',
       message: 'Failed to fetch',
       stack: '',
       project: 'Google Chrome',
       foundInSpec: 'e2e/playwright/snapshot-tests.spec.ts',
-    },
-    // TODO: fix this error in the code
-    {
-      name: 'ReferenceError',
-      message: 'originalCode is not defined',
-      stack: '',
-      project: 'Google Chrome',
-      foundInSpec: 'e2e/playwright/onboarding-tests.spec.ts',
     },
     // TODO: fix this error in the code
     {

--- a/e2e/playwright/onboarding-tests.spec.ts
+++ b/e2e/playwright/onboarding-tests.spec.ts
@@ -230,9 +230,9 @@ test.describe('Onboarding tests', () => {
 
     // Override beforeEach test setup
     await context.addInitScript(
-      async ({ settingsKey, settings }) => {
+      async ({ settingsKey, settings, code }) => {
         // Give some initial code, so we can test that it's cleared
-        localStorage.setItem('persistCode', originalCode)
+        localStorage.setItem('persistCode', code)
         localStorage.setItem(settingsKey, settings)
       },
       {
@@ -240,6 +240,7 @@ test.describe('Onboarding tests', () => {
         settings: settingsToToml({
           settings: TEST_SETTINGS_ONBOARDING_EXPORT,
         }),
+        code: originalCode,
       }
     )
 


### PR DESCRIPTION
The browser context can't directly access variables from the test scope, so I think this test was passing for the wrong reason.