### PR TITLE
Try running with 8 macOS cores again

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -285,7 +285,7 @@ jobs:
         # TODO: enable namespace-profile-windows-latest once available
         os:
           - "runs-on=${{ github.run_id }}/family=i7ie.2xlarge/image=ubuntu22-full-x64"
-          - namespace-profile-macos-6-cores
+          - namespace-profile-macos-8-cores
           - windows-latest-8-cores
         shardIndex: [1, 2, 3, 4]
         shardTotal: [4]
@@ -295,7 +295,7 @@ jobs:
         isScheduled:
           - ${{ github.event_name == 'schedule' }}
         exclude:
-          - os: namespace-profile-macos-6-cores
+          - os: namespace-profile-macos-8-cores
             isScheduled: true
           - os: windows-latest-8-cores
             isScheduled: true

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -285,8 +285,7 @@ jobs:
         # TODO: enable namespace-profile-windows-latest once available
         os:
           - "runs-on=${{ github.run_id }}/family=i7ie.2xlarge/image=ubuntu22-full-x64"
-          # TODO: renable this when macoOS runner seem more stable
-          # - namespace-profile-macos-6-cores
+          - namespace-profile-macos-6-cores
           - windows-latest-8-cores
         shardIndex: [1, 2, 3, 4]
         shardTotal: [4]


### PR DESCRIPTION
8-cores seems to result in fewer instances of these:

> Test timeout of 120000ms exceeded while setting up "tronApp".