### PR TITLE
Shard macOS and Windows e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -234,10 +234,16 @@ jobs:
             shardTotal: 8
           - os: namespace-profile-macos-8-cores
             shardIndex: 1
-            shardTotal: 1
+            shardTotal: 2
+          - os: namespace-profile-macos-8-cores
+            shardIndex: 2
+            shardTotal: 2
           - os: windows-latest-8-cores
             shardIndex: 1
-            shardTotal: 1
+            shardTotal: 2
+          - os: windows-latest-8-cores
+            shardIndex: 2
+            shardTotal: 2
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Now that we're running the native file menu tests again, the macOS shard is averaging above 10 minutes.

With this change the smaller macOS and Windows suites should finish before Ubuntu.