### PR TITLE
Change Sketch to use the units of the module

### DIFF
--- a/rust/kcl-lib/src/std/sketch.rs
+++ b/rust/kcl-lib/src/std/sketch.rs
@@ -26,7 +26,7 @@ use crate::{
         args::{Args, TyF64},
         utils::{
             arc_center_and_end, get_tangential_arc_to_info, get_x_component, get_y_component,
-            intersection_with_parallel_line, point_to_len_unit, point_to_mm, untype_point, untyped_point_to_mm,
+            intersection_with_parallel_line, point_to_len_unit, point_to_mm, untyped_point_to_mm,
             TangentialArcInfoInput,
         },
     },
@@ -1396,12 +1396,14 @@ pub(crate) async fn inner_start_profile(
     ])
     .await?;
 
-    let (to, ty) = untype_point(at);
+    // Convert to the units of the module.  This is what the frontend expects.
+    let units = exec_state.length_unit();
+    let to = point_to_len_unit(at, units);
     let current_path = BasePath {
         from: to,
         to,
         tag: tag.clone(),
-        units: ty.expect_length(),
+        units,
         geo_meta: GeoMeta {
             id: move_pen_id,
             metadata: args.source_range.into(),
@@ -1414,7 +1416,7 @@ pub(crate) async fn inner_start_profile(
         artifact_id: path_id.into(),
         on: sketch_surface.clone(),
         paths: vec![],
-        units: ty.expect_length(),
+        units,
         mirror: Default::default(),
         meta: vec![args.source_range.into()],
         tags: if let Some(tag) = &tag {

--- a/rust/kcl-lib/tests/kcl_samples/helium-tank/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/helium-tank/artifact_commands.snap
@@ -203,7 +203,7 @@ description: Artifact commands helium-tank.kcl
       "path": "[uuid]",
       "segment": {
         "type": "tangential_arc",
-        "radius": 95.88500000000016,
+        "radius": 95.8850000000001,
         "offset": {
           "unit": "degrees",
           "value": -90.0

--- a/rust/kcl-lib/tests/kcl_samples/helium-tank/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/helium-tank/program_memory.snap
@@ -1078,15 +1078,15 @@ description: Variables in memory after executing helium-tank.kcl
         },
         "start": {
           "from": [
-            0.1771,
-            1.675
+            2.125,
+            20.1
           ],
           "to": [
-            0.1771,
-            1.675
+            2.125,
+            20.1
           ],
           "units": {
-            "type": "Feet"
+            "type": "Inches"
           },
           "tag": null,
           "__geoMeta": {
@@ -1097,14 +1097,14 @@ description: Variables in memory after executing helium-tank.kcl
         "artifactId": "[uuid]",
         "originalId": "[uuid]",
         "units": {
-          "type": "Feet"
+          "type": "Inches"
         }
       },
-      "height": -0.4166666666666667,
+      "height": -5.0,
       "startCapId": "[uuid]",
       "endCapId": "[uuid]",
       "units": {
-        "type": "Feet"
+        "type": "Inches"
       },
       "sectional": false
     }
@@ -1573,17 +1573,17 @@ description: Variables in memory after executing helium-tank.kcl
               "sourceRange": []
             },
             "from": [
-              0.0521,
-              2.5
+              0.625,
+              30.0
             ],
             "tag": null,
             "to": [
-              0.0521,
-              2.45
+              0.625,
+              29.4
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Feet"
+              "type": "Inches"
             }
           },
           {
@@ -1592,17 +1592,17 @@ description: Variables in memory after executing helium-tank.kcl
               "sourceRange": []
             },
             "from": [
-              0.0521,
-              2.45
+              0.625,
+              29.4
             ],
             "tag": null,
             "to": [
-              0.0604,
-              2.45
+              0.725,
+              29.4
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Feet"
+              "type": "Inches"
             }
           },
           {
@@ -1612,21 +1612,21 @@ description: Variables in memory after executing helium-tank.kcl
             },
             "ccw": false,
             "center": [
-              0.0604,
-              2.4417
+              0.725,
+              29.3
             ],
             "from": [
-              0.0604,
-              2.45
+              0.725,
+              29.4
             ],
             "tag": null,
             "to": [
-              0.0682,
-              2.4388
+              0.819,
+              29.2658
             ],
             "type": "TangentialArc",
             "units": {
-              "type": "Feet"
+              "type": "Inches"
             }
           },
           {
@@ -1636,21 +1636,21 @@ description: Variables in memory after executing helium-tank.kcl
             },
             "ccw": true,
             "center": [
-              0.1152,
-              2.4217
+              1.3828,
+              29.0606
             ],
             "from": [
-              0.0682,
-              2.4388
+              0.819,
+              29.2658
             ],
             "tag": null,
             "to": [
-              0.0682,
-              2.4046
+              0.819,
+              28.8554
             ],
             "type": "TangentialArc",
             "units": {
-              "type": "Feet"
+              "type": "Inches"
             }
           },
           {
@@ -1660,21 +1660,21 @@ description: Variables in memory after executing helium-tank.kcl
             },
             "ccw": false,
             "center": [
-              0.0604,
-              2.4018
+              0.725,
+              28.8212
             ],
             "from": [
-              0.0682,
-              2.4046
+              0.819,
+              28.8554
             ],
             "tag": null,
             "to": [
-              0.0604,
-              2.3934
+              0.725,
+              28.7212
             ],
             "type": "TangentialArc",
             "units": {
-              "type": "Feet"
+              "type": "Inches"
             }
           },
           {
@@ -1684,21 +1684,21 @@ description: Variables in memory after executing helium-tank.kcl
             },
             "ccw": true,
             "center": [
-              0.0604,
-              2.3851
+              0.725,
+              28.6212
             ],
             "from": [
-              0.0604,
-              2.3934
+              0.725,
+              28.7212
             ],
             "tag": null,
             "to": [
-              0.0604,
-              2.3768
+              0.725,
+              28.5212
             ],
             "type": "TangentialArc",
             "units": {
-              "type": "Feet"
+              "type": "Inches"
             }
           },
           {
@@ -1708,12 +1708,12 @@ description: Variables in memory after executing helium-tank.kcl
             },
             "ccw": false,
             "center": [
-              0.0604,
-              2.0622
+              0.725,
+              24.7462
             ],
             "from": [
-              0.0604,
-              2.3768
+              0.725,
+              28.5212
             ],
             "tag": {
               "commentStart": 843,
@@ -1723,12 +1723,12 @@ description: Variables in memory after executing helium-tank.kcl
               "value": "seg01"
             },
             "to": [
-              0.375,
-              2.0622
+              4.5,
+              24.7462
             ],
             "type": "TangentialArc",
             "units": {
-              "type": "Feet"
+              "type": "Inches"
             }
           },
           {
@@ -1737,8 +1737,8 @@ description: Variables in memory after executing helium-tank.kcl
               "sourceRange": []
             },
             "from": [
-              0.375,
-              2.0622
+              4.5,
+              24.7462
             ],
             "tag": {
               "commentStart": 922,
@@ -1748,12 +1748,12 @@ description: Variables in memory after executing helium-tank.kcl
               "value": "seg09"
             },
             "to": [
-              0.375,
-              0.125
+              4.5,
+              1.5
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Feet"
+              "type": "Inches"
             }
           },
           {
@@ -1763,12 +1763,12 @@ description: Variables in memory after executing helium-tank.kcl
             },
             "ccw": false,
             "center": [
-              0.2083,
-              0.125
+              2.5,
+              1.5
             ],
             "from": [
-              0.375,
-              0.125
+              4.5,
+              1.5
             ],
             "tag": {
               "commentStart": 980,
@@ -1778,12 +1778,12 @@ description: Variables in memory after executing helium-tank.kcl
               "value": "seg02"
             },
             "to": [
-              0.2083,
-              -0.0417
+              2.5,
+              -0.5
             ],
             "type": "TangentialArc",
             "units": {
-              "type": "Feet"
+              "type": "Inches"
             }
           },
           {
@@ -1792,8 +1792,8 @@ description: Variables in memory after executing helium-tank.kcl
               "sourceRange": []
             },
             "from": [
-              0.2083,
-              -0.0417
+              2.5,
+              -0.5
             ],
             "tag": {
               "commentStart": 1061,
@@ -1803,12 +1803,12 @@ description: Variables in memory after executing helium-tank.kcl
               "value": "seg08"
             },
             "to": [
-              0.0001,
-              -0.0417
+              0.001,
+              -0.5
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Feet"
+              "type": "Inches"
             }
           },
           {
@@ -1817,17 +1817,17 @@ description: Variables in memory after executing helium-tank.kcl
               "sourceRange": []
             },
             "from": [
-              0.0001,
-              -0.0417
+              0.001,
+              -0.5
             ],
             "tag": null,
             "to": [
-              0.0001,
-              -0.0312
+              0.001,
+              -0.375
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Feet"
+              "type": "Inches"
             }
           },
           {
@@ -1836,17 +1836,17 @@ description: Variables in memory after executing helium-tank.kcl
               "sourceRange": []
             },
             "from": [
-              0.0001,
-              -0.0312
+              0.001,
+              -0.375
             ],
             "tag": null,
             "to": [
-              0.2083,
-              -0.0312
+              2.5,
+              -0.375
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Feet"
+              "type": "Inches"
             }
           },
           {
@@ -1856,21 +1856,21 @@ description: Variables in memory after executing helium-tank.kcl
             },
             "ccw": true,
             "center": [
-              0.2083,
-              0.125
+              2.5,
+              1.5
             ],
             "from": [
-              0.2083,
-              -0.0312
+              2.5,
+              -0.375
             ],
             "tag": null,
             "to": [
-              0.3646,
-              0.125
+              4.375,
+              1.5
             ],
             "type": "TangentialArc",
             "units": {
-              "type": "Feet"
+              "type": "Inches"
             }
           },
           {
@@ -1879,17 +1879,17 @@ description: Variables in memory after executing helium-tank.kcl
               "sourceRange": []
             },
             "from": [
-              0.3646,
-              0.125
+              4.375,
+              1.5
             ],
             "tag": null,
             "to": [
-              0.3646,
-              2.0622
+              4.375,
+              24.7462
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Feet"
+              "type": "Inches"
             }
           },
           {
@@ -1899,21 +1899,21 @@ description: Variables in memory after executing helium-tank.kcl
             },
             "ccw": true,
             "center": [
-              0.1083,
-              2.0622
+              1.3,
+              24.7462
             ],
             "from": [
-              0.3646,
-              2.0622
+              4.375,
+              24.7462
             ],
             "tag": null,
             "to": [
-              0.1083,
-              2.3184
+              1.3,
+              27.8212
             ],
             "type": "TangentialArc",
             "units": {
-              "type": "Feet"
+              "type": "Inches"
             }
           },
           {
@@ -1922,17 +1922,17 @@ description: Variables in memory after executing helium-tank.kcl
               "sourceRange": []
             },
             "from": [
-              0.1083,
-              2.3184
+              1.3,
+              27.8212
             ],
             "tag": null,
             "to": [
-              0.0438,
-              2.3184
+              0.525,
+              27.8212
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Feet"
+              "type": "Inches"
             }
           },
           {
@@ -1941,17 +1941,17 @@ description: Variables in memory after executing helium-tank.kcl
               "sourceRange": []
             },
             "from": [
-              0.0438,
-              2.3184
+              0.525,
+              27.8212
             ],
             "tag": null,
             "to": [
-              0.0438,
-              2.5
+              0.525,
+              30.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Feet"
+              "type": "Inches"
             }
           },
           {
@@ -1960,17 +1960,17 @@ description: Variables in memory after executing helium-tank.kcl
               "sourceRange": []
             },
             "from": [
-              0.0438,
-              2.5
+              0.525,
+              30.0
             ],
             "tag": null,
             "to": [
-              0.0521,
-              2.5
+              0.625,
+              30.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Feet"
+              "type": "Inches"
             }
           },
           {
@@ -1979,17 +1979,17 @@ description: Variables in memory after executing helium-tank.kcl
               "sourceRange": []
             },
             "from": [
-              0.0521,
-              2.5
+              0.625,
+              30.0
             ],
             "tag": null,
             "to": [
-              0.0521,
-              2.5
+              0.625,
+              30.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Feet"
+              "type": "Inches"
             }
           }
         ],
@@ -2025,15 +2025,15 @@ description: Variables in memory after executing helium-tank.kcl
         },
         "start": {
           "from": [
-            0.0521,
-            2.5
+            0.625,
+            30.0
           ],
           "to": [
-            0.0521,
-            2.5
+            0.625,
+            30.0
           ],
           "units": {
-            "type": "Feet"
+            "type": "Inches"
           },
           "tag": null,
           "__geoMeta": {
@@ -2062,14 +2062,14 @@ description: Variables in memory after executing helium-tank.kcl
         "artifactId": "[uuid]",
         "originalId": "[uuid]",
         "units": {
-          "type": "Feet"
+          "type": "Inches"
         }
       },
       "height": 0.0,
       "startCapId": "[uuid]",
       "endCapId": "[uuid]",
       "units": {
-        "type": "Feet"
+        "type": "Inches"
       },
       "sectional": false
     }
@@ -2086,17 +2086,17 @@ description: Variables in memory after executing helium-tank.kcl
             "sourceRange": []
           },
           "from": [
-            0.0521,
-            2.5
+            0.625,
+            30.0
           ],
           "tag": null,
           "to": [
-            0.0521,
-            2.45
+            0.625,
+            29.4
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Feet"
+            "type": "Inches"
           }
         },
         {
@@ -2105,17 +2105,17 @@ description: Variables in memory after executing helium-tank.kcl
             "sourceRange": []
           },
           "from": [
-            0.0521,
-            2.45
+            0.625,
+            29.4
           ],
           "tag": null,
           "to": [
-            0.0604,
-            2.45
+            0.725,
+            29.4
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Feet"
+            "type": "Inches"
           }
         },
         {
@@ -2125,21 +2125,21 @@ description: Variables in memory after executing helium-tank.kcl
           },
           "ccw": false,
           "center": [
-            0.0604,
-            2.4417
+            0.725,
+            29.3
           ],
           "from": [
-            0.0604,
-            2.45
+            0.725,
+            29.4
           ],
           "tag": null,
           "to": [
-            0.0682,
-            2.4388
+            0.819,
+            29.2658
           ],
           "type": "TangentialArc",
           "units": {
-            "type": "Feet"
+            "type": "Inches"
           }
         },
         {
@@ -2149,21 +2149,21 @@ description: Variables in memory after executing helium-tank.kcl
           },
           "ccw": true,
           "center": [
-            0.1152,
-            2.4217
+            1.3828,
+            29.0606
           ],
           "from": [
-            0.0682,
-            2.4388
+            0.819,
+            29.2658
           ],
           "tag": null,
           "to": [
-            0.0682,
-            2.4046
+            0.819,
+            28.8554
           ],
           "type": "TangentialArc",
           "units": {
-            "type": "Feet"
+            "type": "Inches"
           }
         },
         {
@@ -2173,21 +2173,21 @@ description: Variables in memory after executing helium-tank.kcl
           },
           "ccw": false,
           "center": [
-            0.0604,
-            2.4018
+            0.725,
+            28.8212
           ],
           "from": [
-            0.0682,
-            2.4046
+            0.819,
+            28.8554
           ],
           "tag": null,
           "to": [
-            0.0604,
-            2.3934
+            0.725,
+            28.7212
           ],
           "type": "TangentialArc",
           "units": {
-            "type": "Feet"
+            "type": "Inches"
           }
         },
         {
@@ -2197,21 +2197,21 @@ description: Variables in memory after executing helium-tank.kcl
           },
           "ccw": true,
           "center": [
-            0.0604,
-            2.3851
+            0.725,
+            28.6212
           ],
           "from": [
-            0.0604,
-            2.3934
+            0.725,
+            28.7212
           ],
           "tag": null,
           "to": [
-            0.0604,
-            2.3768
+            0.725,
+            28.5212
           ],
           "type": "TangentialArc",
           "units": {
-            "type": "Feet"
+            "type": "Inches"
           }
         },
         {
@@ -2221,12 +2221,12 @@ description: Variables in memory after executing helium-tank.kcl
           },
           "ccw": false,
           "center": [
-            0.0604,
-            2.0622
+            0.725,
+            24.7462
           ],
           "from": [
-            0.0604,
-            2.3768
+            0.725,
+            28.5212
           ],
           "tag": {
             "commentStart": 843,
@@ -2236,12 +2236,12 @@ description: Variables in memory after executing helium-tank.kcl
             "value": "seg01"
           },
           "to": [
-            0.375,
-            2.0622
+            4.5,
+            24.7462
           ],
           "type": "TangentialArc",
           "units": {
-            "type": "Feet"
+            "type": "Inches"
           }
         },
         {
@@ -2250,8 +2250,8 @@ description: Variables in memory after executing helium-tank.kcl
             "sourceRange": []
           },
           "from": [
-            0.375,
-            2.0622
+            4.5,
+            24.7462
           ],
           "tag": {
             "commentStart": 922,
@@ -2261,12 +2261,12 @@ description: Variables in memory after executing helium-tank.kcl
             "value": "seg09"
           },
           "to": [
-            0.375,
-            0.125
+            4.5,
+            1.5
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Feet"
+            "type": "Inches"
           }
         },
         {
@@ -2276,12 +2276,12 @@ description: Variables in memory after executing helium-tank.kcl
           },
           "ccw": false,
           "center": [
-            0.2083,
-            0.125
+            2.5,
+            1.5
           ],
           "from": [
-            0.375,
-            0.125
+            4.5,
+            1.5
           ],
           "tag": {
             "commentStart": 980,
@@ -2291,12 +2291,12 @@ description: Variables in memory after executing helium-tank.kcl
             "value": "seg02"
           },
           "to": [
-            0.2083,
-            -0.0417
+            2.5,
+            -0.5
           ],
           "type": "TangentialArc",
           "units": {
-            "type": "Feet"
+            "type": "Inches"
           }
         },
         {
@@ -2305,8 +2305,8 @@ description: Variables in memory after executing helium-tank.kcl
             "sourceRange": []
           },
           "from": [
-            0.2083,
-            -0.0417
+            2.5,
+            -0.5
           ],
           "tag": {
             "commentStart": 1061,
@@ -2316,12 +2316,12 @@ description: Variables in memory after executing helium-tank.kcl
             "value": "seg08"
           },
           "to": [
-            0.0001,
-            -0.0417
+            0.001,
+            -0.5
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Feet"
+            "type": "Inches"
           }
         },
         {
@@ -2330,17 +2330,17 @@ description: Variables in memory after executing helium-tank.kcl
             "sourceRange": []
           },
           "from": [
-            0.0001,
-            -0.0417
+            0.001,
+            -0.5
           ],
           "tag": null,
           "to": [
-            0.0001,
-            -0.0312
+            0.001,
+            -0.375
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Feet"
+            "type": "Inches"
           }
         },
         {
@@ -2349,17 +2349,17 @@ description: Variables in memory after executing helium-tank.kcl
             "sourceRange": []
           },
           "from": [
-            0.0001,
-            -0.0312
+            0.001,
+            -0.375
           ],
           "tag": null,
           "to": [
-            0.2083,
-            -0.0312
+            2.5,
+            -0.375
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Feet"
+            "type": "Inches"
           }
         },
         {
@@ -2369,21 +2369,21 @@ description: Variables in memory after executing helium-tank.kcl
           },
           "ccw": true,
           "center": [
-            0.2083,
-            0.125
+            2.5,
+            1.5
           ],
           "from": [
-            0.2083,
-            -0.0312
+            2.5,
+            -0.375
           ],
           "tag": null,
           "to": [
-            0.3646,
-            0.125
+            4.375,
+            1.5
           ],
           "type": "TangentialArc",
           "units": {
-            "type": "Feet"
+            "type": "Inches"
           }
         },
         {
@@ -2392,17 +2392,17 @@ description: Variables in memory after executing helium-tank.kcl
             "sourceRange": []
           },
           "from": [
-            0.3646,
-            0.125
+            4.375,
+            1.5
           ],
           "tag": null,
           "to": [
-            0.3646,
-            2.0622
+            4.375,
+            24.7462
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Feet"
+            "type": "Inches"
           }
         },
         {
@@ -2412,21 +2412,21 @@ description: Variables in memory after executing helium-tank.kcl
           },
           "ccw": true,
           "center": [
-            0.1083,
-            2.0622
+            1.3,
+            24.7462
           ],
           "from": [
-            0.3646,
-            2.0622
+            4.375,
+            24.7462
           ],
           "tag": null,
           "to": [
-            0.1083,
-            2.3184
+            1.3,
+            27.8212
           ],
           "type": "TangentialArc",
           "units": {
-            "type": "Feet"
+            "type": "Inches"
           }
         },
         {
@@ -2435,17 +2435,17 @@ description: Variables in memory after executing helium-tank.kcl
             "sourceRange": []
           },
           "from": [
-            0.1083,
-            2.3184
+            1.3,
+            27.8212
           ],
           "tag": null,
           "to": [
-            0.0438,
-            2.3184
+            0.525,
+            27.8212
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Feet"
+            "type": "Inches"
           }
         },
         {
@@ -2454,17 +2454,17 @@ description: Variables in memory after executing helium-tank.kcl
             "sourceRange": []
           },
           "from": [
-            0.0438,
-            2.3184
+            0.525,
+            27.8212
           ],
           "tag": null,
           "to": [
-            0.0438,
-            2.5
+            0.525,
+            30.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Feet"
+            "type": "Inches"
           }
         },
         {
@@ -2473,17 +2473,17 @@ description: Variables in memory after executing helium-tank.kcl
             "sourceRange": []
           },
           "from": [
-            0.0438,
-            2.5
+            0.525,
+            30.0
           ],
           "tag": null,
           "to": [
-            0.0521,
-            2.5
+            0.625,
+            30.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Feet"
+            "type": "Inches"
           }
         },
         {
@@ -2492,17 +2492,17 @@ description: Variables in memory after executing helium-tank.kcl
             "sourceRange": []
           },
           "from": [
-            0.0521,
-            2.5
+            0.625,
+            30.0
           ],
           "tag": null,
           "to": [
-            0.0521,
-            2.5
+            0.625,
+            30.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Feet"
+            "type": "Inches"
           }
         }
       ],
