### PR TITLE
Remove remaining links to nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ The 3D view in Design Studio is just a video stream from our hosted geometry eng
 
 We recommend downloading the latest application binary from our [releases](https://github.com/KittyCAD/modeling-app/releases) page. If you don't see your platform or architecture supported there, please file an issue.
 
-If you'd like to try out upcoming changes sooner, you can also download those from our [nightly releases](https://zoo.dev/modeling-app/download/nightly) page.
-
 ## Developing
 
 Finally, if you'd like to run a development build or contribute to the project, please visit our [contributor guide](CONTRIBUTING.md) to get started.

--- a/src/components/Settings/AllSettingsFields.tsx
+++ b/src/components/Settings/AllSettingsFields.tsx
@@ -30,7 +30,7 @@ import {
   settingsActor,
   useSettings,
 } from '@src/lib/singletons'
-import { APP_VERSION, IS_NIGHTLY, getReleaseUrl } from '@src/routes/utils'
+import { APP_VERSION, getReleaseUrl } from '@src/routes/utils'
 import {
   acceptOnboarding,
   catchOnboardingWarnError,
@@ -276,25 +276,6 @@ export const AllSettingsFields = forwardRef(
               , and start a discussion if you don't see it! Your feedback will
               help us prioritize what to build next.
             </p>
-            {!IS_NIGHTLY && (
-              <p className="max-w-2xl mt-6">
-                Want to experience the latest and (hopefully) greatest from our
-                main development branch?{' '}
-                <a
-                  onClick={openExternalBrowserIfDesktop(
-                    'https://zoo.dev/modeling-app/download/nightly'
-                  )}
-                  href="https://zoo.dev/modeling-app/download/nightly"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Click here to grab Zoo Design Studio (Nightly)
-                </a>
-                . It can be installed side-by-side with the stable version
-                you're running now. But careful there, a lot less testing is
-                involved in their release 🤖.
-              </p>
-            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Follow-up to link clean up in #7010.

Now that 'nightly' builds are straight from main they can be confusing to regular users stumbling on these links in the wild. 