### PR TITLE
Fix resetting onboarding from settings in web after #6564

### DIFF
--- a/src/components/Settings/AllSettingsFields.tsx
+++ b/src/components/Settings/AllSettingsFields.tsx
@@ -74,6 +74,11 @@ export const AllSettingsFields = forwardRef(
         codeManager,
         kclManager,
       }
+      // We need to navigate out of settings before accepting onboarding
+      // in the web
+      if (!isDesktop()) {
+        navigate('..')
+      }
       acceptOnboarding(props).catch((reason) =>
         catchOnboardingWarnError(reason, props)
       )


### PR DESCRIPTION
Oversight on my part while refactoring the onboarding system in #6564. The new centralized `acceptOnboarding` workflow constructs a relative path, so we have to get out of the settings before invoking it.