### PR TITLE
Remove unnecessary timeouts waiting for command bar

### DIFF
--- a/e2e/playwright/desktop-export.spec.ts
+++ b/e2e/playwright/desktop-export.spec.ts
@@ -38,7 +38,6 @@ test(
       await expect(projectName).toBeVisible()
       await projectName.click()
       await scene.settled(cmdBar)
-      await page.waitForTimeout(1_000) // wait for panel buttons to be available
 
       // Expect zero errors in gutter
       await expect(page.locator('.cm-lint-marker-error')).not.toBeVisible()
@@ -46,12 +45,10 @@ test(
       // Click the export button
       const exportButton = page.getByTestId('export-pane-button')
       await expect(exportButton).toBeVisible()
-
       await exportButton.click()
-      await page.waitForTimeout(1_000) // wait for export options to be available
 
       // Select the first format option
-      const gltfOption = page.getByText('glTF')
+      const gltfOption = cmdBar.selectOption({ name: 'glTF' })
       const exportFileName = `main.gltf` // source file is named `main.kcl`
       await expect(gltfOption).toBeVisible()
       await page.keyboard.press('Enter')
@@ -59,7 +56,6 @@ test(
       // Click the checkbox
       const submitButton = page.getByText('Confirm Export')
       await expect(submitButton).toBeVisible()
-      await page.waitForTimeout(500)
       await page.keyboard.press('Enter')
 
       // Look out for the toast message
@@ -113,17 +109,16 @@ test(
       await u.closeFilePanel()
       await scene.settled(cmdBar)
 
-      // expect zero errors in guter
+      // Expect zero errors in gutter
       await expect(page.locator('.cm-lint-marker-error')).not.toBeVisible()
 
       // Click the export button
       const exportButton = page.getByTestId('export-pane-button')
       await expect(exportButton).toBeVisible()
       await exportButton.click()
-      await page.waitForTimeout(1_000) // wait for export options to be available
 
       // Select the first format option
-      const gltfOption = page.getByText('glTF')
+      const gltfOption = cmdBar.selectOption({ name: 'glTF' })
       const exportFileName = `other.gltf` // source file is named `other.kcl`
       await expect(gltfOption).toBeVisible()
       await page.keyboard.press('Enter')
@@ -131,7 +126,6 @@ test(
       // Click the checkbox
       const submitButton = page.getByText('Confirm Export')
       await expect(submitButton).toBeVisible()
-      await page.waitForTimeout(500)
       await page.keyboard.press('Enter')
 
       // Look out for the toast message


### PR DESCRIPTION
This addresses some feedback on https://github.com/KittyCAD/modeling-app/pull/6143 to use the newer fixtures for waiting.

---

```
yarn test:playwright:electron:local --grep="export works on the first try" --repeat-each=10
```