### PR TITLE
Keep toast message around longer when testing

### DIFF
--- a/e2e/playwright/test-utils.ts
+++ b/e2e/playwright/test-utils.ts
@@ -809,8 +809,6 @@ export const doExport = async (
 
   await page.getByRole('button', { name: 'Submit command' }).click()
 
-  // This usually happens immediately after. If we're too slow we don't
-  // catch it.
   await expect(page.getByText('Exported successfully')).toBeVisible()
 
   if (exportFrom === 'sidebarButton' || exportFrom === 'commandBar') {

--- a/src/lib/exportSave.ts
+++ b/src/lib/exportSave.ts
@@ -29,7 +29,10 @@ const save_ = async (file: ModelingAppFile, toastId: string) => {
           window.electron.join(downloadDir, file.name),
           new Uint8Array(file.contents)
         )
-        toast.success(EXPORT_TOAST_MESSAGES.SUCCESS, { id: toastId })
+        toast.success(EXPORT_TOAST_MESSAGES.SUCCESS + ' [TEST]', {
+          id: toastId,
+          duration: 5_000,
+        })
         return
       }
 


### PR DESCRIPTION
Contributes to https://github.com/KittyCAD/modeling-app/issues/2978 by addressing flakiness in this test: https://test-analysis-bot.hawk-dinosaur.ts.net/projects/KittyCAD/modeling-app/tests/257?branch=longer-toast-in-test