### PR TITLE
Remove skips to align with new way of opting-in tests

### DIFF
--- a/e2e/playwright/file-tree.spec.ts
+++ b/e2e/playwright/file-tree.spec.ts
@@ -102,8 +102,6 @@ test.describe('when using the file tree to', () => {
     `rename ${fromFile} to ${toFile}, and doesn't crash on reload and settings load`,
     { tag: '@electron' },
     async ({ page }, testInfo) => {
-      // TODO: fix this test on windows after the electron migration
-      test.skip(process.platform === 'win32', 'Skip on windows')
       const { panesOpen, pasteCodeInEditor, renameFile, editorTextMatches } =
         await getUtils(page, test)
 
@@ -146,8 +144,6 @@ test.describe('when using the file tree to', () => {
     `create many new files of the same name, incrementing their names`,
     { tag: '@electron' },
     async ({ page }, testInfo) => {
-      // TODO: fix this test on windows after the electron migration
-      test.skip(process.platform === 'win32', 'Skip on windows')
       const { panesOpen, createNewFile } = await getUtils(page, test)
 
       await page.setBodyDimensions({ width: 1200, height: 500 })
@@ -1031,8 +1027,6 @@ test.describe('Undo and redo do not keep history when navigating between files',
     `open a file, change something, open a different file, hitting undo should do nothing`,
     { tag: '@electron' },
     async ({ context, page }, testInfo) => {
-      // TODO: fix this test on windows after the electron migration
-      test.skip(process.platform === 'win32', 'Skip on windows')
       await context.folderSetupFn(async (dir) => {
         const testDir = join(dir, 'testProject')
         await fsp.mkdir(testDir, { recursive: true })
@@ -1099,10 +1093,7 @@ test.describe('Undo and redo do not keep history when navigating between files',
   test(
     `open a file, change something, undo it, open a different file, hitting redo should do nothing`,
     { tag: '@electron' },
-    // Skip on windows i think the keybindings are different for redo.
     async ({ context, page }, testInfo) => {
-      // TODO: fix this test on windows after the electron migration
-      test.skip(process.platform === 'win32', 'Skip on windows')
       await context.folderSetupFn(async (dir) => {
         const testDir = join(dir, 'testProject')
         await fsp.mkdir(testDir, { recursive: true })

--- a/e2e/playwright/named-views.spec.ts
+++ b/e2e/playwright/named-views.spec.ts
@@ -62,7 +62,7 @@ function tomlStringOverWriteNamedViewUuids(toml: string): string {
 }
 
 test.describe('Named view tests', () => {
-  test.skip(runningOnWindows(), 'Windows line endings break snapshot matching')
+  test.fail(runningOnWindows(), 'Windows line endings break snapshot matching')
   test('Verify project.toml is not created', async ({ page }, testInfo) => {
     // Create project and load it
     const projectName = 'named-views'

--- a/e2e/playwright/regression-tests.spec.ts
+++ b/e2e/playwright/regression-tests.spec.ts
@@ -223,21 +223,6 @@ extrude001 = extrude(sketch001, length = 50)
     })
   })
 
-  // Not relevant to us anymore, or at least for the time being.
-  test.skip('ensure the Zoo logo is not a link in browser app', async ({
-    page,
-    homePage,
-  }) => {
-    const u = await getUtils(page)
-    await page.setBodyDimensions({ width: 1000, height: 500 })
-    await homePage.goToModelingScene()
-    await u.waitForPageLoad()
-
-    const zooLogo = page.locator('[data-testid="app-logo"]')
-    // Make sure it's not a link
-    await expect(zooLogo).not.toHaveAttribute('href')
-  })
-
   test('Position _ Is Out Of Range... regression test', async ({
     context,
     page,

--- a/e2e/playwright/testing-samples-loading.spec.ts
+++ b/e2e/playwright/testing-samples-loading.spec.ts
@@ -19,64 +19,62 @@ test.describe('Testing loading external models', () => {
    * its title, and its units settings. https://github.com/KittyCAD/kcl-samples/blob/main/parametric-bearing-pillow-block/main.kcl
    */
   // We have no more web tests
-  test.skip('Web: should overwrite current code, cannot create new file', async ({
-    editor,
-    context,
-    page,
-    homePage,
-  }) => {
-    const u = await getUtils(page)
+  test.fail(
+    'Web: should overwrite current code, cannot create new file',
+    async ({ editor, context, page, homePage }) => {
+      const u = await getUtils(page)
 
-    await test.step(`Test setup`, async () => {
-      await context.addInitScript((code) => {
-        window.localStorage.setItem('persistCode', code)
-      }, bracket)
-      await page.setBodyDimensions({ width: 1200, height: 500 })
-      await homePage.goToModelingScene()
-    })
-
-    // Locators and constants
-    const newSample = {
-      file: 'parametric-bearing-pillow-block' + FILE_EXT,
-      title: 'Parametric Bearing Pillow Block',
-    }
-    const commandBarButton = page.getByRole('button', { name: 'Commands' })
-    const samplesCommandOption = page.getByRole('option', {
-      name: 'Load external model',
-    })
-    const commandSampleOption = page.getByRole('option', {
-      name: newSample.title,
-      exact: true,
-    })
-    const commandMethodArgButton = page.getByRole('button', {
-      name: 'Method',
-    })
-    const commandMethodOption = (name: 'Overwrite' | 'Create new file') =>
-      page.getByRole('option', {
-        name,
+      await test.step(`Test setup`, async () => {
+        await context.addInitScript((code) => {
+          window.localStorage.setItem('persistCode', code)
+        }, bracket)
+        await page.setBodyDimensions({ width: 1200, height: 500 })
+        await homePage.goToModelingScene()
       })
-    const warningText = page.getByText('Overwrite current file with sample?')
-    const confirmButton = page.getByRole('button', { name: 'Submit command' })
 
-    await test.step(`Precondition: check the initial code`, async () => {
-      await u.openKclCodePanel()
-      await editor.scrollToText(bracket.split('\n')[0])
-      await editor.expectEditor.toContain(bracket.split('\n')[0])
-    })
+      // Locators and constants
+      const newSample = {
+        file: 'parametric-bearing-pillow-block' + FILE_EXT,
+        title: 'Parametric Bearing Pillow Block',
+      }
+      const commandBarButton = page.getByRole('button', { name: 'Commands' })
+      const samplesCommandOption = page.getByRole('option', {
+        name: 'Load external model',
+      })
+      const commandSampleOption = page.getByRole('option', {
+        name: newSample.title,
+        exact: true,
+      })
+      const commandMethodArgButton = page.getByRole('button', {
+        name: 'Method',
+      })
+      const commandMethodOption = (name: 'Overwrite' | 'Create new file') =>
+        page.getByRole('option', {
+          name,
+        })
+      const warningText = page.getByText('Overwrite current file with sample?')
+      const confirmButton = page.getByRole('button', { name: 'Submit command' })
 
-    await test.step(`Load a KCL sample with the command palette`, async () => {
-      await commandBarButton.click()
-      await samplesCommandOption.click()
-      await commandSampleOption.click()
-      await commandMethodArgButton.click()
-      await expect(commandMethodOption('Create new file')).not.toBeVisible()
-      await commandMethodOption('Overwrite').click()
-      await expect(warningText).toBeVisible()
-      await confirmButton.click()
+      await test.step(`Precondition: check the initial code`, async () => {
+        await u.openKclCodePanel()
+        await editor.scrollToText(bracket.split('\n')[0])
+        await editor.expectEditor.toContain(bracket.split('\n')[0])
+      })
 
-      await editor.expectEditor.toContain('// ' + newSample.title)
-    })
-  })
+      await test.step(`Load a KCL sample with the command palette`, async () => {
+        await commandBarButton.click()
+        await samplesCommandOption.click()
+        await commandSampleOption.click()
+        await commandMethodArgButton.click()
+        await expect(commandMethodOption('Create new file')).not.toBeVisible()
+        await commandMethodOption('Overwrite').click()
+        await expect(warningText).toBeVisible()
+        await confirmButton.click()
+
+        await editor.expectEditor.toContain('// ' + newSample.title)
+      })
+    }
+  )
 
   /**
    * Note this test implicitly depends on the KCL samples:

--- a/e2e/playwright/testing-settings.spec.ts
+++ b/e2e/playwright/testing-settings.spec.ts
@@ -158,8 +158,6 @@ test.describe(
       page,
       homePage,
     }) => {
-      // TODO: fix this test on windows after the electron migration
-      test.skip(process.platform === 'win32', 'Skip on windows')
       const u = await getUtils(page)
       await page.setBodyDimensions({ width: 1200, height: 500 })
       await homePage.goToModelingScene()
@@ -531,8 +529,6 @@ test.describe(
       `Closing settings modal should go back to the original file being viewed`,
       { tag: '@electron' },
       async ({ context, page }, testInfo) => {
-        // TODO: fix this test on windows after the electron migration
-        test.skip(process.platform === 'win32', 'Skip on windows')
         await context.folderSetupFn(async (dir) => {
           const bracketDir = join(dir, 'project-000')
           await fsp.mkdir(bracketDir, { recursive: true })
@@ -598,8 +594,6 @@ test.describe(
 
     test('Changing modeling default unit', async ({ page, homePage }) => {
       await test.step(`Test setup`, async () => {
-        // TODO: fix this test on windows after the electron migration
-        test.skip(process.platform === 'win32', 'Skip on windows')
         await page.setBodyDimensions({ width: 1200, height: 500 })
         await homePage.goToModelingScene()
         const toastMessage = page.getByText(
@@ -760,8 +754,6 @@ test.describe(
       scene,
       cmdBar,
     }) => {
-      // TODO: fix this test on windows after the electron migration
-      test.skip(process.platform === 'win32', 'Skip on windows')
       const u = await getUtils(page)
       await context.addInitScript(() => {
         localStorage.setItem(

--- a/e2e/playwright/various.spec.ts
+++ b/e2e/playwright/various.spec.ts
@@ -256,19 +256,6 @@ test('Basic default modeling and sketch hotkeys work', async ({
   homePage,
 }) => {
   const u = await getUtils(page)
-
-  // This test can run long if it takes a little too long to load
-  // the engine.
-  test.setTimeout(90000)
-  // This test has a weird bug on ubuntu
-  // Funny, it's flaking on Windows too :). I think there is just something
-  // actually wrong.
-  test.skip(
-    process.platform === 'linux',
-    'weird playwright bug on ubuntu https://github.com/KittyCAD/modeling-app/issues/2444'
-  )
-  // Load the app with the code pane open
-
   await test.step(`Set up test`, async () => {
     await page.addInitScript(async () => {
       localStorage.setItem(


### PR DESCRIPTION
We're now tagging tests that cover platform-dependent functionality with `@macos` and/or `@windows` so these runtime `test.skip()` calls are no longer necessary. We'll also want to use `test.fail()` for expected failures.