### PR TITLE
Add a sidebar action to create a share link

### DIFF
--- a/src/components/ModelingSidebar/ModelingSidebar.tsx
+++ b/src/components/ModelingSidebar/ModelingSidebar.tsx
@@ -76,6 +76,18 @@ export function ModelingSidebar({ paneOpacity }: ModelingSidebarProps) {
         }),
     },
     {
+      id: 'share-link',
+      title: 'Create share link',
+      sidebarName: 'Create share link',
+      icon: 'link',
+      keybinding: 'Mod + Alt + S',
+      action: () =>
+        commandBarActor.send({
+          type: 'Find and select command',
+          data: { name: 'share-file-link', groupId: 'code' },
+        }),
+    },
+    {
       id: 'export',
       title: 'Export part',
       sidebarName: 'Export part',


### PR DESCRIPTION
I'm not sure if there's an issue for this but we've talked about how the "Share link" functionality is too buried in the hard-to-find project menu. This adds it to the "actions" section of the left sidebar. [I made a "link-with-right-arrow" icon in Figma](https://www.figma.com/design/5UUPOawPLEs3D0Gptf42vy/Designs?node-id=543-1464&t=M3RApEzU7kSfl2ln-11) but decided to just use the link icon we already have in there, since it's a cleaner shape. Let me know if you think I should use that one instead.

This is a part of a flurry of last minute pre-1.0 appearance tweaks to the app.