### PR TITLE
Update snapshots on CI

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -147,7 +147,7 @@ jobs:
         uses: nick-fields/retry@v3.0.2
         with:
           shell: bash
-          command: npm run test:snapshots
+          command: npm run test:snapshots -- --update-snapshots
           timeout_minutes: 5
           max_attempts: 5
         env:
@@ -173,7 +173,7 @@ jobs:
         id: git-check
         run: |
             git add e2e/playwright/snapshot-tests.spec.ts-snapshots e2e/playwright/snapshots
-            if git status | grep -q "Changes to be committed"
+            if git status | grep --quiet "Changes to be committed"
             then echo "modified=true" >> $GITHUB_OUTPUT
             else echo "modified=false" >> $GITHUB_OUTPUT
             fi


### PR DESCRIPTION
This change is needed for https://github.com/KittyCAD/modeling-app/pull/6960 to actually work.

If we don't do this, we should instead removed the unused steps via https://github.com/KittyCAD/modeling-app/pull/7074.