### PR TITLE
Add path argument error to console error whitelist

### DIFF
--- a/e2e/playwright/lib/console-error-whitelist.ts
+++ b/e2e/playwright/lib/console-error-whitelist.ts
@@ -300,7 +300,8 @@ export const isErrorWhitelisted = (exception: Error) => {
     {
       name: 'Error',
       message: 'The "path" argument must be of type string. Received undefined',
-      stack: 'Error: The "path" argument must be of type string. Received undefined',
+      stack:
+        'Error: The "path" argument must be of type string. Received undefined',
       project: 'Google Chrome',
       foundInSpec: '', // many tests are impacted by this error
     },

--- a/e2e/playwright/lib/console-error-whitelist.ts
+++ b/e2e/playwright/lib/console-error-whitelist.ts
@@ -297,6 +297,13 @@ export const isErrorWhitelisted = (exception: Error) => {
       project: 'Google Chrome',
       foundInSpec: 'e2e/playwright/testing-constraints.spec.ts',
     },
+    {
+      name: 'Error',
+      message: 'The "path" argument must be of type string. Received undefined',
+      stack: 'Error: The "path" argument must be of type string. Received undefined',
+      project: 'Google Chrome',
+      foundInSpec: '', // many tests are impacted by this error
+    },
   ]
 
   const cleanString = (str: string) => str.replace(/[`"]/g, '')


### PR DESCRIPTION
Been seeing this one a lot locally. Not always tho. But very frequently.

```
1) [chromium] › e2e/playwright/point-click.spec.ts:1347:7 › Point-and-click tests › Helix point-and-click on cylinder 

    Error: expect(received).toEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 9

    - Console error detected
    + An error was detected in the console: 
    +  message:The "path" argument must be of type string. Received undefined 
    +  name:Error 
    +  stack:Error: The "path" argument must be of type string. Received undefined
    +     at eoe (file:///Users/pierremtb/Documents/zoo/modeling-app/.vite/renderer/main_window/assets/index-BFZhA1Jp.js:56621:33)
    +     at async roe (file:///Users/pierremtb/Documents/zoo/modeling-app/.vite/renderer/main_window/assets/index-BFZhA1Jp.js:56705:15)
    +
    +         *Either fix the console error or add it to the whitelist defined in ./lib/console-error-whitelist.ts (if the error can be safely ignored)
    +         
```