### PR TITLE
More propagation of numeric types

### DIFF
--- a/public/kcl-samples/gear/main.kcl
+++ b/public/kcl-samples/gear/main.kcl
@@ -97,11 +97,11 @@ keyWay = startSketchOn(body, 'END')
   |> xLine(length = -keywayDepth)
   |> arc({
        angleEnd = 180,
-       angleStart = -1 * 180 / PI * startAngle + 360,
+       angleStart = -1 * toDegrees(startAngle) + 360,
        radius = holeRadius
      }, %)
   |> arc({
-       angleEnd = 180 / PI * startAngle,
+       angleEnd = toDegrees(startAngle),
        angleStart = 180,
        radius = holeRadius
      }, %)

--- a/rust/kcl-derive-docs/src/lib.rs
+++ b/rust/kcl-derive-docs/src/lib.rs
@@ -764,14 +764,14 @@ fn rust_type_to_openapi_type(t: &str) -> String {
         t = format!("[{inner_type}]")
     }
 
-    if t == "f64" {
+    if t == "f64" || t == "TyF64" {
         return "number".to_string();
     } else if t == "u32" {
         return "integer".to_string();
     } else if t == "str" {
         return "string".to_string();
     } else {
-        return t.replace("f64", "number").to_string();
+        return t.replace("f64", "number").replace("TyF64", "number").to_string();
     }
 }
 

--- a/rust/kcl-lib/src/docs/gen_std_tests.rs
+++ b/rust/kcl-lib/src/docs/gen_std_tests.rs
@@ -709,7 +709,7 @@ fn add_to_types(
         return Err(anyhow::anyhow!("Empty type name"));
     }
 
