### PR TITLE
Permit concurrent unit tests

### DIFF
--- a/rust/.config/nextest.toml
+++ b/rust/.config/nextest.toml
@@ -1,12 +1,12 @@
 [test-groups]
 # If a test uses the engine, we want to limit the number that can run in parallel.
 # This way we don't start and stop too many engine instances, putting pressure on our cloud.
-uses-engine = { max-threads = 4 }
+uses-engine = { max-threads = 32 }
 # If a test must run after the engine tests, we want to make sure the engine tests are done first.
-after-engine = { max-threads = 12 }
+after-engine = { max-threads = 32 }
 
 [profile.default]
-slow-timeout = { period = "180s", terminate-after = 1 }
+slow-timeout = { period = "280s", terminate-after = 1 }
 
 [profile.ci]
 slow-timeout = { period = "280s", terminate-after = 5 }


### PR DESCRIPTION
I'm not sure this is all correct, but this increases the max concurrency for engine tests from 2 (4/2, iiuc) to 32 (32/1) locally and 16 (32/2) in CI.

It also increases the local timeout to the same as in CI, since I sometimes hit it for the longer tests and it annoys me :-)