### PR TITLE
Same hotkey for center rect and center circle

### DIFF
--- a/src/lib/toolbar.ts
+++ b/src/lib/toolbar.ts
@@ -678,10 +678,6 @@ export const toolbarConfig: Record<ToolbarModeName, ToolbarMode> = {
             status: 'available',
             disabled: (state) => state.matches('Sketch no face'),
             title: 'Center rectangle',
-            hotkey: (state) =>
-              state.matches({ Sketch: 'Center Rectangle tool' })
-                ? ['Esc', 'C']
-                : 'C',
             description: 'Start drawing a rectangle from its center',
             links: [],
             isActive: (state) => {


### PR DESCRIPTION
Removed clashing hotkey on center rectangle, seems less common than corner rectangle. Happy to be chalenged. Fixes #6634