### PR TITLE
Revert "KCL: Error when user sets a keyword arg multiple times (#6339)"

### DIFF
--- a/rust/kcl-lib/src/parsing/parser.rs
+++ b/rust/kcl-lib/src/parsing/parser.rs
@@ -3,7 +3,6 @@
 
 use std::{cell::RefCell, collections::BTreeMap};
 
-use indexmap::IndexMap;
 use winnow::{
     combinator::{alt, delimited, opt, peek, preceded, repeat, repeat_till, separated, separated_pair, terminated},
     dispatch,
@@ -3139,21 +3138,6 @@ fn fn_call_kw(i: &mut TokenSlice) -> PResult<Node<CallExpressionKw>> {
     opt(comma_sep).parse_next(i)?;
     let end = close_paren.parse_next(i)?.end;
 
-    // Validate there aren't any duplicate labels.
-    let mut counted_labels = IndexMap::with_capacity(args.len());
-    for arg in &args {
-        *counted_labels.entry(&arg.label.inner.name).or_insert(0) += 1;
-    }
-    if let Some((duplicated, n)) = counted_labels.iter().find(|(_label, n)| n > &&1) {
-        let msg = format!(
-            "You've used the parameter labelled '{duplicated}' {n} times in a single function call. You can only set each parameter once! Remove all but one use."
-        );
-        ParseContext::err(CompilationError::err(
-            SourceRange::new(fn_name.start, end, fn_name.module_id),
-            msg,
-        ));
-    }
-
     let non_code_meta = NonCodeMeta {
         non_code_nodes,
         ..Default::default()
@@ -5090,18 +5074,6 @@ baz = 2
                 "failed test {i}: {program}"
             );
         }
-    }
-
-    #[test]
-    fn test_sensible_error_duplicated_args() {
-        let program = r#"f(arg = 1, normal = 44, arg = 2)"#;
-        let (_, mut errs) = assert_no_fatal(program);
-        assert_eq!(errs.len(), 1);
-        let err = errs.pop().unwrap();
-        assert_eq!(
-            err.message,
-            "You've used the parameter labelled 'arg' 2 times in a single function call. You can only set each parameter once! Remove all but one use.",
-        );
     }
 }
 


### PR DESCRIPTION
This reverts commit e955e783f4497f82f63af11ae3bd10d6d6b5ada3.