### PR TITLE
Keep test toast messages around for longer

### DIFF
--- a/e2e/playwright/regression-tests.spec.ts
+++ b/e2e/playwright/regression-tests.spec.ts
@@ -545,7 +545,8 @@ extrude002 = extrude(profile002, length = 150)
         expect(alreadyExportingToastMessage).not.toBeVisible(),
       ])
 
-      await expect(successToastMessage).toHaveCount(2)
+      const count = await successToastMessage.count()
+      await expect(count).toBeGreaterThanOrEqual(2)
     })
   })
 

--- a/src/lib/exportSave.ts
+++ b/src/lib/exportSave.ts
@@ -31,7 +31,7 @@ const save_ = async (file: ModelingAppFile, toastId: string) => {
         )
         toast.success(EXPORT_TOAST_MESSAGES.SUCCESS + ' [TEST]', {
           id: toastId,
-          duration: 5_000,
+          duration: 10_000,
         })
         return
       }


### PR DESCRIPTION
[This test](https://test-analysis-bot.hawk-dinosaur.ts.net/projects/KittyCAD/modeling-app/tests/257 ) is still failing occasionally with this error:

```Locator: getByText('Exported successfully')
Expected: 2
Received: 1
Call log:
  - expect.toHaveCount with timeout 5000ms
  - waiting for getByText('Exported successfully')
    8 × locator resolved to 3 elements
      - unexpected value "3"
    - locator resolved to 1 element
    - unexpected value "1"

    at /home/runner/_work/modeling-app/modeling-app/e2e/playwright/regression-tests.spec.ts:548:41
```

If we want to confirm both export toasts are visible then we need them to stay around even longer. The 5 seconds added in https://github.com/KittyCAD/modeling-app/pull/6902 isn't always enough.

Results for this branch: https://test-analysis-bot.hawk-dinosaur.ts.net/projects/KittyCAD/modeling-app/tests/257?branch=longer-test-toast