### PR TITLE
Suggest a list of possible arg labels when an argument is unlabelled

### DIFF
--- a/rust/kcl-lib/src/parsing/ast/digest.rs
+++ b/rust/kcl-lib/src/parsing/ast/digest.rs
@@ -488,7 +488,9 @@ impl CallExpressionKw {
         }
         hasher.update(slf.arguments.len().to_ne_bytes());
         for argument in slf.arguments.iter_mut() {
-            hasher.update(argument.label.compute_digest());
+            if let Some(l) = &mut argument.label {
+                hasher.update(l.compute_digest());
+            }
             hasher.update(argument.arg.compute_digest());
         }
     });

--- a/rust/kcl-lib/src/parsing/ast/types/mod.rs
+++ b/rust/kcl-lib/src/parsing/ast/types/mod.rs
@@ -460,10 +460,12 @@ impl Node<Program> {
                 crate::walk::Node::CallExpressionKw(call) => {
                     if call.inner.callee.inner.name.inner.name == "appearance" {
                         for arg in &call.arguments {
-                            if arg.label.inner.name == "color" {
-                                // Get the value of the argument.
-                                if let Expr::Literal(literal) = &arg.arg {
-                                    add_color(literal);
+                            if let Some(l) = &arg.label {
+                                if l.inner.name == "color" {
+                                    // Get the value of the argument.
+                                    if let Expr::Literal(literal) = &arg.arg {
+                                        add_color(literal);
+                                    }
                                 }
                             }
                         }
@@ -1872,7 +1874,7 @@ pub struct CallExpressionKw {
 #[ts(export)]
 #[serde(tag = "type")]
 pub struct LabeledArg {
-    pub label: Node<Identifier>,
+    pub label: Option<Node<Identifier>>,
     pub arg: Expr,
 }
 
@@ -1917,7 +1919,7 @@ impl CallExpressionKw {
         self.unlabeled
             .iter()
             .map(|e| (None, e))
-            .chain(self.arguments.iter().map(|arg| (Some(&arg.label), &arg.arg)))
+            .chain(self.arguments.iter().map(|arg| (arg.label.as_ref(), &arg.arg)))
     }
 
     pub fn replace_value(&mut self, source_range: SourceRange, new_value: Expr) {

--- a/rust/kcl-lib/src/std/args.rs
+++ b/rust/kcl-lib/src/std/args.rs
@@ -62,6 +62,7 @@ pub struct KwArgs {
     pub unlabeled: Option<Arg>,
     /// Labeled args.
     pub labeled: IndexMap<String, Arg>,
+    pub errors: Vec<Arg>,
 }
 
 impl KwArgs {

--- a/rust/kcl-lib/src/std/array.rs
+++ b/rust/kcl-lib/src/std/array.rs
@@ -88,6 +88,7 @@ async fn call_map_closure(
     let kw_args = KwArgs {
         unlabeled: Some(Arg::new(input, source_range)),
         labeled: Default::default(),
+        errors: Vec::new(),
     };
     let args = Args::new_kw(
         kw_args,
@@ -233,6 +234,7 @@ async fn call_reduce_closure(
     let kw_args = KwArgs {
         unlabeled: Some(Arg::new(elem, source_range)),
         labeled,
+        errors: Vec::new(),
     };
     let reduce_fn_args = Args::new_kw(
         kw_args,

--- a/rust/kcl-lib/src/std/patterns.rs
+++ b/rust/kcl-lib/src/std/patterns.rs
@@ -430,6 +430,7 @@ async fn make_transform<T: GeometryTrait>(
     let kw_args = KwArgs {
         unlabeled: Some(Arg::new(repetition_num, source_range)),
         labeled: Default::default(),
+        errors: Vec::new(),
     };
     let transform_fn_args = Args::new_kw(
         kw_args,

--- a/rust/kcl-lib/src/unparser.rs
+++ b/rust/kcl-lib/src/unparser.rs
@@ -405,9 +405,13 @@ impl CallExpressionKw {
 
 impl LabeledArg {
     fn recast(&self, options: &FormatOptions, indentation_level: usize, ctxt: ExprContext) -> String {
-        let label = &self.label.name;
-        let arg = self.arg.recast(options, indentation_level, ctxt);
-        format!("{label} = {arg}")
+        let mut result = String::new();
+        if let Some(l) = &self.label {
+            result.push_str(&l.name);
+            result.push_str(" = ");
+        }
+        result.push_str(&self.arg.recast(options, indentation_level, ctxt));
+        result
     }
 }
 

--- a/src/lang/modifyAst.ts
+++ b/src/lang/modifyAst.ts
@@ -223,7 +223,7 @@ export function mutateKwArg(
 ): boolean | 'no-mutate' {
   for (let i = 0; i < node.arguments.length; i++) {
     const arg = node.arguments[i]
-    if (arg.label.name === label) {
+    if (arg.label?.name === label) {
       if (isLiteralArrayOrStatic(val) && isLiteralArrayOrStatic(arg.arg)) {
         node.arguments[i].arg = val
         return true
@@ -259,7 +259,7 @@ export function mutateKwArgOnly(
 ): boolean {
   for (let i = 0; i < node.arguments.length; i++) {
     const arg = node.arguments[i]
-    if (arg.label.name === label) {
+    if (arg.label?.name === label) {
       node.arguments[i].arg = val
       return true
     }
@@ -273,7 +273,7 @@ Mutates the given node by removing the labeled arguments.
 */
 export function removeKwArgs(labels: string[], node: CallExpressionKw) {
   for (const label of labels) {
-    const i = node.arguments.findIndex((la) => la.label.name === label)
+    const i = node.arguments.findIndex((la) => la.label?.name === label)
     if (i == -1) {
       continue
     }

--- a/src/lang/modifyAst/addEdgeTreatment.ts
+++ b/src/lang/modifyAst/addEdgeTreatment.ts
@@ -773,7 +773,7 @@ export async function editEdgeTreatment(
 
   // find the index of an argument to update
   const index = edgeTreatmentCall.node.arguments.findIndex(
-    (arg) => arg.label.name === parameterName
+    (arg) => arg.label?.name === parameterName
   )
 
   // create a new argument with the updated value

--- a/src/lang/modifyAst/tagManagement.ts
+++ b/src/lang/modifyAst/tagManagement.ts
@@ -500,7 +500,7 @@ function modifyAstWithTagForCapFace(
 
   // Check for existing tag with this parameter name
   const existingTag = callExp.node.arguments.find(
-    (arg) => arg.label.name === tagParamName
+    (arg) => arg.label?.name === tagParamName
   )
 
   if (existingTag && existingTag.arg.type === 'TagDeclarator') {

--- a/src/lang/std/sketch.ts
+++ b/src/lang/std/sketch.ts
@@ -190,7 +190,10 @@ const commonConstraintInfoHelper = (
             if (lengthishIndex === undefined) {
               return [undefined, undefined]
             }
-            const lengthKey = callExp.arguments[lengthishIndex].label.name
+            const lengthKey = callExp.arguments[lengthishIndex].label?.name
+            if (lengthKey === undefined) {
+              return [undefined, undefined]
+            }
             const lengthVal = callExp.arguments[lengthishIndex].arg
             // Note: The order of keys here matters.
             // Always assumes the angle was the first param, and then the length followed.
@@ -1057,7 +1060,7 @@ export const tangentialArc: SketchLineHelperKw = {
     }
 
     for (const arg of callExpression.arguments) {
-      if (arg.label.name !== ARG_END_ABSOLUTE && arg.label.name !== ARG_TAG) {
+      if (arg.label?.name !== ARG_END_ABSOLUTE && arg.label?.name !== ARG_TAG) {
         console.debug(
           'Trying to edit unsupported tangentialArc keyword arguments; skipping'
         )

--- a/src/lang/std/sketchcombos.ts
+++ b/src/lang/std/sketchcombos.ts
@@ -1375,12 +1375,12 @@ export function removeSingleConstraint({
 
         // 1. Filter out any existing tag argument since it will be handled separately
         const filteredArgs = existingArgs.filter(
-          (arg) => arg.label.name !== ARG_TAG
+          (arg) => arg.label?.name !== ARG_TAG
         )
 
         // 2. Map through the args, replacing only the one we want to change
         const labeledArgs = filteredArgs.map((arg) => {
-          if (arg.label.name === toReplace) {
+          if (arg.label?.name === toReplace) {
             // Find the raw value to use for the argument being replaced
             const rawArgVersion = rawArgs.find(
               (a) => a.type === 'labeledArg' && a.key === toReplace
@@ -1430,7 +1430,7 @@ export function removeSingleConstraint({
         const labeledArgs = existingArgs.map((arg) => {
           // Only modify the specific argument that matches the targeted key
           if (
-            arg.label.name === targetKey &&
+            arg.label?.name === targetKey &&
             arg.arg.type === 'ArrayExpression'
           ) {
             // We're dealing with an array expression within a labeled argument
@@ -1560,7 +1560,7 @@ export function removeSingleConstraint({
             arrayInput[inputToReplace.key][inputToReplace.index] =
               rawLiteralArrayInObjectExpr
             let existingKwgForKey = kwArgInput.find(
-              (kwArg) => kwArg.label.name === currentArg.key
+              (kwArg) => kwArg.label?.name === currentArg.key
             )
             if (!existingKwgForKey) {
               existingKwgForKey = createLabeledArg(
@@ -1586,7 +1586,7 @@ export function removeSingleConstraint({
             if (!arrayInput[currentArg.key]) arrayInput[currentArg.key] = []
             arrayInput[currentArg.key][currentArg.index] = currentArgExpr
             let existingKwgForKey = kwArgInput.find(
-              (kwArg) => kwArg.label.name === currentArg.key
+              (kwArg) => kwArg.label?.name === currentArg.key
             )
             if (!existingKwgForKey) {
               existingKwgForKey = createLabeledArg(
@@ -2190,7 +2190,7 @@ export function getConstraintLevelFromSourceRange(
           }
           const arg = findKwArgAny(DETERMINING_ARGS, nodeMeta.node)
           if (arg === undefined) {
-            const argStr = nodeMeta.node.arguments.map((a) => a.label.name)
+            const argStr = nodeMeta.node.arguments.map((a) => a.label?.name)
             return new Error(
               `call to expression ${name} has unexpected args: ${argStr} `
             )

--- a/src/lang/util.ts
+++ b/src/lang/util.ts
@@ -136,7 +136,7 @@ export function findKwArg(
   call: CallExpressionKw
 ): Expr | undefined {
   return call?.arguments?.find((arg) => {
-    return arg.label.name === label
+    return arg.label?.name === label
   })?.arg
 }
 
@@ -149,7 +149,7 @@ export function findKwArgWithIndex(
   call: CallExpressionKw
 ): { expr: Expr; argIndex: number } | undefined {
   const index = call.arguments.findIndex((arg) => {
-    return arg.label.name === label
+    return arg.label?.name === label
   })
   return index >= 0
     ? { expr: call.arguments[index].arg, argIndex: index }
@@ -164,7 +164,7 @@ export function findKwArgAny(
   call: CallExpressionKw
 ): Expr | undefined {
   return call.arguments.find((arg) => {
-    return labels.includes(arg.label.name)
+    return labels.includes(arg.label?.name || '')
   })?.arg
 }
 
@@ -176,7 +176,7 @@ export function findKwArgAnyIndex(
   call: CallExpressionKw
 ): number | undefined {
   const index = call.arguments.findIndex((arg) => {
-    return labels.includes(arg.label.name)
+    return labels.includes(arg.label?.name || '')
   })
   if (index == -1) {
     return undefined

--- a/src/lib/kclHelpers.ts
+++ b/src/lib/kclHelpers.ts
@@ -60,7 +60,7 @@ export async function retrieveArgFromPipedCallExpression(
   name: string
 ): Promise<KclCommandValue | undefined> {
   const arg = callExpression.arguments.find(
-    (a) => a.label.type === 'Identifier' && a.label.name === name
+    (a) => a.label?.type === 'Identifier' && a.label?.name === name
   )
   if (
     arg?.type === 'LabeledArg' &&

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -41,7 +41,9 @@ export async function refreshPage(method = 'UI button') {
  * Get all labels for a keyword call expression.
  */
 export function allLabels(callExpression: CallExpressionKw): string[] {
-  return callExpression.arguments.map((a) => a.label.name)
+  return callExpression.arguments
+    .map((a) => a.label?.name)
+    .filter((a) => a !== undefined)
 }
 
 /**


### PR DESCRIPTION
This makes parsing a fair bit more generous and catches those errors later when type checking the KW args, which allows us to suggest the missing args.