### PR TITLE
Bump kcl versions

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-bumper"
-version = "0.1.56"
+version = "0.1.57"
 dependencies = [
  "anyhow",
  "clap",
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-derive-docs"
-version = "0.1.56"
+version = "0.1.57"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-directory-test-macro"
-version = "0.1.56"
+version = "0.1.57"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1819,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-language-server"
-version = "0.2.56"
+version = "0.2.57"
 dependencies = [
  "anyhow",
  "clap",
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-language-server-release"
-version = "0.1.56"
+version = "0.1.57"
 dependencies = [
  "anyhow",
  "clap",
@@ -1860,7 +1860,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-lib"
-version = "0.2.56"
+version = "0.2.57"
 dependencies = [
  "anyhow",
  "approx 0.5.1",
@@ -1928,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-python-bindings"
-version = "0.3.56"
+version = "0.3.57"
 dependencies = [
  "anyhow",
  "kcl-lib",
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-test-server"
-version = "0.1.56"
+version = "0.1.57"
 dependencies = [
  "anyhow",
  "hyper 0.14.32",
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-to-core"
-version = "0.1.56"
+version = "0.1.57"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1970,7 +1970,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-wasm-lib"
-version = "0.1.56"
+version = "0.1.57"
 dependencies = [
  "bson",
  "console_error_panic_hook",

--- a/rust/kcl-bumper/Cargo.toml
+++ b/rust/kcl-bumper/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "kcl-bumper"
-version = "0.1.56"
+version = "0.1.57"
 edition = "2021"
 repository = "https://github.com/KittyCAD/modeling-api"
 rust-version = "1.76"

--- a/rust/kcl-derive-docs/Cargo.toml
+++ b/rust/kcl-derive-docs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-derive-docs"
 description = "A tool for generating documentation from Rust derive macros"
-version = "0.1.56"
+version = "0.1.57"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-directory-test-macro/Cargo.toml
+++ b/rust/kcl-directory-test-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-directory-test-macro"
 description = "A tool for generating tests from a directory of kcl files"
-version = "0.1.56"
+version = "0.1.57"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-language-server-release/Cargo.toml
+++ b/rust/kcl-language-server-release/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-language-server-release"
-version = "0.1.56"
+version = "0.1.57"
 edition = "2021"
 authors = ["KittyCAD Inc <kcl@kittycad.io>"]
 publish = false

--- a/rust/kcl-language-server/Cargo.toml
+++ b/rust/kcl-language-server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kcl-language-server"
 description = "A language server for KCL."
 authors = ["KittyCAD Inc <kcl@kittycad.io>"]
-version = "0.2.56"
+version = "0.2.57"
 edition = "2021"
 license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust/kcl-lib/Cargo.toml
+++ b/rust/kcl-lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-lib"
 description = "KittyCAD Language implementation and tools"
-version = "0.2.56"
+version = "0.2.57"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-python-bindings/Cargo.toml
+++ b/rust/kcl-python-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-python-bindings"
-version = "0.3.56"
+version = "0.3.57"
 edition = "2021"
 repository = "https://github.com/kittycad/modeling-app"
 

--- a/rust/kcl-test-server/Cargo.toml
+++ b/rust/kcl-test-server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-test-server"
 description = "A test server for KCL"
-version = "0.1.56"
+version = "0.1.57"
 edition = "2021"
 license = "MIT"
 

--- a/rust/kcl-to-core/Cargo.toml
+++ b/rust/kcl-to-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-to-core"
 description = "Utility methods to convert kcl to engine core executable tests"
-version = "0.1.56"
+version = "0.1.57"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-wasm-lib/Cargo.toml
+++ b/rust/kcl-wasm-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-wasm-lib"
-version = "0.1.56"
+version = "0.1.57"
 edition = "2021"
 repository = "https://github.com/KittyCAD/modeling-app"
 rust-version = "1.83"


### PR DESCRIPTION
v57

[Release process](https://github.com/KittyCAD/modeling-app/blob/0583eb07d56d414a1fe4948cc6ac60098ab8f9fa/rust/README.md)