### PR TITLE
Some improvements to math::sqrt

### DIFF
--- a/docs/kcl-lang/numeric.md
+++ b/docs/kcl-lang/numeric.md
@@ -28,6 +28,8 @@ Any of the suffixes described above can be used meaning that values with that ty
 
 You can also use `number(Length)`, `number(Angle)`, or `number(Count)`. These types mean a number with any length, angle, or unitless (count) units, respectively (note that `number(_)` and `number(Count)` are equivalent since there is only one kind of unitless-ness).
 
+Using just `number` means accepting any kind of number, even where the units are unknown by KCL.
+
 
 ## Function calls
 

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -2653,4 +2653,13 @@ sketch001 = startSketchOn(XY)
         let ast = r#"foo = tan(0): number(rad) - 4deg"#;
         parse_execute(ast).await.unwrap();
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn neg_sqrt() {
+        let ast = r#"bad = sqrt(-2)"#;
+
+        let e = parse_execute(ast).await.unwrap_err();
+        // Make sure we get a useful error message and not an engine error.
+        assert!(e.message().contains("sqrt"), "Error message: '{}'", e.message());
+    }
 }

--- a/rust/kcl-lib/src/std/math.rs
+++ b/rust/kcl-lib/src/std/math.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 
 use crate::{
-    errors::KclError,
+    errors::{KclError, KclErrorDetails},
     execution::{
         types::{ArrayLen, NumericType, RuntimeType},
         ExecState, KclValue,
@@ -54,6 +54,17 @@ pub async fn tan(exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kcl
 /// Compute the square root of a number.
 pub async fn sqrt(exec_state: &mut ExecState, args: Args) -> Result<KclValue, KclError> {
     let input: TyF64 = args.get_unlabeled_kw_arg_typed("input", &RuntimeType::num_any(), exec_state)?;
+
+    if input.n < 0.0 {
+        return Err(KclError::Semantic(KclErrorDetails {
+            source_ranges: vec![args.source_range],
+            message: format!(
+                "Attempt to take square root (`sqrt`) of a number less than zero ({})",
+                input.n
+            ),
+        }));
+    }
+
     let result = input.n.sqrt();
 
     Ok(args.make_user_val_from_f64_with_type(TyF64::new(result, exec_state.current_default_units())))


### PR DESCRIPTION
- Treat the type `number` as `Any` rather than `Default` numbers. I think this makes sense because we probably only want to use the default number type if there is no type at all, but still wish I wasn't doing this the day before launch! It makes me feel a bit better that I had been assuming this was how things worked, but still.
- Give an error message trying to take the sqrt of a negative number rather than letting the engine choke on it.