### PR TITLE
Release KCL 66

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1815,7 +1815,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-bumper"
-version = "0.1.65"
+version = "0.1.66"
 dependencies = [
  "anyhow",
  "clap",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-derive-docs"
-version = "0.1.65"
+version = "0.1.66"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-directory-test-macro"
-version = "0.1.65"
+version = "0.1.66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1854,7 +1854,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-language-server"
-version = "0.2.65"
+version = "0.2.66"
 dependencies = [
  "anyhow",
  "clap",
@@ -1875,7 +1875,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-language-server-release"
-version = "0.1.65"
+version = "0.1.66"
 dependencies = [
  "anyhow",
  "clap",
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-lib"
-version = "0.2.65"
+version = "0.2.66"
 dependencies = [
  "anyhow",
  "approx 0.5.1",
@@ -1969,7 +1969,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-python-bindings"
-version = "0.3.65"
+version = "0.3.66"
 dependencies = [
  "anyhow",
  "kcl-lib",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-test-server"
-version = "0.1.65"
+version = "0.1.66"
 dependencies = [
  "anyhow",
  "hyper 0.14.32",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-to-core"
-version = "0.1.65"
+version = "0.1.66"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2011,7 +2011,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-wasm-lib"
-version = "0.1.65"
+version = "0.1.66"
 dependencies = [
  "bson",
  "console_error_panic_hook",

--- a/rust/justfile
+++ b/rust/justfile
@@ -58,6 +58,7 @@ bump-kcl-crate-versions bump='patch':
     # First build the kcl-bumper tool.
     cargo build -p kcl-bumper
     ./target/debug/kcl-bumper --bump {{bump}}
+    cargo check -p kcl-bumper # this way Cargo.lock gets updated
 
 publish-kcl version:
     git tag kcl-{{version}} -m "Release kcl-{{version}}"

--- a/rust/kcl-bumper/Cargo.toml
+++ b/rust/kcl-bumper/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "kcl-bumper"
-version = "0.1.65"
+version = "0.1.66"
 edition = "2021"
 repository = "https://github.com/KittyCAD/modeling-api"
 rust-version = "1.76"

--- a/rust/kcl-derive-docs/Cargo.toml
+++ b/rust/kcl-derive-docs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-derive-docs"
 description = "A tool for generating documentation from Rust derive macros"
-version = "0.1.65"
+version = "0.1.66"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-directory-test-macro/Cargo.toml
+++ b/rust/kcl-directory-test-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-directory-test-macro"
 description = "A tool for generating tests from a directory of kcl files"
-version = "0.1.65"
+version = "0.1.66"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-language-server-release/Cargo.toml
+++ b/rust/kcl-language-server-release/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-language-server-release"
-version = "0.1.65"
+version = "0.1.66"
 edition = "2021"
 authors = ["KittyCAD Inc <kcl@kittycad.io>"]
 publish = false

--- a/rust/kcl-language-server/Cargo.toml
+++ b/rust/kcl-language-server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kcl-language-server"
 description = "A language server for KCL."
 authors = ["KittyCAD Inc <kcl@kittycad.io>"]
-version = "0.2.65"
+version = "0.2.66"
 edition = "2021"
 license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust/kcl-lib/Cargo.toml
+++ b/rust/kcl-lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-lib"
 description = "KittyCAD Language implementation and tools"
-version = "0.2.65"
+version = "0.2.66"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-python-bindings/Cargo.toml
+++ b/rust/kcl-python-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-python-bindings"
-version = "0.3.65"
+version = "0.3.66"
 edition = "2021"
 repository = "https://github.com/kittycad/modeling-app"
 exclude = ["tests/*", "files/*", "venv/*"]

--- a/rust/kcl-test-server/Cargo.toml
+++ b/rust/kcl-test-server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-test-server"
 description = "A test server for KCL"
-version = "0.1.65"
+version = "0.1.66"
 edition = "2021"
 license = "MIT"
 

--- a/rust/kcl-to-core/Cargo.toml
+++ b/rust/kcl-to-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-to-core"
 description = "Utility methods to convert kcl to engine core executable tests"
-version = "0.1.65"
+version = "0.1.66"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-wasm-lib/Cargo.toml
+++ b/rust/kcl-wasm-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-wasm-lib"
-version = "0.1.65"
+version = "0.1.66"
 edition = "2021"
 repository = "https://github.com/KittyCAD/modeling-app"
 rust-version = "1.83"


### PR DESCRIPTION
Breaking changes:

 - All functions (even functions defined by users) must use keyword arguments, not positional arguments