### PR TITLE
Allow snapshot tests to report status

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -225,7 +225,7 @@ jobs:
         uses: nick-fields/retry@v3.0.2
         with:
           shell: bash
-          command: npm run test:snapshots || true
+          command: npm run test:snapshots
           timeout_minutes: 5
           max_attempts: 5
         env:


### PR DESCRIPTION
Instead, I'm going to silence the individual bad tests from the TAB API, which was enabled by https://github.com/KittyCAD/modeling-app/pull/6405.