### PR TITLE
Fix light mode code mirror tooltip

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -241,7 +241,7 @@ code {
 }
 
 .dark #code-mirror-override .cm-tooltip,
-.cm-tooltip {
+.dark .cm-tooltip {
   @apply bg-chalkboard-110 text-chalkboard-40;
   @apply border-chalkboard-70/20 border-l-liquid-70;
 }


### PR DESCRIPTION
A CSS selector just needed `.dark` prepended to it.

After:
![Screenshot 2025-05-16 at 9 19 27 AM](https://github.com/user-attachments/assets/d8485cff-7245-474d-a9ab-dcc5dc965c19)
