### PR TITLE
Add text to the error message when JSON parse fails

### DIFF
--- a/src/components/EngineCommands.tsx
+++ b/src/components/EngineCommands.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import type { CommandLog } from '@src/lang/std/commandLog'
 import { engineCommandManager } from '@src/lib/singletons'
 import { reportRejection } from '@src/lib/trap'
+import { parseJson } from '@src/lib/utils'
 
 export function useEngineCommands(): [CommandLog[], () => void] {
   const [engineCommands, setEngineCommands] = useState<CommandLog[]>(
@@ -84,7 +85,7 @@ export const EngineCommands = () => {
         data-testid="custom-cmd-send-button"
         onClick={() => {
           engineCommandManager
-            .sendSceneCommand(JSON.parse(customCmd))
+            .sendSceneCommand(parseJson(customCmd))
             .catch(reportRejection)
         }}
       >

--- a/src/lang/kclSamples.test.ts
+++ b/src/lang/kclSamples.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { assertParse } from '@src/lang/wasm'
 import { initPromise } from '@src/lang/wasmUtils'
 import { enginelessExecutor } from '@src/lib/testHelpers'
+import { parseJson } from '@src/lib/utils'
 
 // The purpose of these tests is to act as a first line of defense
 // if something gets real screwy with our KCL ecosystem.
@@ -27,7 +28,7 @@ const manifestJsonStr = await fs.readFile(
   path.resolve(DIR_KCL_SAMPLES, 'manifest.json'),
   'utf-8'
 )
-const manifest = JSON.parse(manifestJsonStr)
+const manifest: KclSampleFile[] = parseJson(manifestJsonStr)
 
 process.chdir(DIR_KCL_SAMPLES)
 

--- a/src/lang/std/engineConnection.ts
+++ b/src/lang/std/engineConnection.ts
@@ -23,7 +23,7 @@ import {
   getThemeColorForEngine,
 } from '@src/lib/theme'
 import { reportRejection } from '@src/lib/trap'
-import { binaryToUuid, uuidv4 } from '@src/lib/utils'
+import { binaryToUuid, parseJson, uuidv4 } from '@src/lib/utils'
 
 const pingIntervalMs = 1_000
 
@@ -390,7 +390,7 @@ class EngineConnection extends EventTarget {
     this.websocket.addEventListener('open', this.onWebSocketOpen)
 
     this.websocket?.addEventListener('message', ((event: MessageEvent) => {
-      const message: Models['WebSocketResponse_type'] = JSON.parse(event.data)
+      const message: Models['WebSocketResponse_type'] = parseJson(event.data)
       const pending =
         this.engineCommandManager.pendingCommands[message.request_id || '']
       if (!('resp' in message)) return
@@ -862,7 +862,7 @@ class EngineConnection extends EventTarget {
           )
 
           this.onDataChannelMessage = (event) => {
-            const result: UnreliableResponses = JSON.parse(event.data)
+            const result: UnreliableResponses = parseJson(event.data)
             Object.values(
               this.engineCommandManager.unreliableSubscriptions[result.type] ||
                 {}
@@ -976,7 +976,7 @@ class EngineConnection extends EventTarget {
             return
           }
 
-          const message: Models['WebSocketResponse_type'] = JSON.parse(
+          const message: Models['WebSocketResponse_type'] = parseJson(
             event.data
           )
 
@@ -1564,7 +1564,7 @@ export class EngineCommandManager extends EventTarget {
           unreliableDataChannel.addEventListener(
             'message',
             (event: MessageEvent) => {
-              const result: UnreliableResponses = JSON.parse(event.data)
+              const result: UnreliableResponses = parseJson(event.data)
               Object.values(
                 this.unreliableSubscriptions[result.type] || {}
               ).forEach(
@@ -1608,7 +1608,7 @@ export class EngineCommandManager extends EventTarget {
             message.request_id = binaryToUuid(message.request_id)
           }
         } else {
-          message = JSON.parse(event.data)
+          message = parseJson(event.data)
         }
 
         if (message === null) {

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -40,7 +40,7 @@ import type { CoreDumpManager } from '@src/lib/coredump'
 import openWindow from '@src/lib/openWindow'
 import { Reason, err } from '@src/lib/trap'
 import type { DeepPartial } from '@src/lib/types'
-import { isArray } from '@src/lib/utils'
+import { isArray, parseJson } from '@src/lib/utils'
 import {
   base64_decode,
   change_kcl_settings,
@@ -219,7 +219,7 @@ export const parse = (code: string | Error): ParseResult | Error => {
   } catch (e: any) {
     // throw e
     console.error(e.toString())
-    const parsed: RustKclError = JSON.parse(e.toString())
+    const parsed: RustKclError = parseJson(e.toString())
     return new KCLError(
       parsed.kind,
       parsed.msg,
@@ -381,7 +381,7 @@ export function sketchFromKclValue(
 }
 
 export const errFromErrWithOutputs = (e: any): KCLError => {
-  const parsed: KclErrorWithOutputs = JSON.parse(e.toString())
+  const parsed: KclErrorWithOutputs = parseJson(e.toString())
   return new KCLError(
     parsed.error.kind,
     parsed.error.msg,

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -217,8 +217,6 @@ export const parse = (code: string | Error): ParseResult | Error => {
     let errs = splitErrors(parsed[1])
     return new ParseResult(parsed[0], errs.errors, errs.warnings)
   } catch (e: any) {
-    // throw e
-    console.error(e.toString())
     const parsed: RustKclError = parseJson(e.toString())
     return new KCLError(
       parsed.kind,

--- a/src/lib/commandBarConfigs/validators.ts
+++ b/src/lib/commandBarConfigs/validators.ts
@@ -3,7 +3,7 @@ import type { ApiError_type } from '@kittycad/lib/dist/types/src/models'
 
 import type { Selections } from '@src/lib/selections'
 import { engineCommandManager, kclManager } from '@src/lib/singletons'
-import { uuidv4 } from '@src/lib/utils'
+import { parseJson, uuidv4 } from '@src/lib/utils'
 import type { CommandBarContext } from '@src/machines/commandBarMachine'
 
 export const disableDryRunWithRetry = async (numberOfRetries = 3) => {
@@ -54,7 +54,7 @@ export function parseEngineErrorMessage(engineError: string) {
     return undefined
   }
 
-  const errors = JSON.parse(parts[1]) as ApiError_type[]
+  const errors = parseJson<ApiError_type[]>(parts[1])
   if (!errors[0]) {
     return undefined
   }

--- a/src/lib/rustContext.ts
+++ b/src/lib/rustContext.ts
@@ -26,6 +26,7 @@ import type { DeepPartial } from '@src/lib/types'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { getModule } from '@src/lib/wasm_lib_wrapper'
 import type { Models } from '@kittycad/lib/dist/types/src'
+import { parseJson } from '@src/lib/utils'
 
 export default class RustContext {
   private wasmInitFailed: boolean = true
@@ -140,7 +141,7 @@ export default class RustContext {
         JSON.stringify(settings)
       )
     } catch (e: any) {
-      const parsed: RustKclError = JSON.parse(e.toString())
+      const parsed: RustKclError = parseJson(e.toString())
       toast.error(parsed.msg, { id: toastId })
       return
     }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -60,6 +60,26 @@ export function isNonNullable<T>(val: T): val is NonNullable<T> {
   return val !== null && val !== undefined
 }
 
+/**
+ * Same as JSON.parse() but if it fails, includes the string that was attempted
+ * to be parsed in the error message.  This is useful since a lot of times this
+ * is called on a string that isn't actually JSON, like another error message.
+ *
+ * You can also use the type parameter to assert the expected type of the parsed
+ * object.
+ */
+export function parseJson<T>(
+  text: string,
+  reviver?: (this: any, key: string, value: any) => any
+): T {
+  try {
+    return JSON.parse(text, reviver)
+  } catch (e) {
+    // eslint-disable-next-line suggest-no-throw/suggest-no-throw
+    throw new Error(`Failed to parse JSON: ${text}`, { cause: e })
+  }
+}
+
 export function isOverlap(a: SourceRange, b: SourceRange) {
   const [startingRange, secondRange] = a[0] < b[0] ? [a, b] : [b, a]
   const [lastOfFirst, firstOfSecond] = [startingRange[1], secondRange[0]]


### PR DESCRIPTION
This makes it so that when JSON parse fails, the thing that we tried to parse is included in the message.

I considered making a lint to force everyone to use it, but maybe we'll see how it goes first.

<img width="525" alt="Screenshot 2025-04-18 at 5 43 47 PM" src="https://github.com/user-attachments/assets/817c3fad-7ecd-47b9-8667-bb6e96bfd465" />
