### PR TITLE
Truncate "text" arg value summaries by default

### DIFF
--- a/src/components/CommandBar/CommandBarHeader.tsx
+++ b/src/components/CommandBar/CommandBarHeader.tsx
@@ -148,6 +148,8 @@ function CommandBarHeader({ children }: React.PropsWithChildren<object>) {
                             ),
                             4
                           )
+                        ) : arg.inputType === 'text' && !arg.valueSummary ? (
+                          `${argValue.slice(0, 12)}${argValue.length > 12 ? '...' : ''}`
                         ) : typeof argValue === 'object' ? (
                           arg.valueSummary ? (
                             arg.valueSummary(argValue)


### PR DESCRIPTION
Splitting out some work I had in #6254 that wasn't directly related to onboarding into its own tiny PR.

Before:
![screenshot showing the prompt input value summary containing the full prompt](https://github.com/user-attachments/assets/e83d9de3-5f54-4942-8c92-cdd773b241a7)

After:
![screenshot showing the prompt input value summary truncated](https://github.com/user-attachments/assets/9497e84e-31bf-4270-8798-44d698c46f23)
