### PR TITLE
Make warning toast not appear if the URL has any search params

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,6 @@ import { WasmErrToast } from '@src/components/WasmErrToast'
 import openWindow from '@src/lib/openWindow'
 import {
   APP_DOWNLOAD_PATH,
-  CREATE_FILE_URL_PARAM,
   DOWNLOAD_APP_TOAST_ID,
   ONBOARDING_TOAST_ID,
   WASM_INIT_FAILED_TOAST_ID,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -153,7 +153,7 @@ export function App() {
     const needsDownloadAppToast =
       !isDesktop() &&
       !isPlaywright() &&
-      searchParams.size > 0 &&
+      searchParams.size === 0 &&
       !settings.app.dismissWebBanner.current
     if (needsDownloadAppToast) {
       toast.success(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -153,7 +153,7 @@ export function App() {
     const needsDownloadAppToast =
       !isDesktop() &&
       !isPlaywright() &&
-      !searchParams.has(CREATE_FILE_URL_PARAM) &&
+      searchParams.size > 0 &&
       !settings.app.dismissWebBanner.current
     if (needsDownloadAppToast) {
       toast.success(

--- a/src/components/WasmErrToast.tsx
+++ b/src/components/WasmErrToast.tsx
@@ -22,9 +22,9 @@ export function WasmErrToast({ onDismiss }: WasmErrorToastProps) {
             >
               WASM or web assembly
             </a>{' '}
-            is core part of how our app works. It might be because your OS is not
-            up-to-date. If you're able to update your OS to a later version, try
-            that. If not create an issue on{' '}
+            is core part of how our app works. It might be because your OS is
+            not up-to-date. If you're able to update your OS to a later version,
+            try that. If not create an issue on{' '}
             <a
               href="https://github.com/KittyCAD/modeling-app"
               rel="noopener noreferrer"


### PR DESCRIPTION
Follow-up to #6973 after I realized that new users will see a tempting little toast at the bottom of their screen that might lead them to dismiss the command palette after arriving in the app from a link with a command query on it. This should avoid the scenario where someone clicks an "open sample" type link and dismisses the command palette before they can finish what they're doing. I want to make the command palette just less easy to accidentally dismiss but I think that will require more thought than I have at the moment.