### PR TITLE
Fix subtract2d icon in the Feature Tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2139,6 +2139,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -1036,8 +1036,8 @@ export const stdLibMap: Record<string, StdLibCallInfo> = {
     icon: 'helix',
     prepareToEdit: prepareToEditHelix,
   },
-  hole: {
-    label: 'Hole',
+  subtract2d: {
+    label: 'Subtract 2D',
     icon: 'hole',
   },
   hollow: {


### PR DESCRIPTION
This should have been done with #6382.

The `package-lock.json` change is unrelated. Just needed to get committed.

Before

<img width="544" alt="Screenshot 2025-05-02 at 10 44 58 PM" src="https://github.com/user-attachments/assets/83f2b656-95bc-4e69-94a4-7a624223c0a3" />

After

<img width="545" alt="Screenshot 2025-05-02 at 10 47 31 PM" src="https://github.com/user-attachments/assets/0c49cce6-63f4-43c1-a5de-0dfce46bdcb0" />
