### PR TITLE
Fix to not double import math in the prelude

### DIFF
--- a/rust/kcl-lib/std/prelude.kcl
+++ b/rust/kcl-lib/std/prelude.kcl
@@ -6,7 +6,6 @@
 export import * from "std::types"
 export import "std::units"
 export import * from "std::math"
-export import "std::math"
 export import * from "std::sketch"
 export import * from "std::solid"
 export import "std::turns"


### PR DESCRIPTION
Follow-up to #6595.