### PR TITLE
Clear errors when leaving file to avoid seeing previous files errors

### DIFF
--- a/src/lang/KclSingleton.ts
+++ b/src/lang/KclSingleton.ts
@@ -151,6 +151,10 @@ export class KclManager {
     // These belonged to the previous file
     this.lastSuccessfulOperations = []
     this.lastSuccessfulVariables = {}
+
+    // Without this, when leaving a project which has errors and opening another project which doesn't,
+    // you'd see the errors from the previous project for a short time until the new code is executed.
+    this._errors = []
   }
 
   get variables() {


### PR DESCRIPTION
Related to https://github.com/KittyCAD/modeling-app/issues/6300, also pretty small, fixes this current behaviour:
- open file with any KCL errors
- leave project and open a new project with no errors
-> you still see the error notification in the Feature Tree from the previous file, until the new code is executed and errors are cleared.