### PR TITLE
Do multiple chamfer/fillet in one API call

### DIFF
--- a/rust/kcl-lib/tests/basic_fillet_cube_close_opposite/artifact_commands.snap
+++ b/rust/kcl-lib/tests/basic_fillet_cube_close_opposite/artifact_commands.snap
@@ -224,30 +224,16 @@ description: Artifact commands basic_fillet_cube_close_opposite.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 2.0,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
         "[uuid]"
-      ],
-      "radius": 2.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/basic_fillet_cube_close_opposite/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/basic_fillet_cube_close_opposite/artifact_graph_flowchart.snap.md
@@ -39,8 +39,6 @@ flowchart LR
   22["SweepEdge Adjacent"]
   23["EdgeCut Fillet<br>[221, 281, 0]"]
     %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  24["EdgeCut Fillet<br>[221, 281, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
   1 --- 2
   2 --- 3
   2 --- 4
@@ -64,7 +62,7 @@ flowchart LR
   6 x--> 13
   6 --- 15
   6 --- 19
-  6 --- 24
+  6 --- 23
   8 --- 9
   8 --- 10
   8 --- 11
@@ -95,5 +93,4 @@ flowchart LR
   16 <--x 14
   17 <--x 14
   18 <--x 14
-  15 <--x 23
 ```

--- a/rust/kcl-lib/tests/basic_fillet_cube_end/artifact_commands.snap
+++ b/rust/kcl-lib/tests/basic_fillet_cube_end/artifact_commands.snap
@@ -224,30 +224,16 @@ description: Artifact commands basic_fillet_cube_end.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 2.0,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
         "[uuid]"
-      ],
-      "radius": 2.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/basic_fillet_cube_end/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/basic_fillet_cube_end/artifact_graph_flowchart.snap.md
@@ -39,8 +39,6 @@ flowchart LR
   22["SweepEdge Adjacent"]
   23["EdgeCut Fillet<br>[209, 267, 0]"]
     %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  24["EdgeCut Fillet<br>[209, 267, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
   1 --- 2
   2 --- 3
   2 --- 4
@@ -52,7 +50,7 @@ flowchart LR
   3 x--> 13
   3 --- 18
   3 --- 22
-  3 --- 24
+  3 --- 23
   4 --- 10
   4 x--> 13
   4 --- 17
@@ -95,5 +93,4 @@ flowchart LR
   16 <--x 14
   17 <--x 14
   18 <--x 14
-  18 <--x 23
 ```

--- a/rust/kcl-lib/tests/basic_fillet_cube_start/artifact_commands.snap
+++ b/rust/kcl-lib/tests/basic_fillet_cube_start/artifact_commands.snap
@@ -224,30 +224,16 @@ description: Artifact commands basic_fillet_cube_start.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 2.0,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
         "[uuid]"
-      ],
-      "radius": 2.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   }
 ]

