### PR TITLE
Update drag regex

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -187,6 +187,12 @@ describe('testing simulateOnMouseDragMatch', () => {
     expect(actual).toStrictEqual(expected)
   })
 
+  it('works with .5', () => {
+    const actual = simulateOnMouseDragMatch('.5')
+    const expected = ['.5']
+    expect(actual).toStrictEqual(expected)
+  })
+
   it('works with 1.0', () => {
     const actual = simulateOnMouseDragMatch('1.0')
     const expected = ['1.0']
@@ -220,6 +226,12 @@ describe('testing simulateOnMouseDragMatch', () => {
   it('works with 10.01', () => {
     const actual = simulateOnMouseDragMatch('10.01')
     const expected = ['10.01']
+    expect(actual).toStrictEqual(expected)
+  })
+
+  it('works with 1.50', () => {
+    const actual = simulateOnMouseDragMatch('1.50')
+    const expected = ['1.50']
     expect(actual).toStrictEqual(expected)
   })
 
@@ -288,6 +300,18 @@ describe('testing simulateOnMouseDragMatch', () => {
   it('works with -0.0001', () => {
     const actual = simulateOnMouseDragMatch('-0.0001')
     const expected = ['-0.0001']
+    expect(actual).toStrictEqual(expected)
+  })
+
+  it('works with -.5', () => {
+    const actual = simulateOnMouseDragMatch('-.5')
+    const expected = ['-.5']
+    expect(actual).toStrictEqual(expected)
+  })
+
+  it('works with -0.50', () => {
+    const actual = simulateOnMouseDragMatch('-0.50')
+    const expected = ['-0.50']
     expect(actual).toStrictEqual(expected)
   })
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -307,7 +307,7 @@ export function getActorNextEvents(snapshot: AnyMachineSnapshot) {
   return [...new Set([...snapshot._nodes.flatMap((sn) => sn.ownEvents)])]
 }
 
-export const onMouseDragRegex = /-?\.?\b\d+\.?\d*\b/g
+export const onMouseDragRegex = /-?(?:\d+(?:\.\d+)?|\.\d+)/g
 
 export function simulateOnMouseDragMatch(text: string) {
   return text.match(onMouseDragRegex)


### PR DESCRIPTION
## Summary
- update drag-number regex to handle decimals more consistently
- add tests for decimals with and without leading/trailing zeros

## Testing
- `npm ci --ignore-scripts` *(fails: connect EHOSTUNREACH)*