### PR TITLE
Remove updater-test builds

### DIFF
--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -123,18 +123,6 @@ jobs:
       - id: export_notes
         run: echo "notes=`cat release-notes.md`" >> "$GITHUB_OUTPUT"
 
-      - name: Prepare electron-builder.yml file for updater test
-        if: ${{ env.IS_RELEASE == 'true' }}
-        run: |
-          yq -i '.publish[0].url = "https://dl.zoo.dev/releases/modeling-app/updater-test"' electron-builder.yml
-
-      - uses: actions/upload-artifact@v4
-        if: ${{ env.IS_RELEASE == 'true' }}
-        with:
-          name: prepared-files-updater-test
-          path: |
-            electron-builder.yml
-
 
   build-apps:
     needs: [prepare-files]
@@ -258,49 +246,6 @@ jobs:
             out/latest*.yml
 
       # TODO: add the 'Build for Mac TestFlight (nightly)' stage back
-
-      # The steps below are for updater-test builds, only on release
-
-      - uses: actions/download-artifact@v4
-        if: ${{ env.IS_RELEASE == 'true' }}
-        name: prepared-files-updater-test
-
-      - name: Copy updated electron-builder.yml file for updater test
-        if: ${{ env.IS_RELEASE == 'true' }}
-        run: |
-          ls -R prepared-files-updater-test
-          cp prepared-files-updater-test/electron-builder.yml electron-builder.yml
-
-      - name: Build the app (updater-test)
-        if: ${{ env.IS_RELEASE == 'true' }}
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          CSC_LINK: ${{ secrets.APPLE_CERTIFICATE }}
-          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          CSC_KEYCHAIN: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          WINDOWS_CERTIFICATE_THUMBPRINT: ${{ secrets.WINDOWS_CERTIFICATE_THUMBPRINT }}
-        run: npm run tronb:package:prod
-
-      - uses: actions/upload-artifact@v4
-        if: ${{ env.IS_RELEASE == 'true' }}
-        with:
-          name: updater-test-arm64-${{ matrix.platform }}
-          path: |
-            out/*-arm64-win.exe
-            out/*-arm64-mac.dmg
-            out/*-arm64-linux.AppImage
-
-      - uses: actions/upload-artifact@v4
-        if: ${{ env.IS_RELEASE == 'true' }}
-        with:
-          name: updater-test-x64-${{ matrix.platform }}
-          path: |
-            out/*-x64-win.exe
-            out/*-x64-mac.dmg
-            out/*-x86_64-linux.AppImage
 
 
   upload-apps-release:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ git tag $VERSION
 git push origin --tags
 ```
 
-This will trigger the `build-apps` workflow, set the version, build & sign the apps, and generate release files as well as updater-test artifacts.
+This will trigger the `build-apps` workflow, set the version, build & sign the apps, and generate release files.
 
 The workflow should be listed right away [in this list](https://github.com/KittyCAD/modeling-app/actions/workflows/build-apps.yml?query=event%3Apush)).
 
@@ -142,13 +142,10 @@ The release builds can be found under the `out-{arch}-{platform}` zip files, at 
 
 Manually test against this [list](https://github.com/KittyCAD/modeling-app/issues/3588) across Windows, MacOS, Linux and posting results as comments in the issue.
 
-##### Updater-test builds
-
-The other `build-apps` output in the release `build-apps` workflow (triggered by 2.) is `updater-test-{arch}-{platform}`. It's a semi-automated process: for macOS, Windows, and Linux, download the corresponding updater-test artifact file, install the app, run it, expect an updater prompt to a dummy v0.255.255, install it and check that the app comes back at that version.
-
-The only difference with these builds is that they point to a different update location on the release bucket, with this dummy v0.255.255 always available. This helps ensuring that the version we release will be able to update to the next one available.
-
-If the prompt doesn't show up, start the app in command line to grab the electron-updater logs. This is likely an issue with the current build that needs addressing (or the updater-test location in the storage bucket).
+A prompt should show up asking for a downgrade to the last release version. Running through that at the end of testing
+and making sure the current release candidate has the ability to be updated to what electron-updater points to is critical,
+but what is actually being downloaded and installed isn't.
+If the prompt doesn't show up, start the app in command line to grab the electron-updater logs. This is likely an issue with the current build that needs addressing.
 
 ```
 # Windows (PowerShell)


### PR DESCRIPTION
Since https://github.com/KittyCAD/modeling-app/pull/6877/files, we allow the electron-updater to downgrade, so whatever is in the release bucket is prompted in the toast to the user.

This effectively makes the current dedicated updater-test builds in release smoke testing useless, since a release candidate will now automatically prompt to update to the last release out there, which is effectively a downgrade, but is still perfectly fine coverage for what we needed here: making sure the build we ship can run the update.

So I'm removing the steps for updater-test, and will also delete my branch publishing the dummy builds https://github.com/KittyCAD/modeling-app/tree/updater-test. The readme is updated as well.

This was noticed and first tested in #6950 