### PR TITLE
Use scene fixture to make test more reliable on macOS

### DIFF
--- a/e2e/playwright/desktop-export.spec.ts
+++ b/e2e/playwright/desktop-export.spec.ts
@@ -47,11 +47,7 @@ test(
       const exportButton = page.getByTestId('export-pane-button')
       await expect(exportButton).toBeVisible()
 
-      // Wait for the model to finish loading
-      const modelStateIndicator = page.getByTestId(
-        'model-state-indicator-execution-done'
-      )
-      await expect(modelStateIndicator).toBeVisible({ timeout: 60000 })
+      await scene.waitForExecutionDone()
 
       const gltfOption = page.getByText('glTF')
       const submitButton = page.getByText('Confirm Export')


### PR DESCRIPTION
This test is failing quite regularly on main, but now passed for me with:

```
yarn test:playwright:electron --grep="export works on the first try" --repeat-each=20
```