### PR TITLE
Fix testing-selections test / clicking on empty space

### DIFF
--- a/e2e/playwright/testing-selections.spec.ts
+++ b/e2e/playwright/testing-selections.spec.ts
@@ -39,12 +39,12 @@ test.describe('Testing selections', { tag: ['@skipWin'] }, () => {
       })
     const emptySpaceHover = () =>
       test.step('Hover over empty space', async () => {
-        await page.mouse.move(700, 143, { steps: 5 })
+        await page.mouse.move(1000, 143, { steps: 5 })
         await expect(page.locator('.hover-highlight')).not.toBeVisible()
       })
     const emptySpaceClick = () =>
       test.step(`Click in empty space`, async () => {
-        await page.mouse.click(700, 143)
+        await page.mouse.click(1000, 143)
         await expect(page.locator('.cm-line').last()).toHaveClass(
           /cm-activeLine/
         )


### PR DESCRIPTION
This test started failing:
```
npm run test:playwright:electron:macos:local -- --workers 1 e2e/playwright/testing-selections.spec.ts -g "Selections work on fresh and edited"
```

It seems the coordinates were just unlucky, the click happens on a UI menu opened in a previous step, so the click doesn't happen on the empty space.
This could have gotten broken by that menu being placed slightly differently recently as it is very close to the edge of it.