### PR TITLE
Sweeps always use trajectoryCurve

### DIFF
--- a/rust/kcl-lib/src/std/sweep.rs
+++ b/rust/kcl-lib/src/std/sweep.rs
@@ -167,7 +167,7 @@ pub async fn sweep(exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
         path = { docs = "The path to sweep the sketch along" },
         sectional = { docs = "If true, the sweep will be broken up into sub-sweeps (extrusions, revolves, sweeps) based on the trajectory path components." },
         tolerance = { docs = "Tolerance for this operation" },
-        relative_to = { docs = "What is the sweep relative to? Can be either 'sketchPlane' or 'trajectoryCurve'. Defaults to sketchPlane."},
+        relative_to = { docs = "What is the sweep relative to? Can be either 'sketchPlane' or 'trajectoryCurve'. Defaults to trajectoryCurve."},
         tag_start = { docs = "A named tag for the face at the start of the sweep, i.e. the original sketch" },
         tag_end = { docs = "A named tag for the face at the end of the sweep" },
     },

--- a/rust/kcl-lib/src/std/sweep.rs
+++ b/rust/kcl-lib/src/std/sweep.rs
@@ -191,14 +191,13 @@ async fn inner_sweep(
     };
     let relative_to = match relative_to.as_deref() {
         Some("sketchPlane") => RelativeTo::SketchPlane,
-        Some("trajectoryCurve") => RelativeTo::TrajectoryCurve,
+        Some("trajectoryCurve") | None => RelativeTo::TrajectoryCurve,
         Some(_) => {
             return Err(KclError::Syntax(crate::errors::KclErrorDetails {
                 source_ranges: vec![args.source_range],
                 message: "If you provide relativeTo, it must either be 'sketchPlane' or 'trajectoryCurve'".to_owned(),
             }))
         }
-        None => RelativeTo::default(),
     };
 
     let mut solids = Vec::new();

--- a/rust/kcl-lib/tests/kcl_samples/bench/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/bench/artifact_commands.snap
@@ -5122,7 +5122,7 @@ description: Artifact commands bench.kcl
       "trajectory": "[uuid]",
       "sectional": false,
       "tolerance": 0.0000001,
-      "relative_to": "sketch_plane"
+      "relative_to": "trajectory_curve"
     }
   },
   {
@@ -5134,7 +5134,7 @@ description: Artifact commands bench.kcl
       "trajectory": "[uuid]",
       "sectional": false,
       "tolerance": 0.0000001,
-      "relative_to": "sketch_plane"
+      "relative_to": "trajectory_curve"
     }
   }
 ]

--- a/rust/kcl-lib/tests/kcl_samples/cold-plate/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/cold-plate/artifact_commands.snap
@@ -906,7 +906,7 @@ description: Artifact commands cold-plate.kcl
       "trajectory": "[uuid]",
       "sectional": false,
       "tolerance": 0.0000001,
-      "relative_to": "sketch_plane"
+      "relative_to": "trajectory_curve"
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/countersunk-plate/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/countersunk-plate/program_memory.snap
@@ -162,7 +162,7 @@ description: Variables in memory after executing countersunk-plate.kcl
             ],
             "tag": null,
             "to": [
-              2.7737,
+              2.7738,
               -0.6983
             ],
             "type": "TangentialArc",
@@ -176,7 +176,7 @@ description: Variables in memory after executing countersunk-plate.kcl
               "sourceRange": []
             },
             "from": [
-              2.7737,
+              2.7738,
               -0.6983
             ],
             "tag": null,
