### PR TITLE
Make the Reset View button do the same view_isometric behavior as load

### DIFF
--- a/src/components/EngineStream.tsx
+++ b/src/components/EngineStream.tsx
@@ -38,6 +38,7 @@ import {
 import { DEFAULT_DEFAULT_LENGTH_UNIT } from '@src/lib/constants'
 import { createThumbnailPNGOnDesktop } from '@src/lib/screenshot'
 import type { SettingsViaQueryString } from '@src/lib/settings/settingsTypes'
+import { resetCameraPosition } from '@src/lib/resetCameraPosition'
 
 export const EngineStream = (props: {
   pool: string | null
@@ -104,31 +105,7 @@ export const EngineStream = (props: {
 
     kmp
       .then(async () => {
-        // Gotcha: Playwright E2E tests will be zoom_to_fit, when you try to recreate the e2e test manually
-        // your localhost will do view_isometric. Turn this boolean on to have the same experience when manually
-        // debugging e2e tests
-
-        // We need a padding of 0.1 for zoom_to_fit for all E2E tests since they were originally
-        // written with zoom_to_fit with padding 0.1
-        const padding = 0.1
-        if (isPlaywright()) {
-          await engineStreamZoomToFit({ engineCommandManager, padding })
-        } else {
-          // If the scene is empty you cannot use view_isometric, it will not move the camera
-          if (kclManager.isAstBodyEmpty(kclManager.ast)) {
-            await engineViewIsometricWithoutGeometryPresent({
-              engineCommandManager,
-              unit:
-                kclManager.fileSettings.defaultLengthUnit ||
-                DEFAULT_DEFAULT_LENGTH_UNIT,
-            })
-          } else {
-            await engineViewIsometricWithGeometryPresent({
-              engineCommandManager,
-              padding,
-            })
-          }
-        }
+        await resetCameraPosition()
 
         if (project && project.path) {
           createThumbnailPNGOnDesktop({

--- a/src/components/EngineStream.tsx
+++ b/src/components/EngineStream.tsx
@@ -29,13 +29,6 @@ import { useSelector } from '@xstate/react'
 import type { MouseEventHandler } from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { useRouteLoaderData } from 'react-router-dom'
-import { isPlaywright } from '@src/lib/isPlaywright'
-import {
-  engineStreamZoomToFit,
-  engineViewIsometricWithGeometryPresent,
-  engineViewIsometricWithoutGeometryPresent,
-} from '@src/lib/utils'
-import { DEFAULT_DEFAULT_LENGTH_UNIT } from '@src/lib/constants'
 import { createThumbnailPNGOnDesktop } from '@src/lib/screenshot'
 import type { SettingsViaQueryString } from '@src/lib/settings/settingsTypes'
 import { resetCameraPosition } from '@src/lib/resetCameraPosition'

--- a/src/components/ViewControlMenu.tsx
+++ b/src/components/ViewControlMenu.tsx
@@ -9,23 +9,10 @@ import {
 } from '@src/components/ContextMenu'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import type { AxisNames } from '@src/lib/constants'
-import {
-  DEFAULT_DEFAULT_LENGTH_UNIT,
-  VIEW_NAMES_SEMANTIC,
-} from '@src/lib/constants'
-import {
-  engineCommandManager,
-  kclManager,
-  sceneInfra,
-} from '@src/lib/singletons'
+import { VIEW_NAMES_SEMANTIC } from '@src/lib/constants'
+import { sceneInfra } from '@src/lib/singletons'
 import { reportRejection } from '@src/lib/trap'
 import { useSettings } from '@src/lib/singletons'
-import { isPlaywright } from '@src/lib/isPlaywright'
-import {
-  engineStreamZoomToFit,
-  engineViewIsometricWithoutGeometryPresent,
-  engineViewIsometricWithGeometryPresent,
-} from '@src/lib/utils'
 import { resetCameraPosition } from '@src/lib/resetCameraPosition'
 
 export function useViewControlMenuItems() {

--- a/src/components/ViewControlMenu.tsx
+++ b/src/components/ViewControlMenu.tsx
@@ -26,6 +26,7 @@ import {
   engineViewIsometricWithoutGeometryPresent,
   engineViewIsometricWithGeometryPresent,
 } from '@src/lib/utils'
+import { resetCameraPosition } from '@src/lib/resetCameraPosition'
 
 export function useViewControlMenuItems() {
   const { state: modelingState, send: modelingSend } = useModelingContext()
@@ -51,33 +52,7 @@ export function useViewControlMenuItems() {
       <ContextMenuDivider />,
       <ContextMenuItem
         onClick={() => {
-          // Gotcha: Playwright E2E tests will be zoom_to_fit, when you try to recreate the e2e test manually
-          // your localhost will do view_isometric. Turn this boolean on to have the same experience when manually
-          // debugging e2e tests
-
-          // We need a padding of 0.1 for zoom_to_fit for all E2E tests since they were originally
-          // written with zoom_to_fit with padding 0.1
-          const padding = 0.1
-          if (isPlaywright()) {
-            engineStreamZoomToFit({ engineCommandManager, padding }).catch(
-              reportRejection
-            )
-          } else {
-            // If the scene is empty you cannot use view_isometric, it will not move the camera
-            if (kclManager.isAstBodyEmpty(kclManager.ast)) {
-              engineViewIsometricWithoutGeometryPresent({
-                engineCommandManager,
-                unit:
-                  kclManager.fileSettings.defaultLengthUnit ||
-                  DEFAULT_DEFAULT_LENGTH_UNIT,
-              }).catch(reportRejection)
-            } else {
-              engineViewIsometricWithGeometryPresent({
-                engineCommandManager,
-                padding,
-              }).catch(reportRejection)
-            }
-          }
+          resetCameraPosition().catch(reportRejection)
         }}
         disabled={shouldLockView}
       >

--- a/src/lib/resetCameraPosition.ts
+++ b/src/lib/resetCameraPosition.ts
@@ -1,12 +1,11 @@
-import { DEFAULT_DEFAULT_LENGTH_UNIT } from './constants'
-import { isPlaywright } from './isPlaywright'
-import { createThumbnailPNGOnDesktop } from './screenshot'
-import { engineCommandManager, kclManager } from './singletons'
+import { DEFAULT_DEFAULT_LENGTH_UNIT } from '@src/lib/constants'
+import { isPlaywright } from '@src/lib/isPlaywright'
+import { engineCommandManager, kclManager } from '@src/lib/singletons'
 import {
   engineStreamZoomToFit,
   engineViewIsometricWithoutGeometryPresent,
   engineViewIsometricWithGeometryPresent,
-} from './utils'
+} from '@src/lib/utils'
 
 /**
  * Reset the camera position to a baseline, which is isometric for

--- a/src/lib/resetCameraPosition.ts
+++ b/src/lib/resetCameraPosition.ts
@@ -1,0 +1,41 @@
+import { DEFAULT_DEFAULT_LENGTH_UNIT } from './constants'
+import { isPlaywright } from './isPlaywright'
+import { createThumbnailPNGOnDesktop } from './screenshot'
+import { engineCommandManager, kclManager } from './singletons'
+import {
+  engineStreamZoomToFit,
+  engineViewIsometricWithoutGeometryPresent,
+  engineViewIsometricWithGeometryPresent,
+} from './utils'
+
+/**
+ * Reset the camera position to a baseline, which is isometric for
+ * normal users and a deprecated "front-down" view for playwright tests.
+ *
+ * Gotcha: Playwright E2E tests will be zoom_to_fit, when you try to recreate the e2e test manually
+ * your localhost will do view_isometric. Turn this boolean on to have the same experience when manually
+ * debugging e2e tests
+ */
+export async function resetCameraPosition() {
+  // We need a padding of 0.1 for zoom_to_fit for all E2E tests since they were originally
+  // written with zoom_to_fit with padding 0.1
+  const padding = 0.1
+  if (isPlaywright()) {
+    await engineStreamZoomToFit({ engineCommandManager, padding })
+  } else {
+    // If the scene is empty you cannot use view_isometric, it will not move the camera
+    if (kclManager.isAstBodyEmpty(kclManager.ast)) {
+      await engineViewIsometricWithoutGeometryPresent({
+        engineCommandManager,
+        unit:
+          kclManager.fileSettings.defaultLengthUnit ||
+          DEFAULT_DEFAULT_LENGTH_UNIT,
+      })
+    } else {
+      await engineViewIsometricWithGeometryPresent({
+        engineCommandManager,
+        padding,
+      })
+    }
+  }
+}


### PR DESCRIPTION
Just copying some logic from the EngineStream code to make that button behave the same way: old initial camera position while in Playwright, isometric view for normal users.