### PR TITLE
Fix simulation_test file load error

### DIFF
--- a/rust/kcl-lib/src/simulation_tests.rs
+++ b/rust/kcl-lib/src/simulation_tests.rs
@@ -42,7 +42,8 @@ impl Test {
 
     /// Read in the entry point file and return its contents as a string.
     pub fn read(&self) -> String {
-        std::fs::read_to_string(&self.entry_point).expect("Failed to read file: {filename}")
+        std::fs::read_to_string(&self.entry_point)
+            .unwrap_or_else(|e| panic!("Failed to read file: {:?} due to {e}", self.entry_point))
     }
 }
 


### PR DESCRIPTION
I was poking around the repo and noticed that an issue slipped through in https://github.com/KittyCAD/modeling-app/pull/7022
String interpolation was attempted but no formatting macro was used.
This PR fixes the issue.
I used `unwrap_or_else` with `panic`, instead of `expect` with `format` to avoid allocating the error string in the success path.

Before:
![image](https://github.com/user-attachments/assets/48c8fd32-7752-496e-a6a6-92da4d78d119)

After:
![image](https://github.com/user-attachments/assets/b3147e4d-8b0a-4942-9469-8ce07310ea5e)
