### PR TITLE
Small touch up to default planes suffix

### DIFF
--- a/src/components/ModelingSidebar/ModelingPanes/FeatureTreePane.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/FeatureTreePane.tsx
@@ -267,8 +267,8 @@ const OperationItemWrapper = ({
         className={`reset flex-1 flex items-center gap-2 text-left text-base ${selectable ? 'border-transparent dark:border-transparent' : 'border-none cursor-default'} ${className}`}
       >
         <CustomIcon name={icon} className="w-5 h-5 block" />
-        <div className="flex items-center">
-          <div className="min-w-24">{name}</div>
+        <div className="flex items-baseline">
+          <div className="mr-2">{name}</div>
           {customSuffix && customSuffix}
         </div>
       </button>


### PR DESCRIPTION
Align to baseline and no min width.

Before:
![image](https://github.com/user-attachments/assets/cdbd365c-956c-4df0-8b0d-f581580fc0a1)

After:
![image](https://github.com/user-attachments/assets/5430cd3c-73fb-4f4f-9683-a4d7f3cbdbc8)