-    if DECLARED_TYPES.contains(&name) {
+    if DECLARED_TYPES.contains(&name) || name == "TyF64" {
         return Ok(());
     }
 
@@ -769,7 +769,7 @@ fn generate_type(
     }
 
     // Skip over TagDeclarator and TagIdentifier since they have custom docs.
-    if name == "TagDeclarator" || name == "TagIdentifier" || name == "TagNode" {
+    if name == "TagDeclarator" || name == "TagIdentifier" || name == "TagNode" || name == "TyF64" {
         return Ok(());
     }
 
@@ -930,7 +930,7 @@ fn recurse_and_create_references(
     schema: &schemars::schema::Schema,
     types: &BTreeMap<String, schemars::schema::Schema>,
 ) -> Result<schemars::schema::Schema> {
-    if DECLARED_TYPES.contains(&name) {
+    if DECLARED_TYPES.contains(&name) || name == "TyF64" {
         return Ok(schema.clone());
     }
 
@@ -944,7 +944,7 @@ fn recurse_and_create_references(
     if let Some(reference) = &o.reference {
         let mut obj = o.clone();
         let reference = reference.trim_start_matches("#/components/schemas/");
-        if DECLARED_TYPES.contains(&reference) {
+        if DECLARED_TYPES.contains(&reference) || reference == "TyF64" {
             return Ok(schema.clone());
         }
 

--- a/rust/kcl-lib/src/execution/geometry.rs
+++ b/rust/kcl-lib/src/execution/geometry.rs
@@ -10,16 +10,16 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     errors::KclError,
-    execution::{ArtifactId, ExecState, Metadata, TagEngineInfo, TagIdentifier, UnitLen},
+    execution::{types::NumericType, ArtifactId, ExecState, Metadata, TagEngineInfo, TagIdentifier, UnitLen},
     parsing::ast::types::{Node, NodeRef, TagDeclarator, TagNode},
-    std::sketch::PlaneData,
+    std::{args::TyF64, sketch::PlaneData},
 };
 
 type Point2D = kcmc::shared::Point2d<f64>;
 type Point3D = kcmc::shared::Point3d<f64>;
 
 /// A geometry.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(tag = "type")]
 pub enum Geometry {
@@ -47,7 +47,7 @@ impl Geometry {
 }
 
 /// A set of geometry.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(tag = "type")]
 #[allow(clippy::vec_box)]
@@ -66,7 +66,7 @@ impl From<Geometry> for Geometries {
 }
 
 /// Data for an imported geometry.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct ImportedGeometry {
@@ -79,7 +79,7 @@ pub struct ImportedGeometry {
 }
 
 /// Data for a solid or an imported geometry.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(tag = "type", rename_all = "camelCase")]
 #[allow(clippy::vec_box)]
@@ -159,7 +159,7 @@ pub struct Helix {
     pub meta: Vec<Metadata>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct Plane {
@@ -353,7 +353,7 @@ impl Plane {
 }
 
 /// A face.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct Face {
@@ -377,7 +377,7 @@ pub struct Face {
 }
 
 /// Type for a plane.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema, FromStr, Display)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema, FromStr, Display)]
 #[ts(export)]
 #[display(style = "camelCase")]
 pub enum PlaneType {
@@ -398,7 +398,7 @@ pub enum PlaneType {
     Uninit,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub struct Sketch {
@@ -463,7 +463,7 @@ impl Sketch {
 }
 
 /// A sketch type.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum SketchSurface {
@@ -582,7 +582,7 @@ impl Sketch {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub struct Solid {
@@ -616,7 +616,7 @@ impl Solid {
 }
 
 /// A fillet or a chamfer.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum EdgeCut {
@@ -675,6 +675,12 @@ pub struct Point2d {
 impl From<[f64; 2]> for Point2d {
     fn from(p: [f64; 2]) -> Self {
         Self { x: p[0], y: p[1] }
+    }
+}
+
+impl From<[TyF64; 2]> for Point2d {
+    fn from(p: [TyF64; 2]) -> Self {
+        Self { x: p[0].n, y: p[1].n }
     }
 }
 
@@ -767,7 +773,7 @@ impl Mul<f64> for Point3d {
 }
 
 /// A base path.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct BasePath {
@@ -786,7 +792,7 @@ pub struct BasePath {
 }
 
 /// Geometry metadata.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct GeoMeta {
@@ -798,7 +804,7 @@ pub struct GeoMeta {
 }
 
 /// A path.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(tag = "type")]
 pub enum Path {
@@ -979,19 +985,23 @@ impl Path {
     }
 
     /// Where does this path segment start?
-    pub fn get_from(&self) -> &[f64; 2] {
-        &self.get_base().from
+    pub fn get_from(&self) -> [TyF64; 2] {
+        let p = &self.get_base().from;
+        let ty: NumericType = self.get_base().units.into();
+        [TyF64::new(p[0], ty.clone()), TyF64::new(p[1], ty)]
     }
     /// Where does this path segment end?
-    pub fn get_to(&self) -> &[f64; 2] {
-        &self.get_base().to
+    pub fn get_to(&self) -> [TyF64; 2] {
+        let p = &self.get_base().to;
+        let ty: NumericType = self.get_base().units.into();
+        [TyF64::new(p[0], ty.clone()), TyF64::new(p[1], ty)]
     }
 
     /// Length of this path segment, in cartesian plane.
-    pub fn length(&self) -> f64 {
-        match self {
+    pub fn length(&self) -> TyF64 {
+        let n = match self {
             Self::ToPoint { .. } | Self::Base { .. } | Self::Horizontal { .. } | Self::AngledLineTo { .. } => {
-                linear_distance(self.get_from(), self.get_to())
+                linear_distance(&self.get_base().from, &self.get_base().to)
             }
             Self::TangentialArc {
                 base: _,
@@ -1005,10 +1015,10 @@ impl Path {
             } => {
                 // The radius can be calculated as the linear distance between `to` and `center`,
                 // or between `from` and `center`. They should be the same.
-                let radius = linear_distance(self.get_from(), center);
-                debug_assert_eq!(radius, linear_distance(self.get_to(), center));
+                let radius = linear_distance(&self.get_base().from, center);
+                debug_assert_eq!(radius, linear_distance(&self.get_base().to, center));
                 // TODO: Call engine utils to figure this out.
-                linear_distance(self.get_from(), self.get_to())
+                linear_distance(&self.get_base().from, &self.get_base().to)
             }
             Self::Circle { radius, .. } => 2.0 * std::f64::consts::PI * radius,
             Self::CircleThreePoint { .. } => {
@@ -1022,13 +1032,14 @@ impl Path {
             }
             Self::Arc { .. } => {
                 // TODO: Call engine utils to figure this out.
-                linear_distance(self.get_from(), self.get_to())
+                linear_distance(&self.get_base().from, &self.get_base().to)
             }
             Self::ArcThreePoint { .. } => {
                 // TODO: Call engine utils to figure this out.
-                linear_distance(self.get_from(), self.get_to())
+                linear_distance(&self.get_base().from, &self.get_base().to)
             }
-        }
+        };
+        TyF64::new(n, self.get_base().units.into())
     }
 
     pub fn get_base_mut(&mut self) -> Option<&mut BasePath> {
@@ -1103,7 +1114,7 @@ fn linear_distance(
 }
 
 /// An extrude surface.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum ExtrudeSurface {
@@ -1115,7 +1126,7 @@ pub enum ExtrudeSurface {
 }
 
 // Chamfer surface.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct ChamferSurface {
@@ -1129,7 +1140,7 @@ pub struct ChamferSurface {
 }
 
 // Fillet surface.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct FilletSurface {
@@ -1143,7 +1154,7 @@ pub struct FilletSurface {
 }
 
 /// An extruded plane.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct ExtrudePlane {
@@ -1157,7 +1168,7 @@ pub struct ExtrudePlane {
 }
 
 /// An extruded arc.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct ExtrudeArc {

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -175,7 +175,7 @@ impl std::hash::Hash for TagIdentifier {
 }
 
 /// Engine information for a tag.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub struct TagEngineInfo {

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -22,6 +22,8 @@ use crate::{
     CompilationError,
 };
 
+use super::types::NumericType;
+
 /// State for executing a program.
 #[derive(Debug, Clone)]
 pub struct ExecState {
@@ -226,6 +228,13 @@ impl ExecState {
         debug_assert!(self.global.path_to_source_id.contains_key(&path));
         let module_info = ModuleInfo { id, repr, path };
         self.global.module_infos.insert(id, module_info);
+    }
+
+    pub fn current_default_units(&self) -> NumericType {
+        NumericType::Default {
+            len: self.length_unit(),
+            angle: self.angle_unit(),
+        }
     }
 
     pub fn length_unit(&self) -> UnitLen {

--- a/rust/kcl-lib/src/execution/types.rs
+++ b/rust/kcl-lib/src/execution/types.rs
@@ -371,12 +371,20 @@ impl Default for NumericType {
 }
 
 impl NumericType {
-    pub fn count() -> Self {
+    pub const fn count() -> Self {
         NumericType::Known(UnitType::Count)
     }
 
-    pub fn mm() -> Self {
+    pub const fn mm() -> Self {
         NumericType::Known(UnitType::Length(UnitLen::Mm))
+    }
+
+    pub const fn radians() -> Self {
+        NumericType::Known(UnitType::Angle(UnitAngle::Radians))
+    }
+
+    pub const fn degrees() -> Self {
+        NumericType::Known(UnitType::Angle(UnitAngle::Degrees))
     }
 
     /// Combine two types when we expect them to be equal.

--- a/rust/kcl-lib/src/std/args.rs
+++ b/rust/kcl-lib/src/std/args.rs
@@ -503,19 +503,19 @@ impl Args {
         Ok(())
     }
 
-    pub(crate) fn make_user_val_from_point(&self, p: [f64; 2]) -> Result<KclValue, KclError> {
+    pub(crate) fn make_user_val_from_point(&self, p: [TyF64; 2]) -> Result<KclValue, KclError> {
         let meta = Metadata {
             source_range: self.source_range,
         };
         let x = KclValue::Number {
-            value: p[0],
+            value: p[0].n,
             meta: vec![meta],
-            ty: NumericType::Unknown,
+            ty: p[0].ty.clone(),
         };
         let y = KclValue::Number {
-            value: p[1],
+            value: p[1].n,
             meta: vec![meta],
-            ty: NumericType::Unknown,
+            ty: p[1].ty.clone(),
         };
         Ok(KclValue::MixedArray {
             value: vec![x, y],
@@ -696,10 +696,9 @@ impl Args {
         FromArgs::from_args(self, 0)
     }
 
-    pub(crate) fn get_data_and_optional_tag<'a, T>(&'a self) -> Result<(T, Option<FaceTag>), KclError>
-    where
-        T: serde::de::DeserializeOwned + FromKclValue<'a> + Sized,
-    {
+    pub(crate) fn get_sketch_data_and_optional_tag(
+        &self,
+    ) -> Result<(super::sketch::SketchData, Option<FaceTag>), KclError> {
         FromArgs::from_args(self, 0)
     }
 

--- a/rust/kcl-lib/src/std/math.rs
+++ b/rust/kcl-lib/src/std/math.rs
@@ -6,7 +6,7 @@ use kcl_derive_docs::stdlib;
 use super::args::FromArgs;
 use crate::{
     errors::{KclError, KclErrorDetails},
-    execution::{ExecState, KclValue},
+    execution::{types::NumericType, ExecState, KclValue},
     std::args::{Args, TyF64},
 };
 
@@ -67,7 +67,7 @@ pub async fn tan(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 pub async fn pi(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let result = inner_pi()?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::count(result)))
 }
 
 /// Return the value of `pi`. Archimedes’ constant (π).
@@ -96,7 +96,7 @@ pub async fn sqrt(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
     let num = args.get_number()?;
     let result = inner_sqrt(num)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, NumericType::Unknown)))
 }
 
 /// Compute the square root of a number.
@@ -123,10 +123,10 @@ fn inner_sqrt(num: f64) -> Result<f64, KclError> {
 
 /// Compute the absolute value of a number.
 pub async fn abs(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
-    let num = args.get_number()?;
-    let result = inner_abs(num)?;
+    let num = args.get_number_with_type()?;
+    let result = inner_abs(num.n)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(num.map_value(result)))
 }
 
 /// Compute the absolute value of a number.
@@ -160,10 +160,10 @@ fn inner_abs(num: f64) -> Result<f64, KclError> {
 
 /// Round a number to the nearest integer.
 pub async fn round(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
-    let num = args.get_number()?;
-    let result = inner_round(num)?;
+    let num = args.get_number_with_type()?;
+    let result = inner_round(num.n)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(num.map_value(result)))
 }
 
 /// Round a number to the nearest integer.
@@ -188,10 +188,10 @@ fn inner_round(num: f64) -> Result<f64, KclError> {
 
 /// Compute the largest integer less than or equal to a number.
 pub async fn floor(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
-    let num = args.get_number()?;
-    let result = inner_floor(num)?;
+    let num = args.get_number_with_type()?;
+    let result = inner_floor(num.n)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(num.map_value(result)))
 }
 
 /// Compute the largest integer less than or equal to a number.
@@ -216,10 +216,10 @@ fn inner_floor(num: f64) -> Result<f64, KclError> {
 
 /// Compute the smallest integer greater than or equal to a number.
 pub async fn ceil(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
-    let num = args.get_number()?;
-    let result = inner_ceil(num)?;
+    let num = args.get_number_with_type()?;
+    let result = inner_ceil(num.n)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(num.map_value(result)))
 }
 
 /// Compute the smallest integer greater than or equal to a number.
@@ -335,7 +335,7 @@ pub async fn pow(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 
     let result = inner_pow(nums[0], nums[1])?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, NumericType::Unknown)))
 }
 
 /// Compute the number to a power.
@@ -365,7 +365,7 @@ pub async fn acos(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
     let num = args.get_number()?;
     let result = inner_acos(num)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, NumericType::radians())))
 }
 
 /// Compute the arccosine of a number (in radians).
@@ -396,7 +396,7 @@ pub async fn asin(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
     let num = args.get_number()?;
     let result = inner_asin(num)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, NumericType::radians())))
 }
 
 /// Compute the arcsine of a number (in radians).
@@ -426,7 +426,7 @@ pub async fn atan(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
     let num = args.get_number()?;
     let result = inner_atan(num)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, NumericType::radians())))
 }
 
 /// Compute the arctangent of a number (in radians).
@@ -456,7 +456,7 @@ pub async fn atan2(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
     let (y, x) = FromArgs::from_args(&args, 0)?;
     let result = inner_atan2(y, x)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, NumericType::radians())))
 }
 
 /// Compute the four quadrant arctangent of Y and X (in radians).
@@ -503,7 +503,7 @@ pub async fn log(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
     }
     let result = inner_log(nums[0], nums[1])?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, NumericType::Unknown)))
 }
 
 /// Compute the logarithm of the number with respect to an arbitrary base.
@@ -535,7 +535,7 @@ pub async fn log2(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
     let num = args.get_number()?;
     let result = inner_log2(num)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, NumericType::Unknown)))
 }
 
 /// Compute the base 2 logarithm of the number.
@@ -563,7 +563,7 @@ pub async fn log10(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
     let num = args.get_number()?;
     let result = inner_log10(num)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, NumericType::Unknown)))
 }
 
 /// Compute the base 10 logarithm of the number.
@@ -591,7 +591,7 @@ pub async fn ln(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kcl
     let num = args.get_number()?;
     let result = inner_ln(num)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, NumericType::Unknown)))
 }
 
 /// Compute the natural logarithm of the number.
