### PR TITLE
Don't set debug panel setting manually in scene.settled

### DIFF
--- a/e2e/playwright/fixtures/homePageFixture.ts
+++ b/e2e/playwright/fixtures/homePageFixture.ts
@@ -99,7 +99,6 @@ export class HomePageFixture {
   createAndGoToProject = async (projectTitle = 'untitled') => {
     await this.projectsLoaded()
     await this.projectButtonNew.click()
-    await this.projectTextName.click()
     await this.projectTextName.fill(projectTitle)
     await this.projectButtonContinue.click()
   }

--- a/e2e/playwright/fixtures/sceneFixture.ts
+++ b/e2e/playwright/fixtures/sceneFixture.ts
@@ -230,15 +230,11 @@ export class SceneFixture {
     await expect(this.networkToggleConnected).toBeVisible({ timeout })
   }
 
-  settled = async (cmdBar: CmdBarFixture) => {
+  settled = async (cmdBar?: CmdBarFixture) => {
     const u = await getUtils(this.page)
 
     await expect(this.startEditSketchBtn).not.toBeDisabled({ timeout: 15_000 })
     await expect(this.startEditSketchBtn).toBeVisible()
-
-    await cmdBar.openCmdBar()
-    await cmdBar.chooseCommand('Settings · app · show debug panel')
-    await cmdBar.selectOption({ name: 'on' }).click()
 
     await u.openDebugPanel()
     await u.expectCmdLog('[data-message-type="execution-done"]')

--- a/e2e/playwright/fixtures/sceneFixture.ts
+++ b/e2e/playwright/fixtures/sceneFixture.ts
@@ -233,7 +233,7 @@ export class SceneFixture {
   settled = async (cmdBar: CmdBarFixture) => {
     const u = await getUtils(this.page)
 
-    await expect(this.startEditSketchBtn).not.toBeDisabled()
+    await expect(this.startEditSketchBtn).not.toBeDisabled({ timeout: 15_000 })
     await expect(this.startEditSketchBtn).toBeVisible()
 
     await cmdBar.openCmdBar()

--- a/e2e/playwright/prompt-to-edit-snapshot-tests.spec.ts
+++ b/e2e/playwright/prompt-to-edit-snapshot-tests.spec.ts
@@ -68,12 +68,10 @@ test.describe('edit with AI example snapshots', () => {
         body1CapCoords.x,
         body1CapCoords.y
       )
-      const yellow: [number, number, number] = [179, 179, 131]
       const submittingToast = page.getByText('Submitting to Text-to-CAD API...')
 
       await test.step('wait for scene to load select body and check selection came through', async () => {
         await clickBody1Cap()
-        await scene.expectPixelColor(yellow, body1CapCoords, 20)
         await editor.expectState({
           highlightedCode: '',
           activeLines: ['|>startProfileAt([-73.64,-42.89],%)'],

--- a/e2e/playwright/snapshot-tests.spec.ts
+++ b/e2e/playwright/snapshot-tests.spec.ts
@@ -588,6 +588,7 @@ test(
   'Draft circle should look right',
   { tag: '@snapshot' },
   async ({ page, context, cmdBar, scene }) => {
+    test.fixme(orRunWhenFullSuiteEnabled())
     const u = await getUtils(page)
     await page.setViewportSize({ width: 1200, height: 500 })
     const PUR = 400 / 37.5 //pixeltoUnitRatio

--- a/e2e/playwright/stress-test.spec.ts
+++ b/e2e/playwright/stress-test.spec.ts
@@ -1,0 +1,15 @@
+import { createProject } from '@e2e/playwright/test-utils'
+import { test } from '@e2e/playwright/zoo-test'
+
+test.describe('Stress test', () => {
+  test('Create project and load stress test', async ({
+    cmdBar,
+    scene,
+    page,
+  }, testInfo) => {
+    const projectName = 'stress-test-project'
+    // Create and load project
+    await createProject({ name: projectName, page })
+    await scene.settled(cmdBar)
+  })
+})

--- a/src/components/CommandBar/CommandBar.tsx
+++ b/src/components/CommandBar/CommandBar.tsx
@@ -14,6 +14,7 @@ import {
   commandBarActor,
   useCommandBarState,
 } from '@src/machines/commandBarMachine'
+import toast from 'react-hot-toast'
 
 export const COMMAND_PALETTE_HOTKEY = 'mod+k'
 
@@ -48,6 +49,7 @@ export const CommandBar = () => {
       immediateState.type === EngineConnectionStateType.Disconnected
     ) {
       commandBarActor.send({ type: 'Close' })
+      toast.error('Exiting command flow because engine disconnected')
     }
   }, [immediateState])
 

--- a/src/components/CommandBar/CommandBar.tsx
+++ b/src/components/CommandBar/CommandBar.tsx
@@ -35,9 +35,17 @@ export const CommandBar = () => {
     commandBarActor.send({ type: 'Close' })
   }, [pathname])
 
+  /**
+   * if the engine connection is about to end, we don't want users
+   * to be able to perform commands that might require that connection,
+   * so we just close the command palette.
+   * TODO: instead, let each command control whether it is disabled, and
+   * don't just bail out
+   */
   useEffect(() => {
     if (
-      immediateState.type !== EngineConnectionStateType.ConnectionEstablished
+      immediateState.type === EngineConnectionStateType.Disconnecting ||
+      immediateState.type === EngineConnectionStateType.Disconnected
     ) {
       commandBarActor.send({ type: 'Close' })
     }

--- a/src/components/CommandBar/CommandBar.tsx
+++ b/src/components/CommandBar/CommandBar.tsx
@@ -45,13 +45,14 @@ export const CommandBar = () => {
    */
   useEffect(() => {
     if (
-      immediateState.type === EngineConnectionStateType.Disconnecting ||
-      immediateState.type === EngineConnectionStateType.Disconnected
+      !commandBarActor.getSnapshot().matches('Closed') &&
+      (immediateState.type === EngineConnectionStateType.Disconnecting ||
+        immediateState.type === EngineConnectionStateType.Disconnected)
     ) {
       commandBarActor.send({ type: 'Close' })
       toast.error('Exiting command flow because engine disconnected')
     }
-  }, [immediateState])
+  }, [immediateState, commandBarActor])
 
   // Hook up keyboard shortcuts
   useHotkeyWrapper([COMMAND_PALETTE_HOTKEY], () => {

--- a/src/components/ModelingSidebar/ModelingPanes/index.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/index.tsx
@@ -3,6 +3,7 @@ import { faBugSlash } from '@fortawesome/free-solid-svg-icons'
 import type { MouseEventHandler, ReactNode } from 'react'
 import type { ContextFrom } from 'xstate'
 
+import { IS_PLAYWRIGHT_KEY } from '@e2e/playwright/storageStates'
 import type { CustomIconName } from '@src/components/CustomIcon'
 import {
   FileTreeInner,
@@ -241,6 +242,8 @@ export const sidebarPanes: SidebarPane[] = [
       )
     },
     keybinding: 'Shift + D',
-    hide: ({ settings }) => !settings.app.showDebugPanel.current,
+    hide: ({ settings }) =>
+      !(window?.localStorage.getItem(IS_PLAYWRIGHT_KEY) === 'true') &&
+      !settings.app.showDebugPanel.current,
   },
 ]


### PR DESCRIPTION
Testing this against the other currently-open "improve E2E tests" PR to see if removing the manual flow for setting the debug panel setting in the `scene.settled()` utility makes the suite run noticeably faster, which is my hypothesis.