@@ -2538,15 +2538,15 @@ description: Variables in memory after executing helium-tank.kcl
       },
       "start": {
         "from": [
-          0.0521,
-          2.5
+          0.625,
+          30.0
         ],
         "to": [
-          0.0521,
-          2.5
+          0.625,
+          30.0
         ],
         "units": {
-          "type": "Feet"
+          "type": "Inches"
         },
         "tag": null,
         "__geoMeta": {
@@ -2575,7 +2575,7 @@ description: Variables in memory after executing helium-tank.kcl
       "artifactId": "[uuid]",
       "originalId": "[uuid]",
       "units": {
-        "type": "Feet"
+        "type": "Inches"
       }
     }
   },
@@ -2982,15 +2982,15 @@ description: Variables in memory after executing helium-tank.kcl
         },
         "start": {
           "from": [
-            0.0347,
-            2.525
+            0.4167,
+            30.3
           ],
           "to": [
-            0.0347,
-            2.525
+            0.4167,
+            30.3
           ],
           "units": {
-            "type": "Feet"
+            "type": "Inches"
           },
           "tag": null,
           "__geoMeta": {
@@ -3001,14 +3001,14 @@ description: Variables in memory after executing helium-tank.kcl
         "artifactId": "[uuid]",
         "originalId": "[uuid]",
         "units": {
-          "type": "Feet"
+          "type": "Inches"
         }
       },
-      "height": 0.10833333333333334,
+      "height": 1.3,
       "startCapId": "[uuid]",
       "endCapId": "[uuid]",
       "units": {
-        "type": "Feet"
+        "type": "Inches"
       },
       "sectional": false
     }

--- a/rust/kcl-lib/tests/kcl_samples/router-template-cross-bar/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/router-template-cross-bar/artifact_commands.snap
@@ -148,7 +148,7 @@ description: Artifact commands router-template-cross-bar.kcl
       "segment": {
         "type": "line",
         "end": {
-          "x": 22.6312,
+          "x": 22.6313,
           "y": -10.0,
           "z": 0.0
         },
@@ -182,7 +182,7 @@ description: Artifact commands router-template-cross-bar.kcl
       "segment": {
         "type": "line",
         "end": {
-          "x": 32.6312,
+          "x": 32.6313,
           "y": 10.9406,
           "z": 0.0
         },
@@ -199,7 +199,7 @@ description: Artifact commands router-template-cross-bar.kcl
       "segment": {
         "type": "line",
         "end": {
-          "x": 102.6312,
+          "x": 102.6313,
           "y": 10.9406,
           "z": 0.0
         },
@@ -233,7 +233,7 @@ description: Artifact commands router-template-cross-bar.kcl
       "segment": {
         "type": "line",
         "end": {
-          "x": 32.6312,
+          "x": 32.6313,
           "y": 30.9406,
           "z": 0.0
         },
@@ -250,7 +250,7 @@ description: Artifact commands router-template-cross-bar.kcl
       "segment": {
         "type": "line",
         "end": {
-          "x": 32.6312,
+          "x": 32.6313,
           "y": 41.8813,
           "z": 0.0
         },
@@ -284,7 +284,7 @@ description: Artifact commands router-template-cross-bar.kcl
       "segment": {
         "type": "line",
         "end": {
-          "x": -32.6312,
+          "x": -32.6313,
           "y": 0.0,
           "z": 0.0
         },

--- a/rust/kcl-lib/tests/kcl_samples/router-template-cross-bar/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/router-template-cross-bar/program_memory.snap
@@ -237,7 +237,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             },
             "from": [
               0.0,
-              1.2552
+              31.8813
             ],
             "tag": {
               "commentStart": 653,
@@ -247,12 +247,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "value": "seg01"
             },
             "to": [
-              0.4232,
-              1.2552
+              10.75,
+              31.8813
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -262,14 +262,14 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             },
             "ccw": false,
             "center": [
-              0.4232,
-              0.7874
+              10.75,
+              20.0
             ],
             "from": [
-              0.4232,
-              1.2552
+              10.75,
+              31.8813
             ],
-            "radius": 0.46776574803149606,
+            "radius": 11.88125,
             "tag": {
               "commentStart": 763,
               "end": 769,
@@ -278,12 +278,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "value": "seg09"
             },
             "to": [
-              0.891,
-              0.7874
+              22.6313,
+              20.0
             ],
             "type": "Arc",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -292,8 +292,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              0.891,
-              0.7874
+              22.6313,
+              20.0
             ],
             "tag": {
               "commentStart": 829,
@@ -303,12 +303,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "value": "seg03"
             },
             "to": [
-              0.891,
-              -0.3937
+              22.6313,
+              -10.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -317,8 +317,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              0.891,
-              -0.3937
+              22.6313,
+              -10.0
             ],
             "tag": {
               "commentStart": 882,
@@ -328,12 +328,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "value": "seg07"
             },
             "to": [
-              1.2847,
-              -0.3937
+              32.6313,
+              -10.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -342,8 +342,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              1.2847,
-              -0.3937
+              32.6313,
+              -10.0
             ],
             "tag": {
               "commentStart": 984,
@@ -353,12 +353,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "value": "seg02"
             },
             "to": [
-              1.2847,
-              0.4307
+              32.6313,
+              10.9406
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -367,8 +367,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              1.2847,
-              0.4307
+              32.6313,
+              10.9406
             ],
             "tag": {
               "commentStart": 1061,
@@ -378,12 +378,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "value": "seg06"
             },
             "to": [
-              4.0406,
-              0.4307
+              102.6313,
+              10.9406
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -392,8 +392,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              4.0406,
-              0.4307
+              102.6313,
+              10.9406
             ],
             "tag": {
               "commentStart": 1118,
@@ -403,12 +403,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "value": "seg08"
             },
             "to": [
-              4.0406,
-              1.2181
+              102.6313,
+              30.9406
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -417,8 +417,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              4.0406,
-              1.2181
+              102.6313,
+              30.9406
             ],
             "tag": {
               "commentStart": 1177,
@@ -428,12 +428,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "value": "seg05"
             },
             "to": [
-              1.2847,
-              1.2181
+              32.6313,
+              30.9406
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -442,8 +442,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              1.2847,
-              1.2181
+              32.6313,
+              30.9406
             ],
             "tag": {
               "commentStart": 1252,
@@ -453,12 +453,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "value": "seg10"
             },
             "to": [
-              1.2847,
-              1.6489
+              32.6313,
+              41.8813
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -467,8 +467,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              1.2847,
-              1.6489
+              32.6313,
+              41.8813
             ],
             "tag": {
               "commentStart": 1294,
@@ -479,11 +479,11 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             },
             "to": [
               0.0,
-              1.6489
+              41.8813
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -493,16 +493,16 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             },
             "from": [
               0.0,
-              1.6489
+              41.8813
             ],
             "tag": null,
             "to": [
-              -1.2847,
-              1.6489
+              -32.6313,
+              41.8813
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -511,17 +511,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              -1.2847,
-              1.6489
+              -32.6313,
+              41.8813
             ],
             "tag": null,
             "to": [
-              -1.2847,
-              1.2181
+              -32.6313,
+              30.9406
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -530,17 +530,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              -1.2847,
-              1.2181
+              -32.6313,
+              30.9406
             ],
             "tag": null,
             "to": [
-              -4.0406,
-              1.2181
+              -102.6313,
+              30.9406
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -549,17 +549,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              -4.0406,
-              1.2181
+              -102.6313,
+              30.9406
             ],
             "tag": null,
             "to": [
-              -4.0406,
-              0.4307
+              -102.6313,
+              10.9406
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -568,17 +568,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              -4.0406,
-              0.4307
+              -102.6313,
+              10.9406
             ],
             "tag": null,
             "to": [
-              -1.2847,
-              0.4307
+              -32.6312,
+              10.9406
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -587,17 +587,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              -1.2847,
-              0.4307
+              -32.6312,
+              10.9406
             ],
             "tag": null,
             "to": [
-              -1.2847,
-              -0.3937
+              -32.6312,
+              -10.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -606,17 +606,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              -1.2847,
-              -0.3937
+              -32.6312,
+              -10.0
             ],
             "tag": null,
             "to": [
-              -0.891,
-              -0.3937
+              -22.6312,
+              -10.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -625,17 +625,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              -0.891,
-              -0.3937
+              -22.6312,
+              -10.0
             ],
             "tag": null,
             "to": [
-              -0.891,
-              0.7874
+              -22.6312,
+              20.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -645,22 +645,22 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             },
             "ccw": false,
             "center": [
-              -0.4232,
-              0.7874
+              -10.75,
+              20.0
             ],
             "from": [
-              -0.891,
-              0.7874
+              -22.6312,
+              20.0
             ],
-            "radius": 0.46776574803149606,
+            "radius": 11.88125,
             "tag": null,
             "to": [
-              -0.4232,
-              1.2552
+              -10.75,
+              31.8813
             ],
             "type": "Arc",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -669,17 +669,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              -0.4232,
-              1.2552
+              -10.75,
+              31.8813
             ],
             "tag": null,
             "to": [
               0.0,
-              1.2552
+              31.8813
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -689,16 +689,16 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             },
             "from": [
               0.0,
-              1.2552
+              31.8813
             ],
             "tag": null,
             "to": [
               0.0,
-              1.2552
+              31.8813
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           }
         ],
@@ -735,14 +735,14 @@ description: Variables in memory after executing router-template-cross-bar.kcl
         "start": {
           "from": [
             0.0,
-            1.2552
+            31.8813
           ],
           "to": [
             0.0,
-            1.2552
+            31.8813
           ],
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           },
           "tag": null,
           "__geoMeta": {
@@ -795,14 +795,14 @@ description: Variables in memory after executing router-template-cross-bar.kcl
         "artifactId": "[uuid]",
         "originalId": "[uuid]",
         "units": {
-          "type": "Inches"
+          "type": "Mm"
         }
       },
-      "height": 0.1968503937007874,
+      "height": 5.0,
       "startCapId": "[uuid]",
       "endCapId": "[uuid]",
       "units": {
-        "type": "Inches"
+        "type": "Mm"
       },
       "sectional": false
     }
@@ -871,7 +871,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              1.2847,
+              32.6313,
               0.0
             ],
             "tag": {
@@ -882,12 +882,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "value": "rectangleSegmentA002"
             },
             "to": [
-              0.891,
+              22.6313,
               0.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -896,7 +896,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              0.891,
+              22.6313,
               0.0
             ],
             "tag": {
@@ -907,12 +907,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "value": "rectangleSegmentB002"
             },
             "to": [
-              0.891,
-              -0.3937
+              22.6312,
+              -10.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -921,8 +921,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              0.891,
-              -0.3937
+              22.6312,
+              -10.0
             ],
             "tag": {
               "commentStart": 2237,
@@ -932,12 +932,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "value": "rectangleSegmentC002"
             },
             "to": [
-              1.2847,
-              -0.3937
+              32.6312,
+              -10.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -946,17 +946,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              1.2847,
-              -0.3937
+              32.6312,
+              -10.0
             ],
             "tag": null,
             "to": [
-              1.2847,
+              32.6313,
               0.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -965,17 +965,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              1.2847,
+              32.6313,
               0.0
             ],
             "tag": null,
             "to": [
-              1.2847,
+              32.6313,
               0.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           }
         ],
@@ -1210,7 +1210,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   },
                   "from": [
                     0.0,
-                    1.2552
+                    31.8813
                   ],
                   "tag": {
                     "commentStart": 653,
@@ -1220,12 +1220,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "value": "seg01"
                   },
                   "to": [
-                    0.4232,
-                    1.2552
+                    10.75,
+                    31.8813
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1235,14 +1235,14 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   },
                   "ccw": false,
                   "center": [
-                    0.4232,
-                    0.7874
+                    10.75,
+                    20.0
                   ],
                   "from": [
-                    0.4232,
-                    1.2552
+                    10.75,
+                    31.8813
                   ],
-                  "radius": 0.46776574803149606,
+                  "radius": 11.88125,
                   "tag": {
                     "commentStart": 763,
                     "end": 769,
@@ -1251,12 +1251,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "value": "seg09"
                   },
                   "to": [
-                    0.891,
-                    0.7874
+                    22.6313,
+                    20.0
                   ],
                   "type": "Arc",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1265,8 +1265,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    0.891,
-                    0.7874
+                    22.6313,
+                    20.0
                   ],
                   "tag": {
                     "commentStart": 829,
@@ -1276,12 +1276,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "value": "seg03"
                   },
                   "to": [
-                    0.891,
-                    -0.3937
+                    22.6313,
+                    -10.0
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1290,8 +1290,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    0.891,
-                    -0.3937
+                    22.6313,
+                    -10.0
                   ],
                   "tag": {
                     "commentStart": 882,
@@ -1301,12 +1301,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "value": "seg07"
                   },
                   "to": [
-                    1.2847,
-                    -0.3937
+                    32.6313,
+                    -10.0
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1315,8 +1315,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    1.2847,
-                    -0.3937
+                    32.6313,
+                    -10.0
                   ],
                   "tag": {
                     "commentStart": 984,
@@ -1326,12 +1326,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "value": "seg02"
                   },
                   "to": [
-                    1.2847,
-                    0.4307
+                    32.6313,
+                    10.9406
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1340,8 +1340,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    1.2847,
-                    0.4307
+                    32.6313,
+                    10.9406
                   ],
                   "tag": {
                     "commentStart": 1061,
@@ -1351,12 +1351,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "value": "seg06"
                   },
                   "to": [
-                    4.0406,
-                    0.4307
+                    102.6313,
+                    10.9406
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1365,8 +1365,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    4.0406,
-                    0.4307
+                    102.6313,
+                    10.9406
                   ],
                   "tag": {
                     "commentStart": 1118,
@@ -1376,12 +1376,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "value": "seg08"
                   },
                   "to": [
-                    4.0406,
-                    1.2181
+                    102.6313,
+                    30.9406
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1390,8 +1390,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    4.0406,
-                    1.2181
+                    102.6313,
+                    30.9406
                   ],
                   "tag": {
                     "commentStart": 1177,
@@ -1401,12 +1401,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "value": "seg05"
                   },
                   "to": [
-                    1.2847,
-                    1.2181
+                    32.6313,
+                    30.9406
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1415,8 +1415,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    1.2847,
-                    1.2181
+                    32.6313,
+                    30.9406
                   ],
                   "tag": {
                     "commentStart": 1252,
@@ -1426,12 +1426,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "value": "seg10"
                   },
                   "to": [
-                    1.2847,
-                    1.6489
+                    32.6313,
+                    41.8813
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1440,8 +1440,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    1.2847,
-                    1.6489
+                    32.6313,
+                    41.8813
                   ],
                   "tag": {
                     "commentStart": 1294,
@@ -1452,11 +1452,11 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   },
                   "to": [
                     0.0,
-                    1.6489
+                    41.8813
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1466,16 +1466,16 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   },
                   "from": [
                     0.0,
-                    1.6489
+                    41.8813
                   ],
                   "tag": null,
                   "to": [
-                    -1.2847,
-                    1.6489
+                    -32.6313,
+                    41.8813
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1484,17 +1484,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -1.2847,
-                    1.6489
+                    -32.6313,
+                    41.8813
                   ],
                   "tag": null,
                   "to": [
-                    -1.2847,
-                    1.2181
+                    -32.6313,
+                    30.9406
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1503,17 +1503,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -1.2847,
-                    1.2181
+                    -32.6313,
+                    30.9406
                   ],
                   "tag": null,
                   "to": [
-                    -4.0406,
-                    1.2181
+                    -102.6313,
+                    30.9406
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1522,17 +1522,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -4.0406,
-                    1.2181
+                    -102.6313,
+                    30.9406
                   ],
                   "tag": null,
                   "to": [
-                    -4.0406,
-                    0.4307
+                    -102.6313,
+                    10.9406
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1541,17 +1541,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -4.0406,
-                    0.4307
+                    -102.6313,
+                    10.9406
                   ],
                   "tag": null,
                   "to": [
-                    -1.2847,
-                    0.4307
+                    -32.6312,
+                    10.9406
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1560,17 +1560,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -1.2847,
-                    0.4307
+                    -32.6312,
+                    10.9406
                   ],
                   "tag": null,
                   "to": [
-                    -1.2847,
-                    -0.3937
+                    -32.6312,
+                    -10.0
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1579,17 +1579,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -1.2847,
-                    -0.3937
+                    -32.6312,
+                    -10.0
                   ],
                   "tag": null,
                   "to": [
-                    -0.891,
-                    -0.3937
+                    -22.6312,
+                    -10.0
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1598,17 +1598,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -0.891,
-                    -0.3937
+                    -22.6312,
+                    -10.0
                   ],
                   "tag": null,
                   "to": [
-                    -0.891,
-                    0.7874
+                    -22.6312,
+                    20.0
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1618,22 +1618,22 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   },
                   "ccw": false,
                   "center": [
-                    -0.4232,
-                    0.7874
+                    -10.75,
+                    20.0
                   ],
                   "from": [
-                    -0.891,
-                    0.7874
+                    -22.6312,
+                    20.0
                   ],
