### PR TITLE
Clean up env vars in e2e-tests.yml

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -229,7 +229,7 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3
         env:
-          VITE_KC_SKIP_AUTH: true
+          token: ${{ secrets.KITTYCAD_API_TOKEN_DEV }}
           snapshottoken: ${{ secrets.KITTYCAD_API_TOKEN }}
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -229,11 +229,6 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3
         env:
-          CI: true
-          NODE_ENV: development
-          VITE_KC_DEV_TOKEN: ${{ secrets.KITTYCAD_API_TOKEN_DEV }}
-          VITE_KC_SKIP_AUTH: true
-          token: ${{ secrets.KITTYCAD_API_TOKEN_DEV }}
           snapshottoken: ${{ secrets.KITTYCAD_API_TOKEN }}
 
       - uses: actions/upload-artifact@v4
@@ -377,11 +372,7 @@ jobs:
           timeout_minutes: 45
           max_attempts: 15
         env:
-          CI: true
           FAIL_ON_CONSOLE_ERRORS: true
-          NODE_ENV: development
-          VITE_KC_DEV_TOKEN: ${{ secrets.KITTYCAD_API_TOKEN_DEV }}
-          VITE_KC_SKIP_AUTH: true
           token: ${{ secrets.KITTYCAD_API_TOKEN_DEV }}
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -229,6 +229,7 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3
         env:
+          VITE_KC_SKIP_AUTH: true
           snapshottoken: ${{ secrets.KITTYCAD_API_TOKEN }}
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
No reason to keep such a stackup of env variables. I believe this is all that's needed.