--- a/rust/kcl-lib/tests/basic_fillet_cube_start/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/basic_fillet_cube_start/artifact_graph_flowchart.snap.md
@@ -39,8 +39,6 @@ flowchart LR
   22["SweepEdge Adjacent"]
   23["EdgeCut Fillet<br>[209, 251, 0]"]
     %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  24["EdgeCut Fillet<br>[209, 251, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
   1 --- 2
   2 --- 3
   2 --- 4
@@ -61,7 +59,6 @@ flowchart LR
   5 x--> 13
   5 --- 16
   5 --- 20
-  5 --- 24
   6 --- 11
   6 x--> 13
   6 --- 15

--- a/rust/kcl-lib/tests/fillet-and-shell/artifact_commands.snap
+++ b/rust/kcl-lib/tests/fillet-and-shell/artifact_commands.snap
@@ -351,64 +351,20 @@ description: Artifact commands fillet-and-shell.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 1.0,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 1.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 1.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 1.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/fillet-and-shell/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/fillet-and-shell/artifact_graph_flowchart.snap.md
@@ -174,12 +174,6 @@ flowchart LR
   85["SweepEdge Adjacent"]
   86["EdgeCut Fillet<br>[1068, 1274, 0]"]
     %% [ProgramBodyItem { index: 17 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  87["EdgeCut Fillet<br>[1068, 1274, 0]"]
-    %% [ProgramBodyItem { index: 17 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  88["EdgeCut Fillet<br>[1068, 1274, 0]"]
-    %% [ProgramBodyItem { index: 17 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  89["EdgeCut Fillet<br>[1068, 1274, 0]"]
-    %% [ProgramBodyItem { index: 17 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
   1 --- 7
   2 --- 8
   3 --- 10
@@ -319,8 +313,5 @@ flowchart LR
   74 <--x 69
   75 <--x 69
   76 <--x 69
-  81 <--x 89
-  82 <--x 87
-  83 <--x 88
-  84 <--x 86
+  81 <--x 86
 ```

--- a/rust/kcl-lib/tests/kcl_samples/80-20-rail/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/80-20-rail/artifact_commands.snap
@@ -1515,268 +1515,44 @@ description: Artifact commands 80-20-rail.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 1.5239999999999998,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 1.5239999999999998,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 1.5239999999999998,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 1.5239999999999998,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 1.5239999999999998,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 1.5239999999999998,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 1.5239999999999998,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 1.5239999999999998,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 1.5239999999999998,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 1.5239999999999998,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 1.5239999999999998,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 1.5239999999999998,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 1.5239999999999998,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 1.5239999999999998,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 1.5239999999999998,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 1.5239999999999998,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {
@@ -1947,268 +1723,44 @@ description: Artifact commands 80-20-rail.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 0.7619999999999999,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 0.7619999999999999,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 0.7619999999999999,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 0.7619999999999999,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 0.7619999999999999,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 0.7619999999999999,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 0.7619999999999999,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 0.7619999999999999,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 0.7619999999999999,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 0.7619999999999999,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 0.7619999999999999,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 0.7619999999999999,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 0.7619999999999999,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 0.7619999999999999,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 0.7619999999999999,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 0.7619999999999999,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/80-20-rail/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/80-20-rail/artifact_graph_flowchart.snap.md
@@ -408,67 +408,7 @@ flowchart LR
   266["SweepEdge Adjacent"]
   267["EdgeCut Fillet<br>[5122, 5827, 0]"]
     %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 69 }]
-  268["EdgeCut Fillet<br>[5122, 5827, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 69 }]
-  269["EdgeCut Fillet<br>[5122, 5827, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 69 }]
-  270["EdgeCut Fillet<br>[5122, 5827, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 69 }]
-  271["EdgeCut Fillet<br>[5122, 5827, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 69 }]
-  272["EdgeCut Fillet<br>[5122, 5827, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 69 }]
-  273["EdgeCut Fillet<br>[5122, 5827, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 69 }]
-  274["EdgeCut Fillet<br>[5122, 5827, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 69 }]
-  275["EdgeCut Fillet<br>[5122, 5827, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 69 }]
-  276["EdgeCut Fillet<br>[5122, 5827, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 69 }]
-  277["EdgeCut Fillet<br>[5122, 5827, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 69 }]
-  278["EdgeCut Fillet<br>[5122, 5827, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 69 }]
-  279["EdgeCut Fillet<br>[5122, 5827, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 69 }]
-  280["EdgeCut Fillet<br>[5122, 5827, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 69 }]
-  281["EdgeCut Fillet<br>[5122, 5827, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 69 }]
-  282["EdgeCut Fillet<br>[5122, 5827, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 69 }]
-  283["EdgeCut Fillet<br>[5835, 6539, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 70 }]
-  284["EdgeCut Fillet<br>[5835, 6539, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 70 }]
-  285["EdgeCut Fillet<br>[5835, 6539, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 70 }]
-  286["EdgeCut Fillet<br>[5835, 6539, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 70 }]
-  287["EdgeCut Fillet<br>[5835, 6539, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 70 }]
-  288["EdgeCut Fillet<br>[5835, 6539, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 70 }]
-  289["EdgeCut Fillet<br>[5835, 6539, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 70 }]
-  290["EdgeCut Fillet<br>[5835, 6539, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 70 }]
-  291["EdgeCut Fillet<br>[5835, 6539, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 70 }]
-  292["EdgeCut Fillet<br>[5835, 6539, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 70 }]
-  293["EdgeCut Fillet<br>[5835, 6539, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 70 }]
-  294["EdgeCut Fillet<br>[5835, 6539, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 70 }]
-  295["EdgeCut Fillet<br>[5835, 6539, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 70 }]
-  296["EdgeCut Fillet<br>[5835, 6539, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 70 }]
-  297["EdgeCut Fillet<br>[5835, 6539, 0]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 70 }]
-  298["EdgeCut Fillet<br>[5835, 6539, 0]"]
+  268["EdgeCut Fillet<br>[5835, 6539, 0]"]
     %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 70 }]
   1 --- 2
   1 --- 3
@@ -1247,36 +1187,6 @@ flowchart LR
   200 <--x 138
   201 <--x 138
   202 <--x 138
-  207 <--x 286
-  208 <--x 292
-  209 <--x 278
-  210 <--x 280
-  211 <--x 273
-  212 <--x 268
-  213 <--x 285
-  214 <--x 294
-  223 <--x 289
-  224 <--x 287
-  225 <--x 272
-  226 <--x 274
-  227 <--x 270
-  228 <--x 271
-  229 <--x 290
-  230 <--x 291
-  239 <--x 284
-  240 <--x 297
-  241 <--x 282
-  242 <--x 281
-  243 <--x 267
-  244 <--x 279
-  245 <--x 283
-  246 <--x 293
-  255 <--x 298
-  256 <--x 295
-  257 <--x 276
-  258 <--x 275
-  259 <--x 269
-  260 <--x 277
-  261 <--x 288
-  262 <--x 296
+  207 <--x 268
+  209 <--x 267
 ```

--- a/rust/kcl-lib/tests/kcl_samples/axial-fan/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/axial-fan/artifact_commands.snap
@@ -2385,132 +2385,28 @@ description: Artifact commands axial-fan.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 7.5,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 7.5,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 7.5,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 7.5,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 7.5,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 7.5,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 7.5,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 7.5,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {
@@ -2802,30 +2698,16 @@ description: Artifact commands axial-fan.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 2.0,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
         "[uuid]"
-      ],
-      "radius": 2.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/axial-fan/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/axial-fan/artifact_graph_flowchart.snap.md
@@ -370,15 +370,7 @@ flowchart LR
   265["SweepEdge Adjacent"]
   266["SweepEdge Adjacent"]
   267["EdgeCut Fillet<br>[5131, 5642, 1]"]
-  268["EdgeCut Fillet<br>[5131, 5642, 1]"]
-  269["EdgeCut Fillet<br>[5131, 5642, 1]"]
-  270["EdgeCut Fillet<br>[5131, 5642, 1]"]
-  271["EdgeCut Fillet<br>[5131, 5642, 1]"]
-  272["EdgeCut Fillet<br>[5131, 5642, 1]"]
-  273["EdgeCut Fillet<br>[5131, 5642, 1]"]
-  274["EdgeCut Fillet<br>[5131, 5642, 1]"]
-  275["EdgeCut Fillet<br>[412, 470, 3]"]
-  276["EdgeCut Fillet<br>[412, 470, 3]"]
+  268["EdgeCut Fillet<br>[412, 470, 3]"]
   1 --- 8
   1 --- 9
   1 --- 10
@@ -619,7 +611,6 @@ flowchart LR
   71 x--> 178
   71 --- 220
   71 --- 264
-  71 --- 276
   72 --- 149
   72 x--> 181
   72 --- 194
@@ -959,13 +950,6 @@ flowchart LR
   213 <--x 189
   214 <--x 189
   215 <--x 189
-  220 <--x 275
-  223 <--x 270
-  224 <--x 274
-  225 <--x 273
-  226 <--x 267
-  260 <--x 271
-  261 <--x 268
-  262 <--x 269
-  263 <--x 272
+  220 <--x 268
+  223 <--x 267
 ```

--- a/rust/kcl-lib/tests/kcl_samples/bracket/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/bracket/artifact_commands.snap
@@ -969,64 +969,20 @@ description: Artifact commands bracket.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 12.7,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 12.7,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 12.7,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 12.7,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/bracket/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/bracket/artifact_graph_flowchart.snap.md
@@ -95,12 +95,6 @@ flowchart LR
     %% [ProgramBodyItem { index: 24 }, ExpressionStatementExpr]
   54["EdgeCut Fillet<br>[3780, 3922, 0]"]
     %% [ProgramBodyItem { index: 25 }, ExpressionStatementExpr]
-  55["EdgeCut Fillet<br>[3780, 3922, 0]"]
-    %% [ProgramBodyItem { index: 25 }, ExpressionStatementExpr]
-  56["EdgeCut Fillet<br>[3780, 3922, 0]"]
-    %% [ProgramBodyItem { index: 25 }, ExpressionStatementExpr]
-  57["EdgeCut Fillet<br>[3780, 3922, 0]"]
-    %% [ProgramBodyItem { index: 25 }, ExpressionStatementExpr]
   1 --- 4
   32 x--> 2
   33 x--> 3
@@ -129,7 +123,7 @@ flowchart LR
   8 x--> 34
   8 --- 39
   8 --- 47
-  8 --- 56
+  8 --- 54
   9 --- 32
   9 x--> 34
   9 --- 40
@@ -142,7 +136,6 @@ flowchart LR
   11 x--> 34
   11 --- 42
   11 --- 50
-  11 --- 54
   12 --- 28
   12 x--> 34
   12 --- 43
@@ -211,8 +204,6 @@ flowchart LR
   41 <--x 35
   42 <--x 35
   43 <--x 35
-  39 <--x 57
-  42 <--x 55
   48 <--x 52
   51 <--x 53
 ```

--- a/rust/kcl-lib/tests/kcl_samples/brake-rotor/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/brake-rotor/artifact_commands.snap
@@ -2672,64 +2672,20 @@ description: Artifact commands brake-rotor.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 2.0,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 2.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 2.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 2.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/brake-rotor/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/brake-rotor/artifact_graph_flowchart.snap.md
@@ -215,12 +215,6 @@ flowchart LR
   111["SweepEdge Adjacent"]
   112["EdgeCut Fillet<br>[3014, 3304, 0]"]
     %% [ProgramBodyItem { index: 26 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 1 }]
-  113["EdgeCut Fillet<br>[3014, 3304, 0]"]
-    %% [ProgramBodyItem { index: 26 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 1 }]
-  114["EdgeCut Fillet<br>[3014, 3304, 0]"]
-    %% [ProgramBodyItem { index: 26 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 1 }]
-  115["EdgeCut Fillet<br>[3014, 3304, 0]"]
-    %% [ProgramBodyItem { index: 26 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 1 }]
   1 --- 8
   1 --- 9
   1 --- 13
@@ -420,8 +414,5 @@ flowchart LR
   94 <--x 87
   90 <--x 88
   96 <--x 89
-  98 <--x 113
-  99 <--x 112
-  100 <--x 115
-  101 <--x 114
+  98 <--x 112
 ```

--- a/rust/kcl-lib/tests/kcl_samples/cpu-cooler/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/cpu-cooler/artifact_commands.snap
@@ -3469,132 +3469,28 @@ description: Artifact commands cpu-cooler.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 7.5,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 7.5,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 7.5,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 7.5,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 7.5,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 7.5,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 7.5,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 7.5,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {
@@ -3869,30 +3765,16 @@ description: Artifact commands cpu-cooler.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 2.0,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
         "[uuid]"
-      ],
-      "radius": 2.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {
@@ -8503,64 +8385,20 @@ description: Artifact commands cpu-cooler.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 2.0,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 2.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 2.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 2.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/enclosure/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/enclosure/artifact_commands.snap
@@ -241,64 +241,20 @@ description: Artifact commands enclosure.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 12.0,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 12.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 12.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 12.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {
@@ -2034,64 +1990,20 @@ description: Artifact commands enclosure.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 12.0,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 12.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 12.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 12.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {
@@ -2673,64 +2585,20 @@ description: Artifact commands enclosure.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 9.0,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 9.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 9.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 9.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/enclosure/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/enclosure/artifact_graph_flowchart.snap.md
@@ -279,27 +279,9 @@ flowchart LR
   145["SweepEdge Adjacent"]
   146["EdgeCut Fillet<br>[780, 1062, 0]"]
     %% [ProgramBodyItem { index: 6 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 1 }]
-  147["EdgeCut Fillet<br>[780, 1062, 0]"]
-    %% [ProgramBodyItem { index: 6 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 1 }]
-  148["EdgeCut Fillet<br>[780, 1062, 0]"]
-    %% [ProgramBodyItem { index: 6 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 1 }]
-  149["EdgeCut Fillet<br>[780, 1062, 0]"]
-    %% [ProgramBodyItem { index: 6 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 1 }]
-  150["EdgeCut Fillet<br>[3593, 3875, 0]"]
+  147["EdgeCut Fillet<br>[3593, 3875, 0]"]
     %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 1 }]
-  151["EdgeCut Fillet<br>[3593, 3875, 0]"]
-    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 1 }]
-  152["EdgeCut Fillet<br>[3593, 3875, 0]"]
-    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 1 }]
-  153["EdgeCut Fillet<br>[3593, 3875, 0]"]
-    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 1 }]
-  154["EdgeCut Fillet<br>[5381, 5663, 0]"]
-    %% [ProgramBodyItem { index: 15 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 1 }]
-  155["EdgeCut Fillet<br>[5381, 5663, 0]"]
-    %% [ProgramBodyItem { index: 15 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 1 }]
-  156["EdgeCut Fillet<br>[5381, 5663, 0]"]
-    %% [ProgramBodyItem { index: 15 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 1 }]
-  157["EdgeCut Fillet<br>[5381, 5663, 0]"]
+  148["EdgeCut Fillet<br>[5381, 5663, 0]"]
     %% [ProgramBodyItem { index: 15 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 1 }]
   1 --- 8
   2 --- 9
@@ -564,16 +546,7 @@ flowchart LR
   122 <--x 111
   123 <--x 112
   124 <--x 113
-  131 <--x 148
-  132 <--x 147
-  133 <--x 149
-  134 <--x 146
-  135 <--x 150
-  136 <--x 153
-  137 <--x 152
-  138 <--x 151
-  141 <--x 157
-  142 <--x 155
-  143 <--x 156
-  144 <--x 154
+  131 <--x 146
+  135 <--x 147
+  141 <--x 148
 ```

--- a/rust/kcl-lib/tests/kcl_samples/exhaust-manifold/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/exhaust-manifold/artifact_commands.snap
@@ -2797,30 +2797,16 @@ description: Artifact commands exhaust-manifold.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 38.099999999999994,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
         "[uuid]"
-      ],
-      "radius": 38.099999999999994,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {
@@ -2851,30 +2837,16 @@ description: Artifact commands exhaust-manifold.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 6.35,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
         "[uuid]"
-      ],
-      "radius": 6.35,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/exhaust-manifold/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/exhaust-manifold/artifact_graph_flowchart.snap.md
@@ -337,11 +337,7 @@ flowchart LR
   175["SweepEdge Adjacent"]
   176["EdgeCut Fillet<br>[3990, 4124, 0]"]
     %% [ProgramBodyItem { index: 9 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 28 }]
-  177["EdgeCut Fillet<br>[3990, 4124, 0]"]
-    %% [ProgramBodyItem { index: 9 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 28 }]
-  178["EdgeCut Fillet<br>[4130, 4264, 0]"]
-    %% [ProgramBodyItem { index: 9 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 29 }]
-  179["EdgeCut Fillet<br>[4130, 4264, 0]"]
+  177["EdgeCut Fillet<br>[4130, 4264, 0]"]
     %% [ProgramBodyItem { index: 9 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 29 }]
   1 --- 13
   2 --- 11
@@ -665,8 +661,6 @@ flowchart LR
   138 <--x 133
   139 <--x 134
   137 <--x 135
-  164 <--x 178
-  165 <--x 176
-  170 <--x 177
-  171 <--x 179
+  170 <--x 176
+  171 <--x 177
 ```

--- a/rust/kcl-lib/tests/kcl_samples/focusrite-scarlett-mounting-bracket/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/focusrite-scarlett-mounting-bracket/artifact_commands.snap
@@ -301,64 +301,20 @@ description: Artifact commands focusrite-scarlett-mounting-bracket.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 6.0,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 6.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 6.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 6.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {
@@ -708,30 +664,16 @@ description: Artifact commands focusrite-scarlett-mounting-bracket.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 2.5,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
         "[uuid]"
-      ],
-      "radius": 2.5,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {
@@ -1101,30 +1043,16 @@ description: Artifact commands focusrite-scarlett-mounting-bracket.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 2.5,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
         "[uuid]"
-      ],
-      "radius": 2.5,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/focusrite-scarlett-mounting-bracket/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/focusrite-scarlett-mounting-bracket/artifact_graph_flowchart.snap.md
@@ -219,19 +219,9 @@ flowchart LR
   128["SweepEdge Adjacent"]
   129["EdgeCut Fillet<br>[1449, 1708, 0]"]
     %% [ProgramBodyItem { index: 12 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 2 }]
-  130["EdgeCut Fillet<br>[1449, 1708, 0]"]
-    %% [ProgramBodyItem { index: 12 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 2 }]
-  131["EdgeCut Fillet<br>[1449, 1708, 0]"]
-    %% [ProgramBodyItem { index: 12 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 2 }]
-  132["EdgeCut Fillet<br>[1449, 1708, 0]"]
-    %% [ProgramBodyItem { index: 12 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 2 }]
-  133["EdgeCut Fillet<br>[2472, 2617, 0]"]
+  130["EdgeCut Fillet<br>[2472, 2617, 0]"]
     %% [ProgramBodyItem { index: 14 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 8 }]
-  134["EdgeCut Fillet<br>[2472, 2617, 0]"]
-    %% [ProgramBodyItem { index: 14 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 8 }]
-  135["EdgeCut Fillet<br>[3300, 3445, 0]"]
-    %% [ProgramBodyItem { index: 15 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 8 }]
-  136["EdgeCut Fillet<br>[3300, 3445, 0]"]
+  131["EdgeCut Fillet<br>[3300, 3445, 0]"]
     %% [ProgramBodyItem { index: 15 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 8 }]
   1 --- 6
   2 --- 7
@@ -540,12 +530,7 @@ flowchart LR
   103 <--x 82
   104 <--x 82
   105 <--x 82
-  106 <--x 135
-  107 <--x 136
-  110 <--x 130
-  111 <--x 131
-  114 <--x 129
-  115 <--x 132
-  123 <--x 134
-  124 <--x 133
+  106 <--x 131
+  115 <--x 129
+  124 <--x 130
 ```

--- a/rust/kcl-lib/tests/kcl_samples/food-service-spatula/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/food-service-spatula/artifact_commands.snap
@@ -771,30 +771,16 @@ description: Artifact commands food-service-spatula.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 5.0,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
         "[uuid]"
-      ],
-      "radius": 5.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {
@@ -1086,30 +1072,16 @@ description: Artifact commands food-service-spatula.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 4.0,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
         "[uuid]"
-      ],
-      "radius": 4.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/food-service-spatula/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/food-service-spatula/artifact_graph_flowchart.snap.md
@@ -245,11 +245,7 @@ flowchart LR
   142["SweepEdge Adjacent"]
   143["EdgeCut Fillet<br>[2546, 2687, 0]"]
     %% [ProgramBodyItem { index: 18 }, ExpressionStatementExpr]
-  144["EdgeCut Fillet<br>[2546, 2687, 0]"]
-    %% [ProgramBodyItem { index: 18 }, ExpressionStatementExpr]
-  145["EdgeCut Fillet<br>[3357, 3488, 0]"]
-    %% [ProgramBodyItem { index: 22 }, ExpressionStatementExpr]
-  146["EdgeCut Fillet<br>[3357, 3488, 0]"]
+  144["EdgeCut Fillet<br>[3357, 3488, 0]"]
     %% [ProgramBodyItem { index: 22 }, ExpressionStatementExpr]
   1 --- 6
   1 --- 8
@@ -582,8 +578,6 @@ flowchart LR
   116 <--x 94
   117 <--x 94
   118 <--x 94
-  119 <--x 145
-  122 <--x 146
-  138 <--x 143
-  139 <--x 144
+  119 <--x 144
+  139 <--x 143
 ```

--- a/rust/kcl-lib/tests/kcl_samples/gridfinity-baseplate-magnets/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/gridfinity-baseplate-magnets/artifact_commands.snap
@@ -3220,64 +3220,20 @@ description: Artifact commands gridfinity-baseplate-magnets.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 4.0,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 4.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 4.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 4.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {
@@ -3427,64 +3383,20 @@ description: Artifact commands gridfinity-baseplate-magnets.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 4.0,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 4.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 4.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 4.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/gridfinity-baseplate-magnets/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/gridfinity-baseplate-magnets/artifact_graph_flowchart.snap.md
@@ -259,19 +259,7 @@ flowchart LR
   143["SweepEdge Adjacent"]
   144["EdgeCut Fillet<br>[5152, 5491, 0]"]
     %% [ProgramBodyItem { index: 24 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  145["EdgeCut Fillet<br>[5152, 5491, 0]"]
-    %% [ProgramBodyItem { index: 24 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  146["EdgeCut Fillet<br>[5152, 5491, 0]"]
-    %% [ProgramBodyItem { index: 24 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  147["EdgeCut Fillet<br>[5152, 5491, 0]"]
-    %% [ProgramBodyItem { index: 24 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  148["EdgeCut Fillet<br>[5816, 6160, 0]"]
-    %% [ProgramBodyItem { index: 27 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  149["EdgeCut Fillet<br>[5816, 6160, 0]"]
-    %% [ProgramBodyItem { index: 27 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  150["EdgeCut Fillet<br>[5816, 6160, 0]"]
-    %% [ProgramBodyItem { index: 27 }, VariableDeclarationDeclaration, VariableDeclarationInit]
-  151["EdgeCut Fillet<br>[5816, 6160, 0]"]
+  145["EdgeCut Fillet<br>[5816, 6160, 0]"]
     %% [ProgramBodyItem { index: 27 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   1 <--x 8
   1 --- 12
@@ -554,12 +542,6 @@ flowchart LR
   123 <--x 107
   124 <--x 107
   125 <--x 107
-  126 <--x 151
-  127 <--x 150
-  128 <--x 148
-  129 <--x 149
-  130 <--x 146
-  131 <--x 145
-  132 <--x 144
-  133 <--x 147
+  126 <--x 145
+  130 <--x 144
 ```

--- a/rust/kcl-lib/tests/kcl_samples/gridfinity-bins-stacking-lip/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/gridfinity-bins-stacking-lip/artifact_commands.snap
@@ -745,64 +745,20 @@ description: Artifact commands gridfinity-bins-stacking-lip.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 0.8,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 0.8,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 0.8,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 0.8,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {
@@ -2982,64 +2938,20 @@ description: Artifact commands gridfinity-bins-stacking-lip.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 3.75,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 3.75,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 3.75,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 3.75,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/gridfinity-bins-stacking-lip/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/gridfinity-bins-stacking-lip/artifact_graph_flowchart.snap.md
@@ -439,19 +439,7 @@ flowchart LR
   265["SweepEdge Adjacent"]
   266["EdgeCut Fillet<br>[2865, 3095, 0]"]
     %% [ProgramBodyItem { index: 29 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  267["EdgeCut Fillet<br>[2865, 3095, 0]"]
-    %% [ProgramBodyItem { index: 29 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  268["EdgeCut Fillet<br>[2865, 3095, 0]"]
-    %% [ProgramBodyItem { index: 29 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  269["EdgeCut Fillet<br>[2865, 3095, 0]"]
-    %% [ProgramBodyItem { index: 29 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  270["EdgeCut Fillet<br>[4934, 5167, 0]"]
-    %% [ProgramBodyItem { index: 34 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  271["EdgeCut Fillet<br>[4934, 5167, 0]"]
-    %% [ProgramBodyItem { index: 34 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  272["EdgeCut Fillet<br>[4934, 5167, 0]"]
-    %% [ProgramBodyItem { index: 34 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  273["EdgeCut Fillet<br>[4934, 5167, 0]"]
+  267["EdgeCut Fillet<br>[4934, 5167, 0]"]
     %% [ProgramBodyItem { index: 34 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
   1 <--x 10
   1 --- 14
@@ -1114,12 +1102,6 @@ flowchart LR
   212 <--x 163
   213 <--x 163
   214 <--x 163
-  249 <--x 267
-  250 <--x 269
-  251 <--x 266
-  252 <--x 268
-  254 <--x 271
-  255 <--x 270
-  256 <--x 272
-  257 <--x 273
+  249 <--x 266
+  254 <--x 267
 ```

--- a/rust/kcl-lib/tests/kcl_samples/gridfinity-bins/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/gridfinity-bins/artifact_commands.snap
@@ -745,64 +745,20 @@ description: Artifact commands gridfinity-bins.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 0.8,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 0.8,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 0.8,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 0.8,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {
@@ -2982,64 +2938,20 @@ description: Artifact commands gridfinity-bins.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 3.75,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 3.75,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 3.75,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 3.75,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/gridfinity-bins/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/gridfinity-bins/artifact_graph_flowchart.snap.md
@@ -195,19 +195,7 @@ flowchart LR
   113["SweepEdge Adjacent"]
   114["EdgeCut Fillet<br>[2606, 2836, 0]"]
     %% [ProgramBodyItem { index: 22 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  115["EdgeCut Fillet<br>[2606, 2836, 0]"]
-    %% [ProgramBodyItem { index: 22 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  116["EdgeCut Fillet<br>[2606, 2836, 0]"]
-    %% [ProgramBodyItem { index: 22 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  117["EdgeCut Fillet<br>[2606, 2836, 0]"]
-    %% [ProgramBodyItem { index: 22 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  118["EdgeCut Fillet<br>[4704, 4937, 0]"]
-    %% [ProgramBodyItem { index: 27 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  119["EdgeCut Fillet<br>[4704, 4937, 0]"]
-    %% [ProgramBodyItem { index: 27 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  120["EdgeCut Fillet<br>[4704, 4937, 0]"]
-    %% [ProgramBodyItem { index: 27 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  121["EdgeCut Fillet<br>[4704, 4937, 0]"]
+  115["EdgeCut Fillet<br>[4704, 4937, 0]"]
     %% [ProgramBodyItem { index: 27 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
   1 <--x 6
   1 --- 10
@@ -466,12 +454,6 @@ flowchart LR
   78 <--x 74
   79 <--x 74
   80 <--x 74
-  105 <--x 115
-  106 <--x 117
-  107 <--x 114
-  108 <--x 116
-  110 <--x 119
-  111 <--x 118
-  112 <--x 120
-  113 <--x 121
+  105 <--x 114
+  110 <--x 115
 ```

--- a/rust/kcl-lib/tests/kcl_samples/keyboard/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/keyboard/artifact_commands.snap
@@ -258,64 +258,20 @@ description: Artifact commands keyboard.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 15.239999999999998,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 15.239999999999998,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 15.239999999999998,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 15.239999999999998,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/keyboard/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/keyboard/artifact_graph_flowchart.snap.md
@@ -1683,12 +1683,6 @@ flowchart LR
   1033["SweepEdge Adjacent"]
   1034["EdgeCut Fillet<br>[932, 1089, 0]"]
     %% [ProgramBodyItem { index: 12 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 9 }]
-  1035["EdgeCut Fillet<br>[932, 1089, 0]"]
-    %% [ProgramBodyItem { index: 12 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 9 }]
-  1036["EdgeCut Fillet<br>[932, 1089, 0]"]
-    %% [ProgramBodyItem { index: 12 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 9 }]
-  1037["EdgeCut Fillet<br>[932, 1089, 0]"]
-    %% [ProgramBodyItem { index: 12 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 9 }]
   1 --- 29
   2 --- 42
   3 --- 34
@@ -2017,7 +2011,6 @@ flowchart LR
   60 x--> 563
   60 --- 637
   60 --- 845
-  60 --- 1035
   61 --- 369
   61 x--> 563
   61 --- 636
@@ -2026,7 +2019,6 @@ flowchart LR
   62 x--> 563
   62 --- 635
   62 --- 843
-  62 --- 1037
   63 --- 371
   63 x--> 563
   63 --- 634
@@ -4357,6 +4349,5 @@ flowchart LR
   675 <--x 616
   676 <--x 616
   677 <--x 616
-  635 <--x 1036
   637 <--x 1034
 ```

--- a/rust/kcl-lib/tests/kcl_samples/mounting-plate/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/mounting-plate/artifact_commands.snap
@@ -694,64 +694,20 @@ description: Artifact commands mounting-plate.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 12.7,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 12.7,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 12.7,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 12.7,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/mounting-plate/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/mounting-plate/artifact_graph_flowchart.snap.md
@@ -74,12 +74,6 @@ flowchart LR
   37["SweepEdge Adjacent"]
   38["EdgeCut Fillet<br>[1927, 2192, 0]"]
     %% [ProgramBodyItem { index: 9 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  39["EdgeCut Fillet<br>[1927, 2192, 0]"]
-    %% [ProgramBodyItem { index: 9 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  40["EdgeCut Fillet<br>[1927, 2192, 0]"]
-    %% [ProgramBodyItem { index: 9 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
-  41["EdgeCut Fillet<br>[1927, 2192, 0]"]
-    %% [ProgramBodyItem { index: 9 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 7 }]
   1 --- 2
   1 --- 3
   1 --- 4
@@ -148,8 +142,5 @@ flowchart LR
   31 <--x 29
   32 <--x 29
   33 <--x 29
-  34 <--x 38
-  35 <--x 39
-  36 <--x 41
-  37 <--x 40
+  37 <--x 38
 ```

--- a/rust/kcl-lib/tests/kcl_samples/pillow-block-bearing/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/pillow-block-bearing/artifact_commands.snap
@@ -1520,64 +1520,20 @@ description: Artifact commands pillow-block-bearing.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 3.175,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 3.175,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 3.175,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 3.175,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/pillow-block-bearing/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/pillow-block-bearing/artifact_graph_flowchart.snap.md
@@ -260,9 +260,6 @@ flowchart LR
   183["SweepEdge Adjacent"]
   184["SweepEdge Adjacent"]
   185["EdgeCut Fillet<br>[1308, 1593, 3]"]
-  186["EdgeCut Fillet<br>[1308, 1593, 3]"]
-  187["EdgeCut Fillet<br>[1308, 1593, 3]"]
-  188["EdgeCut Fillet<br>[1308, 1593, 3]"]
   1 --- 6
   2 --- 7
   3 --- 8
@@ -655,8 +652,5 @@ flowchart LR
   142 <--x 134
   143 <--x 134
   138 <--x 135
-  172 <--x 187
-  173 <--x 186
-  174 <--x 185
-  175 <--x 188
+  173 <--x 185
 ```

--- a/rust/kcl-lib/tests/kcl_samples/pipe-flange-assembly/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/pipe-flange-assembly/artifact_commands.snap
@@ -2810,30 +2810,16 @@ description: Artifact commands pipe-flange-assembly.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 0.508,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
         "[uuid]"
-      ],
-      "radius": 0.508,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/pipe-flange-assembly/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/pipe-flange-assembly/artifact_graph_flowchart.snap.md
@@ -325,7 +325,6 @@ flowchart LR
   236["SweepEdge Adjacent"]
   237["SweepEdge Adjacent"]
   238["EdgeCut Fillet<br>[576, 642, 5]"]
-  239["EdgeCut Fillet<br>[576, 642, 5]"]
   1 --- 23
   2 --- 26
   3 --- 25
@@ -490,7 +489,7 @@ flowchart LR
   60 x--> 168
   60 --- 185
   60 --- 216
-  60 --- 239
+  60 --- 238
   61 --- 140
   61 x--> 157
   61 --- 197
@@ -783,5 +782,4 @@ flowchart LR
   177 <--x 174
   205 <--x 174
   184 <--x 175
-  185 <--x 238
 ```

--- a/rust/kcl-lib/tests/kcl_samples/sheet-metal-bracket/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/sheet-metal-bracket/artifact_commands.snap
@@ -539,64 +539,20 @@ description: Artifact commands sheet-metal-bracket.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 12.7,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 12.7,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 12.7,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 12.7,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/sheet-metal-bracket/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/sheet-metal-bracket/artifact_graph_flowchart.snap.md
@@ -211,12 +211,6 @@ flowchart LR
   126["SweepEdge Adjacent"]
   127["EdgeCut Fillet<br>[2644, 2815, 0]"]
     %% [ProgramBodyItem { index: 14 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 26 }]
-  128["EdgeCut Fillet<br>[2644, 2815, 0]"]
-    %% [ProgramBodyItem { index: 14 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 26 }]
-  129["EdgeCut Fillet<br>[2644, 2815, 0]"]
-    %% [ProgramBodyItem { index: 14 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 26 }]
-  130["EdgeCut Fillet<br>[2644, 2815, 0]"]
-    %% [ProgramBodyItem { index: 14 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 26 }]
   1 --- 6
   73 x--> 2
   72 x--> 3
@@ -303,7 +297,7 @@ flowchart LR
   21 x--> 77
   21 --- 89
   21 --- 113
-  21 --- 128
+  21 --- 127
   22 --- 71
   22 x--> 77
   22 --- 90
@@ -344,7 +338,6 @@ flowchart LR
   32 x--> 77
   32 --- 99
   32 --- 123
-  32 --- 127
   34 x--> 71
   34 --- 76
   34 --- 102
@@ -527,6 +520,4 @@ flowchart LR
   97 <--x 78
   98 <--x 78
   99 <--x 78
-  89 <--x 129
-  99 <--x 130
 ```

--- a/rust/kcl-lib/tests/kcl_samples/socket-head-cap-screw/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/socket-head-cap-screw/artifact_commands.snap
@@ -198,30 +198,16 @@ description: Artifact commands socket-head-cap-screw.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 0.508,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
         "[uuid]"
-      ],
-      "radius": 0.508,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/socket-head-cap-screw/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/socket-head-cap-screw/artifact_graph_flowchart.snap.md
@@ -85,9 +85,7 @@ flowchart LR
   48["SweepEdge Adjacent"]
   49["EdgeCut Fillet<br>[798, 864, 0]"]
     %% [ProgramBodyItem { index: 6 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 3 }]
-  50["EdgeCut Fillet<br>[798, 864, 0]"]
-    %% [ProgramBodyItem { index: 6 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 3 }]
-  51["EdgeCut Fillet<br>[1571, 1630, 0]"]
+  50["EdgeCut Fillet<br>[1571, 1630, 0]"]
     %% [ProgramBodyItem { index: 8 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 3 }]
   1 --- 4
   29 x--> 2
@@ -112,7 +110,7 @@ flowchart LR
   7 x--> 31
   7 --- 40
   7 --- 48
-  7 --- 50
+  7 --- 49
   8 --- 26
   8 x--> 29
   8 --- 39
@@ -199,6 +197,5 @@ flowchart LR
   38 <--x 30
   39 <--x 30
   33 <--x 32
-  33 <--x 51
-  40 <--x 49
+  33 <--x 50
 ```

--- a/rust/kcl-lib/tests/kcl_samples/surgical-drill-guide/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/surgical-drill-guide/artifact_commands.snap
@@ -1435,30 +1435,16 @@ description: Artifact commands surgical-drill-guide.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 1.0,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
         "[uuid]"
-      ],
-      "radius": 1.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {
@@ -2266,30 +2252,16 @@ description: Artifact commands surgical-drill-guide.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 1.0,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
         "[uuid]"
-      ],
-      "radius": 1.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/surgical-drill-guide/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/surgical-drill-guide/artifact_graph_flowchart.snap.md
@@ -273,13 +273,9 @@ flowchart LR
     %% [ProgramBodyItem { index: 12 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 3 }]
   148["EdgeCut Fillet<br>[2915, 3079, 0]"]
     %% [ProgramBodyItem { index: 14 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 4 }]
-  149["EdgeCut Fillet<br>[2915, 3079, 0]"]
-    %% [ProgramBodyItem { index: 14 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 4 }]
-  150["EdgeCut Chamfer<br>[3547, 3670, 0]"]
+  149["EdgeCut Chamfer<br>[3547, 3670, 0]"]
     %% [ProgramBodyItem { index: 16 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 3 }]
-  151["EdgeCut Fillet<br>[4240, 4404, 0]"]
-    %% [ProgramBodyItem { index: 18 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 4 }]
-  152["EdgeCut Fillet<br>[4240, 4404, 0]"]
+  150["EdgeCut Fillet<br>[4240, 4404, 0]"]
     %% [ProgramBodyItem { index: 18 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 4 }]
   1 --- 17
   2 --- 18
@@ -407,7 +403,7 @@ flowchart LR
   44 x--> 109
   44 --- 121
   44 --- 139
-  44 --- 149
+  44 --- 148
   46 --- 88
   46 x--> 96
   46 --- 122
@@ -424,7 +420,6 @@ flowchart LR
   49 x--> 105
   49 --- 111
   49 --- 129
-  49 --- 151
   64 --- 78
   64 --- 79
   64 --- 80
@@ -558,8 +553,7 @@ flowchart LR
   119 <--x 104
   126 <--x 106
   125 <--x 108
-  111 <--x 152
-  121 <--x 148
+  111 <--x 150
   125 <--x 147
-  126 <--x 150
+  126 <--x 149
 ```

--- a/rust/kcl-lib/tests/kcl_samples/walkie-talkie/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/walkie-talkie/artifact_commands.snap
@@ -10058,64 +10058,20 @@ description: Artifact commands walkie-talkie.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 1.27,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
+        "[uuid]",
+        "[uuid]",
         "[uuid]"
-      ],
-      "radius": 1.27,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 1.27,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
-        "[uuid]"
-      ],
-      "radius": 1.27,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/walkie-talkie/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/walkie-talkie/artifact_graph_flowchart.snap.md
@@ -463,18 +463,15 @@ flowchart LR
   347["EdgeCut Chamfer<br>[657, 888, 2]"]
   348["EdgeCut Chamfer<br>[657, 888, 2]"]
   349["EdgeCut Fillet<br>[667, 873, 6]"]
-  350["EdgeCut Fillet<br>[667, 873, 6]"]
-  351["EdgeCut Fillet<br>[667, 873, 6]"]
-  352["EdgeCut Fillet<br>[667, 873, 6]"]
-  353["EdgeCut Fillet<br>[443, 512, 7]"]
+  350["EdgeCut Fillet<br>[443, 512, 7]"]
+  351["EdgeCut Chamfer<br>[707, 853, 8]"]
+  352["EdgeCut Chamfer<br>[707, 853, 8]"]
+  353["EdgeCut Chamfer<br>[707, 853, 8]"]
   354["EdgeCut Chamfer<br>[707, 853, 8]"]
   355["EdgeCut Chamfer<br>[707, 853, 8]"]
   356["EdgeCut Chamfer<br>[707, 853, 8]"]
   357["EdgeCut Chamfer<br>[707, 853, 8]"]
   358["EdgeCut Chamfer<br>[707, 853, 8]"]
-  359["EdgeCut Chamfer<br>[707, 853, 8]"]
-  360["EdgeCut Chamfer<br>[707, 853, 8]"]
-  361["EdgeCut Chamfer<br>[707, 853, 8]"]
   1 --- 18
   2 --- 22
   3 --- 23
@@ -1230,21 +1227,18 @@ flowchart LR
   285 <--x 238
   286 <--x 238
   287 <--x 238
-  283 <--x 353
-  296 <--x 352
-  297 <--x 351
-  298 <--x 349
-  299 <--x 350
-  300 <--x 360
-  301 <--x 359
+  283 <--x 350
+  299 <--x 349
+  300 <--x 357
+  301 <--x 356
   308 <--x 348
   309 <--x 345
   310 <--x 346
   311 <--x 347
-  332 <--x 357
-  333 <--x 358
-  337 <--x 356
-  338 <--x 361
-  341 <--x 355
-  342 <--x 354
+  332 <--x 354
+  333 <--x 355
+  337 <--x 353
+  338 <--x 358
+  341 <--x 352
+  342 <--x 351
 ```

--- a/rust/kcl-lib/tests/pentagon_fillet_sugar/artifact_commands.snap
+++ b/rust/kcl-lib/tests/pentagon_fillet_sugar/artifact_commands.snap
@@ -416,30 +416,16 @@ description: Artifact commands pentagon_fillet_sugar.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 5.0,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
         "[uuid]"
-      ],
-      "radius": 5.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {
@@ -516,30 +502,16 @@ description: Artifact commands pentagon_fillet_sugar.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 5.0,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
         "[uuid]"
-      ],
-      "radius": 5.0,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/pentagon_fillet_sugar/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/pentagon_fillet_sugar/artifact_graph_flowchart.snap.md
@@ -70,11 +70,7 @@ flowchart LR
   37["SweepEdge Adjacent"]
   38["EdgeCut Fillet<br>[685, 812, 0]"]
     %% [ProgramBodyItem { index: 7 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 2 }]
-  39["EdgeCut Fillet<br>[685, 812, 0]"]
-    %% [ProgramBodyItem { index: 7 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 2 }]
-  40["EdgeCut Fillet<br>[896, 1023, 0]"]
-    %% [ProgramBodyItem { index: 9 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 2 }]
-  41["EdgeCut Fillet<br>[896, 1023, 0]"]
+  39["EdgeCut Fillet<br>[896, 1023, 0]"]
     %% [ProgramBodyItem { index: 9 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 2 }]
   1 --- 4
   22 x--> 2
@@ -109,12 +105,12 @@ flowchart LR
   10 x--> 22
   10 --- 28
   10 --- 33
-  10 --- 39
+  10 --- 38
   11 --- 20
   11 x--> 23
   11 --- 29
   11 --- 34
-  11 --- 40
+  11 --- 39
   16 --- 21
   16 --- 22
   16 --- 23
@@ -152,6 +148,4 @@ flowchart LR
   30 <--x 27
   31 <--x 27
   32 <--x 27
-  28 <--x 38
-  29 <--x 41
 ```

--- a/rust/kcl-lib/tests/rotate_after_fillet/artifact_commands.snap
+++ b/rust/kcl-lib/tests/rotate_after_fillet/artifact_commands.snap
@@ -198,30 +198,16 @@ description: Artifact commands rotate_after_fillet.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 0.02,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
         "[uuid]"
-      ],
-      "radius": 0.02,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/rotate_after_fillet/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/rotate_after_fillet/artifact_graph_flowchart.snap.md
@@ -85,9 +85,7 @@ flowchart LR
   48["SweepEdge Adjacent"]
   49["EdgeCut Fillet<br>[456, 522, 0]"]
     %% [ProgramBodyItem { index: 7 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 3 }]
-  50["EdgeCut Fillet<br>[456, 522, 0]"]
-    %% [ProgramBodyItem { index: 7 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 3 }]
-  51["EdgeCut Fillet<br>[1381, 1440, 0]"]
+  50["EdgeCut Fillet<br>[1381, 1440, 0]"]
     %% [ProgramBodyItem { index: 7 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 2 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 3 }]
   1 --- 4
   29 x--> 2
@@ -112,7 +110,7 @@ flowchart LR
   7 x--> 31
   7 --- 40
   7 --- 48
-  7 --- 50
+  7 --- 49
   8 --- 26
   8 x--> 29
   8 --- 39
@@ -199,6 +197,5 @@ flowchart LR
   38 <--x 30
   39 <--x 30
   33 <--x 32
-  33 <--x 51
-  40 <--x 49
+  33 <--x 50
 ```

--- a/rust/kcl-lib/tests/scale_after_fillet/artifact_commands.snap
+++ b/rust/kcl-lib/tests/scale_after_fillet/artifact_commands.snap
@@ -198,30 +198,16 @@ description: Artifact commands scale_after_fillet.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 0.02,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
         "[uuid]"
-      ],
-      "radius": 0.02,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/scale_after_fillet/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/scale_after_fillet/artifact_graph_flowchart.snap.md
@@ -85,9 +85,7 @@ flowchart LR
   48["SweepEdge Adjacent"]
   49["EdgeCut Fillet<br>[456, 522, 0]"]
     %% [ProgramBodyItem { index: 7 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 3 }]
-  50["EdgeCut Fillet<br>[456, 522, 0]"]
-    %% [ProgramBodyItem { index: 7 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 3 }]
-  51["EdgeCut Fillet<br>[1381, 1440, 0]"]
+  50["EdgeCut Fillet<br>[1381, 1440, 0]"]
     %% [ProgramBodyItem { index: 7 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 2 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 3 }]
   1 --- 4
   29 x--> 2
@@ -112,7 +110,7 @@ flowchart LR
   7 x--> 31
   7 --- 40
   7 --- 48
-  7 --- 50
+  7 --- 49
   8 --- 26
   8 x--> 29
   8 --- 39
@@ -199,6 +197,5 @@ flowchart LR
   38 <--x 30
   39 <--x 30
   33 <--x 32
-  33 <--x 51
-  40 <--x 49
+  33 <--x 50
 ```

--- a/rust/kcl-lib/tests/subtract_regression10/artifact_commands.snap
+++ b/rust/kcl-lib/tests/subtract_regression10/artifact_commands.snap
@@ -1017,30 +1017,16 @@ description: Artifact commands subtract_regression10.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 1.875,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
         "[uuid]"
-      ],
-      "radius": 1.875,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/subtract_regression10/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/subtract_regression10/artifact_graph_flowchart.snap.md
@@ -337,8 +337,6 @@ flowchart LR
   179["SweepEdge Adjacent"]
   180["EdgeCut Fillet<br>[3052, 3126, 0]"]
     %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 3 }]
-  181["EdgeCut Fillet<br>[3052, 3126, 0]"]
-    %% [ProgramBodyItem { index: 13 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 3 }]
   1 --- 10
   2 --- 11
   3 --- 12
@@ -514,7 +512,6 @@ flowchart LR
   48 x--> 137
   48 --- 148
   48 --- 174
-  48 --- 181
   79 --- 131
   79 x--> 139
   79 --- 149

--- a/rust/kcl-lib/tests/translate_after_fillet/artifact_commands.snap
+++ b/rust/kcl-lib/tests/translate_after_fillet/artifact_commands.snap
@@ -198,30 +198,16 @@ description: Artifact commands translate_after_fillet.kcl
       "object_id": "[uuid]",
       "edge_id": null,
       "edge_ids": [
+        "[uuid]",
         "[uuid]"
       ],
       "radius": 0.02,
       "tolerance": 0.0000001,
       "cut_type": "fillet",
       "strategy": "automatic",
-      "extra_face_ids": []
-    }
-  },
-  {
-    "cmdId": "[uuid]",
-    "range": [],
-    "command": {
-      "type": "solid3d_fillet_edge",
-      "object_id": "[uuid]",
-      "edge_id": null,
-      "edge_ids": [
+      "extra_face_ids": [
         "[uuid]"
-      ],
-      "radius": 0.02,
-      "tolerance": 0.0000001,
-      "cut_type": "fillet",
-      "strategy": "automatic",
-      "extra_face_ids": []
+      ]
     }
   },
   {

--- a/rust/kcl-lib/tests/translate_after_fillet/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/translate_after_fillet/artifact_graph_flowchart.snap.md
@@ -85,9 +85,7 @@ flowchart LR
   48["SweepEdge Adjacent"]
   49["EdgeCut Fillet<br>[456, 522, 0]"]
     %% [ProgramBodyItem { index: 7 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 3 }]
-  50["EdgeCut Fillet<br>[456, 522, 0]"]
-    %% [ProgramBodyItem { index: 7 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 3 }]
-  51["EdgeCut Fillet<br>[1381, 1440, 0]"]
+  50["EdgeCut Fillet<br>[1381, 1440, 0]"]
     %% [ProgramBodyItem { index: 7 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 2 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 3 }]
   1 --- 4
   29 x--> 2
@@ -112,7 +110,7 @@ flowchart LR
   7 x--> 31
   7 --- 40
   7 --- 48
-  7 --- 50
+  7 --- 49
   8 --- 26
   8 x--> 29
   8 --- 39
@@ -199,6 +197,5 @@ flowchart LR
   38 <--x 30
   39 <--x 30
   33 <--x 32
-  33 <--x 51
-  40 <--x 49
+  33 <--x 50
 ```


### PR DESCRIPTION
KCL's `fillet` function takes an array of edges to fillet. Previously this would do `n` fillet API commands, one per edge. This PR combines them all into one call, which should improve performance. Here's a typical example, from a KCL artifact command snapshot: 

<img width="1025" alt="Screenshot 2025-05-22 at 4 10 15 PM" src="https://github.com/user-attachments/assets/56235e83-cbb1-4192-8556-90647c47425a" />

Besides performance, this should fix a bug where some KCL fillets would fail, when they should have succeeded. Example from @max-mrgrsk:

```kcl
sketch001 = startSketchOn(XY)
  |> startProfile(at = [-12, -6])
  |> line(end = [0, 12], tag = $seg04)
  |> line(end = [24, 0], tag = $seg03)
  |> line(end = [0, -12], tag = $seg02)
  |> line(endAbsolute = [profileStartX(%), profileStartY(%)], tag = $seg01)
  |> close()
extrude001 = extrude(
       sketch001,
       length = 12,
       tagEnd = $capEnd001,
       tagStart = $capStart001,
     )
  |> fillet(
       radius = 5,
       tags = [
         getCommonEdge(faces = [seg02, capEnd001]),
         getCommonEdge(faces = [seg01, capEnd001]),
         getCommonEdge(faces = [seg03, capEnd001]),
         getCommonEdge(faces = [seg04, capEnd001])
       ],
     )
```

This program fails on main, but succeeds on this branch.