-                  "radius": 0.46776574803149606,
+                  "radius": 11.88125,
                   "tag": null,
                   "to": [
-                    -0.4232,
-                    1.2552
+                    -10.75,
+                    31.8813
                   ],
                   "type": "Arc",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1642,17 +1642,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -0.4232,
-                    1.2552
+                    -10.75,
+                    31.8813
                   ],
                   "tag": null,
                   "to": [
                     0.0,
-                    1.2552
+                    31.8813
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1662,16 +1662,16 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   },
                   "from": [
                     0.0,
-                    1.2552
+                    31.8813
                   ],
                   "tag": null,
                   "to": [
                     0.0,
-                    1.2552
+                    31.8813
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 }
               ],
@@ -1708,14 +1708,14 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "start": {
                 "from": [
                   0.0,
-                  1.2552
+                  31.8813
                 ],
                 "to": [
                   0.0,
-                  1.2552
+                  31.8813
                 ],
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 },
                 "tag": null,
                 "__geoMeta": {
@@ -1768,32 +1768,32 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "artifactId": "[uuid]",
               "originalId": "[uuid]",
               "units": {
-                "type": "Inches"
+                "type": "Mm"
               }
             },
-            "height": 0.1968503937007874,
+            "height": 5.0,
             "startCapId": "[uuid]",
             "endCapId": "[uuid]",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             },
             "sectional": false
           },
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         "start": {
           "from": [
-            1.2847,
+            32.6313,
             0.0
           ],
           "to": [
-            1.2847,
+            32.6313,
             0.0
           ],
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           },
           "tag": null,
           "__geoMeta": {
@@ -1818,14 +1818,14 @@ description: Variables in memory after executing router-template-cross-bar.kcl
         "artifactId": "[uuid]",
         "originalId": "[uuid]",
         "units": {
-          "type": "Inches"
+          "type": "Mm"
         }
       },
-      "height": 0.5118110236220472,
+      "height": 13.0,
       "startCapId": "[uuid]",
       "endCapId": "[uuid]",
       "units": {
-        "type": "Inches"
+        "type": "Mm"
       },
       "sectional": false
     }
@@ -1894,7 +1894,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              -1.2847,
+              -32.6313,
               0.0
             ],
             "tag": {
@@ -1905,12 +1905,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "value": "rectangleSegmentA001"
             },
             "to": [
-              -0.891,
+              -22.6313,
               0.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -1919,7 +1919,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              -0.891,
+              -22.6313,
               0.0
             ],
             "tag": {
@@ -1930,12 +1930,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "value": "rectangleSegmentB001"
             },
             "to": [
-              -0.891,
-              -0.3937
+              -22.6313,
+              -10.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -1944,8 +1944,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              -0.891,
-              -0.3937
+              -22.6313,
+              -10.0
             ],
             "tag": {
               "commentStart": 2841,
@@ -1955,12 +1955,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "value": "rectangleSegmentC001"
             },
             "to": [
-              -1.2847,
-              -0.3937
+              -32.6313,
+              -10.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -1969,17 +1969,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              -1.2847,
-              -0.3937
+              -32.6313,
+              -10.0
             ],
             "tag": null,
             "to": [
-              -1.2847,
+              -32.6313,
               0.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -1988,17 +1988,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              -1.2847,
+              -32.6313,
               0.0
             ],
             "tag": null,
             "to": [
-              -1.2847,
+              -32.6313,
               0.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           }
         ],
@@ -2233,7 +2233,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   },
                   "from": [
                     0.0,
-                    1.2552
+                    31.8813
                   ],
                   "tag": {
                     "commentStart": 653,
@@ -2243,12 +2243,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "value": "seg01"
                   },
                   "to": [
-                    0.4232,
-                    1.2552
+                    10.75,
+                    31.8813
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -2258,14 +2258,14 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   },
                   "ccw": false,
                   "center": [
-                    0.4232,
-                    0.7874
+                    10.75,
+                    20.0
                   ],
                   "from": [
-                    0.4232,
-                    1.2552
+                    10.75,
+                    31.8813
                   ],
-                  "radius": 0.46776574803149606,
+                  "radius": 11.88125,
                   "tag": {
                     "commentStart": 763,
                     "end": 769,
@@ -2274,12 +2274,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "value": "seg09"
                   },
                   "to": [
-                    0.891,
-                    0.7874
+                    22.6313,
+                    20.0
                   ],
                   "type": "Arc",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -2288,8 +2288,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    0.891,
-                    0.7874
+                    22.6313,
+                    20.0
                   ],
                   "tag": {
                     "commentStart": 829,
@@ -2299,12 +2299,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "value": "seg03"
                   },
                   "to": [
-                    0.891,
-                    -0.3937
+                    22.6313,
+                    -10.0
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -2313,8 +2313,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    0.891,
-                    -0.3937
+                    22.6313,
+                    -10.0
                   ],
                   "tag": {
                     "commentStart": 882,
@@ -2324,12 +2324,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "value": "seg07"
                   },
                   "to": [
-                    1.2847,
-                    -0.3937
+                    32.6313,
+                    -10.0
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -2338,8 +2338,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    1.2847,
-                    -0.3937
+                    32.6313,
+                    -10.0
                   ],
                   "tag": {
                     "commentStart": 984,
@@ -2349,12 +2349,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "value": "seg02"
                   },
                   "to": [
-                    1.2847,
-                    0.4307
+                    32.6313,
+                    10.9406
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -2363,8 +2363,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    1.2847,
-                    0.4307
+                    32.6313,
+                    10.9406
                   ],
                   "tag": {
                     "commentStart": 1061,
@@ -2374,12 +2374,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "value": "seg06"
                   },
                   "to": [
-                    4.0406,
-                    0.4307
+                    102.6313,
+                    10.9406
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -2388,8 +2388,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    4.0406,
-                    0.4307
+                    102.6313,
+                    10.9406
                   ],
                   "tag": {
                     "commentStart": 1118,
@@ -2399,12 +2399,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "value": "seg08"
                   },
                   "to": [
-                    4.0406,
-                    1.2181
+                    102.6313,
+                    30.9406
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -2413,8 +2413,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    4.0406,
-                    1.2181
+                    102.6313,
+                    30.9406
                   ],
                   "tag": {
                     "commentStart": 1177,
@@ -2424,12 +2424,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "value": "seg05"
                   },
                   "to": [
-                    1.2847,
-                    1.2181
+                    32.6313,
+                    30.9406
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -2438,8 +2438,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    1.2847,
-                    1.2181
+                    32.6313,
+                    30.9406
                   ],
                   "tag": {
                     "commentStart": 1252,
@@ -2449,12 +2449,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "value": "seg10"
                   },
                   "to": [
-                    1.2847,
-                    1.6489
+                    32.6313,
+                    41.8813
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -2463,8 +2463,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    1.2847,
-                    1.6489
+                    32.6313,
+                    41.8813
                   ],
                   "tag": {
                     "commentStart": 1294,
@@ -2475,11 +2475,11 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   },
                   "to": [
                     0.0,
-                    1.6489
+                    41.8813
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -2489,16 +2489,16 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   },
                   "from": [
                     0.0,
-                    1.6489
+                    41.8813
                   ],
                   "tag": null,
                   "to": [
-                    -1.2847,
-                    1.6489
+                    -32.6313,
+                    41.8813
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -2507,17 +2507,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -1.2847,
-                    1.6489
+                    -32.6313,
+                    41.8813
                   ],
                   "tag": null,
                   "to": [
-                    -1.2847,
-                    1.2181
+                    -32.6313,
+                    30.9406
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -2526,17 +2526,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -1.2847,
-                    1.2181
+                    -32.6313,
+                    30.9406
                   ],
                   "tag": null,
                   "to": [
-                    -4.0406,
-                    1.2181
+                    -102.6313,
+                    30.9406
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -2545,17 +2545,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -4.0406,
-                    1.2181
+                    -102.6313,
+                    30.9406
                   ],
                   "tag": null,
                   "to": [
-                    -4.0406,
-                    0.4307
+                    -102.6313,
+                    10.9406
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -2564,17 +2564,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -4.0406,
-                    0.4307
+                    -102.6313,
+                    10.9406
                   ],
                   "tag": null,
                   "to": [
-                    -1.2847,
-                    0.4307
+                    -32.6312,
+                    10.9406
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -2583,17 +2583,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -1.2847,
-                    0.4307
+                    -32.6312,
+                    10.9406
                   ],
                   "tag": null,
                   "to": [
-                    -1.2847,
-                    -0.3937
+                    -32.6312,
+                    -10.0
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -2602,17 +2602,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -1.2847,
-                    -0.3937
+                    -32.6312,
+                    -10.0
                   ],
                   "tag": null,
                   "to": [
-                    -0.891,
-                    -0.3937
+                    -22.6312,
+                    -10.0
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -2621,17 +2621,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -0.891,
-                    -0.3937
+                    -22.6312,
+                    -10.0
                   ],
                   "tag": null,
                   "to": [
-                    -0.891,
-                    0.7874
+                    -22.6312,
+                    20.0
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -2641,22 +2641,22 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   },
                   "ccw": false,
                   "center": [
-                    -0.4232,
-                    0.7874
+                    -10.75,
+                    20.0
                   ],
                   "from": [
-                    -0.891,
-                    0.7874
+                    -22.6312,
+                    20.0
                   ],
-                  "radius": 0.46776574803149606,
+                  "radius": 11.88125,
                   "tag": null,
                   "to": [
-                    -0.4232,
-                    1.2552
+                    -10.75,
+                    31.8813
                   ],
                   "type": "Arc",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -2665,17 +2665,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -0.4232,
-                    1.2552
+                    -10.75,
+                    31.8813
                   ],
                   "tag": null,
                   "to": [
                     0.0,
-                    1.2552
+                    31.8813
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -2685,16 +2685,16 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   },
                   "from": [
                     0.0,
-                    1.2552
+                    31.8813
                   ],
                   "tag": null,
                   "to": [
                     0.0,
-                    1.2552
+                    31.8813
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 }
               ],
@@ -2731,14 +2731,14 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "start": {
                 "from": [
                   0.0,
-                  1.2552
+                  31.8813
                 ],
                 "to": [
                   0.0,
-                  1.2552
+                  31.8813
                 ],
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 },
                 "tag": null,
                 "__geoMeta": {
@@ -2791,32 +2791,32 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "artifactId": "[uuid]",
               "originalId": "[uuid]",
               "units": {
-                "type": "Inches"
+                "type": "Mm"
               }
             },
-            "height": 0.1968503937007874,
+            "height": 5.0,
             "startCapId": "[uuid]",
             "endCapId": "[uuid]",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             },
             "sectional": false
           },
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         "start": {
           "from": [
-            -1.2847,
+            -32.6313,
             0.0
           ],
           "to": [
-            -1.2847,
+            -32.6313,
             0.0
           ],
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           },
           "tag": null,
           "__geoMeta": {
@@ -2841,14 +2841,14 @@ description: Variables in memory after executing router-template-cross-bar.kcl
         "artifactId": "[uuid]",
         "originalId": "[uuid]",
         "units": {
-          "type": "Inches"
+          "type": "Mm"
         }
       },
-      "height": 0.5118110236220472,
+      "height": 13.0,
       "startCapId": "[uuid]",
       "endCapId": "[uuid]",
       "units": {
-        "type": "Inches"
+        "type": "Mm"
       },
       "sectional": false
     }
@@ -2917,7 +2917,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              -1.2847,
+              -32.6313,
               0.0
             ],
             "tag": {
@@ -2928,12 +2928,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "value": "rectangleSegmentA003"
             },
             "to": [
-              1.2847,
+              32.6313,
               0.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -2942,7 +2942,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              1.2847,
+              32.6313,
               0.0
             ],
             "tag": {
@@ -2953,12 +2953,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "value": "rectangleSegmentB003"
             },
             "to": [
-              1.2847,
-              -0.3937
+              32.6313,
+              -10.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -2967,8 +2967,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              1.2847,
-              -0.3937
+              32.6313,
+              -10.0
             ],
             "tag": {
               "commentStart": 3450,
@@ -2978,12 +2978,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "value": "rectangleSegmentC003"
             },
             "to": [
-              -1.2847,
-              -0.3937
+              -32.6313,
+              -10.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -2992,17 +2992,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              -1.2847,
-              -0.3937
+              -32.6313,
+              -10.0
             ],
             "tag": null,
             "to": [
-              -1.2847,
+              -32.6313,
               0.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -3011,17 +3011,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "sourceRange": []
             },
             "from": [
-              -1.2847,
+              -32.6313,
               0.0
             ],
             "tag": null,
             "to": [
-              -1.2847,
+              -32.6313,
               0.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           }
         ],
@@ -3108,7 +3108,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    1.2847,
+                    32.6313,
                     0.0
                   ],
                   "tag": {
@@ -3119,12 +3119,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "value": "rectangleSegmentA002"
                   },
                   "to": [
-                    0.891,
+                    22.6313,
                     0.0
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -3133,7 +3133,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    0.891,
+                    22.6313,
                     0.0
                   ],
                   "tag": {
@@ -3144,12 +3144,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "value": "rectangleSegmentB002"
                   },
                   "to": [
-                    0.891,
-                    -0.3937
+                    22.6312,
+                    -10.0
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -3158,8 +3158,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    0.891,
-                    -0.3937
+                    22.6312,
+                    -10.0
                   ],
                   "tag": {
                     "commentStart": 2237,
@@ -3169,12 +3169,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "value": "rectangleSegmentC002"
                   },
                   "to": [
-                    1.2847,
-                    -0.3937
+                    32.6312,
+                    -10.0
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -3183,17 +3183,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    1.2847,
-                    -0.3937
+                    32.6312,
+                    -10.0
                   ],
                   "tag": null,
                   "to": [
-                    1.2847,
+                    32.6313,
                     0.0
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -3202,17 +3202,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    1.2847,
+                    32.6313,
                     0.0
                   ],
                   "tag": null,
                   "to": [
-                    1.2847,
+                    32.6313,
                     0.0
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 }
               ],
@@ -3447,7 +3447,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         },
                         "from": [
                           0.0,
-                          1.2552
+                          31.8813
                         ],
                         "tag": {
                           "commentStart": 653,
@@ -3457,12 +3457,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "value": "seg01"
                         },
                         "to": [
-                          0.4232,
-                          1.2552
+                          10.75,
+                          31.8813
                         ],
                         "type": "ToPoint",
                         "units": {
-                          "type": "Inches"
+                          "type": "Mm"
                         }
                       },
                       {
@@ -3472,14 +3472,14 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         },
                         "ccw": false,
                         "center": [
-                          0.4232,
-                          0.7874
+                          10.75,
+                          20.0
                         ],
                         "from": [
-                          0.4232,
-                          1.2552
+                          10.75,
+                          31.8813
                         ],
