### PR TITLE
KCL bugfix: CallExpressionKw was not usable as math operand

### DIFF
--- a/rust/kcl-lib/src/parsing/parser.rs
+++ b/rust/kcl-lib/src/parsing/parser.rs
@@ -2074,6 +2074,7 @@ fn possible_operands(i: &mut TokenSlice) -> PResult<Expr> {
         member_expression.map(Box::new).map(Expr::MemberExpression),
         literal.map(Expr::Literal),
         fn_call.map(Box::new).map(Expr::CallExpression),
+        fn_call_kw.map(Box::new).map(Expr::CallExpressionKw),
         name.map(Box::new).map(Expr::Name),
         binary_expr_in_parens.map(Box::new).map(Expr::BinaryExpression),
         unnecessarily_bracketed,
@@ -3252,6 +3253,14 @@ mod tests {
         // TODO: Better comment. This should explain the compiler expected ) because the user had started declaring the function's parameters.
         // Part of https://github.com/KittyCAD/modeling-app/issues/784
         assert_eq!(err.message, "Unexpected end of file. The compiler expected )");
+    }
+
+    #[test]
+    fn kw_call_as_operand() {
+        let tokens = crate::parsing::token::lex("f(x = 1)", ModuleId::default()).unwrap();
+        let tokens = tokens.as_slice();
+        let op = operand.parse(tokens).unwrap();
+        println!("{op:#?}");
     }
 
     #[test]
@@ -5389,6 +5398,7 @@ my14 = 4 ^ 2 - 3 ^ 2 * 2
              bar = x,
            )"#
     );
+    snapshot_test!(kw_function_in_binary_op, r#"val = f(x = 1) + 1"#);
 }
 
 #[allow(unused)]

--- a/rust/kcl-lib/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__kw_function_in_binary_op.snap
+++ b/rust/kcl-lib/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__kw_function_in_binary_op.snap
@@ -1,0 +1,99 @@
+---
+source: kcl-lib/src/parsing/parser.rs
+expression: actual
+---
+{
+  "body": [
+    {
+      "commentStart": 0,
+      "declaration": {
+        "commentStart": 0,
+        "end": 18,
+        "id": {
+          "commentStart": 0,
+          "end": 3,
+          "name": "val",
+          "start": 0,
+          "type": "Identifier"
+        },
+        "init": {
+          "commentStart": 6,
+          "end": 18,
+          "left": {
+            "arguments": [
+              {
+                "type": "LabeledArg",
+                "label": {
+                  "commentStart": 8,
+                  "end": 9,
+                  "name": "x",
+                  "start": 8,
+                  "type": "Identifier"
+                },
+                "arg": {
+                  "commentStart": 12,
+                  "end": 13,
+                  "raw": "1",
+                  "start": 12,
+                  "type": "Literal",
+                  "type": "Literal",
+                  "value": {
+                    "value": 1.0,
+                    "suffix": "None"
+                  }
+                }
+              }
+            ],
+            "callee": {
+              "abs_path": false,
+              "commentStart": 6,
+              "end": 7,
+              "name": {
+                "commentStart": 6,
+                "end": 7,
+                "name": "f",
+                "start": 6,
+                "type": "Identifier"
+              },
+              "path": [],
+              "start": 6,
+              "type": "Name"
+            },
+            "commentStart": 6,
+            "end": 14,
+            "start": 6,
+            "type": "CallExpressionKw",
+            "type": "CallExpressionKw",
+            "unlabeled": null
+          },
+          "operator": "+",
+          "right": {
+            "commentStart": 17,
+            "end": 18,
+            "raw": "1",
+            "start": 17,
+            "type": "Literal",
+            "type": "Literal",
+            "value": {
+              "value": 1.0,
+              "suffix": "None"
+            }
+          },
+          "start": 6,
+          "type": "BinaryExpression",
+          "type": "BinaryExpression"
+        },
+        "start": 0,
+        "type": "VariableDeclarator"
+      },
+      "end": 18,
+      "kind": "const",
+      "start": 0,
+      "type": "VariableDeclaration",
+      "type": "VariableDeclaration"
+    }
+  ],
+  "commentStart": 0,
+  "end": 18,
+  "start": 0
+}


### PR DESCRIPTION
Closes https://github.com/KittyCAD/modeling-app/issues/4992