### PR TITLE
Add involute to Path info

### DIFF
--- a/rust/kcl-lib/src/std/args.rs
+++ b/rust/kcl-lib/src/std/args.rs
@@ -805,6 +805,17 @@ impl Args {
                     None
                 }
             }
+            ExtrudeSurface::ExtrudeInvolute(extrude_involute) => {
+                if let Some(involute_tag) = &extrude_involute.tag {
+                    if involute_tag.name == tag.value {
+                        Some(Ok(extrude_involute.face_id))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            }
             ExtrudeSurface::Chamfer(chamfer) => {
                 if let Some(chamfer_tag) = &chamfer.tag {
                     if chamfer_tag.name == tag.value {

--- a/rust/kcl-lib/src/std/extrude.rs
+++ b/rust/kcl-lib/src/std/extrude.rs
@@ -399,6 +399,17 @@ pub(crate) async fn do_post_extrude<'a>(
                         });
                         Some(extrude_surface)
                     }
+                    Path::CircularInvolute { .. } => {
+                        let extrude_surface = ExtrudeSurface::ExtrudeInvolute(crate::execution::ExtrudeInvolute {
+                            face_id: *actual_face_id,
+                            tag: path.get_base().tag.clone(),
+                            geo_meta: GeoMeta {
+                                id: path.get_base().geo_meta.id,
+                                metadata: path.get_base().geo_meta.metadata,
+                            },
+                        });
+                        Some(extrude_surface)
+                    }
                 }
             } else if no_engine_commands {
                 // Only pre-populate the extrude surface if we are in mock mode.

--- a/rust/kcl-lib/src/std/sketch.rs
+++ b/rust/kcl-lib/src/std/sketch.rs
@@ -198,7 +198,7 @@ async fn inner_involute_circular(
     end.x += from.x;
     end.y += from.y;
 
-    let current_path = Path::ToPoint {
+    let current_path = Path::CircularInvolute {
         base: BasePath {
             from: from.ignore_units(),
             to: [end.x, end.y],
@@ -209,6 +209,10 @@ async fn inner_involute_circular(
                 metadata: args.source_range.into(),
             },
         },
+        start_radius,
+        end_radius,
+        angle: angle.to_degrees(),
+        reverse: reverse.unwrap_or_default(),
     };
 
     let mut new_sketch = sketch.clone();


### PR DESCRIPTION
The circular involute sketch segment was using ToPoint as its path type. This adds a specific involute path type