-                        "radius": 0.46776574803149606,
+                        "radius": 11.88125,
                         "tag": {
                           "commentStart": 763,
                           "end": 769,
@@ -3488,12 +3488,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "value": "seg09"
                         },
                         "to": [
-                          0.891,
-                          0.7874
+                          22.6313,
+                          20.0
                         ],
                         "type": "Arc",
                         "units": {
-                          "type": "Inches"
+                          "type": "Mm"
                         }
                       },
                       {
@@ -3502,8 +3502,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "sourceRange": []
                         },
                         "from": [
-                          0.891,
-                          0.7874
+                          22.6313,
+                          20.0
                         ],
                         "tag": {
                           "commentStart": 829,
@@ -3513,12 +3513,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "value": "seg03"
                         },
                         "to": [
-                          0.891,
-                          -0.3937
+                          22.6313,
+                          -10.0
                         ],
                         "type": "ToPoint",
                         "units": {
-                          "type": "Inches"
+                          "type": "Mm"
                         }
                       },
                       {
@@ -3527,8 +3527,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "sourceRange": []
                         },
                         "from": [
-                          0.891,
-                          -0.3937
+                          22.6313,
+                          -10.0
                         ],
                         "tag": {
                           "commentStart": 882,
@@ -3538,12 +3538,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "value": "seg07"
                         },
                         "to": [
-                          1.2847,
-                          -0.3937
+                          32.6313,
+                          -10.0
                         ],
                         "type": "ToPoint",
                         "units": {
-                          "type": "Inches"
+                          "type": "Mm"
                         }
                       },
                       {
@@ -3552,8 +3552,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "sourceRange": []
                         },
                         "from": [
-                          1.2847,
-                          -0.3937
+                          32.6313,
+                          -10.0
                         ],
                         "tag": {
                           "commentStart": 984,
@@ -3563,12 +3563,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "value": "seg02"
                         },
                         "to": [
-                          1.2847,
-                          0.4307
+                          32.6313,
+                          10.9406
                         ],
                         "type": "ToPoint",
                         "units": {
-                          "type": "Inches"
+                          "type": "Mm"
                         }
                       },
                       {
@@ -3577,8 +3577,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "sourceRange": []
                         },
                         "from": [
-                          1.2847,
-                          0.4307
+                          32.6313,
+                          10.9406
                         ],
                         "tag": {
                           "commentStart": 1061,
@@ -3588,12 +3588,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "value": "seg06"
                         },
                         "to": [
-                          4.0406,
-                          0.4307
+                          102.6313,
+                          10.9406
                         ],
                         "type": "ToPoint",
                         "units": {
-                          "type": "Inches"
+                          "type": "Mm"
                         }
                       },
                       {
@@ -3602,8 +3602,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "sourceRange": []
                         },
                         "from": [
-                          4.0406,
-                          0.4307
+                          102.6313,
+                          10.9406
                         ],
                         "tag": {
                           "commentStart": 1118,
@@ -3613,12 +3613,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "value": "seg08"
                         },
                         "to": [
-                          4.0406,
-                          1.2181
+                          102.6313,
+                          30.9406
                         ],
                         "type": "ToPoint",
                         "units": {
-                          "type": "Inches"
+                          "type": "Mm"
                         }
                       },
                       {
@@ -3627,8 +3627,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "sourceRange": []
                         },
                         "from": [
-                          4.0406,
-                          1.2181
+                          102.6313,
+                          30.9406
                         ],
                         "tag": {
                           "commentStart": 1177,
@@ -3638,12 +3638,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "value": "seg05"
                         },
                         "to": [
-                          1.2847,
-                          1.2181
+                          32.6313,
+                          30.9406
                         ],
                         "type": "ToPoint",
                         "units": {
-                          "type": "Inches"
+                          "type": "Mm"
                         }
                       },
                       {
@@ -3652,8 +3652,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "sourceRange": []
                         },
                         "from": [
-                          1.2847,
-                          1.2181
+                          32.6313,
+                          30.9406
                         ],
                         "tag": {
                           "commentStart": 1252,
@@ -3663,12 +3663,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "value": "seg10"
                         },
                         "to": [
-                          1.2847,
-                          1.6489
+                          32.6313,
+                          41.8813
                         ],
                         "type": "ToPoint",
                         "units": {
-                          "type": "Inches"
+                          "type": "Mm"
                         }
                       },
                       {
@@ -3677,8 +3677,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "sourceRange": []
                         },
                         "from": [
-                          1.2847,
-                          1.6489
+                          32.6313,
+                          41.8813
                         ],
                         "tag": {
                           "commentStart": 1294,
@@ -3689,11 +3689,11 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         },
                         "to": [
                           0.0,
-                          1.6489
+                          41.8813
                         ],
                         "type": "ToPoint",
                         "units": {
-                          "type": "Inches"
+                          "type": "Mm"
                         }
                       },
                       {
@@ -3703,16 +3703,16 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         },
                         "from": [
                           0.0,
-                          1.6489
+                          41.8813
                         ],
                         "tag": null,
                         "to": [
-                          -1.2847,
-                          1.6489
+                          -32.6313,
+                          41.8813
                         ],
                         "type": "ToPoint",
                         "units": {
-                          "type": "Inches"
+                          "type": "Mm"
                         }
                       },
                       {
@@ -3721,17 +3721,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "sourceRange": []
                         },
                         "from": [
-                          -1.2847,
-                          1.6489
+                          -32.6313,
+                          41.8813
                         ],
                         "tag": null,
                         "to": [
-                          -1.2847,
-                          1.2181
+                          -32.6313,
+                          30.9406
                         ],
                         "type": "ToPoint",
                         "units": {
-                          "type": "Inches"
+                          "type": "Mm"
                         }
                       },
                       {
@@ -3740,17 +3740,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "sourceRange": []
                         },
                         "from": [
-                          -1.2847,
-                          1.2181
+                          -32.6313,
+                          30.9406
                         ],
                         "tag": null,
                         "to": [
-                          -4.0406,
-                          1.2181
+                          -102.6313,
+                          30.9406
                         ],
                         "type": "ToPoint",
                         "units": {
-                          "type": "Inches"
+                          "type": "Mm"
                         }
                       },
                       {
@@ -3759,17 +3759,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "sourceRange": []
                         },
                         "from": [
-                          -4.0406,
-                          1.2181
+                          -102.6313,
+                          30.9406
                         ],
                         "tag": null,
                         "to": [
-                          -4.0406,
-                          0.4307
+                          -102.6313,
+                          10.9406
                         ],
                         "type": "ToPoint",
                         "units": {
-                          "type": "Inches"
+                          "type": "Mm"
                         }
                       },
                       {
@@ -3778,17 +3778,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "sourceRange": []
                         },
                         "from": [
-                          -4.0406,
-                          0.4307
+                          -102.6313,
+                          10.9406
                         ],
                         "tag": null,
                         "to": [
-                          -1.2847,
-                          0.4307
+                          -32.6312,
+                          10.9406
                         ],
                         "type": "ToPoint",
                         "units": {
-                          "type": "Inches"
+                          "type": "Mm"
                         }
                       },
                       {
@@ -3797,17 +3797,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "sourceRange": []
                         },
                         "from": [
-                          -1.2847,
-                          0.4307
+                          -32.6312,
+                          10.9406
                         ],
                         "tag": null,
                         "to": [
-                          -1.2847,
-                          -0.3937
+                          -32.6312,
+                          -10.0
                         ],
                         "type": "ToPoint",
                         "units": {
-                          "type": "Inches"
+                          "type": "Mm"
                         }
                       },
                       {
@@ -3816,17 +3816,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "sourceRange": []
                         },
                         "from": [
-                          -1.2847,
-                          -0.3937
+                          -32.6312,
+                          -10.0
                         ],
                         "tag": null,
                         "to": [
-                          -0.891,
-                          -0.3937
+                          -22.6312,
+                          -10.0
                         ],
                         "type": "ToPoint",
                         "units": {
-                          "type": "Inches"
+                          "type": "Mm"
                         }
                       },
                       {
@@ -3835,17 +3835,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "sourceRange": []
                         },
                         "from": [
-                          -0.891,
-                          -0.3937
+                          -22.6312,
+                          -10.0
                         ],
                         "tag": null,
                         "to": [
-                          -0.891,
-                          0.7874
+                          -22.6312,
+                          20.0
                         ],
                         "type": "ToPoint",
                         "units": {
-                          "type": "Inches"
+                          "type": "Mm"
                         }
                       },
                       {
@@ -3855,22 +3855,22 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         },
                         "ccw": false,
                         "center": [
-                          -0.4232,
-                          0.7874
+                          -10.75,
+                          20.0
                         ],
                         "from": [
-                          -0.891,
-                          0.7874
+                          -22.6312,
+                          20.0
                         ],
-                        "radius": 0.46776574803149606,
+                        "radius": 11.88125,
                         "tag": null,
                         "to": [
-                          -0.4232,
-                          1.2552
+                          -10.75,
+                          31.8813
                         ],
                         "type": "Arc",
                         "units": {
-                          "type": "Inches"
+                          "type": "Mm"
                         }
                       },
                       {
@@ -3879,17 +3879,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                           "sourceRange": []
                         },
                         "from": [
-                          -0.4232,
-                          1.2552
+                          -10.75,
+                          31.8813
                         ],
                         "tag": null,
                         "to": [
                           0.0,
-                          1.2552
+                          31.8813
                         ],
                         "type": "ToPoint",
                         "units": {
-                          "type": "Inches"
+                          "type": "Mm"
                         }
                       },
                       {
@@ -3899,16 +3899,16 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         },
                         "from": [
                           0.0,
-                          1.2552
+                          31.8813
                         ],
                         "tag": null,
                         "to": [
                           0.0,
-                          1.2552
+                          31.8813
                         ],
                         "type": "ToPoint",
                         "units": {
-                          "type": "Inches"
+                          "type": "Mm"
                         }
                       }
                     ],
@@ -3945,14 +3945,14 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "start": {
                       "from": [
                         0.0,
-                        1.2552
+                        31.8813
                       ],
                       "to": [
                         0.0,
-                        1.2552
+                        31.8813
                       ],
                       "units": {
-                        "type": "Inches"
+                        "type": "Mm"
                       },
                       "tag": null,
                       "__geoMeta": {
@@ -4005,32 +4005,32 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                     "artifactId": "[uuid]",
                     "originalId": "[uuid]",
                     "units": {
-                      "type": "Inches"
+                      "type": "Mm"
                     }
                   },
-                  "height": 0.1968503937007874,
+                  "height": 5.0,
                   "startCapId": "[uuid]",
                   "endCapId": "[uuid]",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   },
                   "sectional": false
                 },
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               "start": {
                 "from": [
-                  1.2847,
+                  32.6313,
                   0.0
                 ],
                 "to": [
-                  1.2847,
+                  32.6313,
                   0.0
                 ],
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 },
                 "tag": null,
                 "__geoMeta": {
@@ -4055,32 +4055,32 @@ description: Variables in memory after executing router-template-cross-bar.kcl
               "artifactId": "[uuid]",
               "originalId": "[uuid]",
               "units": {
-                "type": "Inches"
+                "type": "Mm"
               }
             },
-            "height": 0.5118110236220472,
+            "height": 13.0,
             "startCapId": "[uuid]",
             "endCapId": "[uuid]",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             },
             "sectional": false
           },
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         "start": {
           "from": [
-            -1.2847,
+            -32.6313,
             0.0
           ],
           "to": [
-            -1.2847,
+            -32.6313,
             0.0
           ],
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           },
           "tag": null,
           "__geoMeta": {
@@ -4105,14 +4105,14 @@ description: Variables in memory after executing router-template-cross-bar.kcl
         "artifactId": "[uuid]",
         "originalId": "[uuid]",
         "units": {
-          "type": "Inches"
+          "type": "Mm"
         }
       },
-      "height": 0.15748031496062992,
+      "height": 4.0,
       "startCapId": "[uuid]",
       "endCapId": "[uuid]",
       "units": {
-        "type": "Inches"
+        "type": "Mm"
       },
       "sectional": false
     }
@@ -4264,7 +4264,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
           },
           "from": [
             0.0,
-            1.2552
+            31.8813
           ],
           "tag": {
             "commentStart": 653,
@@ -4274,12 +4274,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "value": "seg01"
           },
           "to": [
-            0.4232,
-            1.2552
+            10.75,
+            31.8813
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4289,14 +4289,14 @@ description: Variables in memory after executing router-template-cross-bar.kcl
           },
           "ccw": false,
           "center": [
-            0.4232,
-            0.7874
+            10.75,
+            20.0
           ],
           "from": [
-            0.4232,
-            1.2552
+            10.75,
+            31.8813
           ],
-          "radius": 0.46776574803149606,
+          "radius": 11.88125,
           "tag": {
             "commentStart": 763,
             "end": 769,
@@ -4305,12 +4305,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "value": "seg09"
           },
           "to": [
-            0.891,
-            0.7874
+            22.6313,
+            20.0
           ],
           "type": "Arc",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4319,8 +4319,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            0.891,
-            0.7874
+            22.6313,
+            20.0
           ],
           "tag": {
             "commentStart": 829,
@@ -4330,12 +4330,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "value": "seg03"
           },
           "to": [
-            0.891,
-            -0.3937
+            22.6313,
+            -10.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4344,8 +4344,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            0.891,
-            -0.3937
+            22.6313,
+            -10.0
           ],
           "tag": {
             "commentStart": 882,
@@ -4355,12 +4355,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "value": "seg07"
           },
           "to": [
-            1.2847,
-            -0.3937
+            32.6313,
+            -10.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4369,8 +4369,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            1.2847,
-            -0.3937
+            32.6313,
+            -10.0
           ],
           "tag": {
             "commentStart": 984,
@@ -4380,12 +4380,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "value": "seg02"
           },
           "to": [
-            1.2847,
-            0.4307
+            32.6313,
+            10.9406
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4394,8 +4394,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            1.2847,
-            0.4307
+            32.6313,
+            10.9406
           ],
           "tag": {
             "commentStart": 1061,
@@ -4405,12 +4405,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "value": "seg06"
           },
           "to": [
-            4.0406,
-            0.4307
+            102.6313,
+            10.9406
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4419,8 +4419,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            4.0406,
-            0.4307
+            102.6313,
+            10.9406
           ],
           "tag": {
             "commentStart": 1118,
@@ -4430,12 +4430,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "value": "seg08"
           },
           "to": [
-            4.0406,
-            1.2181
+            102.6313,
+            30.9406
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4444,8 +4444,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            4.0406,
-            1.2181
+            102.6313,
+            30.9406
           ],
           "tag": {
             "commentStart": 1177,
@@ -4455,12 +4455,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "value": "seg05"
           },
           "to": [
-            1.2847,
-            1.2181
+            32.6313,
+            30.9406
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4469,8 +4469,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            1.2847,
-            1.2181
+            32.6313,
+            30.9406
           ],
           "tag": {
             "commentStart": 1252,
@@ -4480,12 +4480,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "value": "seg10"
           },
           "to": [
-            1.2847,
-            1.6489
+            32.6313,
+            41.8813
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4494,8 +4494,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            1.2847,
-            1.6489
+            32.6313,
+            41.8813
           ],
           "tag": {
             "commentStart": 1294,
@@ -4506,11 +4506,11 @@ description: Variables in memory after executing router-template-cross-bar.kcl
           },
           "to": [
             0.0,
-            1.6489
+            41.8813
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4520,16 +4520,16 @@ description: Variables in memory after executing router-template-cross-bar.kcl
           },
           "from": [
             0.0,
-            1.6489
+            41.8813
           ],
           "tag": null,
           "to": [
-            -1.2847,
-            1.6489
+            -32.6313,
+            41.8813
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4538,17 +4538,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            -1.2847,
-            1.6489
+            -32.6313,
+            41.8813
           ],
           "tag": null,
           "to": [
-            -1.2847,
-            1.2181
+            -32.6313,
+            30.9406
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4557,17 +4557,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            -1.2847,
-            1.2181
+            -32.6313,
+            30.9406
           ],
           "tag": null,
           "to": [
-            -4.0406,
-            1.2181
+            -102.6313,
+            30.9406
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4576,17 +4576,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            -4.0406,
-            1.2181
+            -102.6313,
+            30.9406
           ],
           "tag": null,
           "to": [
-            -4.0406,
-            0.4307
+            -102.6313,
+            10.9406
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4595,17 +4595,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            -4.0406,
-            0.4307
+            -102.6313,
+            10.9406
           ],
           "tag": null,
           "to": [
-            -1.2847,
-            0.4307
+            -32.6312,
+            10.9406
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4614,17 +4614,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            -1.2847,
-            0.4307
+            -32.6312,
+            10.9406
           ],
           "tag": null,
           "to": [
-            -1.2847,
-            -0.3937
+            -32.6312,
+            -10.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4633,17 +4633,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            -1.2847,
-            -0.3937
+            -32.6312,
+            -10.0
           ],
           "tag": null,
           "to": [
-            -0.891,
-            -0.3937
+            -22.6312,
+            -10.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4652,17 +4652,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            -0.891,
-            -0.3937
+            -22.6312,
+            -10.0
           ],
           "tag": null,
           "to": [
-            -0.891,
-            0.7874
+            -22.6312,
+            20.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4672,22 +4672,22 @@ description: Variables in memory after executing router-template-cross-bar.kcl
           },
           "ccw": false,
           "center": [
-            -0.4232,
-            0.7874
+            -10.75,
+            20.0
           ],
           "from": [
-            -0.891,
-            0.7874
+            -22.6312,
+            20.0
           ],
-          "radius": 0.46776574803149606,
+          "radius": 11.88125,
           "tag": null,
           "to": [
-            -0.4232,
-            1.2552
+            -10.75,
+            31.8813
           ],
           "type": "Arc",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4696,17 +4696,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            -0.4232,
-            1.2552
+            -10.75,
+            31.8813
           ],
           "tag": null,
           "to": [
             0.0,
-            1.2552
+            31.8813
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4716,16 +4716,16 @@ description: Variables in memory after executing router-template-cross-bar.kcl
           },
           "from": [
             0.0,
-            1.2552
+            31.8813
           ],
           "tag": null,
           "to": [
             0.0,
-            1.2552
+            31.8813
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         }
       ],
@@ -4762,14 +4762,14 @@ description: Variables in memory after executing router-template-cross-bar.kcl
       "start": {
         "from": [
           0.0,
-          1.2552
+          31.8813
         ],
         "to": [
           0.0,
-          1.2552
+          31.8813
         ],
         "units": {
-          "type": "Inches"
+          "type": "Mm"
         },
         "tag": null,
         "__geoMeta": {
@@ -4822,7 +4822,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
       "artifactId": "[uuid]",
       "originalId": "[uuid]",
       "units": {
-        "type": "Inches"
+        "type": "Mm"
       }
     }
   },
@@ -4838,7 +4838,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            1.2847,
+            32.6313,
             0.0
           ],
           "tag": {
@@ -4849,12 +4849,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "value": "rectangleSegmentA002"
           },
           "to": [
-            0.891,
+            22.6313,
             0.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4863,7 +4863,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            0.891,
+            22.6313,
             0.0
           ],
           "tag": {
@@ -4874,12 +4874,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "value": "rectangleSegmentB002"
           },
           "to": [
-            0.891,
-            -0.3937
+            22.6312,
+            -10.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4888,8 +4888,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            0.891,
-            -0.3937
+            22.6312,
+            -10.0
           ],
           "tag": {
             "commentStart": 2237,
@@ -4899,12 +4899,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "value": "rectangleSegmentC002"
           },
           "to": [
-            1.2847,
-            -0.3937
+            32.6312,
+            -10.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4913,17 +4913,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            1.2847,
-            -0.3937
+            32.6312,
+            -10.0
           ],
           "tag": null,
           "to": [
-            1.2847,
+            32.6313,
             0.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -4932,17 +4932,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            1.2847,
+            32.6313,
             0.0
           ],
           "tag": null,
           "to": [
-            1.2847,
+            32.6313,
             0.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         }
       ],
@@ -5177,7 +5177,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                 },
                 "from": [
                   0.0,
-                  1.2552
+                  31.8813
                 ],
                 "tag": {
                   "commentStart": 653,
@@ -5187,12 +5187,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "value": "seg01"
                 },
                 "to": [
-                  0.4232,
-                  1.2552
+                  10.75,
+                  31.8813
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -5202,14 +5202,14 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                 },
                 "ccw": false,
                 "center": [
-                  0.4232,
-                  0.7874
+                  10.75,
+                  20.0
                 ],
                 "from": [
-                  0.4232,
-                  1.2552
+                  10.75,
+                  31.8813
                 ],
-                "radius": 0.46776574803149606,
+                "radius": 11.88125,
                 "tag": {
                   "commentStart": 763,
                   "end": 769,
@@ -5218,12 +5218,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "value": "seg09"
                 },
                 "to": [
-                  0.891,
-                  0.7874
+                  22.6313,
+                  20.0
                 ],
                 "type": "Arc",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -5232,8 +5232,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  0.891,