@@ -618,7 +618,7 @@ fn inner_ln(num: f64) -> Result<f64, KclError> {
 pub async fn e(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let result = inner_e()?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, NumericType::count())))
 }
 
 /// Return the value of Euler’s number `e`.
@@ -650,7 +650,7 @@ fn inner_e() -> Result<f64, KclError> {
 pub async fn tau(_exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let result = inner_tau()?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, NumericType::count())))
 }
 
 /// Return the value of `tau`. The full circle constant (τ). Equal to 2π.
@@ -683,7 +683,7 @@ pub async fn to_radians(_exec_state: &mut ExecState, args: Args) -> Result<KclVa
     let num = args.get_number()?;
     let result = inner_to_radians(num)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, NumericType::radians())))
 }
 
 /// Converts a number from degrees to radians.
@@ -713,7 +713,7 @@ pub async fn to_degrees(_exec_state: &mut ExecState, args: Args) -> Result<KclVa
     let num = args.get_number()?;
     let result = inner_to_degrees(num)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, NumericType::degrees())))
 }
 
 /// Converts a number from radians to degrees.

--- a/rust/kcl-lib/src/std/segment.rs
+++ b/rust/kcl-lib/src/std/segment.rs
@@ -7,10 +7,10 @@ use kittycad_modeling_cmds::shared::Angle;
 use crate::{
     errors::{KclError, KclErrorDetails},
     execution::{
-        types::{PrimitiveType, RuntimeType},
+        types::{NumericType, PrimitiveType, RuntimeType},
         ExecState, KclValue, Point2d, Sketch, TagIdentifier,
     },
-    std::{utils::between, Args},
+    std::{args::TyF64, utils::between, Args},
 };
 
 /// Returns the point at the end of the given segment.
