### PR TITLE
Fix: thumbnail.png would not be created in a few scenarios, the commandType wasn't populated in some workflows.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -129,6 +129,7 @@ export function App() {
 
   // Generate thumbnail.png when loading the app
   useEffect(() => {
+    console.log(`command:${lastCommandType}`)
     if (isDesktop() && lastCommandType === 'execution-done') {
       setTimeout(() => {
         const projectDirectoryWithoutEndingSlash = loaderData?.project?.path
@@ -138,8 +139,11 @@ export function App() {
         const dataUrl: string = takeScreenshotOfVideoStreamCanvas()
         // zoom to fit command does not wait, wait 500ms to see if zoom to fit finishes
         writeProjectThumbnailFile(dataUrl, projectDirectoryWithoutEndingSlash)
-          .then(() => {})
+          .then(() => {
+            toast.success(`made thumbnail${projectDirectoryWithoutEndingSlash}`)
+          })
           .catch((e) => {
+            toast.error('no thumbnail')
             console.error(
               `Failed to generate thumbnail for ${projectDirectoryWithoutEndingSlash}`
             )

--- a/src/components/EngineStream.tsx
+++ b/src/components/EngineStream.tsx
@@ -36,6 +36,7 @@ import {
   engineViewIsometricWithoutGeometryPresent,
 } from '@src/lib/utils'
 import { DEFAULT_DEFAULT_LENGTH_UNIT } from '@src/lib/constants'
+import { createThumbnailPNGOnDesktop } from '@src/lib/screenshot'
 
 export const EngineStream = (props: {
   pool: string | null
@@ -49,7 +50,7 @@ export const EngineStream = (props: {
 
   const engineStreamState = useSelector(engineStreamActor, (state) => state)
 
-  const { file } = useRouteLoaderData(PATHS.FILE) as IndexLoaderData
+  const { file, project } = useRouteLoaderData(PATHS.FILE) as IndexLoaderData
   const last = useRef<number>(Date.now())
   const videoWrapperRef = useRef<HTMLDivElement>(null)
 
@@ -121,6 +122,12 @@ export const EngineStream = (props: {
               padding,
             })
           }
+        }
+
+        if (project && project.path) {
+          createThumbnailPNGOnDesktop({
+            projectDirectoryWithoutEndingSlash: project.path,
+          })
         }
       })
       .catch(trap)

--- a/src/lib/screenshot.ts
+++ b/src/lib/screenshot.ts
@@ -1,6 +1,5 @@
 import { isDesktop } from '@src/lib/isDesktop'
 import { writeProjectThumbnailFile } from '@src/lib/desktop'
-import toast from 'react-hot-toast'
 
 export function takeScreenshotOfVideoStreamCanvas() {
   const canvas = document.querySelector('[data-engine]')
@@ -59,11 +58,8 @@ export function createThumbnailPNGOnDesktop({
       const dataUrl: string = takeScreenshotOfVideoStreamCanvas()
       // zoom to fit command does not wait, wait 500ms to see if zoom to fit finishes
       writeProjectThumbnailFile(dataUrl, projectDirectoryWithoutEndingSlash)
-        .then(() => {
-          toast.success(`made thumbnail${projectDirectoryWithoutEndingSlash}`)
-        })
+        .then(() => {})
         .catch((e) => {
-          toast.error('no thumbnail')
           console.error(
             `Failed to generate thumbnail for ${projectDirectoryWithoutEndingSlash}`
           )

--- a/src/lib/screenshot.ts
+++ b/src/lib/screenshot.ts
@@ -1,3 +1,7 @@
+import { isDesktop } from '@src/lib/isDesktop'
+import { writeProjectThumbnailFile } from '@src/lib/desktop'
+import toast from 'react-hot-toast'
+
 export function takeScreenshotOfVideoStreamCanvas() {
   const canvas = document.querySelector('[data-engine]')
   const video = document.getElementById('video-stream')
@@ -40,4 +44,31 @@ export default async function screenshot(): Promise<string> {
   }
 
   return takeScreenshotOfVideoStreamCanvas()
+}
+
+export function createThumbnailPNGOnDesktop({
+  projectDirectoryWithoutEndingSlash,
+}: {
+  projectDirectoryWithoutEndingSlash: string
+}) {
+  if (isDesktop()) {
+    setTimeout(() => {
+      if (!projectDirectoryWithoutEndingSlash) {
+        return
+      }
+      const dataUrl: string = takeScreenshotOfVideoStreamCanvas()
+      // zoom to fit command does not wait, wait 500ms to see if zoom to fit finishes
+      writeProjectThumbnailFile(dataUrl, projectDirectoryWithoutEndingSlash)
+        .then(() => {
+          toast.success(`made thumbnail${projectDirectoryWithoutEndingSlash}`)
+        })
+        .catch((e) => {
+          toast.error('no thumbnail')
+          console.error(
+            `Failed to generate thumbnail for ${projectDirectoryWithoutEndingSlash}`
+          )
+          console.error(e)
+        })
+    }, 500)
+  }
 }


### PR DESCRIPTION
closes https://github.com/KittyCAD/modeling-app/issues/6645

# Issue

`thumbnail.png` was not being created when it looks like it should have. `useEngineCommands` would not set all of the engine commands if you created a project from text to cad workflow.

# Implementation

After the engine gets connection, the KCL is done executing, and we set the camera we will now take a screenshot.

# Scenarios

- Home page text to cad -> new project -> :heavy_check_mark: 
- Home page -> create blank project -> :heavy_check_mark: 
- Home page -> create from sample -> :heavy_check_mark: 
- Home page -> opening a prexesiting project -> :heavy_check_mark: 