### PR TITLE
Do not coerce unknown numbers and preserve known units if present

### DIFF
--- a/rust/kcl-lib/src/execution/types.rs
+++ b/rust/kcl-lib/src/execution/types.rs
@@ -664,6 +664,17 @@ impl NumericType {
         )
     }
 
+    pub fn is_fully_specified(&self) -> bool {
+        !matches!(
+            self,
+            NumericType::Unknown
+                | NumericType::Known(UnitType::Angle(UnitAngle::Unknown))
+                | NumericType::Known(UnitType::Length(UnitLen::Unknown))
+                | NumericType::Any
+                | NumericType::Default { .. }
+        )
+    }
+
     fn example_ty(&self) -> Option<String> {
         match self {
             Self::Known(t) if !self.is_unknown() => Some(t.to_string()),

--- a/rust/kcl-lib/src/std/args.rs
+++ b/rust/kcl-lib/src/std/args.rs
@@ -102,7 +102,7 @@ impl TyF64 {
             t => unreachable!("expected length, found {t:?}"),
         };
 
-        assert_ne!(len, UnitLen::Unknown);
+        debug_assert_ne!(len, UnitLen::Unknown);
 
         len.adjust_to(self.n, units).0
     }
@@ -114,7 +114,7 @@ impl TyF64 {
             _ => unreachable!(),
         };
 
-        assert_ne!(angle, UnitAngle::Unknown);
+        debug_assert_ne!(angle, UnitAngle::Unknown);
 
         angle.adjust_to(self.n, UnitAngle::Degrees).0
     }
@@ -126,7 +126,7 @@ impl TyF64 {
             _ => unreachable!(),
         };
 
-        assert_ne!(angle, UnitAngle::Unknown);
+        debug_assert_ne!(angle, UnitAngle::Unknown);
 
         angle.adjust_to(self.n, UnitAngle::Radians).0
     }


### PR DESCRIPTION
Closes https://github.com/KittyCAD/modeling-app/issues/6953

If we coerce a number to another number then we hack things a little bit so as to avoid converting units. However, if you coerce to an unknown number type, that resulted in number value with unknown units, breaking an invariant that units are never partially specified (i.e., no values should ever have type `number(Length)`).

This PR fixes that by not resetting the type of a number before coercion unless it is being coerced to a fully specified numeric type. Such coercions are still allowed, but will only succeed if the number already has units and those are then not erased (we keep the more precise units). Both conditions are tested in the new unit test.

For good measure, I've made the assertion which caught this debug-only to try and avoid crashes, though giving any kind of error in that case is pretty tough, so we'll get some odd results and no specific error.