@@ -54,7 +54,7 @@ pub async fn segment_end(exec_state: &mut ExecState, args: Args) -> Result<KclVa
         tag = { docs = "The line segment being queried by its tag"},
     }
 }]
-fn inner_segment_end(tag: &TagIdentifier, exec_state: &mut ExecState, args: Args) -> Result<[f64; 2], KclError> {
+fn inner_segment_end(tag: &TagIdentifier, exec_state: &mut ExecState, args: Args) -> Result<[TyF64; 2], KclError> {
     let line = args.get_tag_engine_info(exec_state, tag)?;
     let path = line.path.clone().ok_or_else(|| {
         KclError::Type(KclErrorDetails {
@@ -63,7 +63,7 @@ fn inner_segment_end(tag: &TagIdentifier, exec_state: &mut ExecState, args: Args
         })
     })?;
 
-    Ok(path.get_base().to)
+    Ok(path.get_to().clone())
 }
 
 /// Returns the segment end of x.
@@ -71,7 +71,7 @@ pub async fn segment_end_x(exec_state: &mut ExecState, args: Args) -> Result<Kcl
     let tag: TagIdentifier = args.get_unlabeled_kw_arg("tag")?;
     let result = inner_segment_end_x(&tag, exec_state, args.clone())?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(result))
 }
 
 /// Compute the ending point of the provided line segment along the 'x' axis.
@@ -95,7 +95,7 @@ pub async fn segment_end_x(exec_state: &mut ExecState, args: Args) -> Result<Kcl
         tag = { docs = "The line segment being queried by its tag"},
     }
 }]
-fn inner_segment_end_x(tag: &TagIdentifier, exec_state: &mut ExecState, args: Args) -> Result<f64, KclError> {
+fn inner_segment_end_x(tag: &TagIdentifier, exec_state: &mut ExecState, args: Args) -> Result<TyF64, KclError> {
     let line = args.get_tag_engine_info(exec_state, tag)?;
     let path = line.path.clone().ok_or_else(|| {
         KclError::Type(KclErrorDetails {
@@ -104,7 +104,7 @@ fn inner_segment_end_x(tag: &TagIdentifier, exec_state: &mut ExecState, args: Ar
         })
     })?;
 
-    Ok(path.get_base().to[0])
+    Ok(TyF64::new(path.get_base().to[0], path.get_base().units.into()))
 }
 
 /// Returns the segment end of y.
@@ -112,7 +112,7 @@ pub async fn segment_end_y(exec_state: &mut ExecState, args: Args) -> Result<Kcl
     let tag: TagIdentifier = args.get_unlabeled_kw_arg("tag")?;
     let result = inner_segment_end_y(&tag, exec_state, args.clone())?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(result))
 }
 
 /// Compute the ending point of the provided line segment along the 'y' axis.
@@ -137,7 +137,7 @@ pub async fn segment_end_y(exec_state: &mut ExecState, args: Args) -> Result<Kcl
         tag = { docs = "The line segment being queried by its tag"},
     }
 }]
-fn inner_segment_end_y(tag: &TagIdentifier, exec_state: &mut ExecState, args: Args) -> Result<f64, KclError> {
+fn inner_segment_end_y(tag: &TagIdentifier, exec_state: &mut ExecState, args: Args) -> Result<TyF64, KclError> {
     let line = args.get_tag_engine_info(exec_state, tag)?;
     let path = line.path.clone().ok_or_else(|| {
         KclError::Type(KclErrorDetails {
@@ -146,7 +146,7 @@ fn inner_segment_end_y(tag: &TagIdentifier, exec_state: &mut ExecState, args: Ar
         })
     })?;
 
-    Ok(path.get_to()[1])
+    Ok(path.get_to()[1].clone())
 }
 
 /// Returns the point at the start of the given segment.
@@ -190,7 +190,7 @@ pub async fn segment_start(exec_state: &mut ExecState, args: Args) -> Result<Kcl
         tag = { docs = "The line segment being queried by its tag"},
     }
 }]
-fn inner_segment_start(tag: &TagIdentifier, exec_state: &mut ExecState, args: Args) -> Result<[f64; 2], KclError> {
+fn inner_segment_start(tag: &TagIdentifier, exec_state: &mut ExecState, args: Args) -> Result<[TyF64; 2], KclError> {
     let line = args.get_tag_engine_info(exec_state, tag)?;
     let path = line.path.clone().ok_or_else(|| {
         KclError::Type(KclErrorDetails {
@@ -207,7 +207,7 @@ pub async fn segment_start_x(exec_state: &mut ExecState, args: Args) -> Result<K
     let tag: TagIdentifier = args.get_unlabeled_kw_arg("tag")?;
     let result = inner_segment_start_x(&tag, exec_state, args.clone())?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(result))
 }
 
 /// Compute the starting point of the provided line segment along the 'x' axis.
@@ -231,7 +231,7 @@ pub async fn segment_start_x(exec_state: &mut ExecState, args: Args) -> Result<K
         tag = { docs = "The line segment being queried by its tag"},
     }
 }]
-fn inner_segment_start_x(tag: &TagIdentifier, exec_state: &mut ExecState, args: Args) -> Result<f64, KclError> {
+fn inner_segment_start_x(tag: &TagIdentifier, exec_state: &mut ExecState, args: Args) -> Result<TyF64, KclError> {
     let line = args.get_tag_engine_info(exec_state, tag)?;
     let path = line.path.clone().ok_or_else(|| {
         KclError::Type(KclErrorDetails {
@@ -240,7 +240,7 @@ fn inner_segment_start_x(tag: &TagIdentifier, exec_state: &mut ExecState, args: 
         })
     })?;
 
-    Ok(path.get_from()[0])
+    Ok(path.get_from()[0].clone())
 }
 
 /// Returns the segment start of y.
@@ -248,7 +248,7 @@ pub async fn segment_start_y(exec_state: &mut ExecState, args: Args) -> Result<K
     let tag: TagIdentifier = args.get_unlabeled_kw_arg("tag")?;
     let result = inner_segment_start_y(&tag, exec_state, args.clone())?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(result))
 }
 
 /// Compute the starting point of the provided line segment along the 'y' axis.
@@ -273,7 +273,7 @@ pub async fn segment_start_y(exec_state: &mut ExecState, args: Args) -> Result<K
         tag = { docs = "The line segment being queried by its tag"},
     }
 }]
