### PR TITLE
Change warning message on Chamfer for a more discreet note in tooltip

### DIFF
--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -179,7 +179,6 @@ export function Toolbar({
           typeof maybeIconConfig.disabledReason === 'function'
             ? maybeIconConfig.disabledReason(state)
             : maybeIconConfig.disabledReason,
-        warningReason: maybeIconConfig.warningReason,
         disableHotkey: maybeIconConfig.disableHotkey?.(state),
         status: maybeIconConfig.status,
       }
@@ -455,15 +454,6 @@ const ToolbarItemTooltip = memo(function ToolbarItemContents({
           Fix KCL errors to enable tools
         </p>
       )}
-      {itemConfig.warningReason && (
-        <p className="text-xs p-1 text-chalkboard-70 dark:text-chalkboard-40">
-          <CustomIcon
-            name="bug"
-            className="w-4 h-4 inline-block mr-1 text-warn-80 bg-warn-10"
-          />
-          {itemConfig.warningReason}
-        </p>
-      )}
     </Tooltip>
   )
 })
@@ -562,6 +552,12 @@ const ToolbarItemTooltipRichContent = ({
         )}
       </div>
       <p className="px-2 my-2 text-ch font-sans">{itemConfig.description}</p>
+      {itemConfig.extraNote && (
+        <p className="px-2 my-2 text-ch font-sans">
+          <span className="font-semibold">Note: </span>
+          {itemConfig.extraNote}
+        </p>
+      )}
       {/* Add disabled reason if item is disabled */}
       {itemConfig.disabled && itemConfig.disabledReason && (
         <>

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -179,6 +179,7 @@ export function Toolbar({
           typeof maybeIconConfig.disabledReason === 'function'
             ? maybeIconConfig.disabledReason(state)
             : maybeIconConfig.disabledReason,
+        warningReason: maybeIconConfig.warningReason,
         disableHotkey: maybeIconConfig.disableHotkey?.(state),
         status: maybeIconConfig.status,
       }
@@ -452,6 +453,15 @@ const ToolbarItemTooltip = memo(function ToolbarItemContents({
             className="w-4 h-4 inline-block mr-1 text-destroy-80 bg-destroy-10"
           />
           Fix KCL errors to enable tools
+        </p>
+      )}
+      {itemConfig.warningReason && (
+        <p className="text-xs p-1 text-chalkboard-70 dark:text-chalkboard-40">
+          <CustomIcon
+            name="bug"
+            className="w-4 h-4 inline-block mr-1 text-warn-80 bg-warn-10"
+          />
+          {itemConfig.warningReason}
         </p>
       )}
     </Tooltip>

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -763,8 +763,6 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         multiple: true,
         required: true,
         skip: false,
-        warningMessage:
-          'Chamfers cannot touch other chamfers yet. This is under development.',
         hidden: (context) => Boolean(context.argumentsToSubmit.nodeToEdit),
       },
       length: {

--- a/src/lib/toolbar.ts
+++ b/src/lib/toolbar.ts
@@ -46,12 +46,12 @@ export type ToolbarItem = {
     | string
     | ((state: StateFrom<typeof modelingMachine>) => string | string[])
   description: string
+  extraNote?: string
   links: { label: string; url: string }[]
   isActive?: (state: StateFrom<typeof modelingMachine>) => boolean
   disabledReason?:
     | string
     | ((state: StateFrom<typeof modelingMachine>) => string | undefined)
-  warningReason?: string
 }
 
 export type ToolbarItemResolved = Omit<
@@ -209,9 +209,15 @@ export const toolbarConfig: Record<ToolbarModeName, ToolbarMode> = {
         title: 'Chamfer',
         hotkey: 'C',
         description: 'Bevel the edges of a 3D solid.',
-        links: [{ label: 'KCL docs', url: 'https://zoo.dev/docs/kcl/chamfer' }],
-        warningReason:
-          'Chamfers cannot touch other chamfers yet. This is under development.',
+        extraNote:
+          'Chamfers cannot touch other chamfers yet. This is under development, see issue tracker.',
+        links: [
+          {
+            label: 'issue tracker',
+            url: 'https://github.com/KittyCAD/modeling-app/issues/6617',
+          },
+          { label: 'KCL docs', url: 'https://zoo.dev/docs/kcl/chamfer' },
+        ],
       },
       {
         id: 'shell',

--- a/src/lib/toolbar.ts
+++ b/src/lib/toolbar.ts
@@ -51,6 +51,7 @@ export type ToolbarItem = {
   disabledReason?:
     | string
     | ((state: StateFrom<typeof modelingMachine>) => string | undefined)
+  warningReason?: string
 }
 
 export type ToolbarItemResolved = Omit<
@@ -209,6 +210,8 @@ export const toolbarConfig: Record<ToolbarModeName, ToolbarMode> = {
         hotkey: 'C',
         description: 'Bevel the edges of a 3D solid.',
         links: [{ label: 'KCL docs', url: 'https://zoo.dev/docs/kcl/chamfer' }],
+        warningReason:
+          'Chamfers cannot touch other chamfers yet. This is under development.',
       },
       {
         id: 'shell',


### PR DESCRIPTION
Relates to #6976

After: Warning in the rich tooltip for the whole command, just like for disabled
![image](https://github.com/user-attachments/assets/f043078c-ad82-4806-a5d1-1f23476fd237)

Before: Warning on the arguments, with an unfortunate tan background:
![image](https://github.com/user-attachments/assets/227cf81d-e4e7-44fb-b603-19aca5caa4bf)




