### PR TITLE
Quick follow up fixing up experimetal progress/submit button colors

### DIFF
--- a/src/components/CommandBar/CommandBarHeader.tsx
+++ b/src/components/CommandBar/CommandBarHeader.tsx
@@ -208,23 +208,27 @@ function CommandBarHeader({ children }: React.PropsWithChildren<object>) {
           {isReviewing ? (
             <ReviewingButton
               bgClassName={
-                selectedCommand.status === 'experimental' ? '!bg-ml-green' : ''
+                selectedCommand.status === 'experimental'
+                  ? '!bg-ml-green'
+                  : '!bg-primary'
               }
               iconClassName={
                 selectedCommand.status === 'experimental'
                   ? '!text-ml-black'
-                  : ''
+                  : '!text-chalkboard-10'
               }
             />
           ) : (
             <GatheringArgsButton
               bgClassName={
-                selectedCommand.status === 'experimental' ? '!bg-ml-green' : ''
+                selectedCommand.status === 'experimental'
+                  ? '!bg-ml-green'
+                  : '!bg-primary'
               }
               iconClassName={
                 selectedCommand.status === 'experimental'
                   ? '!text-ml-black'
-                  : ''
+                  : '!text-chalkboard-10'
               }
             />
           )}
@@ -248,8 +252,8 @@ function ReviewingButton({ bgClassName, iconClassName }: ButtonProps) {
       data-testid="command-bar-submit"
       iconStart={{
         icon: 'checkmark',
-        bgClassName: `p-1 rounded-sm !bg-primary hover:brightness-110 ${bgClassName}`,
-        iconClassName: `!text-chalkboard-10 ${iconClassName}`,
+        bgClassName: `p-1 rounded-sm hover:brightness-110 ${bgClassName}`,
+        iconClassName: `${iconClassName}`,
       }}
     >
       <span className="sr-only">Submit command</span>
@@ -267,8 +271,8 @@ function GatheringArgsButton({ bgClassName, iconClassName }: ButtonProps) {
       data-testid="command-bar-continue"
       iconStart={{
         icon: 'arrowRight',
-        bgClassName: `p-1 rounded-sm !bg-primary hover:brightness-110 ${bgClassName}`,
-        iconClassName: `!text-chalkboard-10 ${iconClassName}`,
+        bgClassName: `p-1 rounded-sm hover:brightness-110 ${bgClassName}`,
+        iconClassName: `${iconClassName}`,
       }}
     >
       <span className="sr-only">Continue</span>


### PR DESCRIPTION
Relates #6976, follow-up to #6989

Before:
<img width="793" alt="image" src="https://github.com/user-attachments/assets/cd87d5e9-a3f1-43a9-a317-9b3311c63ee7" />


After:
<img width="781" alt="image" src="https://github.com/user-attachments/assets/767e5589-0e7e-4352-a725-23b7718ed17b" />