-                  0.7874
+                  22.6313,
+                  20.0
                 ],
                 "tag": {
                   "commentStart": 829,
@@ -5243,12 +5243,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "value": "seg03"
                 },
                 "to": [
-                  0.891,
-                  -0.3937
+                  22.6313,
+                  -10.0
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -5257,8 +5257,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  0.891,
-                  -0.3937
+                  22.6313,
+                  -10.0
                 ],
                 "tag": {
                   "commentStart": 882,
@@ -5268,12 +5268,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "value": "seg07"
                 },
                 "to": [
-                  1.2847,
-                  -0.3937
+                  32.6313,
+                  -10.0
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -5282,8 +5282,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  1.2847,
-                  -0.3937
+                  32.6313,
+                  -10.0
                 ],
                 "tag": {
                   "commentStart": 984,
@@ -5293,12 +5293,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "value": "seg02"
                 },
                 "to": [
-                  1.2847,
-                  0.4307
+                  32.6313,
+                  10.9406
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -5307,8 +5307,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  1.2847,
-                  0.4307
+                  32.6313,
+                  10.9406
                 ],
                 "tag": {
                   "commentStart": 1061,
@@ -5318,12 +5318,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "value": "seg06"
                 },
                 "to": [
-                  4.0406,
-                  0.4307
+                  102.6313,
+                  10.9406
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -5332,8 +5332,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  4.0406,
-                  0.4307
+                  102.6313,
+                  10.9406
                 ],
                 "tag": {
                   "commentStart": 1118,
@@ -5343,12 +5343,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "value": "seg08"
                 },
                 "to": [
-                  4.0406,
-                  1.2181
+                  102.6313,
+                  30.9406
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -5357,8 +5357,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  4.0406,
-                  1.2181
+                  102.6313,
+                  30.9406
                 ],
                 "tag": {
                   "commentStart": 1177,
@@ -5368,12 +5368,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "value": "seg05"
                 },
                 "to": [
-                  1.2847,
-                  1.2181
+                  32.6313,
+                  30.9406
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -5382,8 +5382,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  1.2847,
-                  1.2181
+                  32.6313,
+                  30.9406
                 ],
                 "tag": {
                   "commentStart": 1252,
@@ -5393,12 +5393,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "value": "seg10"
                 },
                 "to": [
-                  1.2847,
-                  1.6489
+                  32.6313,
+                  41.8813
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -5407,8 +5407,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  1.2847,
-                  1.6489
+                  32.6313,
+                  41.8813
                 ],
                 "tag": {
                   "commentStart": 1294,
@@ -5419,11 +5419,11 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                 },
                 "to": [
                   0.0,
-                  1.6489
+                  41.8813
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -5433,16 +5433,16 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                 },
                 "from": [
                   0.0,
-                  1.6489
+                  41.8813
                 ],
                 "tag": null,
                 "to": [
-                  -1.2847,
-                  1.6489
+                  -32.6313,
+                  41.8813
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -5451,17 +5451,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -1.2847,
-                  1.6489
+                  -32.6313,
+                  41.8813
                 ],
                 "tag": null,
                 "to": [
-                  -1.2847,
-                  1.2181
+                  -32.6313,
+                  30.9406
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -5470,17 +5470,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -1.2847,
-                  1.2181
+                  -32.6313,
+                  30.9406
                 ],
                 "tag": null,
                 "to": [
-                  -4.0406,
-                  1.2181
+                  -102.6313,
+                  30.9406
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -5489,17 +5489,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -4.0406,
-                  1.2181
+                  -102.6313,
+                  30.9406
                 ],
                 "tag": null,
                 "to": [
-                  -4.0406,
-                  0.4307
+                  -102.6313,
+                  10.9406
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -5508,17 +5508,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -4.0406,
-                  0.4307
+                  -102.6313,
+                  10.9406
                 ],
                 "tag": null,
                 "to": [
-                  -1.2847,
-                  0.4307
+                  -32.6312,
+                  10.9406
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -5527,17 +5527,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -1.2847,
-                  0.4307
+                  -32.6312,
+                  10.9406
                 ],
                 "tag": null,
                 "to": [
-                  -1.2847,
-                  -0.3937
+                  -32.6312,
+                  -10.0
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -5546,17 +5546,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -1.2847,
-                  -0.3937
+                  -32.6312,
+                  -10.0
                 ],
                 "tag": null,
                 "to": [
-                  -0.891,
-                  -0.3937
+                  -22.6312,
+                  -10.0
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -5565,17 +5565,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -0.891,
-                  -0.3937
+                  -22.6312,
+                  -10.0
                 ],
                 "tag": null,
                 "to": [
-                  -0.891,
-                  0.7874
+                  -22.6312,
+                  20.0
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -5585,22 +5585,22 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                 },
                 "ccw": false,
                 "center": [
-                  -0.4232,
-                  0.7874
+                  -10.75,
+                  20.0
                 ],
                 "from": [
-                  -0.891,
-                  0.7874
+                  -22.6312,
+                  20.0
                 ],
-                "radius": 0.46776574803149606,
+                "radius": 11.88125,
                 "tag": null,
                 "to": [
-                  -0.4232,
-                  1.2552
+                  -10.75,
+                  31.8813
                 ],
                 "type": "Arc",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -5609,17 +5609,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -0.4232,
-                  1.2552
+                  -10.75,
+                  31.8813
                 ],
                 "tag": null,
                 "to": [
                   0.0,
-                  1.2552
+                  31.8813
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -5629,16 +5629,16 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                 },
                 "from": [
                   0.0,
-                  1.2552
+                  31.8813
                 ],
                 "tag": null,
                 "to": [
                   0.0,
-                  1.2552
+                  31.8813
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               }
             ],
@@ -5675,14 +5675,14 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "start": {
               "from": [
                 0.0,
-                1.2552
+                31.8813
               ],
               "to": [
                 0.0,
-                1.2552
+                31.8813
               ],
               "units": {
-                "type": "Inches"
+                "type": "Mm"
               },
               "tag": null,
               "__geoMeta": {
@@ -5735,32 +5735,32 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "artifactId": "[uuid]",
             "originalId": "[uuid]",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
-          "height": 0.1968503937007874,
+          "height": 5.0,
           "startCapId": "[uuid]",
           "endCapId": "[uuid]",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           },
           "sectional": false
         },
         "units": {
-          "type": "Inches"
+          "type": "Mm"
         }
       },
       "start": {
         "from": [
-          1.2847,
+          32.6313,
           0.0
         ],
         "to": [
-          1.2847,
+          32.6313,
           0.0
         ],
         "units": {
-          "type": "Inches"
+          "type": "Mm"
         },
         "tag": null,
         "__geoMeta": {
@@ -5785,7 +5785,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
       "artifactId": "[uuid]",
       "originalId": "[uuid]",
       "units": {
-        "type": "Inches"
+        "type": "Mm"
       }
     }
   },
@@ -5801,7 +5801,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            -1.2847,
+            -32.6313,
             0.0
           ],
           "tag": {
@@ -5812,12 +5812,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "value": "rectangleSegmentA001"
           },
           "to": [
-            -0.891,
+            -22.6313,
             0.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -5826,7 +5826,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            -0.891,
+            -22.6313,
             0.0
           ],
           "tag": {
@@ -5837,12 +5837,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "value": "rectangleSegmentB001"
           },
           "to": [
-            -0.891,
-            -0.3937
+            -22.6313,
+            -10.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -5851,8 +5851,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            -0.891,
-            -0.3937
+            -22.6313,
+            -10.0
           ],
           "tag": {
             "commentStart": 2841,
@@ -5862,12 +5862,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "value": "rectangleSegmentC001"
           },
           "to": [
-            -1.2847,
-            -0.3937
+            -32.6313,
+            -10.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -5876,17 +5876,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            -1.2847,
-            -0.3937
+            -32.6313,
+            -10.0
           ],
           "tag": null,
           "to": [
-            -1.2847,
+            -32.6313,
             0.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -5895,17 +5895,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            -1.2847,
+            -32.6313,
             0.0
           ],
           "tag": null,
           "to": [
-            -1.2847,
+            -32.6313,
             0.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         }
       ],
@@ -6140,7 +6140,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                 },
                 "from": [
                   0.0,
-                  1.2552
+                  31.8813
                 ],
                 "tag": {
                   "commentStart": 653,
@@ -6150,12 +6150,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "value": "seg01"
                 },
                 "to": [
-                  0.4232,
-                  1.2552
+                  10.75,
+                  31.8813
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -6165,14 +6165,14 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                 },
                 "ccw": false,
                 "center": [
-                  0.4232,
-                  0.7874
+                  10.75,
+                  20.0
                 ],
                 "from": [
-                  0.4232,
-                  1.2552
+                  10.75,
+                  31.8813
                 ],
-                "radius": 0.46776574803149606,
+                "radius": 11.88125,
                 "tag": {
                   "commentStart": 763,
                   "end": 769,
@@ -6181,12 +6181,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "value": "seg09"
                 },
                 "to": [
-                  0.891,
-                  0.7874
+                  22.6313,
+                  20.0
                 ],
                 "type": "Arc",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -6195,8 +6195,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  0.891,
-                  0.7874
+                  22.6313,
+                  20.0
                 ],
                 "tag": {
                   "commentStart": 829,
@@ -6206,12 +6206,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "value": "seg03"
                 },
                 "to": [
-                  0.891,
-                  -0.3937
+                  22.6313,
+                  -10.0
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -6220,8 +6220,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  0.891,
-                  -0.3937
+                  22.6313,
+                  -10.0
                 ],
                 "tag": {
                   "commentStart": 882,
@@ -6231,12 +6231,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "value": "seg07"
                 },
                 "to": [
-                  1.2847,
-                  -0.3937
+                  32.6313,
+                  -10.0
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -6245,8 +6245,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  1.2847,
-                  -0.3937
+                  32.6313,
+                  -10.0
                 ],
                 "tag": {
                   "commentStart": 984,
@@ -6256,12 +6256,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "value": "seg02"
                 },
                 "to": [
-                  1.2847,
-                  0.4307
+                  32.6313,
+                  10.9406
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -6270,8 +6270,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  1.2847,
-                  0.4307
+                  32.6313,
+                  10.9406
                 ],
                 "tag": {
                   "commentStart": 1061,
@@ -6281,12 +6281,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "value": "seg06"
                 },
                 "to": [
-                  4.0406,
-                  0.4307
+                  102.6313,
+                  10.9406
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -6295,8 +6295,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  4.0406,
-                  0.4307
+                  102.6313,
+                  10.9406
                 ],
                 "tag": {
                   "commentStart": 1118,
@@ -6306,12 +6306,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "value": "seg08"
                 },
                 "to": [
-                  4.0406,
-                  1.2181
+                  102.6313,
+                  30.9406
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -6320,8 +6320,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  4.0406,
-                  1.2181
+                  102.6313,
+                  30.9406
                 ],
                 "tag": {
                   "commentStart": 1177,
@@ -6331,12 +6331,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "value": "seg05"
                 },
                 "to": [
-                  1.2847,
-                  1.2181
+                  32.6313,
+                  30.9406
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -6345,8 +6345,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  1.2847,
-                  1.2181
+                  32.6313,
+                  30.9406
                 ],
                 "tag": {
                   "commentStart": 1252,
@@ -6356,12 +6356,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "value": "seg10"
                 },
                 "to": [
-                  1.2847,
-                  1.6489
+                  32.6313,
+                  41.8813
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -6370,8 +6370,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  1.2847,
-                  1.6489
+                  32.6313,
+                  41.8813
                 ],
                 "tag": {
                   "commentStart": 1294,
@@ -6382,11 +6382,11 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                 },
                 "to": [
                   0.0,
-                  1.6489
+                  41.8813
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -6396,16 +6396,16 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                 },
                 "from": [
                   0.0,
-                  1.6489
+                  41.8813
                 ],
                 "tag": null,
                 "to": [
-                  -1.2847,
-                  1.6489
+                  -32.6313,
+                  41.8813
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -6414,17 +6414,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -1.2847,
-                  1.6489
+                  -32.6313,
+                  41.8813
                 ],
                 "tag": null,
                 "to": [
-                  -1.2847,
-                  1.2181
+                  -32.6313,
+                  30.9406
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -6433,17 +6433,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -1.2847,
-                  1.2181
+                  -32.6313,
+                  30.9406
                 ],
                 "tag": null,
                 "to": [
-                  -4.0406,
-                  1.2181
+                  -102.6313,
+                  30.9406
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -6452,17 +6452,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -4.0406,
-                  1.2181
+                  -102.6313,
+                  30.9406
                 ],
                 "tag": null,
                 "to": [
-                  -4.0406,
-                  0.4307
+                  -102.6313,
+                  10.9406
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -6471,17 +6471,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -4.0406,
-                  0.4307
+                  -102.6313,
+                  10.9406
                 ],
                 "tag": null,
                 "to": [
-                  -1.2847,
-                  0.4307
+                  -32.6312,
+                  10.9406
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -6490,17 +6490,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -1.2847,
-                  0.4307
+                  -32.6312,
+                  10.9406
                 ],
                 "tag": null,
                 "to": [
-                  -1.2847,
-                  -0.3937
+                  -32.6312,
+                  -10.0
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -6509,17 +6509,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -1.2847,
-                  -0.3937
+                  -32.6312,
+                  -10.0
                 ],
                 "tag": null,
                 "to": [
-                  -0.891,
-                  -0.3937
+                  -22.6312,
+                  -10.0
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -6528,17 +6528,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -0.891,
-                  -0.3937
+                  -22.6312,
+                  -10.0
                 ],
                 "tag": null,
                 "to": [
-                  -0.891,
-                  0.7874
+                  -22.6312,
+                  20.0
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -6548,22 +6548,22 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                 },
                 "ccw": false,
                 "center": [
-                  -0.4232,
-                  0.7874
+                  -10.75,
+                  20.0
                 ],
                 "from": [
-                  -0.891,
-                  0.7874
+                  -22.6312,
+                  20.0
                 ],
-                "radius": 0.46776574803149606,
+                "radius": 11.88125,
                 "tag": null,
                 "to": [
-                  -0.4232,
-                  1.2552
+                  -10.75,
+                  31.8813
                 ],
                 "type": "Arc",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -6572,17 +6572,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -0.4232,
-                  1.2552
+                  -10.75,
+                  31.8813
                 ],
                 "tag": null,
                 "to": [
                   0.0,
-                  1.2552
+                  31.8813
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -6592,16 +6592,16 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                 },
                 "from": [
                   0.0,
-                  1.2552
+                  31.8813
                 ],
                 "tag": null,
                 "to": [
                   0.0,
-                  1.2552
+                  31.8813
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               }
             ],
@@ -6638,14 +6638,14 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "start": {
               "from": [
                 0.0,
-                1.2552
+                31.8813
               ],
               "to": [
                 0.0,
-                1.2552
+                31.8813
               ],
               "units": {
-                "type": "Inches"
+                "type": "Mm"
               },
               "tag": null,
               "__geoMeta": {
@@ -6698,32 +6698,32 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "artifactId": "[uuid]",
             "originalId": "[uuid]",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
-          "height": 0.1968503937007874,
+          "height": 5.0,
           "startCapId": "[uuid]",
           "endCapId": "[uuid]",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           },
           "sectional": false
         },
         "units": {
-          "type": "Inches"
+          "type": "Mm"
         }
       },
       "start": {
         "from": [
-          -1.2847,
+          -32.6313,
           0.0
         ],
         "to": [
-          -1.2847,
+          -32.6313,
           0.0
         ],
         "units": {
-          "type": "Inches"
+          "type": "Mm"
         },
         "tag": null,
         "__geoMeta": {
@@ -6748,7 +6748,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
       "artifactId": "[uuid]",
       "originalId": "[uuid]",
       "units": {
-        "type": "Inches"
+        "type": "Mm"
       }
     }
   },
@@ -6764,7 +6764,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            -1.2847,
+            -32.6313,
             0.0
           ],
           "tag": {
@@ -6775,12 +6775,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "value": "rectangleSegmentA003"
           },
           "to": [
-            1.2847,
+            32.6313,
             0.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -6789,7 +6789,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            1.2847,
+            32.6313,
             0.0
           ],
           "tag": {
@@ -6800,12 +6800,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "value": "rectangleSegmentB003"
           },
           "to": [
-            1.2847,
-            -0.3937
+            32.6313,
+            -10.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -6814,8 +6814,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            1.2847,
-            -0.3937
+            32.6313,
+            -10.0
           ],
           "tag": {
             "commentStart": 3450,
@@ -6825,12 +6825,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "value": "rectangleSegmentC003"
           },
           "to": [
-            -1.2847,
-            -0.3937
+            -32.6313,
+            -10.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -6839,17 +6839,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            -1.2847,
-            -0.3937
+            -32.6313,
+            -10.0
           ],
           "tag": null,
           "to": [
-            -1.2847,
+            -32.6313,
             0.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -6858,17 +6858,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "sourceRange": []
           },
           "from": [
-            -1.2847,
+            -32.6313,
             0.0
           ],
           "tag": null,
           "to": [
-            -1.2847,
+            -32.6313,
             0.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         }
       ],
@@ -6955,7 +6955,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  1.2847,
+                  32.6313,
                   0.0
                 ],
                 "tag": {
@@ -6966,12 +6966,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "value": "rectangleSegmentA002"
                 },
                 "to": [
-                  0.891,
+                  22.6313,
                   0.0
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -6980,7 +6980,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  0.891,
+                  22.6313,
                   0.0
                 ],
                 "tag": {
@@ -6991,12 +6991,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "value": "rectangleSegmentB002"
                 },
                 "to": [
-                  0.891,
-                  -0.3937
+                  22.6312,
+                  -10.0
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -7005,8 +7005,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  0.891,
-                  -0.3937
+                  22.6312,
+                  -10.0
                 ],
                 "tag": {
                   "commentStart": 2237,
@@ -7016,12 +7016,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "value": "rectangleSegmentC002"
                 },
                 "to": [
-                  1.2847,
-                  -0.3937
+                  32.6312,
+                  -10.0
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -7030,17 +7030,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  1.2847,
-                  -0.3937
+                  32.6312,
+                  -10.0
                 ],
                 "tag": null,
                 "to": [
-                  1.2847,
+                  32.6313,
                   0.0
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -7049,17 +7049,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  1.2847,
+                  32.6313,
                   0.0
                 ],
                 "tag": null,
                 "to": [
-                  1.2847,
+                  32.6313,
                   0.0
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               }
             ],
@@ -7294,7 +7294,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                       },
                       "from": [
                         0.0,
-                        1.2552
+                        31.8813
                       ],
                       "tag": {
                         "commentStart": 653,
@@ -7304,12 +7304,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "value": "seg01"
                       },
                       "to": [
-                        0.4232,
-                        1.2552
+                        10.75,
+                        31.8813
                       ],
                       "type": "ToPoint",
                       "units": {
-                        "type": "Inches"
+                        "type": "Mm"
                       }
                     },
                     {
@@ -7319,14 +7319,14 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                       },
                       "ccw": false,
                       "center": [
-                        0.4232,
-                        0.7874
+                        10.75,
+                        20.0
                       ],
                       "from": [
-                        0.4232,
-                        1.2552
+                        10.75,
+                        31.8813
                       ],
