### PR TITLE
Test all platforms hourly

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -289,17 +289,6 @@ jobs:
           - windows-latest-8-cores
         shardIndex: [1, 2, 3, 4]
         shardTotal: [4]
-        # Disable macos and windows tests on hourly e2e tests since we only care
-        # about server side changes.
-        # Technique from https://github.com/joaomcteixeira/python-project-skeleton/pull/31/files
-        isScheduled:
-          - ${{ github.event_name == 'schedule' }}
-        exclude:
-          - os: namespace-profile-macos-8-cores
-            isScheduled: true
-          - os: windows-latest-8-cores
-            isScheduled: true
-        # TODO: add ref here for main and latest release tag
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
We're now running a tiny fraction of tests on macOS and Windows so I see no reason to run them every hour and simplify the CI logic.