-fn inner_segment_start_y(tag: &TagIdentifier, exec_state: &mut ExecState, args: Args) -> Result<f64, KclError> {
+fn inner_segment_start_y(tag: &TagIdentifier, exec_state: &mut ExecState, args: Args) -> Result<TyF64, KclError> {
     let line = args.get_tag_engine_info(exec_state, tag)?;
     let path = line.path.clone().ok_or_else(|| {
         KclError::Type(KclErrorDetails {
@@ -282,7 +282,7 @@ fn inner_segment_start_y(tag: &TagIdentifier, exec_state: &mut ExecState, args: 
         })
     })?;
 
-    Ok(path.get_from()[1])
+    Ok(path.get_from()[1].clone())
 }
 /// Returns the last segment of x.
 pub async fn last_segment_x(exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
@@ -290,7 +290,7 @@ pub async fn last_segment_x(exec_state: &mut ExecState, args: Args) -> Result<Kc
         args.get_unlabeled_kw_arg_typed("sketch", &RuntimeType::Primitive(PrimitiveType::Sketch), exec_state)?;
     let result = inner_last_segment_x(sketch, args.clone())?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(result))
 }
 
 /// Extract the 'x' axis value of the last line segment in the provided 2-d
@@ -315,7 +315,7 @@ pub async fn last_segment_x(exec_state: &mut ExecState, args: Args) -> Result<Kc
         sketch = { docs = "The sketch whose line segment is being queried"},
     }
 }]
-fn inner_last_segment_x(sketch: Sketch, args: Args) -> Result<f64, KclError> {
+fn inner_last_segment_x(sketch: Sketch, args: Args) -> Result<TyF64, KclError> {
     let last_line = sketch
         .paths
         .last()
@@ -327,7 +327,7 @@ fn inner_last_segment_x(sketch: Sketch, args: Args) -> Result<f64, KclError> {
         })?
         .get_base();
 
-    Ok(last_line.to[0])
+    Ok(TyF64::new(last_line.to[0], last_line.units.into()))
 }
 
 /// Returns the last segment of y.
@@ -336,7 +336,7 @@ pub async fn last_segment_y(exec_state: &mut ExecState, args: Args) -> Result<Kc
         args.get_unlabeled_kw_arg_typed("sketch", &RuntimeType::Primitive(PrimitiveType::Sketch), exec_state)?;
     let result = inner_last_segment_y(sketch, args.clone())?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(result))
 }
 
 /// Extract the 'y' axis value of the last line segment in the provided 2-d
@@ -361,7 +361,7 @@ pub async fn last_segment_y(exec_state: &mut ExecState, args: Args) -> Result<Kc
         sketch = { docs = "The sketch whose line segment is being queried"},
     }
 }]
-fn inner_last_segment_y(sketch: Sketch, args: Args) -> Result<f64, KclError> {
+fn inner_last_segment_y(sketch: Sketch, args: Args) -> Result<TyF64, KclError> {
     let last_line = sketch
         .paths
         .last()
@@ -373,14 +373,14 @@ fn inner_last_segment_y(sketch: Sketch, args: Args) -> Result<f64, KclError> {
         })?
         .get_base();
 
-    Ok(last_line.to[1])
+    Ok(TyF64::new(last_line.to[1], last_line.units.into()))
 }
 
 /// Returns the length of the segment.
 pub async fn segment_length(exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let tag: TagIdentifier = args.get_unlabeled_kw_arg("tag")?;
     let result = inner_segment_length(&tag, exec_state, args.clone())?;
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(result))
 }
 
 /// Compute the length of the provided line segment.
@@ -412,7 +412,7 @@ pub async fn segment_length(exec_state: &mut ExecState, args: Args) -> Result<Kc
         tag = { docs = "The line segment being queried by its tag"},
     }
 }]
-fn inner_segment_length(tag: &TagIdentifier, exec_state: &mut ExecState, args: Args) -> Result<f64, KclError> {
+fn inner_segment_length(tag: &TagIdentifier, exec_state: &mut ExecState, args: Args) -> Result<TyF64, KclError> {
     let line = args.get_tag_engine_info(exec_state, tag)?;
     let path = line.path.clone().ok_or_else(|| {
         KclError::Type(KclErrorDetails {
@@ -421,9 +421,7 @@ fn inner_segment_length(tag: &TagIdentifier, exec_state: &mut ExecState, args: A
         })
     })?;
 
-    let result = path.length();
-
-    Ok(result)
+    Ok(path.length())
 }
 
 /// Returns the angle of the segment.
@@ -431,7 +429,7 @@ pub async fn segment_angle(exec_state: &mut ExecState, args: Args) -> Result<Kcl
     let tag: TagIdentifier = args.get_unlabeled_kw_arg("tag")?;
 
     let result = inner_segment_angle(&tag, exec_state, args.clone())?;
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, NumericType::degrees())))
 }
 
 /// Compute the angle (in degrees) of the provided line segment.
@@ -476,7 +474,7 @@ pub async fn tangent_to_end(exec_state: &mut ExecState, args: Args) -> Result<Kc
     let tag: TagIdentifier = args.get_unlabeled_kw_arg("tag")?;
 
     let result = inner_tangent_to_end(&tag, exec_state, args.clone()).await?;
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, NumericType::degrees())))
 }
 
 /// Returns the angle coming out of the end of the segment in degrees.
