### PR TITLE
Make Modify with Text-to-CAD selection arg optional by honoring `skip: false` on non-required args

### DIFF
--- a/src/components/CommandBar/CommandBarHeader.tsx
+++ b/src/components/CommandBar/CommandBarHeader.tsx
@@ -95,10 +95,12 @@ function CommandBarHeader({ children }: React.PropsWithChildren<object>) {
               </span>
             </p>
             {Object.entries(nonHiddenArgs || {})
-              .filter(([_, argConfig]) =>
-                typeof argConfig.required === 'function'
-                  ? argConfig.required(commandBarState.context)
-                  : argConfig.required
+              .filter(
+                ([_, argConfig]) =>
+                  argConfig.skip === false ||
+                  (typeof argConfig.required === 'function'
+                    ? argConfig.required(commandBarState.context)
+                    : argConfig.required)
               )
               .map(([argName, arg], i) => {
                 const argValue =

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -958,12 +958,12 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
           'edgeCutEdge',
         ],
         multiple: true,
-        required: true,
+        required: false,
         selectionSource: {
           allowSceneSelection: true,
           allowCodeSelection: true,
         },
-        skip: true,
+        skip: false,
         warningMessage: ML_EXPERIMENTAL_MESSAGE,
       },
       prompt: {

--- a/src/machines/commandBarMachine.ts
+++ b/src/machines/commandBarMachine.ts
@@ -146,8 +146,15 @@ export const commandBarMachine = setup({
             typeof argConfig.required === 'function'
               ? argConfig.required(context)
               : argConfig.required
+          /**
+           * TODO: we need to think harder about the relationship between
+           * `required`, `skip`, and `hidden`.
+           * This bit of logic essentially makes "skip false" arguments required.
+           * We may need a bit of state to mark an argument as "visited" for "skip false" args
+           * to truly not require any value to continue.
+           */
           const mustNotSkipArg =
-            argIsRequired &&
+            (argIsRequired || argConfig.skip === false) &&
             (!context.argumentsToSubmit.hasOwnProperty(argName) ||
               context.argumentsToSubmit[argName] === undefined ||
               (rejectedArg &&


### PR DESCRIPTION
Fixes the UX papercut where users don't want to or can't select geometry in the scene but want to modify with Text-to-CAD.