### PR TITLE
Add fixmes to failing e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -227,7 +227,7 @@ jobs:
           shell: bash
           command: npm run test:snapshots
           timeout_minutes: 30
-          max_attempts: 5
+          max_attempts: 3
         env:
           token: ${{ secrets.KITTYCAD_API_TOKEN_DEV }}
           snapshottoken: ${{ secrets.KITTYCAD_API_TOKEN }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -227,7 +227,7 @@ jobs:
           shell: bash
           command: npm run test:snapshots
           timeout_minutes: 30
-          max_attempts: 3
+          max_attempts: 5
         env:
           token: ${{ secrets.KITTYCAD_API_TOKEN_DEV }}
           snapshottoken: ${{ secrets.KITTYCAD_API_TOKEN }}

--- a/e2e/playwright/point-click.spec.ts
+++ b/e2e/playwright/point-click.spec.ts
@@ -5,7 +5,10 @@ import type { Locator, Page } from '@playwright/test'
 import type { EditorFixture } from '@e2e/playwright/fixtures/editorFixture'
 import type { SceneFixture } from '@e2e/playwright/fixtures/sceneFixture'
 import type { ToolbarFixture } from '@e2e/playwright/fixtures/toolbarFixture'
-import { orRunWhenFullSuiteEnabled, runningOnWindows } from '@e2e/playwright/test-utils'
+import {
+  orRunWhenFullSuiteEnabled,
+  runningOnWindows,
+} from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 
 // test file is for testing point an click code gen functionality that's not sketch mode related

--- a/e2e/playwright/point-click.spec.ts
+++ b/e2e/playwright/point-click.spec.ts
@@ -5,7 +5,7 @@ import type { Locator, Page } from '@playwright/test'
 import type { EditorFixture } from '@e2e/playwright/fixtures/editorFixture'
 import type { SceneFixture } from '@e2e/playwright/fixtures/sceneFixture'
 import type { ToolbarFixture } from '@e2e/playwright/fixtures/toolbarFixture'
-import { orRunWhenFullSuiteEnabled } from '@e2e/playwright/test-utils'
+import { orRunWhenFullSuiteEnabled, runningOnWindows } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 
 // test file is for testing point an click code gen functionality that's not sketch mode related
@@ -3544,6 +3544,9 @@ tag=$rectangleSegmentC002,
       toolbar,
       cmdBar,
     }) => {
+      if (runningOnWindows()) {
+        test.fixme(orRunWhenFullSuiteEnabled())
+      }
       const initialCode = `sketch001 = startSketchOn(XZ)
   |> startProfileAt([-102.57, 101.72], %)
   |> angledLine(angle = 0, length = 202.6, tag = $rectangleSegmentA001)

--- a/e2e/playwright/prompt-to-edit-snapshot-tests.spec.ts
+++ b/e2e/playwright/prompt-to-edit-snapshot-tests.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@e2e/playwright/zoo-test'
+import { orRunWhenFullSuiteEnabled } from './test-utils'
 
 /* eslint-disable jest/no-conditional-expect */
 
@@ -57,6 +58,7 @@ test.describe('edit with AI example snapshots', () => {
     `change colour`,
     { tag: '@snapshot' },
     async ({ context, homePage, cmdBar, editor, page, scene }) => {
+      test.fixme(orRunWhenFullSuiteEnabled())
       await context.addInitScript((file) => {
         localStorage.setItem('persistCode', file)
       }, file)

--- a/e2e/playwright/prompt-to-edit-snapshot-tests.spec.ts
+++ b/e2e/playwright/prompt-to-edit-snapshot-tests.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@e2e/playwright/zoo-test'
-import { orRunWhenFullSuiteEnabled } from './test-utils'
+import { orRunWhenFullSuiteEnabled } from '@e2e/playwright/test-utils'
 
 /* eslint-disable jest/no-conditional-expect */
 

--- a/e2e/playwright/snapshot-tests.spec.ts
+++ b/e2e/playwright/snapshot-tests.spec.ts
@@ -377,8 +377,7 @@ test.describe(
   'extrude on default planes should be stable',
   { tag: '@snapshot' },
   () => {
-    // FIXME: Skip on macos its being weird.
-    test.skip(process.platform === 'darwin', 'Skip on macos')
+    test.fixme(orRunWhenFullSuiteEnabled())
 
     test('XY', async ({ page, context, cmdBar, scene }) => {
       await extrudeDefaultPlane(context, page, cmdBar, scene, 'XY')
@@ -410,6 +409,7 @@ test(
   'Draft segments should look right',
   { tag: '@snapshot' },
   async ({ page, scene, toolbar }) => {
+    test.fixme(orRunWhenFullSuiteEnabled())
     const u = await getUtils(page)
     await page.setViewportSize({ width: 1200, height: 500 })
     const PUR = 400 / 37.5 //pixeltoUnitRatio
@@ -534,8 +534,7 @@ test(
   'Draft rectangles should look right',
   { tag: '@snapshot' },
   async ({ page, context, cmdBar, scene }) => {
-    // FIXME: Skip on macos its being weird.
-    test.skip(process.platform === 'darwin', 'Skip on macos')
+    test.fixme(orRunWhenFullSuiteEnabled())
 
     const u = await getUtils(page)
     await page.setViewportSize({ width: 1200, height: 500 })
@@ -629,8 +628,7 @@ test.describe(
   'Client side scene scale should match engine scale',
   { tag: '@snapshot' },
   () => {
-    // FIXME: Skip on macos its being weird.
-    test.skip(process.platform === 'darwin', 'Skip on macos')
+    test.fixme(orRunWhenFullSuiteEnabled())
 
     test('Inch scale', async ({ page, cmdBar, scene }) => {
       const u = await getUtils(page)
@@ -868,8 +866,7 @@ test(
   'Zoom to fit on load - solid 2d',
   { tag: '@snapshot' },
   async ({ page, context, cmdBar, scene }) => {
-    // FIXME: Skip on macos its being weird.
-    test.skip(process.platform === 'darwin', 'Skip on macos')
+    test.fixme(orRunWhenFullSuiteEnabled())
 
     const u = await getUtils(page)
     await context.addInitScript(async () => {
@@ -907,8 +904,7 @@ test(
   'Zoom to fit on load - solid 3d',
   { tag: '@snapshot' },
   async ({ page, context, cmdBar, scene }) => {
-    // FIXME: Skip on macos its being weird.
-    test.skip(process.platform === 'darwin', 'Skip on macos')
+    test.fixme(orRunWhenFullSuiteEnabled())
 
     const u = await getUtils(page)
     await context.addInitScript(async () => {
@@ -949,6 +945,7 @@ test.describe('Grid visibility', { tag: '@snapshot' }, () => {
     cmdBar,
     scene,
   }) => {
+    test.fixme(orRunWhenFullSuiteEnabled())
     const u = await getUtils(page)
     const stream = page.getByTestId('stream')
 

--- a/e2e/playwright/snapshot-tests.spec.ts
+++ b/e2e/playwright/snapshot-tests.spec.ts
@@ -1005,6 +1005,7 @@ test.describe('Grid visibility', { tag: '@snapshot' }, () => {
   })
 
   test('Grid turned off', async ({ page, cmdBar, scene }) => {
+    test.fixme(orRunWhenFullSuiteEnabled())
     const u = await getUtils(page)
     const stream = page.getByTestId('stream')
 

--- a/e2e/playwright/snapshot-tests.spec.ts
+++ b/e2e/playwright/snapshot-tests.spec.ts
@@ -1027,6 +1027,7 @@ test.describe('Grid visibility', { tag: '@snapshot' }, () => {
   })
 
   test('Grid turned on', async ({ page, context, cmdBar, scene }) => {
+    test.fixme(orRunWhenFullSuiteEnabled())
     await context.addInitScript(
       async ({ settingsKey, settings }) => {
         localStorage.setItem(settingsKey, settings)


### PR DESCRIPTION
Around the timing of #6342 snapshots started failing consistently