### PR TITLE
#6202 Save input value before closing settings dialogue

### DIFF
--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -33,9 +33,6 @@ export const Settings = () => {
   const scrollRef = useRef<HTMLDivElement>(null)
   const dotDotSlash = useDotDotSlash()
 
-  // Does this ever run?
-  useHotkeys('esc', () => navigate(dotDotSlash()))
-
   // Scroll to the hash on load if it exists
   useEffect(() => {
     console.log('hash', location.hash)

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -17,7 +17,13 @@ import type { SettingsLevel } from '@src/lib/settings/settingsTypes'
 export const Settings = () => {
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
-  const close = () => navigate(location.pathname.replace(PATHS.SETTINGS, ''))
+  const close = () => {
+    // This makes sure input texts are saved before closing the dialog (eg. default project name).
+    if (document.activeElement instanceof HTMLInputElement) {
+      document.activeElement.blur()
+    }
+    navigate(location.pathname.replace(PATHS.SETTINGS, ''))
+  }
   const location = useLocation()
   const isFileSettings = location.pathname.includes(PATHS.FILE)
   const searchParamTab =
@@ -26,6 +32,8 @@ export const Settings = () => {
 
   const scrollRef = useRef<HTMLDivElement>(null)
   const dotDotSlash = useDotDotSlash()
+
+  // Does this ever run?
   useHotkeys('esc', () => navigate(dotDotSlash()))
 
   // Scroll to the hash on load if it exists

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -1,6 +1,5 @@
 import { Dialog, Transition } from '@headlessui/react'
 import { Fragment, useEffect, useRef } from 'react'
-import { useHotkeys } from 'react-hotkeys-hook'
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 
 import { CustomIcon } from '@src/components/CustomIcon'
@@ -10,7 +9,6 @@ import { KeybindingsSectionsList } from '@src/components/Settings/KeybindingsSec
 import { SettingsSearchBar } from '@src/components/Settings/SettingsSearchBar'
 import { SettingsSectionsList } from '@src/components/Settings/SettingsSectionsList'
 import { SettingsTabs } from '@src/components/Settings/SettingsTabs'
-import { useDotDotSlash } from '@src/hooks/useDotDotSlash'
 import { PATHS } from '@src/lib/paths'
 import type { SettingsLevel } from '@src/lib/settings/settingsTypes'
 
@@ -31,7 +29,6 @@ export const Settings = () => {
     (isFileSettings ? 'project' : 'user')
 
   const scrollRef = useRef<HTMLDivElement>(null)
-  const dotDotSlash = useDotDotSlash()
 
   // Scroll to the hash on load if it exists
   useEffect(() => {


### PR DESCRIPTION
Fixes #6202 

Very small, bit of a hack..
I think this was working already when closing the settings with the "x" button, it was only needed when closing it with the Esc key.
Also, I'm not sure the `useHotkey('esc', ..)` is needed, escape works for me without that.. 