### PR TITLE
fix text-to-CAD test bug

### DIFF
--- a/e2e/playwright/text-to-cad-tests.spec.ts
+++ b/e2e/playwright/text-to-cad-tests.spec.ts
@@ -37,18 +37,18 @@ test.describe('Text-to-CAD tests', { tag: ['@skipWin'] }, () => {
     await expect(successToastMessage).toBeVisible({ timeout: 15000 })
 
     // Hit accept.
-    const copyToClipboardButton = page.getByRole('button', {
+    const acceptButton = page.getByRole('button', {
       name: 'Accept',
     })
-    await expect(copyToClipboardButton).toBeVisible()
+    await expect(acceptButton).toBeVisible()
 
-    await copyToClipboardButton.click()
+    await acceptButton.click()
 
     // Click in the code editor.
     await page.locator('.cm-content').click()
 
     // Expect the code to be pasted.
-    await expect(page.locator('.cm-content')).toContainText(`const`)
+    await expect(page.locator('.cm-content')).toContainText(`startSketchOn`)
 
     // make sure a model renders.
     // wait for execution done


### PR DESCRIPTION
` await expect(page.locator('.cm-content')).toContainText(`const`)` was there as a way of asserting "there's some code in the editor right?"

But we haven't used the const keyword in ages, so maybe text-to-cad has kept using it all this time??
It's possible as the cost keyword was a lint warning, not an error.

Relevant slack thread:
https://kittycadworkspace.slack.com/archives/C04KFV6NKL0/p1744585241148889