### PR TITLE
KCL: Rephrase confusing error msg

### DIFF
--- a/e2e/playwright/sketch-tests.spec.ts
+++ b/e2e/playwright/sketch-tests.spec.ts
@@ -3295,7 +3295,7 @@ profile003 = startProfileAt([-201.08, 254.17], sketch002)
         )
         await editor.expectState({
           activeLines: [],
-          diagnostics: ['memoryitemkey`badBadBadFn`isnotdefined'],
+          diagnostics: ['`badBadBadFn`isnotdefined'],
           highlightedCode: '',
         })
         await expect(

--- a/rust/kcl-lib/src/execution/memory.rs
+++ b/rust/kcl-lib/src/execution/memory.rs
@@ -365,7 +365,7 @@ impl ProgramMemory {
         }
 
         Err(KclError::UndefinedValue(KclErrorDetails {
-            message: format!("memory item key `{}` is not defined", var),
+            message: format!("`{}` is not defined", var),
             source_ranges: vec![source_range],
         }))
     }
@@ -486,7 +486,7 @@ impl ProgramMemory {
         }
 
         Err(KclError::UndefinedValue(KclErrorDetails {
-            message: format!("memory item key `{}` is not defined", var),
+            message: format!("`{}` is not defined", var),
             source_ranges: vec![],
         }))
     }

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -1585,7 +1585,7 @@ const answer = returnX()"#;
         assert_eq!(
             err,
             KclError::UndefinedValue(KclErrorDetails {
-                message: "memory item key `x` is not defined".to_owned(),
+                message: "`x` is not defined".to_owned(),
                 source_ranges: vec![
                     SourceRange::new(64, 65, ModuleId::default()),
                     SourceRange::new(97, 106, ModuleId::default())
@@ -1669,7 +1669,7 @@ let shape = layer() |> patternTransform(instances = 10, transform = transform)
         assert_eq!(
             err,
             KclError::UndefinedValue(KclErrorDetails {
-                message: "memory item key `x` is not defined".to_owned(),
+                message: "`x` is not defined".to_owned(),
                 source_ranges: vec![SourceRange::new(80, 81, ModuleId::default())],
             }),
         );

--- a/rust/kcl-lib/tests/cube_with_error/execution_error.snap
+++ b/rust/kcl-lib/tests/cube_with_error/execution_error.snap
@@ -4,7 +4,7 @@ description: Error from executing cube_with_error.kcl
 ---
 KCL UndefinedValue error
 
-  × undefined value: memory item key `foo` is not defined
+  × undefined value: `foo` is not defined
     ╭─[23:1]
  22 │ // Error, after creating meaningful output.
  23 │ foo

--- a/src/lang/executor.test.ts
+++ b/src/lang/executor.test.ts
@@ -462,7 +462,7 @@ const theExtrude = startSketchOn(XY)
     await expect(exe(code)).rejects.toEqual(
       new KCLError(
         'undefined_value',
-        'memory item key `myVarZ` is not defined',
+        '`myVarZ` is not defined',
         topLevelRange(129, 135),
         [],
         [],


### PR DESCRIPTION
Before:

  × undefined value: memory item key `foo` is not defined

Now:

  × undefined value: `foo` is not defined