### PR TITLE
Remove the warningMessage field for command args

### DIFF
--- a/src/components/CommandBar/CommandBarSelectionInput.tsx
+++ b/src/components/CommandBar/CommandBarSelectionInput.tsx
@@ -159,11 +159,6 @@ function CommandBarSelectionInput({
           : `Please select ${
               arg.multiple ? 'one or more ' : 'one '
             }${getSemanticSelectionType(arg.selectionTypes).join(' or ')}`}
-        {arg.warningMessage && (
-          <p className="text-warn-80 bg-warn-10 px-2 py-1 rounded-sm mt-3 mr-2 -mb-2 w-full text-sm cursor-default">
-            {arg.warningMessage}
-          </p>
-        )}
         <span data-testid="cmd-bar-arg-name" className="sr-only">
           {arg.name}
         </span>

--- a/src/components/CommandBar/CommandBarSelectionMixedInput.tsx
+++ b/src/components/CommandBar/CommandBarSelectionMixedInput.tsx
@@ -133,11 +133,6 @@ export default function CommandBarSelectionMixedInput({
             Continue without selection
           </button>
         )}
-        {arg.warningMessage && (
-          <p className="text-warn-80 bg-warn-10 px-2 py-1 rounded-sm mt-3 mr-2 -mb-2 w-full text-sm cursor-default">
-            {arg.warningMessage}
-          </p>
-        )}
         <span data-testid="cmd-bar-arg-name" className="sr-only">
           {arg.name}
         </span>

--- a/src/components/CommandBar/CommandBarTextareaInput.tsx
+++ b/src/components/CommandBar/CommandBarTextareaInput.tsx
@@ -91,11 +91,6 @@ function CommandBarTextareaInput({
           autoFocus
         />
       </label>
-      {arg.warningMessage && (
-        <p className="text-warn-80 bg-warn-10 px-2 py-1 rounded-sm mt-3 mr-2 -mb-2 w-full text-sm cursor-default">
-          {arg.warningMessage}
-        </p>
-      )}
     </form>
   )
 }

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -22,7 +22,6 @@ import {
   KCL_DEFAULT_DEGREE,
   KCL_DEFAULT_LENGTH,
   KCL_DEFAULT_TRANSFORM,
-  ML_EXPERIMENTAL_MESSAGE,
 } from '@src/lib/constants'
 import type { components } from '@src/lib/machine-api'
 import type { Selections } from '@src/lib/selections'
@@ -962,7 +961,6 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
           allowCodeSelection: true,
         },
         skip: false,
-        warningMessage: ML_EXPERIMENTAL_MESSAGE,
       },
       prompt: {
         inputType: 'text',

--- a/src/lib/commandTypes.ts
+++ b/src/lib/commandTypes.ts
@@ -138,7 +138,6 @@ export type CommandArgumentConfig<
         commandBarContext: { argumentsToSubmit: Record<string, unknown> }, // Should be the commandbarMachine's context, but it creates a circular dependency
         machineContext?: C
       ) => boolean)
-  warningMessage?: string
   /** If `true`, arg is used as passed-through data, never for user input */
   hidden?:
     | boolean
@@ -280,7 +279,6 @@ export type CommandArgument<
       ) => boolean)
   skip?: boolean
   machineActor?: Actor<T>
-  warningMessage?: string
   /** For showing a summary display of the current value, such as in
    *  the command bar's header
    */

--- a/src/lib/createMachineCommand.ts
+++ b/src/lib/createMachineCommand.ts
@@ -175,7 +175,6 @@ export function buildCommandArgument<
     skip: arg.skip,
     machineActor,
     valueSummary: arg.valueSummary,
-    warningMessage: arg.warningMessage ?? '',
   } satisfies Omit<CommandArgument<O, T>, 'inputType'>
 
   if (arg.inputType === 'options') {


### PR DESCRIPTION
Relates to #6976.

Removing one last forgotten warning message for prompt to edit. And also taking the whole pattern down so we stop using it.