### PR TITLE
Change runtime assert to runtime error and debug assert

### DIFF
--- a/rust/kcl-lib/src/execution/types.rs
+++ b/rust/kcl-lib/src/execution/types.rs
@@ -1266,7 +1266,15 @@ impl KclValue {
                     .satisfied(values.len(), allow_shrink)
                     .ok_or(CoercionError::from(self))?;
 
-                assert!(len <= values.len());
+                if len > values.len() {
+                    let message = format!(
+                        "Internal: Expected coerced array length {len} to be less than or equal to original length {}",
+                        values.len()
+                    );
+                    exec_state.err(CompilationError::err(self.into(), message.clone()));
+                    #[cfg(debug_assertions)]
+                    panic!("{message}");
+                }
                 values.truncate(len);
 
                 Ok(KclValue::HomArray {


### PR DESCRIPTION
I created this just recently, so figured I'd remove the panic.

Maybe we could make a macro for this so that it isn't so verbose. The correct thing should be easy and ergonomic.