### PR TITLE
Fix trackball camera by weaving through EngineStream

### DIFF
--- a/src/components/EngineStream.tsx
+++ b/src/components/EngineStream.tsx
@@ -37,7 +37,7 @@ import {
 } from '@src/lib/utils'
 import { DEFAULT_DEFAULT_LENGTH_UNIT } from '@src/lib/constants'
 import { createThumbnailPNGOnDesktop } from '@src/lib/screenshot'
-import { SettingsViaQueryString } from '@src/lib/settings/settingsTypes'
+import type { SettingsViaQueryString } from '@src/lib/settings/settingsTypes'
 
 export const EngineStream = (props: {
   pool: string | null

--- a/src/components/EngineStream.tsx
+++ b/src/components/EngineStream.tsx
@@ -37,6 +37,7 @@ import {
 } from '@src/lib/utils'
 import { DEFAULT_DEFAULT_LENGTH_UNIT } from '@src/lib/constants'
 import { createThumbnailPNGOnDesktop } from '@src/lib/screenshot'
+import { SettingsViaQueryString } from '@src/lib/settings/settingsTypes'
 
 export const EngineStream = (props: {
   pool: string | null
@@ -54,12 +55,17 @@ export const EngineStream = (props: {
   const last = useRef<number>(Date.now())
   const videoWrapperRef = useRef<HTMLDivElement>(null)
 
-  const settingsEngine = {
+  /**
+   * We omit `pool` here because `engineStreamMachine` will override it anyway
+   * within the `EngineStreamTransition.StartOrReconfigureEngine` Promise actor.
+   */
+  const settingsEngine: Omit<SettingsViaQueryString, 'pool'> = {
     theme: settings.app.theme.current,
     enableSSAO: settings.modeling.enableSSAO.current,
     highlightEdges: settings.modeling.highlightEdges.current,
     showScaleGrid: settings.modeling.showScaleGrid.current,
     cameraProjection: settings.modeling.cameraProjection.current,
+    cameraOrbit: settings.modeling.cameraOrbit.current,
   }
 
   const { state: modelingMachineState, send: modelingMachineActorSend } =


### PR DESCRIPTION
Fixes #6472. Just a missing setting moved in #5312, which wasn't caught because testing that the orbit maneuver is actually performing a "trackball-like" movement is nonexistent. I don't know how to test that reliably, but typing this object provides the red squiggles to reveal the missing property.