### PR TITLE
Change getOppositeEdge, getNextAdjacentEdge, and getPreviousAdjacentEdge to keyword args

### DIFF
--- a/docs/kcl/getNextAdjacentEdge.md
+++ b/docs/kcl/getNextAdjacentEdge.md
@@ -9,7 +9,7 @@ Get the next adjacent edge to the edge given.
 
 
 ```js
-getNextAdjacentEdge(tag: TagIdentifier): Uuid
+getNextAdjacentEdge(edge: TagIdentifier): Uuid
 ```
 
 
@@ -17,7 +17,7 @@ getNextAdjacentEdge(tag: TagIdentifier): Uuid
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| [`tag`](/docs/kcl/types/tag) | [`TagIdentifier`](/docs/kcl/types#tag-identifier) |  | Yes |
+| `edge` | [`TagIdentifier`](/docs/kcl/types#tag-identifier) | The tag of the edge you want to find the next adjacent edge of. | Yes |
 
 ### Returns
 

--- a/docs/kcl/getOppositeEdge.md
+++ b/docs/kcl/getOppositeEdge.md
@@ -9,7 +9,7 @@ Get the opposite edge to the edge given.
 
 
 ```js
-getOppositeEdge(tag: TagIdentifier): Uuid
+getOppositeEdge(edge: TagIdentifier): Uuid
 ```
 
 
@@ -17,7 +17,7 @@ getOppositeEdge(tag: TagIdentifier): Uuid
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| [`tag`](/docs/kcl/types/tag) | [`TagIdentifier`](/docs/kcl/types#tag-identifier) |  | Yes |
+| `edge` | [`TagIdentifier`](/docs/kcl/types#tag-identifier) | The tag of the edge you want to find the opposite edge of. | Yes |
 
 ### Returns
 

--- a/docs/kcl/getPreviousAdjacentEdge.md
+++ b/docs/kcl/getPreviousAdjacentEdge.md
@@ -9,7 +9,7 @@ Get the previous adjacent edge to the edge given.
 
 
 ```js
-getPreviousAdjacentEdge(tag: TagIdentifier): Uuid
+getPreviousAdjacentEdge(edge: TagIdentifier): Uuid
 ```
 
 
@@ -17,7 +17,7 @@ getPreviousAdjacentEdge(tag: TagIdentifier): Uuid
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| [`tag`](/docs/kcl/types/tag) | [`TagIdentifier`](/docs/kcl/types#tag-identifier) |  | Yes |
+| `edge` | [`TagIdentifier`](/docs/kcl/types#tag-identifier) | The tag of the edge you want to find the previous adjacent edge of. | Yes |
 
 ### Returns
 

--- a/rust/kcl-lib/src/execution/types.rs
+++ b/rust/kcl-lib/src/execution/types.rs
@@ -28,6 +28,10 @@ pub enum RuntimeType {
 }
 
 impl RuntimeType {
+    pub fn edge() -> Self {
+        RuntimeType::Primitive(PrimitiveType::Edge)
+    }
+
     pub fn sketch() -> Self {
         RuntimeType::Primitive(PrimitiveType::Sketch)
     }

--- a/rust/kcl-lib/src/std/args.rs
+++ b/rust/kcl-lib/src/std/args.rs
@@ -675,13 +675,6 @@ impl Args {
         Ok((sketches, sketch))
     }
 
-    pub(crate) fn get_data<'a, T>(&'a self) -> Result<T, KclError>
-    where
-        T: FromArgs<'a>,
-    {
-        FromArgs::from_args(self, 0)
-    }
-
     pub(crate) fn get_data_and_sketch_surface(&self) -> Result<([TyF64; 2], SketchSurface, Option<TagNode>), KclError> {
         FromArgs::from_args(self, 0)
     }

--- a/rust/kcl-lib/src/std/edge.rs
+++ b/rust/kcl-lib/src/std/edge.rs
@@ -8,15 +8,15 @@ use uuid::Uuid;
 
 use crate::{
     errors::{KclError, KclErrorDetails},
-    execution::{ExecState, ExtrudeSurface, KclValue, TagIdentifier},
+    execution::{types::RuntimeType, ExecState, ExtrudeSurface, KclValue, TagIdentifier},
     std::Args,
 };
 
 /// Get the opposite edge to the edge given.
 pub async fn get_opposite_edge(exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
-    let tag: TagIdentifier = args.get_data()?;
+    let input_edge = args.get_unlabeled_kw_arg_typed("edge", &RuntimeType::edge(), exec_state)?;
 
-    let edge = inner_get_opposite_edge(tag, exec_state, args.clone()).await?;
+    let edge = inner_get_opposite_edge(input_edge, exec_state, args.clone()).await?;
     Ok(KclValue::Uuid {
         value: edge,
         meta: vec![args.source_range.into()],
@@ -53,15 +53,24 @@ pub async fn get_opposite_edge(exec_state: &mut ExecState, args: Args) -> Result
 /// ```
 #[stdlib {
     name = "getOppositeEdge",
+    keywords = true,
+    unlabeled_first = true,
+    args = {
+        edge = { docs = "The tag of the edge you want to find the opposite edge of." },
+    }
 }]
-async fn inner_get_opposite_edge(tag: TagIdentifier, exec_state: &mut ExecState, args: Args) -> Result<Uuid, KclError> {
+async fn inner_get_opposite_edge(
+    edge: TagIdentifier,
+    exec_state: &mut ExecState,
+    args: Args,
+) -> Result<Uuid, KclError> {
     if args.ctx.no_engine_commands().await {
         return Ok(exec_state.next_uuid());
     }
-    let face_id = args.get_adjacent_face_to_tag(exec_state, &tag, false).await?;
+    let face_id = args.get_adjacent_face_to_tag(exec_state, &edge, false).await?;
 
     let id = exec_state.next_uuid();
-    let tagged_path = args.get_tag_engine_info(exec_state, &tag)?;
+    let tagged_path = args.get_tag_engine_info(exec_state, &edge)?;
 
     let resp = args
         .send_modeling_cmd(
@@ -88,9 +97,9 @@ async fn inner_get_opposite_edge(tag: TagIdentifier, exec_state: &mut ExecState,
 
 /// Get the next adjacent edge to the edge given.
 pub async fn get_next_adjacent_edge(exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
-    let tag: TagIdentifier = args.get_data()?;
+    let input_edge = args.get_unlabeled_kw_arg_typed("edge", &RuntimeType::edge(), exec_state)?;
 
-    let edge = inner_get_next_adjacent_edge(tag, exec_state, args.clone()).await?;
+    let edge = inner_get_next_adjacent_edge(input_edge, exec_state, args.clone()).await?;
     Ok(KclValue::Uuid {
         value: edge,
         meta: vec![args.source_range.into()],
@@ -127,19 +136,24 @@ pub async fn get_next_adjacent_edge(exec_state: &mut ExecState, args: Args) -> R
 /// ```
 #[stdlib {
     name = "getNextAdjacentEdge",
+    keywords = true,
+    unlabeled_first = true,
+    args = {
+        edge = { docs = "The tag of the edge you want to find the next adjacent edge of." },
+    }
 }]
 async fn inner_get_next_adjacent_edge(
-    tag: TagIdentifier,
+    edge: TagIdentifier,
     exec_state: &mut ExecState,
     args: Args,
 ) -> Result<Uuid, KclError> {
     if args.ctx.no_engine_commands().await {
         return Ok(exec_state.next_uuid());
     }
-    let face_id = args.get_adjacent_face_to_tag(exec_state, &tag, false).await?;
+    let face_id = args.get_adjacent_face_to_tag(exec_state, &edge, false).await?;
 
     let id = exec_state.next_uuid();
-    let tagged_path = args.get_tag_engine_info(exec_state, &tag)?;
+    let tagged_path = args.get_tag_engine_info(exec_state, &edge)?;
 
     let resp = args
         .send_modeling_cmd(
@@ -167,7 +181,7 @@ async fn inner_get_next_adjacent_edge(
 
     adjacent_edge.edge.ok_or_else(|| {
         KclError::Type(KclErrorDetails {
-            message: format!("No edge found next adjacent to tag: `{}`", tag.value),
+            message: format!("No edge found next adjacent to tag: `{}`", edge.value),
             source_ranges: vec![args.source_range],
         })
     })
@@ -175,9 +189,9 @@ async fn inner_get_next_adjacent_edge(
 
 /// Get the previous adjacent edge to the edge given.
 pub async fn get_previous_adjacent_edge(exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
-    let tag: TagIdentifier = args.get_data()?;
+    let input_edge = args.get_unlabeled_kw_arg_typed("edge", &RuntimeType::edge(), exec_state)?;
 
-    let edge = inner_get_previous_adjacent_edge(tag, exec_state, args.clone()).await?;
+    let edge = inner_get_previous_adjacent_edge(input_edge, exec_state, args.clone()).await?;
     Ok(KclValue::Uuid {
         value: edge,
         meta: vec![args.source_range.into()],
@@ -214,19 +228,24 @@ pub async fn get_previous_adjacent_edge(exec_state: &mut ExecState, args: Args) 
 /// ```
 #[stdlib {
     name = "getPreviousAdjacentEdge",
+    keywords = true,
+    unlabeled_first = true,
+    args = {
+        edge = { docs = "The tag of the edge you want to find the previous adjacent edge of." },
+    }
 }]
 async fn inner_get_previous_adjacent_edge(
-    tag: TagIdentifier,
+    edge: TagIdentifier,
     exec_state: &mut ExecState,
     args: Args,
 ) -> Result<Uuid, KclError> {
     if args.ctx.no_engine_commands().await {
         return Ok(exec_state.next_uuid());
     }
-    let face_id = args.get_adjacent_face_to_tag(exec_state, &tag, false).await?;
+    let face_id = args.get_adjacent_face_to_tag(exec_state, &edge, false).await?;
 
     let id = exec_state.next_uuid();
-    let tagged_path = args.get_tag_engine_info(exec_state, &tag)?;
+    let tagged_path = args.get_tag_engine_info(exec_state, &edge)?;
 
     let resp = args
         .send_modeling_cmd(
@@ -253,7 +272,7 @@ async fn inner_get_previous_adjacent_edge(
 
     adjacent_edge.edge.ok_or_else(|| {
         KclError::Type(KclErrorDetails {
-            message: format!("No edge found previous adjacent to tag: `{}`", tag.value),
+            message: format!("No edge found previous adjacent to tag: `{}`", edge.value),
             source_ranges: vec![args.source_range],
         })
     })

--- a/src/lang/modifyAst/addEdgeTreatment.ts
+++ b/src/lang/modifyAst/addEdgeTreatment.ts
@@ -7,7 +7,6 @@ import type CodeManager from '@src/lang/codeManager'
 import { ARG_TAG } from '@src/lang/constants'
 import {
   createArrayExpression,
-  createCallExpressionStdLib,
   createCallExpressionStdLibKw,
   createLabeledArg,
   createLocalName,
@@ -355,9 +354,9 @@ export function getEdgeTagCall(
 
   // Modify the tag based on selectionType
   if (artifact.type === 'sweepEdge' && artifact.subType === 'opposite') {
-    tagCall = createCallExpressionStdLib('getOppositeEdge', [tagCall])
+    tagCall = createCallExpressionStdLibKw('getOppositeEdge', tagCall, [])
   } else if (artifact.type === 'sweepEdge' && artifact.subType === 'adjacent') {
-    tagCall = createCallExpressionStdLib('getNextAdjacentEdge', [tagCall])
+    tagCall = createCallExpressionStdLibKw('getNextAdjacentEdge', tagCall, [])
   }
   return tagCall
 }

--- a/src/lang/std/sketch.ts
+++ b/src/lang/std/sketch.ts
@@ -3468,23 +3468,36 @@ function addTagToChamfer(
 
     // e.g. chamfer(tags: [getOppositeEdge(tagOfInterest), tag2])
     //                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    // Note: Single unlabeled arg calls could be either CallExpression or
+    // CallExpressionKw.
     const tagMatchesOppositeTagType =
       edgeCutMeta?.subType === 'opposite' &&
-      tag.type === 'CallExpression' &&
-      tag.callee.name.name === 'getOppositeEdge' &&
-      tag.arguments[0].type === 'Name' &&
-      tag.arguments[0].name.name === edgeCutMeta.tagName
+      ((tag.type === 'CallExpression' &&
+        tag.callee.name.name === 'getOppositeEdge' &&
+        tag.arguments[0].type === 'Name' &&
+        tag.arguments[0].name.name === edgeCutMeta.tagName) ||
+        (tag.type === 'CallExpressionKw' &&
+          tag.callee.name.name === 'getOppositeEdge' &&
+          tag.unlabeled?.type === 'Name' &&
+          tag.unlabeled.name.name === edgeCutMeta.tagName))
     if (tagMatchesOppositeTagType) return true
 
     // e.g. chamfer(tags: [getNextAdjacentEdge(tagOfInterest), tag2])
     //                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    // Note: Single unlabeled arg calls could be either CallExpression or
+    // CallExpressionKw.
     const tagMatchesAdjacentTagType =
       edgeCutMeta?.subType === 'adjacent' &&
-      tag.type === 'CallExpression' &&
-      (tag.callee.name.name === 'getNextAdjacentEdge' ||
-        tag.callee.name.name === 'getPrevAdjacentEdge') &&
-      tag.arguments[0].type === 'Name' &&
-      tag.arguments[0].name.name === edgeCutMeta.tagName
+      ((tag.type === 'CallExpression' &&
+        (tag.callee.name.name === 'getNextAdjacentEdge' ||
+          tag.callee.name.name === 'getPrevAdjacentEdge') &&
+        tag.arguments[0].type === 'Name' &&
+        tag.arguments[0].name.name === edgeCutMeta.tagName) ||
+        (tag.type === 'CallExpressionKw' &&
+          (tag.callee.name.name === 'getNextAdjacentEdge' ||
+            tag.callee.name.name === 'getPrevAdjacentEdge') &&
+          tag.unlabeled?.type === 'Name' &&
+          tag.unlabeled.name.name === edgeCutMeta.tagName))
     if (tagMatchesAdjacentTagType) return true
     return false
   })


### PR DESCRIPTION
This isn't a breaking change since these functions only accept one unlabeled arg.