### PR TITLE
Remove unneeded check on the network health text label

### DIFF
--- a/e2e/playwright/regression-tests.spec.ts
+++ b/e2e/playwright/regression-tests.spec.ts
@@ -552,7 +552,7 @@ extrude002 = extrude(profile002, length = 150)
   test(
     `Network health indicator only appears in modeling view`,
     { tag: '@electron' },
-    async ({ context, page }, testInfo) => {
+    async ({ context, page }) => {
       await context.folderSetupFn(async (dir) => {
         const bracketDir = path.join(dir, 'bracket')
         await fsp.mkdir(bracketDir, { recursive: true })
@@ -561,9 +561,7 @@ extrude002 = extrude(profile002, length = 150)
           path.join(bracketDir, 'main.kcl')
         )
       })
-
       await page.setBodyDimensions({ width: 1200, height: 500 })
-      const u = await getUtils(page)
 
       // Locators
       const projectsHeading = page.getByRole('heading', {
@@ -583,10 +581,8 @@ extrude002 = extrude(profile002, length = 150)
       })
 
       await test.step('Check the modeling view', async () => {
+        await expect(projectsHeading).not.toBeVisible()
         await expect(networkHealthIndicator).toBeVisible()
-        await expect(networkHealthIndicator).toContainText('Problem')
-        await u.waitForPageLoad()
-        await expect(networkHealthIndicator).toContainText('Connected')
       })
     }
   )


### PR DESCRIPTION
Contributes to https://github.com/KittyCAD/modeling-app/issues/2978 by addressing flakiness in this test: https://test-analysis-bot.hawk-dinosaur.ts.net/projects/KittyCAD/modeling-app/tests/239?branch=remove-unneeded-checks