@@ -586,7 +584,7 @@ async fn inner_tangent_to_end(tag: &TagIdentifier, exec_state: &mut ExecState, a
 pub async fn angle_to_match_length_x(exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let (tag, to, sketch) = args.get_tag_to_number_sketch()?;
     let result = inner_angle_to_match_length_x(&tag, to, sketch, exec_state, args.clone())?;
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, NumericType::degrees())))
 }
 
 /// Returns the angle to match the given length for x.
@@ -621,7 +619,7 @@ fn inner_angle_to_match_length_x(
         })
     })?;
 
-    let length = path.length();
+    let length = path.length().n;
 
     let last_line = sketch
         .paths
@@ -634,6 +632,7 @@ fn inner_angle_to_match_length_x(
         })?
         .get_base();
 
+    // TODO assumption about the units of to
     let diff = (to - last_line.to[0]).abs();
 
     let angle_r = (diff / length).acos();
@@ -649,7 +648,7 @@ fn inner_angle_to_match_length_x(
 pub async fn angle_to_match_length_y(exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let (tag, to, sketch) = args.get_tag_to_number_sketch()?;
     let result = inner_angle_to_match_length_y(&tag, to, sketch, exec_state, args.clone())?;
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, NumericType::degrees())))
 }
 
 /// Returns the angle to match the given length for y.
@@ -685,7 +684,7 @@ fn inner_angle_to_match_length_y(
         })
     })?;
 
-    let length = path.length();
+    let length = path.length().n;
 
     let last_line = sketch
         .paths
@@ -698,6 +697,7 @@ fn inner_angle_to_match_length_y(
         })?
         .get_base();
 
+    // TODO assumption about the units of to
     let diff = (to - last_line.to[1]).abs();
 
     let angle_r = (diff / length).asin();

--- a/rust/kcl-lib/src/std/shapes.rs
+++ b/rust/kcl-lib/src/std/shapes.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 
 /// A sketch surface or a sketch.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(untagged)]
 pub enum SketchOrSurface {

--- a/rust/kcl-lib/src/std/sketch.rs
+++ b/rust/kcl-lib/src/std/sketch.rs
@@ -840,7 +840,7 @@ async fn inner_angled_line_that_intersects(
 
 /// Data for start sketch on.
 /// You can start a sketch on a plane or an solid.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(rename_all = "camelCase", untagged)]
 #[allow(clippy::large_enum_variant)]
@@ -892,7 +892,7 @@ pub enum PlaneData {
 
 /// Start a sketch on a specific plane or face.
 pub async fn start_sketch_on(exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
-    let (data, tag): (SketchData, Option<FaceTag>) = args.get_data_and_optional_tag()?;
+    let (data, tag) = args.get_sketch_data_and_optional_tag()?;
 
     match inner_start_sketch_on(data, tag, exec_state, &args).await? {
         SketchSurface::Plane(value) => Ok(KclValue::Plane { value }),

--- a/rust/kcl-lib/src/std/sweep.rs
+++ b/rust/kcl-lib/src/std/sweep.rs
@@ -5,7 +5,7 @@ use kcl_derive_docs::stdlib;
 use kcmc::{each_cmd as mcmd, length_unit::LengthUnit, ModelingCmd};
 use kittycad_modeling_cmds::{self as kcmc};
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use super::DEFAULT_TOLERANCE;
 use crate::{
@@ -16,7 +16,7 @@ use crate::{
 };
 
 /// A path to sweep along.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
+#[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(untagged)]
 pub enum SweepPath {

--- a/rust/kcl-lib/src/std/units.rs
+++ b/rust/kcl-lib/src/std/units.rs
@@ -6,14 +6,14 @@ use kcl_derive_docs::stdlib;
 use crate::{
     errors::KclError,
     execution::{types::UnitLen, ExecState, KclValue},
-    std::Args,
+    std::{args::TyF64, Args},
 };
 
 /// Millimeters conversion factor for current projects units.
 pub async fn mm(exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let result = inner_mm(exec_state)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, exec_state.current_default_units())))
 }
 
 /// Millimeters conversion factor for current projects units.
@@ -54,7 +54,7 @@ fn inner_mm(exec_state: &ExecState) -> Result<f64, KclError> {
 pub async fn inch(exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let result = inner_inch(exec_state)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, exec_state.current_default_units())))
 }
 
 /// Inches conversion factor for current projects units.
@@ -95,7 +95,7 @@ fn inner_inch(exec_state: &ExecState) -> Result<f64, KclError> {
 pub async fn ft(exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let result = inner_ft(exec_state)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, exec_state.current_default_units())))
 }
 
 /// Feet conversion factor for current projects units.
@@ -137,7 +137,7 @@ fn inner_ft(exec_state: &ExecState) -> Result<f64, KclError> {
 pub async fn m(exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let result = inner_m(exec_state)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, exec_state.current_default_units())))
 }
 
 /// Meters conversion factor for current projects units.
@@ -179,7 +179,7 @@ fn inner_m(exec_state: &ExecState) -> Result<f64, KclError> {
 pub async fn cm(exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let result = inner_cm(exec_state)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, exec_state.current_default_units())))
 }
 
 /// Centimeters conversion factor for current projects units.
@@ -221,7 +221,7 @@ fn inner_cm(exec_state: &ExecState) -> Result<f64, KclError> {
 pub async fn yd(exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let result = inner_yd(exec_state)?;
 
-    Ok(args.make_user_val_from_f64(result))
+    Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, exec_state.current_default_units())))
 }
 
 /// Yards conversion factor for current projects units.

