### PR TITLE
Give a default value to `projectName` in Text-to-CAD Create command to allow invocation through command palette

### DIFF
--- a/src/lib/commandBarConfigs/applicationCommandConfig.ts
+++ b/src/lib/commandBarConfigs/applicationCommandConfig.ts
@@ -150,7 +150,7 @@ export function createApplicationCommands({
         required: (commandsContext) =>
           isDesktop() &&
           commandsContext.argumentsToSubmit.method === 'existingProject',
-        defaultValue: 'browser',
+        defaultValue: isDesktop() ? '' : 'browser',
         skip: true,
         options: (_, _context) => {
           const { folders } = systemIOActor.getSnapshot().context

--- a/src/lib/commandBarConfigs/applicationCommandConfig.ts
+++ b/src/lib/commandBarConfigs/applicationCommandConfig.ts
@@ -150,6 +150,7 @@ export function createApplicationCommands({
         required: (commandsContext) =>
           isDesktop() &&
           commandsContext.argumentsToSubmit.method === 'existingProject',
+        defaultValue: 'browser',
         skip: true,
         options: (_, _context) => {
           const { folders } = systemIOActor.getSnapshot().context

--- a/src/lib/commandBarConfigs/applicationCommandConfig.ts
+++ b/src/lib/commandBarConfigs/applicationCommandConfig.ts
@@ -150,7 +150,7 @@ export function createApplicationCommands({
         required: (commandsContext) =>
           isDesktop() &&
           commandsContext.argumentsToSubmit.method === 'existingProject',
-        defaultValue: isDesktop() ? '' : 'browser',
+        defaultValue: isDesktop() ? undefined : 'browser',
         skip: true,
         options: (_, _context) => {
           const { folders } = systemIOActor.getSnapshot().context


### PR DESCRIPTION
This argument is hidden since it's marked as skip, so browser users who must now invoke the command through the command palette have no way of setting the value. Since it is also required, the command palette fails silently on submission (which we need to fix more broadly). This gives it a default value so that users can submit properly.