### PR TITLE
add toast for selections we don't recognise

### DIFF
--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -330,6 +330,13 @@ export const ModelingMachineProvider = ({
             }
             if (setSelections.selectionType === 'singleCodeCursor') {
               if (!setSelections.selection && editorManager.isShiftDown) {
+                // if the user is holding shift, but they didn't select anything
+                // don't nuke their other selections (frustrating to have one bad click ruin your
+                // whole selection)
+                selections = {
+                  graphSelections: selectionRanges.graphSelections,
+                  otherSelections: selectionRanges.otherSelections,
+                }
               } else if (
                 !setSelections.selection &&
                 !editorManager.isShiftDown

--- a/src/components/ToastUnsupportedSelection.tsx
+++ b/src/components/ToastUnsupportedSelection.tsx
@@ -1,0 +1,49 @@
+import toast from 'react-hot-toast'
+
+import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
+
+export function ToastUnsupportedSelection({
+  toastId,
+}: {
+  toastId: string
+}) {
+  const githubIssueUrl = 'https://github.com/KittyCAD/modeling-app/issues/6368'
+
+  return (
+    <div className="inset-0 z-50 grid place-content-center rounded bg-chalkboard-10 dark:bg-chalkboard-90 shadow-md p-3">
+      <section>
+        <p className="text-sm text-chalkboard-70 dark:text-chalkboard-30">
+          Some faces and edges are not currently selectable.{' '}
+          <a
+            href={githubIssueUrl}
+            onClick={openExternalBrowserIfDesktop(githubIssueUrl)}
+            className="underline"
+          >
+            The team is working on it
+          </a>
+          .
+        </p>
+      </section>
+    </div>
+  )
+}
+
+/**
+ * Show a toast notification for when users try to select unsupported faces/edges
+ * @example
+ * // In your component or handler:
+ * import { showUnsupportedSelectionToast } from '@src/components/ToastUnsupportedSelection'
+ *
+ * // When user tries to select an unsupported face/edge
+ * showUnsupportedSelectionToast()
+ */
+export function showUnsupportedSelectionToast() {
+  const toastId = toast.custom(
+    (t) => <ToastUnsupportedSelection toastId={t.id} />,
+    {
+      duration: 4_000,
+    }
+  )
+
+  return toastId
+}

--- a/src/lib/selections.ts
+++ b/src/lib/selections.ts
@@ -387,7 +387,6 @@ function resetAndSetEngineEntitySelectionCmds(
   if (!engineCommandManager.engineConnection?.isReady()) {
     return []
   }
-  console.log('selections', selections)
   return [
     {
       type: 'modeling_cmd_req',


### PR DESCRIPTION
Closes #4866 (a P0 bug)

And opens a much lower priority one #6368 (which is a public facing issue that we can link to from within the app)

This change, 
- Updates the selection logic so we don't clear a users selections, even if they select nothing when they are holding shift (a single mis click could clear they 30 item selection :( )
- Changes logic in `getEventForSelectWithPoint` so that when we receive an entity we don't recognise from the engine (i.e. not in the artifactGrahp) we return an empty `singleCodeCursor` event which allow it to plug it with there rest of the selection logic (holding shift or not logic)
- show a toast message to the user in this case linking them to #6368 
- No tests because


https://github.com/user-attachments/assets/28f2e5d4-779d-48d9-bcfb-1b3d16f1afb8


