### PR TITLE
put execution benchmarks behind flag

### DIFF
--- a/.github/workflows/cargo-bench.yml
+++ b/.github/workflows/cargo-bench.yml
@@ -50,13 +50,12 @@ jobs:
       - name: Build the benchmark target(s)
         run: |
           cd rust
-          cargo codspeed build --measurement-mode walltime
+          cargo codspeed build
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v3
         with:
           working-directory: rust
           run: cargo codspeed run
           token: ${{ secrets.CODSPEED_TOKEN }}
-          mode: walltime
         env:
           KITTYCAD_API_TOKEN: ${{ secrets.KITTYCAD_API_TOKEN }}

--- a/rust/kcl-lib/Cargo.toml
+++ b/rust/kcl-lib/Cargo.toml
@@ -105,6 +105,7 @@ tower-lsp = { workspace = true, features = ["proposed", "default"] }
 
 [features]
 default = ["cli", "engine"]
+benchmark-execution = []
 cli = ["dep:clap", "kittycad/clap"]
 dhat-heap = ["dep:dhat"]
 # For the lsp server, when run with stdout for rpc we want to disable println.

--- a/rust/kcl-lib/benches/benchmark_kcl_samples.rs
+++ b/rust/kcl-lib/benches/benchmark_kcl_samples.rs
@@ -45,6 +45,7 @@ fn run_benchmarks(c: &mut Criterion) {
 
     let benchmark_dirs = discover_benchmark_dirs(&base_dir);
 
+    #[cfg(feature = "benchmark-execution")]
     let rt = tokio::runtime::Runtime::new().unwrap();
 
     for dir in benchmark_dirs {
@@ -67,12 +68,14 @@ fn run_benchmarks(c: &mut Criterion) {
             .sample_size(10)
             .measurement_time(std::time::Duration::from_secs(1)); // Short measurement time to keep it from running in parallel
 
+        #[cfg(feature = "benchmark-execution")]
         let program = kcl_lib::Program::parse_no_errs(&input_content).unwrap();
 
         group.bench_function(format!("parse_{}", dir_name), |b| {
             b.iter(|| kcl_lib::Program::parse_no_errs(black_box(&input_content)).unwrap())
         });
 
+        #[cfg(feature = "benchmark-execution")]
         group.bench_function(format!("execute_{}", dir_name), |b| {
             b.iter(|| {
                 if let Err(err) = rt.block_on(async {


### PR DESCRIPTION
- the execution benchmarks were always failing due to websockets closing and we had to use walltime which sucks
- at least now we will good metrics for parse without walltime and in a nice vm to make sure data is good, walltime couldnt guarantee that
- you can run the execution benchmarks w the feature flag `benchmark-execution`
- this also allows us to require benchmarks to pass for ci, which means people cant make parsing significantly slower