### PR TITLE
Change display of mixed array to be clear what it is

### DIFF
--- a/rust/kcl-lib/src/execution/kcl_value.rs
+++ b/rust/kcl-lib/src/execution/kcl_value.rs
@@ -307,7 +307,7 @@ impl KclValue {
             } => "number(Angle)",
             KclValue::Number { .. } => "number",
             KclValue::String { .. } => "string (text)",
-            KclValue::MixedArray { .. } => "array (list)",
+            KclValue::MixedArray { .. } => "mixed array (list)",
             KclValue::HomArray { .. } => "array (list)",
             KclValue::Object { .. } => "object",
             KclValue::Module { .. } => "module",

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -1932,7 +1932,7 @@ a = []
 notArray = !a";
         assert_eq!(
             parse_execute(code5).await.unwrap_err().message(),
-            "Cannot apply unary operator ! to non-boolean value: array (list)",
+            "Cannot apply unary operator ! to non-boolean value: mixed array (list)",
         );
 
         let code6 = "


### PR DESCRIPTION
Until we remove `MixedArray`, this should make it easier to debug error messages. We've received reports in the past where the message said something like "expected array but found array". This change will at least make it clear that one of them is a `MixedArray`.

If #6748 gets merged, might need to fix new error messages.