### PR TITLE
reexecute KCL code when reloading due to external file modification

### DIFF
--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -245,6 +245,7 @@ const FileTreeItem = ({
         let code = await window.electron.readFile(path, { encoding: 'utf-8' })
         code = normalizeLineEndings(code)
         codeManager.updateCodeStateEditor(code)
+        await kclManager.executeCode()
       } else if (isImportedInCurrentFile && eventType === 'change') {
         await kclManager.executeAst()
       }


### PR DESCRIPTION
Closes https://github.com/KittyCAD/modeling-app/issues/7029

This fixes the issue when running locally on my machine via `npm run tronb:package:dev`.

I'm not familiar with this codebase but it seems we were just missing the call to re-evaluate the KCL.
If its more involved than this I can close the PR and defer to the zoo team.

Unlike the `isImportedInCurrentFile` case, I found that for the `isCurrentFile` case, `executeAst` is not sufficient. Instead `executeCode` (which calls `executeAst`) is required.