### PR TITLE
Error on "Open in desktop" click if URL is too long on Windows

### DIFF
--- a/e2e/playwright/share-link.spec.ts
+++ b/e2e/playwright/share-link.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@e2e/playwright/zoo-test'
+
+const isWindows =
+  navigator.platform === 'Windows' || navigator.platform === 'Win32'
+test.describe('Share link tests', () => {
+  ;[
+    {
+      codeLength: 1000,
+      showsErrorOnWindows: false,
+    },
+    {
+      codeLength: 2000,
+      showsErrorOnWindows: true,
+    },
+  ].forEach(({ codeLength, showsErrorOnWindows }) => {
+    test(`Open in desktop app with ${codeLength}-long code ${isWindows && showsErrorOnWindows ? 'shows error' : "doesn't show error"}`, async ({
+      page,
+    }) => {
+      if (process.env.PLATFORM !== 'web') {
+        // This test is web-only
+        // TODO: re-enable on CI as part of a new web test suite
+        return
+      }
+
+      const code = Array(codeLength).fill('0').join('')
+      const targetURL = `?create-file=true&browser=test&code=${code}&ask-open-desktop=true`
+      expect(targetURL.length).toEqual(codeLength + 58)
+      await page.goto(page.url() + targetURL)
+      expect(page.url()).toContain(targetURL)
+      const button = page.getByRole('button', { name: 'Open in desktop app' })
+      await button.click()
+      const toastError = page.getByText(
+        'The URL is too long to open in the desktop app on Windows'
+      )
+      if (isWindows && showsErrorOnWindows) {
+        await expect(toastError).toBeVisible()
+      } else {
+        await expect(toastError).not.toBeVisible()
+        // TODO: check if we could verify the deep link dialog shows up
+      }
+    })
+  })
+})

--- a/src/components/OpenInDesktopAppHandler.tsx
+++ b/src/components/OpenInDesktopAppHandler.tsx
@@ -9,6 +9,8 @@ import {
 } from '@src/lib/constants'
 import { isDesktop } from '@src/lib/isDesktop'
 import { Themes, getSystemTheme } from '@src/lib/theme'
+import toast from 'react-hot-toast'
+import { platform } from '@src/lib/utils'
 
 /**
  * This component is a handler that checks if a certain query parameter
@@ -35,11 +37,24 @@ export const OpenInDesktopAppHandler = (props: React.PropsWithChildren) => {
    */
   function onOpenInDesktopApp() {
     const newSearchParams = new URLSearchParams(globalThis.location.search)
-    newSearchParams.delete(ASK_TO_OPEN_QUERY_PARAM)
     const newURL = `${ZOO_STUDIO_PROTOCOL}://${globalThis.location.pathname.replace(
       '/',
       ''
     )}${searchParams.size > 0 ? `?${newSearchParams.toString()}` : ''}`
+
+    // TODO: find a way to workaround this limitation, modeling-app#6200
+    // Electron issue: https://github.com/electron/electron/issues/40776
+    // This 2046 value comes from https://issues.chromium.org/issues/41322340#comment3
+    // and empirical testing on Chrome and Windows 11
+    const MAX_URL_LENGTH = 2046
+    if (platform() === 'windows' && newURL.length > MAX_URL_LENGTH) {
+      toast.error(
+        'The URL is too long to open in the desktop app on Windows. Try another platform or use the web app.'
+      )
+      return
+    }
+
+    newSearchParams.delete(ASK_TO_OPEN_QUERY_PARAM)
     globalThis.location.href = newURL
   }
 


### PR DESCRIPTION
Won't be the solution for #6200 but may downgrade its priority from P0 to P1.

Added non-CI web tests:
```
npm run chrome:test -- -g "Open in desktop app" --headed
```