### PR TITLE
[bug]: Chokidar + reading projects spams multiple times

### DIFF
--- a/src/components/Providers/SystemIOProviderDesktop.tsx
+++ b/src/components/Providers/SystemIOProviderDesktop.tsx
@@ -9,7 +9,7 @@ import {
   useRequestedTextToCadGeneration,
   useFolders,
 } from '@src/machines/systemIO/hooks'
-import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
+import { NO_PROJECT_DIRECTORY, SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import { useNavigate } from 'react-router-dom'
 import { useEffect } from 'react'
 import { submitAndAwaitTextToKclSystemIO } from '@src/lib/textToCad'
@@ -85,7 +85,7 @@ export function SystemIOMachineLogicListenerDesktop() {
 
   const useWatchingApplicationProjectDirectory = () => {
     useFileSystemWatcher(
-      async () => {
+      async (eventType, path) => {
         // Gotcha: Chokidar is buggy. It will emit addDir or add on files that did not get created.
         // This means while the application initialize and Chokidar initializes you cannot tell if
         // a directory or file is actually created or they are buggy signals. This means you must
@@ -95,9 +95,18 @@ export function SystemIOMachineLogicListenerDesktop() {
         if (!hasListedProjects) {
           return
         }
-        systemIOActor.send({
-          type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-        })
+
+        const folderName = systemIOActor.getSnapshot().context.lastProjectDeleteRequest.project
+        const folderPath = `${projectDirectoryPath}${window.electron.sep}${folderName}`
+        if (folderName !== NO_PROJECT_DIRECTORY && (eventType === 'unlinkDir' || eventType === 'unlink') && path.includes(folderPath)) {
+          // NO OP: The systemIOMachine will be triggering the read in the state transition, don't spam it again
+          // once this event is processed after the deletion.
+        } else {
+          // Prevents spamming reading from disk twice on deletion due to files and folders being deleted async
+          systemIOActor.send({
+            type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+          })
+        }
       },
       settings.app.projectDirectory.current
         ? [settings.app.projectDirectory.current]

--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -32,30 +32,34 @@ export const systemIOMachine = setup({
       | {
           type: SystemIOMachineEvents.done_checkReadWrite
           output: { value: boolean; error: unknown }
-        }
+      }
       | {
-          type: SystemIOMachineEvents.setProjectDirectoryPath
-          data: { requestedProjectDirectoryPath: string }
-        }
+        type: SystemIOMachineEvents.setProjectDirectoryPath
+        data: { requestedProjectDirectoryPath: string }
+      }
       | {
-          type: SystemIOMachineEvents.navigateToProject
-          data: { requestedProjectName: string }
-        }
+        type: SystemIOMachineEvents.navigateToProject
+        data: { requestedProjectName: string }
+      }
       | {
-          type: SystemIOMachineEvents.navigateToFile
-          data: { requestedProjectName: string; requestedFileName: string }
-        }
+        type: SystemIOMachineEvents.navigateToFile
+        data: { requestedProjectName: string; requestedFileName: string }
+      }
       | {
-          type: SystemIOMachineEvents.createProject
-          data: { requestedProjectName: string }
-        }
+        type: SystemIOMachineEvents.createProject
+        data: { requestedProjectName: string }
+      }
       | {
-          type: SystemIOMachineEvents.renameProject
-          data: { requestedProjectName: string; projectName: string }
-        }
+        type: SystemIOMachineEvents.renameProject
+        data: { requestedProjectName: string; projectName: string }
+      }
       | {
-          type: SystemIOMachineEvents.deleteProject
-          data: { requestedProjectName: string }
+        type: SystemIOMachineEvents.deleteProject
+        data: { requestedProjectName: string }
+      }
+      | {
+          type: SystemIOMachineEvents.done_deleteProject
+          output: { message: string; name: string }
         }
       | {
           type: SystemIOMachineEvents.createKCLFile
@@ -163,6 +167,12 @@ export const systemIOMachine = setup({
       requestedTextToCadGeneration: ({ event }) => {
         assertEvent(event, SystemIOMachineEvents.generateTextToCAD)
         return event.data
+      },
+    }),
+    [SystemIOMachineActions.setLastProjectDeleteRequest]: assign({
+      lastProjectDeleteRequest: ({ event }) => {
+        assertEvent(event, SystemIOMachineEvents.done_deleteProject)
+        return {project: event.output.name}
       },
     }),
   },
@@ -275,6 +285,9 @@ export const systemIOMachine = setup({
       requestedProjectName: NO_PROJECT_DIRECTORY,
       isProjectNew: true,
     },
+    lastProjectDeleteRequest: {
+      project: NO_PROJECT_DIRECTORY
+    }
   }),
   states: {
     [SystemIOMachineStates.idle]: {
@@ -401,7 +414,7 @@ export const systemIOMachine = setup({
         },
         onDone: {
           target: SystemIOMachineStates.readingFolders,
-          actions: [SystemIOMachineActions.toastSuccess],
+          actions: [SystemIOMachineActions.toastSuccess, SystemIOMachineActions.setLastProjectDeleteRequest]
         },
         onError: {
           target: SystemIOMachineStates.idle,

--- a/src/machines/systemIO/utils.ts
+++ b/src/machines/systemIO/utils.ts
@@ -37,6 +37,7 @@ export enum SystemIOMachineEvents {
   createProject = 'create project',
   renameProject = 'rename project',
   deleteProject = 'delete project',
+  done_deleteProject = donePrefix + 'delete project',
   createKCLFile = 'create kcl file',
   setDefaultProjectFolderName = 'set default project folder name',
   done_checkReadWrite = donePrefix + 'check read write',
@@ -56,6 +57,7 @@ export enum SystemIOMachineActions {
   toastError = 'toastError',
   setReadWriteProjectDirectory = 'set read write project directory',
   setRequestedTextToCadGeneration = 'set requested text to cad generation',
+  setLastProjectDeleteRequest = 'set last project delete request'
 }
 
 export const NO_PROJECT_DIRECTORY = ''
@@ -79,5 +81,8 @@ export type SystemIOContext = {
     requestedPrompt: string
     requestedProjectName: string
     isProjectNew: boolean
+  }
+  lastProjectDeleteRequest: {
+    project: string
   }
 }


### PR DESCRIPTION
# Issue

When you delete a project externally or internally it would refresh the home page multiple times and flash. It is really annoying.

# Implementation

- Added a deleteProject set last requested value to see what was the last requested project to be deleted
- When processing file deletion or project deletion see if the project was asked to be deleted and if it was successful
- If the conditions are met it won't trigger the file system watcher to reload off disk since it caught the fact that the application deleted the project. 

# Expected behavior
- When deleting a project in the system `reading projects` should be called exactly one in the system. 
- We should not have visual flickers when refreshing the home page after project deletion.
