### PR TITLE
[Chore] Minor CSS changes for error overlay in feature tree

### DIFF
--- a/src/components/ModelingSidebar/ModelingPanes/FeatureTreePane.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/FeatureTreePane.tsx
@@ -109,6 +109,7 @@ export const FeatureTreePane = () => {
       // devTools: true,
     }
   )
+
   // If there are parse errors we show the last successful operations
   // and overlay a message on top of the pane
   const parseErrors = kclManager.errors.filter((e) => e.kind !== 'engine')
@@ -161,7 +162,7 @@ export const FeatureTreePane = () => {
             {parseErrors.length > 0 && (
               <div
                 className={`absolute inset-0 p-2 ${
-                  operationList.length &&
+                  operationList.length || parseErrors.length > 0 &&
                   `bg-destroy-10/40 dark:bg-destroy-80/40`
                 }`}
               >

--- a/src/components/ModelingSidebar/ModelingPanes/FeatureTreePane.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/FeatureTreePane.tsx
@@ -162,11 +162,12 @@ export const FeatureTreePane = () => {
             {parseErrors.length > 0 && (
               <div
                 className={`absolute inset-0 p-2 ${
-                  operationList.length || parseErrors.length > 0 &&
-                  `bg-destroy-10/40 dark:bg-destroy-80/40`
+                  operationList.length ||
+                  (parseErrors.length > 0 &&
+                    `bg-destroy-10/40 dark:bg-destroy-80/40`)
                 }`}
               >
-                <div className="text-sm bg-destroy-80 text-chalkboard-10 py-1 px-2 rounded flex gap-2 items-center">
+                <div className="text-base font-sans font-normal text-destroy-80 dark:text-destroy-10 bg-destroy-10 dark:bg-destroy-80 py-1 px-2 rounded flex gap-2 items-center">
                   <p className="flex-1">
                     Errors found in KCL code.
                     <br />
@@ -174,7 +175,7 @@ export const FeatureTreePane = () => {
                   </p>
                   <button
                     onClick={goToError}
-                    className="bg-chalkboard-10 text-destroy-80 p-1 rounded-sm flex-none hover:bg-chalkboard-10 hover:border-destroy-70 hover:text-destroy-80 border-transparent"
+                    className="border bg-chalkboard-10 text-destroy-80 p-1 rounded flex-none hover:bg-chalkboard-10 hover:border-destroy-70 hover:text-destroy-80 border-transparent"
                   >
                     View error
                   </button>

--- a/src/components/ModelingSidebar/ModelingPanes/FeatureTreePane.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/FeatureTreePane.tsx
@@ -160,7 +160,7 @@ export const FeatureTreePane = () => {
             {!modelingState.matches('Sketch') && <DefaultPlanes />}
             {parseErrors.length > 0 && (
               <div
-                className={`absolute inset-0 rounded-lg p-2 ${
+                className={`absolute inset-0 p-2 ${
                   operationList.length &&
                   `bg-destroy-10/40 dark:bg-destroy-80/40`
                 }`}

--- a/src/components/NetworkHealthIndicator.tsx
+++ b/src/components/NetworkHealthIndicator.tsx
@@ -49,16 +49,16 @@ const hasIssueToIconColors: Record<string | number | symbol, IconColorConfig> =
 const overallConnectionStateColor: Record<NetworkHealthState, IconColorConfig> =
   {
     [NetworkHealthState.Ok]: {
-      icon: 'text-succeed-80 dark:text-succeed-10',
-      bg: 'bg-succeed-10/30 dark:bg-succeed-80/50',
+      icon: 'text-destroy-80 dark:text-destroy-10',
+      bg: 'bg-destroy-10 dark:bg-destroy-80',
     },
     [NetworkHealthState.Weak]: {
-      icon: 'text-warn-80 dark:text-warn-10',
-      bg: 'bg-warn-10 dark:bg-warn-80/80',
+      icon: 'text-destroy-80 dark:text-destroy-10',
+      bg: 'bg-destroy-10 dark:bg-destroy-80',
     },
     [NetworkHealthState.Issue]: {
       icon: 'text-destroy-80 dark:text-destroy-10',
-      bg: 'bg-destroy-10 dark:bg-destroy-80/80',
+      bg: 'bg-destroy-10 dark:bg-destroy-80',
     },
     [NetworkHealthState.Disconnected]: {
       icon: 'text-destroy-80 dark:text-destroy-10',


### PR DESCRIPTION
- Display the error pane if there are errors or the operation list is present
  - The problem was when you refresh the page you don't have the feature tree because it hasn't executed once so the error header shows up but not the error background this is confusing
- Changed the font coloring and size for the error header
- Rounded the view error button it was too square