### PR TITLE
#6686 Fix Unable to double click to edit sketch with specific set of actions

### DIFF
--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -3384,8 +3384,6 @@ export const modelingMachine = setup({
                   target: 'normal',
                   actions: 'set up draft line',
                 },
-
-                Cancel: '#Modeling.Sketch.undo startSketchOn',
               },
 
               exit: 'remove draft entities',
@@ -4208,6 +4206,7 @@ export const modelingMachine = setup({
       initial: 'Init',
 
       on: {
+        Cancel: '.undo startSketchOn',
         CancelSketch: '.SketchIdle',
 
         'Delete segment': {


### PR DESCRIPTION
Fixes #6686 

Moves the Cancel transition from Line up one level into Sketch.

Prior to this, only the Line tool cleaned up the empty draft sketch when exiting sketch mode, which caused double click to not work when Line was unequipped, or if any other tool was equipped.
