### PR TITLE
Use all available CPUs to run tests on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ lint: install ## Lint the code
 ###############################################################################
 # RUN
 
-TARGET ?= web
+TARGET ?= desktop
 
 .PHONY: run
 run: run-$(TARGET)
@@ -104,6 +104,7 @@ run-desktop: install build-desktop ## Start the desktop app
 # TEST
 
 E2E_GREP ?=
+E2E_WORKERS ?=
 E2E_FAILURES ?= 1
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,8 @@ run-desktop: install build-desktop ## Start the desktop app
 ###############################################################################
 # TEST
 
-E2E_WORKERS ?= 1
+E2E_GREP ?=
 E2E_FAILURES ?= 1
-E2E_GREP ?= ""
 
 .PHONY: test
 test: test-unit test-e2e
@@ -121,11 +120,19 @@ test-e2e: test-e2e-$(TARGET)
 .PHONY: test-e2e-web
 test-e2e-web: install build-web ## Run the web e2e tests
 	@ curl -fs localhost:3000 >/dev/null || ( echo "Error: localhost:3000 not available, 'make run-web' first" && exit 1 )
-	yarn chrome:test --headed --workers=$(E2E_WORKERS) --max-failures=$(E2E_FAILURES) --grep=$(E2E_GREP)
+ifdef E2E_GREP
+	yarn chrome:test --headed --grep="$(E2E_GREP)" --max-failures=$(E2E_FAILURES)
+else
+	yarn chrome:test --headed --workers='100%'
+endif
 
 .PHONY: test-e2e-desktop
 test-e2e-desktop: install build-desktop ## Run the desktop e2e tests
-	yarn test:playwright:electron --workers=$(E2E_WORKERS) --max-failures=$(E2E_FAILURES) --grep="$(E2E_GREP)"
+ifdef E2E_GREP
+	yarn test:playwright:electron --grep="$(E2E_GREP)" --max-failures=$(E2E_FAILURES)
+else
+	yarn test:playwright:electron --workers='100%'
+endif
 
 ###############################################################################
 # CLEAN

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,8 +19,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Do not retry */
   retries: process.env.CI ? 0 : 0,
-  /* Different amount of parallelism on CI and local. */
-  workers: process.env.CI ? 1 : 4,
+  /* Use all available CPU cores */
+  workers: process.env.CI ? '100%' : 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     [process.env.CI ? 'dot' : 'list'],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,27 @@
 import { defineConfig, devices } from '@playwright/test'
+import os from 'os'
 
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// require('dotenv').config();
+const platform = os.platform() // 'linux' (Ubuntu), 'darwin' (macOS), 'win32' (Windows)
+
+let workers: number | string
+
+if (process.env.E2E_WORKERS) {
+  workers = process.env.E2E_WORKERS
+} else if (!process.env.CI) {
+  workers = 1 // Local dev: keep things simple and deterministic by default
+} else {
+  // On CI: adjust based on OS
+  switch (platform) {
+    case 'linux':
+      workers = '100%' // CI Linux runners are generally beefier
+      break
+    case 'darwin':
+    case 'win32':
+    default:
+      workers = '75%' // Slightly conservative for GUI-based OSes
+      break
+  }
+}
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -20,7 +37,7 @@ export default defineConfig({
   /* Do not retry */
   retries: process.env.CI ? 0 : 0,
   /* Use all available CPU cores */
-  workers: process.env.CI ? '100%' : 1,
+  workers: workers,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     [process.env.CI ? 'dot' : 'list'],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,9 @@ const platform = os.platform() // 'linux' (Ubuntu), 'darwin' (macOS), 'win32' (W
 let workers: number | string
 
 if (process.env.E2E_WORKERS) {
-  workers = process.env.E2E_WORKERS
+  workers = process.env.E2E_WORKERS.includes('%')
+    ? process.env.E2E_WORKERS
+    : parseInt(process.env.E2E_WORKERS)
 } else if (!process.env.CI) {
   workers = 1 // Local dev: keep things simple and deterministic by default
 } else {

--- a/playwright.electron.config.ts
+++ b/playwright.electron.config.ts
@@ -6,7 +6,9 @@ const platform = os.platform() // 'linux' (Ubuntu), 'darwin' (macOS), 'win32' (W
 let workers: number | string
 
 if (process.env.E2E_WORKERS) {
-  workers = process.env.E2E_WORKERS
+  workers = process.env.E2E_WORKERS.includes('%')
+    ? process.env.E2E_WORKERS
+    : parseInt(process.env.E2E_WORKERS)
 } else if (!process.env.CI) {
   workers = 1 // Local dev: keep things simple and deterministic by default
 } else {

--- a/playwright.electron.config.ts
+++ b/playwright.electron.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig, devices } from '@playwright/test'
-import { platform } from 'os'
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -14,8 +13,8 @@ export default defineConfig({
   forbidOnly: true,
   /* Do not retry */
   retries: 0,
-  /* Different amount of parallelism on CI and local. */
-  workers: platform() === 'win32' ? 1 : 2,
+  /* Use all available CPU cores */
+  workers: process.env.CI ? '100%' : 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ['dot'],

--- a/playwright.electron.config.ts
+++ b/playwright.electron.config.ts
@@ -1,4 +1,27 @@
 import { defineConfig, devices } from '@playwright/test'
+import os from 'os'
+
+const platform = os.platform() // 'linux' (Ubuntu), 'darwin' (macOS), 'win32' (Windows)
+
+let workers: number | string
+
+if (process.env.E2E_WORKERS) {
+  workers = process.env.E2E_WORKERS
+} else if (!process.env.CI) {
+  workers = 1 // Local dev: keep things simple and deterministic by default
+} else {
+  // On CI: adjust based on OS
+  switch (platform) {
+    case 'linux':
+      workers = '50%' // CI Linux runners are generally beefier
+      break
+    case 'darwin':
+    case 'win32':
+    default:
+      workers = '25%' // Lower concurrency for heavier Electron processes
+      break
+  }
+}
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -14,7 +37,7 @@ export default defineConfig({
   /* Do not retry */
   retries: 0,
   /* Use all available CPU cores */
-  workers: process.env.CI ? '100%' : 1,
+  workers: workers,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ['dot'],


### PR DESCRIPTION
With the fix from https://github.com/KittyCAD/modeling-app/pull/6137, we might be able to speed up CI by running more workers. I'm still defaulting to one worker locally to avoid lots of windows getting in our way.