### PR TITLE
[Bug] fix big screen boot up bug

### DIFF
--- a/src/components/EngineStream.tsx
+++ b/src/components/EngineStream.tsx
@@ -264,8 +264,9 @@ export const EngineStream = (props: {
         last.current = Date.now()
 
         if (
-          Math.abs(video.width - window.innerWidth) > 4 ||
-          Math.abs(video.height - window.innerHeight) > 4
+          (Math.abs(video.width - window.innerWidth) > 4 ||
+            Math.abs(video.height - window.innerHeight) > 4) &&
+          !engineStreamState.matches(EngineStreamState.WaitingToPlay)
         ) {
           timeoutStart.current = Date.now()
           startOrReconfigureEngine()


### PR DESCRIPTION
I did this fix, because @lee-at-zoo-corp said basically yeah just fix the effect.

But can't help but think we should add a guard to the `start-or-reconfigure-engine` event when it comes from the `waiting-for-dependecies` state, to check whatever something and not allow the transition.

Should get this in, because it's no the hot path for sure.