### PR TITLE
Removes "fillets cannot touch" warning message

### DIFF
--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -746,8 +746,6 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         multiple: true,
         required: true,
         skip: false,
-        warningMessage:
-          'Fillets cannot touch other fillets yet. This is under development.',
         hidden: (context) => Boolean(context.argumentsToSubmit.nodeToEdit),
       },
       radius: {


### PR DESCRIPTION
Closes: #6770

since [fillet revisit](https://github.com/KittyCAD/engine/issues/1591), this warning message is no longer needed

<img width="512" alt="Screenshot 2025-05-08 at 17 38 38" src="https://github.com/user-attachments/assets/5d01e291-4659-4224-9335-fef25ec00b83" />


before:
<img width="511" alt="Screenshot 2025-05-08 at 17 21 55" src="https://github.com/user-attachments/assets/b5db0975-c2e0-439f-b238-4fc0412c67bf" />
