### PR TITLE
SystemIOMachine: Toast default error instead of empty string

### DIFF
--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -191,7 +191,7 @@ export const systemIOMachine = setup({
           ('error' in event &&
             event.error instanceof Error &&
             event.error.message) ||
-          ''
+          'Unknown error in SystemIOMachine'
       )
     },
     [SystemIOMachineActions.setReadWriteProjectDirectory]: assign({


### PR DESCRIPTION
Relates to #6820, no fix but would help pinpoint this in the future