### PR TITLE
Revert "Switch to a 6-core profile for mac"

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -285,7 +285,7 @@ jobs:
         # TODO: enable namespace-profile-windows-latest once available
         os:
           - "runs-on=${{ github.run_id }}/family=i7ie.2xlarge/image=ubuntu22-full-x64"
-          - namespace-profile-macos-6-cores
+          - namespace-profile-macos-8-cores
           - windows-latest-8-cores
         shardIndex: [1, 2, 3, 4]
         shardTotal: [4]
@@ -295,7 +295,7 @@ jobs:
         isScheduled:
           - ${{ github.event_name == 'schedule' }}
         exclude:
-          - os: namespace-profile-macos-6-cores
+          - os: namespace-profile-macos-8-cores
             isScheduled: true
           - os: windows-latest-8-cores
             isScheduled: true

--- a/playwright.electron.config.ts
+++ b/playwright.electron.config.ts
@@ -20,7 +20,7 @@ if (process.env.E2E_WORKERS) {
     case 'darwin':
     case 'win32':
     default:
-      workers = '40%' // Lower concurrency for heavier Electron processes
+      workers = '25%' // Lower concurrency for heavier Electron processes
       break
   }
 }


### PR DESCRIPTION
Reverts KittyCAD/modeling-app#6323 as we think fewer CPUs has increased the startup time, resulting in more of these:

> Test timeout of 120000ms exceeded while setting up "tronApp".

---

Before: https://test-analysis-bot.hawk-dinosaur.ts.net/projects/KittyCAD/modeling-app/tests/307?status=error

After: https://test-analysis-bot.hawk-dinosaur.ts.net/projects/KittyCAD/modeling-app/tests/307?status=error&branch=revert-6323-try-6-core-runners