### PR TITLE
Adjust sharding to account for more tests being run

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -282,12 +282,37 @@ jobs:
       fail-fast: false
       matrix:
         # TODO: enable namespace-profile-windows-latest once available
-        os:
-          - "runs-on=${{ github.run_id }}/family=i7ie.2xlarge/image=ubuntu22-full-x64"
-          - namespace-profile-macos-8-cores
-          - windows-latest-8-cores
-        shardIndex: [1, 2, 3, 4]
-        shardTotal: [4]
+        include:
+          - os: "runs-on=${{ github.run_id }}/family=i7ie.2xlarge/image=ubuntu22-full-x64"
+            shardIndex: 1
+            shardTotal: 8
+          - os: "runs-on=${{ github.run_id }}/family=i7ie.2xlarge/image=ubuntu22-full-x64"
+            shardIndex: 2
+            shardTotal: 8
+          - os: "runs-on=${{ github.run_id }}/family=i7ie.2xlarge/image=ubuntu22-full-x64"
+            shardIndex: 3
+            shardTotal: 8
+          - os: "runs-on=${{ github.run_id }}/family=i7ie.2xlarge/image=ubuntu22-full-x64"
+            shardIndex: 4
+            shardTotal: 8
+          - os: "runs-on=${{ github.run_id }}/family=i7ie.2xlarge/image=ubuntu22-full-x64"
+            shardIndex: 5
+            shardTotal: 8
+          - os: "runs-on=${{ github.run_id }}/family=i7ie.2xlarge/image=ubuntu22-full-x64"
+            shardIndex: 6
+            shardTotal: 8
+          - os: "runs-on=${{ github.run_id }}/family=i7ie.2xlarge/image=ubuntu22-full-x64"
+            shardIndex: 7
+            shardTotal: 8
+          - os: "runs-on=${{ github.run_id }}/family=i7ie.2xlarge/image=ubuntu22-full-x64"
+            shardIndex: 8
+            shardTotal: 8
+          - os: namespace-profile-macos-8-cores
+            shardIndex: 1
+            shardTotal: 1
+          - os: windows-latest-8-cores
+            shardIndex: 1
+            shardTotal: 1
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
After https://github.com/KittyCAD/modeling-app/pull/6492, we're now running more tests on Linux. Increasing shards gets the longest one down from ~20 minutes to ~12 minutes.