### PR TITLE
Docs: Links and desciptions for number types

### DIFF
--- a/docs/kcl-std/functions/std-helix.md
+++ b/docs/kcl-std/functions/std-helix.md
@@ -25,12 +25,12 @@ helix(
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `revolutions` | `number(_)` | Number of revolutions. | Yes |
-| `angleStart` | `number(Angle)` | Start angle. | Yes |
+| `revolutions` | [`number(_)`](/docs/kcl-std/types/std-types-number) | Number of revolutions. | Yes |
+| `angleStart` | [`number(Angle)`](/docs/kcl-std/types/std-types-number) | Start angle. | Yes |
 | `ccw` | [`bool`](/docs/kcl-std/types/std-types-bool) | Is the helix rotation counter clockwise? The default is `false`. | No |
-| `radius` | `number(Length)` | Radius of the helix. | No |
+| `radius` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | Radius of the helix. | No |
 | `axis` | [`Axis3d`](/docs/kcl-std/types/std-types-Axis3d) or [`Edge`](/docs/kcl-std/types/std-types-Edge) | Axis to use for the helix. | No |
-| `length` | `number(Length)` | Length of the helix. This is not necessary if the helix is created around an edge. If not given the length of the edge is used. | No |
+| `length` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | Length of the helix. This is not necessary if the helix is created around an edge. If not given the length of the edge is used. | No |
 | `cylinder` | [`Solid`](/docs/kcl-std/types/std-types-Solid) | Cylinder to create the helix on. | No |
 
 ### Returns

--- a/docs/kcl-std/functions/std-math-acos.md
+++ b/docs/kcl-std/functions/std-math-acos.md
@@ -17,11 +17,11 @@ acos(@num: number(_)): number(rad)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | `number(_)` |  | Yes |
+| `num` | [`number(_)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
 
 ### Returns
 
-`number(rad)`
+[`number(rad)`](/docs/kcl-std/types/std-types-number) - A number
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-asin.md
+++ b/docs/kcl-std/functions/std-math-asin.md
@@ -17,11 +17,11 @@ asin(@num: number(_)): number(rad)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | `number(_)` |  | Yes |
+| `num` | [`number(_)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
 
 ### Returns
 
-`number(rad)`
+[`number(rad)`](/docs/kcl-std/types/std-types-number) - A number
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-atan.md
+++ b/docs/kcl-std/functions/std-math-atan.md
@@ -17,11 +17,11 @@ Consider using `atan2()` instead for the true inverse of tangent.
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | `number(_)` |  | Yes |
+| `num` | [`number(_)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
 
 ### Returns
 
-`number(rad)`
+[`number(rad)`](/docs/kcl-std/types/std-types-number) - A number
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-atan2.md
+++ b/docs/kcl-std/functions/std-math-atan2.md
@@ -20,12 +20,12 @@ atan2(
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `y` | `number(Length)` |  | Yes |
-| `x` | `number(Length)` |  | Yes |
+| `y` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `x` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
 
 ### Returns
 
-`number(rad)`
+[`number(rad)`](/docs/kcl-std/types/std-types-number) - A number
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-cos.md
+++ b/docs/kcl-std/functions/std-math-cos.md
@@ -17,11 +17,11 @@ cos(@num: number(Angle)): number(_)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | `number(Angle)` |  | Yes |
+| `num` | [`number(Angle)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
 
 ### Returns
 
-`number(_)`
+[`number(_)`](/docs/kcl-std/types/std-types-number) - A number
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-log.md
+++ b/docs/kcl-std/functions/std-math-log.md
@@ -23,7 +23,7 @@ and `log10` can produce more accurate results for base 10.
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
 | `input` | [`number`](/docs/kcl-std/types/std-types-number) | The number to compute the logarithm of. | Yes |
-| `base` | `number(_)` | The base of the logarithm. | Yes |
+| `base` | [`number(_)`](/docs/kcl-std/types/std-types-number) | The base of the logarithm. | Yes |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-math-polar.md
+++ b/docs/kcl-std/functions/std-math-polar.md
@@ -21,8 +21,8 @@ cartesian (x/y/z grid) coordinates.
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `angle` | `number(rad)` |  | Yes |
-| `length` | `number(Length)` |  | Yes |
+| `angle` | [`number(rad)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `length` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-math-pow.md
+++ b/docs/kcl-std/functions/std-math-pow.md
@@ -21,7 +21,7 @@ pow(
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
 | `input` | [`number`](/docs/kcl-std/types/std-types-number) | The number to raise. | Yes |
-| `exp` | `number(_)` | The power to raise to. | Yes |
+| `exp` | [`number(_)`](/docs/kcl-std/types/std-types-number) | The power to raise to. | Yes |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-math-sin.md
+++ b/docs/kcl-std/functions/std-math-sin.md
@@ -17,11 +17,11 @@ sin(@num: number(Angle)): number(_)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | `number(Angle)` |  | Yes |
+| `num` | [`number(Angle)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
 
 ### Returns
 
-`number(_)`
+[`number(_)`](/docs/kcl-std/types/std-types-number) - A number
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-tan.md
+++ b/docs/kcl-std/functions/std-math-tan.md
@@ -17,11 +17,11 @@ tan(@num: number(Angle)): number(_)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | `number(Angle)` |  | Yes |
+| `num` | [`number(Angle)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
 
 ### Returns
 
-`number(_)`
+[`number(_)`](/docs/kcl-std/types/std-types-number) - A number
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-offsetPlane.md
+++ b/docs/kcl-std/functions/std-offsetPlane.md
@@ -22,7 +22,7 @@ plane and 10 units away from it.
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
 | `plane` | [`Plane`](/docs/kcl-std/types/std-types-Plane) | The plane (e.g. `XY`) which this new plane is created from. | Yes |
-| `offset` | `number(Length)` | Distance from the standard plane this new plane will be created at. | Yes |
+| `offset` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | Distance from the standard plane this new plane will be created at. | Yes |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-sketch-circle.md
+++ b/docs/kcl-std/functions/std-sketch-circle.md
@@ -25,7 +25,7 @@ the provided (x, y) origin point.
 |----------|------|-------------|----------|
 | `sketch_or_surface` | [`Sketch`](/docs/kcl-std/types/std-types-Sketch) or [`Plane`](/docs/kcl-std/types/std-types-Plane) or [`Face`](/docs/kcl-std/types/std-types-Face) | Sketch to extend, or plane or surface to sketch on. | Yes |
 | `center` | [`Point2d`](/docs/kcl-std/types/std-types-Point2d) | The center of the circle. | Yes |
-| `radius` | `number(Length)` | The radius of the circle. | Yes |
+| `radius` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The radius of the circle. | Yes |
 | [`tag`](/docs/kcl-std/types/std-types-tag) | [`tag`](/docs/kcl-std/types/std-types-tag) | Create a new tag which refers to this circle. | No |
 
 ### Returns

--- a/docs/kcl-std/functions/std-sketch-revolve.md
+++ b/docs/kcl-std/functions/std-sketch-revolve.md
@@ -37,10 +37,10 @@ revolved around the same axis.
 |----------|------|-------------|----------|
 | `sketches` | [`[Sketch; 1+]`](/docs/kcl-std/types/std-types-Sketch) | The sketch or set of sketches that should be revolved | Yes |
 | `axis` | [`Axis2d`](/docs/kcl-std/types/std-types-Axis2d) or [`Edge`](/docs/kcl-std/types/std-types-Edge) | Axis of revolution. | Yes |
-| `angle` | `number(Angle)` | Angle to revolve (in degrees). Default is 360. | No |
-| `tolerance` | `number(Length)` | Tolerance for the revolve operation. | No |
+| `angle` | [`number(Angle)`](/docs/kcl-std/types/std-types-number) | Angle to revolve (in degrees). Default is 360. | No |
+| `tolerance` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | Tolerance for the revolve operation. | No |
 | `symmetric` | [`bool`](/docs/kcl-std/types/std-types-bool) | If true, the extrusion will happen symmetrically around the sketch. Otherwise, the extrusion will happen on only one side of the sketch. | No |
-| `bidirectionalAngle` | `number(Angle)` | If specified, will also revolve in the opposite direction to 'angle' to the specified angle. If 'symmetric' is true, this value is ignored. | No |
+| `bidirectionalAngle` | [`number(Angle)`](/docs/kcl-std/types/std-types-number) | If specified, will also revolve in the opposite direction to 'angle' to the specified angle. If 'symmetric' is true, this value is ignored. | No |
 | `tagStart` | [`tag`](/docs/kcl-std/types/std-types-tag) | A named tag for the face at the start of the revolve, i.e. the original sketch. | No |
 | `tagEnd` | [`tag`](/docs/kcl-std/types/std-types-tag) | A named tag for the face at the end of the revolve. | No |
 

--- a/docs/kcl-std/functions/std-solid-chamfer.md
+++ b/docs/kcl-std/functions/std-solid-chamfer.md
@@ -25,7 +25,7 @@ a sharp, straight transitional edge.
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
 | `solid` | [`Solid`](/docs/kcl-std/types/std-types-Solid) | The solid whose edges should be chamfered | Yes |
-| `length` | `number(Length)` | The length of the chamfer | Yes |
+| `length` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The length of the chamfer | Yes |
 | `tags` | [`[Edge; 1+]`](/docs/kcl-std/types/std-types-Edge) | The paths you want to chamfer | Yes |
 | [`tag`](/docs/kcl-std/types/std-types-tag) | [`tag`](/docs/kcl-std/types/std-types-tag) | Create a new tag which refers to this chamfer | No |
 

--- a/docs/kcl-std/functions/std-solid-fillet.md
+++ b/docs/kcl-std/functions/std-solid-fillet.md
@@ -26,9 +26,9 @@ will smoothly blend the transition.
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
 | `solid` | [`Solid`](/docs/kcl-std/types/std-types-Solid) | The solid whose edges should be filletted | Yes |
-| `radius` | `number(Length)` | The radius of the fillet | Yes |
+| `radius` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The radius of the fillet | Yes |
 | `tags` | [`[Edge; 1+]`](/docs/kcl-std/types/std-types-Edge) | The paths you want to fillet | Yes |
-| `tolerance` | `number(Length)` | The tolerance for this fillet | No |
+| `tolerance` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The tolerance for this fillet | No |
 | [`tag`](/docs/kcl-std/types/std-types-tag) | [`tag`](/docs/kcl-std/types/std-types-tag) | Create a new tag which refers to this fillet | No |
 
 ### Returns

--- a/docs/kcl-std/functions/std-solid-hollow.md
+++ b/docs/kcl-std/functions/std-solid-hollow.md
@@ -22,7 +22,7 @@ provided thickness remains around the exterior of the shape.
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
 | `solid` | [`Solid`](/docs/kcl-std/types/std-types-Solid) | Which solid to hollow out | Yes |
-| `thickness` | `number(Length)` | The thickness of the remaining shell | Yes |
+| `thickness` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The thickness of the remaining shell | Yes |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-solid-shell.md
+++ b/docs/kcl-std/functions/std-solid-shell.md
@@ -23,7 +23,7 @@ provided thickness remains, taking volume starting at the providedface, leaving 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
 | `solids` | [`[Solid; 1+]`](/docs/kcl-std/types/std-types-Solid) | Which solid (or solids) to shell out | Yes |
-| `thickness` | `number(Length)` | The thickness of the shell | Yes |
+| `thickness` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | The thickness of the shell | Yes |
 | `faces` | [`[tag; 1+]`](/docs/kcl-std/types/std-types-tag) | The faces you want removed | Yes |
 
 ### Returns

--- a/docs/kcl-std/functions/std-units-toCentimeters.md
+++ b/docs/kcl-std/functions/std-units-toCentimeters.md
@@ -17,11 +17,11 @@ units::toCentimeters(@num: number(cm)): number(cm)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | `number(cm)` |  | Yes |
+| `num` | [`number(cm)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
 
 ### Returns
 
-`number(cm)`
+[`number(cm)`](/docs/kcl-std/types/std-types-number) - A number
 
 
 

--- a/docs/kcl-std/functions/std-units-toDegrees.md
+++ b/docs/kcl-std/functions/std-units-toDegrees.md
@@ -17,11 +17,11 @@ units::toDegrees(@num: number(deg)): number(deg)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | `number(deg)` |  | Yes |
+| `num` | [`number(deg)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
 
 ### Returns
 
-`number(deg)`
+[`number(deg)`](/docs/kcl-std/types/std-types-number) - A number
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-units-toFeet.md
+++ b/docs/kcl-std/functions/std-units-toFeet.md
@@ -17,11 +17,11 @@ units::toFeet(@num: number(ft)): number(ft)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | `number(ft)` |  | Yes |
+| `num` | [`number(ft)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
 
 ### Returns
 
-`number(ft)`
+[`number(ft)`](/docs/kcl-std/types/std-types-number) - A number
 
 
 

--- a/docs/kcl-std/functions/std-units-toInches.md
+++ b/docs/kcl-std/functions/std-units-toInches.md
@@ -17,11 +17,11 @@ units::toInches(@num: number(in)): number(in)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | `number(in)` |  | Yes |
+| `num` | [`number(in)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
 
 ### Returns
 
-`number(in)`
+[`number(in)`](/docs/kcl-std/types/std-types-number) - A number
 
 
 

--- a/docs/kcl-std/functions/std-units-toMeters.md
+++ b/docs/kcl-std/functions/std-units-toMeters.md
@@ -17,11 +17,11 @@ units::toMeters(@num: number(m)): number(m)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | `number(m)` |  | Yes |
+| `num` | [`number(m)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
 
 ### Returns
 
-`number(m)`
+[`number(m)`](/docs/kcl-std/types/std-types-number) - A number
 
 
 

--- a/docs/kcl-std/functions/std-units-toMillimeters.md
+++ b/docs/kcl-std/functions/std-units-toMillimeters.md
@@ -17,11 +17,11 @@ units::toMillimeters(@num: number(mm)): number(mm)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | `number(mm)` |  | Yes |
+| `num` | [`number(mm)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
 
 ### Returns
 
-`number(mm)`
+[`number(mm)`](/docs/kcl-std/types/std-types-number) - A number
 
 
 

--- a/docs/kcl-std/functions/std-units-toRadians.md
+++ b/docs/kcl-std/functions/std-units-toRadians.md
@@ -17,11 +17,11 @@ units::toRadians(@num: number(rad)): number(rad)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | `number(rad)` |  | Yes |
+| `num` | [`number(rad)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
 
 ### Returns
 
-`number(rad)`
+[`number(rad)`](/docs/kcl-std/types/std-types-number) - A number
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-units-toYards.md
+++ b/docs/kcl-std/functions/std-units-toYards.md
@@ -17,11 +17,11 @@ units::toYards(@num: number(yd)): number(yd)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | `number(yd)` |  | Yes |
+| `num` | [`number(yd)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
 
 ### Returns
 
-`number(yd)`
+[`number(yd)`](/docs/kcl-std/types/std-types-number) - A number
 
 
 

--- a/docs/kcl-std/types/std-types-number.md
+++ b/docs/kcl-std/types/std-types-number.md
@@ -9,7 +9,7 @@ A number
 
 May be signed or unsigned, an integer or decimal value.
 
-You may see a number type with units, e.g., `number(mm)`. These are currently experimental.
+You may see a number type with units, e.g., [`number(mm)`](/docs/kcl-std/types/std-types-number). These are currently experimental.
 
 
 

--- a/rust/kcl-lib/src/docs/gen_std_tests.rs
+++ b/rust/kcl-lib/src/docs/gen_std_tests.rs
@@ -664,7 +664,9 @@ fn cleanup_type_string(input: &str, fmt_for_text: bool) -> String {
             // If we can handle signatures more manually we could get highlighting and links and
             // we might want to restore the links by not checking `fmt_for_text` here.
 
-            if fmt_for_text && SPECIAL_TYPES.contains(&ty) {
+            if fmt_for_text && ty.starts_with("number") {
+                format!("[{prefix}{ty}{suffix}](/docs/kcl-std/types/std-types-number)")
+            } else if fmt_for_text && SPECIAL_TYPES.contains(&ty) {
                 format!("[{prefix}{ty}{suffix}](/docs/kcl-lang/types#{ty})")
             } else if fmt_for_text && DECLARED_TYPES.contains(&ty) {
                 format!("[{prefix}{ty}{suffix}](/docs/kcl-std/types/std-types-{ty})")

--- a/rust/kcl-lib/src/docs/mod.rs
+++ b/rust/kcl-lib/src/docs/mod.rs
@@ -398,8 +398,10 @@ impl From<StdLibFnArg> for ParameterInformation {
 }
 
 fn docs_for_type(ty: &str, kcl_std: &ModData) -> Option<String> {
-    if DECLARED_TYPES.contains(&ty) {
-        if let Some(data) = kcl_std.find_by_name(ty) {
+    let key = if ty.starts_with("number") { "number" } else { ty };
+
+    if DECLARED_TYPES.contains(&key) {
+        if let Some(data) = kcl_std.find_by_name(key) {
             return data.summary().cloned();
         }
     }


### PR DESCRIPTION
Hack the checks for numbers so that we ignore the units for looking them up (for docs only)