### PR TITLE
Include test annotations for analysis

### DIFF
--- a/e2e/playwright/lib/api-reporter.ts
+++ b/e2e/playwright/lib/api-reporter.ts
@@ -19,9 +19,9 @@ class MyAPIReporter implements Reporter {
       target: process.env.TARGET || null,
       platform: process.env.RUNNER_OS || process.platform,
       // Extra test and result data
-      annotations: test.annotations.map((a) => a.type),
+      annotations: test.annotations.map((a) => a.type), // e.g. 'fail' or 'fixme'
       retry: result.retry,
-      tags: test.tags,
+      tags: test.tags, // e.g. '@snapshot' or '@skipWin'
       // Extra environment variables
       CI_COMMIT_SHA: process.env.CI_COMMIT_SHA || null,
       CI_PR_NUMBER: process.env.CI_PR_NUMBER || null,

--- a/e2e/playwright/lib/api-reporter.ts
+++ b/e2e/playwright/lib/api-reporter.ts
@@ -19,6 +19,7 @@ class MyAPIReporter implements Reporter {
       target: process.env.TARGET || null,
       platform: process.env.RUNNER_OS || process.platform,
       // Extra test and result data
+      annotations: test.annotations.map((a) => a.type),
       retry: result.retry,
       tags: test.tags,
       // Extra environment variables


### PR DESCRIPTION
This will let me identify tests that are expected to fail (e.g. `test.fail()`).