### PR TITLE
Source range for pipe value used as unlabelled arg

### DIFF
--- a/rust/kcl-lib/e2e/executor/main.rs
+++ b/rust/kcl-lib/e2e/executor/main.rs
@@ -2038,17 +2038,6 @@ async fn kcl_test_ensure_nothing_left_in_batch_multi_file() {
 
     ctx.close().await;
 }
-#[tokio::test(flavor = "multi_thread")]
-async fn kcl_test_default_param_for_unlabeled() {
-    let code = r#"fn myExtrude(@sk, len) {
-  return extrude(sk, length = len)
-}
-
-sketch001 = startSketchOn(XY)
-|> circle(center = [0, 0], radius = 93.75)
-|> myExtrude(len = 40)"#;
-    let _ = execute_and_snapshot(code, None).await.unwrap();
-}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn kcl_test_better_type_names() {

--- a/rust/kcl-lib/src/std/args.rs
+++ b/rust/kcl-lib/src/std/args.rs
@@ -161,7 +161,7 @@ pub struct Args {
     pub ctx: ExecutorContext,
     /// If this call happens inside a pipe (|>) expression, this holds the LHS of that |>.
     /// Otherwise it's None.
-    pipe_value: Option<Arg>,
+    pub pipe_value: Option<Arg>,
 }
 
 impl Args {


### PR DESCRIPTION
Fixes #6613 

Extracted from #6644 to just fix the source range without touching the kwarg shorthand (left for post 1.0).