### PR TITLE
Remove false positive missing messages for other module SourceRanges

### DIFF
--- a/rust/kcl-lib/src/execution/artifact/mermaid_tests.rs
+++ b/rust/kcl-lib/src/execution/artifact/mermaid_tests.rs
@@ -308,6 +308,11 @@ impl ArtifactGraph {
             // a child of the line above it.
             let label = label.unwrap_or("");
             if code_ref.node_path.is_empty() {
+                if !code_ref.range.module_id().is_top_level() {
+                    // This is pointing to another module. We don't care about
+                    // these. It's okay that it's missing, for now.
+                    return Ok(());
+                }
                 return writeln!(output, "{prefix}  %% {label}Missing NodePath");
             }
             writeln!(output, "{prefix}  %% {label}{:?}", code_ref.node_path.steps)

--- a/rust/kcl-lib/tests/assembly_mixed_units_cubes/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/assembly_mixed_units_cubes/artifact_graph_flowchart.snap.md
@@ -2,42 +2,26 @@
 flowchart LR
   subgraph path3 [Path]
     3["Path<br>[74, 114, 1]"]
-      %% Missing NodePath
     5["Segment<br>[120, 137, 1]"]
-      %% Missing NodePath
     6["Segment<br>[143, 161, 1]"]
-      %% Missing NodePath
     7["Segment<br>[167, 185, 1]"]
-      %% Missing NodePath
     8["Segment<br>[191, 247, 1]"]
-      %% Missing NodePath
     9["Segment<br>[253, 260, 1]"]
-      %% Missing NodePath
     15[Solid2d]
   end
   subgraph path4 [Path]
     4["Path<br>[74, 112, 2]"]
-      %% Missing NodePath
     10["Segment<br>[118, 135, 2]"]
-      %% Missing NodePath
     11["Segment<br>[141, 159, 2]"]
-      %% Missing NodePath
     12["Segment<br>[165, 183, 2]"]
-      %% Missing NodePath
     13["Segment<br>[189, 245, 2]"]
-      %% Missing NodePath
     14["Segment<br>[251, 258, 2]"]
-      %% Missing NodePath
     16[Solid2d]
   end
   1["Plane<br>[47, 64, 1]"]
-    %% Missing NodePath
   2["Plane<br>[47, 64, 2]"]
-    %% Missing NodePath
   17["Sweep Extrusion<br>[266, 288, 1]"]
-    %% Missing NodePath
   18["Sweep Extrusion<br>[264, 286, 2]"]
-    %% Missing NodePath
   19[Wall]
     %% face_code_ref=Missing NodePath
   20[Wall]

--- a/rust/kcl-lib/tests/assembly_non_default_units/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/assembly_non_default_units/artifact_graph_flowchart.snap.md
@@ -2,22 +2,16 @@
 flowchart LR
   subgraph path3 [Path]
     3["Path<br>[195, 230, 1]"]
-      %% Missing NodePath
     5["Segment<br>[195, 230, 1]"]
-      %% Missing NodePath
     8[Solid2d]
   end
   subgraph path4 [Path]
     4["Path<br>[111, 146, 3]"]
-      %% Missing NodePath
     6["Segment<br>[111, 146, 3]"]
-      %% Missing NodePath
     7[Solid2d]
   end
   1["Plane<br>[172, 189, 1]"]
-    %% Missing NodePath
   2["Plane<br>[88, 105, 3]"]
-    %% Missing NodePath
   1 --- 3
   2 --- 4
   3 --- 5

--- a/rust/kcl-lib/tests/import_function_not_sketch/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/import_function_not_sketch/artifact_graph_flowchart.snap.md
@@ -2,29 +2,18 @@
 flowchart LR
   subgraph path2 [Path]
     2["Path<br>[75, 101, 1]"]
-      %% Missing NodePath
     3["Segment<br>[107, 125, 1]"]
-      %% Missing NodePath
     4["Segment<br>[131, 150, 1]"]
-      %% Missing NodePath
     5["Segment<br>[156, 175, 1]"]
-      %% Missing NodePath
     6["Segment<br>[181, 200, 1]"]
-      %% Missing NodePath
     7["Segment<br>[206, 231, 1]"]
-      %% Missing NodePath
     8["Segment<br>[237, 258, 1]"]
-      %% Missing NodePath
     9["Segment<br>[264, 283, 1]"]
-      %% Missing NodePath
     10["Segment<br>[289, 296, 1]"]
-      %% Missing NodePath
     11[Solid2d]
   end
   1["Plane<br>[52, 69, 1]"]
-    %% Missing NodePath
   12["Sweep Revolve<br>[302, 319, 1]"]
-    %% Missing NodePath
   13[Wall]
     %% face_code_ref=Missing NodePath
   14[Wall]

--- a/rust/kcl-lib/tests/import_side_effect/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/import_side_effect/artifact_graph_flowchart.snap.md
@@ -2,13 +2,10 @@
 flowchart LR
   subgraph path2 [Path]
     2["Path<br>[100, 136, 1]"]
-      %% Missing NodePath
     3["Segment<br>[100, 136, 1]"]
-      %% Missing NodePath
     4[Solid2d]
   end
   1["Plane<br>[77, 94, 1]"]
-    %% Missing NodePath
   1 --- 2
   2 --- 3
   2 --- 4

--- a/rust/kcl-lib/tests/import_whole_simple/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/import_whole_simple/artifact_graph_flowchart.snap.md
@@ -2,15 +2,11 @@
 flowchart LR
   subgraph path2 [Path]
     2["Path<br>[82, 118, 1]"]
-      %% Missing NodePath
     3["Segment<br>[82, 118, 1]"]
-      %% Missing NodePath
     4[Solid2d]
   end
   1["Plane<br>[59, 76, 1]"]
-    %% Missing NodePath
   5["Sweep Extrusion<br>[124, 144, 1]"]
-    %% Missing NodePath
   6[Wall]
     %% face_code_ref=Missing NodePath
   7["Cap Start"]

--- a/rust/kcl-lib/tests/import_whole_transitive_import/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/import_whole_transitive_import/artifact_graph_flowchart.snap.md
@@ -2,15 +2,11 @@
 flowchart LR
   subgraph path2 [Path]
     2["Path<br>[101, 137, 1]"]
-      %% Missing NodePath
     3["Segment<br>[101, 137, 1]"]
-      %% Missing NodePath
     4[Solid2d]
   end
   1["Plane<br>[78, 95, 1]"]
-    %% Missing NodePath
   5["Sweep Extrusion<br>[143, 163, 1]"]
-    %% Missing NodePath
   6[Wall]
     %% face_code_ref=Missing NodePath
   7["Cap Start"]

--- a/rust/kcl-lib/tests/kcl_samples/axial-fan/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/axial-fan/artifact_graph_flowchart.snap.md
@@ -2,292 +2,182 @@
 flowchart LR
   subgraph path8 [Path]
     8["Path<br>[341, 388, 1]"]
-      %% Missing NodePath
     31["Segment<br>[394, 462, 1]"]
-      %% Missing NodePath
     32["Segment<br>[468, 568, 1]"]
-      %% Missing NodePath
     33["Segment<br>[574, 691, 1]"]
-      %% Missing NodePath
     34["Segment<br>[697, 782, 1]"]
-      %% Missing NodePath
     35["Segment<br>[788, 795, 1]"]
-      %% Missing NodePath
     105[Solid2d]
   end
   subgraph path9 [Path]
     9["Path<br>[819, 854, 1]"]
-      %% Missing NodePath
     36["Segment<br>[819, 854, 1]"]
-      %% Missing NodePath
     100[Solid2d]
   end
   subgraph path10 [Path]
     10["Path<br>[879, 1026, 1]"]
-      %% Missing NodePath
     37["Segment<br>[879, 1026, 1]"]
-      %% Missing NodePath
     114[Solid2d]
   end
   subgraph path11 [Path]
     11["Path<br>[1051, 1199, 1]"]
-      %% Missing NodePath
     38["Segment<br>[1051, 1199, 1]"]
-      %% Missing NodePath
     104[Solid2d]
   end
   subgraph path12 [Path]
     12["Path<br>[1224, 1372, 1]"]
-      %% Missing NodePath
     39["Segment<br>[1224, 1372, 1]"]
-      %% Missing NodePath
     110[Solid2d]
   end
   subgraph path13 [Path]
     13["Path<br>[1397, 1546, 1]"]
-      %% Missing NodePath
     40["Segment<br>[1397, 1546, 1]"]
-      %% Missing NodePath
     115[Solid2d]
   end
   subgraph path14 [Path]
     14["Path<br>[1714, 1770, 1]"]
-      %% Missing NodePath
     41["Segment<br>[1776, 1841, 1]"]
-      %% Missing NodePath
     42["Segment<br>[1847, 1899, 1]"]
-      %% Missing NodePath
     43["Segment<br>[1905, 1956, 1]"]
-      %% Missing NodePath
     44["Segment<br>[1962, 2014, 1]"]
-      %% Missing NodePath
     45["Segment<br>[2020, 2086, 1]"]
-      %% Missing NodePath
     46["Segment<br>[2092, 2144, 1]"]
-      %% Missing NodePath
     47["Segment<br>[2150, 2182, 1]"]
-      %% Missing NodePath
     48["Segment<br>[2188, 2253, 1]"]
-      %% Missing NodePath
     49["Segment<br>[2259, 2266, 1]"]
-      %% Missing NodePath
     101[Solid2d]
   end
   subgraph path15 [Path]
     15["Path<br>[2615, 2728, 1]"]
-      %% Missing NodePath
     50["Segment<br>[2734, 2789, 1]"]
-      %% Missing NodePath
     51["Segment<br>[2795, 2830, 1]"]
-      %% Missing NodePath
     52["Segment<br>[2836, 2891, 1]"]
-      %% Missing NodePath
     53["Segment<br>[2897, 2933, 1]"]
-      %% Missing NodePath
     54["Segment<br>[2939, 2994, 1]"]
-      %% Missing NodePath
     55["Segment<br>[3000, 3036, 1]"]
-      %% Missing NodePath
     56["Segment<br>[3042, 3097, 1]"]
-      %% Missing NodePath
     57["Segment<br>[3103, 3159, 1]"]
-      %% Missing NodePath
   end
   subgraph path16 [Path]
     16["Path<br>[3308, 3359, 1]"]
-      %% Missing NodePath
     58["Segment<br>[3308, 3359, 1]"]
-      %% Missing NodePath
     113[Solid2d]
   end
   subgraph path17 [Path]
     17["Path<br>[3538, 3600, 1]"]
-      %% Missing NodePath
     59["Segment<br>[3606, 3674, 1]"]
-      %% Missing NodePath
     60["Segment<br>[3680, 3780, 1]"]
-      %% Missing NodePath
     61["Segment<br>[3786, 3903, 1]"]
-      %% Missing NodePath
     62["Segment<br>[3909, 3994, 1]"]
-      %% Missing NodePath
     63["Segment<br>[4000, 4007, 1]"]
-      %% Missing NodePath
     107[Solid2d]
   end
   subgraph path18 [Path]
     18["Path<br>[4031, 4082, 1]"]
-      %% Missing NodePath
     64["Segment<br>[4031, 4082, 1]"]
-      %% Missing NodePath
     99[Solid2d]
   end
   subgraph path19 [Path]
     19["Path<br>[4107, 4254, 1]"]
-      %% Missing NodePath
     65["Segment<br>[4107, 4254, 1]"]
-      %% Missing NodePath
     108[Solid2d]
   end
   subgraph path20 [Path]
     20["Path<br>[4279, 4427, 1]"]
-      %% Missing NodePath
     66["Segment<br>[4279, 4427, 1]"]
-      %% Missing NodePath
     106[Solid2d]
   end
   subgraph path21 [Path]
     21["Path<br>[4452, 4600, 1]"]
-      %% Missing NodePath
     67["Segment<br>[4452, 4600, 1]"]
-      %% Missing NodePath
     103[Solid2d]
   end
   subgraph path22 [Path]
     22["Path<br>[4625, 4774, 1]"]
-      %% Missing NodePath
     68["Segment<br>[4625, 4774, 1]"]
-      %% Missing NodePath
     98[Solid2d]
   end
   subgraph path23 [Path]
     23["Path<br>[4916, 4954, 1]"]
-      %% Missing NodePath
     69["Segment<br>[4916, 4954, 1]"]
-      %% Missing NodePath
     118[Solid2d]
   end
   subgraph path24 [Path]
     24["Path<br>[5027, 5063, 1]"]
-      %% Missing NodePath
     70["Segment<br>[5027, 5063, 1]"]
-      %% Missing NodePath
     111[Solid2d]
   end
   subgraph path25 [Path]
     25["Path<br>[295, 345, 3]"]
-      %% Missing NodePath
     71["Segment<br>[295, 345, 3]"]
-      %% Missing NodePath
     102[Solid2d]
   end
   subgraph path26 [Path]
     26["Path<br>[520, 555, 3]"]
-      %% Missing NodePath
     72["Segment<br>[520, 555, 3]"]
-      %% Missing NodePath
     112[Solid2d]
   end
   subgraph path27 [Path]
     27["Path<br>[234, 273, 4]"]
-      %% Missing NodePath
     73["Segment<br>[279, 309, 4]"]
-      %% Missing NodePath
     74["Segment<br>[315, 354, 4]"]
-      %% Missing NodePath
     75["Segment<br>[360, 384, 4]"]
-      %% Missing NodePath
     76["Segment<br>[390, 414, 4]"]
-      %% Missing NodePath
     77["Segment<br>[420, 461, 4]"]
-      %% Missing NodePath
     78["Segment<br>[467, 505, 4]"]
-      %% Missing NodePath
     79["Segment<br>[511, 534, 4]"]
-      %% Missing NodePath
     80["Segment<br>[540, 557, 4]"]
-      %% Missing NodePath
     81["Segment<br>[563, 584, 4]"]
-      %% Missing NodePath
     82["Segment<br>[590, 677, 4]"]
-      %% Missing NodePath
     83["Segment<br>[683, 720, 4]"]
-      %% Missing NodePath
     84["Segment<br>[726, 763, 4]"]
-      %% Missing NodePath
     85["Segment<br>[769, 776, 4]"]
-      %% Missing NodePath
     109[Solid2d]
   end
   subgraph path28 [Path]
     28["Path<br>[1131, 1221, 4]"]
-      %% Missing NodePath
     87["Segment<br>[1229, 1298, 4]"]
-      %% Missing NodePath
     89["Segment<br>[1306, 1606, 4]"]
-      %% Missing NodePath
     91["Segment<br>[1614, 1916, 4]"]
-      %% Missing NodePath
     93["Segment<br>[1924, 2143, 4]"]
-      %% Missing NodePath
     94["Segment<br>[2151, 2158, 4]"]
-      %% Missing NodePath
     97[Solid2d]
   end
   subgraph path29 [Path]
     29["Path<br>[1131, 1221, 4]"]
-      %% Missing NodePath
     96["Segment<br>[2151, 2158, 4]"]
-      %% Missing NodePath
     116[Solid2d]
   end
   subgraph path30 [Path]
     30["Path<br>[1131, 1221, 4]"]
-      %% Missing NodePath
     86["Segment<br>[1229, 1298, 4]"]
-      %% Missing NodePath
     88["Segment<br>[1306, 1606, 4]"]
-      %% Missing NodePath
     90["Segment<br>[1614, 1916, 4]"]
-      %% Missing NodePath
     92["Segment<br>[1924, 2143, 4]"]
-      %% Missing NodePath
     95["Segment<br>[2151, 2158, 4]"]
-      %% Missing NodePath
     117[Solid2d]
   end
   1["Plane<br>[318, 335, 1]"]
-    %% Missing NodePath
   2["Plane<br>[222, 249, 3]"]
-    %% Missing NodePath
   3["Plane<br>[485, 513, 3]"]
-    %% Missing NodePath
   4["Plane<br>[211, 228, 4]"]
-    %% Missing NodePath
   5["Plane<br>[1084, 1122, 4]"]
-    %% Missing NodePath
   6["Plane<br>[1084, 1122, 4]"]
-    %% Missing NodePath
   7["Plane<br>[1084, 1122, 4]"]
-    %% Missing NodePath
   119["Sweep Extrusion<br>[1553, 1572, 1]"]
-    %% Missing NodePath
   120["Sweep Extrusion<br>[2406, 2426, 1]"]
-    %% Missing NodePath
   121["Sweep Extrusion<br>[2406, 2426, 1]"]
-    %% Missing NodePath
   122["Sweep Extrusion<br>[2406, 2426, 1]"]
-    %% Missing NodePath
   123["Sweep Extrusion<br>[2406, 2426, 1]"]
-    %% Missing NodePath
   124["Sweep Extrusion<br>[3165, 3200, 1]"]
-    %% Missing NodePath
   125["Sweep Extrusion<br>[3365, 3403, 1]"]
-    %% Missing NodePath
   126["Sweep Extrusion<br>[4781, 4800, 1]"]
-    %% Missing NodePath
   127["Sweep Extrusion<br>[4960, 4980, 1]"]
-    %% Missing NodePath
   128["Sweep Extrusion<br>[5069, 5090, 1]"]
-    %% Missing NodePath
   129["Sweep Extrusion<br>[351, 371, 3]"]
-    %% Missing NodePath
   130["Sweep Extrusion<br>[561, 582, 3]"]
-    %% Missing NodePath
   131["Sweep Revolve<br>[782, 864, 4]"]
-    %% Missing NodePath
   132["Sweep Loft<br>[2472, 2491, 4]"]
-    %% Missing NodePath
   133[Wall]
     %% face_code_ref=Missing NodePath
   134[Wall]
@@ -480,25 +370,15 @@ flowchart LR
   265["SweepEdge Adjacent"]
   266["SweepEdge Adjacent"]
   267["EdgeCut Fillet<br>[5131, 5642, 1]"]
-    %% Missing NodePath
   268["EdgeCut Fillet<br>[5131, 5642, 1]"]
-    %% Missing NodePath
   269["EdgeCut Fillet<br>[5131, 5642, 1]"]
-    %% Missing NodePath
   270["EdgeCut Fillet<br>[5131, 5642, 1]"]
-    %% Missing NodePath
   271["EdgeCut Fillet<br>[5131, 5642, 1]"]
-    %% Missing NodePath
   272["EdgeCut Fillet<br>[5131, 5642, 1]"]
-    %% Missing NodePath
   273["EdgeCut Fillet<br>[5131, 5642, 1]"]
-    %% Missing NodePath
   274["EdgeCut Fillet<br>[5131, 5642, 1]"]
-    %% Missing NodePath
   275["EdgeCut Fillet<br>[412, 470, 3]"]
-    %% Missing NodePath
   276["EdgeCut Fillet<br>[412, 470, 3]"]
-    %% Missing NodePath
   1 --- 8
   1 --- 9
   1 --- 10
@@ -781,19 +661,19 @@ flowchart LR
   84 --- 144
   84 --- 237
   86 --- 168
-  86 x--> 188
+  86 x--> 189
   86 --- 212
   86 --- 256
   88 --- 169
-  88 x--> 188
+  88 x--> 189
   88 --- 213
   88 --- 257
   90 --- 167
-  90 x--> 188
+  90 x--> 189
   90 --- 214
   90 --- 258
   92 --- 170
-  92 x--> 188
+  92 x--> 189
   92 --- 215
   92 --- 259
   119 --- 133
@@ -1075,10 +955,10 @@ flowchart LR
   218 <--x 186
   219 <--x 186
   194 <--x 187
-  212 <--x 189
-  213 <--x 189
-  214 <--x 189
-  215 <--x 189
+  212 <--x 188
+  213 <--x 188
+  214 <--x 188
+  215 <--x 188
   220 <--x 275
   223 <--x 270
   224 <--x 274

--- a/rust/kcl-lib/tests/kcl_samples/bench/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/bench/artifact_graph_flowchart.snap.md
@@ -2,422 +2,234 @@
 flowchart LR
   subgraph path24 [Path]
     24["Path<br>[380, 413, 1]"]
-      %% Missing NodePath
     42["Segment<br>[421, 447, 1]"]
-      %% Missing NodePath
     50["Segment<br>[455, 517, 1]"]
-      %% Missing NodePath
     55["Segment<br>[525, 587, 1]"]
-      %% Missing NodePath
     63["Segment<br>[595, 658, 1]"]
-      %% Missing NodePath
     64["Segment<br>[666, 691, 1]"]
-      %% Missing NodePath
     70["Segment<br>[699, 719, 1]"]
-      %% Missing NodePath
     77["Segment<br>[727, 751, 1]"]
-      %% Missing NodePath
     83["Segment<br>[759, 821, 1]"]
-      %% Missing NodePath
     89["Segment<br>[829, 854, 1]"]
-      %% Missing NodePath
     96["Segment<br>[862, 882, 1]"]
-      %% Missing NodePath
     102["Segment<br>[890, 914, 1]"]
-      %% Missing NodePath
     106["Segment<br>[922, 983, 1]"]
-      %% Missing NodePath
     112["Segment<br>[991, 1052, 1]"]
-      %% Missing NodePath
     118["Segment<br>[1060, 1085, 1]"]
-      %% Missing NodePath
     125["Segment<br>[1093, 1117, 1]"]
-      %% Missing NodePath
     132["Segment<br>[1125, 1187, 1]"]
-      %% Missing NodePath
     139["Segment<br>[1195, 1220, 1]"]
-      %% Missing NodePath
     146["Segment<br>[1228, 1255, 1]"]
-      %% Missing NodePath
     152["Segment<br>[1263, 1324, 1]"]
-      %% Missing NodePath
     157["Segment<br>[1332, 1376, 1]"]
-      %% Missing NodePath
     162["Segment<br>[1384, 1391, 1]"]
-      %% Missing NodePath
     213[Solid2d]
   end
   subgraph path25 [Path]
     25["Path<br>[380, 413, 1]"]
-      %% Missing NodePath
     40["Segment<br>[421, 447, 1]"]
-      %% Missing NodePath
     51["Segment<br>[455, 517, 1]"]
-      %% Missing NodePath
     57["Segment<br>[525, 587, 1]"]
-      %% Missing NodePath
     58["Segment<br>[595, 658, 1]"]
-      %% Missing NodePath
     69["Segment<br>[666, 691, 1]"]
-      %% Missing NodePath
     75["Segment<br>[699, 719, 1]"]
-      %% Missing NodePath
     80["Segment<br>[727, 751, 1]"]
-      %% Missing NodePath
     82["Segment<br>[759, 821, 1]"]
-      %% Missing NodePath
     90["Segment<br>[829, 854, 1]"]
-      %% Missing NodePath
     97["Segment<br>[862, 882, 1]"]
-      %% Missing NodePath
     103["Segment<br>[890, 914, 1]"]
-      %% Missing NodePath
     108["Segment<br>[922, 983, 1]"]
-      %% Missing NodePath
     114["Segment<br>[991, 1052, 1]"]
-      %% Missing NodePath
     121["Segment<br>[1060, 1085, 1]"]
-      %% Missing NodePath
     129["Segment<br>[1093, 1117, 1]"]
-      %% Missing NodePath
     133["Segment<br>[1125, 1187, 1]"]
-      %% Missing NodePath
     140["Segment<br>[1195, 1220, 1]"]
-      %% Missing NodePath
     143["Segment<br>[1228, 1255, 1]"]
-      %% Missing NodePath
     150["Segment<br>[1263, 1324, 1]"]
-      %% Missing NodePath
     154["Segment<br>[1332, 1376, 1]"]
-      %% Missing NodePath
     163["Segment<br>[1384, 1391, 1]"]
-      %% Missing NodePath
     214[Solid2d]
   end
   subgraph path26 [Path]
     26["Path<br>[380, 413, 1]"]
-      %% Missing NodePath
     44["Segment<br>[421, 447, 1]"]
-      %% Missing NodePath
     48["Segment<br>[455, 517, 1]"]
-      %% Missing NodePath
     53["Segment<br>[525, 587, 1]"]
-      %% Missing NodePath
     61["Segment<br>[595, 658, 1]"]
-      %% Missing NodePath
     66["Segment<br>[666, 691, 1]"]
-      %% Missing NodePath
     73["Segment<br>[699, 719, 1]"]
-      %% Missing NodePath
     81["Segment<br>[727, 751, 1]"]
-      %% Missing NodePath
     87["Segment<br>[759, 821, 1]"]
-      %% Missing NodePath
     92["Segment<br>[829, 854, 1]"]
-      %% Missing NodePath
     95["Segment<br>[862, 882, 1]"]
-      %% Missing NodePath
     101["Segment<br>[890, 914, 1]"]
-      %% Missing NodePath
     111["Segment<br>[922, 983, 1]"]
-      %% Missing NodePath
     117["Segment<br>[991, 1052, 1]"]
-      %% Missing NodePath
     119["Segment<br>[1060, 1085, 1]"]
-      %% Missing NodePath
     124["Segment<br>[1093, 1117, 1]"]
-      %% Missing NodePath
     135["Segment<br>[1125, 1187, 1]"]
-      %% Missing NodePath
     137["Segment<br>[1195, 1220, 1]"]
-      %% Missing NodePath
     147["Segment<br>[1228, 1255, 1]"]
-      %% Missing NodePath
     148["Segment<br>[1263, 1324, 1]"]
-      %% Missing NodePath
     159["Segment<br>[1332, 1376, 1]"]
-      %% Missing NodePath
     164["Segment<br>[1384, 1391, 1]"]
-      %% Missing NodePath
     218[Solid2d]
   end
   subgraph path27 [Path]
     27["Path<br>[380, 413, 1]"]
-      %% Missing NodePath
     43["Segment<br>[421, 447, 1]"]
-      %% Missing NodePath
     47["Segment<br>[455, 517, 1]"]
-      %% Missing NodePath
     56["Segment<br>[525, 587, 1]"]
-      %% Missing NodePath
     59["Segment<br>[595, 658, 1]"]
-      %% Missing NodePath
     65["Segment<br>[666, 691, 1]"]
-      %% Missing NodePath
     71["Segment<br>[699, 719, 1]"]
-      %% Missing NodePath
     76["Segment<br>[727, 751, 1]"]
-      %% Missing NodePath
     86["Segment<br>[759, 821, 1]"]
-      %% Missing NodePath
     91["Segment<br>[829, 854, 1]"]
-      %% Missing NodePath
     99["Segment<br>[862, 882, 1]"]
-      %% Missing NodePath
     100["Segment<br>[890, 914, 1]"]
-      %% Missing NodePath
     110["Segment<br>[922, 983, 1]"]
-      %% Missing NodePath
     116["Segment<br>[991, 1052, 1]"]
-      %% Missing NodePath
     122["Segment<br>[1060, 1085, 1]"]
-      %% Missing NodePath
     128["Segment<br>[1093, 1117, 1]"]
-      %% Missing NodePath
     134["Segment<br>[1125, 1187, 1]"]
-      %% Missing NodePath
     136["Segment<br>[1195, 1220, 1]"]
-      %% Missing NodePath
     145["Segment<br>[1228, 1255, 1]"]
-      %% Missing NodePath
     151["Segment<br>[1263, 1324, 1]"]
-      %% Missing NodePath
     156["Segment<br>[1332, 1376, 1]"]
-      %% Missing NodePath
     161["Segment<br>[1384, 1391, 1]"]
-      %% Missing NodePath
     220[Solid2d]
   end
   subgraph path28 [Path]
     28["Path<br>[380, 413, 1]"]
-      %% Missing NodePath
     41["Segment<br>[421, 447, 1]"]
-      %% Missing NodePath
     46["Segment<br>[455, 517, 1]"]
-      %% Missing NodePath
     54["Segment<br>[525, 587, 1]"]
-      %% Missing NodePath
     62["Segment<br>[595, 658, 1]"]
-      %% Missing NodePath
     67["Segment<br>[666, 691, 1]"]
-      %% Missing NodePath
     74["Segment<br>[699, 719, 1]"]
-      %% Missing NodePath
     78["Segment<br>[727, 751, 1]"]
-      %% Missing NodePath
     85["Segment<br>[759, 821, 1]"]
-      %% Missing NodePath
     93["Segment<br>[829, 854, 1]"]
-      %% Missing NodePath
     94["Segment<br>[862, 882, 1]"]
-      %% Missing NodePath
     104["Segment<br>[890, 914, 1]"]
-      %% Missing NodePath
     107["Segment<br>[922, 983, 1]"]
-      %% Missing NodePath
     115["Segment<br>[991, 1052, 1]"]
-      %% Missing NodePath
     123["Segment<br>[1060, 1085, 1]"]
-      %% Missing NodePath
     126["Segment<br>[1093, 1117, 1]"]
-      %% Missing NodePath
     130["Segment<br>[1125, 1187, 1]"]
-      %% Missing NodePath
     138["Segment<br>[1195, 1220, 1]"]
-      %% Missing NodePath
     144["Segment<br>[1228, 1255, 1]"]
-      %% Missing NodePath
     149["Segment<br>[1263, 1324, 1]"]
-      %% Missing NodePath
     158["Segment<br>[1332, 1376, 1]"]
-      %% Missing NodePath
     165["Segment<br>[1384, 1391, 1]"]
-      %% Missing NodePath
     221[Solid2d]
   end
   subgraph path29 [Path]
     29["Path<br>[380, 413, 1]"]
-      %% Missing NodePath
     45["Segment<br>[421, 447, 1]"]
-      %% Missing NodePath
     49["Segment<br>[455, 517, 1]"]
-      %% Missing NodePath
     52["Segment<br>[525, 587, 1]"]
-      %% Missing NodePath
     60["Segment<br>[595, 658, 1]"]
-      %% Missing NodePath
     68["Segment<br>[666, 691, 1]"]
-      %% Missing NodePath
     72["Segment<br>[699, 719, 1]"]
-      %% Missing NodePath
     79["Segment<br>[727, 751, 1]"]
-      %% Missing NodePath
     84["Segment<br>[759, 821, 1]"]
-      %% Missing NodePath
     88["Segment<br>[829, 854, 1]"]
-      %% Missing NodePath
     98["Segment<br>[862, 882, 1]"]
-      %% Missing NodePath
     105["Segment<br>[890, 914, 1]"]
-      %% Missing NodePath
     109["Segment<br>[922, 983, 1]"]
-      %% Missing NodePath
     113["Segment<br>[991, 1052, 1]"]
-      %% Missing NodePath
     120["Segment<br>[1060, 1085, 1]"]
-      %% Missing NodePath
     127["Segment<br>[1093, 1117, 1]"]
-      %% Missing NodePath
     131["Segment<br>[1125, 1187, 1]"]
-      %% Missing NodePath
     141["Segment<br>[1195, 1220, 1]"]
-      %% Missing NodePath
     142["Segment<br>[1228, 1255, 1]"]
-      %% Missing NodePath
     153["Segment<br>[1263, 1324, 1]"]
-      %% Missing NodePath
     155["Segment<br>[1332, 1376, 1]"]
-      %% Missing NodePath
     160["Segment<br>[1384, 1391, 1]"]
-      %% Missing NodePath
     223[Solid2d]
   end
   subgraph path30 [Path]
     30["Path<br>[1783, 1807, 1]"]
-      %% Missing NodePath
   end
   subgraph path31 [Path]
     31["Path<br>[1783, 1807, 1]"]
-      %% Missing NodePath
   end
   subgraph path32 [Path]
     32["Path<br>[1815, 1941, 1]"]
-      %% Missing NodePath
     167["Segment<br>[1815, 1941, 1]"]
-      %% Missing NodePath
     170["Segment<br>[1815, 1941, 1]"]
-      %% Missing NodePath
     172["Segment<br>[1815, 1941, 1]"]
-      %% Missing NodePath
     173["Segment<br>[1815, 1941, 1]"]
-      %% Missing NodePath
     176["Segment<br>[1815, 1941, 1]"]
-      %% Missing NodePath
     177["Segment<br>[1815, 1941, 1]"]
-      %% Missing NodePath
     178["Segment<br>[1815, 1941, 1]"]
-      %% Missing NodePath
     212[Solid2d]
   end
   subgraph path33 [Path]
     33["Path<br>[1815, 1941, 1]"]
-      %% Missing NodePath
     166["Segment<br>[1815, 1941, 1]"]
-      %% Missing NodePath
     168["Segment<br>[1815, 1941, 1]"]
-      %% Missing NodePath
     169["Segment<br>[1815, 1941, 1]"]
-      %% Missing NodePath
     171["Segment<br>[1815, 1941, 1]"]
-      %% Missing NodePath
     174["Segment<br>[1815, 1941, 1]"]
-      %% Missing NodePath
     175["Segment<br>[1815, 1941, 1]"]
-      %% Missing NodePath
     179["Segment<br>[1815, 1941, 1]"]
-      %% Missing NodePath
     216[Solid2d]
   end
   subgraph path34 [Path]
     34["Path<br>[2217, 2244, 1]"]
-      %% Missing NodePath
     180["Segment<br>[2252, 2274, 1]"]
-      %% Missing NodePath
     181["Segment<br>[2282, 2304, 1]"]
-      %% Missing NodePath
     182["Segment<br>[2312, 2334, 1]"]
-      %% Missing NodePath
     183["Segment<br>[2342, 2365, 1]"]
-      %% Missing NodePath
     184["Segment<br>[2373, 2396, 1]"]
-      %% Missing NodePath
     185["Segment<br>[2404, 2439, 1]"]
-      %% Missing NodePath
     186["Segment<br>[2447, 2454, 1]"]
-      %% Missing NodePath
     215[Solid2d]
   end
   subgraph path35 [Path]
     35["Path<br>[2719, 2748, 1]"]
-      %% Missing NodePath
     187["Segment<br>[2756, 2791, 1]"]
-      %% Missing NodePath
     188["Segment<br>[2799, 2824, 1]"]
-      %% Missing NodePath
     189["Segment<br>[2832, 2868, 1]"]
-      %% Missing NodePath
     190["Segment<br>[2876, 2900, 1]"]
-      %% Missing NodePath
     191["Segment<br>[2908, 2942, 1]"]
-      %% Missing NodePath
     192["Segment<br>[2950, 2985, 1]"]
-      %% Missing NodePath
     193["Segment<br>[2993, 3000, 1]"]
-      %% Missing NodePath
     219[Solid2d]
   end
   subgraph path36 [Path]
     36["Path<br>[3268, 3295, 1]"]
-      %% Missing NodePath
     195["Segment<br>[3303, 3322, 1]"]
-      %% Missing NodePath
     197["Segment<br>[3330, 3379, 1]"]
-      %% Missing NodePath
   end
   subgraph path37 [Path]
     37["Path<br>[3268, 3295, 1]"]
-      %% Missing NodePath
     194["Segment<br>[3303, 3322, 1]"]
-      %% Missing NodePath
     196["Segment<br>[3330, 3379, 1]"]
-      %% Missing NodePath
   end
   subgraph path38 [Path]
     38["Path<br>[3480, 3513, 1]"]
-      %% Missing NodePath
     198["Segment<br>[3521, 3540, 1]"]
-      %% Missing NodePath
     201["Segment<br>[3548, 3570, 1]"]
-      %% Missing NodePath
     202["Segment<br>[3578, 3601, 1]"]
-      %% Missing NodePath
     204["Segment<br>[3609, 3629, 1]"]
-      %% Missing NodePath
     206["Segment<br>[3637, 3661, 1]"]
-      %% Missing NodePath
     208["Segment<br>[3669, 3692, 1]"]
-      %% Missing NodePath
     211["Segment<br>[3700, 3707, 1]"]
-      %% Missing NodePath
     217[Solid2d]
   end
   subgraph path39 [Path]
     39["Path<br>[3480, 3513, 1]"]
-      %% Missing NodePath
     199["Segment<br>[3521, 3540, 1]"]
-      %% Missing NodePath
     200["Segment<br>[3548, 3570, 1]"]
-      %% Missing NodePath
     203["Segment<br>[3578, 3601, 1]"]
-      %% Missing NodePath
     205["Segment<br>[3609, 3629, 1]"]
-      %% Missing NodePath
     207["Segment<br>[3637, 3661, 1]"]
-      %% Missing NodePath
     209["Segment<br>[3669, 3692, 1]"]
-      %% Missing NodePath
     210["Segment<br>[3700, 3707, 1]"]
-      %% Missing NodePath
     222[Solid2d]
   end
   1["Plane<br>[841, 882, 0]"]
@@ -431,71 +243,38 @@ flowchart LR
   5["Plane<br>[1241, 1308, 0]"]
     %% [ProgramBodyItem { index: 12 }, ExpressionStatementExpr, CallKwUnlabeledArg]
   6["Plane<br>[352, 372, 1]"]
-    %% Missing NodePath
   7["Plane<br>[352, 372, 1]"]
-    %% Missing NodePath
   8["Plane<br>[3787, 3822, 1]"]
-    %% Missing NodePath
   9["Plane<br>[3787, 3822, 1]"]
-    %% Missing NodePath
   10["Plane<br>[3851, 3880, 1]"]
-    %% Missing NodePath
   11["Plane<br>[3851, 3880, 1]"]
-    %% Missing NodePath
   12["StartSketchOnPlane<br>[352, 372, 1]"]
-    %% Missing NodePath
   13["StartSketchOnPlane<br>[3240, 3260, 1]"]
-    %% Missing NodePath
   14["StartSketchOnPlane<br>[3452, 3472, 1]"]
-    %% Missing NodePath
   15["StartSketchOnPlane<br>[2691, 2711, 1]"]
-    %% Missing NodePath
   16["StartSketchOnPlane<br>[3452, 3472, 1]"]
-    %% Missing NodePath
   17["StartSketchOnPlane<br>[2189, 2209, 1]"]
-    %% Missing NodePath
   18["StartSketchOnPlane<br>[352, 372, 1]"]
-    %% Missing NodePath
   19["StartSketchOnPlane<br>[1755, 1775, 1]"]
-    %% Missing NodePath
   20["StartSketchOnPlane<br>[1755, 1775, 1]"]
-    %% Missing NodePath
   21["StartSketchOnPlane<br>[3240, 3260, 1]"]
-    %% Missing NodePath
   22["StartSketchOnPlane<br>[352, 372, 1]"]
-    %% Missing NodePath
   23["StartSketchOnPlane<br>[352, 372, 1]"]
-    %% Missing NodePath
   224["Sweep Extrusion<br>[1480, 1518, 1]"]
-    %% Missing NodePath
   225["Sweep Extrusion<br>[1480, 1518, 1]"]
-    %% Missing NodePath
   226["Sweep Extrusion<br>[1480, 1518, 1]"]
-    %% Missing NodePath
   227["Sweep Extrusion<br>[1556, 1595, 1]"]
-    %% Missing NodePath
   228["Sweep Extrusion<br>[1556, 1595, 1]"]
-    %% Missing NodePath
   229["Sweep Extrusion<br>[1556, 1595, 1]"]
-    %% Missing NodePath
   230["Sweep Extrusion<br>[2052, 2067, 1]"]
-    %% Missing NodePath
   231["Sweep Extrusion<br>[2117, 2132, 1]"]
-    %% Missing NodePath
   232["Sweep Extrusion<br>[2618, 2633, 1]"]
-    %% Missing NodePath
   233["Sweep Extrusion<br>[2618, 2633, 1]"]
-    %% Missing NodePath
   234["Sweep Extrusion<br>[2618, 2633, 1]"]
-    %% Missing NodePath
   235["Sweep Extrusion<br>[3171, 3186, 1]"]
-    %% Missing NodePath
   236["Sweep Extrusion<br>[3171, 3186, 1]"]
-    %% Missing NodePath
   237["Sweep Sweep<br>[3902, 3929, 1]"]
-    %% Missing NodePath
   238["Sweep Sweep<br>[3902, 3929, 1]"]
-    %% Missing NodePath
   239[Wall]
     %% face_code_ref=Missing NodePath
   240[Wall]

--- a/rust/kcl-lib/tests/kcl_samples/car-wheel-assembly/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/car-wheel-assembly/artifact_graph_flowchart.snap.md
@@ -2,473 +2,273 @@
 flowchart LR
   subgraph path11 [Path]
     11["Path<br>[372, 428, 1]"]
-      %% Missing NodePath
     34["Segment<br>[372, 428, 1]"]
-      %% Missing NodePath
     148[Solid2d]
   end
   subgraph path12 [Path]
     12["Path<br>[452, 508, 1]"]
-      %% Missing NodePath
     35["Segment<br>[452, 508, 1]"]
-      %% Missing NodePath
     141[Solid2d]
   end
   subgraph path13 [Path]
     13["Path<br>[675, 731, 1]"]
-      %% Missing NodePath
     36["Segment<br>[675, 731, 1]"]
-      %% Missing NodePath
     155[Solid2d]
   end
   subgraph path14 [Path]
     14["Path<br>[755, 811, 1]"]
-      %% Missing NodePath
     37["Segment<br>[755, 811, 1]"]
-      %% Missing NodePath
     157[Solid2d]
   end
   subgraph path15 [Path]
     15["Path<br>[957, 1011, 1]"]
-      %% Missing NodePath
     38["Segment<br>[957, 1011, 1]"]
-      %% Missing NodePath
     156[Solid2d]
   end
   subgraph path16 [Path]
     16["Path<br>[1294, 1349, 1]"]
-      %% Missing NodePath
     39["Segment<br>[1294, 1349, 1]"]
-      %% Missing NodePath
     150[Solid2d]
   end
   subgraph path17 [Path]
     17["Path<br>[1707, 1753, 1]"]
-      %% Missing NodePath
     40["Segment<br>[1759, 1811, 1]"]
-      %% Missing NodePath
     41["Segment<br>[1817, 1890, 1]"]
-      %% Missing NodePath
     42["Segment<br>[1896, 1918, 1]"]
-      %% Missing NodePath
     43["Segment<br>[1924, 1980, 1]"]
-      %% Missing NodePath
     44["Segment<br>[1986, 1993, 1]"]
-      %% Missing NodePath
     152[Solid2d]
   end
   subgraph path18 [Path]
     18["Path<br>[2125, 2171, 1]"]
-      %% Missing NodePath
     45["Segment<br>[2177, 2229, 1]"]
-      %% Missing NodePath
     46["Segment<br>[2235, 2310, 1]"]
-      %% Missing NodePath
     47["Segment<br>[2316, 2353, 1]"]
-      %% Missing NodePath
     48["Segment<br>[2359, 2415, 1]"]
-      %% Missing NodePath
     49["Segment<br>[2421, 2428, 1]"]
-      %% Missing NodePath
     147[Solid2d]
   end
   subgraph path19 [Path]
     19["Path<br>[2909, 2956, 1]"]
-      %% Missing NodePath
     51["Segment<br>[2964, 3301, 1]"]
-      %% Missing NodePath
     52["Segment<br>[3309, 3341, 1]"]
-      %% Missing NodePath
     54["Segment<br>[3349, 3690, 1]"]
-      %% Missing NodePath
     57["Segment<br>[3698, 3754, 1]"]
-      %% Missing NodePath
     59["Segment<br>[3762, 3769, 1]"]
-      %% Missing NodePath
     146[Solid2d]
   end
   subgraph path20 [Path]
     20["Path<br>[2909, 2956, 1]"]
-      %% Missing NodePath
     50["Segment<br>[2964, 3301, 1]"]
-      %% Missing NodePath
     53["Segment<br>[3309, 3341, 1]"]
-      %% Missing NodePath
     55["Segment<br>[3349, 3690, 1]"]
-      %% Missing NodePath
     56["Segment<br>[3698, 3754, 1]"]
-      %% Missing NodePath
     58["Segment<br>[3762, 3769, 1]"]
-      %% Missing NodePath
     159[Solid2d]
   end
   subgraph path21 [Path]
     21["Path<br>[4379, 4474, 1]"]
-      %% Missing NodePath
     60["Segment<br>[4480, 4513, 1]"]
-      %% Missing NodePath
     61["Segment<br>[4519, 4570, 1]"]
-      %% Missing NodePath
     62["Segment<br>[4576, 4609, 1]"]
-      %% Missing NodePath
     63["Segment<br>[4615, 4665, 1]"]
-      %% Missing NodePath
     64["Segment<br>[4671, 4712, 1]"]
-      %% Missing NodePath
     65["Segment<br>[4718, 4767, 1]"]
-      %% Missing NodePath
     66["Segment<br>[4773, 4806, 1]"]
-      %% Missing NodePath
     67["Segment<br>[4812, 4846, 1]"]
-      %% Missing NodePath
     68["Segment<br>[4852, 4886, 1]"]
-      %% Missing NodePath
     69["Segment<br>[4892, 4944, 1]"]
-      %% Missing NodePath
     70["Segment<br>[4950, 4984, 1]"]
-      %% Missing NodePath
     71["Segment<br>[4990, 5066, 1]"]
-      %% Missing NodePath
     72["Segment<br>[5072, 5105, 1]"]
-      %% Missing NodePath
     73["Segment<br>[5111, 5187, 1]"]
-      %% Missing NodePath
     74["Segment<br>[5193, 5227, 1]"]
-      %% Missing NodePath
     75["Segment<br>[5233, 5307, 1]"]
-      %% Missing NodePath
     76["Segment<br>[5313, 5347, 1]"]
-      %% Missing NodePath
     77["Segment<br>[5353, 5404, 1]"]
-      %% Missing NodePath
     78["Segment<br>[5410, 5472, 1]"]
-      %% Missing NodePath
     79["Segment<br>[5478, 5529, 1]"]
-      %% Missing NodePath
     80["Segment<br>[5535, 5569, 1]"]
-      %% Missing NodePath
     81["Segment<br>[5575, 5608, 1]"]
-      %% Missing NodePath
     82["Segment<br>[5614, 5647, 1]"]
-      %% Missing NodePath
     83["Segment<br>[5653, 5660, 1]"]
-      %% Missing NodePath
     158[Solid2d]
   end
   subgraph path22 [Path]
     22["Path<br>[589, 640, 3]"]
-      %% Missing NodePath
     84["Segment<br>[589, 640, 3]"]
-      %% Missing NodePath
     142[Solid2d]
   end
   subgraph path23 [Path]
     23["Path<br>[830, 886, 3]"]
-      %% Missing NodePath
     85["Segment<br>[830, 886, 3]"]
-      %% Missing NodePath
     153[Solid2d]
   end
   subgraph path24 [Path]
     24["Path<br>[1016, 1069, 3]"]
-      %% Missing NodePath
     86["Segment<br>[1016, 1069, 3]"]
-      %% Missing NodePath
     161[Solid2d]
   end
   subgraph path25 [Path]
     25["Path<br>[1457, 1497, 3]"]
-      %% Missing NodePath
     87["Segment<br>[1457, 1497, 3]"]
-      %% Missing NodePath
     151[Solid2d]
   end
   subgraph path26 [Path]
     26["Path<br>[1606, 1657, 3]"]
-      %% Missing NodePath
     88["Segment<br>[1606, 1657, 3]"]
-      %% Missing NodePath
     149[Solid2d]
   end
   subgraph path27 [Path]
     27["Path<br>[1795, 1847, 3]"]
-      %% Missing NodePath
     89["Segment<br>[1795, 1847, 3]"]
-      %% Missing NodePath
     162[Solid2d]
   end
   subgraph path28 [Path]
     28["Path<br>[2095, 2167, 3]"]
-      %% Missing NodePath
     90["Segment<br>[2095, 2167, 3]"]
-      %% Missing NodePath
     160[Solid2d]
   end
   subgraph path29 [Path]
     29["Path<br>[2429, 2460, 3]"]
-      %% Missing NodePath
     91["Segment<br>[2466, 2486, 3]"]
-      %% Missing NodePath
     92["Segment<br>[2492, 2512, 3]"]
-      %% Missing NodePath
     93["Segment<br>[2518, 2539, 3]"]
-      %% Missing NodePath
     94["Segment<br>[2545, 2601, 3]"]
-      %% Missing NodePath
     95["Segment<br>[2607, 2614, 3]"]
-      %% Missing NodePath
     144[Solid2d]
   end
   subgraph path30 [Path]
     30["Path<br>[2921, 2953, 3]"]
-      %% Missing NodePath
     96["Segment<br>[2959, 2980, 3]"]
-      %% Missing NodePath
     97["Segment<br>[2986, 3006, 3]"]
-      %% Missing NodePath
     98["Segment<br>[3012, 3032, 3]"]
-      %% Missing NodePath
     99["Segment<br>[3038, 3094, 3]"]
-      %% Missing NodePath
     100["Segment<br>[3100, 3107, 3]"]
-      %% Missing NodePath
     143[Solid2d]
   end
   subgraph path31 [Path]
     31["Path<br>[529, 610, 4]"]
-      %% Missing NodePath
     101["Segment<br>[616, 717, 4]"]
-      %% Missing NodePath
     102["Segment<br>[723, 781, 4]"]
-      %% Missing NodePath
     103["Segment<br>[787, 871, 4]"]
-      %% Missing NodePath
     104["Segment<br>[877, 936, 4]"]
-      %% Missing NodePath
     105["Segment<br>[942, 1027, 4]"]
-      %% Missing NodePath
     106["Segment<br>[1033, 1092, 4]"]
-      %% Missing NodePath
     107["Segment<br>[1098, 1221, 4]"]
-      %% Missing NodePath
     108["Segment<br>[1227, 1286, 4]"]
-      %% Missing NodePath
     109["Segment<br>[1292, 1427, 4]"]
-      %% Missing NodePath
     110["Segment<br>[1433, 1492, 4]"]
-      %% Missing NodePath
     111["Segment<br>[1498, 1622, 4]"]
-      %% Missing NodePath
     112["Segment<br>[1628, 1687, 4]"]
-      %% Missing NodePath
     113["Segment<br>[1693, 1778, 4]"]
-      %% Missing NodePath
     114["Segment<br>[1784, 1843, 4]"]
-      %% Missing NodePath
     115["Segment<br>[1849, 1934, 4]"]
-      %% Missing NodePath
     116["Segment<br>[1940, 1998, 4]"]
-      %% Missing NodePath
     117["Segment<br>[2004, 2011, 4]"]
-      %% Missing NodePath
     154[Solid2d]
   end
   subgraph path32 [Path]
     32["Path<br>[711, 751, 5]"]
-      %% Missing NodePath
     118["Segment<br>[759, 806, 5]"]
-      %% Missing NodePath
     119["Segment<br>[814, 850, 5]"]
-      %% Missing NodePath
     120["Segment<br>[858, 888, 5]"]
-      %% Missing NodePath
     121["Segment<br>[896, 935, 5]"]
-      %% Missing NodePath
     122["Segment<br>[943, 983, 5]"]
-      %% Missing NodePath
     123["Segment<br>[991, 1026, 5]"]
-      %% Missing NodePath
     124["Segment<br>[1034, 1072, 5]"]
-      %% Missing NodePath
     125["Segment<br>[1080, 1102, 5]"]
-      %% Missing NodePath
     126["Segment<br>[1110, 1117, 5]"]
-      %% Missing NodePath
     145[Solid2d]
   end
   subgraph path33 [Path]
     33["Path<br>[505, 562, 6]"]
-      %% Missing NodePath
     127["Segment<br>[568, 702, 6]"]
-      %% Missing NodePath
     128["Segment<br>[708, 755, 6]"]
-      %% Missing NodePath
     129["Segment<br>[761, 858, 6]"]
-      %% Missing NodePath
     130["Segment<br>[864, 896, 6]"]
-      %% Missing NodePath
     131["Segment<br>[902, 934, 6]"]
-      %% Missing NodePath
     132["Segment<br>[940, 971, 6]"]
-      %% Missing NodePath
     133["Segment<br>[977, 1092, 6]"]
-      %% Missing NodePath
     134["Segment<br>[1098, 1130, 6]"]
-      %% Missing NodePath
     135["Segment<br>[1136, 1168, 6]"]
-      %% Missing NodePath
     136["Segment<br>[1174, 1205, 6]"]
-      %% Missing NodePath
     137["Segment<br>[1211, 1304, 6]"]
-      %% Missing NodePath
     138["Segment<br>[1310, 1357, 6]"]
-      %% Missing NodePath
     139["Segment<br>[1363, 1436, 6]"]
-      %% Missing NodePath
     140["Segment<br>[1442, 1449, 6]"]
-      %% Missing NodePath
     163[Solid2d]
   end
   1["Plane<br>[349, 366, 1]"]
-    %% Missing NodePath
   2["Plane<br>[1684, 1701, 1]"]
-    %% Missing NodePath
   3["Plane<br>[2102, 2119, 1]"]
-    %% Missing NodePath
   4["Plane<br>[2878, 2901, 1]"]
-    %% Missing NodePath
   5["Plane<br>[2878, 2901, 1]"]
-    %% Missing NodePath
   6["Plane<br>[4356, 4373, 1]"]
-    %% Missing NodePath
   7["Plane<br>[566, 583, 3]"]
-    %% Missing NodePath
   8["Plane<br>[506, 523, 4]"]
-    %% Missing NodePath
   9["Plane<br>[677, 703, 5]"]
-    %% Missing NodePath
   10["Plane<br>[482, 499, 6]"]
-    %% Missing NodePath
   164["Sweep Extrusion<br>[515, 548, 1]"]
-    %% Missing NodePath
   165["Sweep Extrusion<br>[818, 851, 1]"]
-    %% Missing NodePath
   166["Sweep Extrusion<br>[1158, 1192, 1]"]
-    %% Missing NodePath
   167["Sweep Extrusion<br>[1158, 1192, 1]"]
-    %% Missing NodePath
   168["Sweep Extrusion<br>[1158, 1192, 1]"]
-    %% Missing NodePath
   169["Sweep Extrusion<br>[1158, 1192, 1]"]
-    %% Missing NodePath
   170["Sweep Extrusion<br>[1158, 1192, 1]"]
-    %% Missing NodePath
   171["Sweep Extrusion<br>[1496, 1530, 1]"]
-    %% Missing NodePath
   172["Sweep Extrusion<br>[1496, 1530, 1]"]
-    %% Missing NodePath
   173["Sweep Extrusion<br>[1496, 1530, 1]"]
-    %% Missing NodePath
   174["Sweep Extrusion<br>[1496, 1530, 1]"]
-    %% Missing NodePath
   175["Sweep Extrusion<br>[1496, 1530, 1]"]
-    %% Missing NodePath
   176["Sweep Revolve<br>[1999, 2016, 1]"]
-    %% Missing NodePath
   177["Sweep Revolve<br>[2434, 2451, 1]"]
-    %% Missing NodePath
   178["Sweep Extrusion<br>[3817, 3863, 1]"]
-    %% Missing NodePath
   179["Sweep Extrusion<br>[3817, 3863, 1]"]
-    %% Missing NodePath
   180["Sweep Revolve<br>[5666, 5683, 1]"]
-    %% Missing NodePath
   181["Sweep Extrusion<br>[649, 705, 3]"]
-    %% Missing NodePath
   182["Sweep Extrusion<br>[899, 961, 3]"]
-    %% Missing NodePath
   183["Sweep Extrusion<br>[1216, 1295, 3]"]
-    %% Missing NodePath
   184["Sweep Extrusion<br>[1216, 1295, 3]"]
-    %% Missing NodePath
   185["Sweep Extrusion<br>[1216, 1295, 3]"]
-    %% Missing NodePath
   186["Sweep Extrusion<br>[1216, 1295, 3]"]
-    %% Missing NodePath
   187["Sweep Extrusion<br>[1216, 1295, 3]"]
-    %% Missing NodePath
   188["Sweep Extrusion<br>[1503, 1536, 3]"]
-    %% Missing NodePath
   189["Sweep Extrusion<br>[1672, 1737, 3]"]
-    %% Missing NodePath
   190["Sweep Extrusion<br>[1994, 2038, 3]"]
-    %% Missing NodePath
   191["Sweep Extrusion<br>[1994, 2038, 3]"]
-    %% Missing NodePath
   192["Sweep Extrusion<br>[1994, 2038, 3]"]
-    %% Missing NodePath
   193["Sweep Extrusion<br>[1994, 2038, 3]"]
-    %% Missing NodePath
   194["Sweep Extrusion<br>[1994, 2038, 3]"]
-    %% Missing NodePath
   195["Sweep Extrusion<br>[2322, 2366, 3]"]
-    %% Missing NodePath
   196["Sweep Extrusion<br>[2322, 2366, 3]"]
-    %% Missing NodePath
   197["Sweep Extrusion<br>[2322, 2366, 3]"]
-    %% Missing NodePath
   198["Sweep Extrusion<br>[2322, 2366, 3]"]
-    %% Missing NodePath
   199["Sweep Extrusion<br>[2322, 2366, 3]"]
-    %% Missing NodePath
   200["Sweep Extrusion<br>[2322, 2366, 3]"]
-    %% Missing NodePath
   201["Sweep Extrusion<br>[2322, 2366, 3]"]
-    %% Missing NodePath
   202["Sweep Extrusion<br>[2322, 2366, 3]"]
-    %% Missing NodePath
   203["Sweep Extrusion<br>[2322, 2366, 3]"]
-    %% Missing NodePath
   204["Sweep Extrusion<br>[2322, 2366, 3]"]
-    %% Missing NodePath
   205["Sweep Extrusion<br>[2322, 2366, 3]"]
-    %% Missing NodePath
   206["Sweep Extrusion<br>[2322, 2366, 3]"]
-    %% Missing NodePath
   207["Sweep Extrusion<br>[2322, 2366, 3]"]
-    %% Missing NodePath
   208["Sweep Extrusion<br>[2322, 2366, 3]"]
-    %% Missing NodePath
   209["Sweep Extrusion<br>[2322, 2366, 3]"]
-    %% Missing NodePath
   210["Sweep Extrusion<br>[2322, 2366, 3]"]
-    %% Missing NodePath
   211["Sweep Extrusion<br>[2780, 2848, 3]"]
-    %% Missing NodePath
   212["Sweep Extrusion<br>[2780, 2848, 3]"]
-    %% Missing NodePath
   213["Sweep Extrusion<br>[2780, 2848, 3]"]
-    %% Missing NodePath
   214["Sweep Extrusion<br>[2780, 2848, 3]"]
-    %% Missing NodePath
   215["Sweep Extrusion<br>[2780, 2848, 3]"]
-    %% Missing NodePath
   216["Sweep Extrusion<br>[3270, 3344, 3]"]
-    %% Missing NodePath
   217["Sweep Extrusion<br>[3270, 3344, 3]"]
-    %% Missing NodePath
   218["Sweep Extrusion<br>[3270, 3344, 3]"]
-    %% Missing NodePath
   219["Sweep Extrusion<br>[3270, 3344, 3]"]
-    %% Missing NodePath
   220["Sweep Extrusion<br>[3270, 3344, 3]"]
-    %% Missing NodePath
   221["Sweep Revolve<br>[2049, 2099, 4]"]
-    %% Missing NodePath
   222["Sweep Revolve<br>[1125, 1142, 5]"]
-    %% Missing NodePath
   223["Sweep Revolve<br>[1502, 1531, 6]"]
-    %% Missing NodePath
   224[Wall]
     %% face_code_ref=Missing NodePath
   225[Wall]

--- a/rust/kcl-lib/tests/kcl_samples/multi-axis-robot/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/multi-axis-robot/artifact_graph_flowchart.snap.md
@@ -2,353 +2,216 @@
 flowchart LR
   subgraph path7 [Path]
     7["Path<br>[242, 297, 1]"]
-      %% Missing NodePath
     32["Segment<br>[303, 383, 1]"]
-      %% Missing NodePath
     33["Segment<br>[389, 501, 1]"]
-      %% Missing NodePath
     34["Segment<br>[507, 624, 1]"]
-      %% Missing NodePath
     35["Segment<br>[630, 715, 1]"]
-      %% Missing NodePath
     36["Segment<br>[721, 728, 1]"]
-      %% Missing NodePath
     101[Solid2d]
   end
   subgraph path8 [Path]
     8["Path<br>[1169, 1226, 1]"]
-      %% Missing NodePath
     37["Segment<br>[1169, 1226, 1]"]
-      %% Missing NodePath
     110[Solid2d]
   end
   subgraph path9 [Path]
     9["Path<br>[1429, 1466, 1]"]
-      %% Missing NodePath
     38["Segment<br>[1429, 1466, 1]"]
-      %% Missing NodePath
     107[Solid2d]
   end
   subgraph path10 [Path]
     10["Path<br>[1603, 1743, 1]"]
-      %% Missing NodePath
     39["Segment<br>[1603, 1743, 1]"]
-      %% Missing NodePath
     93[Solid2d]
   end
   subgraph path11 [Path]
     11["Path<br>[1994, 2134, 1]"]
-      %% Missing NodePath
     40["Segment<br>[1994, 2134, 1]"]
-      %% Missing NodePath
     108[Solid2d]
   end
   subgraph path12 [Path]
     12["Path<br>[221, 281, 3]"]
-      %% Missing NodePath
     41["Segment<br>[221, 281, 3]"]
-      %% Missing NodePath
     100[Solid2d]
   end
   subgraph path13 [Path]
     13["Path<br>[511, 547, 3]"]
-      %% Missing NodePath
     42["Segment<br>[553, 590, 3]"]
-      %% Missing NodePath
     43["Segment<br>[596, 651, 3]"]
-      %% Missing NodePath
     44["Segment<br>[657, 706, 3]"]
-      %% Missing NodePath
     45["Segment<br>[712, 768, 3]"]
-      %% Missing NodePath
     46["Segment<br>[774, 781, 3]"]
-      %% Missing NodePath
     89[Solid2d]
   end
   subgraph path14 [Path]
     14["Path<br>[883, 1036, 3]"]
-      %% Missing NodePath
     47["Segment<br>[883, 1036, 3]"]
-      %% Missing NodePath
     103[Solid2d]
   end
   subgraph path15 [Path]
     15["Path<br>[1245, 1370, 3]"]
-      %% Missing NodePath
     48["Segment<br>[1245, 1370, 3]"]
-      %% Missing NodePath
     104[Solid2d]
   end
   subgraph path16 [Path]
     16["Path<br>[1670, 1822, 3]"]
-      %% Missing NodePath
     49["Segment<br>[1670, 1822, 3]"]
-      %% Missing NodePath
     91[Solid2d]
   end
   subgraph path17 [Path]
     17["Path<br>[2047, 2087, 3]"]
-      %% Missing NodePath
     50["Segment<br>[2047, 2087, 3]"]
-      %% Missing NodePath
     90[Solid2d]
   end
   subgraph path18 [Path]
     18["Path<br>[269, 390, 4]"]
-      %% Missing NodePath
     51["Segment<br>[396, 479, 4]"]
-      %% Missing NodePath
     52["Segment<br>[485, 537, 4]"]
-      %% Missing NodePath
     53["Segment<br>[543, 626, 4]"]
-      %% Missing NodePath
     54["Segment<br>[632, 688, 4]"]
-      %% Missing NodePath
     55["Segment<br>[694, 701, 4]"]
-      %% Missing NodePath
     105[Solid2d]
   end
   subgraph path19 [Path]
     19["Path<br>[822, 886, 4]"]
-      %% Missing NodePath
     56["Segment<br>[822, 886, 4]"]
-      %% Missing NodePath
     98[Solid2d]
   end
   subgraph path20 [Path]
     20["Path<br>[1060, 1246, 4]"]
-      %% Missing NodePath
     57["Segment<br>[1060, 1246, 4]"]
-      %% Missing NodePath
     109[Solid2d]
   end
   subgraph path21 [Path]
     21["Path<br>[1454, 1498, 4]"]
-      %% Missing NodePath
     58["Segment<br>[1454, 1498, 4]"]
-      %% Missing NodePath
     87[Solid2d]
   end
   subgraph path22 [Path]
     22["Path<br>[1741, 1911, 4]"]
-      %% Missing NodePath
     59["Segment<br>[1741, 1911, 4]"]
-      %% Missing NodePath
     88[Solid2d]
   end
   subgraph path23 [Path]
     23["Path<br>[2247, 2400, 4]"]
-      %% Missing NodePath
     60["Segment<br>[2247, 2400, 4]"]
-      %% Missing NodePath
     92[Solid2d]
   end
   subgraph path24 [Path]
     24["Path<br>[289, 478, 5]"]
-      %% Missing NodePath
     61["Segment<br>[484, 570, 5]"]
-      %% Missing NodePath
     62["Segment<br>[576, 630, 5]"]
-      %% Missing NodePath
     63["Segment<br>[636, 722, 5]"]
-      %% Missing NodePath
     64["Segment<br>[728, 798, 5]"]
-      %% Missing NodePath
     65["Segment<br>[804, 811, 5]"]
-      %% Missing NodePath
     99[Solid2d]
   end
   subgraph path25 [Path]
     25["Path<br>[930, 1117, 5]"]
-      %% Missing NodePath
     66["Segment<br>[930, 1117, 5]"]
-      %% Missing NodePath
     95[Solid2d]
   end
   subgraph path26 [Path]
     26["Path<br>[1327, 1494, 5]"]
-      %% Missing NodePath
     67["Segment<br>[1327, 1494, 5]"]
-      %% Missing NodePath
     111[Solid2d]
   end
   subgraph path27 [Path]
     27["Path<br>[1898, 2140, 5]"]
-      %% Missing NodePath
     68["Segment<br>[1898, 2140, 5]"]
-      %% Missing NodePath
     102[Solid2d]
   end
   subgraph path28 [Path]
     28["Path<br>[2244, 2484, 5]"]
-      %% Missing NodePath
     69["Segment<br>[2244, 2484, 5]"]
-      %% Missing NodePath
     97[Solid2d]
   end
   subgraph path29 [Path]
     29["Path<br>[2643, 2681, 5]"]
-      %% Missing NodePath
     70["Segment<br>[2643, 2681, 5]"]
-      %% Missing NodePath
     106[Solid2d]
   end
   subgraph path30 [Path]
     30["Path<br>[2816, 2997, 5]"]
-      %% Missing NodePath
     71["Segment<br>[3003, 3071, 5]"]
-      %% Missing NodePath
     72["Segment<br>[3077, 3187, 5]"]
-      %% Missing NodePath
     73["Segment<br>[3193, 3261, 5]"]
-      %% Missing NodePath
     74["Segment<br>[3267, 3343, 5]"]
-      %% Missing NodePath
     75["Segment<br>[3349, 3425, 5]"]
-      %% Missing NodePath
     76["Segment<br>[3431, 3505, 5]"]
-      %% Missing NodePath
     77["Segment<br>[3511, 3567, 5]"]
-      %% Missing NodePath
     78["Segment<br>[3573, 3580, 5]"]
-      %% Missing NodePath
     94[Solid2d]
   end
   subgraph path31 [Path]
     31["Path<br>[3714, 3895, 5]"]
-      %% Missing NodePath
     79["Segment<br>[3901, 3971, 5]"]
-      %% Missing NodePath
     80["Segment<br>[3977, 4092, 5]"]
-      %% Missing NodePath
     81["Segment<br>[4098, 4168, 5]"]
-      %% Missing NodePath
     82["Segment<br>[4174, 4252, 5]"]
-      %% Missing NodePath
     83["Segment<br>[4258, 4336, 5]"]
-      %% Missing NodePath
     84["Segment<br>[4342, 4418, 5]"]
-      %% Missing NodePath
     85["Segment<br>[4424, 4480, 5]"]
-      %% Missing NodePath
     86["Segment<br>[4486, 4493, 5]"]
-      %% Missing NodePath
     96[Solid2d]
   end
   1["Plane<br>[219, 236, 1]"]
-    %% Missing NodePath
   2["Plane<br>[192, 215, 3]"]
-    %% Missing NodePath
   3["Plane<br>[482, 505, 3]"]
-    %% Missing NodePath
   4["Plane<br>[2018, 2041, 3]"]
-    %% Missing NodePath
   5["Plane<br>[240, 263, 4]"]
-    %% Missing NodePath
   6["Plane<br>[260, 283, 5]"]
-    %% Missing NodePath
   112["Sweep Extrusion<br>[742, 789, 1]"]
-    %% Missing NodePath
   113["Sweep Extrusion<br>[1240, 1306, 1]"]
-    %% Missing NodePath
   114["Sweep Extrusion<br>[1480, 1510, 1]"]
-    %% Missing NodePath
   115["Sweep Extrusion<br>[1891, 1938, 1]"]
-    %% Missing NodePath
   116["Sweep Extrusion<br>[1891, 1938, 1]"]
-    %% Missing NodePath
   117["Sweep Extrusion<br>[1891, 1938, 1]"]
-    %% Missing NodePath
   118["Sweep Extrusion<br>[1891, 1938, 1]"]
-    %% Missing NodePath
   119["Sweep Extrusion<br>[2270, 2317, 1]"]
-    %% Missing NodePath
   120["Sweep Extrusion<br>[2270, 2317, 1]"]
-    %% Missing NodePath
   121["Sweep Extrusion<br>[2270, 2317, 1]"]
-    %% Missing NodePath
   122["Sweep Extrusion<br>[2270, 2317, 1]"]
-    %% Missing NodePath
   123["Sweep Extrusion<br>[295, 333, 3]"]
-    %% Missing NodePath
   124["Sweep Extrusion<br>[796, 826, 3]"]
-    %% Missing NodePath
   125["Sweep Extrusion<br>[1050, 1082, 3]"]
-    %% Missing NodePath
   126["Sweep Extrusion<br>[1581, 1613, 3]"]
-    %% Missing NodePath
   127["Sweep Extrusion<br>[1581, 1613, 3]"]
-    %% Missing NodePath
   128["Sweep Extrusion<br>[1581, 1613, 3]"]
-    %% Missing NodePath
   129["Sweep Extrusion<br>[1581, 1613, 3]"]
-    %% Missing NodePath
   130["Sweep Extrusion<br>[1836, 1869, 3]"]
-    %% Missing NodePath
   131["Sweep Extrusion<br>[2089, 2120, 3]"]
-    %% Missing NodePath
   132["Sweep Extrusion<br>[715, 763, 4]"]
-    %% Missing NodePath
   133["Sweep Extrusion<br>[901, 934, 4]"]
-    %% Missing NodePath
   134["Sweep Extrusion<br>[1261, 1291, 4]"]
-    %% Missing NodePath
   135["Sweep Extrusion<br>[1651, 1684, 4]"]
-    %% Missing NodePath
   136["Sweep Extrusion<br>[1651, 1684, 4]"]
-    %% Missing NodePath
   137["Sweep Extrusion<br>[1651, 1684, 4]"]
-    %% Missing NodePath
   138["Sweep Extrusion<br>[1651, 1684, 4]"]
-    %% Missing NodePath
   139["Sweep Extrusion<br>[1651, 1684, 4]"]
-    %% Missing NodePath
   140["Sweep Extrusion<br>[1651, 1684, 4]"]
-    %% Missing NodePath
   141["Sweep Extrusion<br>[1651, 1684, 4]"]
-    %% Missing NodePath
   142["Sweep Extrusion<br>[1651, 1684, 4]"]
-    %% Missing NodePath
   143["Sweep Extrusion<br>[2157, 2190, 4]"]
-    %% Missing NodePath
   144["Sweep Extrusion<br>[2157, 2190, 4]"]
-    %% Missing NodePath
   145["Sweep Extrusion<br>[2157, 2190, 4]"]
-    %% Missing NodePath
   146["Sweep Extrusion<br>[2157, 2190, 4]"]
-    %% Missing NodePath
   147["Sweep Extrusion<br>[2402, 2432, 4]"]
-    %% Missing NodePath
   148["Sweep Extrusion<br>[825, 873, 5]"]
-    %% Missing NodePath
   149["Sweep Extrusion<br>[1132, 1165, 5]"]
-    %% Missing NodePath
   150["Sweep Extrusion<br>[1737, 1770, 5]"]
-    %% Missing NodePath
   151["Sweep Extrusion<br>[1737, 1770, 5]"]
-    %% Missing NodePath
   152["Sweep Extrusion<br>[1737, 1770, 5]"]
-    %% Missing NodePath
   153["Sweep Extrusion<br>[1737, 1770, 5]"]
-    %% Missing NodePath
   154["Sweep Extrusion<br>[1737, 1770, 5]"]
-    %% Missing NodePath
   155["Sweep Extrusion<br>[1737, 1770, 5]"]
-    %% Missing NodePath
   156["Sweep Extrusion<br>[1737, 1770, 5]"]
-    %% Missing NodePath
   157["Sweep Extrusion<br>[1737, 1770, 5]"]
-    %% Missing NodePath
   158["Sweep Extrusion<br>[2154, 2187, 5]"]
-    %% Missing NodePath
   159["Sweep Extrusion<br>[2499, 2532, 5]"]
-    %% Missing NodePath
   160["Sweep Extrusion<br>[2696, 2730, 5]"]
-    %% Missing NodePath
   161["Sweep Extrusion<br>[3595, 3628, 5]"]
-    %% Missing NodePath
   162["Sweep Extrusion<br>[4495, 4528, 5]"]
-    %% Missing NodePath
   163[Wall]
     %% face_code_ref=Missing NodePath
   164[Wall]
@@ -614,27 +477,16 @@ flowchart LR
   342["SweepEdge Adjacent"]
   343["SweepEdge Adjacent"]
   344["EdgeCut Chamfer<br>[795, 1072, 1]"]
-    %% Missing NodePath
   345["EdgeCut Chamfer<br>[795, 1072, 1]"]
-    %% Missing NodePath
   346["EdgeCut Chamfer<br>[795, 1072, 1]"]
-    %% Missing NodePath
   347["EdgeCut Chamfer<br>[795, 1072, 1]"]
-    %% Missing NodePath
   348["EdgeCut Fillet<br>[1312, 1373, 1]"]
-    %% Missing NodePath
   349["EdgeCut Fillet<br>[339, 401, 3]"]
-    %% Missing NodePath
   350["EdgeCut Fillet<br>[1088, 1150, 3]"]
-    %% Missing NodePath
   351["EdgeCut Fillet<br>[1875, 1937, 3]"]
-    %% Missing NodePath
   352["EdgeCut Fillet<br>[940, 1002, 4]"]
-    %% Missing NodePath
   353["EdgeCut Fillet<br>[1297, 1359, 4]"]
-    %% Missing NodePath
   354["EdgeCut Fillet<br>[1171, 1233, 5]"]
-    %% Missing NodePath
   1 --- 7
   2 --- 12
   3 --- 13

--- a/rust/kcl-lib/tests/kcl_samples/pillow-block-bearing/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/pillow-block-bearing/artifact_graph_flowchart.snap.md
@@ -2,199 +2,124 @@
 flowchart LR
   subgraph path6 [Path]
     6["Path<br>[410, 467, 2]"]
-      %% Missing NodePath
     21["Segment<br>[473, 532, 2]"]
-      %% Missing NodePath
     22["Segment<br>[538, 545, 2]"]
-      %% Missing NodePath
     63[Solid2d]
   end
   subgraph path7 [Path]
     7["Path<br>[953, 1079, 2]"]
-      %% Missing NodePath
     23["Segment<br>[1085, 1145, 2]"]
-      %% Missing NodePath
     24["Segment<br>[1151, 1182, 2]"]
-      %% Missing NodePath
     25["Segment<br>[1188, 1216, 2]"]
-      %% Missing NodePath
     26["Segment<br>[1222, 1229, 2]"]
-      %% Missing NodePath
     69[Solid2d]
   end
   subgraph path8 [Path]
     8["Path<br>[1559, 1719, 2]"]
-      %% Missing NodePath
     27["Segment<br>[1559, 1719, 2]"]
-      %% Missing NodePath
     73[Solid2d]
   end
   subgraph path9 [Path]
     9["Path<br>[1803, 1932, 2]"]
-      %% Missing NodePath
     28["Segment<br>[1938, 1976, 2]"]
-      %% Missing NodePath
     29["Segment<br>[1982, 2060, 2]"]
-      %% Missing NodePath
     30["Segment<br>[2066, 2092, 2]"]
-      %% Missing NodePath
     31["Segment<br>[2098, 2120, 2]"]
-      %% Missing NodePath
     32["Segment<br>[2126, 2181, 2]"]
-      %% Missing NodePath
     33["Segment<br>[2187, 2243, 2]"]
-      %% Missing NodePath
     34["Segment<br>[2249, 2256, 2]"]
-      %% Missing NodePath
     71[Solid2d]
   end
   subgraph path10 [Path]
     10["Path<br>[2347, 2411, 2]"]
-      %% Missing NodePath
     35["Segment<br>[2417, 2437, 2]"]
-      %% Missing NodePath
     36["Segment<br>[2443, 2494, 2]"]
-      %% Missing NodePath
     37["Segment<br>[2500, 2520, 2]"]
-      %% Missing NodePath
     38["Segment<br>[2526, 2573, 2]"]
-      %% Missing NodePath
     39["Segment<br>[2579, 2624, 2]"]
-      %% Missing NodePath
     40["Segment<br>[2630, 2660, 2]"]
-      %% Missing NodePath
     41["Segment<br>[2666, 2687, 2]"]
-      %% Missing NodePath
     42["Segment<br>[2693, 2756, 2]"]
-      %% Missing NodePath
     43["Segment<br>[2762, 2805, 2]"]
-      %% Missing NodePath
     44["Segment<br>[2811, 2871, 2]"]
-      %% Missing NodePath
     45["Segment<br>[2877, 2914, 2]"]
-      %% Missing NodePath
     46["Segment<br>[2920, 2976, 2]"]
-      %% Missing NodePath
     47["Segment<br>[2982, 2989, 2]"]
-      %% Missing NodePath
     65[Solid2d]
   end
   subgraph path11 [Path]
     11["Path<br>[655, 709, 3]"]
-      %% Missing NodePath
     48["Segment<br>[715, 787, 3]"]
-      %% Missing NodePath
     49["Segment<br>[793, 896, 3]"]
-      %% Missing NodePath
     50["Segment<br>[902, 1019, 3]"]
-      %% Missing NodePath
     51["Segment<br>[1025, 1110, 3]"]
-      %% Missing NodePath
     52["Segment<br>[1116, 1123, 3]"]
-      %% Missing NodePath
     66[Solid2d]
   end
   subgraph path12 [Path]
     12["Path<br>[1147, 1205, 3]"]
-      %% Missing NodePath
     53["Segment<br>[1147, 1205, 3]"]
-      %% Missing NodePath
     72[Solid2d]
   end
   subgraph path13 [Path]
     13["Path<br>[1933, 1996, 3]"]
-      %% Missing NodePath
     54["Segment<br>[1933, 1996, 3]"]
-      %% Missing NodePath
     62[Solid2d]
   end
   subgraph path14 [Path]
     14["Path<br>[1933, 1996, 3]"]
-      %% Missing NodePath
     57["Segment<br>[1933, 1996, 3]"]
-      %% Missing NodePath
     64[Solid2d]
   end
   subgraph path15 [Path]
     15["Path<br>[1933, 1996, 3]"]
-      %% Missing NodePath
     55["Segment<br>[1933, 1996, 3]"]
-      %% Missing NodePath
     70[Solid2d]
   end
   subgraph path16 [Path]
     16["Path<br>[1933, 1996, 3]"]
-      %% Missing NodePath
     56["Segment<br>[1933, 1996, 3]"]
-      %% Missing NodePath
     76[Solid2d]
   end
   subgraph path17 [Path]
     17["Path<br>[2094, 2165, 3]"]
-      %% Missing NodePath
     58["Segment<br>[2094, 2165, 3]"]
-      %% Missing NodePath
     67[Solid2d]
   end
   subgraph path18 [Path]
     18["Path<br>[2094, 2165, 3]"]
-      %% Missing NodePath
     59["Segment<br>[2094, 2165, 3]"]
-      %% Missing NodePath
     68[Solid2d]
   end
   subgraph path19 [Path]
     19["Path<br>[2094, 2165, 3]"]
-      %% Missing NodePath
     61["Segment<br>[2094, 2165, 3]"]
-      %% Missing NodePath
     74[Solid2d]
   end
   subgraph path20 [Path]
     20["Path<br>[2094, 2165, 3]"]
-      %% Missing NodePath
     60["Segment<br>[2094, 2165, 3]"]
-      %% Missing NodePath
     75[Solid2d]
   end
   1["Plane<br>[359, 403, 2]"]
-    %% Missing NodePath
   2["Plane<br>[902, 946, 2]"]
-    %% Missing NodePath
   3["Plane<br>[1536, 1553, 2]"]
-    %% Missing NodePath
   4["Plane<br>[1770, 1787, 2]"]
-    %% Missing NodePath
   5["Plane<br>[632, 649, 3]"]
-    %% Missing NodePath
   77["Sweep Revolve<br>[627, 657, 2]"]
-    %% Missing NodePath
   78["Sweep Revolve<br>[1271, 1301, 2]"]
-    %% Missing NodePath
   79["Sweep Revolve<br>[2262, 2292, 2]"]
-    %% Missing NodePath
   80["Sweep Revolve<br>[2995, 3025, 2]"]
-    %% Missing NodePath
   81["Sweep Revolve<br>[3092, 3139, 2]"]
-    %% Missing NodePath
   82["Sweep Extrusion<br>[1219, 1264, 3]"]
-    %% Missing NodePath
   83["Sweep Extrusion<br>[2004, 2039, 3]"]
-    %% Missing NodePath
   84["Sweep Extrusion<br>[2004, 2039, 3]"]
-    %% Missing NodePath
   85["Sweep Extrusion<br>[2004, 2039, 3]"]
-    %% Missing NodePath
   86["Sweep Extrusion<br>[2004, 2039, 3]"]
-    %% Missing NodePath
   87["Sweep Extrusion<br>[2173, 2225, 3]"]
-    %% Missing NodePath
   88["Sweep Extrusion<br>[2173, 2225, 3]"]
-    %% Missing NodePath
   89["Sweep Extrusion<br>[2173, 2225, 3]"]
-    %% Missing NodePath
   90["Sweep Extrusion<br>[2173, 2225, 3]"]
-    %% Missing NodePath
   91[Wall]
     %% face_code_ref=Missing NodePath
   92[Wall]
@@ -335,13 +260,9 @@ flowchart LR
   183["SweepEdge Adjacent"]
   184["SweepEdge Adjacent"]
   185["EdgeCut Fillet<br>[1308, 1593, 3]"]
-    %% Missing NodePath
   186["EdgeCut Fillet<br>[1308, 1593, 3]"]
-    %% Missing NodePath
   187["EdgeCut Fillet<br>[1308, 1593, 3]"]
-    %% Missing NodePath
   188["EdgeCut Fillet<br>[1308, 1593, 3]"]
-    %% Missing NodePath
   1 --- 6
   2 --- 7
   3 --- 8

--- a/rust/kcl-lib/tests/kcl_samples/pipe-flange-assembly/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/pipe-flange-assembly/artifact_graph_flowchart.snap.md
@@ -2,271 +2,172 @@
 flowchart LR
   subgraph path23 [Path]
     23["Path<br>[440, 502, 2]"]
-      %% Missing NodePath
     46["Segment<br>[440, 502, 2]"]
-      %% Missing NodePath
     97[Solid2d]
   end
   subgraph path24 [Path]
     24["Path<br>[640, 700, 2]"]
-      %% Missing NodePath
     47["Segment<br>[640, 700, 2]"]
-      %% Missing NodePath
     80[Solid2d]
   end
   subgraph path25 [Path]
     25["Path<br>[613, 706, 3]"]
-      %% Missing NodePath
     49["Segment<br>[613, 706, 3]"]
-      %% Missing NodePath
     90[Solid2d]
   end
   subgraph path26 [Path]
     26["Path<br>[613, 706, 3]"]
-      %% Missing NodePath
     48["Segment<br>[613, 706, 3]"]
-      %% Missing NodePath
     98[Solid2d]
   end
   subgraph path27 [Path]
     27["Path<br>[935, 990, 3]"]
-      %% Missing NodePath
     51["Segment<br>[935, 990, 3]"]
-      %% Missing NodePath
     84[Solid2d]
   end
   subgraph path28 [Path]
     28["Path<br>[935, 990, 3]"]
-      %% Missing NodePath
     50["Segment<br>[935, 990, 3]"]
-      %% Missing NodePath
     88[Solid2d]
   end
   subgraph path29 [Path]
     29["Path<br>[1220, 1279, 3]"]
-      %% Missing NodePath
     53["Segment<br>[1220, 1279, 3]"]
-      %% Missing NodePath
     83[Solid2d]
   end
   subgraph path30 [Path]
     30["Path<br>[1220, 1279, 3]"]
-      %% Missing NodePath
     52["Segment<br>[1220, 1279, 3]"]
-      %% Missing NodePath
     87[Solid2d]
   end
   subgraph path31 [Path]
     31["Path<br>[1386, 1446, 3]"]
-      %% Missing NodePath
     54["Segment<br>[1386, 1446, 3]"]
-      %% Missing NodePath
     91[Solid2d]
   end
   subgraph path32 [Path]
     32["Path<br>[1386, 1446, 3]"]
-      %% Missing NodePath
     55["Segment<br>[1386, 1446, 3]"]
-      %% Missing NodePath
     95[Solid2d]
   end
   subgraph path33 [Path]
     33["Path<br>[1608, 1661, 3]"]
-      %% Missing NodePath
     56["Segment<br>[1608, 1661, 3]"]
-      %% Missing NodePath
     86[Solid2d]
   end
   subgraph path34 [Path]
     34["Path<br>[1608, 1661, 3]"]
-      %% Missing NodePath
     57["Segment<br>[1608, 1661, 3]"]
-      %% Missing NodePath
     93[Solid2d]
   end
   subgraph path35 [Path]
     35["Path<br>[429, 481, 4]"]
-      %% Missing NodePath
     58["Segment<br>[429, 481, 4]"]
-      %% Missing NodePath
     96[Solid2d]
   end
   subgraph path36 [Path]
     36["Path<br>[619, 671, 4]"]
-      %% Missing NodePath
     59["Segment<br>[619, 671, 4]"]
-      %% Missing NodePath
     99[Solid2d]
   end
   subgraph path37 [Path]
     37["Path<br>[457, 527, 5]"]
-      %% Missing NodePath
     60["Segment<br>[457, 527, 5]"]
-      %% Missing NodePath
     79[Solid2d]
   end
   subgraph path38 [Path]
     38["Path<br>[796, 883, 5]"]
-      %% Missing NodePath
     61["Segment<br>[891, 942, 5]"]
-      %% Missing NodePath
     62["Segment<br>[950, 1001, 5]"]
-      %% Missing NodePath
     63["Segment<br>[1009, 1060, 5]"]
-      %% Missing NodePath
     64["Segment<br>[1068, 1118, 5]"]
-      %% Missing NodePath
     65["Segment<br>[1126, 1176, 5]"]
-      %% Missing NodePath
     66["Segment<br>[1184, 1191, 5]"]
-      %% Missing NodePath
     100[Solid2d]
   end
   subgraph path39 [Path]
     39["Path<br>[1330, 1399, 5]"]
-      %% Missing NodePath
     67["Segment<br>[1330, 1399, 5]"]
-      %% Missing NodePath
     82[Solid2d]
   end
   subgraph path40 [Path]
     40["Path<br>[443, 533, 6]"]
-      %% Missing NodePath
     68["Segment<br>[541, 591, 6]"]
-      %% Missing NodePath
     69["Segment<br>[599, 649, 6]"]
-      %% Missing NodePath
     70["Segment<br>[657, 707, 6]"]
-      %% Missing NodePath
     71["Segment<br>[715, 764, 6]"]
-      %% Missing NodePath
     72["Segment<br>[772, 821, 6]"]
-      %% Missing NodePath
     73["Segment<br>[829, 836, 6]"]
-      %% Missing NodePath
     81[Solid2d]
   end
   subgraph path41 [Path]
     41["Path<br>[985, 1037, 6]"]
-      %% Missing NodePath
     74["Segment<br>[985, 1037, 6]"]
-      %% Missing NodePath
     101[Solid2d]
   end
   subgraph path42 [Path]
     42["Path<br>[343, 401, 7]"]
-      %% Missing NodePath
     75["Segment<br>[343, 401, 7]"]
-      %% Missing NodePath
     89[Solid2d]
   end
   subgraph path43 [Path]
     43["Path<br>[343, 401, 7]"]
-      %% Missing NodePath
     76["Segment<br>[343, 401, 7]"]
-      %% Missing NodePath
     94[Solid2d]
   end
   subgraph path44 [Path]
     44["Path<br>[545, 600, 7]"]
-      %% Missing NodePath
     77["Segment<br>[545, 600, 7]"]
-      %% Missing NodePath
     85[Solid2d]
   end
   subgraph path45 [Path]
     45["Path<br>[545, 600, 7]"]
-      %% Missing NodePath
     78["Segment<br>[545, 600, 7]"]
-      %% Missing NodePath
     92[Solid2d]
   end
   1["Plane<br>[417, 434, 2]"]
-    %% Missing NodePath
   2["Plane<br>[588, 605, 3]"]
-    %% Missing NodePath
   3["Plane<br>[588, 605, 3]"]
-    %% Missing NodePath
   4["Plane<br>[910, 927, 3]"]
-    %% Missing NodePath
   5["Plane<br>[910, 927, 3]"]
-    %% Missing NodePath
   6["Plane<br>[404, 421, 4]"]
-    %% Missing NodePath
   7["Plane<br>[432, 449, 5]"]
-    %% Missing NodePath
   8["Plane<br>[418, 435, 6]"]
-    %% Missing NodePath
   9["Plane<br>[318, 335, 7]"]
-    %% Missing NodePath
   10["Plane<br>[318, 335, 7]"]
-    %% Missing NodePath
   11["StartSketchOnFace<br>[940, 977, 6]"]
-    %% Missing NodePath
   12["StartSketchOnFace<br>[1341, 1378, 3]"]
-    %% Missing NodePath
   13["StartSketchOnFace<br>[502, 537, 7]"]
-    %% Missing NodePath
   14["StartSketchOnFace<br>[502, 537, 7]"]
-    %% Missing NodePath
   15["StartSketchOnFace<br>[1173, 1212, 3]"]
-    %% Missing NodePath
   16["StartSketchOnFace<br>[574, 611, 4]"]
-    %% Missing NodePath
   17["StartSketchOnFace<br>[751, 788, 5]"]
-    %% Missing NodePath
   18["StartSketchOnFace<br>[1562, 1600, 3]"]
-    %% Missing NodePath
   19["StartSketchOnFace<br>[1562, 1600, 3]"]
-    %% Missing NodePath
   20["StartSketchOnFace<br>[1341, 1378, 3]"]
-    %% Missing NodePath
   21["StartSketchOnFace<br>[1287, 1322, 5]"]
-    %% Missing NodePath
   22["StartSketchOnFace<br>[1173, 1212, 3]"]
-    %% Missing NodePath
   102["Sweep Extrusion<br>[508, 544, 2]"]
-    %% Missing NodePath
   103["Sweep Extrusion<br>[706, 743, 2]"]
-    %% Missing NodePath
   104["Sweep Extrusion<br>[1038, 1078, 3]"]
-    %% Missing NodePath
   105["Sweep Extrusion<br>[1038, 1078, 3]"]
-    %% Missing NodePath
   106["Sweep Extrusion<br>[1287, 1324, 3]"]
-    %% Missing NodePath
   107["Sweep Extrusion<br>[1287, 1324, 3]"]
-    %% Missing NodePath
   108["Sweep Extrusion<br>[1454, 1492, 3]"]
-    %% Missing NodePath
   109["Sweep Extrusion<br>[1454, 1492, 3]"]
-    %% Missing NodePath
   110["Sweep Extrusion<br>[1669, 1711, 3]"]
-    %% Missing NodePath
   111["Sweep Extrusion<br>[1669, 1711, 3]"]
-    %% Missing NodePath
   112["Sweep Extrusion<br>[489, 522, 4]"]
-    %% Missing NodePath
   113["Sweep Extrusion<br>[679, 716, 4]"]
-    %% Missing NodePath
   114["Sweep Extrusion<br>[535, 568, 5]"]
-    %% Missing NodePath
   115["Sweep Extrusion<br>[1199, 1239, 5]"]
-    %% Missing NodePath
   116["Sweep Extrusion<br>[1407, 1435, 5]"]
-    %% Missing NodePath
   117["Sweep Extrusion<br>[844, 877, 6]"]
-    %% Missing NodePath
   118["Sweep Extrusion<br>[1045, 1082, 6]"]
-    %% Missing NodePath
   119["Sweep Extrusion<br>[409, 440, 7]"]
-    %% Missing NodePath
   120["Sweep Extrusion<br>[409, 440, 7]"]
-    %% Missing NodePath
   121["Sweep Extrusion<br>[608, 640, 7]"]
-    %% Missing NodePath
   122["Sweep Extrusion<br>[608, 640, 7]"]
-    %% Missing NodePath
   123[Wall]
     %% face_code_ref=Missing NodePath
   124[Wall]
@@ -330,49 +231,37 @@ flowchart LR
   153[Wall]
     %% face_code_ref=Missing NodePath
   154["Cap Start"]
-    %% face_code_ref=Missing NodePath
   155["Cap Start"]
     %% face_code_ref=Missing NodePath
   156["Cap Start"]
     %% face_code_ref=Missing NodePath
   157["Cap Start"]
-    %% face_code_ref=Missing NodePath
   158["Cap Start"]
     %% face_code_ref=Missing NodePath
   159["Cap Start"]
     %% face_code_ref=Missing NodePath
   160["Cap Start"]
-    %% face_code_ref=Missing NodePath
   161["Cap Start"]
     %% face_code_ref=Missing NodePath
   162["Cap Start"]
     %% face_code_ref=Missing NodePath
   163["Cap End"]
-    %% face_code_ref=Missing NodePath
   164["Cap End"]
     %% face_code_ref=Missing NodePath
   165["Cap End"]
-    %% face_code_ref=Missing NodePath
   166["Cap End"]
-    %% face_code_ref=Missing NodePath
   167["Cap End"]
     %% face_code_ref=Missing NodePath
   168["Cap End"]
-    %% face_code_ref=Missing NodePath
   169["Cap End"]
-    %% face_code_ref=Missing NodePath
   170["Cap End"]
-    %% face_code_ref=Missing NodePath
   171["Cap End"]
     %% face_code_ref=Missing NodePath
   172["Cap End"]
-    %% face_code_ref=Missing NodePath
   173["Cap End"]
-    %% face_code_ref=Missing NodePath
   174["Cap End"]
     %% face_code_ref=Missing NodePath
   175["Cap End"]
-    %% face_code_ref=Missing NodePath
   176["SweepEdge Opposite"]
   177["SweepEdge Opposite"]
   178["SweepEdge Opposite"]
@@ -436,9 +325,7 @@ flowchart LR
   236["SweepEdge Adjacent"]
   237["SweepEdge Adjacent"]
   238["EdgeCut Fillet<br>[576, 642, 5]"]
-    %% Missing NodePath
   239["EdgeCut Fillet<br>[576, 642, 5]"]
-    %% Missing NodePath
   1 --- 23
   2 --- 26
   3 --- 25

--- a/rust/kcl-lib/tests/kcl_samples/walkie-talkie/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/walkie-talkie/artifact_graph_flowchart.snap.md
@@ -2,352 +2,208 @@
 flowchart LR
   subgraph path18 [Path]
     18["Path<br>[409, 452, 2]"]
-      %% Missing NodePath
     38["Segment<br>[458, 496, 2]"]
-      %% Missing NodePath
     39["Segment<br>[502, 542, 2]"]
-      %% Missing NodePath
     40["Segment<br>[548, 587, 2]"]
-      %% Missing NodePath
     41["Segment<br>[593, 615, 2]"]
-      %% Missing NodePath
     149[Solid2d]
   end
   subgraph path19 [Path]
     19["Path<br>[986, 1103, 2]"]
-      %% Missing NodePath
     42["Segment<br>[1109, 1167, 2]"]
-      %% Missing NodePath
     43["Segment<br>[1173, 1290, 2]"]
-      %% Missing NodePath
     44["Segment<br>[1296, 1354, 2]"]
-      %% Missing NodePath
     45["Segment<br>[1360, 1480, 2]"]
-      %% Missing NodePath
     46["Segment<br>[1486, 1547, 2]"]
-      %% Missing NodePath
     47["Segment<br>[1553, 1674, 2]"]
-      %% Missing NodePath
     48["Segment<br>[1680, 1740, 2]"]
-      %% Missing NodePath
     49["Segment<br>[1746, 1753, 2]"]
-      %% Missing NodePath
     137[Solid2d]
   end
   subgraph path20 [Path]
     20["Path<br>[1908, 1962, 2]"]
-      %% Missing NodePath
     50["Segment<br>[1968, 2009, 2]"]
-      %% Missing NodePath
     51["Segment<br>[2015, 2044, 2]"]
-      %% Missing NodePath
     52["Segment<br>[2050, 2080, 2]"]
-      %% Missing NodePath
     53["Segment<br>[2086, 2142, 2]"]
-      %% Missing NodePath
     54["Segment<br>[2148, 2155, 2]"]
-      %% Missing NodePath
     148[Solid2d]
   end
   subgraph path21 [Path]
     21["Path<br>[2298, 2335, 2]"]
-      %% Missing NodePath
     55["Segment<br>[2341, 2372, 2]"]
-      %% Missing NodePath
     56["Segment<br>[2378, 2411, 2]"]
-      %% Missing NodePath
     57["Segment<br>[2417, 2449, 2]"]
-      %% Missing NodePath
     58["Segment<br>[2455, 2462, 2]"]
-      %% Missing NodePath
     138[Solid2d]
   end
   subgraph path22 [Path]
     22["Path<br>[496, 550, 3]"]
-      %% Missing NodePath
     59["Segment<br>[556, 583, 3]"]
-      %% Missing NodePath
     60["Segment<br>[589, 618, 3]"]
-      %% Missing NodePath
     61["Segment<br>[624, 652, 3]"]
-      %% Missing NodePath
     62["Segment<br>[658, 714, 3]"]
-      %% Missing NodePath
     63["Segment<br>[720, 727, 3]"]
-      %% Missing NodePath
     135[Solid2d]
   end
   subgraph path23 [Path]
     23["Path<br>[1000, 1047, 3]"]
-      %% Missing NodePath
     64["Segment<br>[1053, 1094, 3]"]
-      %% Missing NodePath
     65["Segment<br>[1100, 1142, 3]"]
-      %% Missing NodePath
     66["Segment<br>[1148, 1190, 3]"]
-      %% Missing NodePath
     67["Segment<br>[1196, 1203, 3]"]
-      %% Missing NodePath
     146[Solid2d]
   end
   subgraph path24 [Path]
     24["Path<br>[1461, 1612, 3]"]
-      %% Missing NodePath
     68["Segment<br>[1618, 1694, 3]"]
-      %% Missing NodePath
     69["Segment<br>[1700, 1853, 3]"]
-      %% Missing NodePath
     70["Segment<br>[1859, 1935, 3]"]
-      %% Missing NodePath
     71["Segment<br>[1941, 2097, 3]"]
-      %% Missing NodePath
     72["Segment<br>[2103, 2180, 3]"]
-      %% Missing NodePath
     73["Segment<br>[2186, 2341, 3]"]
-      %% Missing NodePath
     74["Segment<br>[2347, 2423, 3]"]
-      %% Missing NodePath
     75["Segment<br>[2429, 2436, 3]"]
-      %% Missing NodePath
     133[Solid2d]
   end
   subgraph path25 [Path]
     25["Path<br>[123, 210, 4]"]
-      %% Missing NodePath
     76["Segment<br>[218, 247, 4]"]
-      %% Missing NodePath
     77["Segment<br>[255, 283, 4]"]
-      %% Missing NodePath
     78["Segment<br>[291, 369, 4]"]
-      %% Missing NodePath
     79["Segment<br>[377, 424, 4]"]
-      %% Missing NodePath
     80["Segment<br>[432, 460, 4]"]
-      %% Missing NodePath
     81["Segment<br>[468, 497, 4]"]
-      %% Missing NodePath
     82["Segment<br>[505, 534, 4]"]
-      %% Missing NodePath
     83["Segment<br>[542, 608, 4]"]
-      %% Missing NodePath
     84["Segment<br>[616, 644, 4]"]
-      %% Missing NodePath
     85["Segment<br>[652, 681, 4]"]
-      %% Missing NodePath
     86["Segment<br>[689, 751, 4]"]
-      %% Missing NodePath
     87["Segment<br>[759, 787, 4]"]
-      %% Missing NodePath
     88["Segment<br>[795, 829, 4]"]
-      %% Missing NodePath
     89["Segment<br>[837, 867, 4]"]
-      %% Missing NodePath
     90["Segment<br>[875, 943, 4]"]
-      %% Missing NodePath
     91["Segment<br>[951, 958, 4]"]
-      %% Missing NodePath
     136[Solid2d]
   end
   subgraph path26 [Path]
     26["Path<br>[1092, 1190, 4]"]
-      %% Missing NodePath
     92["Segment<br>[1198, 1276, 4]"]
-      %% Missing NodePath
     95["Segment<br>[1284, 1331, 4]"]
-      %% Missing NodePath
     97["Segment<br>[1339, 1419, 4]"]
-      %% Missing NodePath
     99["Segment<br>[1427, 1434, 4]"]
-      %% Missing NodePath
     147[Solid2d]
   end
   subgraph path27 [Path]
     27["Path<br>[1092, 1190, 4]"]
-      %% Missing NodePath
     93["Segment<br>[1198, 1276, 4]"]
-      %% Missing NodePath
     94["Segment<br>[1284, 1331, 4]"]
-      %% Missing NodePath
     96["Segment<br>[1339, 1419, 4]"]
-      %% Missing NodePath
     98["Segment<br>[1427, 1434, 4]"]
-      %% Missing NodePath
     152[Solid2d]
   end
   subgraph path28 [Path]
     28["Path<br>[1531, 1628, 4]"]
-      %% Missing NodePath
     101["Segment<br>[1636, 1714, 4]"]
-      %% Missing NodePath
     103["Segment<br>[1722, 1770, 4]"]
-      %% Missing NodePath
     104["Segment<br>[1778, 1858, 4]"]
-      %% Missing NodePath
     106["Segment<br>[1866, 1873, 4]"]
-      %% Missing NodePath
     139[Solid2d]
   end
   subgraph path29 [Path]
     29["Path<br>[1531, 1628, 4]"]
-      %% Missing NodePath
     100["Segment<br>[1636, 1714, 4]"]
-      %% Missing NodePath
     102["Segment<br>[1722, 1770, 4]"]
-      %% Missing NodePath
     105["Segment<br>[1778, 1858, 4]"]
-      %% Missing NodePath
     107["Segment<br>[1866, 1873, 4]"]
-      %% Missing NodePath
     142[Solid2d]
   end
   subgraph path30 [Path]
     30["Path<br>[348, 434, 5]"]
-      %% Missing NodePath
     108["Segment<br>[440, 473, 5]"]
-      %% Missing NodePath
     109["Segment<br>[479, 514, 5]"]
-      %% Missing NodePath
     110["Segment<br>[520, 554, 5]"]
-      %% Missing NodePath
     111["Segment<br>[560, 567, 5]"]
-      %% Missing NodePath
     134[Solid2d]
   end
   subgraph path31 [Path]
     31["Path<br>[703, 830, 5]"]
-      %% Missing NodePath
     150[Solid2d]
   end
   subgraph path32 [Path]
     32["Path<br>[279, 372, 6]"]
-      %% Missing NodePath
     112["Segment<br>[378, 427, 6]"]
-      %% Missing NodePath
     113["Segment<br>[433, 483, 6]"]
-      %% Missing NodePath
     114["Segment<br>[489, 539, 6]"]
-      %% Missing NodePath
     115["Segment<br>[545, 563, 6]"]
-      %% Missing NodePath
     151[Solid2d]
   end
   subgraph path33 [Path]
     33["Path<br>[333, 400, 7]"]
-      %% Missing NodePath
     116["Segment<br>[333, 400, 7]"]
-      %% Missing NodePath
     144[Solid2d]
   end
   subgraph path34 [Path]
     34["Path<br>[416, 441, 8]"]
-      %% Missing NodePath
     120["Segment<br>[449, 507, 8]"]
-      %% Missing NodePath
     122["Segment<br>[515, 574, 8]"]
-      %% Missing NodePath
     125["Segment<br>[582, 625, 8]"]
-      %% Missing NodePath
     130["Segment<br>[633, 640, 8]"]
-      %% Missing NodePath
     140[Solid2d]
   end
   subgraph path35 [Path]
     35["Path<br>[416, 441, 8]"]
-      %% Missing NodePath
     117["Segment<br>[449, 507, 8]"]
-      %% Missing NodePath
     123["Segment<br>[515, 574, 8]"]
-      %% Missing NodePath
     128["Segment<br>[582, 625, 8]"]
-      %% Missing NodePath
     132["Segment<br>[633, 640, 8]"]
-      %% Missing NodePath
     141[Solid2d]
   end
   subgraph path36 [Path]
     36["Path<br>[416, 441, 8]"]
-      %% Missing NodePath
     118["Segment<br>[449, 507, 8]"]
-      %% Missing NodePath
     121["Segment<br>[515, 574, 8]"]
-      %% Missing NodePath
     127["Segment<br>[582, 625, 8]"]
-      %% Missing NodePath
     129["Segment<br>[633, 640, 8]"]
-      %% Missing NodePath
     143[Solid2d]
   end
   subgraph path37 [Path]
     37["Path<br>[416, 441, 8]"]
-      %% Missing NodePath
     119["Segment<br>[449, 507, 8]"]
-      %% Missing NodePath
     124["Segment<br>[515, 574, 8]"]
-      %% Missing NodePath
     126["Segment<br>[582, 625, 8]"]
-      %% Missing NodePath
     131["Segment<br>[633, 640, 8]"]
-      %% Missing NodePath
     145[Solid2d]
   end
   1["Plane<br>[386, 403, 2]"]
-    %% Missing NodePath
   2["Plane<br>[473, 490, 3]"]
-    %% Missing NodePath
   3["Plane<br>[977, 994, 3]"]
-    %% Missing NodePath
   4["Plane<br>[1438, 1455, 3]"]
-    %% Missing NodePath
   5["Plane<br>[2587, 2604, 3]"]
-    %% Missing NodePath
   6["Plane<br>[2684, 2701, 3]"]
-    %% Missing NodePath
   7["Plane<br>[2783, 2800, 3]"]
-    %% Missing NodePath
   8["Plane<br>[2881, 2898, 3]"]
-    %% Missing NodePath
   9["Plane<br>[2979, 2996, 3]"]
-    %% Missing NodePath
   10["Plane<br>[325, 342, 5]"]
-    %% Missing NodePath
   11["Plane<br>[614, 653, 5]"]
-    %% Missing NodePath
   12["Plane<br>[256, 273, 6]"]
-    %% Missing NodePath
   13["Plane<br>[310, 327, 7]"]
-    %% Missing NodePath
   14["Plane<br>[391, 408, 8]"]
-    %% Missing NodePath
   15["Plane<br>[391, 408, 8]"]
-    %% Missing NodePath
   16["Plane<br>[391, 408, 8]"]
-    %% Missing NodePath
   17["Plane<br>[391, 408, 8]"]
-    %% Missing NodePath
   153["Sweep Extrusion<br>[621, 651, 2]"]
-    %% Missing NodePath
   154["Sweep Extrusion<br>[1767, 1810, 2]"]
-    %% Missing NodePath
   155["Sweep Extrusion<br>[2169, 2212, 2]"]
-    %% Missing NodePath
   156["Sweep Extrusion<br>[2464, 2497, 2]"]
-    %% Missing NodePath
   157["Sweep Extrusion<br>[3037, 3068, 3]"]
-    %% Missing NodePath
   158["Sweep Loft<br>[994, 1037, 5]"]
-    %% Missing NodePath
   159["Sweep Extrusion<br>[609, 661, 6]"]
-    %% Missing NodePath
   160["Sweep Extrusion<br>[406, 437, 7]"]
-    %% Missing NodePath
   161["Sweep Extrusion<br>[652, 699, 8]"]
-    %% Missing NodePath
   162["Sweep Extrusion<br>[652, 699, 8]"]
-    %% Missing NodePath
   163["Sweep Extrusion<br>[652, 699, 8]"]
-    %% Missing NodePath
   164["Sweep Extrusion<br>[652, 699, 8]"]
-    %% Missing NodePath
   165[Wall]
     %% face_code_ref=Missing NodePath
   166[Wall]
@@ -603,39 +459,22 @@ flowchart LR
   343["SweepEdge Adjacent"]
   344["SweepEdge Adjacent"]
   345["EdgeCut Chamfer<br>[657, 888, 2]"]
-    %% Missing NodePath
   346["EdgeCut Chamfer<br>[657, 888, 2]"]
-    %% Missing NodePath
   347["EdgeCut Chamfer<br>[657, 888, 2]"]
-    %% Missing NodePath
   348["EdgeCut Chamfer<br>[657, 888, 2]"]
-    %% Missing NodePath
   349["EdgeCut Fillet<br>[667, 873, 6]"]
-    %% Missing NodePath
   350["EdgeCut Fillet<br>[667, 873, 6]"]
-    %% Missing NodePath
   351["EdgeCut Fillet<br>[667, 873, 6]"]
-    %% Missing NodePath
   352["EdgeCut Fillet<br>[667, 873, 6]"]
-    %% Missing NodePath
   353["EdgeCut Fillet<br>[443, 512, 7]"]
-    %% Missing NodePath
   354["EdgeCut Chamfer<br>[707, 853, 8]"]
-    %% Missing NodePath
   355["EdgeCut Chamfer<br>[707, 853, 8]"]
-    %% Missing NodePath
   356["EdgeCut Chamfer<br>[707, 853, 8]"]
-    %% Missing NodePath
   357["EdgeCut Chamfer<br>[707, 853, 8]"]
-    %% Missing NodePath
   358["EdgeCut Chamfer<br>[707, 853, 8]"]
-    %% Missing NodePath
   359["EdgeCut Chamfer<br>[707, 853, 8]"]
-    %% Missing NodePath
   360["EdgeCut Chamfer<br>[707, 853, 8]"]
-    %% Missing NodePath
   361["EdgeCut Chamfer<br>[707, 853, 8]"]
-    %% Missing NodePath
   1 --- 18
   2 --- 22
   3 --- 23

--- a/rust/kcl-lib/tests/module_return_using_var/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/module_return_using_var/artifact_graph_flowchart.snap.md
@@ -2,23 +2,15 @@
 flowchart LR
   subgraph path2 [Path]
     2["Path<br>[80, 105, 1]"]
-      %% Missing NodePath
     3["Segment<br>[111, 128, 1]"]
-      %% Missing NodePath
     4["Segment<br>[134, 151, 1]"]
-      %% Missing NodePath
     5["Segment<br>[157, 175, 1]"]
-      %% Missing NodePath
     6["Segment<br>[181, 199, 1]"]
-      %% Missing NodePath
     7["Segment<br>[205, 213, 1]"]
-      %% Missing NodePath
     8[Solid2d]
   end
   1["Plane<br>[57, 74, 1]"]
-    %% Missing NodePath
   9["Sweep Extrusion<br>[219, 238, 1]"]
-    %% Missing NodePath
   10[Wall]
     %% face_code_ref=Missing NodePath
   11[Wall]

--- a/rust/kcl-lib/tests/pattern_circular_in_module/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/pattern_circular_in_module/artifact_graph_flowchart.snap.md
@@ -2,50 +2,30 @@
 flowchart LR
   subgraph path3 [Path]
     3["Path<br>[63, 90, 1]"]
-      %% Missing NodePath
     5["Segment<br>[98, 116, 1]"]
-      %% Missing NodePath
     7["Segment<br>[124, 143, 1]"]
-      %% Missing NodePath
     9["Segment<br>[151, 170, 1]"]
-      %% Missing NodePath
     12["Segment<br>[178, 185, 1]"]
-      %% Missing NodePath
     13[Solid2d]
   end
   subgraph path4 [Path]
     4["Path<br>[63, 90, 1]"]
-      %% Missing NodePath
     6["Segment<br>[98, 116, 1]"]
-      %% Missing NodePath
     8["Segment<br>[124, 143, 1]"]
-      %% Missing NodePath
     10["Segment<br>[151, 170, 1]"]
-      %% Missing NodePath
     11["Segment<br>[178, 185, 1]"]
-      %% Missing NodePath
     14[Solid2d]
   end
   1["Plane<br>[38, 55, 1]"]
-    %% Missing NodePath
   2["Plane<br>[38, 55, 1]"]
-    %% Missing NodePath
   15["Sweep Extrusion<br>[342, 376, 1]"]
-    %% Missing NodePath
   16["Sweep Extrusion<br>[342, 376, 1]"]
-    %% Missing NodePath
   17["Sweep Extrusion<br>[342, 376, 1]"]
-    %% Missing NodePath
   18["Sweep Extrusion<br>[342, 376, 1]"]
-    %% Missing NodePath
   19["Sweep Extrusion<br>[342, 376, 1]"]
-    %% Missing NodePath
   20["Sweep Extrusion<br>[342, 376, 1]"]
-    %% Missing NodePath
   21["Sweep Extrusion<br>[342, 376, 1]"]
-    %% Missing NodePath
   22["Sweep Extrusion<br>[342, 376, 1]"]
-    %% Missing NodePath
   23[Wall]
     %% face_code_ref=Missing NodePath
   24[Wall]

--- a/rust/kcl-lib/tests/pattern_linear_in_module/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/pattern_linear_in_module/artifact_graph_flowchart.snap.md
@@ -2,50 +2,30 @@
 flowchart LR
   subgraph path3 [Path]
     3["Path<br>[54, 89, 1]"]
-      %% Missing NodePath
     5["Segment<br>[54, 89, 1]"]
-      %% Missing NodePath
     7[Solid2d]
   end
   subgraph path4 [Path]
     4["Path<br>[54, 89, 1]"]
-      %% Missing NodePath
     6["Segment<br>[54, 89, 1]"]
-      %% Missing NodePath
     8[Solid2d]
   end
   1["Plane<br>[29, 46, 1]"]
-    %% Missing NodePath
   2["Plane<br>[29, 46, 1]"]
-    %% Missing NodePath
   9["Sweep Extrusion<br>[200, 219, 1]"]
-    %% Missing NodePath
   10["Sweep Extrusion<br>[200, 219, 1]"]
-    %% Missing NodePath
   11["Sweep Extrusion<br>[200, 219, 1]"]
-    %% Missing NodePath
   12["Sweep Extrusion<br>[200, 219, 1]"]
-    %% Missing NodePath
   13["Sweep Extrusion<br>[200, 219, 1]"]
-    %% Missing NodePath
   14["Sweep Extrusion<br>[200, 219, 1]"]
-    %% Missing NodePath
   15["Sweep Extrusion<br>[200, 219, 1]"]
-    %% Missing NodePath
   16["Sweep Extrusion<br>[200, 219, 1]"]
-    %% Missing NodePath
   17["Sweep Extrusion<br>[200, 219, 1]"]
-    %% Missing NodePath
   18["Sweep Extrusion<br>[200, 219, 1]"]
-    %% Missing NodePath
   19["Sweep Extrusion<br>[200, 219, 1]"]
-    %% Missing NodePath
   20["Sweep Extrusion<br>[200, 219, 1]"]
-    %% Missing NodePath
   21["Sweep Extrusion<br>[200, 219, 1]"]
-    %% Missing NodePath
   22["Sweep Extrusion<br>[200, 219, 1]"]
-    %% Missing NodePath
   23[Wall]
     %% face_code_ref=Missing NodePath
   24[Wall]


### PR DESCRIPTION
We don't support editing geometry generated in other modules. So these aren't actually a problem.