### PR TITLE
Make the textarea command bar input run its resize initially

### DIFF
--- a/src/components/CommandBar/CommandBarTextareaInput.tsx
+++ b/src/components/CommandBar/CommandBarTextareaInput.tsx
@@ -111,6 +111,8 @@ const useTextareaAutoGrow = (ref: RefObject<HTMLTextAreaElement>) => {
     }
 
     if (ref.current === null) return
+    // Run initially to set all this stuff at the start
+    listener()
     ref.current.addEventListener('input', listener)
 
     return () => {


### PR DESCRIPTION
We have a hook to auto-grow the textarea input but it wasn't running once initially. This is noticable on the onboarding, where we show the user a long Text-to-CAD Edit prompt that overflows.