### PR TITLE
ci: Fix just lint to check all targets

### DIFF
--- a/rust/justfile
+++ b/rust/justfile
@@ -4,9 +4,9 @@ kcl_lib_flags := "-p kcl-lib --features artifact-graph"
 
 # Run the same lint checks we run in CI.
 lint:
-    cargo clippy --workspace --all-targets --tests --all-features --examples --benches -- -D warnings
+    cargo clippy --workspace --all-targets --all-features -- -D warnings
     # Ensure we can build without extra feature flags.
-    cargo clippy -p kcl-lib --tests --examples --benches -- -D warnings
+    cargo clippy -p kcl-lib --all-targets -- -D warnings
 
 # Run the stdlib docs generation
 redo-kcl-stdlib-docs-no-imgs:


### PR DESCRIPTION
This is used by CI, so we need to make it good.

From `cargo check --help`:

<img width="552" alt="Screenshot 2025-05-08 at 12 55 27 PM" src="https://github.com/user-attachments/assets/d61eaffc-a2e6-4b5e-9a7b-557aca2519e0" />
