### PR TITLE
[Fix]: Always show stack trace on the page if an Error shows up

### DIFF
--- a/src/components/ErrorPage.tsx
+++ b/src/components/ErrorPage.tsx
@@ -34,7 +34,8 @@ function stackTraceMessage(error: unknown): string {
 /** Generate a GitHub issue URL from the error */
 function generateToUrl(error: unknown) {
   const title: string = 'An unexpected error occurred'
-  const body = errorMessage(error)
+  const newLine = '%0A'
+  const body = `${errorMessage(error)} ${newLine} >${stackTraceMessage(error)} ${newLine}`
   const result = `https://github.com/KittyCAD/modeling-app/issues/new?title=${title}&body=${body}`
   return result
 }
@@ -50,10 +51,10 @@ export const ErrorPage = () => {
         <h1 className="text-4xl mb-8 font-bold" data-testid="unexpected-error">
           An unexpected error occurred
         </h1>
-        <p className="mb-8 w-full overflow-aut">
+        <p className="mb-8 w-full overflow-auto">
           <>{errorMessage(error)}</>
         </p>
-        <p className="mb-8 w-full overflow-aut">
+        <p className="mb-8 w-full overflow-auto">
           <>{stackTraceMessage(error)}</>
         </p>
         <div className="flex justify-between gap-2 mt-6">

--- a/src/components/ErrorPage.tsx
+++ b/src/components/ErrorPage.tsx
@@ -24,6 +24,13 @@ function errorMessage(error: unknown): string {
   }
 }
 
+function stackTraceMessage(error: unknown): string {
+  if (error !== undefined && error instanceof Error) {
+    return error.stack || ''
+  }
+  return ''
+}
+
 /** Generate a GitHub issue URL from the error */
 function generateToUrl(error: unknown) {
   const title: string = 'An unexpected error occurred'
@@ -45,6 +52,9 @@ export const ErrorPage = () => {
         </h1>
         <p className="mb-8 w-full overflow-aut">
           <>{errorMessage(error)}</>
+        </p>
+        <p className="mb-8 w-full overflow-aut">
+          <>{stackTraceMessage(error)}</>
         </p>
         <div className="flex justify-between gap-2 mt-6">
           {isDesktop() && (


### PR DESCRIPTION
# Issue

Whenever users screenshot the page it only shows an error message that has no context. We actually console log the error but the user is not expected to open the console to see the error

# Implementation

Just show the entire stack trace to see if that can help us on the off chance they don't give us more information.
![Screenshot from 2025-05-08 16-10-05](https://github.com/user-attachments/assets/a9653ec9-cd86-43ad-8a7a-1ae4e76c5123)

This is to help debug future bug reports, asking someone "open your console", "press this button to copy the error message" is not seamless enough. 

Here are two tickets that the stack trace would have been useful but we do not have them
- https://github.com/KittyCAD/modeling-app/issues/6302
- https://github.com/KittyCAD/modeling-app/issues/6660

Updated GH link as well

![image](https://github.com/user-attachments/assets/e54090e3-3e80-4b9a-b917-7a1a24c5f574)
