### PR TITLE
fix: clear scene and bust cache if rust panics

### DIFF
--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -2244,7 +2244,7 @@ w = f() + f()
     |> line(end = [0, 0])
     |> close()
 }
-  
+
 sketch = startSketchOn(XY)
   |> startProfile(at = [0,0])
   |> line(end = [0, 10])

--- a/src/lang/KclSingleton.ts
+++ b/src/lang/KclSingleton.ts
@@ -426,6 +426,7 @@ export class KclManager {
         EXECUTE_AST_INTERRUPT_ERROR_MESSAGE
       )
       // Exit early if we are already executing.
+
       return
     }
 
@@ -437,6 +438,7 @@ export class KclManager {
 
     this.isExecuting = true
     await this.ensureWasmInit()
+
     const { logs, errors, execState, isInterrupted } = await executeAst({
       ast,
       path: this.singletons.codeManager.currentFilePath || undefined,

--- a/src/lang/langHelpers.ts
+++ b/src/lang/langHelpers.ts
@@ -68,6 +68,7 @@ export async function executeAst({
     const settings = await jsAppSettings()
     const execState = await rustContext.execute(ast, settings, path)
 
+    console.log('execstate', execState)
     await rustContext.waitForAllEngineCommands()
     return {
       logs: [],

--- a/src/lib/exceptions.ts
+++ b/src/lib/exceptions.ts
@@ -1,8 +1,9 @@
 import toast from 'react-hot-toast'
 
-import { kclManager } from '@src/lib/singletons'
+import { kclManager, rustContext } from '@src/lib/singletons'
 import { reportRejection } from '@src/lib/trap'
 import { getModule, reloadModule } from '@src/lib/wasm_lib_wrapper'
+import { jsAppSettings } from '@src/lib/settings/settingsUtils'
 
 let initialized = false
 
@@ -16,7 +17,11 @@ export const initializeWindowExceptionHandler = () => {
   if (window && !initialized) {
     window.addEventListener('error', (event) => {
       void (async () => {
-        if (matchImportExportErrorCrash(event.message)) {
+        if (
+          matchImportExportErrorCrash(event.message) ||
+          matchUnreachableErrorCrash(event.message) ||
+          matchGenericWasmRuntimeHeuristicErrorCrash(event)
+        ) {
           // do global singleton cleanup
           kclManager.executeAstCleanUp()
           toast.error(
@@ -25,6 +30,19 @@ export const initializeWindowExceptionHandler = () => {
           try {
             await reloadModule()
             await getModule().default()
+            /**
+             * If I do not cache bust, swapping between files when a rust runtime error happens
+             * it will cache the result of the crashed result and not re executing a new good file
+             * CacheResult::NoAction(false) => {
+             *  let outcome = old_state.to_exec_outcome(result_env).await;
+             *  return Ok(outcome);
+             * }
+             * ^-- this is the block of code that returns which prevents it from running a new execute
+             */
+            await rustContext?.clearSceneAndBustCache(
+              await jsAppSettings(),
+              undefined
+            )
           } catch (e) {
             console.error('Failed to initialize wasm_lib')
             console.error(e)
@@ -49,4 +67,21 @@ const matchImportExportErrorCrash = (message: string): boolean => {
   // called `Result::unwrap_throw()` on an `Err` value
   const substringError = '`Result::unwrap_throw()` on an `Err` value'
   return message.indexOf(substringError) !== -1 ? true : false
+}
+
+const matchUnreachableErrorCrash = (message: string): boolean => {
+  const substringError = `Uncaught RuntimeError: unreachable`
+  return message.indexOf(substringError) !== -1 ? true : false
+}
+
+const matchGenericWasmRuntimeHeuristicErrorCrash = (
+  error: ErrorEvent
+): boolean => {
+  const stack = error?.error?.stack || null
+  if (typeof stack === 'string') {
+    const substringError = `WebAssembly.instantiate:wasm-function`
+    return stack.indexOf(substringError) !== -1 ? true : false
+  }
+
+  return false
 }


### PR DESCRIPTION
closes https://github.com/KittyCAD/modeling-app/issues/6808

# Issue

When rust panics the rust cache can become stale and prevent you from rendering other KCL files in your project.

# Implementation

- added new custom unreachable panic error message matching
- added generic stack track panic error message for rust runtime
- clearSceneAndBustCache if rust panics to prevent the cache from not re executing when it needs to

 
