### PR TITLE
Fix to use correct units for array range expressions

### DIFF
--- a/rust/kcl-lib/src/execution/kcl_value.rs
+++ b/rust/kcl-lib/src/execution/kcl_value.rs
@@ -404,6 +404,13 @@ impl KclValue {
         }
     }
 
+    pub fn as_int_with_ty(&self) -> Option<(i64, NumericType)> {
+        match self {
+            KclValue::Number { value, ty, .. } => crate::try_f64_to_i64(*value).map(|i| (i, ty.clone())),
+            _ => None,
+        }
+    }
+
     pub fn as_object(&self) -> Option<&KclObjectFields> {
         if let KclValue::Object { value, meta: _ } = &self {
             Some(value)

--- a/rust/kcl-lib/src/simulation_tests.rs
+++ b/rust/kcl-lib/src/simulation_tests.rs
@@ -594,6 +594,48 @@ mod array_range_negative_expr {
         super::execute(TEST_NAME, false).await
     }
 }
+mod array_range_with_units {
+    const TEST_NAME: &str = "array_range_with_units";
+
+    /// Test parsing KCL.
+    #[test]
+    fn parse() {
+        super::parse(TEST_NAME)
+    }
+
+    /// Test that parsing and unparsing KCL produces the original KCL input.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unparse() {
+        super::unparse(TEST_NAME).await
+    }
+
+    /// Test that KCL is executed correctly.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn kcl_test_execute() {
+        super::execute(TEST_NAME, false).await
+    }
+}
+mod array_range_mismatch_units {
+    const TEST_NAME: &str = "array_range_mismatch_units";
+
+    /// Test parsing KCL.
+    #[test]
+    fn parse() {
+        super::parse(TEST_NAME)
+    }
+
+    /// Test that parsing and unparsing KCL produces the original KCL input.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unparse() {
+        super::unparse(TEST_NAME).await
+    }
+
+    /// Test that KCL is executed correctly.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn kcl_test_execute() {
+        super::execute(TEST_NAME, false).await
+    }
+}
 mod sketch_in_object {
     const TEST_NAME: &str = "sketch_in_object";
 

--- a/rust/kcl-lib/tests/array_range_expr/program_memory.snap
+++ b/rust/kcl-lib/tests/array_range_expr/program_memory.snap
@@ -36,40 +36,65 @@ description: Variables in memory after executing array_range_expr.kcl
         "type": "Number",
         "value": 0.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 1.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 2.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 3.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 4.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       }
     ]
@@ -81,40 +106,65 @@ description: Variables in memory after executing array_range_expr.kcl
         "type": "Number",
         "value": 0.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 1.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 2.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 3.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 4.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       }
     ]
@@ -126,48 +176,78 @@ description: Variables in memory after executing array_range_expr.kcl
         "type": "Number",
         "value": 0.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 1.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 2.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 3.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 4.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 5.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       }
     ]
@@ -179,32 +259,52 @@ description: Variables in memory after executing array_range_expr.kcl
         "type": "Number",
         "value": 1.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 2.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 3.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 4.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       }
     ]

--- a/rust/kcl-lib/tests/array_range_mismatch_units/artifact_commands.snap
+++ b/rust/kcl-lib/tests/array_range_mismatch_units/artifact_commands.snap
@@ -1,0 +1,32 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Artifact commands array_range_mismatch_units.kcl
+---
+[
+  {
+    "cmdId": "[uuid]",
+    "range": [],
+    "command": {
+      "type": "edge_lines_visible",
+      "hidden": false
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [],
+    "command": {
+      "type": "object_visible",
+      "object_id": "[uuid]",
+      "hidden": true
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [],
+    "command": {
+      "type": "object_visible",
+      "object_id": "[uuid]",
+      "hidden": true
+    }
+  }
+]

--- a/rust/kcl-lib/tests/array_range_mismatch_units/artifact_graph_flowchart.snap
+++ b/rust/kcl-lib/tests/array_range_mismatch_units/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Artifact graph flowchart array_range_mismatch_units.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/rust/kcl-lib/tests/array_range_mismatch_units/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/array_range_mismatch_units/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/rust/kcl-lib/tests/array_range_mismatch_units/ast.snap
+++ b/rust/kcl-lib/tests/array_range_mismatch_units/ast.snap
@@ -1,0 +1,125 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Result of parsing array_range_mismatch_units.kcl
+---
+{
+  "Ok": {
+    "body": [
+      {
+        "commentStart": 0,
+        "declaration": {
+          "commentStart": 0,
+          "end": 0,
+          "id": {
+            "commentStart": 0,
+            "end": 0,
+            "name": "a",
+            "start": 0,
+            "type": "Identifier"
+          },
+          "init": {
+            "commentStart": 0,
+            "end": 0,
+            "endElement": {
+              "commentStart": 0,
+              "end": 0,
+              "raw": "3cm",
+              "start": 0,
+              "type": "Literal",
+              "type": "Literal",
+              "value": {
+                "value": 3.0,
+                "suffix": "Cm"
+              }
+            },
+            "endInclusive": true,
+            "start": 0,
+            "startElement": {
+              "commentStart": 0,
+              "end": 0,
+              "raw": "1mm",
+              "start": 0,
+              "type": "Literal",
+              "type": "Literal",
+              "value": {
+                "value": 1.0,
+                "suffix": "Mm"
+              }
+            },
+            "type": "ArrayRangeExpression",
+            "type": "ArrayRangeExpression"
+          },
+          "start": 0,
+          "type": "VariableDeclarator"
+        },
+        "end": 0,
+        "kind": "const",
+        "start": 0,
+        "type": "VariableDeclaration",
+        "type": "VariableDeclaration"
+      },
+      {
+        "commentStart": 0,
+        "end": 0,
+        "expression": {
+          "arguments": [
+            {
+              "type": "LabeledArg",
+              "label": {
+                "commentStart": 0,
+                "end": 0,
+                "name": "error",
+                "start": 0,
+                "type": "Identifier"
+              },
+              "arg": {
+                "commentStart": 0,
+                "end": 0,
+                "raw": "\"shouldn't make it here\"",
+                "start": 0,
+                "type": "Literal",
+                "type": "Literal",
+                "value": "shouldn't make it here"
+              }
+            }
+          ],
+          "callee": {
+            "abs_path": false,
+            "commentStart": 0,
+            "end": 0,
+            "name": {
+              "commentStart": 0,
+              "end": 0,
+              "name": "assertIs",
+              "start": 0,
+              "type": "Identifier"
+            },
+            "path": [],
+            "start": 0,
+            "type": "Name"
+          },
+          "commentStart": 0,
+          "end": 0,
+          "start": 0,
+          "type": "CallExpressionKw",
+          "type": "CallExpressionKw",
+          "unlabeled": {
+            "commentStart": 0,
+            "end": 0,
+            "raw": "false",
+            "start": 0,
+            "type": "Literal",
+            "type": "Literal",
+            "value": false
+          }
+        },
+        "start": 0,
+        "type": "ExpressionStatement",
+        "type": "ExpressionStatement"
+      }
+    ],
+    "commentStart": 0,
+    "end": 0,
+    "start": 0
+  }
+}

--- a/rust/kcl-lib/tests/array_range_mismatch_units/execution_error.snap
+++ b/rust/kcl-lib/tests/array_range_mismatch_units/execution_error.snap
@@ -1,0 +1,14 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Error from executing array_range_mismatch_units.kcl
+---
+KCL Semantic error
+
+  × semantic: Range start and end must be of the same type, but found 1:
+  │ number(mm) and 3: number(cm)
+   ╭─[1:5]
+ 1 │ a = [1mm..3cm]
+   ·     ─────┬────
+   ·          ╰── tests/array_range_mismatch_units/input.kcl
+ 2 │ assertIs(false, error = "shouldn't make it here")
+   ╰────

--- a/rust/kcl-lib/tests/array_range_mismatch_units/input.kcl
+++ b/rust/kcl-lib/tests/array_range_mismatch_units/input.kcl
@@ -1,0 +1,2 @@
+a = [1mm..3cm]
+assertIs(false, error = "shouldn't make it here")

--- a/rust/kcl-lib/tests/array_range_mismatch_units/ops.snap
+++ b/rust/kcl-lib/tests/array_range_mismatch_units/ops.snap
@@ -1,0 +1,5 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Operations executed array_range_mismatch_units.kcl
+---
+[]

--- a/rust/kcl-lib/tests/array_range_mismatch_units/unparsed.snap
+++ b/rust/kcl-lib/tests/array_range_mismatch_units/unparsed.snap
@@ -1,0 +1,6 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Result of unparsing array_range_mismatch_units.kcl
+---
+a = [1mm..3cm]
+assertIs(false, error = "shouldn't make it here")

--- a/rust/kcl-lib/tests/array_range_negative_expr/program_memory.snap
+++ b/rust/kcl-lib/tests/array_range_negative_expr/program_memory.snap
@@ -10,88 +10,143 @@ description: Variables in memory after executing array_range_negative_expr.kcl
         "type": "Number",
         "value": -5.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": -4.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": -3.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": -2.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": -1.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 0.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 1.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 2.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 3.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 4.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 5.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       }
     ]