-                      "radius": 0.46776574803149606,
+                      "radius": 11.88125,
                       "tag": {
                         "commentStart": 763,
                         "end": 769,
@@ -7335,12 +7335,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "value": "seg09"
                       },
                       "to": [
-                        0.891,
-                        0.7874
+                        22.6313,
+                        20.0
                       ],
                       "type": "Arc",
                       "units": {
-                        "type": "Inches"
+                        "type": "Mm"
                       }
                     },
                     {
@@ -7349,8 +7349,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "sourceRange": []
                       },
                       "from": [
-                        0.891,
-                        0.7874
+                        22.6313,
+                        20.0
                       ],
                       "tag": {
                         "commentStart": 829,
@@ -7360,12 +7360,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "value": "seg03"
                       },
                       "to": [
-                        0.891,
-                        -0.3937
+                        22.6313,
+                        -10.0
                       ],
                       "type": "ToPoint",
                       "units": {
-                        "type": "Inches"
+                        "type": "Mm"
                       }
                     },
                     {
@@ -7374,8 +7374,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "sourceRange": []
                       },
                       "from": [
-                        0.891,
-                        -0.3937
+                        22.6313,
+                        -10.0
                       ],
                       "tag": {
                         "commentStart": 882,
@@ -7385,12 +7385,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "value": "seg07"
                       },
                       "to": [
-                        1.2847,
-                        -0.3937
+                        32.6313,
+                        -10.0
                       ],
                       "type": "ToPoint",
                       "units": {
-                        "type": "Inches"
+                        "type": "Mm"
                       }
                     },
                     {
@@ -7399,8 +7399,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "sourceRange": []
                       },
                       "from": [
-                        1.2847,
-                        -0.3937
+                        32.6313,
+                        -10.0
                       ],
                       "tag": {
                         "commentStart": 984,
@@ -7410,12 +7410,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "value": "seg02"
                       },
                       "to": [
-                        1.2847,
-                        0.4307
+                        32.6313,
+                        10.9406
                       ],
                       "type": "ToPoint",
                       "units": {
-                        "type": "Inches"
+                        "type": "Mm"
                       }
                     },
                     {
@@ -7424,8 +7424,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "sourceRange": []
                       },
                       "from": [
-                        1.2847,
-                        0.4307
+                        32.6313,
+                        10.9406
                       ],
                       "tag": {
                         "commentStart": 1061,
@@ -7435,12 +7435,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "value": "seg06"
                       },
                       "to": [
-                        4.0406,
-                        0.4307
+                        102.6313,
+                        10.9406
                       ],
                       "type": "ToPoint",
                       "units": {
-                        "type": "Inches"
+                        "type": "Mm"
                       }
                     },
                     {
@@ -7449,8 +7449,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "sourceRange": []
                       },
                       "from": [
-                        4.0406,
-                        0.4307
+                        102.6313,
+                        10.9406
                       ],
                       "tag": {
                         "commentStart": 1118,
@@ -7460,12 +7460,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "value": "seg08"
                       },
                       "to": [
-                        4.0406,
-                        1.2181
+                        102.6313,
+                        30.9406
                       ],
                       "type": "ToPoint",
                       "units": {
-                        "type": "Inches"
+                        "type": "Mm"
                       }
                     },
                     {
@@ -7474,8 +7474,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "sourceRange": []
                       },
                       "from": [
-                        4.0406,
-                        1.2181
+                        102.6313,
+                        30.9406
                       ],
                       "tag": {
                         "commentStart": 1177,
@@ -7485,12 +7485,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "value": "seg05"
                       },
                       "to": [
-                        1.2847,
-                        1.2181
+                        32.6313,
+                        30.9406
                       ],
                       "type": "ToPoint",
                       "units": {
-                        "type": "Inches"
+                        "type": "Mm"
                       }
                     },
                     {
@@ -7499,8 +7499,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "sourceRange": []
                       },
                       "from": [
-                        1.2847,
-                        1.2181
+                        32.6313,
+                        30.9406
                       ],
                       "tag": {
                         "commentStart": 1252,
@@ -7510,12 +7510,12 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "value": "seg10"
                       },
                       "to": [
-                        1.2847,
-                        1.6489
+                        32.6313,
+                        41.8813
                       ],
                       "type": "ToPoint",
                       "units": {
-                        "type": "Inches"
+                        "type": "Mm"
                       }
                     },
                     {
@@ -7524,8 +7524,8 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "sourceRange": []
                       },
                       "from": [
-                        1.2847,
-                        1.6489
+                        32.6313,
+                        41.8813
                       ],
                       "tag": {
                         "commentStart": 1294,
@@ -7536,11 +7536,11 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                       },
                       "to": [
                         0.0,
-                        1.6489
+                        41.8813
                       ],
                       "type": "ToPoint",
                       "units": {
-                        "type": "Inches"
+                        "type": "Mm"
                       }
                     },
                     {
@@ -7550,16 +7550,16 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                       },
                       "from": [
                         0.0,
-                        1.6489
+                        41.8813
                       ],
                       "tag": null,
                       "to": [
-                        -1.2847,
-                        1.6489
+                        -32.6313,
+                        41.8813
                       ],
                       "type": "ToPoint",
                       "units": {
-                        "type": "Inches"
+                        "type": "Mm"
                       }
                     },
                     {
@@ -7568,17 +7568,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "sourceRange": []
                       },
                       "from": [
-                        -1.2847,
-                        1.6489
+                        -32.6313,
+                        41.8813
                       ],
                       "tag": null,
                       "to": [
-                        -1.2847,
-                        1.2181
+                        -32.6313,
+                        30.9406
                       ],
                       "type": "ToPoint",
                       "units": {
-                        "type": "Inches"
+                        "type": "Mm"
                       }
                     },
                     {
@@ -7587,17 +7587,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "sourceRange": []
                       },
                       "from": [
-                        -1.2847,
-                        1.2181
+                        -32.6313,
+                        30.9406
                       ],
                       "tag": null,
                       "to": [
-                        -4.0406,
-                        1.2181
+                        -102.6313,
+                        30.9406
                       ],
                       "type": "ToPoint",
                       "units": {
-                        "type": "Inches"
+                        "type": "Mm"
                       }
                     },
                     {
@@ -7606,17 +7606,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "sourceRange": []
                       },
                       "from": [
-                        -4.0406,
-                        1.2181
+                        -102.6313,
+                        30.9406
                       ],
                       "tag": null,
                       "to": [
-                        -4.0406,
-                        0.4307
+                        -102.6313,
+                        10.9406
                       ],
                       "type": "ToPoint",
                       "units": {
-                        "type": "Inches"
+                        "type": "Mm"
                       }
                     },
                     {
@@ -7625,17 +7625,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "sourceRange": []
                       },
                       "from": [
-                        -4.0406,
-                        0.4307
+                        -102.6313,
+                        10.9406
                       ],
                       "tag": null,
                       "to": [
-                        -1.2847,
-                        0.4307
+                        -32.6312,
+                        10.9406
                       ],
                       "type": "ToPoint",
                       "units": {
-                        "type": "Inches"
+                        "type": "Mm"
                       }
                     },
                     {
@@ -7644,17 +7644,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "sourceRange": []
                       },
                       "from": [
-                        -1.2847,
-                        0.4307
+                        -32.6312,
+                        10.9406
                       ],
                       "tag": null,
                       "to": [
-                        -1.2847,
-                        -0.3937
+                        -32.6312,
+                        -10.0
                       ],
                       "type": "ToPoint",
                       "units": {
-                        "type": "Inches"
+                        "type": "Mm"
                       }
                     },
                     {
@@ -7663,17 +7663,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "sourceRange": []
                       },
                       "from": [
-                        -1.2847,
-                        -0.3937
+                        -32.6312,
+                        -10.0
                       ],
                       "tag": null,
                       "to": [
-                        -0.891,
-                        -0.3937
+                        -22.6312,
+                        -10.0
                       ],
                       "type": "ToPoint",
                       "units": {
-                        "type": "Inches"
+                        "type": "Mm"
                       }
                     },
                     {
@@ -7682,17 +7682,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "sourceRange": []
                       },
                       "from": [
-                        -0.891,
-                        -0.3937
+                        -22.6312,
+                        -10.0
                       ],
                       "tag": null,
                       "to": [
-                        -0.891,
-                        0.7874
+                        -22.6312,
+                        20.0
                       ],
                       "type": "ToPoint",
                       "units": {
-                        "type": "Inches"
+                        "type": "Mm"
                       }
                     },
                     {
@@ -7702,22 +7702,22 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                       },
                       "ccw": false,
                       "center": [
-                        -0.4232,
-                        0.7874
+                        -10.75,
+                        20.0
                       ],
                       "from": [
-                        -0.891,
-                        0.7874
+                        -22.6312,
+                        20.0
                       ],
-                      "radius": 0.46776574803149606,
+                      "radius": 11.88125,
                       "tag": null,
                       "to": [
-                        -0.4232,
-                        1.2552
+                        -10.75,
+                        31.8813
                       ],
                       "type": "Arc",
                       "units": {
-                        "type": "Inches"
+                        "type": "Mm"
                       }
                     },
                     {
@@ -7726,17 +7726,17 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                         "sourceRange": []
                       },
                       "from": [
-                        -0.4232,
-                        1.2552
+                        -10.75,
+                        31.8813
                       ],
                       "tag": null,
                       "to": [
                         0.0,
-                        1.2552
+                        31.8813
                       ],
                       "type": "ToPoint",
                       "units": {
-                        "type": "Inches"
+                        "type": "Mm"
                       }
                     },
                     {
@@ -7746,16 +7746,16 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                       },
                       "from": [
                         0.0,
-                        1.2552
+                        31.8813
                       ],
                       "tag": null,
                       "to": [
                         0.0,
-                        1.2552
+                        31.8813
                       ],
                       "type": "ToPoint",
                       "units": {
-                        "type": "Inches"
+                        "type": "Mm"
                       }
                     }
                   ],
@@ -7792,14 +7792,14 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "start": {
                     "from": [
                       0.0,
-                      1.2552
+                      31.8813
                     ],
                     "to": [
                       0.0,
-                      1.2552
+                      31.8813
                     ],
                     "units": {
-                      "type": "Inches"
+                      "type": "Mm"
                     },
                     "tag": null,
                     "__geoMeta": {
@@ -7852,32 +7852,32 @@ description: Variables in memory after executing router-template-cross-bar.kcl
                   "artifactId": "[uuid]",
                   "originalId": "[uuid]",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
-                "height": 0.1968503937007874,
+                "height": 5.0,
                 "startCapId": "[uuid]",
                 "endCapId": "[uuid]",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 },
                 "sectional": false
               },
               "units": {
-                "type": "Inches"
+                "type": "Mm"
               }
             },
             "start": {
               "from": [
-                1.2847,
+                32.6313,
                 0.0
               ],
               "to": [
-                1.2847,
+                32.6313,
                 0.0
               ],
               "units": {
-                "type": "Inches"
+                "type": "Mm"
               },
               "tag": null,
               "__geoMeta": {
@@ -7902,32 +7902,32 @@ description: Variables in memory after executing router-template-cross-bar.kcl
             "artifactId": "[uuid]",
             "originalId": "[uuid]",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
-          "height": 0.5118110236220472,
+          "height": 13.0,
           "startCapId": "[uuid]",
           "endCapId": "[uuid]",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           },
           "sectional": false
         },
         "units": {
-          "type": "Inches"
+          "type": "Mm"
         }
       },
       "start": {
         "from": [
-          -1.2847,
+          -32.6313,
           0.0
         ],
         "to": [
-          -1.2847,
+          -32.6313,
           0.0
         ],
         "units": {
-          "type": "Inches"
+          "type": "Mm"
         },
         "tag": null,
         "__geoMeta": {
@@ -7952,7 +7952,7 @@ description: Variables in memory after executing router-template-cross-bar.kcl
       "artifactId": "[uuid]",
       "originalId": "[uuid]",
       "units": {
-        "type": "Inches"
+        "type": "Mm"
       }
     }
   },

--- a/rust/kcl-lib/tests/kcl_samples/router-template-slate/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/router-template-slate/program_memory.snap
@@ -136,7 +136,7 @@ description: Variables in memory after executing router-template-slate.kcl
             },
             "from": [
               0.0,
-              1.107
+              28.1188
             ],
             "tag": {
               "commentStart": 638,
@@ -146,12 +146,12 @@ description: Variables in memory after executing router-template-slate.kcl
               "value": "seg01"
             },
             "to": [
-              0.4232,
-              1.107
+              10.75,
+              28.1188
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -161,22 +161,22 @@ description: Variables in memory after executing router-template-slate.kcl
             },
             "ccw": false,
             "center": [
-              0.4232,
-              0.7874
+              10.75,
+              20.0
             ],
             "from": [
-              0.4232,
-              1.107
+              10.75,
+              28.1188
             ],
-            "radius": 0.3196358267716536,
+            "radius": 8.11875,
             "tag": null,
             "to": [
-              0.7429,
-              0.7874
+              18.8688,
+              20.0
             ],
             "type": "Arc",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -185,8 +185,8 @@ description: Variables in memory after executing router-template-slate.kcl
               "sourceRange": []
             },
             "from": [
-              0.7429,
-              0.7874
+              18.8688,
+              20.0
             ],
             "tag": {
               "commentStart": 791,
@@ -196,12 +196,12 @@ description: Variables in memory after executing router-template-slate.kcl
               "value": "seg05"
             },
             "to": [
-              0.7429,
-              -0.4919
+              18.8688,
+              -12.4938
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -210,8 +210,8 @@ description: Variables in memory after executing router-template-slate.kcl
               "sourceRange": []
             },
             "from": [
-              0.7429,
-              -0.4919
+              18.8688,
+              -12.4938
             ],
             "tag": {
               "commentStart": 866,
@@ -221,12 +221,12 @@ description: Variables in memory after executing router-template-slate.kcl
               "value": "seg04"
             },
             "to": [
-              1.2106,
-              -0.4919
+              30.75,
+              -12.4938
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -235,8 +235,8 @@ description: Variables in memory after executing router-template-slate.kcl
               "sourceRange": []
             },
             "from": [
-              1.2106,
-              -0.4919
+              30.75,
+              -12.4938
             ],
             "tag": {
               "commentStart": 912,
@@ -246,12 +246,12 @@ description: Variables in memory after executing router-template-slate.kcl
               "value": "seg03"
             },
             "to": [
-              1.2106,
-              -4.8226
+              30.75,
+              -122.4938
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -260,8 +260,8 @@ description: Variables in memory after executing router-template-slate.kcl
               "sourceRange": []
             },
             "from": [
-              1.2106,
-              -4.8226
+              30.75,
+              -122.4938
             ],
             "tag": {
               "commentStart": 954,
@@ -272,11 +272,11 @@ description: Variables in memory after executing router-template-slate.kcl
             },
             "to": [
               0.0,
-              -4.8226
+              -122.4938
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -286,16 +286,16 @@ description: Variables in memory after executing router-template-slate.kcl
             },
             "from": [
               0.0,
-              -4.8226
+              -122.4938
             ],
             "tag": null,
             "to": [
-              -1.2106,
-              -4.8226
+              -30.75,
+              -122.4938
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -304,17 +304,17 @@ description: Variables in memory after executing router-template-slate.kcl
               "sourceRange": []
             },
             "from": [
-              -1.2106,
-              -4.8226
+              -30.75,
+              -122.4938
             ],
             "tag": null,
             "to": [
-              -1.2106,
-              -0.4919
+              -30.75,
+              -12.4938
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -323,17 +323,17 @@ description: Variables in memory after executing router-template-slate.kcl
               "sourceRange": []
             },
             "from": [
-              -1.2106,
-              -0.4919
+              -30.75,
+              -12.4938
             ],
             "tag": null,
             "to": [
-              -0.7429,
-              -0.4919
+              -18.8688,
+              -12.4938
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -342,17 +342,17 @@ description: Variables in memory after executing router-template-slate.kcl
               "sourceRange": []
             },
             "from": [
-              -0.7429,
-              -0.4919
+              -18.8688,
+              -12.4938
             ],
             "tag": null,
             "to": [
-              -0.7429,
-              0.7874
+              -18.8688,
+              20.0
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -362,22 +362,22 @@ description: Variables in memory after executing router-template-slate.kcl
             },
             "ccw": false,
             "center": [
-              -0.4232,
-              0.7874
+              -10.75,
+              20.0
             ],
             "from": [
-              -0.7429,
-              0.7874
+              -18.8688,
+              20.0
             ],
-            "radius": 0.3196358267716536,
+            "radius": 8.11875,
             "tag": null,
             "to": [
-              -0.4232,
-              1.107
+              -10.75,
+              28.1187
             ],
             "type": "Arc",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -386,17 +386,17 @@ description: Variables in memory after executing router-template-slate.kcl
               "sourceRange": []
             },
             "from": [
-              -0.4232,
-              1.107
+              -10.75,
+              28.1187
             ],
             "tag": null,
             "to": [
               0.0,
-              1.107
+              28.1188
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -406,16 +406,16 @@ description: Variables in memory after executing router-template-slate.kcl
             },
             "from": [
               0.0,
-              1.107
+              28.1188
             ],
             "tag": null,
             "to": [
               0.0,
-              1.107
+              28.1188
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           }
         ],
@@ -452,14 +452,14 @@ description: Variables in memory after executing router-template-slate.kcl
         "start": {
           "from": [
             0.0,
-            1.107
+            28.1188
           ],
           "to": [
             0.0,
-            1.107
+            28.1188
           ],
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           },
           "tag": null,
           "__geoMeta": {
@@ -492,14 +492,14 @@ description: Variables in memory after executing router-template-slate.kcl
         "artifactId": "[uuid]",
         "originalId": "[uuid]",
         "units": {
-          "type": "Inches"
+          "type": "Mm"
         }
       },
-      "height": 0.1968503937007874,
+      "height": 5.0,
       "startCapId": "[uuid]",
       "endCapId": "[uuid]",
       "units": {
-        "type": "Inches"
+        "type": "Mm"
       },
       "sectional": false
     }
@@ -568,8 +568,8 @@ description: Variables in memory after executing router-template-slate.kcl
               "sourceRange": []
             },
             "from": [
-              -0.8169,
-              -0.4919
+              -20.75,
+              -12.4938
             ],
             "tag": {
               "commentStart": 1575,
@@ -579,12 +579,12 @@ description: Variables in memory after executing router-template-slate.kcl
               "value": "rectangleSegmentA001"
             },
             "to": [
-              -1.0925,
-              -0.4919
+              -27.75,
+              -12.4938
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -593,8 +593,8 @@ description: Variables in memory after executing router-template-slate.kcl
               "sourceRange": []
             },
             "from": [
-              -1.0925,
-              -0.4919
+              -27.75,
+              -12.4938
             ],
             "tag": {
               "commentStart": 1693,
@@ -604,12 +604,12 @@ description: Variables in memory after executing router-template-slate.kcl
               "value": "rectangleSegmentB001"
             },
             "to": [
-              -1.0925,
-              -3.6415
+              -27.75,
+              -92.4938
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -618,8 +618,8 @@ description: Variables in memory after executing router-template-slate.kcl
               "sourceRange": []
             },
             "from": [
-              -1.0925,
-              -3.6415
+              -27.75,
+              -92.4938
             ],
             "tag": {
               "commentStart": 1816,
@@ -629,12 +629,12 @@ description: Variables in memory after executing router-template-slate.kcl
               "value": "rectangleSegmentC001"
             },
             "to": [
-              -0.8169,
-              -3.6415
+              -20.75,
+              -92.4938
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -643,17 +643,17 @@ description: Variables in memory after executing router-template-slate.kcl
               "sourceRange": []
             },
             "from": [
-              -0.8169,
-              -3.6415
+              -20.75,
+              -92.4938
             ],
             "tag": null,
             "to": [
-              -0.8169,
-              -0.4919
+              -20.75,
+              -12.4938
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -662,17 +662,17 @@ description: Variables in memory after executing router-template-slate.kcl
               "sourceRange": []
             },
             "from": [
-              -0.8169,
-              -0.4919
+              -20.75,
+              -12.4938
             ],
             "tag": null,
             "to": [
-              -0.8169,
-              -0.4919
+              -20.75,
+              -12.4938
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           }
         ],
@@ -815,7 +815,7 @@ description: Variables in memory after executing router-template-slate.kcl
                   },
                   "from": [
                     0.0,
-                    1.107
+                    28.1188
                   ],
                   "tag": {
                     "commentStart": 638,
@@ -825,12 +825,12 @@ description: Variables in memory after executing router-template-slate.kcl
                     "value": "seg01"
                   },
                   "to": [
-                    0.4232,
-                    1.107
+                    10.75,
+                    28.1188
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -840,22 +840,22 @@ description: Variables in memory after executing router-template-slate.kcl
                   },
                   "ccw": false,
                   "center": [
-                    0.4232,
-                    0.7874
+                    10.75,
+                    20.0
                   ],
                   "from": [
-                    0.4232,
-                    1.107
+                    10.75,
+                    28.1188
                   ],
-                  "radius": 0.3196358267716536,
+                  "radius": 8.11875,
                   "tag": null,
                   "to": [
-                    0.7429,
-                    0.7874
+                    18.8688,
+                    20.0
                   ],
                   "type": "Arc",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -864,8 +864,8 @@ description: Variables in memory after executing router-template-slate.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    0.7429,
