### PR TITLE
Don't bail command palette if there's no engineConnection

### DIFF
--- a/src/components/CommandBar/CommandBar.tsx
+++ b/src/components/CommandBar/CommandBar.tsx
@@ -10,6 +10,7 @@ import Tooltip from '@src/components/Tooltip'
 import { useNetworkContext } from '@src/hooks/useNetworkContext'
 import { EngineConnectionStateType } from '@src/lang/std/engineConnection'
 import useHotkeyWrapper from '@src/lib/hotkeyWrapper'
+import { engineCommandManager } from '@src/lib/singletons'
 import {
   commandBarActor,
   useCommandBarState,
@@ -46,6 +47,7 @@ export const CommandBar = () => {
   useEffect(() => {
     if (
       !commandBarActor.getSnapshot().matches('Closed') &&
+      engineCommandManager.engineConnection &&
       (immediateState.type === EngineConnectionStateType.Disconnecting ||
         immediateState.type === EngineConnectionStateType.Disconnected)
     ) {


### PR DESCRIPTION
The connection can't be bad if there is none yet `:galaxy-brain:`.

But seriously this behavior regressed share links because we would bail from the command palette because the connection wasn't healthy. This behavior was introduced in #5312 and not fixed by changes in #6265, only caught during smoke testing in #6283 luckily.