### PR TITLE
Display the next version using native git commands

### DIFF
--- a/scripts/semantic-release.sh
+++ b/scripts/semantic-release.sh
@@ -1,9 +1,9 @@
-# Requires access to an environment variable GH_TOKEN
-# If you are in the path of the git repository the gh release list will automatically point to that git repo
-# aka cd /some/path/modeling-app
-# $ gh release list
-# Get the latest semver tag from git
-latest_tag=$(gh release list --json name,isLatest --jq '.[] | select(.isLatest)|.name')
+#!/bin/bash
+set -euo pipefail
+
+# Fetch the latest release tag
+git fetch --all --tags
+latest_tag=$(git tag --sort=-v:refname | grep "^v[0-9]" | head -n 1)
 
 # Function to bump version numbers
 bump_version() {


### PR DESCRIPTION
`gh` has to be installed and requires an auth flow with GitHub. Could we do the same thing with local `git` commands?

To test this:

```
unset GH_TOKEN
./scripts/semantic-release.sh
```