### PR TITLE
Docs content

### DIFF
--- a/docs/kcl-lang/arithmetic.md
+++ b/docs/kcl-lang/arithmetic.md
@@ -1,0 +1,53 @@
+---
+title: "Arithmetic and logic"
+excerpt: "Documentation of the KCL language for the Zoo Design Studio."
+layout: manual
+---
+
+KCL supports the usual arithmetic operators on numbers and logic operators on booleans:
+
+| Operator | Meaning |
+|----------|---------|
+| `+` | Addition |
+| `-` | Subtraction or unary negation |
+| `*` | Multiplication |
+| `/` | Division |
+| `%` | Modulus aka remainder |
+| `^` | Power, e.g., `x ^ 2` means `x` squared |
+| `&` | Logical 'and' |
+| `|` | Logical 'or' |
+| `!` | Unary logical 'not' |
+
+KCL also supports comparsion operators which operate on numbers and produce booleans:
+
+| Operator | Meaning |
+|----------|---------|
+| `==` | Equal |
+| `!=` | Not equal |
+| `<` | Less than |
+| `>` | Greater than |
+| `<=` | Less than or equal |
+| `>=` | Greater than or equal |
+
+Arithmetics and logic expressions can be arbitrairly combined with the usual rules of associativity and precedence, e.g.,
+
+```
+myMathExpression = 3 + 1 * 2 / 3 - 7
+```
+
+You can also nest expressions in parenthesis:
+
+```
+myMathExpression = 3 + (1 * 2 / (3 - 7))
+```
+
+KCL numbers are implemented using [floating point numbers](https://en.wikipedia.org/wiki/Floating-point_arithmetic). This means that there are occasionally representation and rounding issues, and some oddities such as supporting positive and negative zero.
+
+Some operators can be applied to other types:
+
+- `+` can be used to concatenate strings, e.g., `'hello' + ' ' + 'world!'`
+- Unary `-` can be used with planes or line-like objects such as axes to produce an object with opposite orientation, e.g., `-XY` is a plain which is aligned with `XY` but whose normal aligns with the negative Z axis.
+- The following operators can be used with solids as shorthand for CSG operations:
+  - `+` or `|` for [`union`](/docs/kcl-std/union).
+  - `-` for [`subtract`](/docs/kcl-std/subtract).
+  - `&` for [`intersect`](/docs/kcl-std/intersect)

--- a/docs/kcl-lang/attributes.md
+++ b/docs/kcl-lang/attributes.md
@@ -1,0 +1,30 @@
+---
+title: "Attributes"
+excerpt: "Documentation of the KCL language for the Zoo Design Studio."
+layout: manual
+---
+
+Attributes are syntax which affects the language item they annotate. In KCL they are indicated using `@`. For example, `@settings` affects the file in which it appears.
+
+There are two kinds of attributes: named and unnamed attributes. Named attributes (e.g., `@settings`) have a name immediately after the `@` (e.g., `settings`) and affect their surrounding scope. Unnamed attributes have no name and affect the following item, e.g.,
+
+```kcl,norun
+@(lengthUnit = ft, coords = opengl)
+import "tests/inputs/cube.obj"
+```
+
+has an unnamed attribute on the `import` statement.
+
+Named and unnamed attributes may take a parenthesized list of arguments (like a function). Named attributes may also appear without any arguments (e.g., `@no_std`).
+
+## Named attributes
+
+The `@settings` attribute affects the current file and accepts the following arguments: `defaultLengthUnit`, `defaultAngleUnit`, and `kclVersion`. See [settings](/docs/kcl-lang/settings) for details.
+
+The `@no_std` attribute affects the current file, takes no arguments, and causes the standard library to not be implicitly available. It can still be used by being explicitly imported.
+
+## Unnamed attributes
+
+Unnamed attributes may be used on `import` statements when importing non-KCL files. See [projects, modules, and imports](/docs/kcl-lang/modules) for details.
+
+Other unnamed attributes are used on functions inside the standard library, but these are not available in user code.

--- a/docs/kcl-lang/functions.md
+++ b/docs/kcl-lang/functions.md
@@ -1,0 +1,46 @@
+---
+title: "Functions"
+excerpt: "Documentation of the KCL language for the Zoo Design Studio."
+layout: manual
+---
+
+We have support for defining your own functions. Functions can take in any
+type of argument. Below is an example of the syntax:
+
+```
+fn myFn(x) {
+  return x
+}
+```
+
+As you can see above `myFn` just returns whatever it is given.
+
+KCL uses keyword arguments:
+
+```
+// If you declare a function like this
+fn add(left, right) {
+  return left + right
+}
+
+// You can call it like this:
+total = add(left = 1, right = 2)
+```
+
+Functions can also declare one *unlabeled* arg. If you do want to declare an unlabeled arg, it must
+be the first arg declared.
+
+```
+// The @ indicates an argument is used without a label.
+// Note that only the first argument can use @.
+fn increment(@x) {
+  return x + 1
+}
+
+fn add(@x, delta) {
+  return x + delta
+}
+
+two = increment(1)
+three = add(1, delta = 2)
+```

--- a/docs/kcl-lang/index.md
+++ b/docs/kcl-lang/index.md
@@ -1,12 +1,20 @@
 ---
-title: "KCL Language Guide"
+title: "KCL Language Reference"
 excerpt: "Documentation of the KCL language for the Zoo Design Studio."
 layout: manual
 ---
 
+This is a reference for KCL. If you are learning KCL, you may prefer the [guide]() which explains
+things in a more tutorial fashion.
+
 ## Topics
 
-* [`Types`](/docs/kcl-lang/types)
-* [`Modules`](/docs/kcl-lang/modules)
-* [`Settings`](/docs/kcl-lang/settings)
-* [`Known Issues`](/docs/kcl-lang/known-issues)
+* [Pipelines](/docs/kcl-lang/pipelines)
+* [Arithmetic and logic](/docs/kcl-lang/arithmetic)
+* [Values and types](/docs/kcl-lang/types)
+* [Numeric types and units](/docs/kcl-lang/numeric)
+* [Functions](/docs/kcl-lang/functions)
+* [Projects, modules, and imports](/docs/kcl-lang/modules)
+* [Attributes](/docs/kcl-lang/attributes)
+* [Settings](/docs/kcl-lang/settings)
+* [Known Issues](/docs/kcl-lang/known-issues)

--- a/docs/kcl-lang/modules.md
+++ b/docs/kcl-lang/modules.md
@@ -1,6 +1,6 @@
 ---
 title: "Modules"
-excerpt: "Documentation of modules for the KCL language for the Zoo Design Studio."
+excerpt: "Documentation of the KCL language for the Zoo Design Studio."
 layout: manual
 ---
 

--- a/docs/kcl-lang/numeric.md
+++ b/docs/kcl-lang/numeric.md
@@ -1,0 +1,46 @@
+---
+title: "Numeric types and units"
+excerpt: "Documentation of the KCL language for the Zoo Design Studio."
+layout: manual
+---
+
+Numbers and numeric types in KCL include information about the units of the numbers. So rather than just having a number like `42`, we always have information about the units so we don't confuse 42 mm with 42 inches.
+
+
+## Numeric literals
+
+When writing a number literal, you can use a unit suffix to explicitly state the unit, e.g., `42mm`. The following units are available:
+
+- Length units:
+  - metric: `mm`, `cm`, `m`
+  - imperial: `in`, `ft`, `yd`
+- Angle units: `deg`, `rad`
+- `_` to indicate a unitless number such as a count or ratio.
+
+If you write a numeric literal without a suffix, then the defaults for the current file are used. These defaults are specified using the `@settings` attribute, see [settings](/docs/kcl-lang/settings) for details. Note that if using the defaults, the KCL interpreter won't know whether you intend the number to be a length, angle, or count and will treat it as being possibly any of them.
+
+
+## Numeric types
+
+Just like numbers carry units information, the `number` type also includes units information. Units are written in parentheses after the type, e.g., `number(mm)`.
+
+Any of the suffixes described above can be used meaning that values with that type have the supplied units. E.g., `number(mm)` is the type of number values with mm units and `number(_)` is the type of number values with no units.
+
+You can also use `number(Length)`, `number(Angle)`, or `number(Count)`. These types mean a number with any length, angle, or unitless (count) units, respectively (note that `number(_)` and `number(Count)` are equivalent since there is only one kind of unitless-ness).
+
+
+## Function calls
+
+When calling a function with an argument with numeric type, the declared numeric type in the function signature and the units of the argument value used in the function call must be compatible. Units are adjusted automatically. For example, if a function requires an argument with type `number(mm)`, then you can call it with `2in` and the units will be automatically adjusted, but calling it with `90deg` will cause an error.
+
+
+## Mixing units with arithmetic
+
+When doing arithmetic or comparisons, units will be adjusted as necessary if possible. However, often arithmetic expressions exceed the ability of KCL to accurately choose units which can result in warnings in your code or sometimes errors. In these cases, you will need to give KCL more information. Sometimes this can be done by making units explicit using suffixes. If not, then you will need to use *type ascription*, which asserts that an expression has the supplied type. For example, `(x * y): number(mm)` tells KCL that the units of `x * y` is mm. Note that type ascription does not do any adjustment of the numbers, e.g., `2mm: number(in)` has the value `2in` (note that this would be a very non-idiomatic way to use numeric type ascription, you could simply write `2in`. Usually type ascription is only necessary for supplying type information about the result of computation).
+
+KCL has no support for area, volume, or other higher dimension units. When internal unit tracking requires multiple dimensions, KCL essentially gives up. This is usually where the extra type information described above is needed. If doing computation with higher dimensioned units, you must ensure that all adjustments occur before any computation. E.g., if you want to compute an area with unknown units, you must convert all numbers to the same unit before starting.
+
+
+## Explicit conversions
+
+You might sometimes need to convert from one unit to another for some calculation. You can do this implicitly when calling a function (see above), but if you can't or don't want to, then you can use the explicit conversion functions in the [`std::units`](/docs/kcl-std/modules/std-units) module.

--- a/docs/kcl-lang/pipelines.md
+++ b/docs/kcl-lang/pipelines.md
@@ -1,0 +1,66 @@
+---
+title: "Pipelines"
+excerpt: "Documentation of the KCL language for the Zoo Design Studio."
+layout: manual
+---
+
+It can be hard to read repeated function calls, because of all the nested brackets.
+
+```norun
+i = 1
+x = h(g(f(i)))
+```
+
+You can make this easier to read by breaking it into many declarations, but that is a bit annoying.
+
+```norun
+i  = 1
+x0 = f(i)
+x1 = g(x0)
+x  = h(x1)
+```
+
+Instead, you can use the pipeline operator (`|>`) to simplify this.
+
+Basically, `x |> f(%)` is a shorthand for `f(x)`. The left-hand side of the `|>` gets put into
+the `%` in the right-hand side.
+
+So, this means `x |> f(%) |> g(%)` is shorthand for `g(f(x))`. The code example above, with its
+somewhat-clunky `x0` and `x1` constants could be rewritten as
+
+```norun
+i = 1
+x = i
+  |> f(%)
+  |> g(%)
+  |> h(%)
+```
+
+This helps keep your code neat and avoid unnecessary declarations.
+
+## Pipelines and keyword arguments
+
+Say you have a long pipeline of sketch functions, like this:
+
+```norun
+startSketchOn(XZ)
+  |> line(%, end = [3, 4])
+  |> line(%, end = [10, 10])
+  |> line(%, end = [-13, -14])
+  |> close(%)
+```
+
+In this example, each function call outputs a sketch, and it gets put into the next function call via
+the `%`, into the first (unlabeled) argument.
+
+If a function call uses an unlabeled first parameter, it will default to `%` if it's not given. This
+means that `|> line(%, end = [3, 4])` and `|> line(end = [3, 4])` are equivalent! So the above
+could be rewritten as 
+
+```norun
+startSketchOn(XZ)
+ |> line(end = [3, 4])
+ |> line(end = [10, 10])
+ |> line(end = [-13, -14])
+ |> close()
+```

--- a/docs/kcl-lang/settings.md
+++ b/docs/kcl-lang/settings.md
@@ -1,6 +1,6 @@
 ---
 title: "Settings"
-excerpt: "Documentation of settings for the KCL language and Zoo Design Studio."
+excerpt: "Documentation of the KCL language for the Zoo Design Studio."
 layout: manual
 ---
 

--- a/docs/kcl-lang/types.md
+++ b/docs/kcl-lang/types.md
@@ -1,6 +1,6 @@
 ---
-title: "Types"
-excerpt: "Documentation of types for the KCL standard library for the Zoo Design Studio."
+title: "Values and types"
+excerpt: "Documentation of the KCL language for the Zoo Design Studio."
 layout: manual
 ---
 
@@ -51,131 +51,6 @@ other solid (they can be rotated, scaled, etc.), although there is no access to
 their internal components. See the [modules and imports docs](modules) for more
 detail on importing geometry.
 
-
-## Binary expressions
-
-You can also do math! Let's show an example below:
-
-```
-myMathExpression = 3 + 1 * 2 / 3 - 7
-```
-
-You can nest expressions in parenthesis as well:
-
-```
-myMathExpression = 3 + (1 * 2 / (3 - 7))
-```
-
-## Functions
-
-We also have support for defining your own functions. Functions can take in any
-type of argument. Below is an example of the syntax:
-
-```
-fn myFn(x) {
-  return x
-}
-```
-
-As you can see above `myFn` just returns whatever it is given.
-
-KCL's early drafts used positional arguments, but we now use keyword arguments:
-
-```
-// If you declare a function like this
-fn add(left, right) {
-  return left + right
-}
-
-// You can call it like this:
-total = add(left = 1, right = 2)
-```
-
-Functions can also declare one *unlabeled* arg. If you do want to declare an unlabeled arg, it must
-be the first arg declared.
-
-```
-// The @ indicates an argument can be used without a label.
-// Note that only the first argument can use @.
-fn increment(@x) {
-  return x + 1
-}
-
-fn add(@x, delta) {
-  return x + delta
-}
-
-two = increment(1)
-three = add(1, delta = 2)
-```
-
-## Pipelines
-
-It can be hard to read repeated function calls, because of all the nested brackets.
-
-```norun
-i = 1
-x = h(g(f(i)))
-```
-
-You can make this easier to read by breaking it into many declarations, but that is a bit annoying.
-
-```norun
-i  = 1
-x0 = f(i)
-x1 = g(x0)
-x  = h(x1)
-```
-
-Instead, you can use the pipeline operator (`|>`) to simplify this.
-
-Basically, `x |> f(%)` is a shorthand for `f(x)`. The left-hand side of the `|>` gets put into
-the `%` in the right-hand side.
-
-So, this means `x |> f(%) |> g(%)` is shorthand for `g(f(x))`. The code example above, with its
-somewhat-clunky `x0` and `x1` constants could be rewritten as
-
-```norun
-i = 1
-x = i
-  |> f(%)
-  |> g(%)
-  |> h(%)
-```
-
-This helps keep your code neat and avoid unnecessary declarations.
-
-## Pipelines and keyword arguments
-
-Say you have a long pipeline of sketch functions, like this:
-
-```norun
-startSketchOn(XZ)
-  |> line(%, end = [3, 4])
-  |> line(%, end = [10, 10])
-  |> line(%, end = [-13, -14])
-  |> close(%)
-```
-
-In this example, each function call outputs a sketch, and it gets put into the next function call via
-the `%`, into the first (unlabeled) argument.
-
-If a function call uses an unlabeled first parameter, it will default to `%` if it's not given. This
-means that `|> line(%, end = [3, 4])` and `|> line(end = [3, 4])` are equivalent! So the above
-could be rewritten as 
-
-```norun
-startSketchOn(XZ)
- |> line(end = [3, 4])
- |> line(end = [10, 10])
- |> line(end = [-13, -14])
- |> close()
-```
-
-Note that we are still in the process of migrating KCL's standard library to use keyword arguments. So some
-functions are still unfortunately using positional arguments. We're moving them over, so keep checking back.
-Some functions are still using the old positional argument syntax.
-Check the docs page for each function and look at its examples to see.
 
 ## Tags
 
@@ -290,7 +165,6 @@ myRect
 See how we use the tag `rectangleSegmentA001` in the `fillet` function outside
 the `rect` function. This is because the `rect` function is returning the
 sketch group that contains the tags.
-
 
 ---
 

--- a/docs/kcl-std/consts/std-X.md
+++ b/docs/kcl-std/consts/std-X.md
@@ -1,11 +1,11 @@
 ---
 title: "X"
 subtitle: "Constant in std"
-excerpt: ""
+excerpt: "The X-axis (can be used in both 2d and 3d contexts)."
 layout: manual
 ---
 
-
+The X-axis (can be used in both 2d and 3d contexts).
 
 ```kcl
 X

--- a/docs/kcl-std/consts/std-XY.md
+++ b/docs/kcl-std/consts/std-XY.md
@@ -1,11 +1,11 @@
 ---
 title: "XY"
 subtitle: "Constant in std"
-excerpt: ""
+excerpt: "An abstract 3d plane aligned with the X and Y axes. It's normal is the positive Z axis."
 layout: manual
 ---
 
-
+An abstract 3d plane aligned with the X and Y axes. It's normal is the positive Z axis.
 
 ```kcl
 XY

--- a/docs/kcl-std/consts/std-XY.md
+++ b/docs/kcl-std/consts/std-XY.md
@@ -1,11 +1,11 @@
 ---
 title: "XY"
 subtitle: "Constant in std"
-excerpt: "An abstract 3d plane aligned with the X and Y axes. It's normal is the positive Z axis."
+excerpt: "An abstract 3d plane aligned with the X and Y axes. Its normal is the positive Z axis."
 layout: manual
 ---
 
-An abstract 3d plane aligned with the X and Y axes. It's normal is the positive Z axis.
+An abstract 3d plane aligned with the X and Y axes. Its normal is the positive Z axis.
 
 ```kcl
 XY

--- a/docs/kcl-std/consts/std-XZ.md
+++ b/docs/kcl-std/consts/std-XZ.md
@@ -1,11 +1,11 @@
 ---
 title: "XZ"
 subtitle: "Constant in std"
-excerpt: ""
+excerpt: "An abstract 3d plane aligned with the X and Z axes. It's normal is the negative Y axis."
 layout: manual
 ---
 
-
+An abstract 3d plane aligned with the X and Z axes. It's normal is the negative Y axis.
 
 ```kcl
 XZ

--- a/docs/kcl-std/consts/std-XZ.md
+++ b/docs/kcl-std/consts/std-XZ.md
@@ -1,11 +1,11 @@
 ---
 title: "XZ"
 subtitle: "Constant in std"
-excerpt: "An abstract 3d plane aligned with the X and Z axes. It's normal is the negative Y axis."
+excerpt: "An abstract 3d plane aligned with the X and Z axes. Its normal is the negative Y axis."
 layout: manual
 ---
 
-An abstract 3d plane aligned with the X and Z axes. It's normal is the negative Y axis.
+An abstract 3d plane aligned with the X and Z axes. Its normal is the negative Y axis.
 
 ```kcl
 XZ

--- a/docs/kcl-std/consts/std-Y.md
+++ b/docs/kcl-std/consts/std-Y.md
@@ -1,11 +1,11 @@
 ---
 title: "Y"
 subtitle: "Constant in std"
-excerpt: ""
+excerpt: "The Y-axis (can be used in both 2d and 3d contexts)."
 layout: manual
 ---
 
-
+The Y-axis (can be used in both 2d and 3d contexts).
 
 ```kcl
 Y

--- a/docs/kcl-std/consts/std-YZ.md
+++ b/docs/kcl-std/consts/std-YZ.md
@@ -1,11 +1,11 @@
 ---
 title: "YZ"
 subtitle: "Constant in std"
-excerpt: "An abstract 3d plane aligned with the Y and Z axes. It's normal is the positive X axis."
+excerpt: "An abstract 3d plane aligned with the Y and Z axes. Its normal is the positive X axis."
 layout: manual
 ---
 
-An abstract 3d plane aligned with the Y and Z axes. It's normal is the positive X axis.
+An abstract 3d plane aligned with the Y and Z axes. Its normal is the positive X axis.
 
 ```kcl
 YZ

--- a/docs/kcl-std/consts/std-YZ.md
+++ b/docs/kcl-std/consts/std-YZ.md
@@ -1,11 +1,11 @@
 ---
 title: "YZ"
 subtitle: "Constant in std"
-excerpt: ""
+excerpt: "An abstract 3d plane aligned with the Y and Z axes. It's normal is the positive X axis."
 layout: manual
 ---
 
-
+An abstract 3d plane aligned with the Y and Z axes. It's normal is the positive X axis.
 
 ```kcl
 YZ

--- a/docs/kcl-std/consts/std-Z.md
+++ b/docs/kcl-std/consts/std-Z.md
@@ -1,11 +1,11 @@
 ---
 title: "Z"
 subtitle: "Constant in std"
-excerpt: ""
+excerpt: "The 3D Z-axis."
 layout: manual
 ---
 
-
+The 3D Z-axis.
 
 ```kcl
 Z

--- a/docs/kcl-std/consts/std-turns-HALF_TURN.md
+++ b/docs/kcl-std/consts/std-turns-HALF_TURN.md
@@ -1,11 +1,11 @@
 ---
 title: "turns::HALF_TURN"
 subtitle: "Constant in std::turns"
-excerpt: ""
+excerpt: "A half turn, 180 degrees or π radians."
 layout: manual
 ---
 
-
+A half turn, 180 degrees or π radians.
 
 ```kcl
 turns::HALF_TURN: number(deg) = 180deg

--- a/docs/kcl-std/consts/std-turns-QUARTER_TURN.md
+++ b/docs/kcl-std/consts/std-turns-QUARTER_TURN.md
@@ -1,11 +1,11 @@
 ---
 title: "turns::QUARTER_TURN"
 subtitle: "Constant in std::turns"
-excerpt: ""
+excerpt: "A quarter turn, 90 degrees or π/2 radians."
 layout: manual
 ---
 
-
+A quarter turn, 90 degrees or π/2 radians.
 
 ```kcl
 turns::QUARTER_TURN: number(deg) = 90deg

--- a/docs/kcl-std/consts/std-turns-THREE_QUARTER_TURN.md
+++ b/docs/kcl-std/consts/std-turns-THREE_QUARTER_TURN.md
@@ -1,11 +1,11 @@
 ---
 title: "turns::THREE_QUARTER_TURN"
 subtitle: "Constant in std::turns"
-excerpt: ""
+excerpt: "Three quarters of a turn, 270 degrees or 1.5*π radians."
 layout: manual
 ---
 
-
+Three quarters of a turn, 270 degrees or 1.5*π radians.
 
 ```kcl
 turns::THREE_QUARTER_TURN: number(deg) = 270deg

--- a/docs/kcl-std/consts/std-turns-ZERO.md
+++ b/docs/kcl-std/consts/std-turns-ZERO.md
@@ -1,11 +1,11 @@
 ---
 title: "turns::ZERO"
 subtitle: "Constant in std::turns"
-excerpt: ""
+excerpt: "No turn, zero degrees/radians."
 layout: manual
 ---
 
-
+No turn, zero degrees/radians.
 
 ```kcl
 turns::ZERO: number = 0

--- a/docs/kcl-std/functions/std-helix.md
+++ b/docs/kcl-std/functions/std-helix.md
@@ -35,7 +35,7 @@ helix(
 
 ### Returns
 
-[`Helix`](/docs/kcl-std/types/std-types-Helix) - A helix.
+[`Helix`](/docs/kcl-std/types/std-types-Helix) - A helix; created by the `helix` function.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-abs.md
+++ b/docs/kcl-std/functions/std-math-abs.md
@@ -17,11 +17,11 @@ abs(@input: number): number
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `input` | [`number`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `input` | [`number`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-acos.md
+++ b/docs/kcl-std/functions/std-math-acos.md
@@ -17,11 +17,11 @@ acos(@num: number(_)): number(rad)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | [`number(_)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `num` | [`number(_)`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number(rad)`](/docs/kcl-std/types/std-types-number) - A number
+[`number(rad)`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-asin.md
+++ b/docs/kcl-std/functions/std-math-asin.md
@@ -17,11 +17,11 @@ asin(@num: number(_)): number(rad)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | [`number(_)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `num` | [`number(_)`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number(rad)`](/docs/kcl-std/types/std-types-number) - A number
+[`number(rad)`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-atan.md
+++ b/docs/kcl-std/functions/std-math-atan.md
@@ -17,11 +17,11 @@ Consider using `atan2()` instead for the true inverse of tangent.
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | [`number(_)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `num` | [`number(_)`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number(rad)`](/docs/kcl-std/types/std-types-number) - A number
+[`number(rad)`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-atan2.md
+++ b/docs/kcl-std/functions/std-math-atan2.md
@@ -20,12 +20,12 @@ atan2(
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `y` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
-| `x` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `y` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
+| `x` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number(rad)`](/docs/kcl-std/types/std-types-number) - A number
+[`number(rad)`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-ceil.md
+++ b/docs/kcl-std/functions/std-math-ceil.md
@@ -17,11 +17,11 @@ ceil(@input: number): number
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `input` | [`number`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `input` | [`number`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-cos.md
+++ b/docs/kcl-std/functions/std-math-cos.md
@@ -17,11 +17,11 @@ cos(@num: number(Angle)): number(_)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | [`number(Angle)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `num` | [`number(Angle)`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number(_)`](/docs/kcl-std/types/std-types-number) - A number
+[`number(_)`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-floor.md
+++ b/docs/kcl-std/functions/std-math-floor.md
@@ -17,11 +17,11 @@ floor(@input: number): number
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `input` | [`number`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `input` | [`number`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-ln.md
+++ b/docs/kcl-std/functions/std-math-ln.md
@@ -17,11 +17,11 @@ ln(@input: number): number
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `input` | [`number`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `input` | [`number`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-log.md
+++ b/docs/kcl-std/functions/std-math-log.md
@@ -27,7 +27,7 @@ and `log10` can produce more accurate results for base 10.
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-log10.md
+++ b/docs/kcl-std/functions/std-math-log10.md
@@ -17,11 +17,11 @@ log10(@input: number): number
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `input` | [`number`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `input` | [`number`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-log2.md
+++ b/docs/kcl-std/functions/std-math-log2.md
@@ -17,11 +17,11 @@ log2(@input: number): number
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `input` | [`number`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `input` | [`number`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-max.md
+++ b/docs/kcl-std/functions/std-math-max.md
@@ -21,7 +21,7 @@ max(@input: [number; 1+]): number
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-min.md
+++ b/docs/kcl-std/functions/std-math-min.md
@@ -21,7 +21,7 @@ min(@input: [number; 1+]): number
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-polar.md
+++ b/docs/kcl-std/functions/std-math-polar.md
@@ -21,8 +21,8 @@ cartesian (x/y/z grid) coordinates.
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `angle` | [`number(rad)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
-| `length` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `angle` | [`number(rad)`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
+| `length` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-math-pow.md
+++ b/docs/kcl-std/functions/std-math-pow.md
@@ -25,7 +25,7 @@ pow(
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-rem.md
+++ b/docs/kcl-std/functions/std-math-rem.md
@@ -26,7 +26,7 @@ If `num` is negative, the result will be too.
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-round.md
+++ b/docs/kcl-std/functions/std-math-round.md
@@ -17,11 +17,11 @@ round(@input: number): number
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `input` | [`number`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `input` | [`number`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-sin.md
+++ b/docs/kcl-std/functions/std-math-sin.md
@@ -17,11 +17,11 @@ sin(@num: number(Angle)): number(_)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | [`number(Angle)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `num` | [`number(Angle)`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number(_)`](/docs/kcl-std/types/std-types-number) - A number
+[`number(_)`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-sqrt.md
+++ b/docs/kcl-std/functions/std-math-sqrt.md
@@ -17,11 +17,11 @@ sqrt(@input: number): number
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `input` | [`number`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `input` | [`number`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-math-tan.md
+++ b/docs/kcl-std/functions/std-math-tan.md
@@ -17,11 +17,11 @@ tan(@num: number(Angle)): number(_)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | [`number(Angle)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `num` | [`number(Angle)`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number(_)`](/docs/kcl-std/types/std-types-number) - A number
+[`number(_)`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-offsetPlane.md
+++ b/docs/kcl-std/functions/std-offsetPlane.md
@@ -26,7 +26,7 @@ plane and 10 units away from it.
 
 ### Returns
 
-[`Plane`](/docs/kcl-std/types/std-types-Plane) - A plane.
+[`Plane`](/docs/kcl-std/types/std-types-Plane) - An abstract plane.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-sketch-revolve.md
+++ b/docs/kcl-std/functions/std-sketch-revolve.md
@@ -46,7 +46,7 @@ revolved around the same axis.
 
 ### Returns
 
-[`Solid`](/docs/kcl-std/types/std-types-Solid) - A solid is a collection of extrude surfaces.
+[`Solid`](/docs/kcl-std/types/std-types-Solid) - A solid is a collection of extruded surfaces.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-solid-chamfer.md
+++ b/docs/kcl-std/functions/std-solid-chamfer.md
@@ -31,7 +31,7 @@ a sharp, straight transitional edge.
 
 ### Returns
 
-[`Solid`](/docs/kcl-std/types/std-types-Solid) - A solid is a collection of extrude surfaces.
+[`Solid`](/docs/kcl-std/types/std-types-Solid) - A solid is a collection of extruded surfaces.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-solid-fillet.md
+++ b/docs/kcl-std/functions/std-solid-fillet.md
@@ -33,7 +33,7 @@ will smoothly blend the transition.
 
 ### Returns
 
-[`Solid`](/docs/kcl-std/types/std-types-Solid) - A solid is a collection of extrude surfaces.
+[`Solid`](/docs/kcl-std/types/std-types-Solid) - A solid is a collection of extruded surfaces.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-solid-hollow.md
+++ b/docs/kcl-std/functions/std-solid-hollow.md
@@ -26,7 +26,7 @@ provided thickness remains around the exterior of the shape.
 
 ### Returns
 
-[`Solid`](/docs/kcl-std/types/std-types-Solid) - A solid is a collection of extrude surfaces.
+[`Solid`](/docs/kcl-std/types/std-types-Solid) - A solid is a collection of extruded surfaces.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-units-toCentimeters.md
+++ b/docs/kcl-std/functions/std-units-toCentimeters.md
@@ -17,11 +17,11 @@ units::toCentimeters(@num: number(cm)): number(cm)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | [`number(cm)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `num` | [`number(cm)`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number(cm)`](/docs/kcl-std/types/std-types-number) - A number
+[`number(cm)`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 

--- a/docs/kcl-std/functions/std-units-toDegrees.md
+++ b/docs/kcl-std/functions/std-units-toDegrees.md
@@ -17,11 +17,11 @@ units::toDegrees(@num: number(deg)): number(deg)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | [`number(deg)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `num` | [`number(deg)`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number(deg)`](/docs/kcl-std/types/std-types-number) - A number
+[`number(deg)`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-units-toFeet.md
+++ b/docs/kcl-std/functions/std-units-toFeet.md
@@ -17,11 +17,11 @@ units::toFeet(@num: number(ft)): number(ft)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | [`number(ft)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `num` | [`number(ft)`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number(ft)`](/docs/kcl-std/types/std-types-number) - A number
+[`number(ft)`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 

--- a/docs/kcl-std/functions/std-units-toInches.md
+++ b/docs/kcl-std/functions/std-units-toInches.md
@@ -17,11 +17,11 @@ units::toInches(@num: number(in)): number(in)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | [`number(in)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `num` | [`number(in)`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number(in)`](/docs/kcl-std/types/std-types-number) - A number
+[`number(in)`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 

--- a/docs/kcl-std/functions/std-units-toMeters.md
+++ b/docs/kcl-std/functions/std-units-toMeters.md
@@ -17,11 +17,11 @@ units::toMeters(@num: number(m)): number(m)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | [`number(m)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `num` | [`number(m)`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number(m)`](/docs/kcl-std/types/std-types-number) - A number
+[`number(m)`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 

--- a/docs/kcl-std/functions/std-units-toMillimeters.md
+++ b/docs/kcl-std/functions/std-units-toMillimeters.md
@@ -17,11 +17,11 @@ units::toMillimeters(@num: number(mm)): number(mm)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | [`number(mm)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `num` | [`number(mm)`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number(mm)`](/docs/kcl-std/types/std-types-number) - A number
+[`number(mm)`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 

--- a/docs/kcl-std/functions/std-units-toRadians.md
+++ b/docs/kcl-std/functions/std-units-toRadians.md
@@ -17,11 +17,11 @@ units::toRadians(@num: number(rad)): number(rad)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | [`number(rad)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `num` | [`number(rad)`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number(rad)`](/docs/kcl-std/types/std-types-number) - A number
+[`number(rad)`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-units-toYards.md
+++ b/docs/kcl-std/functions/std-units-toYards.md
@@ -17,11 +17,11 @@ units::toYards(@num: number(yd)): number(yd)
 
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
-| `num` | [`number(yd)`](/docs/kcl-std/types/std-types-number) | A number | Yes |
+| `num` | [`number(yd)`](/docs/kcl-std/types/std-types-number) | A number. | Yes |
 
 ### Returns
 
-[`number(yd)`](/docs/kcl-std/types/std-types-number) - A number
+[`number(yd)`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 

--- a/docs/kcl-std/lastSegX.md
+++ b/docs/kcl-std/lastSegX.md
@@ -21,7 +21,7 @@ lastSegX(@sketch: Sketch): number
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/lastSegY.md
+++ b/docs/kcl-std/lastSegY.md
@@ -21,7 +21,7 @@ lastSegY(@sketch: Sketch): number
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/legAngX.md
+++ b/docs/kcl-std/legAngX.md
@@ -25,7 +25,7 @@ legAngX(
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/legAngY.md
+++ b/docs/kcl-std/legAngY.md
@@ -25,7 +25,7 @@ legAngY(
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/legLen.md
+++ b/docs/kcl-std/legLen.md
@@ -25,7 +25,7 @@ legLen(
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/loft.md
+++ b/docs/kcl-std/loft.md
@@ -35,7 +35,7 @@ The sketches need to closed and on the same plane.
 
 ### Returns
 
-[`Solid`](/docs/kcl-std/types/std-types-Solid) - A solid is a collection of extrude surfaces.
+[`Solid`](/docs/kcl-std/types/std-types-Solid) - A solid is a collection of extruded surfaces.
 
 
 ### Examples

--- a/docs/kcl-std/modules/std-array.md
+++ b/docs/kcl-std/modules/std-array.md
@@ -1,11 +1,11 @@
 ---
 title: "array"
 subtitle: "Module in std"
-excerpt: ""
+excerpt: "Functions for manipulating arrays of values. "
 layout: manual
 ---
 
-
+Functions for manipulating arrays of values. 
 
 
 

--- a/docs/kcl-std/modules/std-math.md
+++ b/docs/kcl-std/modules/std-math.md
@@ -1,11 +1,11 @@
 ---
 title: "math"
 subtitle: "Module in std"
-excerpt: ""
+excerpt: "Functions for mathematical operations and some useful constants. "
 layout: manual
 ---
 
-
+Functions for mathematical operations and some useful constants. 
 
 
 

--- a/docs/kcl-std/modules/std-sketch.md
+++ b/docs/kcl-std/modules/std-sketch.md
@@ -1,13 +1,13 @@
 ---
 title: "sketch"
 subtitle: "Module in std"
-excerpt: ""
+excerpt: "Sketching is the foundational activity for most KCL programs. A sketch is a two-dimensional drawing made from paths or shapes. A sketch is always drawn on a surface (either an abstract plane of a face of a solid). A sketch can be made into a solid by extruding it (or revolving, etc.). "
 layout: manual
 ---
 
+Sketching is the foundational activity for most KCL programs. A sketch is a two-dimensional drawing made from paths or shapes. A sketch is always drawn on a surface (either an abstract plane of a face of a solid). A sketch can be made into a solid by extruding it (or revolving, etc.). 
 
-
-
+This module contains functions for creating and manipulating sketches, and making them into solids. 
 
 
 ## Functions and constants

--- a/docs/kcl-std/modules/std-solid.md
+++ b/docs/kcl-std/modules/std-solid.md
@@ -1,11 +1,11 @@
 ---
 title: "solid"
 subtitle: "Module in std"
-excerpt: ""
+excerpt: "This module contains functions for modifying solids, e.g.. by adding a fillet or chamfer, or removing part of a solid. "
 layout: manual
 ---
 
-
+This module contains functions for modifying solids, e.g.. by adding a fillet or chamfer, or removing part of a solid. 
 
 
 

--- a/docs/kcl-std/modules/std-solid.md
+++ b/docs/kcl-std/modules/std-solid.md
@@ -1,11 +1,11 @@
 ---
 title: "solid"
 subtitle: "Module in std"
-excerpt: "This module contains functions for modifying solids, e.g.. by adding a fillet or chamfer, or removing part of a solid. "
+excerpt: "This module contains functions for modifying solids, e.g., by adding a fillet or chamfer, or removing part of a solid. "
 layout: manual
 ---
 
-This module contains functions for modifying solids, e.g.. by adding a fillet or chamfer, or removing part of a solid. 
+This module contains functions for modifying solids, e.g., by adding a fillet or chamfer, or removing part of a solid. 
 
 
 

--- a/docs/kcl-std/modules/std-transform.md
+++ b/docs/kcl-std/modules/std-transform.md
@@ -1,11 +1,11 @@
 ---
 title: "transform"
 subtitle: "Module in std"
-excerpt: ""
+excerpt: "This module contains functions for transforming sketches and solids. "
 layout: manual
 ---
 
-
+This module contains functions for transforming sketches and solids. 
 
 
 

--- a/docs/kcl-std/modules/std-turns.md
+++ b/docs/kcl-std/modules/std-turns.md
@@ -1,11 +1,11 @@
 ---
 title: "turns"
 subtitle: "Module in std"
-excerpt: ""
+excerpt: "This module contains a few handy constants for defining turns. "
 layout: manual
 ---
 
-
+This module contains a few handy constants for defining turns. 
 
 
 

--- a/docs/kcl-std/modules/std-types.md
+++ b/docs/kcl-std/modules/std-types.md
@@ -7,7 +7,7 @@ layout: manual
 
 KCL types. This module contains fundamental types like `number`, `string`, `Solid`, and `Sketch`. 
 
-Types can (optionally) be used to describe a function's arguments returned value. They are checked when a program runs and can help avoid errors. They are also useful to help document what a function does. 
+Types can (optionally) be used to describe a function's arguments and returned value. They are checked when a program runs and can help avoid errors. They are also useful to help document what a function does. 
 
 
 

--- a/docs/kcl-std/modules/std-types.md
+++ b/docs/kcl-std/modules/std-types.md
@@ -1,13 +1,13 @@
 ---
 title: "types"
 subtitle: "Module in std"
-excerpt: ""
+excerpt: "KCL types. This module contains fundamental types like `number`, `string`, `Solid`, and `Sketch`. "
 layout: manual
 ---
 
+KCL types. This module contains fundamental types like `number`, `string`, `Solid`, and `Sketch`. 
 
-
-
+Types can (optionally) be used to describe a function's arguments returned value. They are checked when a program runs and can help avoid errors. They are also useful to help document what a function does. 
 
 
 

--- a/docs/kcl-std/modules/std-units.md
+++ b/docs/kcl-std/modules/std-units.md
@@ -7,7 +7,9 @@ layout: manual
 
 Functions for converting numbers to different units. 
 
+All numbers in KCL include units, e.g., the number `42` is always '42 mm' or '42 degrees', etc. it is never just '42'. For more information, see [numeric types](/docs/kcl-std/modules/types/number). 
 
+Note that you only need to explicitly convert the units of a number if you need a specific unit for your own calculations. When calling a function, KCL will convert a number to the required units automatically (where possible, and give an error or warning if it's not possible). 
 
 
 ## Functions and constants

--- a/docs/kcl-std/modules/std-units.md
+++ b/docs/kcl-std/modules/std-units.md
@@ -7,7 +7,7 @@ layout: manual
 
 Functions for converting numbers to different units. 
 
-All numbers in KCL include units, e.g., the number `42` is always '42 mm' or '42 degrees', etc. it is never just '42'. For more information, see [numeric types](/docs/kcl-std/modules/types/number). 
+All numbers in KCL include units, e.g., the number `42` is always '42 mm' or '42 degrees', etc. it is never just '42'. For more information, see [numeric types](/docs/kcl-lang/numeric). 
 
 Note that you only need to explicitly convert the units of a number if you need a specific unit for your own calculations. When calling a function, KCL will convert a number to the required units automatically (where possible, and give an error or warning if it's not possible). 
 

--- a/docs/kcl-std/modules/std.md
+++ b/docs/kcl-std/modules/std.md
@@ -9,6 +9,8 @@ The KCL standard library
 
 Contains frequently used constants, functions for interacting with the KittyCAD servers to create sketches and geometry, and utility functions. 
 
+The standard library is organised into modules (listed below), but most things are always available in KCL programs. 
+
 ## Modules
 
 * [`array`](/docs/kcl-std/modules/std-array)

--- a/docs/kcl-std/profileStartX.md
+++ b/docs/kcl-std/profileStartX.md
@@ -21,7 +21,7 @@ profileStartX(@profile: Sketch): number
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/profileStartY.md
+++ b/docs/kcl-std/profileStartY.md
@@ -21,7 +21,7 @@ profileStartY(@profile: Sketch): number
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/segAng.md
+++ b/docs/kcl-std/segAng.md
@@ -21,7 +21,7 @@ segAng(@tag: TagIdentifier): number
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/segEndX.md
+++ b/docs/kcl-std/segEndX.md
@@ -21,7 +21,7 @@ segEndX(@tag: TagIdentifier): number
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/segEndY.md
+++ b/docs/kcl-std/segEndY.md
@@ -21,7 +21,7 @@ segEndY(@tag: TagIdentifier): number
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/segLen.md
+++ b/docs/kcl-std/segLen.md
@@ -21,7 +21,7 @@ segLen(@tag: TagIdentifier): number
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/segStartX.md
+++ b/docs/kcl-std/segStartX.md
@@ -21,7 +21,7 @@ segStartX(@tag: TagIdentifier): number
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/segStartY.md
+++ b/docs/kcl-std/segStartY.md
@@ -21,7 +21,7 @@ segStartY(@tag: TagIdentifier): number
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/tangentToEnd.md
+++ b/docs/kcl-std/tangentToEnd.md
@@ -21,7 +21,7 @@ tangentToEnd(@tag: TagIdentifier): number
 
 ### Returns
 
-[`number`](/docs/kcl-std/types/std-types-number) - A number
+[`number`](/docs/kcl-std/types/std-types-number) - A number.
 
 
 ### Examples

--- a/docs/kcl-std/types/std-types-Axis2d.md
+++ b/docs/kcl-std/types/std-types-Axis2d.md
@@ -1,11 +1,11 @@
 ---
 title: "Axis2d"
 subtitle: "Type in std::types"
-excerpt: "An infinite line in 2d space."
+excerpt: "An abstract and infinite line in 2d space."
 layout: manual
 ---
 
-An infinite line in 2d space.
+An abstract and infinite line in 2d space.
 
 
 

--- a/docs/kcl-std/types/std-types-Axis3d.md
+++ b/docs/kcl-std/types/std-types-Axis3d.md
@@ -1,11 +1,11 @@
 ---
 title: "Axis3d"
 subtitle: "Type in std::types"
-excerpt: "An infinite line in 3d space."
+excerpt: "An abstract and infinite line in 3d space."
 layout: manual
 ---
 
-An infinite line in 3d space.
+An abstract and infinite line in 3d space.
 
 
 

--- a/docs/kcl-std/types/std-types-Edge.md
+++ b/docs/kcl-std/types/std-types-Edge.md
@@ -1,11 +1,11 @@
 ---
 title: "Edge"
 subtitle: "Type in std::types"
-excerpt: "The edge of a solid."
+excerpt: "An edge of a solid."
 layout: manual
 ---
 
-The edge of a solid.
+An edge of a solid.
 
 
 

--- a/docs/kcl-std/types/std-types-Face.md
+++ b/docs/kcl-std/types/std-types-Face.md
@@ -1,11 +1,11 @@
 ---
 title: "Face"
 subtitle: "Type in std::types"
-excerpt: "A face."
+excerpt: "A face of a solid."
 layout: manual
 ---
 
-A face.
+A face of a solid.
 
 
 

--- a/docs/kcl-std/types/std-types-Helix.md
+++ b/docs/kcl-std/types/std-types-Helix.md
@@ -1,11 +1,11 @@
 ---
 title: "Helix"
 subtitle: "Type in std::types"
-excerpt: "A helix."
+excerpt: "A helix; created by the `helix` function."
 layout: manual
 ---
 
-A helix.
+A helix; created by the `helix` function.
 
 
 

--- a/docs/kcl-std/types/std-types-Plane.md
+++ b/docs/kcl-std/types/std-types-Plane.md
@@ -1,13 +1,14 @@
 ---
 title: "Plane"
 subtitle: "Type in std::types"
-excerpt: "A plane."
+excerpt: "An abstract plane."
 layout: manual
 ---
 
-A plane.
+An abstract plane.
 
-
+A plane has a position and orientation in space defined by its origin and axes. A plane can be used
+to sketch on.
 
 
 

--- a/docs/kcl-std/types/std-types-Solid.md
+++ b/docs/kcl-std/types/std-types-Solid.md
@@ -1,11 +1,11 @@
 ---
 title: "Solid"
 subtitle: "Type in std::types"
-excerpt: "A solid is a collection of extrude surfaces."
+excerpt: "A solid is a collection of extruded surfaces."
 layout: manual
 ---
 
-A solid is a collection of extrude surfaces.
+A solid is a collection of extruded surfaces.
 
 When you define a solid to a variable like:
 

--- a/docs/kcl-std/types/std-types-any.md
+++ b/docs/kcl-std/types/std-types-any.md
@@ -1,13 +1,28 @@
 ---
 title: "any"
 subtitle: "Type in std::types"
-excerpt: "Any value."
+excerpt: ""
 layout: manual
 ---
 
-Any value.
 
 
+The [`any`](/docs/kcl-std/types/std-types-any) type is the type of all possible values in KCL. I.e., if a function accepts an argument
+with type [`any`](/docs/kcl-std/types/std-types-any), then it can accept any value.
+
+
+### Examples
+
+```kcl
+fn acceptAnything(@input: any) {
+  return true
+}
+
+acceptAnything(42)
+acceptAnything('hello')
+acceptAnything(XY)
+acceptAnything([0, 1, 2])
+```
 
 
 

--- a/docs/kcl-std/types/std-types-bool.md
+++ b/docs/kcl-std/types/std-types-bool.md
@@ -7,7 +7,7 @@ layout: manual
 
 A boolean value.
 
-`true` or `false`
+`true` or `false`.
 
 
 

--- a/docs/kcl-std/types/std-types-number.md
+++ b/docs/kcl-std/types/std-types-number.md
@@ -1,15 +1,26 @@
 ---
 title: "number"
 subtitle: "Type in std::types"
-excerpt: "A number"
+excerpt: "A number."
 layout: manual
 ---
 
-A number
+A number.
 
 May be signed or unsigned, an integer or decimal value.
 
-You may see a number type with units, e.g., [`number(mm)`](/docs/kcl-std/types/std-types-number). These are currently experimental.
+KCL numbers always include units, e.g., the number `42` is always '42 mm' or '42 degrees', etc.
+it is never just '42'. The [`number`](/docs/kcl-std/types/std-types-number) type may or may not include units, if none are specified, then
+it is the type of any number. E.g.,
+
+- [`number`](/docs/kcl-std/types/std-types-number): the type of any numbers,
+- [`number(mm)`](/docs/kcl-std/types/std-types-number): the type of numbers in milimeters,
+- [`number(in)`](/docs/kcl-std/types/std-types-number): the type of numbers in inches,
+- [`number(Length)`](/docs/kcl-std/types/std-types-number): the type of numbers in any length unit,
+- [`number(deg)`](/docs/kcl-std/types/std-types-number): the type of numbers in degrees,
+- [`number(Angle)`](/docs/kcl-std/types/std-types-number): the type of numbers in any angle unit,
+- [`number(_)`](/docs/kcl-std/types/std-types-number) or [`number(Count)`](/docs/kcl-std/types/std-types-number): the type of unit-less numbers, representing a count of things,
+or a ratio, etc.
 
 
 

--- a/docs/kcl-std/types/std-types-number.md
+++ b/docs/kcl-std/types/std-types-number.md
@@ -14,13 +14,15 @@ it is never just '42'. The [`number`](/docs/kcl-std/types/std-types-number) type
 it is the type of any number. E.g.,
 
 - [`number`](/docs/kcl-std/types/std-types-number): the type of any numbers,
-- [`number(mm)`](/docs/kcl-std/types/std-types-number): the type of numbers in milimeters,
+- [`number(mm)`](/docs/kcl-std/types/std-types-number): the type of numbers in millimeters,
 - [`number(in)`](/docs/kcl-std/types/std-types-number): the type of numbers in inches,
 - [`number(Length)`](/docs/kcl-std/types/std-types-number): the type of numbers in any length unit,
 - [`number(deg)`](/docs/kcl-std/types/std-types-number): the type of numbers in degrees,
 - [`number(Angle)`](/docs/kcl-std/types/std-types-number): the type of numbers in any angle unit,
 - [`number(_)`](/docs/kcl-std/types/std-types-number) or [`number(Count)`](/docs/kcl-std/types/std-types-number): the type of unit-less numbers, representing a count of things,
 or a ratio, etc.
+
+For more information, see [numeric types](/docs/kcl-lang/numeric).
 
 
 

--- a/rust/kcl-lib/std/array.kcl
+++ b/rust/kcl-lib/std/array.kcl
@@ -1,2 +1,4 @@
+/// Functions for manipulating arrays of values.
+
 @no_std
 @settings(defaultLengthUnit = mm, kclVersion = 1.0)

--- a/rust/kcl-lib/std/math.kcl
+++ b/rust/kcl-lib/std/math.kcl
@@ -1,3 +1,5 @@
+/// Functions for mathematical operations and some useful constants.
+
 @no_std
 @settings(defaultLengthUnit = mm, kclVersion = 1.0)
 

--- a/rust/kcl-lib/std/prelude.kcl
+++ b/rust/kcl-lib/std/prelude.kcl
@@ -20,21 +20,21 @@ export import * from "std::solid"
 export import * from "std::transform"
 export import "std::turns"
 
-/// An abstract 3d plane aligned with the X and Y axes. It's normal is the positive Z axis.
+/// An abstract 3d plane aligned with the X and Y axes. Its normal is the positive Z axis.
 export XY = {
   origin = { x = 0, y = 0, z = 0 },
   xAxis = { x = 1, y = 0, z = 0 },
   yAxis = { x = 0, y = 1, z = 0 },
 }: Plane
 
-/// An abstract 3d plane aligned with the X and Z axes. It's normal is the negative Y axis.
+/// An abstract 3d plane aligned with the X and Z axes. Its normal is the negative Y axis.
 export XZ = {
   origin = { x = 0, y = 0, z = 0 },
   xAxis = { x = 1, y = 0, z = 0 },
   yAxis = { x = 0, y = 0, z = 1 },
 }: Plane
 
-/// An abstract 3d plane aligned with the Y and Z axes. It's normal is the positive X axis.
+/// An abstract 3d plane aligned with the Y and Z axes. Its normal is the positive X axis.
 export YZ = {
   origin = { x = 0, y = 0, z = 0 },
   xAxis = { x = 0, y = 1, z = 0 },

--- a/rust/kcl-lib/std/prelude.kcl
+++ b/rust/kcl-lib/std/prelude.kcl
@@ -2,6 +2,9 @@
 ///
 /// Contains frequently used constants, functions for interacting with the KittyCAD servers to
 /// create sketches and geometry, and utility functions.
+///
+/// The standard library is organised into modules (listed below), but most things are always available
+/// in KCL programs.
 
 @no_std
 @settings(defaultLengthUnit = mm, kclVersion = 1.0)
@@ -17,34 +20,40 @@ export import * from "std::solid"
 export import * from "std::transform"
 export import "std::turns"
 
+/// An abstract 3d plane aligned with the X and Y axes. It's normal is the positive Z axis.
 export XY = {
   origin = { x = 0, y = 0, z = 0 },
   xAxis = { x = 1, y = 0, z = 0 },
   yAxis = { x = 0, y = 1, z = 0 },
 }: Plane
 
+/// An abstract 3d plane aligned with the X and Z axes. It's normal is the negative Y axis.
 export XZ = {
   origin = { x = 0, y = 0, z = 0 },
   xAxis = { x = 1, y = 0, z = 0 },
   yAxis = { x = 0, y = 0, z = 1 },
 }: Plane
 
+/// An abstract 3d plane aligned with the Y and Z axes. It's normal is the positive X axis.
 export YZ = {
   origin = { x = 0, y = 0, z = 0 },
   xAxis = { x = 0, y = 1, z = 0 },
   yAxis = { x = 0, y = 0, z = 1 },
 }: Plane
 
+/// The X-axis (can be used in both 2d and 3d contexts).
 export X = {
   origin = [0, 0, 0],
   direction = [1, 0, 0],
 }: Axis3d
 
+/// The Y-axis (can be used in both 2d and 3d contexts).
 export Y = {
   origin = [0, 0, 0],
   direction = [0, 1, 0],
 }: Axis3d
 
+/// The 3D Z-axis.
 export Z = {
   origin = [0, 0, 0],
   direction = [0, 0, 1],

--- a/rust/kcl-lib/std/sketch.kcl
+++ b/rust/kcl-lib/std/sketch.kcl
@@ -1,3 +1,9 @@
+/// Sketching is the foundational activity for most KCL programs. A sketch is a two-dimensional
+/// drawing made from paths or shapes. A sketch is always drawn on a surface (either an abstract
+/// plane of a face of a solid). A sketch can be made into a solid by extruding it (or revolving, etc.).
+///
+/// This module contains functions for creating and manipulating sketches, and making them into solids.
+
 @no_std
 @settings(defaultLengthUnit = mm, kclVersion = 1.0)
 

--- a/rust/kcl-lib/std/solid.kcl
+++ b/rust/kcl-lib/std/solid.kcl
@@ -1,3 +1,6 @@
+/// This module contains functions for modifying solids, e.g.. by adding a fillet or chamfer, or
+/// removing part of a solid.
+
 @no_std
 @settings(defaultLengthUnit = mm, kclVersion = 1.0)
 

--- a/rust/kcl-lib/std/solid.kcl
+++ b/rust/kcl-lib/std/solid.kcl
@@ -1,4 +1,4 @@
-/// This module contains functions for modifying solids, e.g.. by adding a fillet or chamfer, or
+/// This module contains functions for modifying solids, e.g., by adding a fillet or chamfer, or
 /// removing part of a solid.
 
 @no_std

--- a/rust/kcl-lib/std/transform.kcl
+++ b/rust/kcl-lib/std/transform.kcl
@@ -1,6 +1,7 @@
+/// This module contains functions for transforming sketches and solids.
+
 @no_std
 @settings(defaultLengthUnit = mm, kclVersion = 1.0)
-
 
 /// Mirror a sketch.
 ///

--- a/rust/kcl-lib/std/turns.kcl
+++ b/rust/kcl-lib/std/turns.kcl
@@ -1,7 +1,16 @@
+/// This module contains a few handy constants for defining turns.
+
 @no_std
 @settings(defaultLengthUnit = mm, kclVersion = 1.0)
 
+/// No turn, zero degrees/radians.
 export ZERO = 0
+
+/// A quarter turn, 90 degrees or π/2 radians.
 export QUARTER_TURN = 90deg
+
+/// A half turn, 180 degrees or π radians.
 export HALF_TURN = 180deg
+
+/// Three quarters of a turn, 270 degrees or 1.5*π radians.
 export THREE_QUARTER_TURN = 270deg

--- a/rust/kcl-lib/std/types.kcl
+++ b/rust/kcl-lib/std/types.kcl
@@ -1,6 +1,6 @@
 /// KCL types. This module contains fundamental types like `number`, `string`, `Solid`, and `Sketch`.
 ///
-/// Types can (optionally) be used to describe a function's arguments returned value. They are checked
+/// Types can (optionally) be used to describe a function's arguments and returned value. They are checked
 /// when a program runs and can help avoid errors. They are also useful to help document what a function
 /// does.
 
@@ -32,13 +32,15 @@ export type any
 /// it is the type of any number. E.g.,
 ///
 /// - `number`: the type of any numbers,
-/// - `number(mm)`: the type of numbers in milimeters,
+/// - `number(mm)`: the type of numbers in millimeters,
 /// - `number(in)`: the type of numbers in inches,
 /// - `number(Length)`: the type of numbers in any length unit,
 /// - `number(deg)`: the type of numbers in degrees,
 /// - `number(Angle)`: the type of numbers in any angle unit,
 /// - `number(_)` or `number(Count)`: the type of unit-less numbers, representing a count of things,
 /// or a ratio, etc.
+///
+/// For more information, see [numeric types](/docs/kcl-lang/numeric).
 @(impl = primitive)
 export type number(unit)
 

--- a/rust/kcl-lib/std/types.kcl
+++ b/rust/kcl-lib/std/types.kcl
@@ -1,21 +1,50 @@
+/// KCL types. This module contains fundamental types like `number`, `string`, `Solid`, and `Sketch`.
+///
+/// Types can (optionally) be used to describe a function's arguments returned value. They are checked
+/// when a program runs and can help avoid errors. They are also useful to help document what a function
+/// does.
+
 @no_std
 @settings(defaultLengthUnit = mm, kclVersion = 1.0)
 
-/// Any value.
+/// The `any` type is the type of all possible values in KCL. I.e., if a function accepts an argument
+/// with type `any`, then it can accept any value.
+///
+/// ```kcl,norun
+/// fn acceptAnything(@input: any) {
+///   return true
+/// }
+///
+/// acceptAnything(42)
+/// acceptAnything('hello')
+/// acceptAnything(XY)
+/// acceptAnything([0, 1, 2])
+/// ```
 @(impl = primitive)
 export type any
 
-/// A number
+/// A number.
 ///
 /// May be signed or unsigned, an integer or decimal value.
 ///
-/// You may see a number type with units, e.g., `number(mm)`. These are currently experimental.
+/// KCL numbers always include units, e.g., the number `42` is always '42 mm' or '42 degrees', etc.
+/// it is never just '42'. The `number` type may or may not include units, if none are specified, then
+/// it is the type of any number. E.g.,
+///
+/// - `number`: the type of any numbers,
+/// - `number(mm)`: the type of numbers in milimeters,
+/// - `number(in)`: the type of numbers in inches,
+/// - `number(Length)`: the type of numbers in any length unit,
+/// - `number(deg)`: the type of numbers in degrees,
+/// - `number(Angle)`: the type of numbers in any angle unit,
+/// - `number(_)` or `number(Count)`: the type of unit-less numbers, representing a count of things,
+/// or a ratio, etc.
 @(impl = primitive)
 export type number(unit)
 
 /// A boolean value.
 ///
-/// `true` or `false`
+/// `true` or `false`.
 @(impl = primitive)
 export type bool
 
@@ -132,7 +161,10 @@ export type string
 @(impl = primitive)
 export type tag
 
-/// A plane.
+/// An abstract plane.
+///
+/// A plane has a position and orientation in space defined by its origin and axes. A plane can be used
+/// to sketch on.
 @(impl = std_rust)
 export type Plane
 
@@ -180,7 +212,7 @@ export type Plane
 @(impl = std_rust)
 export type Sketch
 
-/// A solid is a collection of extrude surfaces.
+/// A solid is a collection of extruded surfaces.
 ///
 /// When you define a solid to a variable like:
 ///
@@ -226,15 +258,15 @@ export type Sketch
 @(impl = std_rust)
 export type Solid
 
-/// A face.
+/// A face of a solid.
 @(impl = std_rust)
 export type Face
 
-/// A helix.
+/// A helix; created by the `helix` function.
 @(impl = std_rust)
 export type Helix
 
-/// The edge of a solid.
+/// An edge of a solid.
 @(impl = std_rust)
 export type Edge
 
@@ -250,10 +282,10 @@ export type Point2d = [number(Length); 2]
 /// with type `Point3d`, use an array, e.g., `[0, 0, 0]` or `[5.0, 3.14, 6.8]`.
 export type Point3d = [number(Length); 3]
 
-/// An infinite line in 2d space.
+/// An abstract and infinite line in 2d space.
 @(impl = std_rust)
 export type Axis2d
 
-/// An infinite line in 3d space.
+/// An abstract and infinite line in 3d space.
 @(impl = std_rust)
 export type Axis3d

--- a/rust/kcl-lib/std/units.kcl
+++ b/rust/kcl-lib/std/units.kcl
@@ -1,4 +1,11 @@
 /// Functions for converting numbers to different units.
+///
+/// All numbers in KCL include units, e.g., the number `42` is always '42 mm' or '42 degrees', etc.
+/// it is never just '42'. For more information, see [numeric types](/docs/kcl-std/modules/types/number).
+///
+/// Note that you only need to explicitly convert the units of a number if you need a specific unit
+/// for your own calculations. When calling a function, KCL will convert a number to the required
+/// units automatically (where possible, and give an error or warning if it's not possible).
 
 @no_std
 @settings(defaultLengthUnit = mm, kclVersion = 1.0)

--- a/rust/kcl-lib/std/units.kcl
+++ b/rust/kcl-lib/std/units.kcl
@@ -1,7 +1,7 @@
 /// Functions for converting numbers to different units.
 ///
 /// All numbers in KCL include units, e.g., the number `42` is always '42 mm' or '42 degrees', etc.
-/// it is never just '42'. For more information, see [numeric types](/docs/kcl-std/modules/types/number).
+/// it is never just '42'. For more information, see [numeric types](/docs/kcl-lang/numeric).
 ///
 /// Note that you only need to explicitly convert the units of a number if you need a specific unit
 /// for your own calculations. When calling a function, KCL will convert a number to the required


### PR DESCRIPTION
Adds basic docs for all modules and items in std (not necessarily great docs, but something for everything). Also breaks up the language reference into more chapters and adds docs for numeric types, attributes, and arithmetic/logic operators. Again these are not perfect and I haven't the existing docs other than to move them into separate files, they'll definitely need another pass (in particular to better compliment, and overlap less with, Adam's guide).