### PR TITLE
Make Text-to-CAD Edit the default workflow in the toolbar

### DIFF
--- a/src/lib/toolbar.ts
+++ b/src/lib/toolbar.ts
@@ -428,6 +428,21 @@ export const toolbarConfig: Record<ToolbarModeName, ToolbarMode> = {
         id: 'ai',
         array: [
           {
+            id: 'prompt-to-edit',
+            onClick: () =>
+              commandBarActor.send({
+                type: 'Find and select command',
+                data: { name: 'Prompt-to-edit', groupId: 'modeling' },
+              }),
+            icon: 'sparkles',
+            iconColor: '#29FFA4',
+            alwaysDark: true,
+            status: IS_ML_EXPERIMENTAL ? 'experimental' : 'available',
+            title: 'Modify with Zoo Text-to-CAD',
+            description: 'Edit geometry with AI / ML.',
+            links: [],
+          },
+          {
             id: 'text-to-cad',
             onClick: () => {
               const currentProject =
@@ -456,21 +471,6 @@ export const toolbarConfig: Record<ToolbarModeName, ToolbarMode> = {
                 url: 'https://zoo.dev/docs/api/ml/generate-a-cad-model-from-text',
               },
             ],
-          },
-          {
-            id: 'prompt-to-edit',
-            onClick: () =>
-              commandBarActor.send({
-                type: 'Find and select command',
-                data: { name: 'Prompt-to-edit', groupId: 'modeling' },
-              }),
-            icon: 'sparkles',
-            iconColor: '#29FFA4',
-            alwaysDark: true,
-            status: IS_ML_EXPERIMENTAL ? 'experimental' : 'available',
-            title: 'Modify with Zoo Text-to-CAD',
-            description: 'Edit geometry with AI / ML.',
-            links: [],
           },
         ],
       },


### PR DESCRIPTION
We want users to make edits first and foremost within projects, so we're going to surface it as the default workflow button in the toolbar. WIP until I verify that tests are okay with this.