### PR TITLE
Check all nested KCL samples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,15 +44,15 @@ endif
 # BUILD
 
 CARGO_SOURCES := rust/.cargo/config.toml $(wildcard rust/Cargo.*) $(wildcard rust/**/Cargo.*)
+KCL_SOURCES := $(wildcard public/kcl-samples/**/*.kcl)
 RUST_SOURCES := $(wildcard rust/**/*.rs)
 
 REACT_SOURCES := $(wildcard src/*.tsx) $(wildcard src/**/*.tsx)
 TYPESCRIPT_SOURCES := tsconfig.* $(wildcard src/*.ts) $(wildcard src/**/*.ts)
 VITE_SOURCES := $(wildcard vite.*) $(wildcard vite/**/*.tsx)
 
-
 .PHONY: build
-build: install public/kcl_wasm_lib_bg.wasm .vite/build/main.js
+build: install public/kcl_wasm_lib_bg.wasm public/kcl-samples/manifest.json .vite/build/main.js
 
 public/kcl_wasm_lib_bg.wasm: $(CARGO_SOURCES) $(RUST_SOURCES)
 ifdef WINDOWS
@@ -60,6 +60,9 @@ ifdef WINDOWS
 else
 	npm run build:wasm:dev
 endif
+
+public/kcl-samples/manifest.json: $(KCL_SOURCES)
+	cd rust/kcl-lib && EXPECTORATE=overwrite cargo test generate_manifest
 
 .vite/build/main.js: $(REACT_SOURCES) $(TYPESCRIPT_SOURCES) $(VITE_SOURCES)
 	npm run tronb:vite:dev

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "files:invalidate-bucket:nightly": "./scripts/invalidate-files-bucket.sh --nightly",
     "postinstall": "electron-rebuild",
     "generate:machine-api": "npx openapi-typescript ./openapi/machine-api.json -o src/lib/machine-api.d.ts",
-    "generate:samples-manifest": "cd public/kcl-samples && node generate-manifest.js",
     "tron:start": "electron-forge start",
     "chrome:test": "PLATFORM=web NODE_ENV=development playwright test --config=playwright.config.ts --project='Google Chrome' --grep-invert=@snapshot",
     "tronb:vite:dev": "vite build -c vite.main.config.ts -m development && vite build -c vite.preload.config.ts -m development && vite build -c vite.renderer.config.ts -m development",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1959,6 +1959,7 @@ dependencies = [
  "url",
  "uuid",
  "validator",
+ "walkdir",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/rust/kcl-lib/Cargo.toml
+++ b/rust/kcl-lib/Cargo.toml
@@ -85,6 +85,7 @@ tynm = "0.1.10"
 url = { version = "2.5.4", features = ["serde"] }
 uuid = { workspace = true, features = ["v4", "v5", "js", "serde"] }
 validator = { version = "0.20.0", features = ["derive"] }
+walkdir = "2.5.0"
 web-time = "1.1"
 winnow = "=0.6.24"
 zip = { workspace = true }


### PR DESCRIPTION
This is preliminary work for https://github.com/KittyCAD/engine/issues/3412. The [internal KCL samples](https://github.com/KittyCAD/kcl-samples-internal) have a nested directory structure so I have updated `generate_kcl_manifest` to support that.

This will let us test against the internal samples locally like so:

```
cd ~/Code/zoo
git clone https://github.com/KittyCAD/kcl-samples-internal 

cd ~/Code/zoo/modeling-app/public/kcl-samples
ln -s ../../../kcl-samples-internal internal

cd ~/Code/zoo/modeling-app/rust/kcl-lib
EXPECTORATE=overwrite cargo test generate_manifest
```

Then, on CI I'll find a way to clone https://github.com/KittyCAD/kcl-samples-internal into the samples directory to test against both.