--- a/rust/kcl-lib/tests/array_range_with_units/artifact_commands.snap
+++ b/rust/kcl-lib/tests/array_range_with_units/artifact_commands.snap
@@ -1,0 +1,32 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Artifact commands array_range_with_units.kcl
+---
+[
+  {
+    "cmdId": "[uuid]",
+    "range": [],
+    "command": {
+      "type": "edge_lines_visible",
+      "hidden": false
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [],
+    "command": {
+      "type": "object_visible",
+      "object_id": "[uuid]",
+      "hidden": true
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [],
+    "command": {
+      "type": "object_visible",
+      "object_id": "[uuid]",
+      "hidden": true
+    }
+  }
+]

--- a/rust/kcl-lib/tests/array_range_with_units/artifact_graph_flowchart.snap
+++ b/rust/kcl-lib/tests/array_range_with_units/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Artifact graph flowchart array_range_with_units.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/rust/kcl-lib/tests/array_range_with_units/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/array_range_with_units/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/rust/kcl-lib/tests/array_range_with_units/ast.snap
+++ b/rust/kcl-lib/tests/array_range_with_units/ast.snap
@@ -1,0 +1,309 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Result of parsing array_range_with_units.kcl
+---
+{
+  "Ok": {
+    "body": [
+      {
+        "commentStart": 0,
+        "declaration": {
+          "commentStart": 0,
+          "end": 0,
+          "id": {
+            "commentStart": 0,
+            "end": 0,
+            "name": "a",
+            "start": 0,
+            "type": "Identifier"
+          },
+          "init": {
+            "commentStart": 0,
+            "end": 0,
+            "endElement": {
+              "commentStart": 0,
+              "end": 0,
+              "raw": "3cm",
+              "start": 0,
+              "type": "Literal",
+              "type": "Literal",
+              "value": {
+                "value": 3.0,
+                "suffix": "Cm"
+              }
+            },
+            "endInclusive": true,
+            "start": 0,
+            "startElement": {
+              "commentStart": 0,
+              "end": 0,
+              "raw": "1cm",
+              "start": 0,
+              "type": "Literal",
+              "type": "Literal",
+              "value": {
+                "value": 1.0,
+                "suffix": "Cm"
+              }
+            },
+            "type": "ArrayRangeExpression",
+            "type": "ArrayRangeExpression"
+          },
+          "start": 0,
+          "type": "VariableDeclarator"
+        },
+        "end": 0,
+        "kind": "const",
+        "start": 0,
+        "type": "VariableDeclaration",
+        "type": "VariableDeclaration"
+      },
+      {
+        "commentStart": 0,
+        "end": 0,
+        "expression": {
+          "arguments": [
+            {
+              "type": "LabeledArg",
+              "label": {
+                "commentStart": 0,
+                "end": 0,
+                "name": "isEqualTo",
+                "start": 0,
+                "type": "Identifier"
+              },
+              "arg": {
+                "commentStart": 0,
+                "end": 0,
+                "raw": "1cm",
+                "start": 0,
+                "type": "Literal",
+                "type": "Literal",
+                "value": {
+                  "value": 1.0,
+                  "suffix": "Cm"
+                }
+              }
+            }
+          ],
+          "callee": {
+            "abs_path": false,
+            "commentStart": 0,
+            "end": 0,
+            "name": {
+              "commentStart": 0,
+              "end": 0,
+              "name": "assert",
+              "start": 0,
+              "type": "Identifier"
+            },
+            "path": [],
+            "start": 0,
+            "type": "Name"
+          },
+          "commentStart": 0,
+          "end": 0,
+          "start": 0,
+          "type": "CallExpressionKw",
+          "type": "CallExpressionKw",
+          "unlabeled": {
+            "commentStart": 0,
+            "computed": false,
+            "end": 0,
+            "object": {
+              "commentStart": 0,
+              "end": 0,
+              "name": "a",
+              "start": 0,
+              "type": "Identifier",
+              "type": "Identifier"
+            },
+            "property": {
+              "commentStart": 0,
+              "end": 0,
+              "raw": "0",
+              "start": 0,
+              "type": "Literal",
+              "type": "Literal",
+              "value": {
+                "value": 0.0,
+                "suffix": "None"
+              }
+            },
+            "start": 0,
+            "type": "MemberExpression",
+            "type": "MemberExpression"
+          }
+        },
+        "start": 0,
+        "type": "ExpressionStatement",
+        "type": "ExpressionStatement"
+      },
+      {
+        "commentStart": 0,
+        "end": 0,
+        "expression": {
+          "arguments": [
+            {
+              "type": "LabeledArg",
+              "label": {
+                "commentStart": 0,
+                "end": 0,
+                "name": "isEqualTo",
+                "start": 0,
+                "type": "Identifier"
+              },
+              "arg": {
+                "commentStart": 0,
+                "end": 0,
+                "raw": "2cm",
+                "start": 0,
+                "type": "Literal",
+                "type": "Literal",
+                "value": {
+                  "value": 2.0,
+                  "suffix": "Cm"
+                }
+              }
+            }
+          ],
+          "callee": {
+            "abs_path": false,
+            "commentStart": 0,
+            "end": 0,
+            "name": {
+              "commentStart": 0,
+              "end": 0,
+              "name": "assert",
+              "start": 0,
+              "type": "Identifier"
+            },
+            "path": [],
+            "start": 0,
+            "type": "Name"
+          },
+          "commentStart": 0,
+          "end": 0,
+          "start": 0,
+          "type": "CallExpressionKw",
+          "type": "CallExpressionKw",
+          "unlabeled": {
+            "commentStart": 0,
+            "computed": false,
+            "end": 0,
+            "object": {
+              "commentStart": 0,
+              "end": 0,
+              "name": "a",
+              "start": 0,
+              "type": "Identifier",
+              "type": "Identifier"
+            },
+            "property": {
+              "commentStart": 0,
+              "end": 0,
+              "raw": "1",
+              "start": 0,
+              "type": "Literal",
+              "type": "Literal",
+              "value": {
+                "value": 1.0,
+                "suffix": "None"
+              }
+            },
+            "start": 0,
+            "type": "MemberExpression",
+            "type": "MemberExpression"
+          }
+        },
+        "start": 0,
+        "type": "ExpressionStatement",
+        "type": "ExpressionStatement"
+      },
+      {
+        "commentStart": 0,
+        "end": 0,
+        "expression": {
+          "arguments": [
+            {
+              "type": "LabeledArg",
+              "label": {
+                "commentStart": 0,
+                "end": 0,
+                "name": "isEqualTo",
+                "start": 0,
+                "type": "Identifier"
+              },
+              "arg": {
+                "commentStart": 0,
+                "end": 0,
+                "raw": "3cm",
+                "start": 0,
+                "type": "Literal",
+                "type": "Literal",
+                "value": {
+                  "value": 3.0,
+                  "suffix": "Cm"
+                }
+              }
+            }
+          ],
+          "callee": {
+            "abs_path": false,
+            "commentStart": 0,
+            "end": 0,
+            "name": {
+              "commentStart": 0,
+              "end": 0,
+              "name": "assert",
+              "start": 0,
+              "type": "Identifier"
+            },
+            "path": [],
+            "start": 0,
+            "type": "Name"
+          },
+          "commentStart": 0,
+          "end": 0,
+          "start": 0,
+          "type": "CallExpressionKw",
+          "type": "CallExpressionKw",
+          "unlabeled": {
+            "commentStart": 0,
+            "computed": false,
+            "end": 0,
+            "object": {
+              "commentStart": 0,
+              "end": 0,
+              "name": "a",
+              "start": 0,
+              "type": "Identifier",
+              "type": "Identifier"
+            },
+            "property": {
+              "commentStart": 0,
+              "end": 0,
+              "raw": "2",
+              "start": 0,
+              "type": "Literal",
+              "type": "Literal",
+              "value": {
+                "value": 2.0,
+                "suffix": "None"
+              }
+            },
+            "start": 0,
+            "type": "MemberExpression",
+            "type": "MemberExpression"
+          }
+        },
+        "start": 0,
+        "type": "ExpressionStatement",
+        "type": "ExpressionStatement"
+      }
+    ],
+    "commentStart": 0,
+    "end": 0,
+    "start": 0
+  }
+}

--- a/rust/kcl-lib/tests/array_range_with_units/input.kcl
+++ b/rust/kcl-lib/tests/array_range_with_units/input.kcl
@@ -1,0 +1,4 @@
+a = [1cm..3cm]
+assert(a[0], isEqualTo = 1cm)
+assert(a[1], isEqualTo = 2cm)
+assert(a[2], isEqualTo = 3cm)

--- a/rust/kcl-lib/tests/array_range_with_units/ops.snap
+++ b/rust/kcl-lib/tests/array_range_with_units/ops.snap
@@ -1,0 +1,5 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Operations executed array_range_with_units.kcl
+---
+[]

--- a/rust/kcl-lib/tests/array_range_with_units/program_memory.snap
+++ b/rust/kcl-lib/tests/array_range_with_units/program_memory.snap
@@ -1,0 +1,35 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Variables in memory after executing array_range_with_units.kcl
+---
+{
+  "a": {
+    "type": "HomArray",
+    "value": [
+      {
+        "type": "Number",
+        "value": 1.0,
+        "ty": {
+          "type": "Known",
+          "type": "Count"
+        }
+      },
+      {
+        "type": "Number",
+        "value": 2.0,
+        "ty": {
+          "type": "Known",
+          "type": "Count"
+        }
+      },
+      {
+        "type": "Number",
+        "value": 3.0,
+        "ty": {
+          "type": "Known",
+          "type": "Count"
+        }
+      }
+    ]
+  }
+}

--- a/rust/kcl-lib/tests/array_range_with_units/program_memory.snap
+++ b/rust/kcl-lib/tests/array_range_with_units/program_memory.snap
@@ -11,7 +11,8 @@ description: Variables in memory after executing array_range_with_units.kcl
         "value": 1.0,
         "ty": {
           "type": "Known",
-          "type": "Count"
+          "type": "Length",
+          "type": "Cm"
         }
       },
       {
@@ -19,7 +20,8 @@ description: Variables in memory after executing array_range_with_units.kcl
         "value": 2.0,
         "ty": {
           "type": "Known",
-          "type": "Count"
+          "type": "Length",
+          "type": "Cm"
         }
       },
       {
@@ -27,7 +29,8 @@ description: Variables in memory after executing array_range_with_units.kcl
         "value": 3.0,
         "ty": {
           "type": "Known",
-          "type": "Count"
+          "type": "Length",
+          "type": "Cm"
         }
       }
     ]