@@ -196,7 +196,7 @@ description: Variables in memory after executing countersunk-plate.kcl
             },
             "ccw": false,
             "center": [
-              -0.0,
+              0.0,
               -0.0
             ],
             "from": [

--- a/rust/kcl-lib/tests/kcl_samples/cpu-cooler/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/cpu-cooler/artifact_commands.snap
@@ -5576,7 +5576,7 @@ description: Artifact commands cpu-cooler.kcl
       "trajectory": "[uuid]",
       "sectional": false,
       "tolerance": 0.0000001,
-      "relative_to": "sketch_plane"
+      "relative_to": "trajectory_curve"
     }
   },
   {
@@ -6111,7 +6111,7 @@ description: Artifact commands cpu-cooler.kcl
       "trajectory": "[uuid]",
       "sectional": false,
       "tolerance": 0.0000001,
-      "relative_to": "sketch_plane"
+      "relative_to": "trajectory_curve"
     }
   },
   {
@@ -9469,7 +9469,7 @@ description: Artifact commands cpu-cooler.kcl
       "trajectory": "[uuid]",
       "sectional": false,
       "tolerance": 0.0000001,
-      "relative_to": "sketch_plane"
+      "relative_to": "trajectory_curve"
     }
   },
   {
@@ -9601,7 +9601,7 @@ description: Artifact commands cpu-cooler.kcl
       "trajectory": "[uuid]",
       "sectional": false,
       "tolerance": 0.0000001,
-      "relative_to": "sketch_plane"
+      "relative_to": "trajectory_curve"
     }
   },
   {
@@ -10120,7 +10120,7 @@ description: Artifact commands cpu-cooler.kcl
       "trajectory": "[uuid]",
       "sectional": false,
       "tolerance": 0.0000001,
-      "relative_to": "sketch_plane"
+      "relative_to": "trajectory_curve"
     }
   },
   {
@@ -10252,7 +10252,7 @@ description: Artifact commands cpu-cooler.kcl
       "trajectory": "[uuid]",
       "sectional": false,
       "tolerance": 0.0000001,
-      "relative_to": "sketch_plane"
+      "relative_to": "trajectory_curve"
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/exhaust-manifold/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/exhaust-manifold/artifact_commands.snap
@@ -1598,7 +1598,7 @@ description: Artifact commands exhaust-manifold.kcl
       "trajectory": "[uuid]",
       "sectional": false,
       "tolerance": 0.0000001,
-      "relative_to": "sketch_plane"
+      "relative_to": "trajectory_curve"
     }
   },
   {
@@ -1610,7 +1610,7 @@ description: Artifact commands exhaust-manifold.kcl
       "trajectory": "[uuid]",
       "sectional": false,
       "tolerance": 0.0000001,
-      "relative_to": "sketch_plane"
+      "relative_to": "trajectory_curve"
     }
   },
   {
@@ -1622,7 +1622,7 @@ description: Artifact commands exhaust-manifold.kcl
       "trajectory": "[uuid]",
       "sectional": false,
       "tolerance": 0.0000001,
-      "relative_to": "sketch_plane"
+      "relative_to": "trajectory_curve"
     }
   },
   {
@@ -1634,7 +1634,7 @@ description: Artifact commands exhaust-manifold.kcl
       "trajectory": "[uuid]",
       "sectional": false,
       "tolerance": 0.0000001,
-      "relative_to": "sketch_plane"
+      "relative_to": "trajectory_curve"
     }
   },
   {

--- a/rust/kcl-lib/tests/kcl_samples/utility-sink/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/utility-sink/artifact_commands.snap
@@ -4491,7 +4491,7 @@ description: Artifact commands utility-sink.kcl
       "trajectory": "[uuid]",
       "sectional": false,
       "tolerance": 0.0000001,
-      "relative_to": "sketch_plane"
+      "relative_to": "trajectory_curve"
     }
   },
   {

--- a/rust/kcl-lib/tests/subtract_regression03/artifact_commands.snap
+++ b/rust/kcl-lib/tests/subtract_regression03/artifact_commands.snap
@@ -418,7 +418,7 @@ description: Artifact commands subtract_regression03.kcl
       "trajectory": "[uuid]",
       "sectional": false,
       "tolerance": 0.0000001,
-      "relative_to": "sketch_plane"
+      "relative_to": "trajectory_curve"
     }
   },
   {

--- a/rust/kcl-lib/tests/subtract_regression05/artifact_commands.snap
+++ b/rust/kcl-lib/tests/subtract_regression05/artifact_commands.snap
@@ -395,7 +395,7 @@ description: Artifact commands subtract_regression05.kcl
       "trajectory": "[uuid]",
       "sectional": false,
       "tolerance": 0.0000001,
-      "relative_to": "sketch_plane"
+      "relative_to": "trajectory_curve"
     }
   },
   {


### PR DESCRIPTION
Follow-up to https://github.com/KittyCAD/engine/issues/3115 -- let's make the desired option the default/only choice. We can always add this flag back in later.