### PR TITLE
Fix: function composition during playwright setup created a massive page.reload loop

### DIFF
--- a/e2e/playwright/fixtures/fixtureSetup.ts
+++ b/e2e/playwright/fixtures/fixtureSetup.ts
@@ -155,8 +155,6 @@ export class ElectronZoo {
     if (!this.electron) {
       this.electron = await electron.launch(options)
 
-      
-
       // Mac takes quite a long time to create the first window in CI.
       // Turns out we can't trust firstWindow() either. So loop.
       let timeoutId: ReturnType<typeof setTimeout>

--- a/e2e/playwright/fixtures/fixtureSetup.ts
+++ b/e2e/playwright/fixtures/fixtureSetup.ts
@@ -219,24 +219,27 @@ export class ElectronZoo {
         }))
     }
 
-    // We need to patch this because addInitScript will bind too late in our
-    // electron tests, never running. We need to call reload() after each call
-    // to guarantee it runs.
-    const oldContextAddInitScript = this.context.addInitScript
-    this.context.addInitScript = async function (a, b) {
-      // @ts-ignore pretty sure way out of tsc's type checking capabilities.
-      // This code works perfectly fine.
-      await oldContextAddInitScript.apply(this, [a, b])
-      await that.page.reload()
+    if (!this.electron) {
+      // We need to patch this because addInitScript will bind too late in our
+      // electron tests, never running. We need to call reload() after each call
+      // to guarantee it runs.
+      const oldContextAddInitScript = this.context.addInitScript
+      this.context.addInitScript = async function (a, b) {
+        // @ts-ignore pretty sure way out of tsc's type checking capabilities.
+        // This code works perfectly fine.
+        await oldContextAddInitScript.apply(this, [a, b])
+        await that.page.reload()
+      }
     }
 
-    // No idea why we mix and match page and context's addInitScript but we do
-    const oldPageAddInitScript = this.page.addInitScript
-    this.page.addInitScript = async function (a: any, b: any) {
-      // @ts-ignore pretty sure way out of tsc's type checking capabilities.
-      // This code works perfectly fine.
-      await oldPageAddInitScript.apply(this, [a, b])
-      await that.page.reload()
+    if (!this.electron || !this.page.addInitScript) {
+      const oldPageAddInitScript = this.page.addInitScript
+      this.page.addInitScript = async function (a: any, b: any) {
+        // @ts-ignore pretty sure way out of tsc's type checking capabilities.
+        // This code works perfectly fine.
+        await oldPageAddInitScript.apply(this, [a, b])
+        await that.page.reload()
+      }
     }
 
     if (!this.firstUrl) {


### PR DESCRIPTION
# Issue

We are spamming `page.reload` in electron playwright. The code created a massive function composition that would do `page.reload` then `page.reload` etc...

# Fix

I check if electron exists, if electron exists do not rebind the function.

# Gotcha
```
Iteration 90: 4006 + 90 = 4096, total: 125670
```

If it was on the 90th test in the suite, it would literally refresh the electron instance `4096` before the test would actually run.

Then the 91st test in the suite would refresh `4187` times before it would run.

# Fun facts

Based on the number of tests that would run in a suite here is the size of the latest shard on main
These are the number of page refreshes that would happen.
```
Iteration 1: 1 + 1 = 2, total: 2
Iteration 2: 2 + 2 = 4, total: 6
Iteration 3: 4 + 3 = 7, total: 13
Iteration 4: 7 + 4 = 11, total: 24
Iteration 5: 11 + 5 = 16, total: 40
Iteration 6: 16 + 6 = 22, total: 62
Iteration 7: 22 + 7 = 29, total: 91
Iteration 8: 29 + 8 = 37, total: 128
Iteration 9: 37 + 9 = 46, total: 174
Iteration 10: 46 + 10 = 56, total: 230
Iteration 11: 56 + 11 = 67, total: 297
Iteration 12: 67 + 12 = 79, total: 376
Iteration 13: 79 + 13 = 92, total: 468
Iteration 14: 92 + 14 = 106, total: 574
Iteration 15: 106 + 15 = 121, total: 695
Iteration 16: 121 + 16 = 137, total: 832
Iteration 17: 137 + 17 = 154, total: 986
Iteration 18: 154 + 18 = 172, total: 1158
Iteration 19: 172 + 19 = 191, total: 1349
Iteration 20: 191 + 20 = 211, total: 1560
Iteration 21: 211 + 21 = 232, total: 1792
Iteration 22: 232 + 22 = 254, total: 2046
Iteration 23: 254 + 23 = 277, total: 2323
Iteration 24: 277 + 24 = 301, total: 2624
Iteration 25: 301 + 25 = 326, total: 2950
Iteration 26: 326 + 26 = 352, total: 3302
Iteration 27: 352 + 27 = 379, total: 3681
Iteration 28: 379 + 28 = 407, total: 4088
Iteration 29: 407 + 29 = 436, total: 4524
Iteration 30: 436 + 30 = 466, total: 4990
Iteration 31: 466 + 31 = 497, total: 5487
Iteration 32: 497 + 32 = 529, total: 6016
Iteration 33: 529 + 33 = 562, total: 6578
Iteration 34: 562 + 34 = 596, total: 7174
Iteration 35: 596 + 35 = 631, total: 7805
Iteration 36: 631 + 36 = 667, total: 8472
Iteration 37: 667 + 37 = 704, total: 9176
Iteration 38: 704 + 38 = 742, total: 9918
Iteration 39: 742 + 39 = 781, total: 10699
Iteration 40: 781 + 40 = 821, total: 11520
Iteration 41: 821 + 41 = 862, total: 12382
Iteration 42: 862 + 42 = 904, total: 13286
Iteration 43: 904 + 43 = 947, total: 14233
Iteration 44: 947 + 44 = 991, total: 15224
Iteration 45: 991 + 45 = 1036, total: 16260
Iteration 46: 1036 + 46 = 1082, total: 17342
Iteration 47: 1082 + 47 = 1129, total: 18471
Iteration 48: 1129 + 48 = 1177, total: 19648
Iteration 49: 1177 + 49 = 1226, total: 20874
Iteration 50: 1226 + 50 = 1276, total: 22150
Iteration 51: 1276 + 51 = 1327, total: 23477
Iteration 52: 1327 + 52 = 1379, total: 24856
Iteration 53: 1379 + 53 = 1432, total: 26288
Iteration 54: 1432 + 54 = 1486, total: 27774
Iteration 55: 1486 + 55 = 1541, total: 29315
Iteration 56: 1541 + 56 = 1597, total: 30912
Iteration 57: 1597 + 57 = 1654, total: 32566
Iteration 58: 1654 + 58 = 1712, total: 34278
Iteration 59: 1712 + 59 = 1771, total: 36049
Iteration 60: 1771 + 60 = 1831, total: 37880
Iteration 61: 1831 + 61 = 1892, total: 39772
Iteration 62: 1892 + 62 = 1954, total: 41726
Iteration 63: 1954 + 63 = 2017, total: 43743
Iteration 64: 2017 + 64 = 2081, total: 45824
Iteration 65: 2081 + 65 = 2146, total: 47970
Iteration 66: 2146 + 66 = 2212, total: 50182
Iteration 67: 2212 + 67 = 2279, total: 52461
Iteration 68: 2279 + 68 = 2347, total: 54808
Iteration 69: 2347 + 69 = 2416, total: 57224
Iteration 70: 2416 + 70 = 2486, total: 59710
Iteration 71: 2486 + 71 = 2557, total: 62267
Iteration 72: 2557 + 72 = 2629, total: 64896
Iteration 73: 2629 + 73 = 2702, total: 67598
Iteration 74: 2702 + 74 = 2776, total: 70374
Iteration 75: 2776 + 75 = 2851, total: 73225
Iteration 76: 2851 + 76 = 2927, total: 76152
Iteration 77: 2927 + 77 = 3004, total: 79156
Iteration 78: 3004 + 78 = 3082, total: 82238
Iteration 79: 3082 + 79 = 3161, total: 85399
Iteration 80: 3161 + 80 = 3241, total: 88640
Iteration 81: 3241 + 81 = 3322, total: 91962
Iteration 82: 3322 + 82 = 3404, total: 95366
Iteration 83: 3404 + 83 = 3487, total: 98853
Iteration 84: 3487 + 84 = 3571, total: 102424
Iteration 85: 3571 + 85 = 3656, total: 106080
Iteration 86: 3656 + 86 = 3742, total: 109822
Iteration 87: 3742 + 87 = 3829, total: 113651
Iteration 88: 3829 + 88 = 3917, total: 117568
Iteration 89: 3917 + 89 = 4006, total: 121574
Iteration 90: 4006 + 90 = 4096, total: 125670
Iteration 91: 4096 + 91 = 4187, total: 129857
Iteration 92: 4187 + 92 = 4279, total: 134136
Iteration 93: 4279 + 93 = 4372, total: 138508
```