-                    0.7874
+                    18.8688,
+                    20.0
                   ],
                   "tag": {
                     "commentStart": 791,
@@ -875,12 +875,12 @@ description: Variables in memory after executing router-template-slate.kcl
                     "value": "seg05"
                   },
                   "to": [
-                    0.7429,
-                    -0.4919
+                    18.8688,
+                    -12.4938
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -889,8 +889,8 @@ description: Variables in memory after executing router-template-slate.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    0.7429,
-                    -0.4919
+                    18.8688,
+                    -12.4938
                   ],
                   "tag": {
                     "commentStart": 866,
@@ -900,12 +900,12 @@ description: Variables in memory after executing router-template-slate.kcl
                     "value": "seg04"
                   },
                   "to": [
-                    1.2106,
-                    -0.4919
+                    30.75,
+                    -12.4938
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -914,8 +914,8 @@ description: Variables in memory after executing router-template-slate.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    1.2106,
-                    -0.4919
+                    30.75,
+                    -12.4938
                   ],
                   "tag": {
                     "commentStart": 912,
@@ -925,12 +925,12 @@ description: Variables in memory after executing router-template-slate.kcl
                     "value": "seg03"
                   },
                   "to": [
-                    1.2106,
-                    -4.8226
+                    30.75,
+                    -122.4938
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -939,8 +939,8 @@ description: Variables in memory after executing router-template-slate.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    1.2106,
-                    -4.8226
+                    30.75,
+                    -122.4938
                   ],
                   "tag": {
                     "commentStart": 954,
@@ -951,11 +951,11 @@ description: Variables in memory after executing router-template-slate.kcl
                   },
                   "to": [
                     0.0,
-                    -4.8226
+                    -122.4938
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -965,16 +965,16 @@ description: Variables in memory after executing router-template-slate.kcl
                   },
                   "from": [
                     0.0,
-                    -4.8226
+                    -122.4938
                   ],
                   "tag": null,
                   "to": [
-                    -1.2106,
-                    -4.8226
+                    -30.75,
+                    -122.4938
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -983,17 +983,17 @@ description: Variables in memory after executing router-template-slate.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -1.2106,
-                    -4.8226
+                    -30.75,
+                    -122.4938
                   ],
                   "tag": null,
                   "to": [
-                    -1.2106,
-                    -0.4919
+                    -30.75,
+                    -12.4938
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1002,17 +1002,17 @@ description: Variables in memory after executing router-template-slate.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -1.2106,
-                    -0.4919
+                    -30.75,
+                    -12.4938
                   ],
                   "tag": null,
                   "to": [
-                    -0.7429,
-                    -0.4919
+                    -18.8688,
+                    -12.4938
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1021,17 +1021,17 @@ description: Variables in memory after executing router-template-slate.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -0.7429,
-                    -0.4919
+                    -18.8688,
+                    -12.4938
                   ],
                   "tag": null,
                   "to": [
-                    -0.7429,
-                    0.7874
+                    -18.8688,
+                    20.0
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1041,22 +1041,22 @@ description: Variables in memory after executing router-template-slate.kcl
                   },
                   "ccw": false,
                   "center": [
-                    -0.4232,
-                    0.7874
+                    -10.75,
+                    20.0
                   ],
                   "from": [
-                    -0.7429,
-                    0.7874
+                    -18.8688,
+                    20.0
                   ],
-                  "radius": 0.3196358267716536,
+                  "radius": 8.11875,
                   "tag": null,
                   "to": [
-                    -0.4232,
-                    1.107
+                    -10.75,
+                    28.1187
                   ],
                   "type": "Arc",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1065,17 +1065,17 @@ description: Variables in memory after executing router-template-slate.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -0.4232,
-                    1.107
+                    -10.75,
+                    28.1187
                   ],
                   "tag": null,
                   "to": [
                     0.0,
-                    1.107
+                    28.1188
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1085,16 +1085,16 @@ description: Variables in memory after executing router-template-slate.kcl
                   },
                   "from": [
                     0.0,
-                    1.107
+                    28.1188
                   ],
                   "tag": null,
                   "to": [
                     0.0,
-                    1.107
+                    28.1188
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 }
               ],
@@ -1131,14 +1131,14 @@ description: Variables in memory after executing router-template-slate.kcl
               "start": {
                 "from": [
                   0.0,
-                  1.107
+                  28.1188
                 ],
                 "to": [
                   0.0,
-                  1.107
+                  28.1188
                 ],
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 },
                 "tag": null,
                 "__geoMeta": {
@@ -1171,32 +1171,32 @@ description: Variables in memory after executing router-template-slate.kcl
               "artifactId": "[uuid]",
               "originalId": "[uuid]",
               "units": {
-                "type": "Inches"
+                "type": "Mm"
               }
             },
-            "height": 0.1968503937007874,
+            "height": 5.0,
             "startCapId": "[uuid]",
             "endCapId": "[uuid]",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             },
             "sectional": false
           },
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         "start": {
           "from": [
-            -0.8169,
-            -0.4919
+            -20.75,
+            -12.4938
           ],
           "to": [
-            -0.8169,
-            -0.4919
+            -20.75,
+            -12.4938
           ],
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           },
           "tag": null,
           "__geoMeta": {
@@ -1221,14 +1221,14 @@ description: Variables in memory after executing router-template-slate.kcl
         "artifactId": "[uuid]",
         "originalId": "[uuid]",
         "units": {
-          "type": "Inches"
+          "type": "Mm"
         }
       },
-      "height": 0.29527559055118113,
+      "height": 7.5,
       "startCapId": "[uuid]",
       "endCapId": "[uuid]",
       "units": {
-        "type": "Inches"
+        "type": "Mm"
       },
       "sectional": false
     }
@@ -1285,8 +1285,8 @@ description: Variables in memory after executing router-template-slate.kcl
               "sourceRange": []
             },
             "from": [
-              0.8169,
-              -0.4919
+              20.75,
+              -12.4938
             ],
             "tag": {
               "commentStart": 2204,
@@ -1296,12 +1296,12 @@ description: Variables in memory after executing router-template-slate.kcl
               "value": "rectangleSegmentA002"
             },
             "to": [
-              1.0925,
-              -0.4919
+              27.75,
+              -12.4938
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -1310,17 +1310,17 @@ description: Variables in memory after executing router-template-slate.kcl
               "sourceRange": []
             },
             "from": [
-              1.0925,
-              -0.4919
+              27.75,
+              -12.4938
             ],
             "tag": null,
             "to": [
-              1.0925,
-              -3.6415
+              27.75,
+              -92.4938
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -1329,17 +1329,17 @@ description: Variables in memory after executing router-template-slate.kcl
               "sourceRange": []
             },
             "from": [
-              1.0925,
-              -3.6415
+              27.75,
+              -92.4938
             ],
             "tag": null,
             "to": [
-              0.8169,
-              -3.6415
+              20.75,
+              -92.4938
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -1348,17 +1348,17 @@ description: Variables in memory after executing router-template-slate.kcl
               "sourceRange": []
             },
             "from": [
-              0.8169,
-              -3.6415
+              20.75,
+              -92.4938
             ],
             "tag": null,
             "to": [
-              0.8169,
-              -0.4919
+              20.75,
+              -12.4938
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
           {
@@ -1367,17 +1367,17 @@ description: Variables in memory after executing router-template-slate.kcl
               "sourceRange": []
             },
             "from": [
-              0.8169,
-              -0.4919
+              20.75,
+              -12.4938
             ],
             "tag": null,
             "to": [
-              0.8169,
-              -0.4919
+              20.75,
+              -12.4938
             ],
             "type": "ToPoint",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           }
         ],
@@ -1520,7 +1520,7 @@ description: Variables in memory after executing router-template-slate.kcl
                   },
                   "from": [
                     0.0,
-                    1.107
+                    28.1188
                   ],
                   "tag": {
                     "commentStart": 638,
@@ -1530,12 +1530,12 @@ description: Variables in memory after executing router-template-slate.kcl
                     "value": "seg01"
                   },
                   "to": [
-                    0.4232,
-                    1.107
+                    10.75,
+                    28.1188
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1545,22 +1545,22 @@ description: Variables in memory after executing router-template-slate.kcl
                   },
                   "ccw": false,
                   "center": [
-                    0.4232,
-                    0.7874
+                    10.75,
+                    20.0
                   ],
                   "from": [
-                    0.4232,
-                    1.107
+                    10.75,
+                    28.1188
                   ],
-                  "radius": 0.3196358267716536,
+                  "radius": 8.11875,
                   "tag": null,
                   "to": [
-                    0.7429,
-                    0.7874
+                    18.8688,
+                    20.0
                   ],
                   "type": "Arc",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1569,8 +1569,8 @@ description: Variables in memory after executing router-template-slate.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    0.7429,
-                    0.7874
+                    18.8688,
+                    20.0
                   ],
                   "tag": {
                     "commentStart": 791,
@@ -1580,12 +1580,12 @@ description: Variables in memory after executing router-template-slate.kcl
                     "value": "seg05"
                   },
                   "to": [
-                    0.7429,
-                    -0.4919
+                    18.8688,
+                    -12.4938
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1594,8 +1594,8 @@ description: Variables in memory after executing router-template-slate.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    0.7429,
-                    -0.4919
+                    18.8688,
+                    -12.4938
                   ],
                   "tag": {
                     "commentStart": 866,
@@ -1605,12 +1605,12 @@ description: Variables in memory after executing router-template-slate.kcl
                     "value": "seg04"
                   },
                   "to": [
-                    1.2106,
-                    -0.4919
+                    30.75,
+                    -12.4938
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1619,8 +1619,8 @@ description: Variables in memory after executing router-template-slate.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    1.2106,
-                    -0.4919
+                    30.75,
+                    -12.4938
                   ],
                   "tag": {
                     "commentStart": 912,
@@ -1630,12 +1630,12 @@ description: Variables in memory after executing router-template-slate.kcl
                     "value": "seg03"
                   },
                   "to": [
-                    1.2106,
-                    -4.8226
+                    30.75,
+                    -122.4938
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1644,8 +1644,8 @@ description: Variables in memory after executing router-template-slate.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    1.2106,
-                    -4.8226
+                    30.75,
+                    -122.4938
                   ],
                   "tag": {
                     "commentStart": 954,
@@ -1656,11 +1656,11 @@ description: Variables in memory after executing router-template-slate.kcl
                   },
                   "to": [
                     0.0,
-                    -4.8226
+                    -122.4938
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1670,16 +1670,16 @@ description: Variables in memory after executing router-template-slate.kcl
                   },
                   "from": [
                     0.0,
-                    -4.8226
+                    -122.4938
                   ],
                   "tag": null,
                   "to": [
-                    -1.2106,
-                    -4.8226
+                    -30.75,
+                    -122.4938
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1688,17 +1688,17 @@ description: Variables in memory after executing router-template-slate.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -1.2106,
-                    -4.8226
+                    -30.75,
+                    -122.4938
                   ],
                   "tag": null,
                   "to": [
-                    -1.2106,
-                    -0.4919
+                    -30.75,
+                    -12.4938
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1707,17 +1707,17 @@ description: Variables in memory after executing router-template-slate.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -1.2106,
-                    -0.4919
+                    -30.75,
+                    -12.4938
                   ],
                   "tag": null,
                   "to": [
-                    -0.7429,
-                    -0.4919
+                    -18.8688,
+                    -12.4938
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1726,17 +1726,17 @@ description: Variables in memory after executing router-template-slate.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -0.7429,
-                    -0.4919
+                    -18.8688,
+                    -12.4938
                   ],
                   "tag": null,
                   "to": [
-                    -0.7429,
-                    0.7874
+                    -18.8688,
+                    20.0
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1746,22 +1746,22 @@ description: Variables in memory after executing router-template-slate.kcl
                   },
                   "ccw": false,
                   "center": [
-                    -0.4232,
-                    0.7874
+                    -10.75,
+                    20.0
                   ],
                   "from": [
-                    -0.7429,
-                    0.7874
+                    -18.8688,
+                    20.0
                   ],
-                  "radius": 0.3196358267716536,
+                  "radius": 8.11875,
                   "tag": null,
                   "to": [
-                    -0.4232,
-                    1.107
+                    -10.75,
+                    28.1187
                   ],
                   "type": "Arc",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1770,17 +1770,17 @@ description: Variables in memory after executing router-template-slate.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -0.4232,
-                    1.107
+                    -10.75,
+                    28.1187
                   ],
                   "tag": null,
                   "to": [
                     0.0,
-                    1.107
+                    28.1188
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 },
                 {
@@ -1790,16 +1790,16 @@ description: Variables in memory after executing router-template-slate.kcl
                   },
                   "from": [
                     0.0,
-                    1.107
+                    28.1188
                   ],
                   "tag": null,
                   "to": [
                     0.0,
-                    1.107
+                    28.1188
                   ],
                   "type": "ToPoint",
                   "units": {
-                    "type": "Inches"
+                    "type": "Mm"
                   }
                 }
               ],
@@ -1836,14 +1836,14 @@ description: Variables in memory after executing router-template-slate.kcl
               "start": {
                 "from": [
                   0.0,
-                  1.107
+                  28.1188
                 ],
                 "to": [
                   0.0,
-                  1.107
+                  28.1188
                 ],
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 },
                 "tag": null,
                 "__geoMeta": {
@@ -1876,32 +1876,32 @@ description: Variables in memory after executing router-template-slate.kcl
               "artifactId": "[uuid]",
               "originalId": "[uuid]",
               "units": {
-                "type": "Inches"
+                "type": "Mm"
               }
             },
-            "height": 0.1968503937007874,
+            "height": 5.0,
             "startCapId": "[uuid]",
             "endCapId": "[uuid]",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             },
             "sectional": false
           },
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         "start": {
           "from": [
-            0.8169,
-            -0.4919
+            20.75,
+            -12.4938
           ],
           "to": [
-            0.8169,
-            -0.4919
+            20.75,
+            -12.4938
           ],
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           },
           "tag": null,
           "__geoMeta": {
@@ -1918,14 +1918,14 @@ description: Variables in memory after executing router-template-slate.kcl
         "artifactId": "[uuid]",
         "originalId": "[uuid]",
         "units": {
-          "type": "Inches"
+          "type": "Mm"
         }
       },
-      "height": 0.29527559055118113,
+      "height": 7.5,
       "startCapId": "[uuid]",
       "endCapId": "[uuid]",
       "units": {
-        "type": "Inches"
+        "type": "Mm"
       },
       "sectional": false
     }
@@ -2053,7 +2053,7 @@ description: Variables in memory after executing router-template-slate.kcl
           },
           "from": [
             0.0,
-            1.107
+            28.1188
           ],
           "tag": {
             "commentStart": 638,
@@ -2063,12 +2063,12 @@ description: Variables in memory after executing router-template-slate.kcl
             "value": "seg01"
           },
           "to": [
-            0.4232,
-            1.107
+            10.75,
+            28.1188
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -2078,22 +2078,22 @@ description: Variables in memory after executing router-template-slate.kcl
           },
           "ccw": false,
           "center": [
-            0.4232,
-            0.7874
+            10.75,
+            20.0
           ],
           "from": [
-            0.4232,
-            1.107
+            10.75,
+            28.1188
           ],
-          "radius": 0.3196358267716536,
+          "radius": 8.11875,
           "tag": null,
           "to": [
-            0.7429,
-            0.7874
+            18.8688,
+            20.0
           ],
           "type": "Arc",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -2102,8 +2102,8 @@ description: Variables in memory after executing router-template-slate.kcl
             "sourceRange": []
           },
           "from": [
-            0.7429,
-            0.7874
+            18.8688,
+            20.0
           ],
           "tag": {
             "commentStart": 791,
@@ -2113,12 +2113,12 @@ description: Variables in memory after executing router-template-slate.kcl
             "value": "seg05"
           },
           "to": [
-            0.7429,
-            -0.4919
+            18.8688,
+            -12.4938
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -2127,8 +2127,8 @@ description: Variables in memory after executing router-template-slate.kcl
             "sourceRange": []
           },
           "from": [
-            0.7429,
-            -0.4919
+            18.8688,
+            -12.4938
           ],
           "tag": {
             "commentStart": 866,
@@ -2138,12 +2138,12 @@ description: Variables in memory after executing router-template-slate.kcl
             "value": "seg04"
           },
           "to": [
-            1.2106,
-            -0.4919
+            30.75,
+            -12.4938
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -2152,8 +2152,8 @@ description: Variables in memory after executing router-template-slate.kcl
             "sourceRange": []
           },
           "from": [
-            1.2106,
-            -0.4919
+            30.75,
+            -12.4938
           ],
           "tag": {
             "commentStart": 912,
@@ -2163,12 +2163,12 @@ description: Variables in memory after executing router-template-slate.kcl
             "value": "seg03"
           },
           "to": [
-            1.2106,
-            -4.8226
+            30.75,
+            -122.4938
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -2177,8 +2177,8 @@ description: Variables in memory after executing router-template-slate.kcl
             "sourceRange": []
           },
           "from": [
-            1.2106,
-            -4.8226
+            30.75,
+            -122.4938
           ],
           "tag": {
             "commentStart": 954,
@@ -2189,11 +2189,11 @@ description: Variables in memory after executing router-template-slate.kcl
           },
           "to": [
             0.0,
-            -4.8226
+            -122.4938
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -2203,16 +2203,16 @@ description: Variables in memory after executing router-template-slate.kcl
           },
           "from": [
             0.0,
-            -4.8226
+            -122.4938
           ],
           "tag": null,
           "to": [
-            -1.2106,
-            -4.8226
+            -30.75,
+            -122.4938
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -2221,17 +2221,17 @@ description: Variables in memory after executing router-template-slate.kcl
             "sourceRange": []
           },
           "from": [
-            -1.2106,
-            -4.8226
+            -30.75,
+            -122.4938
           ],
           "tag": null,
           "to": [
-            -1.2106,
-            -0.4919
+            -30.75,
+            -12.4938
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -2240,17 +2240,17 @@ description: Variables in memory after executing router-template-slate.kcl
             "sourceRange": []
           },
           "from": [
-            -1.2106,
-            -0.4919
+            -30.75,
+            -12.4938
           ],
           "tag": null,
           "to": [
-            -0.7429,
-            -0.4919
+            -18.8688,
+            -12.4938
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -2259,17 +2259,17 @@ description: Variables in memory after executing router-template-slate.kcl
             "sourceRange": []
           },
           "from": [
-            -0.7429,
-            -0.4919
+            -18.8688,
+            -12.4938
           ],
           "tag": null,
           "to": [
-            -0.7429,
-            0.7874
+            -18.8688,
+            20.0
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -2279,22 +2279,22 @@ description: Variables in memory after executing router-template-slate.kcl
           },
           "ccw": false,
           "center": [
-            -0.4232,
-            0.7874
+            -10.75,
+            20.0
           ],
           "from": [
-            -0.7429,
-            0.7874
+            -18.8688,
+            20.0
           ],