--- a/rust/kcl-lib/tests/array_range_with_units/unparsed.snap
+++ b/rust/kcl-lib/tests/array_range_with_units/unparsed.snap
@@ -1,0 +1,8 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Result of unparsing array_range_with_units.kcl
+---
+a = [1cm..3cm]
+assert(a[0], isEqualTo = 1cm)
+assert(a[1], isEqualTo = 2cm)
+assert(a[2], isEqualTo = 3cm)

--- a/rust/kcl-lib/tests/double_map_fn/ops.snap
+++ b/rust/kcl-lib/tests/double_map_fn/ops.snap
@@ -14,8 +14,13 @@ description: Operations executed double_map_fn.kcl
           "type": "Number",
           "value": 0.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -35,8 +40,13 @@ description: Operations executed double_map_fn.kcl
           "type": "Number",
           "value": 1.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -56,8 +66,13 @@ description: Operations executed double_map_fn.kcl
           "type": "Number",
           "value": 2.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -77,8 +92,13 @@ description: Operations executed double_map_fn.kcl
           "type": "Number",
           "value": 1.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -98,8 +118,13 @@ description: Operations executed double_map_fn.kcl
           "type": "Number",
           "value": 2.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -119,8 +144,13 @@ description: Operations executed double_map_fn.kcl
           "type": "Number",
           "value": 3.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []

--- a/rust/kcl-lib/tests/double_map_fn/program_memory.snap
+++ b/rust/kcl-lib/tests/double_map_fn/program_memory.snap
@@ -14,24 +14,39 @@ description: Variables in memory after executing double_map_fn.kcl
         "type": "Number",
         "value": 0.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 1.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 2.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       }
     ]
@@ -43,24 +58,39 @@ description: Variables in memory after executing double_map_fn.kcl
         "type": "Number",
         "value": 2.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 3.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       },
       {
         "type": "Number",
         "value": 4.0,
         "ty": {
-          "type": "Known",
-          "type": "Count"
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
+          }
         }
       }
     ]

