### PR TITLE
Fix to not use cursed empty object type and add lint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,7 @@
       "plugin:react-hooks/recommended"
     ],
     "rules": {
+      "@typescript-eslint/no-empty-object-type": "error",
       "@typescript-eslint/no-floating-promises": "error",
       "@typescript-eslint/no-misused-promises": "error",
       "@typescript-eslint/no-unused-vars": ["error", {

--- a/src/components/CommandBar/CommandBarHeader.tsx
+++ b/src/components/CommandBar/CommandBarHeader.tsx
@@ -8,7 +8,7 @@ import Tooltip from 'components/Tooltip'
 import { roundOff } from 'lib/utils'
 import { commandBarActor, useCommandBarState } from 'machines/commandBarMachine'
 
-function CommandBarHeader({ children }: React.PropsWithChildren<{}>) {
+function CommandBarHeader({ children }: React.PropsWithChildren<object>) {
   const commandBarState = useCommandBarState()
   const {
     context: { selectedCommand, currentArgument, argumentsToSubmit },

--- a/src/components/ProjectCard/DeleteProjectDialog.tsx
+++ b/src/components/ProjectCard/DeleteProjectDialog.tsx
@@ -1,11 +1,11 @@
 import { Dialog } from '@headlessui/react'
 import { ActionButton } from 'components/ActionButton'
 
-interface DeleteConfirmationDialogProps extends React.PropsWithChildren<{}> {
+type DeleteConfirmationDialogProps = React.PropsWithChildren<{
   title: string
   onConfirm: () => void
   onDismiss: () => void
-}
+}>
 
 export function DeleteConfirmationDialog({
   title,

--- a/src/components/Settings/AllKeybindingsFields.tsx
+++ b/src/components/Settings/AllKeybindingsFields.tsx
@@ -6,7 +6,7 @@ import {
 import { ForwardedRef, forwardRef } from 'react'
 import { useLocation } from 'react-router-dom'
 
-interface AllKeybindingsFieldsProps {}
+type AllKeybindingsFieldsProps = object
 
 export const AllKeybindingsFields = forwardRef(
   (

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -41,7 +41,7 @@ export const COMMAND_APPEARANCE_COLOR_DEFAULT = 'default'
 export type HelixModes = 'Axis' | 'Edge' | 'Cylinder'
 
 export type ModelingCommandSchema = {
-  'Enter sketch': {}
+  'Enter sketch': { forceNewSketch?: boolean }
   Export: {
     type: OutputTypeKey
     storage?: StorageUnion
@@ -146,6 +146,8 @@ export type ModelingCommandSchema = {
     prompt: string
     selection: Selections
   }
+  // TODO: {} means any non-nullish value. This is probably not what we want.
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   'Delete selection': {}
   Appearance: {
     nodeToEdit?: PathToNode

--- a/src/lib/commandBarConfigs/projectsCommandConfig.ts
+++ b/src/lib/commandBarConfigs/projectsCommandConfig.ts
@@ -4,7 +4,7 @@ import { isDesktop } from 'lib/isDesktop'
 import { projectsMachine } from 'machines/projectsMachine'
 
 export type ProjectsCommandSchema = {
-  'Read projects': {}
+  'Read projects': Record<string, unknown>
   'Create project': {
     name: string
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,7 +12,7 @@ export type FileLoaderData = {
   file?: FileEntry
 }
 
-export type HomeLoaderData = {}
+export type HomeLoaderData = Record<string, never>
 
 // From the very helpful @jcalz on StackOverflow: https://stackoverflow.com/a/58436959/22753272
 type Join<K, P> = K extends string | number

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -668,7 +668,10 @@ export const modelingMachine = setup({
     },
     'assign tool in context': assign({
       currentTool: ({ event }) =>
-        'data' in event && event.data && 'tool' in event.data
+        'data' in event &&
+        event.data &&
+        typeof event.data === 'object' &&
+        'tool' in event.data
           ? event.data.tool
           : 'none',
     }),

--- a/src/machines/projectsMachine.ts
+++ b/src/machines/projectsMachine.ts
@@ -12,7 +12,7 @@ export const projectsMachine = setup({
       hasListedProjects: boolean
     },
     events: {} as
-      | { type: 'Read projects'; data: {} }
+      | { type: 'Read projects'; data: ProjectsCommandSchema['Read projects'] }
       | { type: 'Open project'; data: ProjectsCommandSchema['Open project'] }
       | {
           type: 'Rename project'


### PR DESCRIPTION
https://typescript-eslint.io/rules/no-empty-object-type/

The one place where I ignored the lint seems to be intertwined in a weird way. Anything I chose caused the `tsc` error to flip-flop.