-          "radius": 0.3196358267716536,
+          "radius": 8.11875,
           "tag": null,
           "to": [
-            -0.4232,
-            1.107
+            -10.75,
+            28.1187
           ],
           "type": "Arc",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -2303,17 +2303,17 @@ description: Variables in memory after executing router-template-slate.kcl
             "sourceRange": []
           },
           "from": [
-            -0.4232,
-            1.107
+            -10.75,
+            28.1187
           ],
           "tag": null,
           "to": [
             0.0,
-            1.107
+            28.1188
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -2323,16 +2323,16 @@ description: Variables in memory after executing router-template-slate.kcl
           },
           "from": [
             0.0,
-            1.107
+            28.1188
           ],
           "tag": null,
           "to": [
             0.0,
-            1.107
+            28.1188
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         }
       ],
@@ -2369,14 +2369,14 @@ description: Variables in memory after executing router-template-slate.kcl
       "start": {
         "from": [
           0.0,
-          1.107
+          28.1188
         ],
         "to": [
           0.0,
-          1.107
+          28.1188
         ],
         "units": {
-          "type": "Inches"
+          "type": "Mm"
         },
         "tag": null,
         "__geoMeta": {
@@ -2409,7 +2409,7 @@ description: Variables in memory after executing router-template-slate.kcl
       "artifactId": "[uuid]",
       "originalId": "[uuid]",
       "units": {
-        "type": "Inches"
+        "type": "Mm"
       }
     }
   },
@@ -2425,8 +2425,8 @@ description: Variables in memory after executing router-template-slate.kcl
             "sourceRange": []
           },
           "from": [
-            -0.8169,
-            -0.4919
+            -20.75,
+            -12.4938
           ],
           "tag": {
             "commentStart": 1575,
@@ -2436,12 +2436,12 @@ description: Variables in memory after executing router-template-slate.kcl
             "value": "rectangleSegmentA001"
           },
           "to": [
-            -1.0925,
-            -0.4919
+            -27.75,
+            -12.4938
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -2450,8 +2450,8 @@ description: Variables in memory after executing router-template-slate.kcl
             "sourceRange": []
           },
           "from": [
-            -1.0925,
-            -0.4919
+            -27.75,
+            -12.4938
           ],
           "tag": {
             "commentStart": 1693,
@@ -2461,12 +2461,12 @@ description: Variables in memory after executing router-template-slate.kcl
             "value": "rectangleSegmentB001"
           },
           "to": [
-            -1.0925,
-            -3.6415
+            -27.75,
+            -92.4938
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -2475,8 +2475,8 @@ description: Variables in memory after executing router-template-slate.kcl
             "sourceRange": []
           },
           "from": [
-            -1.0925,
-            -3.6415
+            -27.75,
+            -92.4938
           ],
           "tag": {
             "commentStart": 1816,
@@ -2486,12 +2486,12 @@ description: Variables in memory after executing router-template-slate.kcl
             "value": "rectangleSegmentC001"
           },
           "to": [
-            -0.8169,
-            -3.6415
+            -20.75,
+            -92.4938
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -2500,17 +2500,17 @@ description: Variables in memory after executing router-template-slate.kcl
             "sourceRange": []
           },
           "from": [
-            -0.8169,
-            -3.6415
+            -20.75,
+            -92.4938
           ],
           "tag": null,
           "to": [
-            -0.8169,
-            -0.4919
+            -20.75,
+            -12.4938
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -2519,17 +2519,17 @@ description: Variables in memory after executing router-template-slate.kcl
             "sourceRange": []
           },
           "from": [
-            -0.8169,
-            -0.4919
+            -20.75,
+            -12.4938
           ],
           "tag": null,
           "to": [
-            -0.8169,
-            -0.4919
+            -20.75,
+            -12.4938
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         }
       ],
@@ -2672,7 +2672,7 @@ description: Variables in memory after executing router-template-slate.kcl
                 },
                 "from": [
                   0.0,
-                  1.107
+                  28.1188
                 ],
                 "tag": {
                   "commentStart": 638,
@@ -2682,12 +2682,12 @@ description: Variables in memory after executing router-template-slate.kcl
                   "value": "seg01"
                 },
                 "to": [
-                  0.4232,
-                  1.107
+                  10.75,
+                  28.1188
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -2697,22 +2697,22 @@ description: Variables in memory after executing router-template-slate.kcl
                 },
                 "ccw": false,
                 "center": [
-                  0.4232,
-                  0.7874
+                  10.75,
+                  20.0
                 ],
                 "from": [
-                  0.4232,
-                  1.107
+                  10.75,
+                  28.1188
                 ],
-                "radius": 0.3196358267716536,
+                "radius": 8.11875,
                 "tag": null,
                 "to": [
-                  0.7429,
-                  0.7874
+                  18.8688,
+                  20.0
                 ],
                 "type": "Arc",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -2721,8 +2721,8 @@ description: Variables in memory after executing router-template-slate.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  0.7429,
-                  0.7874
+                  18.8688,
+                  20.0
                 ],
                 "tag": {
                   "commentStart": 791,
@@ -2732,12 +2732,12 @@ description: Variables in memory after executing router-template-slate.kcl
                   "value": "seg05"
                 },
                 "to": [
-                  0.7429,
-                  -0.4919
+                  18.8688,
+                  -12.4938
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -2746,8 +2746,8 @@ description: Variables in memory after executing router-template-slate.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  0.7429,
-                  -0.4919
+                  18.8688,
+                  -12.4938
                 ],
                 "tag": {
                   "commentStart": 866,
@@ -2757,12 +2757,12 @@ description: Variables in memory after executing router-template-slate.kcl
                   "value": "seg04"
                 },
                 "to": [
-                  1.2106,
-                  -0.4919
+                  30.75,
+                  -12.4938
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -2771,8 +2771,8 @@ description: Variables in memory after executing router-template-slate.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  1.2106,
-                  -0.4919
+                  30.75,
+                  -12.4938
                 ],
                 "tag": {
                   "commentStart": 912,
@@ -2782,12 +2782,12 @@ description: Variables in memory after executing router-template-slate.kcl
                   "value": "seg03"
                 },
                 "to": [
-                  1.2106,
-                  -4.8226
+                  30.75,
+                  -122.4938
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -2796,8 +2796,8 @@ description: Variables in memory after executing router-template-slate.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  1.2106,
-                  -4.8226
+                  30.75,
+                  -122.4938
                 ],
                 "tag": {
                   "commentStart": 954,
@@ -2808,11 +2808,11 @@ description: Variables in memory after executing router-template-slate.kcl
                 },
                 "to": [
                   0.0,
-                  -4.8226
+                  -122.4938
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -2822,16 +2822,16 @@ description: Variables in memory after executing router-template-slate.kcl
                 },
                 "from": [
                   0.0,
-                  -4.8226
+                  -122.4938
                 ],
                 "tag": null,
                 "to": [
-                  -1.2106,
-                  -4.8226
+                  -30.75,
+                  -122.4938
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -2840,17 +2840,17 @@ description: Variables in memory after executing router-template-slate.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -1.2106,
-                  -4.8226
+                  -30.75,
+                  -122.4938
                 ],
                 "tag": null,
                 "to": [
-                  -1.2106,
-                  -0.4919
+                  -30.75,
+                  -12.4938
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -2859,17 +2859,17 @@ description: Variables in memory after executing router-template-slate.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -1.2106,
-                  -0.4919
+                  -30.75,
+                  -12.4938
                 ],
                 "tag": null,
                 "to": [
-                  -0.7429,
-                  -0.4919
+                  -18.8688,
+                  -12.4938
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -2878,17 +2878,17 @@ description: Variables in memory after executing router-template-slate.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -0.7429,
-                  -0.4919
+                  -18.8688,
+                  -12.4938
                 ],
                 "tag": null,
                 "to": [
-                  -0.7429,
-                  0.7874
+                  -18.8688,
+                  20.0
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -2898,22 +2898,22 @@ description: Variables in memory after executing router-template-slate.kcl
                 },
                 "ccw": false,
                 "center": [
-                  -0.4232,
-                  0.7874
+                  -10.75,
+                  20.0
                 ],
                 "from": [
-                  -0.7429,
-                  0.7874
+                  -18.8688,
+                  20.0
                 ],
-                "radius": 0.3196358267716536,
+                "radius": 8.11875,
                 "tag": null,
                 "to": [
-                  -0.4232,
-                  1.107
+                  -10.75,
+                  28.1187
                 ],
                 "type": "Arc",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -2922,17 +2922,17 @@ description: Variables in memory after executing router-template-slate.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -0.4232,
-                  1.107
+                  -10.75,
+                  28.1187
                 ],
                 "tag": null,
                 "to": [
                   0.0,
-                  1.107
+                  28.1188
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -2942,16 +2942,16 @@ description: Variables in memory after executing router-template-slate.kcl
                 },
                 "from": [
                   0.0,
-                  1.107
+                  28.1188
                 ],
                 "tag": null,
                 "to": [
                   0.0,
-                  1.107
+                  28.1188
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               }
             ],
@@ -2988,14 +2988,14 @@ description: Variables in memory after executing router-template-slate.kcl
             "start": {
               "from": [
                 0.0,
-                1.107
+                28.1188
               ],
               "to": [
                 0.0,
-                1.107
+                28.1188
               ],
               "units": {
-                "type": "Inches"
+                "type": "Mm"
               },
               "tag": null,
               "__geoMeta": {
@@ -3028,32 +3028,32 @@ description: Variables in memory after executing router-template-slate.kcl
             "artifactId": "[uuid]",
             "originalId": "[uuid]",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
-          "height": 0.1968503937007874,
+          "height": 5.0,
           "startCapId": "[uuid]",
           "endCapId": "[uuid]",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           },
           "sectional": false
         },
         "units": {
-          "type": "Inches"
+          "type": "Mm"
         }
       },
       "start": {
         "from": [
-          -0.8169,
-          -0.4919
+          -20.75,
+          -12.4938
         ],
         "to": [
-          -0.8169,
-          -0.4919
+          -20.75,
+          -12.4938
         ],
         "units": {
-          "type": "Inches"
+          "type": "Mm"
         },
         "tag": null,
         "__geoMeta": {
@@ -3078,7 +3078,7 @@ description: Variables in memory after executing router-template-slate.kcl
       "artifactId": "[uuid]",
       "originalId": "[uuid]",
       "units": {
-        "type": "Inches"
+        "type": "Mm"
       }
     }
   },
@@ -3094,8 +3094,8 @@ description: Variables in memory after executing router-template-slate.kcl
             "sourceRange": []
           },
           "from": [
-            0.8169,
-            -0.4919
+            20.75,
+            -12.4938
           ],
           "tag": {
             "commentStart": 2204,
@@ -3105,12 +3105,12 @@ description: Variables in memory after executing router-template-slate.kcl
             "value": "rectangleSegmentA002"
           },
           "to": [
-            1.0925,
-            -0.4919
+            27.75,
+            -12.4938
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -3119,17 +3119,17 @@ description: Variables in memory after executing router-template-slate.kcl
             "sourceRange": []
           },
           "from": [
-            1.0925,
-            -0.4919
+            27.75,
+            -12.4938
           ],
           "tag": null,
           "to": [
-            1.0925,
-            -3.6415
+            27.75,
+            -92.4938
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -3138,17 +3138,17 @@ description: Variables in memory after executing router-template-slate.kcl
             "sourceRange": []
           },
           "from": [
-            1.0925,
-            -3.6415
+            27.75,
+            -92.4938
           ],
           "tag": null,
           "to": [
-            0.8169,
-            -3.6415
+            20.75,
+            -92.4938
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -3157,17 +3157,17 @@ description: Variables in memory after executing router-template-slate.kcl
             "sourceRange": []
           },
           "from": [
-            0.8169,
-            -3.6415
+            20.75,
+            -92.4938
           ],
           "tag": null,
           "to": [
-            0.8169,
-            -0.4919
+            20.75,
+            -12.4938
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         },
         {
@@ -3176,17 +3176,17 @@ description: Variables in memory after executing router-template-slate.kcl
             "sourceRange": []
           },
           "from": [
-            0.8169,
-            -0.4919
+            20.75,
+            -12.4938
           ],
           "tag": null,
           "to": [
-            0.8169,
-            -0.4919
+            20.75,
+            -12.4938
           ],
           "type": "ToPoint",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           }
         }
       ],
@@ -3329,7 +3329,7 @@ description: Variables in memory after executing router-template-slate.kcl
                 },
                 "from": [
                   0.0,
-                  1.107
+                  28.1188
                 ],
                 "tag": {
                   "commentStart": 638,
@@ -3339,12 +3339,12 @@ description: Variables in memory after executing router-template-slate.kcl
                   "value": "seg01"
                 },
                 "to": [
-                  0.4232,
-                  1.107
+                  10.75,
+                  28.1188
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -3354,22 +3354,22 @@ description: Variables in memory after executing router-template-slate.kcl
                 },
                 "ccw": false,
                 "center": [
-                  0.4232,
-                  0.7874
+                  10.75,
+                  20.0
                 ],
                 "from": [
-                  0.4232,
-                  1.107
+                  10.75,
+                  28.1188
                 ],
-                "radius": 0.3196358267716536,
+                "radius": 8.11875,
                 "tag": null,
                 "to": [
-                  0.7429,
-                  0.7874
+                  18.8688,
+                  20.0
                 ],
                 "type": "Arc",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -3378,8 +3378,8 @@ description: Variables in memory after executing router-template-slate.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  0.7429,
-                  0.7874
+                  18.8688,
+                  20.0
                 ],
                 "tag": {
                   "commentStart": 791,
@@ -3389,12 +3389,12 @@ description: Variables in memory after executing router-template-slate.kcl
                   "value": "seg05"
                 },
                 "to": [
-                  0.7429,
-                  -0.4919
+                  18.8688,
+                  -12.4938
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -3403,8 +3403,8 @@ description: Variables in memory after executing router-template-slate.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  0.7429,
-                  -0.4919
+                  18.8688,
+                  -12.4938
                 ],
                 "tag": {
                   "commentStart": 866,
@@ -3414,12 +3414,12 @@ description: Variables in memory after executing router-template-slate.kcl
                   "value": "seg04"
                 },
                 "to": [
-                  1.2106,
-                  -0.4919
+                  30.75,
+                  -12.4938
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -3428,8 +3428,8 @@ description: Variables in memory after executing router-template-slate.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  1.2106,
-                  -0.4919
+                  30.75,
+                  -12.4938
                 ],
                 "tag": {
                   "commentStart": 912,
@@ -3439,12 +3439,12 @@ description: Variables in memory after executing router-template-slate.kcl
                   "value": "seg03"
                 },
                 "to": [
-                  1.2106,
-                  -4.8226
+                  30.75,
+                  -122.4938
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -3453,8 +3453,8 @@ description: Variables in memory after executing router-template-slate.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  1.2106,
-                  -4.8226
+                  30.75,
+                  -122.4938
                 ],
                 "tag": {
                   "commentStart": 954,
@@ -3465,11 +3465,11 @@ description: Variables in memory after executing router-template-slate.kcl
                 },
                 "to": [
                   0.0,
-                  -4.8226
+                  -122.4938
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -3479,16 +3479,16 @@ description: Variables in memory after executing router-template-slate.kcl
                 },
                 "from": [
                   0.0,
-                  -4.8226
+                  -122.4938
                 ],
                 "tag": null,
                 "to": [
-                  -1.2106,
-                  -4.8226
+                  -30.75,
+                  -122.4938
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -3497,17 +3497,17 @@ description: Variables in memory after executing router-template-slate.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -1.2106,
-                  -4.8226
+                  -30.75,
+                  -122.4938
                 ],
                 "tag": null,
                 "to": [
-                  -1.2106,
-                  -0.4919
+                  -30.75,
+                  -12.4938
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -3516,17 +3516,17 @@ description: Variables in memory after executing router-template-slate.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -1.2106,
-                  -0.4919
+                  -30.75,
+                  -12.4938
                 ],
                 "tag": null,
                 "to": [
-                  -0.7429,
-                  -0.4919
+                  -18.8688,
+                  -12.4938
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -3535,17 +3535,17 @@ description: Variables in memory after executing router-template-slate.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -0.7429,
-                  -0.4919
+                  -18.8688,
+                  -12.4938
                 ],
                 "tag": null,
                 "to": [
-                  -0.7429,
-                  0.7874
+                  -18.8688,
+                  20.0
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -3555,22 +3555,22 @@ description: Variables in memory after executing router-template-slate.kcl
                 },
                 "ccw": false,
                 "center": [
-                  -0.4232,
-                  0.7874
+                  -10.75,
+                  20.0
                 ],
                 "from": [
-                  -0.7429,
-                  0.7874
+                  -18.8688,
+                  20.0
                 ],
-                "radius": 0.3196358267716536,
+                "radius": 8.11875,
                 "tag": null,
                 "to": [
-                  -0.4232,
-                  1.107
+                  -10.75,
+                  28.1187
                 ],
                 "type": "Arc",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -3579,17 +3579,17 @@ description: Variables in memory after executing router-template-slate.kcl
                   "sourceRange": []
                 },
                 "from": [
-                  -0.4232,
-                  1.107
+                  -10.75,
+                  28.1187
                 ],
                 "tag": null,
                 "to": [
                   0.0,
-                  1.107
+                  28.1188
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               },
               {
@@ -3599,16 +3599,16 @@ description: Variables in memory after executing router-template-slate.kcl
                 },
                 "from": [
                   0.0,
-                  1.107
+                  28.1188
                 ],
                 "tag": null,
                 "to": [
                   0.0,
-                  1.107
+                  28.1188
                 ],
                 "type": "ToPoint",
                 "units": {
-                  "type": "Inches"
+                  "type": "Mm"
                 }
               }
             ],
@@ -3645,14 +3645,14 @@ description: Variables in memory after executing router-template-slate.kcl
             "start": {
               "from": [
                 0.0,
-                1.107
+                28.1188
               ],
               "to": [
                 0.0,
-                1.107
+                28.1188
               ],
               "units": {
-                "type": "Inches"
+                "type": "Mm"
               },
               "tag": null,
               "__geoMeta": {
@@ -3685,32 +3685,32 @@ description: Variables in memory after executing router-template-slate.kcl
             "artifactId": "[uuid]",
             "originalId": "[uuid]",
             "units": {
-              "type": "Inches"
+              "type": "Mm"
             }
           },
-          "height": 0.1968503937007874,
+          "height": 5.0,
           "startCapId": "[uuid]",
           "endCapId": "[uuid]",
           "units": {
-            "type": "Inches"
+            "type": "Mm"
           },
           "sectional": false
         },
         "units": {
-          "type": "Inches"
+          "type": "Mm"
         }
       },
       "start": {
         "from": [
-          0.8169,
-          -0.4919
+          20.75,
+          -12.4938
         ],
         "to": [
-          0.8169,
-          -0.4919
+          20.75,
+          -12.4938
         ],
         "units": {
-          "type": "Inches"
+          "type": "Mm"
         },
         "tag": null,
         "__geoMeta": {
@@ -3727,7 +3727,7 @@ description: Variables in memory after executing router-template-slate.kcl
       "artifactId": "[uuid]",
       "originalId": "[uuid]",
       "units": {
-        "type": "Inches"
+        "type": "Mm"
       }
     }
   },


### PR DESCRIPTION
Resolves #5621.

The `Sketch` and `Path` structs used to store coordinates in the units of whatever the first point (from `startSketch(at = ...)`) used. But now we store them in the default length unit of the module, i.e. whatever is set by `@settings()`. This is what the frontend expects and uses in point-and-click.

I find it interesting that there are a few samples that use one default unit, but specify variables in another unit, so their internal representation was changed by this.