### PR TITLE
Fix to display errors at the call site

### DIFF
--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1467,7 +1467,6 @@ impl Node<CallExpressionKw> {
                     .await
                     .map_err(|e| {
                         // Add the call expression to the source ranges.
-                        // TODO currently ignored by the frontend
                         e.add_source_ranges(vec![callsite])
                     })?;
 

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -69,6 +69,7 @@ import {
   UNLABELED_ARG,
 } from '@src/lang/queryAstConstants'
 import type { NumericType } from '@rust/kcl-lib/bindings/NumericType'
+import { isTopLevelModule } from '@src/lang/util'
 
 export type { ArrayExpression } from '@rust/kcl-lib/bindings/ArrayExpression'
 export type {
@@ -157,10 +158,23 @@ export function defaultSourceRange(): SourceRange {
   return [0, 0, 0]
 }
 
-function firstSourceRange(error: RustKclError): SourceRange {
-  return error.sourceRanges.length > 0
-    ? sourceRangeFromRust(error.sourceRanges[0])
-    : defaultSourceRange()
+function bestSourceRange(error: RustKclError): SourceRange {
+  if (error.sourceRanges.length === 0) {
+    return defaultSourceRange()
+  }
+
+  // When there's an error, the call stack is unwound, and the locations are
+  // built up from deepest location to shallowest. So the shallowest call is
+  // last. That's the most useful to the user.
+  for (let i = error.sourceRanges.length - 1; i >= 0; i--) {
+    const range = error.sourceRanges[i]
+    // Skip ranges pointing into files that aren't the top-level module.
+    if (isTopLevelModule(range)) {
+      return sourceRangeFromRust(range)
+    }
+  }
+  // We didn't find a top-level module range, so just use the last one.
+  return sourceRangeFromRust(error.sourceRanges[error.sourceRanges.length - 1])
 }
 
 const splitErrors = (
@@ -230,7 +244,7 @@ export const parse = (code: string | Error): ParseResult | Error => {
     return new KCLError(
       parsed.kind,
       parsed.msg,
-      firstSourceRange(parsed),
+      bestSourceRange(parsed),
       [],
       [],
       defaultArtifactGraph(),
@@ -386,7 +400,7 @@ export const errFromErrWithOutputs = (e: any): KCLError => {
   return new KCLError(
     parsed.error.kind,
     parsed.error.msg,
-    firstSourceRange(parsed.error),
+    bestSourceRange(parsed.error),
     parsed.operations,
     parsed.artifactCommands,
     rustArtifactGraphToMap(parsed.artifactGraph),


### PR DESCRIPTION
Resolves #6879.

I made a `lib.kcl` file that looks like this:

```kcl
export fn check(@x) {
  return assert(x, isGreaterThan = 0)
}
```

Before

<img width="549" alt="Screenshot 2025-05-15 at 8 01 32 PM" src="https://github.com/user-attachments/assets/52ded2b2-f63b-464d-954b-1b3483b6b6cd" />

Clicking "View error" does nothing.

After

<img width="550" alt="Screenshot 2025-05-15 at 8 01 54 PM" src="https://github.com/user-attachments/assets/429c68cb-a1e7-44dd-a26b-bb8264343c0a" />

Clicking "View error" moves the cursor to the line with the red underline. Hover displays the message in the tooltip.

When it's in the same file, we also correctly show the call location now.

Before

<img width="509" alt="Screenshot 2025-05-15 at 8 48 25 PM" src="https://github.com/user-attachments/assets/ad02e7f1-8f2b-4d8a-aa34-b84b7f9ab9e6" />

After

<img width="506" alt="Screenshot 2025-05-15 at 8 11 01 PM" src="https://github.com/user-attachments/assets/a16a378e-9fca-45fb-b092-22df269b9bba" />
