### PR TITLE
Release link and updater toast touchups on Nightly

### DIFF
--- a/src/components/LowerRightControls.tsx
+++ b/src/components/LowerRightControls.tsx
@@ -12,15 +12,11 @@ import { NetworkHealthIndicator } from '@src/components/NetworkHealthIndicator'
 import { NetworkMachineIndicator } from '@src/components/NetworkMachineIndicator'
 import Tooltip from '@src/components/Tooltip'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
-import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
 import { PATHS } from '@src/lib/paths'
-import {
-  APP_VERSION,
-  getReleaseUrl,
-  IS_NIGHTLY_OR_DEBUG,
-} from '@src/routes/utils'
+import { APP_VERSION, getReleaseUrl } from '@src/routes/utils'
 
 import { billingActor } from '@src/lib/singletons'
+import { ActionButton } from '@src/components/ActionButton'
 
 export function LowerRightControls({
   children,
@@ -56,19 +52,16 @@ export function LowerRightControls({
             <BillingDialog billingActor={billingActor} />
           </Popover.Panel>
         </Popover>
-        <a
-          onClick={
-            !IS_NIGHTLY_OR_DEBUG
-              ? openExternalBrowserIfDesktop(getReleaseUrl())
-              : undefined
+        <ActionButton
+          Element="externalLink"
+          to={getReleaseUrl()}
+          className={
+            '!no-underline !border-none font-mono text-xs' +
+            linkOverrideClassName
           }
-          href={!IS_NIGHTLY_OR_DEBUG ? getReleaseUrl() : undefined}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={'!no-underline font-mono text-xs ' + linkOverrideClassName}
         >
           v{APP_VERSION}
-        </a>
+        </ActionButton>
         <Link
           to={
             location.pathname.includes(PATHS.FILE)

--- a/src/components/LowerRightControls.tsx
+++ b/src/components/LowerRightControls.tsx
@@ -14,7 +14,11 @@ import Tooltip from '@src/components/Tooltip'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
 import { PATHS } from '@src/lib/paths'
-import { APP_VERSION, getReleaseUrl } from '@src/routes/utils'
+import {
+  APP_VERSION,
+  getReleaseUrl,
+  IS_NIGHTLY_OR_DEBUG,
+} from '@src/routes/utils'
 
 import { billingActor } from '@src/lib/singletons'
 
@@ -53,8 +57,12 @@ export function LowerRightControls({
           </Popover.Panel>
         </Popover>
         <a
-          onClick={openExternalBrowserIfDesktop(getReleaseUrl())}
-          href={getReleaseUrl()}
+          onClick={
+            !IS_NIGHTLY_OR_DEBUG
+              ? openExternalBrowserIfDesktop(getReleaseUrl())
+              : undefined
+          }
+          href={!IS_NIGHTLY_OR_DEBUG ? getReleaseUrl() : undefined}
           target="_blank"
           rel="noopener noreferrer"
           className={'!no-underline font-mono text-xs ' + linkOverrideClassName}

--- a/src/components/ToastUpdate.tsx
+++ b/src/components/ToastUpdate.tsx
@@ -5,7 +5,7 @@ import toast from 'react-hot-toast'
 import { ActionButton } from '@src/components/ActionButton'
 import { SafeRenderer } from '@src/lib/markdown'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
-import { getReleaseUrl } from '@src/routes/utils'
+import { getReleaseUrl, IS_NIGHTLY_OR_DEBUG } from '@src/routes/utils'
 
 export function ToastUpdate({
   version,
@@ -41,16 +41,20 @@ export function ToastUpdate({
             v{version}
           </span>
           <p className="ml-4 text-md text-bold">
-            A new update has downloaded and will be available next time you
-            start the app. You can view the release notes{' '}
-            <a
-              onClick={openExternalBrowserIfDesktop(getReleaseUrl(version))}
-              href={getReleaseUrl(version)}
-              target="_blank"
-              rel="noreferrer"
-            >
-              here on GitHub.
-            </a>
+            A new update is available.
+            {!IS_NIGHTLY_OR_DEBUG && (
+              <span>
+                You can view the release notes{' '}
+                <a
+                  onClick={openExternalBrowserIfDesktop(getReleaseUrl(version))}
+                  href={getReleaseUrl(version)}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  here on GitHub.
+                </a>
+              </span>
+            )}
           </p>
         </div>
         {releaseNotes && (

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -22,7 +22,9 @@ export const IS_NIGHTLY_OR_DEBUG =
   IS_NIGHTLY || APP_VERSION === '0.0.0' || APP_VERSION === '11.22.33'
 
 export function getReleaseUrl(version: string = APP_VERSION) {
-  return `https://github.com/KittyCAD/modeling-app/releases/tag/${
-    IS_NIGHTLY ? 'nightly-' : ''
-  }v${version}`
+  if (IS_NIGHTLY_OR_DEBUG || version === 'main') {
+    return 'https://github.com/KittyCAD/modeling-app/commits/main'
+  }
+
+  return `https://github.com/KittyCAD/modeling-app/releases/tag/v${version}`
 }


### PR DESCRIPTION
Two more tweaks around release links and updater toast after #6871 

Tested locally:
![image](https://github.com/user-attachments/assets/1eee9810-214b-4692-a64c-c386b5fba4c2)