--- a/rust/kcl-lib/tests/import_async/ops.snap
+++ b/rust/kcl-lib/tests/import_async/ops.snap
@@ -36,8 +36,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 0.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -57,8 +62,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 1.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -78,8 +88,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 2.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -99,8 +114,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 3.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -120,8 +140,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 4.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -141,8 +166,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 5.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -162,8 +192,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 6.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -183,8 +218,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 7.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -204,8 +244,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 8.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -225,8 +270,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 9.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -246,8 +296,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 10.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -267,8 +322,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 11.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -288,8 +348,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 12.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -309,8 +374,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 13.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -330,8 +400,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 14.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -351,8 +426,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 15.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -372,8 +452,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 16.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -393,8 +478,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 17.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -414,8 +504,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 18.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -435,8 +530,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 19.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -456,8 +556,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 20.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -477,8 +582,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 21.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -498,8 +608,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 22.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -519,8 +634,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 23.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -540,8 +660,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 24.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -561,8 +686,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 25.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -582,8 +712,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 26.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -603,8 +738,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 27.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -624,8 +764,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 28.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -645,8 +790,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 29.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -666,8 +816,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 30.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -687,8 +842,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 31.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -708,8 +868,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 32.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -729,8 +894,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 33.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -750,8 +920,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 34.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -771,8 +946,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 35.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -792,8 +972,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 36.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -813,8 +998,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 37.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -834,8 +1024,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 38.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -855,8 +1050,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 39.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -876,8 +1076,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 40.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -897,8 +1102,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 41.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -918,8 +1128,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 42.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -939,8 +1154,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 43.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -960,8 +1180,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 44.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -981,8 +1206,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 45.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1002,8 +1232,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 46.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1023,8 +1258,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 47.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1044,8 +1284,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 48.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1065,8 +1310,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 49.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1086,8 +1336,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 50.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1107,8 +1362,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 51.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1128,8 +1388,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 52.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1149,8 +1414,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 53.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1170,8 +1440,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 54.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1191,8 +1466,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 55.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1212,8 +1492,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 56.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1233,8 +1518,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 57.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1254,8 +1544,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 58.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1275,8 +1570,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 59.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1296,8 +1596,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 60.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1317,8 +1622,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 61.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1338,8 +1648,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 62.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1359,8 +1674,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 63.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1380,8 +1700,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 64.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1401,8 +1726,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 65.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1422,8 +1752,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 66.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1443,8 +1778,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 67.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1464,8 +1804,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 68.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1485,8 +1830,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 69.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1506,8 +1856,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 70.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1527,8 +1882,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 71.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1548,8 +1908,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 72.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1569,8 +1934,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 73.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1590,8 +1960,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 74.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1611,8 +1986,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 75.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1632,8 +2012,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 76.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1653,8 +2038,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 77.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1674,8 +2064,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 78.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1695,8 +2090,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 79.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1716,8 +2116,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 80.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1737,8 +2142,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 81.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1758,8 +2168,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 82.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1779,8 +2194,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 83.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1800,8 +2220,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 84.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1821,8 +2246,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 85.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1842,8 +2272,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 86.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1863,8 +2298,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 87.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1884,8 +2324,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 88.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1905,8 +2350,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 89.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1926,8 +2376,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 90.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1947,8 +2402,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 91.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1968,8 +2428,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 92.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1989,8 +2454,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 93.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2010,8 +2480,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 94.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2031,8 +2506,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 95.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2052,8 +2532,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 96.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2073,8 +2558,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 97.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2094,8 +2584,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 98.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2115,8 +2610,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 99.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2136,8 +2636,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 100.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2157,8 +2662,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 101.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13806,8 +14316,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 0.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13827,8 +14342,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 1.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13848,8 +14368,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 2.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13869,8 +14394,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 3.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13890,8 +14420,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 4.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13911,8 +14446,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 5.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13932,8 +14472,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 6.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13953,8 +14498,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 7.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13974,8 +14524,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 8.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13995,8 +14550,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 9.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14016,8 +14576,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 10.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14037,8 +14602,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 11.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14058,8 +14628,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 12.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14079,8 +14654,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 13.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14100,8 +14680,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 14.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14121,8 +14706,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 15.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14142,8 +14732,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 16.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14163,8 +14758,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 17.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14184,8 +14784,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 18.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14205,8 +14810,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 19.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14226,8 +14836,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 20.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14247,8 +14862,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 21.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14268,8 +14888,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 22.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14289,8 +14914,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 23.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14310,8 +14940,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 24.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14331,8 +14966,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 25.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14352,8 +14992,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 26.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14373,8 +15018,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 27.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14394,8 +15044,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 28.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14415,8 +15070,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 29.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14436,8 +15096,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 30.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14457,8 +15122,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 31.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14478,8 +15148,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 32.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14499,8 +15174,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 33.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14520,8 +15200,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 34.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14541,8 +15226,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 35.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14562,8 +15252,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 36.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14583,8 +15278,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 37.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14604,8 +15304,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 38.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14625,8 +15330,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 39.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14646,8 +15356,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 40.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14667,8 +15382,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 41.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14688,8 +15408,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 42.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14709,8 +15434,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 43.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14730,8 +15460,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 44.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14751,8 +15486,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 45.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14772,8 +15512,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 46.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14793,8 +15538,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 47.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14814,8 +15564,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 48.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14835,8 +15590,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 49.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14856,8 +15616,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 50.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14877,8 +15642,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 51.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14898,8 +15668,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 52.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14919,8 +15694,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 53.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14940,8 +15720,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 54.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14961,8 +15746,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 55.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14982,8 +15772,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 56.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15003,8 +15798,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 57.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15024,8 +15824,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 58.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15045,8 +15850,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 59.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15066,8 +15876,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 60.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15087,8 +15902,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 61.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15108,8 +15928,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 62.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15129,8 +15954,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 63.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15150,8 +15980,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 64.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15171,8 +16006,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 65.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15192,8 +16032,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 66.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15213,8 +16058,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 67.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15234,8 +16084,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 68.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15255,8 +16110,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 69.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15276,8 +16136,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 70.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15297,8 +16162,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 71.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15318,8 +16188,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 72.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15339,8 +16214,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 73.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15360,8 +16240,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 74.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15381,8 +16266,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 75.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15402,8 +16292,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 76.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15423,8 +16318,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 77.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15444,8 +16344,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 78.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15465,8 +16370,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 79.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15486,8 +16396,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 80.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15507,8 +16422,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 81.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15528,8 +16448,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 82.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15549,8 +16474,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 83.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15570,8 +16500,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 84.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15591,8 +16526,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 85.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15612,8 +16552,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 86.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15633,8 +16578,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 87.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15654,8 +16604,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 88.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15675,8 +16630,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 89.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15696,8 +16656,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 90.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15717,8 +16682,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 91.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15738,8 +16708,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 92.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15759,8 +16734,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 93.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15780,8 +16760,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 94.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15801,8 +16786,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 95.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15822,8 +16812,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 96.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15843,8 +16838,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 97.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15864,8 +16864,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 98.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15885,8 +16890,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 99.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15906,8 +16916,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 100.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15927,8 +16942,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 101.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15948,8 +16968,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 0.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15969,8 +16994,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 1.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15990,8 +17020,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 2.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16011,8 +17046,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 3.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16032,8 +17072,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 4.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16053,8 +17098,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 5.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16074,8 +17124,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 6.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16095,8 +17150,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 7.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16116,8 +17176,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 8.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16137,8 +17202,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 9.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16158,8 +17228,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 10.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16179,8 +17254,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 11.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16200,8 +17280,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 12.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16221,8 +17306,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 13.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16242,8 +17332,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 14.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16263,8 +17358,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 15.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16284,8 +17384,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 16.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16305,8 +17410,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 17.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16326,8 +17436,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 18.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16347,8 +17462,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 19.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16368,8 +17488,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 20.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16389,8 +17514,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 21.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16410,8 +17540,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 22.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16431,8 +17566,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 23.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16452,8 +17592,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 24.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16473,8 +17618,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 25.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16494,8 +17644,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 26.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16515,8 +17670,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 27.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16536,8 +17696,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 28.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16557,8 +17722,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 29.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16578,8 +17748,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 30.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16599,8 +17774,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 31.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16620,8 +17800,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 32.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16641,8 +17826,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 33.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16662,8 +17852,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 34.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16683,8 +17878,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 35.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16704,8 +17904,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 36.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16725,8 +17930,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 37.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16746,8 +17956,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 38.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16767,8 +17982,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 39.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16788,8 +18008,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 40.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16809,8 +18034,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 41.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16830,8 +18060,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 42.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16851,8 +18086,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 43.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16872,8 +18112,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 44.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16893,8 +18138,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 45.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16914,8 +18164,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 46.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16935,8 +18190,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 47.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16956,8 +18216,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 48.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16977,8 +18242,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 49.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -16998,8 +18268,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 50.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17019,8 +18294,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 51.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17040,8 +18320,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 52.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17061,8 +18346,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 53.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17082,8 +18372,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 54.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17103,8 +18398,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 55.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17124,8 +18424,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 56.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17145,8 +18450,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 57.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17166,8 +18476,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 58.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17187,8 +18502,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 59.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17208,8 +18528,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 60.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17229,8 +18554,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 61.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17250,8 +18580,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 62.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17271,8 +18606,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 63.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17292,8 +18632,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 64.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17313,8 +18658,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 65.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17334,8 +18684,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 66.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17355,8 +18710,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 67.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17376,8 +18736,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 68.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17397,8 +18762,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 69.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17418,8 +18788,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 70.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17439,8 +18814,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 71.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17460,8 +18840,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 72.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17481,8 +18866,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 73.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17502,8 +18892,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 74.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17523,8 +18918,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 75.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17544,8 +18944,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 76.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17565,8 +18970,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 77.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17586,8 +18996,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 78.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17607,8 +19022,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 79.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17628,8 +19048,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 80.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17649,8 +19074,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 81.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17670,8 +19100,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 82.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17691,8 +19126,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 83.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17712,8 +19152,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 84.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17733,8 +19178,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 85.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17754,8 +19204,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 86.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17775,8 +19230,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 87.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17796,8 +19256,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 88.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17817,8 +19282,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 89.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17838,8 +19308,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 90.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17859,8 +19334,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 91.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17880,8 +19360,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 92.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17901,8 +19386,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 93.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17922,8 +19412,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 94.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17943,8 +19438,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 95.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17964,8 +19464,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 96.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -17985,8 +19490,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 97.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -18006,8 +19516,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 98.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -18027,8 +19542,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 99.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -18048,8 +19568,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 100.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -18069,8 +19594,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 101.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22592,8 +24122,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 0.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22623,8 +24158,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 1.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22654,8 +24194,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 2.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22685,8 +24230,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 3.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22716,8 +24266,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 4.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22747,8 +24302,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 5.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22778,8 +24338,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 6.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22809,8 +24374,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 7.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22840,8 +24410,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 8.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22871,8 +24446,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 9.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22902,8 +24482,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 10.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22933,8 +24518,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 11.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22964,8 +24554,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 12.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22995,8 +24590,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 13.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23026,8 +24626,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 14.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23057,8 +24662,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 15.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23088,8 +24698,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 16.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23119,8 +24734,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 17.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23150,8 +24770,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 18.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23181,8 +24806,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 19.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23212,8 +24842,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 20.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23243,8 +24878,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 21.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23274,8 +24914,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 22.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23305,8 +24950,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 23.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23336,8 +24986,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 24.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23367,8 +25022,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 25.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23398,8 +25058,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 26.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23429,8 +25094,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 27.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23460,8 +25130,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 28.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23491,8 +25166,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 29.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23522,8 +25202,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 30.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23553,8 +25238,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 31.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23584,8 +25274,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 32.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23615,8 +25310,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 33.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23646,8 +25346,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 34.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23677,8 +25382,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 35.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23708,8 +25418,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 36.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23739,8 +25454,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 37.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23770,8 +25490,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 38.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23801,8 +25526,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 39.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23832,8 +25562,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 40.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23863,8 +25598,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 41.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23894,8 +25634,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 42.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23925,8 +25670,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 43.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23956,8 +25706,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 44.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23987,8 +25742,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 45.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24018,8 +25778,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 46.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24049,8 +25814,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 47.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24080,8 +25850,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 48.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24111,8 +25886,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 49.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24142,8 +25922,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 50.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24173,8 +25958,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 51.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24204,8 +25994,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 52.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24235,8 +26030,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 53.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24266,8 +26066,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 54.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24297,8 +26102,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 55.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24328,8 +26138,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 56.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24359,8 +26174,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 57.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24390,8 +26210,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 58.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24421,8 +26246,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 59.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24452,8 +26282,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 60.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24483,8 +26318,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 61.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24514,8 +26354,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 62.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24545,8 +26390,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 63.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24576,8 +26426,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 64.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24607,8 +26462,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 65.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24638,8 +26498,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 66.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24669,8 +26534,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 67.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24700,8 +26570,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 68.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24731,8 +26606,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 69.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24762,8 +26642,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 70.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24793,8 +26678,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 71.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24824,8 +26714,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 72.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24855,8 +26750,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 73.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24886,8 +26786,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 74.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24917,8 +26822,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 75.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24948,8 +26858,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 76.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24979,8 +26894,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 77.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25010,8 +26930,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 78.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25041,8 +26966,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 79.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25072,8 +27002,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 80.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25103,8 +27038,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 81.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25134,8 +27074,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 82.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25165,8 +27110,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 83.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25196,8 +27146,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 84.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25227,8 +27182,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 85.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25258,8 +27218,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 86.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25289,8 +27254,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 87.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25320,8 +27290,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 88.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25351,8 +27326,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 89.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25382,8 +27362,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 90.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25413,8 +27398,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 91.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25444,8 +27434,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 92.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25475,8 +27470,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 93.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25506,8 +27506,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 94.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25537,8 +27542,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 95.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25568,8 +27578,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 96.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25599,8 +27614,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 97.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25630,8 +27650,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 98.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25661,8 +27686,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 99.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25692,8 +27722,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 100.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25723,8 +27758,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 1.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25754,8 +27794,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 2.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25785,8 +27830,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 3.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25816,8 +27866,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 4.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25847,8 +27902,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 5.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25878,8 +27938,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 6.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25909,8 +27974,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 7.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25940,8 +28010,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 8.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25971,8 +28046,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 9.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26002,8 +28082,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 10.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26033,8 +28118,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 11.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26064,8 +28154,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 12.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26095,8 +28190,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 13.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26126,8 +28226,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 14.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26157,8 +28262,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 15.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26188,8 +28298,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 16.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26219,8 +28334,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 17.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26250,8 +28370,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 18.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26281,8 +28406,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 19.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26312,8 +28442,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 20.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26343,8 +28478,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 21.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26374,8 +28514,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 22.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26405,8 +28550,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 23.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26436,8 +28586,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 24.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26467,8 +28622,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 25.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26498,8 +28658,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 26.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26529,8 +28694,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 27.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26560,8 +28730,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 28.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26591,8 +28766,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 29.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26622,8 +28802,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 30.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26653,8 +28838,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 31.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26684,8 +28874,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 32.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26715,8 +28910,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 33.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26746,8 +28946,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 34.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26777,8 +28982,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 35.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26808,8 +29018,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 36.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26839,8 +29054,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 37.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26870,8 +29090,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 38.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26901,8 +29126,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 39.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26932,8 +29162,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 40.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26963,8 +29198,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 41.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26994,8 +29234,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 42.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27025,8 +29270,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 43.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27056,8 +29306,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 44.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27087,8 +29342,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 45.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27118,8 +29378,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 46.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27149,8 +29414,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 47.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27180,8 +29450,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 48.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27211,8 +29486,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 49.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27242,8 +29522,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 50.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27273,8 +29558,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 51.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27304,8 +29594,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 52.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27335,8 +29630,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 53.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27366,8 +29666,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 54.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27397,8 +29702,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 55.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27428,8 +29738,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 56.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27459,8 +29774,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 57.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27490,8 +29810,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 58.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27521,8 +29846,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 59.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27552,8 +29882,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 60.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27583,8 +29918,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 61.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27614,8 +29954,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 62.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27645,8 +29990,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 63.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27676,8 +30026,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 64.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27707,8 +30062,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 65.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27738,8 +30098,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 66.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27769,8 +30134,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 67.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27800,8 +30170,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 68.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27831,8 +30206,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 69.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27862,8 +30242,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 70.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27893,8 +30278,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 71.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27924,8 +30314,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 72.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27955,8 +30350,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 73.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -27986,8 +30386,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 74.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28017,8 +30422,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 75.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28048,8 +30458,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 76.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28079,8 +30494,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 77.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28110,8 +30530,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 78.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28141,8 +30566,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 79.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28172,8 +30602,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 80.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28203,8 +30638,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 81.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28234,8 +30674,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 82.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28265,8 +30710,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 83.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28296,8 +30746,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 84.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28327,8 +30782,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 85.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28358,8 +30818,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 86.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28389,8 +30854,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 87.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28420,8 +30890,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 88.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28451,8 +30926,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 89.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28482,8 +30962,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 90.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28513,8 +30998,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 91.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28544,8 +31034,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 92.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28575,8 +31070,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 93.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28606,8 +31106,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 94.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28637,8 +31142,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 95.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28668,8 +31178,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 96.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28699,8 +31214,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 97.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28730,8 +31250,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 98.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28761,8 +31286,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 99.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28792,8 +31322,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 100.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -28823,8 +31358,13 @@ description: Operations executed import_async.kcl
           "type": "Number",
           "value": 101.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []

--- a/rust/kcl-lib/tests/kcl_samples/gear/ops.snap
+++ b/rust/kcl-lib/tests/kcl_samples/gear/ops.snap
@@ -14,8 +14,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 0.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -35,8 +40,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 1.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -56,8 +66,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 2.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -77,8 +92,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 3.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -98,8 +118,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 4.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -119,8 +144,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 5.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -140,8 +170,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 6.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -161,8 +196,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 7.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -182,8 +222,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 8.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -203,8 +248,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 9.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -224,8 +274,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 10.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -245,8 +300,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 11.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -266,8 +326,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 12.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -287,8 +352,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 13.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -308,8 +378,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 14.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -329,8 +404,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 15.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -350,8 +430,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 16.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -371,8 +456,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 17.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -392,8 +482,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 18.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -413,8 +508,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 19.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -434,8 +534,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 20.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -455,8 +560,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 21.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -476,8 +586,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 22.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -497,8 +612,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 23.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -518,8 +638,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 24.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -539,8 +664,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 25.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -560,8 +690,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 26.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -581,8 +716,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 27.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -602,8 +742,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 28.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -623,8 +768,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 29.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -644,8 +794,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 30.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -665,8 +820,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 31.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -686,8 +846,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 32.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -707,8 +872,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 33.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -728,8 +898,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 34.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -749,8 +924,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 35.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -770,8 +950,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 36.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -791,8 +976,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 37.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -812,8 +1002,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 38.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -833,8 +1028,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 39.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -854,8 +1054,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 40.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -875,8 +1080,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 41.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -896,8 +1106,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 42.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -917,8 +1132,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 43.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -938,8 +1158,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 44.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -959,8 +1184,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 45.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -980,8 +1210,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 46.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1001,8 +1236,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 47.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1022,8 +1262,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 48.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1043,8 +1288,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 49.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1064,8 +1314,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 50.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1085,8 +1340,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 51.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1106,8 +1366,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 52.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1127,8 +1392,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 53.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1148,8 +1418,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 54.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1169,8 +1444,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 55.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1190,8 +1470,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 56.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1211,8 +1496,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 57.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1232,8 +1522,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 58.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1253,8 +1548,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 59.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1274,8 +1574,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 60.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1295,8 +1600,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 61.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1316,8 +1626,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 62.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1337,8 +1652,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 63.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1358,8 +1678,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 64.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1379,8 +1704,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 65.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1400,8 +1730,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 66.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1421,8 +1756,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 67.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1442,8 +1782,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 68.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1463,8 +1808,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 69.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1484,8 +1834,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 70.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1505,8 +1860,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 71.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1526,8 +1886,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 72.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1547,8 +1912,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 73.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1568,8 +1938,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 74.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1589,8 +1964,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 75.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1610,8 +1990,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 76.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1631,8 +2016,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 77.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1652,8 +2042,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 78.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1673,8 +2068,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 79.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1694,8 +2094,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 80.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1715,8 +2120,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 81.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1736,8 +2146,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 82.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1757,8 +2172,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 83.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1778,8 +2198,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 84.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1799,8 +2224,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 85.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1820,8 +2250,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 86.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1841,8 +2276,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 87.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1862,8 +2302,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 88.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1883,8 +2328,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 89.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1904,8 +2354,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 90.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1925,8 +2380,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 91.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1946,8 +2406,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 92.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1967,8 +2432,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 93.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1988,8 +2458,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 94.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2009,8 +2484,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 95.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2030,8 +2510,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 96.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2051,8 +2536,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 97.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2072,8 +2562,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 98.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2093,8 +2588,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 99.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2114,8 +2614,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 100.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2135,8 +2640,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 101.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -11540,8 +12050,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 0.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -11561,8 +12076,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 1.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -11582,8 +12102,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 2.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -11603,8 +12128,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 3.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -11624,8 +12154,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 4.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -11645,8 +12180,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 5.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -11666,8 +12206,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 6.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -11687,8 +12232,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 7.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -11708,8 +12258,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 8.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -11729,8 +12284,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 9.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -11750,8 +12310,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 10.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -11771,8 +12336,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 11.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -11792,8 +12362,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 12.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -11813,8 +12388,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 13.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -11834,8 +12414,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 14.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -11855,8 +12440,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 15.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -11876,8 +12466,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 16.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -11897,8 +12492,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 17.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -11918,8 +12518,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 18.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -11939,8 +12544,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 19.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -11960,8 +12570,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 20.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -11981,8 +12596,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 21.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12002,8 +12622,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 22.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12023,8 +12648,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 23.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12044,8 +12674,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 24.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12065,8 +12700,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 25.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12086,8 +12726,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 26.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12107,8 +12752,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 27.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12128,8 +12778,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 28.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12149,8 +12804,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 29.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12170,8 +12830,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 30.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12191,8 +12856,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 31.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12212,8 +12882,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 32.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12233,8 +12908,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 33.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12254,8 +12934,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 34.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12275,8 +12960,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 35.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12296,8 +12986,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 36.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12317,8 +13012,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 37.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12338,8 +13038,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 38.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12359,8 +13064,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 39.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12380,8 +13090,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 40.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12401,8 +13116,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 41.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12422,8 +13142,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 42.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12443,8 +13168,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 43.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12464,8 +13194,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 44.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12485,8 +13220,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 45.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12506,8 +13246,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 46.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12527,8 +13272,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 47.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12548,8 +13298,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 48.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12569,8 +13324,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 49.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12590,8 +13350,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 50.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12611,8 +13376,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 51.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12632,8 +13402,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 52.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12653,8 +13428,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 53.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12674,8 +13454,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 54.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12695,8 +13480,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 55.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12716,8 +13506,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 56.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12737,8 +13532,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 57.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12758,8 +13558,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 58.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12779,8 +13584,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 59.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12800,8 +13610,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 60.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12821,8 +13636,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 61.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12842,8 +13662,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 62.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12863,8 +13688,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 63.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12884,8 +13714,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 64.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12905,8 +13740,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 65.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12926,8 +13766,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 66.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12947,8 +13792,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 67.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12968,8 +13818,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 68.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -12989,8 +13844,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 69.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13010,8 +13870,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 70.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13031,8 +13896,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 71.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13052,8 +13922,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 72.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13073,8 +13948,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 73.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13094,8 +13974,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 74.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13115,8 +14000,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 75.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13136,8 +14026,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 76.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13157,8 +14052,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 77.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13178,8 +14078,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 78.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13199,8 +14104,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 79.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13220,8 +14130,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 80.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13241,8 +14156,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 81.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13262,8 +14182,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 82.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13283,8 +14208,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 83.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13304,8 +14234,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 84.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13325,8 +14260,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 85.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13346,8 +14286,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 86.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13367,8 +14312,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 87.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13388,8 +14338,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 88.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13409,8 +14364,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 89.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13430,8 +14390,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 90.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13451,8 +14416,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 91.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13472,8 +14442,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 92.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13493,8 +14468,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 93.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13514,8 +14494,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 94.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13535,8 +14520,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 95.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13556,8 +14546,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 96.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13577,8 +14572,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 97.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13598,8 +14598,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 98.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13619,8 +14624,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 99.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13640,8 +14650,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 100.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13661,8 +14676,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 101.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13682,8 +14702,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 0.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13703,8 +14728,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 1.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13724,8 +14754,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 2.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13745,8 +14780,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 3.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13766,8 +14806,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 4.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13787,8 +14832,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 5.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13808,8 +14858,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 6.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13829,8 +14884,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 7.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13850,8 +14910,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 8.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13871,8 +14936,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 9.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13892,8 +14962,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 10.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13913,8 +14988,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 11.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13934,8 +15014,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 12.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13955,8 +15040,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 13.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13976,8 +15066,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 14.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -13997,8 +15092,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 15.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14018,8 +15118,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 16.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14039,8 +15144,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 17.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14060,8 +15170,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 18.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14081,8 +15196,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 19.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14102,8 +15222,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 20.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14123,8 +15248,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 21.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14144,8 +15274,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 22.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14165,8 +15300,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 23.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14186,8 +15326,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 24.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14207,8 +15352,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 25.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14228,8 +15378,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 26.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14249,8 +15404,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 27.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14270,8 +15430,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 28.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14291,8 +15456,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 29.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14312,8 +15482,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 30.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14333,8 +15508,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 31.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14354,8 +15534,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 32.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14375,8 +15560,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 33.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14396,8 +15586,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 34.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14417,8 +15612,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 35.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14438,8 +15638,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 36.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14459,8 +15664,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 37.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14480,8 +15690,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 38.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14501,8 +15716,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 39.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14522,8 +15742,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 40.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14543,8 +15768,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 41.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14564,8 +15794,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 42.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14585,8 +15820,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 43.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14606,8 +15846,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 44.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14627,8 +15872,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 45.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14648,8 +15898,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 46.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14669,8 +15924,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 47.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14690,8 +15950,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 48.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14711,8 +15976,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 49.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14732,8 +16002,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 50.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14753,8 +16028,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 51.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14774,8 +16054,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 52.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14795,8 +16080,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 53.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14816,8 +16106,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 54.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14837,8 +16132,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 55.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14858,8 +16158,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 56.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14879,8 +16184,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 57.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14900,8 +16210,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 58.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14921,8 +16236,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 59.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14942,8 +16262,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 60.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14963,8 +16288,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 61.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -14984,8 +16314,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 62.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15005,8 +16340,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 63.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15026,8 +16366,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 64.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15047,8 +16392,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 65.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15068,8 +16418,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 66.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15089,8 +16444,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 67.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15110,8 +16470,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 68.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15131,8 +16496,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 69.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15152,8 +16522,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 70.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15173,8 +16548,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 71.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15194,8 +16574,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 72.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15215,8 +16600,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 73.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15236,8 +16626,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 74.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15257,8 +16652,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 75.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15278,8 +16678,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 76.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15299,8 +16704,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 77.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15320,8 +16730,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 78.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15341,8 +16756,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 79.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15362,8 +16782,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 80.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15383,8 +16808,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 81.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15404,8 +16834,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 82.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15425,8 +16860,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 83.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15446,8 +16886,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 84.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15467,8 +16912,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 85.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15488,8 +16938,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 86.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15509,8 +16964,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 87.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15530,8 +16990,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 88.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15551,8 +17016,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 89.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15572,8 +17042,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 90.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15593,8 +17068,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 91.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15614,8 +17094,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 92.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15635,8 +17120,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 93.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15656,8 +17146,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 94.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15677,8 +17172,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 95.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15698,8 +17198,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 96.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15719,8 +17224,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 97.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15740,8 +17250,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 98.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15761,8 +17276,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 99.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15782,8 +17302,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 100.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -15803,8 +17328,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 101.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -20326,8 +21856,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 0.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -20357,8 +21892,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 1.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -20388,8 +21928,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 2.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -20419,8 +21964,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 3.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -20450,8 +22000,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 4.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -20481,8 +22036,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 5.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -20512,8 +22072,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 6.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -20543,8 +22108,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 7.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -20574,8 +22144,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 8.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -20605,8 +22180,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 9.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -20636,8 +22216,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 10.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -20667,8 +22252,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 11.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -20698,8 +22288,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 12.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -20729,8 +22324,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 13.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -20760,8 +22360,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 14.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -20791,8 +22396,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 15.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -20822,8 +22432,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 16.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -20853,8 +22468,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 17.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -20884,8 +22504,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 18.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -20915,8 +22540,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 19.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -20946,8 +22576,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 20.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -20977,8 +22612,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 21.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21008,8 +22648,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 22.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21039,8 +22684,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 23.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21070,8 +22720,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 24.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21101,8 +22756,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 25.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21132,8 +22792,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 26.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21163,8 +22828,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 27.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21194,8 +22864,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 28.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21225,8 +22900,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 29.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21256,8 +22936,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 30.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21287,8 +22972,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 31.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21318,8 +23008,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 32.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21349,8 +23044,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 33.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21380,8 +23080,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 34.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21411,8 +23116,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 35.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21442,8 +23152,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 36.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21473,8 +23188,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 37.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21504,8 +23224,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 38.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21535,8 +23260,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 39.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21566,8 +23296,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 40.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21597,8 +23332,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 41.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21628,8 +23368,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 42.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21659,8 +23404,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 43.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21690,8 +23440,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 44.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21721,8 +23476,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 45.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21752,8 +23512,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 46.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21783,8 +23548,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 47.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21814,8 +23584,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 48.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21845,8 +23620,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 49.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21876,8 +23656,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 50.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21907,8 +23692,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 51.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21938,8 +23728,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 52.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -21969,8 +23764,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 53.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22000,8 +23800,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 54.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22031,8 +23836,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 55.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22062,8 +23872,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 56.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22093,8 +23908,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 57.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22124,8 +23944,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 58.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22155,8 +23980,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 59.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22186,8 +24016,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 60.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22217,8 +24052,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 61.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22248,8 +24088,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 62.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22279,8 +24124,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 63.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22310,8 +24160,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 64.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22341,8 +24196,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 65.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22372,8 +24232,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 66.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22403,8 +24268,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 67.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22434,8 +24304,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 68.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22465,8 +24340,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 69.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22496,8 +24376,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 70.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22527,8 +24412,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 71.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22558,8 +24448,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 72.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22589,8 +24484,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 73.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22620,8 +24520,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 74.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22651,8 +24556,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 75.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22682,8 +24592,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 76.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22713,8 +24628,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 77.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22744,8 +24664,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 78.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22775,8 +24700,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 79.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22806,8 +24736,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 80.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22837,8 +24772,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 81.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22868,8 +24808,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 82.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22899,8 +24844,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 83.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22930,8 +24880,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 84.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22961,8 +24916,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 85.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -22992,8 +24952,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 86.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23023,8 +24988,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 87.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23054,8 +25024,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 88.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23085,8 +25060,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 89.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23116,8 +25096,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 90.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23147,8 +25132,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 91.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23178,8 +25168,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 92.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23209,8 +25204,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 93.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23240,8 +25240,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 94.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23271,8 +25276,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 95.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23302,8 +25312,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 96.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23333,8 +25348,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 97.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23364,8 +25384,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 98.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23395,8 +25420,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 99.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23426,8 +25456,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 100.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23457,8 +25492,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 1.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23488,8 +25528,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 2.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23519,8 +25564,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 3.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23550,8 +25600,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 4.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23581,8 +25636,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 5.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23612,8 +25672,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 6.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23643,8 +25708,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 7.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23674,8 +25744,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 8.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23705,8 +25780,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 9.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23736,8 +25816,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 10.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23767,8 +25852,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 11.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23798,8 +25888,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 12.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23829,8 +25924,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 13.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23860,8 +25960,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 14.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23891,8 +25996,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 15.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23922,8 +26032,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 16.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23953,8 +26068,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 17.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -23984,8 +26104,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 18.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24015,8 +26140,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 19.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24046,8 +26176,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 20.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24077,8 +26212,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 21.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24108,8 +26248,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 22.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24139,8 +26284,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 23.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24170,8 +26320,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 24.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24201,8 +26356,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 25.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24232,8 +26392,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 26.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24263,8 +26428,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 27.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24294,8 +26464,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 28.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24325,8 +26500,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 29.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24356,8 +26536,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 30.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24387,8 +26572,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 31.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24418,8 +26608,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 32.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24449,8 +26644,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 33.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24480,8 +26680,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 34.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24511,8 +26716,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 35.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24542,8 +26752,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 36.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24573,8 +26788,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 37.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24604,8 +26824,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 38.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24635,8 +26860,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 39.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24666,8 +26896,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 40.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24697,8 +26932,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 41.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24728,8 +26968,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 42.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24759,8 +27004,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 43.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24790,8 +27040,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 44.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24821,8 +27076,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 45.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24852,8 +27112,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 46.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24883,8 +27148,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 47.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24914,8 +27184,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 48.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24945,8 +27220,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 49.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -24976,8 +27256,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 50.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25007,8 +27292,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 51.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25038,8 +27328,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 52.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25069,8 +27364,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 53.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25100,8 +27400,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 54.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25131,8 +27436,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 55.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25162,8 +27472,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 56.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25193,8 +27508,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 57.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25224,8 +27544,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 58.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25255,8 +27580,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 59.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25286,8 +27616,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 60.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25317,8 +27652,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 61.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25348,8 +27688,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 62.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25379,8 +27724,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 63.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25410,8 +27760,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 64.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25441,8 +27796,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 65.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25472,8 +27832,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 66.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25503,8 +27868,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 67.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25534,8 +27904,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 68.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25565,8 +27940,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 69.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25596,8 +27976,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 70.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25627,8 +28012,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 71.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25658,8 +28048,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 72.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25689,8 +28084,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 73.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25720,8 +28120,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 74.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25751,8 +28156,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 75.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25782,8 +28192,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 76.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25813,8 +28228,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 77.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25844,8 +28264,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 78.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25875,8 +28300,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 79.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25906,8 +28336,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 80.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25937,8 +28372,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 81.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25968,8 +28408,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 82.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -25999,8 +28444,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 83.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26030,8 +28480,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 84.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26061,8 +28516,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 85.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26092,8 +28552,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 86.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26123,8 +28588,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 87.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26154,8 +28624,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 88.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26185,8 +28660,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 89.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26216,8 +28696,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 90.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26247,8 +28732,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 91.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26278,8 +28768,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 92.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26309,8 +28804,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 93.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26340,8 +28840,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 94.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26371,8 +28876,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 95.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26402,8 +28912,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 96.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26433,8 +28948,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 97.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26464,8 +28984,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 98.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26495,8 +29020,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 99.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26526,8 +29056,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 100.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -26557,8 +29092,13 @@ description: Operations executed gear.kcl
           "type": "Number",
           "value": 101.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Inches"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []

--- a/rust/kcl-lib/tests/loop_tag/ops.snap
+++ b/rust/kcl-lib/tests/loop_tag/ops.snap
@@ -53,8 +53,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 1.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -84,8 +89,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 2.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -115,8 +125,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 3.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -146,8 +161,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 4.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -177,8 +197,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 5.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -208,8 +233,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 6.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -239,8 +269,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 7.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -270,8 +305,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 8.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -301,8 +341,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 9.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -332,8 +377,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 10.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -363,8 +413,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 11.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -394,8 +449,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 12.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -425,8 +485,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 13.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -456,8 +521,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 14.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -487,8 +557,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 15.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -518,8 +593,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 16.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -549,8 +629,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 17.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -580,8 +665,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 18.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -611,8 +701,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 19.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -642,8 +737,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 20.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -673,8 +773,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 21.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -704,8 +809,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 22.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -735,8 +845,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 23.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -766,8 +881,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 24.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -797,8 +917,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 25.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -828,8 +953,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 26.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -859,8 +989,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 27.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -890,8 +1025,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 28.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -921,8 +1061,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 29.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -952,8 +1097,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 30.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -983,8 +1133,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 31.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1014,8 +1169,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 32.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1045,8 +1205,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 33.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1076,8 +1241,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 34.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1107,8 +1277,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 35.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1138,8 +1313,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 36.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1169,8 +1349,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 37.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1200,8 +1385,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 38.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1231,8 +1421,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 39.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1262,8 +1457,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 40.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1293,8 +1493,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 41.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1324,8 +1529,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 42.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1355,8 +1565,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 43.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1386,8 +1601,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 44.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1417,8 +1637,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 45.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1448,8 +1673,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 46.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1479,8 +1709,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 47.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1510,8 +1745,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 48.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1541,8 +1781,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 49.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1572,8 +1817,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 1.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1593,8 +1843,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 2.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1614,8 +1869,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 3.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1635,8 +1895,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 4.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1656,8 +1921,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 5.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1677,8 +1947,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 6.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1698,8 +1973,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 7.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1719,8 +1999,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 8.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1740,8 +2025,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 9.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1761,8 +2051,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 10.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1782,8 +2077,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 11.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1803,8 +2103,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 12.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1824,8 +2129,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 13.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1845,8 +2155,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 14.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1866,8 +2181,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 15.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1887,8 +2207,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 16.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1908,8 +2233,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 17.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1929,8 +2259,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 18.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1950,8 +2285,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 19.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1971,8 +2311,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 20.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -1992,8 +2337,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 21.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2013,8 +2363,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 22.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2034,8 +2389,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 23.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2055,8 +2415,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 24.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2076,8 +2441,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 25.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2097,8 +2467,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 26.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2118,8 +2493,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 27.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2139,8 +2519,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 28.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2160,8 +2545,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 29.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2181,8 +2571,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 30.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2202,8 +2597,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 31.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2223,8 +2623,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 32.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2244,8 +2649,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 33.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2265,8 +2675,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 34.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2286,8 +2701,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 35.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2307,8 +2727,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 36.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2328,8 +2753,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 37.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2349,8 +2779,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 38.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2370,8 +2805,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 39.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2391,8 +2831,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 40.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2412,8 +2857,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 41.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2433,8 +2883,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 42.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2454,8 +2909,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 43.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2475,8 +2935,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 44.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2496,8 +2961,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 45.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2517,8 +2987,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 46.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2538,8 +3013,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 47.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2559,8 +3039,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 48.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []
@@ -2580,8 +3065,13 @@ description: Operations executed loop_tag.kcl
           "type": "Number",
           "value": 49.0,
           "ty": {
-            "type": "Known",
-            "type": "Count"
+            "type": "Default",
+            "len": {
+              "type": "Mm"
+            },
+            "angle": {
+              "type": "Degrees"
+            }
           }
         },
         "sourceRange": []


### PR DESCRIPTION
Stacked on #6816.

Before, we silently ignored units in array range expressions and always returned Count. Possible design choices:

1. Automatically coerce start and end values to Count
2. Error out if either start or end are not Count
3. Allow ranges to have any units

This PR chooses # 3 because I don't see any reason why we should prevent users from creating ranges of numbers that have units other than Count.

This is a breaking change because the units of resulting numbers can affect automatic unit conversion. It's also now an error to try to make a range where the units of start and end do not match. E.g. this is an error now: `[1mm..3in]`.

KCL samples use ranges, and their internal memory was changed. But no visual output was affected by this.