### PR TITLE
Shorten feedback cycle for legitimate failures

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -370,8 +370,8 @@ jobs:
         with:
           shell: bash
           command: .github/ci-cd-scripts/playwright-electron.sh ${{matrix.shardIndex}} ${{matrix.shardTotal}} ${{ env.OS_NAME }}
-          timeout_minutes: 45
-          max_attempts: 15
+          timeout_minutes: 30
+          max_attempts: 9
         env:
           FAIL_ON_CONSOLE_ERRORS: true
           token: ${{ secrets.KITTYCAD_API_TOKEN_DEV }}


### PR DESCRIPTION
With the recent testing improvements, _good_ shard runs now take less than 15 minutes and retry no more than 5 times. I think we can now lower the limits so that we don't waste time retrying legitimate test failures and provide a shorter feedback cycle.