### PR TITLE
Wait for export button to make test more reliable

### DIFF
--- a/e2e/playwright/desktop-export.spec.ts
+++ b/e2e/playwright/desktop-export.spec.ts
@@ -32,53 +32,44 @@ test(
     })
     await page.setBodyDimensions({ width: 1200, height: 500 })
 
-    page.on('console', console.log)
-
     await test.step('on open of project', async () => {
-      await expect(page.getByText(`bracket`)).toBeVisible()
+      // Open the project
+      const projectName = page.getByText(`bracket`)
+      await expect(projectName).toBeVisible()
+      await projectName.click()
+      await scene.waitForExecutionDone()
+      await page.waitForTimeout(1_000) // wait for panel buttons to be available
 
-      // open the project
-      await page.getByText(`bracket`).click()
-
-      // expect zero errors in guter
+      // Expect zero errors in gutter
       await expect(page.locator('.cm-lint-marker-error')).not.toBeVisible()
 
-      // export the model
+      // Click the export button
       const exportButton = page.getByTestId('export-pane-button')
       await expect(exportButton).toBeVisible()
-
-      await scene.waitForExecutionDone()
-
-      const gltfOption = page.getByText('glTF')
-      const submitButton = page.getByText('Confirm Export')
-      const exportingToastMessage = page.getByText(`Exporting...`)
-      const errorToastMessage = page.getByText(`Error while exporting`)
-      const engineErrorToastMessage = page.getByText(`Nothing to export`)
-      const alreadyExportingToastMessage = page.getByText(`Already exporting`)
-      // The open file's name is `main.kcl`, so the export file name should be `main.gltf`
-      const exportFileName = `main.gltf`
-
-      // Click the export button
       await exportButton.click()
+      await page.waitForTimeout(1_000) // wait for export options to be available
 
+      // Select the first format option
+      const gltfOption = page.getByText('glTF')
+      const exportFileName = `main.gltf` // source file is named `main.kcl`
       await expect(gltfOption).toBeVisible()
-      await expect(page.getByText('STL')).toBeVisible()
-
       await page.keyboard.press('Enter')
 
       // Click the checkbox
+      const submitButton = page.getByText('Confirm Export')
       await expect(submitButton).toBeVisible()
-
       await page.waitForTimeout(500)
-
       await page.keyboard.press('Enter')
 
-      // Find the toast.
       // Look out for the toast message
+      const exportingToastMessage = page.getByText(`Exporting...`)
+      const alreadyExportingToastMessage = page.getByText(`Already exporting`)
       await expect(exportingToastMessage).toBeVisible()
       await expect(alreadyExportingToastMessage).not.toBeVisible()
 
-      // Expect it to succeed.
+      // Expect it to succeed
+      const errorToastMessage = page.getByText(`Error while exporting`)
+      const engineErrorToastMessage = page.getByText(`Nothing to export`)
       await expect(errorToastMessage).not.toBeVisible()
       await expect(engineErrorToastMessage).not.toBeVisible()
 
@@ -86,6 +77,7 @@ test(
       await expect(successToastMessage).toBeVisible()
       await expect(exportingToastMessage).not.toBeVisible()
 
+      // Check for the exported file
       const firstFileFullPath = path.resolve(
         getPlaywrightDownloadDir(tronApp.projectDirName),
         exportFileName
@@ -112,60 +104,53 @@ test(
       const u = await getUtils(page)
       await u.openFilePanel()
 
+      // Click on the other file
       const otherKclButton = page.getByRole('button', { name: 'other.kcl' })
-
-      // Click the file
       await otherKclButton.click()
 
       // Close the file pane
       await u.closeFilePanel()
+      await scene.waitForExecutionDone()
+      await page.waitForTimeout(1_000) // wait for panel buttons to be available
 
-      // FIXME: await scene.waitForExecutionDone() does not work. The modeling indicator stays in -receive-reliable and not execution done
-      await page.waitForTimeout(10000)
-
-      // expect zero errors in guter
+      // Expect zero errors in gutter
       await expect(page.locator('.cm-lint-marker-error')).not.toBeVisible()
 
-      // export the model
+      // Click the export button
       const exportButton = page.getByTestId('export-pane-button')
       await expect(exportButton).toBeVisible()
-
-      const gltfOption = page.getByText('glTF')
-      const submitButton = page.getByText('Confirm Export')
-      const exportingToastMessage = page.getByText(`Exporting...`)
-      const errorToastMessage = page.getByText(`Error while exporting`)
-      const engineErrorToastMessage = page.getByText(`Nothing to export`)
-      const alreadyExportingToastMessage = page.getByText(`Already exporting`)
-      // The open file's name is `other.kcl`, so the export file name should be `other.gltf`
-      const exportFileName = `other.gltf`
-
-      // Click the export button
       await exportButton.click()
+      await page.waitForTimeout(1_000) // wait for export options to be available
 
+      // Select the first format option
+      const gltfOption = page.getByText('glTF')
+      const exportFileName = `other.gltf` // source file is named `other.kcl`
       await expect(gltfOption).toBeVisible()
-      await expect(page.getByText('STL')).toBeVisible()
-
       await page.keyboard.press('Enter')
 
       // Click the checkbox
+      const submitButton = page.getByText('Confirm Export')
       await expect(submitButton).toBeVisible()
-
+      await page.waitForTimeout(500)
       await page.keyboard.press('Enter')
 
-      // Find the toast.
       // Look out for the toast message
+      const exportingToastMessage = page.getByText(`Exporting...`)
+      const alreadyExportingToastMessage = page.getByText(`Already exporting`)
       await expect(exportingToastMessage).toBeVisible()
+      await expect(alreadyExportingToastMessage).not.toBeVisible()
+
+      // Expect it to succeed
+      const errorToastMessage = page.getByText(`Error while exporting`)
+      const engineErrorToastMessage = page.getByText(`Nothing to export`)
+      await expect(errorToastMessage).not.toBeVisible()
+      await expect(engineErrorToastMessage).not.toBeVisible()
 
       const successToastMessage = page.getByText(`Exported successfully`)
-      await test.step('Check the success toast message shows and nothing else', async () =>
-        Promise.all([
-          expect(alreadyExportingToastMessage).not.toBeVisible(),
-          expect(errorToastMessage).not.toBeVisible(),
-          expect(engineErrorToastMessage).not.toBeVisible(),
-          expect(successToastMessage).toBeVisible(),
-          expect(exportingToastMessage).not.toBeVisible(),
-        ]))
+      await expect(successToastMessage).toBeVisible()
+      await expect(exportingToastMessage).not.toBeVisible()
 
+      // Check for the exported file=
       const secondFileFullPath = path.resolve(
         getPlaywrightDownloadDir(tronApp.projectDirName),
         exportFileName


### PR DESCRIPTION
The main source of flakiness in the `export works on the first try` test seems to be the export button in the panel not always being available right after the scene execution finishes. Adding a short delay ensures that clicking the button actually opens up the export menu.   

---

```
yarn test:playwright:electron:local --grep="export works on the first try" --repeat-each=10
```