### PR TITLE
Stabilize test by allowing more time before clicking object

### DIFF
--- a/e2e/playwright/file-tree.spec.ts
+++ b/e2e/playwright/file-tree.spec.ts
@@ -29,7 +29,7 @@ test.describe('integrations tests', () => {
         )
       })
 
-      const [clickObj] = await scene.makeMouseHelpers(726, 272)
+      const [clickObj] = scene.makeMouseHelpers(726, 272)
 
       await test.step('setup test', async () => {
         await homePage.expectState({
@@ -73,7 +73,7 @@ test.describe('integrations tests', () => {
       })
       await test.step('setup for next assertion', async () => {
         await toolbar.openFile('main.kcl')
-        await page.waitForTimeout(1000)
+        await page.waitForTimeout(2000)
         await clickObj()
         await page.waitForTimeout(1000)
         await scene.moveNoWhere()


### PR DESCRIPTION
It seems more time is needed before clicking the object.
With 2seconds I'm getting 10/10 passes locally instead of 4-7/10.