--- a/rust/kcl-lib/tests/kcl_samples/car-wheel-assembly/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/car-wheel-assembly/ops.snap
@@ -2153,14 +2153,21 @@ description: Operations executed car-wheel-assembly.kcl
                       "type": "Number",
                       "value": 2.25,
                       "ty": {
-                        "type": "Unknown"
+                        "type": "Known",
+                        "type": "Count"
                       }
                     },
                     "y": {
                       "type": "Number",
                       "value": -1.1811023622047243,
                       "ty": {
-                        "type": "Unknown"
+                        "type": "Default",
+                        "len": {
+                          "type": "Inches"
+                        },
+                        "angle": {
+                          "type": "Degrees"
+                        }
                       }
                     },
                     "z": {

--- a/rust/kcl-lib/tests/kcl_samples/car-wheel-assembly/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/car-wheel-assembly/program_memory.snap
@@ -145,14 +145,26 @@ description: Variables in memory after executing car-wheel-assembly.kcl
     "type": "Number",
     "value": 0.9449,
     "ty": {
-      "type": "Unknown"
+      "type": "Default",
+      "len": {
+        "type": "Inches"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
     }
   },
   "lugHeadLength": {
     "type": "Number",
     "value": 0.4724,
     "ty": {
-      "type": "Unknown"
+      "type": "Default",
+      "len": {
+        "type": "Inches"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
     }
   },
   "lugHolePatternDia": {
@@ -172,7 +184,13 @@ description: Variables in memory after executing car-wheel-assembly.kcl
     "type": "Number",
     "value": 1.1811,
     "ty": {
-      "type": "Unknown"
+      "type": "Default",
+      "len": {
+        "type": "Inches"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
     }
   },
   "lugNut": {
@@ -183,28 +201,52 @@ description: Variables in memory after executing car-wheel-assembly.kcl
     "type": "Number",
     "value": 4.5,
     "ty": {
-      "type": "Unknown"
+      "type": "Default",
+      "len": {
+        "type": "Inches"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
     }
   },
   "lugThreadDepth": {
     "type": "Number",
     "value": 0.6811,
     "ty": {
-      "type": "Unknown"
+      "type": "Default",
+      "len": {
+        "type": "Inches"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
     }
   },
   "lugThreadDiameter": {
     "type": "Number",
     "value": 0.4016,
     "ty": {
-      "type": "Unknown"
+      "type": "Default",
+      "len": {
+        "type": "Inches"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
     }
   },
   "offset": {
     "type": "Number",
     "value": -1.378,
     "ty": {
-      "type": "Unknown"
+      "type": "Default",
+      "len": {
+        "type": "Inches"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
     }
   },
   "rotorDiameter": {

--- a/rust/kcl-lib/tests/kcl_samples/dodecahedron/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/dodecahedron/program_memory.snap
@@ -1765,7 +1765,9 @@ description: Variables in memory after executing dodecahedron.kcl
     "type": "Number",
     "value": 2.0344,
     "ty": {
-      "type": "Unknown"
+      "type": "Known",
+      "type": "Angle",
+      "type": "Radians"
     }
   },
   "edgeL": {

--- a/rust/kcl-lib/tests/kcl_samples/gear/ast.snap
+++ b/rust/kcl-lib/tests/kcl_samples/gear/ast.snap
@@ -4321,85 +4321,65 @@ description: Result of parsing gear.kcl
                             "commentStart": 0,
                             "end": 0,
                             "left": {
-                              "commentStart": 0,
-                              "end": 0,
-                              "left": {
+                              "argument": {
                                 "commentStart": 0,
                                 "end": 0,
-                                "left": {
-                                  "argument": {
+                                "raw": "1",
+                                "start": 0,
+                                "type": "Literal",
+                                "type": "Literal",
+                                "value": {
+                                  "value": 1.0,
+                                  "suffix": "None"
+                                }
+                              },
+                              "commentStart": 0,
+                              "end": 0,
+                              "operator": "-",
+                              "start": 0,
+                              "type": "UnaryExpression",
+                              "type": "UnaryExpression"
+                            },
+                            "operator": "*",
+                            "right": {
+                              "arguments": [
+                                {
+                                  "abs_path": false,
+                                  "commentStart": 0,
+                                  "end": 0,
+                                  "name": {
                                     "commentStart": 0,
                                     "end": 0,
-                                    "raw": "1",
+                                    "name": "startAngle",
                                     "start": 0,
-                                    "type": "Literal",
-                                    "type": "Literal",
-                                    "value": {
-                                      "value": 1.0,
-                                      "suffix": "None"
-                                    }
+                                    "type": "Identifier"
                                   },
-                                  "commentStart": 0,
-                                  "end": 0,
-                                  "operator": "-",
+                                  "path": [],
                                   "start": 0,
-                                  "type": "UnaryExpression",
-                                  "type": "UnaryExpression"
-                                },
-                                "operator": "*",
-                                "right": {
-                                  "commentStart": 0,
-                                  "end": 0,
-                                  "raw": "180",
-                                  "start": 0,
-                                  "type": "Literal",
-                                  "type": "Literal",
-                                  "value": {
-                                    "value": 180.0,
-                                    "suffix": "None"
-                                  }
-                                },
-                                "start": 0,
-                                "type": "BinaryExpression",
-                                "type": "BinaryExpression"
-                              },
-                              "operator": "/",
-                              "right": {
+                                  "type": "Name",
+                                  "type": "Name"
+                                }
+                              ],
+                              "callee": {
                                 "abs_path": false,
                                 "commentStart": 0,
                                 "end": 0,
                                 "name": {
                                   "commentStart": 0,
                                   "end": 0,
-                                  "name": "PI",
+                                  "name": "toDegrees",
                                   "start": 0,
                                   "type": "Identifier"
                                 },
                                 "path": [],
                                 "start": 0,
-                                "type": "Name",
                                 "type": "Name"
                               },
-                              "start": 0,
-                              "type": "BinaryExpression",
-                              "type": "BinaryExpression"
-                            },
-                            "operator": "*",
-                            "right": {
-                              "abs_path": false,
                               "commentStart": 0,
                               "end": 0,
-                              "name": {
-                                "commentStart": 0,
-                                "end": 0,
-                                "name": "startAngle",
-                                "start": 0,
-                                "type": "Identifier"
-                              },
-                              "path": [],
                               "start": 0,
-                              "type": "Name",
-                              "type": "Name"
+                              "type": "CallExpression",
+                              "type": "CallExpression"
                             },
                             "start": 0,
                             "type": "BinaryExpression",
@@ -4505,32 +4485,15 @@ description: Result of parsing gear.kcl
                         "start": 0,
                         "type": "ObjectProperty",
                         "value": {
-                          "commentStart": 0,
-                          "end": 0,
-                          "left": {
-                            "commentStart": 0,
-                            "end": 0,
-                            "left": {
-                              "commentStart": 0,
-                              "end": 0,
-                              "raw": "180",
-                              "start": 0,
-                              "type": "Literal",
-                              "type": "Literal",
-                              "value": {
-                                "value": 180.0,
-                                "suffix": "None"
-                              }
-                            },
-                            "operator": "/",
-                            "right": {
+                          "arguments": [
+                            {
                               "abs_path": false,
                               "commentStart": 0,
                               "end": 0,
                               "name": {
                                 "commentStart": 0,
                                 "end": 0,
-                                "name": "PI",
+                                "name": "startAngle",
                                 "start": 0,
                                 "type": "Identifier"
                               },
@@ -4538,31 +4501,28 @@ description: Result of parsing gear.kcl
                               "start": 0,
                               "type": "Name",
                               "type": "Name"
-                            },
-                            "start": 0,
-                            "type": "BinaryExpression",
-                            "type": "BinaryExpression"
-                          },
-                          "operator": "*",
-                          "right": {
+                            }
+                          ],
+                          "callee": {
                             "abs_path": false,
                             "commentStart": 0,
                             "end": 0,
                             "name": {
                               "commentStart": 0,
                               "end": 0,
-                              "name": "startAngle",
+                              "name": "toDegrees",
                               "start": 0,
                               "type": "Identifier"
                             },
                             "path": [],
                             "start": 0,
-                            "type": "Name",
                             "type": "Name"
                           },
+                          "commentStart": 0,
+                          "end": 0,
                           "start": 0,
-                          "type": "BinaryExpression",
-                          "type": "BinaryExpression"
+                          "type": "CallExpression",
+                          "type": "CallExpression"
                         }
                       },
                       {

--- a/rust/kcl-lib/tests/kcl_samples/gear/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/gear/program_memory.snap
@@ -23,714 +23,918 @@ description: Variables in memory after executing gear.kcl
         "type": "Number",
         "value": 0.0,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 3.2781,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 4.6327,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 5.67,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 6.5427,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 7.31,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 8.0023,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 8.6377,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 9.2278,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 9.781,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 10.3031,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 10.7987,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 11.2713,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 11.7237,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 12.1581,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 12.5764,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 12.9802,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 13.3708,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 13.7492,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 14.1166,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 14.4737,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 14.8213,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 15.16,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 15.4905,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 15.8132,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 16.1286,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 16.4372,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 16.7393,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 17.0353,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 17.3255,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 17.6101,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 17.8895,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 18.1639,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 18.4335,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 18.6985,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 18.9591,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 19.2156,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 19.468,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 19.7165,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 19.9613,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 20.2026,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 20.4404,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 20.6748,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 20.906,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 21.1341,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 21.3592,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 21.5814,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 21.8007,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 22.0174,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 22.2313,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 22.4427,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 22.6516,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 22.858,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 23.0621,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 23.2639,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 23.4635,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 23.6608,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 23.8561,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 24.0492,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 24.2404,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 24.4296,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 24.6168,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 24.8022,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 24.9858,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 25.1675,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 25.3475,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 25.5258,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 25.7024,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 25.8774,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 26.0508,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 26.2226,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 26.3928,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 26.5616,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 26.7289,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 26.8947,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 27.0591,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 27.2221,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 27.3837,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 27.544,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 27.703,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 27.8607,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 28.0171,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 28.1723,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 28.3263,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 28.479,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 28.6306,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 28.781,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 28.9302,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 29.0783,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 29.2254,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 29.3713,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 29.5162,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 29.66,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 29.8028,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 29.9445,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 30.0853,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 30.225,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 30.3638,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 30.5016,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 30.6385,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 30.7744,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       },
       {
         "type": "Number",
         "value": 30.9094,
         "ty": {
-          "type": "Unknown"
+          "type": "Known",
+          "type": "Angle",
+          "type": "Degrees"
         }
       }
     ]
@@ -2923,7 +3127,9 @@ description: Variables in memory after executing gear.kcl
     "type": "Number",
     "value": 0.1253,
     "ty": {
-      "type": "Unknown"
+      "type": "Known",
+      "type": "Angle",
+      "type": "Radians"
     }
   },
   "teeth": {

--- a/rust/kcl-lib/tests/kcl_samples/i-beam/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/i-beam/ops.snap
@@ -25,7 +25,13 @@ description: Operations executed i-beam.kcl
           "type": "Number",
           "value": 72.00000000000001,
           "ty": {
-            "type": "Unknown"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []

--- a/rust/kcl-lib/tests/kcl_samples/i-beam/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/i-beam/program_memory.snap
@@ -20,7 +20,13 @@ description: Variables in memory after executing i-beam.kcl
     "type": "Number",
     "value": 72.0,
     "ty": {
-      "type": "Unknown"
+      "type": "Default",
+      "len": {
+        "type": "Inches"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
     }
   },
   "flangeThickness": {

--- a/rust/kcl-lib/tests/kcl_samples/router-template-cross-bar/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/router-template-cross-bar/program_memory.snap
@@ -20,7 +20,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
     "type": "Number",
     "value": 32.6313,
     "ty": {
-      "type": "Unknown"
+      "type": "Known",
+      "type": "Count"
     }
   },
   "extrude001": {
@@ -7938,14 +7939,21 @@ description: Variables in memory after executing router-template-cross-bar.kcl
     "type": "Number",
     "value": 17.4625,
     "ty": {
-      "type": "Unknown"
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
     }
   },
   "templateGap": {
     "type": "Number",
     "value": 1.8812,
     "ty": {
-      "type": "Unknown"
+      "type": "Known",
+      "type": "Count"
     }
   },
   "templateThickness": {

--- a/rust/kcl-lib/tests/kcl_samples/router-template-slate/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/router-template-slate/program_memory.snap
@@ -3721,14 +3721,21 @@ description: Variables in memory after executing router-template-slate.kcl
     "type": "Number",
     "value": 17.4625,
     "ty": {
-      "type": "Unknown"
+      "type": "Default",
+      "len": {
+        "type": "Mm"
+      },
+      "angle": {
+        "type": "Degrees"
+      }
     }
   },
   "templateGap": {
     "type": "Number",
     "value": 1.8812,
     "ty": {
-      "type": "Unknown"
+      "type": "Known",
+      "type": "Count"
     }
   },
   "templateThickness": {


### PR DESCRIPTION
More carrying around numeric types rather than just using plain f64s. This is almost all of them, but there are a few left which depend on in-flight PRs. No user-facing changes. I also removed a few more deserialize derives.