### PR TITLE
Restore tests that use Text-to-CAD

### DIFF
--- a/e2e/playwright/prompt-to-edit.spec.ts
+++ b/e2e/playwright/prompt-to-edit.spec.ts
@@ -1,4 +1,3 @@
-import { orRunWhenFullSuiteEnabled } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 
 /* eslint-disable jest/no-conditional-expect */
@@ -51,7 +50,6 @@ test.describe('Prompt-to-edit tests', { tag: '@skipWin' }, () => {
         page,
         scene,
       }) => {
-        test.fixme(orRunWhenFullSuiteEnabled())
         await context.addInitScript((file) => {
           localStorage.setItem('persistCode', file)
         }, file)
@@ -200,7 +198,6 @@ test.describe('Prompt-to-edit tests', { tag: '@skipWin' }, () => {
     page,
     scene,
   }) => {
-    test.fixme(orRunWhenFullSuiteEnabled())
     const body1CapCoords = { x: 571, y: 311 }
 
     await context.addInitScript((file) => {
@@ -260,7 +257,6 @@ test.describe('Prompt-to-edit tests', { tag: '@skipWin' }, () => {
     page,
     scene,
   }) => {
-    test.fixme(orRunWhenFullSuiteEnabled())
     const body1CapCoords = { x: 571, y: 311 }
     const body2WallCoords = { x: 620, y: 152 }
     const [clickBody1Cap] = scene.makeMouseHelpers(


### PR DESCRIPTION
I think these still need work, but I'd like to enable/disable them programmatically based on the status of Text-to-CAD rather than directly in our test code.