### PR TITLE
Put XY back into default plane feature tree

### DIFF
--- a/src/components/ModelingSidebar/ModelingPanes/FeatureTreePane.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/FeatureTreePane.tsx
@@ -242,7 +242,7 @@ const OperationItemWrapper = ({
   visibilityToggle,
   menuItems,
   errors,
-  codeName,
+  customSuffix,
   className,
   selectable = true,
   ...props
@@ -250,7 +250,7 @@ const OperationItemWrapper = ({
   icon: CustomIconName
   name: string
   visibilityToggle?: VisibilityToggleProps
-  codeName?: string
+  customSuffix?: JSX.Element
   menuItems?: ComponentProps<typeof ContextMenu>['items']
   errors?: Diagnostic[]
   selectable?: boolean
@@ -269,11 +269,7 @@ const OperationItemWrapper = ({
         <CustomIcon name={icon} className="w-5 h-5 block" />
         <div className="flex items-center">
           <div className="min-w-24">{name}</div>
-          {codeName && (
-            <span className="text-chalkboard-50/50 text-xs">
-              {codeName.toUpperCase()}
-            </span>
-          )}
+          {customSuffix && customSuffix}
         </div>
       </button>
       {errors && errors.length > 0 && (
@@ -546,9 +542,30 @@ const DefaultPlanes = () => {
   if (!defaultPlanes) return null
 
   const planes = [
-    { name: 'Front plane', id: defaultPlanes.xz, key: 'xz' },
-    { name: 'Top plane', id: defaultPlanes.xy, key: 'xy' },
-    { name: 'Side plane', id: defaultPlanes.yz, key: 'yz' },
+    {
+      name: 'Front plane',
+      id: defaultPlanes.xz,
+      key: 'xz',
+      customSuffix: (
+        <div className="text-blue-500/50 font-bold text-xs">XZ</div>
+      ),
+    },
+    {
+      name: 'Top plane',
+      id: defaultPlanes.xy,
+      key: 'xy',
+      customSuffix: (
+        <div className="text-red-500/50 font-bold, text-xs">XY</div>
+      ),
+    },
+    {
+      name: 'Side plane',
+      id: defaultPlanes.yz,
+      key: 'yz',
+      customSuffix: (
+        <div className="text-green-500/50 font-bold text-xs">YZ</div>
+      ),
+    },
   ] as const
 
   return (
@@ -556,7 +573,7 @@ const DefaultPlanes = () => {
       {planes.map((plane) => (
         <OperationItemWrapper
           key={plane.key}
-          codeName={plane.key}
+          customSuffix={plane.customSuffix}
           icon={'plane'}
           name={plane.name}
           selectable={false}

--- a/src/components/ModelingSidebar/ModelingPanes/FeatureTreePane.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/FeatureTreePane.tsx
@@ -242,6 +242,7 @@ const OperationItemWrapper = ({
   visibilityToggle,
   menuItems,
   errors,
+  codeName,
   className,
   selectable = true,
   ...props
@@ -249,6 +250,7 @@ const OperationItemWrapper = ({
   icon: CustomIconName
   name: string
   visibilityToggle?: VisibilityToggleProps
+  codeName?: string
   menuItems?: ComponentProps<typeof ContextMenu>['items']
   errors?: Diagnostic[]
   selectable?: boolean
@@ -265,7 +267,14 @@ const OperationItemWrapper = ({
         className={`reset flex-1 flex items-center gap-2 text-left text-base ${selectable ? 'border-transparent dark:border-transparent' : 'border-none cursor-default'} ${className}`}
       >
         <CustomIcon name={icon} className="w-5 h-5 block" />
-        {name}
+        <div className="flex items-center">
+          <div className="min-w-24">{name}</div>
+          {codeName && (
+            <span className="text-chalkboard-50/50 text-xs">
+              {codeName.toUpperCase()}
+            </span>
+          )}
+        </div>
       </button>
       {errors && errors.length > 0 && (
         <em className="text-destroy-80 text-xs">has error</em>
@@ -547,6 +556,7 @@ const DefaultPlanes = () => {
       {planes.map((plane) => (
         <OperationItemWrapper
           key={plane.key}
+          codeName={plane.key}
           icon={'plane'}
           name={plane.name}
           selectable={false}

--- a/src/components/ModelingSidebar/ModelingPanes/FeatureTreePane.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/FeatureTreePane.tsx
@@ -555,7 +555,7 @@ const DefaultPlanes = () => {
       id: defaultPlanes.xy,
       key: 'xy',
       customSuffix: (
-        <div className="text-red-500/50 font-bold, text-xs">XY</div>
+        <div className="text-red-500/50 font-bold text-xs">XY</div>
       ),
     },
     {


### PR DESCRIPTION
It's weird to not have them consistent with the code, this at least bring back a connection between both, but is trying to be fairly subtle.

![image](https://github.com/user-attachments/assets/a1037c55-5f9c-4f86-bd98-bfe13d5fc693)

