### PR TITLE
Register modeling commands as disabled, enable without needing to re-open the command palette

### DIFF
--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -34,7 +34,7 @@ import {
   useMenuListener,
   useSketchModeMenuEnableDisable,
 } from '@src/hooks/useMenu'
-import useStateMachineCommands from '@src/hooks/useStateMachineCommands'
+import useModelingMachineCommands from '@src/hooks/useStateMachineCommands'
 import { useKclContext } from '@src/lang/KclProvider'
 import { updateModelingState } from '@src/lang/modelingWorkflows'
 import {
@@ -2091,13 +2091,12 @@ export const ModelingMachineProvider = ({
     modelingSend({ type: 'Center camera on selection' })
   })
 
-  useStateMachineCommands({
+  useModelingMachineCommands({
     machineId: 'modeling',
     state: modelingState,
     send: modelingSend,
     actor: modelingActor,
     commandBarConfig: modelingMachineCommandConfig,
-    allCommandsRequireNetwork: true,
     // TODO for when sketch tools are in the toolbar: This was added when we used one "Cancel" event,
     // but we need to support "SketchCancel" and basically
     // make this function take the actor or state so it

--- a/src/lib/commandTypes.ts
+++ b/src/lib/commandTypes.ts
@@ -103,6 +103,7 @@ export type Command<
   icon?: Icon
   hide?: PLATFORM[number]
   hideFromSearch?: boolean
+  disabled?: boolean
   status?: CommandStatus
 }
 

--- a/src/lib/createMachineCommand.ts
+++ b/src/lib/createMachineCommand.ts
@@ -45,7 +45,7 @@ export function createMachineCommand<
   actor,
   commandBarConfig,
   onCancel,
-  forceDisable: shouldDisable = false,
+  forceDisable = false,
 }: CreateMachineCommandProps<T, S>):
   | Command<T, typeof type, S[typeof type]>
   | Command<T, typeof type, S[typeof type]>[]
@@ -73,7 +73,7 @@ export function createMachineCommand<
           actor,
           commandBarConfig: recursiveCommandBarConfig,
           onCancel,
-          shouldDisable,
+          forceDisable,
         })
       })
       .filter((c) => c !== null) as Command<T, typeof type, S[typeof type]>[]
@@ -108,7 +108,7 @@ export function createMachineCommand<
         send({ type })
       }
     },
-    disabled: shouldDisable,
+    disabled: forceDisable,
   }
 
   if (commandConfig.args) {

--- a/src/lib/createMachineCommand.ts
+++ b/src/lib/createMachineCommand.ts
@@ -29,6 +29,7 @@ interface CreateMachineCommandProps<
   actor: Actor<T>
   commandBarConfig?: StateMachineCommandSetConfig<T, S>
   onCancel?: () => void
+  forceDisable?: boolean
 }
 
 // Creates a command with subcommands, ready for use in the CommandBar component,
@@ -44,6 +45,7 @@ export function createMachineCommand<
   actor,
   commandBarConfig,
   onCancel,
+  forceDisable: shouldDisable = false,
 }: CreateMachineCommandProps<T, S>):
   | Command<T, typeof type, S[typeof type]>
   | Command<T, typeof type, S[typeof type]>[]
@@ -71,6 +73,7 @@ export function createMachineCommand<
           actor,
           commandBarConfig: recursiveCommandBarConfig,
           onCancel,
+          shouldDisable,
         })
       })
       .filter((c) => c !== null) as Command<T, typeof type, S[typeof type]>[]
@@ -105,6 +108,7 @@ export function createMachineCommand<
         send({ type })
       }
     },
+    disabled: shouldDisable,
   }
 
   if (commandConfig.args) {

--- a/src/machines/commandBarMachine.ts
+++ b/src/machines/commandBarMachine.ts
@@ -459,35 +459,6 @@ export const commandBarMachine = setup({
         Open: {
           target: 'Selecting command',
         },
-
-        'Add commands': {
-          target: 'Closed',
-
-          actions: [
-            assign({
-              commands: ({ context, event }) =>
-                [...context.commands, ...event.data.commands].sort(
-                  sortCommands
-                ),
-            }),
-          ],
-        },
-
-        'Remove commands': {
-          target: 'Closed',
-
-          actions: [
-            assign({
-              commands: ({ context, event }) =>
-                context.commands.filter(
-                  (c) =>
-                    !event.data.commands.some(
-                      (c2) => c2.name === c.name && c2.groupId === c.groupId
-                    )
-                ),
-            }),
-          ],
-        },
       },
 
       always: {
@@ -644,6 +615,29 @@ export const commandBarMachine = setup({
     'Find and select command': {
       target: '.Command selected',
       actions: ['Find and select command', 'Initialize arguments to submit'],
+    },
+
+    'Add commands': {
+      actions: [
+        assign({
+          commands: ({ context, event }) =>
+            [...context.commands, ...event.data.commands].sort(sortCommands),
+        }),
+      ],
+    },
+
+    'Remove commands': {
+      actions: [
+        assign({
+          commands: ({ context, event }) =>
+            context.commands.filter(
+              (c) =>
+                !event.data.commands.some(
+                  (c2) => c2.name === c.name && c2.groupId === c.groupId
+                )
+            ),
+        }),
+      ],
     },
   },
 })


### PR DESCRIPTION
Currently, if you open the command palette before an engine connection is established, **you will never see them in the palette**. This is bad. This PR makes it possible to add and remove commands from any `commandBarMachine` state without changing the state, and it adds a `disabled` command configuration option, which it uses for the modeling commands.

## Demo

https://github.com/user-attachments/assets/8ffb3f72-5269-4114-91f1-12e77158715d

@lee-at-zoo-corp I do actually need a `useMemo` for once 😆 

