### PR TITLE
Change default tolerance value to not depend on units

### DIFF
--- a/rust/kcl-lib/src/std/fillet.rs
+++ b/rust/kcl-lib/src/std/fillet.rs
@@ -8,6 +8,7 @@ use kittycad_modeling_cmds as kcmc;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use super::DEFAULT_TOLERANCE;
 use crate::{
     errors::{KclError, KclErrorDetails},
     execution::{
@@ -15,7 +16,6 @@ use crate::{
         EdgeCut, ExecState, ExtrudeSurface, FilletSurface, GeoMeta, KclValue, Solid, TagIdentifier,
     },
     parsing::ast::types::TagNode,
-    settings::types::UnitLength,
     std::Args,
     SourceRange,
 };
@@ -165,7 +165,7 @@ async fn inner_fillet(
                 edge_id,
                 object_id: solid.id,
                 radius: LengthUnit(radius),
-                tolerance: LengthUnit(tolerance.unwrap_or_else(|| default_tolerance(&exec_state.length_unit().into()))),
+                tolerance: LengthUnit(tolerance.unwrap_or(DEFAULT_TOLERANCE)),
                 cut_type: CutType::Fillet,
                 // We make this a none so that we can remove it in the future.
                 face_id: None,
@@ -193,17 +193,6 @@ async fn inner_fillet(
     }
 
     Ok(solid)
-}
-
-pub(crate) fn default_tolerance(units: &UnitLength) -> f64 {
-    match units {
-        UnitLength::Mm => 0.0000001,
-        UnitLength::Cm => 0.0000001,
-        UnitLength::In => 0.0000001,
-        UnitLength::Ft => 0.0001,
-        UnitLength::Yd => 0.001,
-        UnitLength::M => 0.001,
-    }
 }
 
 #[cfg(test)]

--- a/rust/kcl-lib/src/std/loft.rs
+++ b/rust/kcl-lib/src/std/loft.rs
@@ -7,11 +7,12 @@ use kcl_derive_docs::stdlib;
 use kcmc::{each_cmd as mcmd, length_unit::LengthUnit, ModelingCmd};
 use kittycad_modeling_cmds as kcmc;
 
+use super::DEFAULT_TOLERANCE;
 use crate::{
     errors::{KclError, KclErrorDetails},
     execution::{types::RuntimeType, ExecState, KclValue, Sketch, Solid},
     parsing::ast::types::TagNode,
-    std::{extrude::do_post_extrude, fillet::default_tolerance, Args},
+    std::{extrude::do_post_extrude, Args},
 };
 
 const DEFAULT_V_DEGREE: u32 = 2;
@@ -159,7 +160,7 @@ async fn inner_loft(
             section_ids: sketches.iter().map(|group| group.id).collect(),
             base_curve_index,
             bez_approximate_rational,
-            tolerance: LengthUnit(tolerance.unwrap_or_else(|| default_tolerance(&exec_state.length_unit().into()))),
+            tolerance: LengthUnit(tolerance.unwrap_or(DEFAULT_TOLERANCE)),
             v_degree,
         }),
     )

--- a/rust/kcl-lib/src/std/mod.rs
+++ b/rust/kcl-lib/src/std/mod.rs
@@ -278,6 +278,9 @@ pub enum FunctionKind {
     UserDefined,
 }
 
+/// The default tolerance for modeling commands in [`kittycad_modeling_cmds::length_unit::LengthUnit`].
+const DEFAULT_TOLERANCE: f64 = 0.0000001;
+
 /// Compute the length of the given leg.
 pub async fn leg_length(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let (hypotenuse, leg, ty) = args.get_hypotenuse_leg()?;

--- a/rust/kcl-lib/src/std/revolve.rs
+++ b/rust/kcl-lib/src/std/revolve.rs
@@ -5,11 +5,12 @@ use kcl_derive_docs::stdlib;
 use kcmc::{each_cmd as mcmd, length_unit::LengthUnit, shared::Angle, ModelingCmd};
 use kittycad_modeling_cmds::{self as kcmc};
 
+use super::DEFAULT_TOLERANCE;
 use crate::{
     errors::{KclError, KclErrorDetails},
     execution::{types::RuntimeType, ExecState, KclValue, Sketch, Solid},
     parsing::ast::types::TagNode,
-    std::{axis_or_reference::Axis2dOrEdgeReference, extrude::do_post_extrude, fillet::default_tolerance, Args},
+    std::{axis_or_reference::Axis2dOrEdgeReference, extrude::do_post_extrude, Args},
 };
 
 /// Revolve a sketch or set of sketches around an axis.
@@ -273,9 +274,7 @@ async fn inner_revolve(
                         target: sketch.id.into(),
                         axis,
                         origin,
-                        tolerance: LengthUnit(
-                            tolerance.unwrap_or_else(|| default_tolerance(&exec_state.length_unit().into())),
-                        ),
+                        tolerance: LengthUnit(tolerance.unwrap_or(DEFAULT_TOLERANCE)),
                         axis_is_2d: true,
                     }),
                 )
@@ -289,9 +288,7 @@ async fn inner_revolve(
                         angle,
                         target: sketch.id.into(),
                         edge_id,
-                        tolerance: LengthUnit(
-                            tolerance.unwrap_or_else(|| default_tolerance(&exec_state.length_unit().into())),
-                        ),
+                        tolerance: LengthUnit(tolerance.unwrap_or(DEFAULT_TOLERANCE)),
                     }),
                 )
                 .await?;

--- a/rust/kcl-lib/src/std/sweep.rs
+++ b/rust/kcl-lib/src/std/sweep.rs
@@ -7,11 +7,12 @@ use kittycad_modeling_cmds::{self as kcmc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use super::DEFAULT_TOLERANCE;
 use crate::{
     errors::KclError,
     execution::{types::RuntimeType, ExecState, Helix, KclValue, Sketch, Solid},
     parsing::ast::types::TagNode,
-    std::{extrude::do_post_extrude, fillet::default_tolerance, Args},
+    std::{extrude::do_post_extrude, Args},
 };
 
 /// A path to sweep along.
@@ -191,7 +192,7 @@ async fn inner_sweep(
                 target: sketch.id.into(),
                 trajectory,
                 sectional: sectional.unwrap_or(false),
-                tolerance: LengthUnit(tolerance.unwrap_or_else(|| default_tolerance(&exec_state.length_unit().into()))),
+                tolerance: LengthUnit(tolerance.unwrap_or(DEFAULT_TOLERANCE)),
             }),
         )
         .await?;


### PR DESCRIPTION
The default tolerance used in modeling commands is a `LengthUnit`, measured in the current scene units. So it doesn't make sense that it would be a larger number when using a larger unit. The fact that it's represented in a larger unit makes it larger. The current approach has led to unexpected failed fillets, like when using meters, which mapped to 10<sup>-3</sup>.

Ping: @nadr0 @lee-at-zoo-corp 