### PR TITLE
Check both public and internal KCL samples

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -213,7 +213,13 @@ jobs:
         if: ${{ github.event_name != 'release' && github.event_name != 'schedule' }}
         run: npm run playwright install chromium --with-deps
 
-      - name: run unit tests for kcl samples
+      - name: Download internal KCL samples
+        run: git clone --depth=1 https://x-access-token:${{ secrets.GH_PAT_KCL_SAMPLES_INTERNAL }}@github.com/KittyCAD/kcl-samples-internal public/kcl-samples/internal
+
+      - name: Regenerate KCL samples manifest
+        run: cd rust/kcl-lib && EXPECTORATE=overwrite cargo test generate_manifest
+
+      - name: Check public and internal KCL samples
         if: ${{ github.event_name != 'release' && github.event_name != 'schedule' }}
         run: npm run test:unit:kcl-samples
         env:


### PR DESCRIPTION
Before: https://github.com/KittyCAD/modeling-app/actions/runs/14984901799/job/42097033589

> ✓ src/lang/kclSamples.test.ts (42 tests) 5788ms

After: https://github.com/KittyCAD/modeling-app/actions/runs/14985208778/job/42097949882?pr=6889

>✓ src/lang/kclSamples.test.ts (101 tests) 8835ms

--- 

This contributes to https://github.com/KittyCAD/engine/issues/3412 using the tooling added in https://github.com/KittyCAD/modeling-app/pull/6880.

`$GH_PAT_KCL_SAMPLES_INTERNAL` is a personal access token with fine-grained scope to https://github.com/KittyCAD/kcl-samples-internal that will expire in one year.