### PR TITLE
Fix: Can't go back to Profiles arg in Extrude, Revolve, Loft

### DIFF
--- a/e2e/playwright/command-bar-tests.spec.ts
+++ b/e2e/playwright/command-bar-tests.spec.ts
@@ -38,6 +38,9 @@ test.describe('Command bar tests', () => {
     // Click the line of code for xLine.
     await page.getByText(`startProfile(at = [-10, -10])`).click()
 
+    // Wait for the selection to register (TODO: we need a definitive way to wait for this)
+    await page.waitForTimeout(200)
+
     await toolbar.extrudeButton.click()
     await cmdBar.expectState({
       stage: 'arguments',

--- a/e2e/playwright/command-bar-tests.spec.ts
+++ b/e2e/playwright/command-bar-tests.spec.ts
@@ -38,21 +38,19 @@ test.describe('Command bar tests', () => {
     // Click the line of code for xLine.
     await page.getByText(`startProfile(at = [-10, -10])`).click()
 
-    // Wait for the selection to register (TODO: we need a definitive way to wait for this)
-    await page.waitForTimeout(200)
-
     await toolbar.extrudeButton.click()
     await cmdBar.expectState({
       stage: 'arguments',
       commandName: 'Extrude',
-      currentArgKey: 'length',
-      currentArgValue: '5',
+      currentArgKey: 'sketches',
+      currentArgValue: '',
       headerArguments: {
-        Profiles: '1 profile',
+        Profiles: '',
         Length: '',
       },
-      highlightedHeaderArg: 'length',
+      highlightedHeaderArg: 'Profiles',
     })
+    await cmdBar.progressCmdBar()
     await cmdBar.progressCmdBar()
     await cmdBar.expectState({
       stage: 'review',

--- a/e2e/playwright/editor-tests.spec.ts
+++ b/e2e/playwright/editor-tests.spec.ts
@@ -1131,6 +1131,8 @@ sketch001 = startSketchOn(XZ)
     await page.waitForTimeout(100)
 
     await page.getByText('startProfile(at = [4.61, -14.01])').click()
+    // Wait for the selection to register (TODO: we need a definitive way to wait for this)
+    await page.waitForTimeout(200)
     await toolbar.extrudeButton.click()
     await cmdBar.progressCmdBar()
     await cmdBar.expectState({

--- a/e2e/playwright/editor-tests.spec.ts
+++ b/e2e/playwright/editor-tests.spec.ts
@@ -1131,9 +1131,8 @@ sketch001 = startSketchOn(XZ)
     await page.waitForTimeout(100)
 
     await page.getByText('startProfile(at = [4.61, -14.01])').click()
-    // Wait for the selection to register (TODO: we need a definitive way to wait for this)
-    await page.waitForTimeout(200)
     await toolbar.extrudeButton.click()
+    await cmdBar.progressCmdBar()
     await cmdBar.expectState({
       stage: 'arguments',
       currentArgKey: 'length',
@@ -1355,9 +1354,7 @@ sketch001 = startSketchOn(XZ)
       const u = await getUtils(page)
       const projectLink = page.getByRole('link', { name: 'cube' })
       const gizmo = page.locator('[aria-label*=gizmo]')
-      const resetCameraButton = page.getByRole('button', {
-        name: 'Reset view',
-      })
+      const resetCameraButton = page.getByRole('button', { name: 'Reset view' })
       const locationToHaveColor = async (
         position: { x: number; y: number },
         color: [number, number, number]

--- a/e2e/playwright/point-click.spec.ts
+++ b/e2e/playwright/point-click.spec.ts
@@ -76,6 +76,15 @@ test.describe('Point-and-click tests', () => {
       await toolbar.extrudeButton.click()
       await cmdBar.expectState({
         stage: 'arguments',
+        currentArgKey: 'sketches',
+        currentArgValue: '',
+        headerArguments: { Profiles: '', Length: '' },
+        highlightedHeaderArg: 'Profiles',
+        commandName: 'Extrude',
+      })
+      await cmdBar.progressCmdBar()
+      await cmdBar.expectState({
+        stage: 'arguments',
         currentArgKey: 'length',
         currentArgValue: '5',
         headerArguments: { Profiles: '1 profile', Length: '' },
@@ -1646,6 +1655,15 @@ sketch002 = startSketchOn(plane001)
         await test.step(`Go through the command bar flow with preselected sketches`, async () => {
           await toolbar.loftButton.click()
           await cmdBar.expectState({
+            stage: 'arguments',
+            currentArgKey: 'sketches',
+            currentArgValue: '',
+            headerArguments: { Profiles: '' },
+            highlightedHeaderArg: 'Profiles',
+            commandName: 'Loft',
+          })
+          await cmdBar.progressCmdBar()
+          await cmdBar.expectState({
             stage: 'review',
             headerArguments: { Profiles: '2 profiles' },
             commandName: 'Loft',
@@ -2088,6 +2106,18 @@ extrude001 = extrude(sketch001, length = -12)
     await test.step(`Apply fillet to the preselected edge`, async () => {
       await page.waitForTimeout(100)
       await toolbar.filletButton.click()
+      await cmdBar.expectState({
+        commandName: 'Fillet',
+        highlightedHeaderArg: 'selection',
+        currentArgKey: 'selection',
+        currentArgValue: '',
+        headerArguments: {
+          Selection: '',
+          Radius: '',
+        },
+        stage: 'arguments',
+      })
+      await cmdBar.progressCmdBar()
       await cmdBar.expectState({
         commandName: 'Fillet',
         highlightedHeaderArg: 'radius',
@@ -2619,6 +2649,18 @@ extrude001 = extrude(profile001, length = 5)
         await toolbar.filletButton.click()
         await cmdBar.expectState({
           commandName: 'Fillet',
+          highlightedHeaderArg: 'selection',
+          currentArgKey: 'selection',
+          currentArgValue: '',
+          headerArguments: {
+            Selection: '',
+            Radius: '',
+          },
+          stage: 'arguments',
+        })
+        await cmdBar.progressCmdBar()
+        await cmdBar.expectState({
+          commandName: 'Fillet',
           highlightedHeaderArg: 'radius',
           currentArgKey: 'radius',
           currentArgValue: '5',
@@ -2722,6 +2764,19 @@ extrude001 = extrude(sketch001, length = -12)
     await test.step(`Apply chamfer to the preselected edge`, async () => {
       await page.waitForTimeout(100)
       await toolbar.chamferButton.click()
+      await cmdBar.expectState({
+        commandName: 'Chamfer',
+        highlightedHeaderArg: 'selection',
+        currentArgKey: 'selection',
+        currentArgValue: '',
+        headerArguments: {
+          Selection: '',
+          Length: '',
+        },
+        stage: 'arguments',
+      })
+      await cmdBar.progressCmdBar()
+      await page.waitForTimeout(1000)
       await cmdBar.expectState({
         commandName: 'Chamfer',
         highlightedHeaderArg: 'length',
@@ -3205,6 +3260,8 @@ extrude001 = extrude(sketch001, length = 30)
         await test.step(`Go through the command bar flow with a preselected face (cap)`, async () => {
           await toolbar.shellButton.click()
           await cmdBar.progressCmdBar()
+          await page.waitForTimeout(500)
+          await cmdBar.progressCmdBar()
           await cmdBar.expectState({
             stage: 'review',
             headerArguments: {
@@ -3638,9 +3695,8 @@ tag=$rectangleSegmentC002,
       // revolve
       await editor.scrollToText(codeToSelection)
       await page.getByText(codeToSelection).click()
-      // Wait for the selection to register (TODO: we need a definitive way to wait for this)
-      await page.waitForTimeout(200)
       await toolbar.revolveButton.click()
+      await cmdBar.progressCmdBar()
       await cmdBar.progressCmdBar()
       await cmdBar.progressCmdBar()
       await cmdBar.progressCmdBar()
@@ -4575,6 +4631,18 @@ path001 = startProfile(sketch001, at = [0, 0])
       await toolbar.extrudeButton.click()
       await cmdBar.expectState({
         stage: 'arguments',
+        currentArgKey: 'sketches',
+        currentArgValue: '',
+        headerArguments: {
+          Profiles: '',
+          Length: '',
+        },
+        highlightedHeaderArg: 'Profiles',
+        commandName: 'Extrude',
+      })
+      await cmdBar.progressCmdBar()
+      await cmdBar.expectState({
+        stage: 'arguments',
         currentArgKey: 'length',
         currentArgValue: '5',
         headerArguments: {
@@ -4655,6 +4723,19 @@ path001 = startProfile(sketch001, at = [0, 0])
 
     await test.step('Go through command bar flow', async () => {
       await toolbar.sweepButton.click()
+      await cmdBar.expectState({
+        stage: 'arguments',
+        currentArgKey: 'sketches',
+        currentArgValue: '',
+        headerArguments: {
+          Profiles: '',
+          Path: '',
+          Sectional: '',
+        },
+        highlightedHeaderArg: 'Profiles',
+        commandName: 'Sweep',
+      })
+      await cmdBar.progressCmdBar()
       await cmdBar.expectState({
         stage: 'arguments',
         currentArgKey: 'path',
@@ -4739,6 +4820,19 @@ path001 = startProfile(sketch001, at = [0, 0])
     await test.step('Go through command bar flow', async () => {
       await toolbar.closePane('code')
       await toolbar.revolveButton.click()
+      await cmdBar.expectState({
+        stage: 'arguments',
+        currentArgKey: 'sketches',
+        currentArgValue: '',
+        headerArguments: {
+          Profiles: '',
+          AxisOrEdge: '',
+          Angle: '',
+        },
+        highlightedHeaderArg: 'Profiles',
+        commandName: 'Revolve',
+      })
+      await cmdBar.progressCmdBar()
       await cmdBar.expectState({
         stage: 'arguments',
         currentArgKey: 'axisOrEdge',

--- a/e2e/playwright/sketch-tests.spec.ts
+++ b/e2e/playwright/sketch-tests.spec.ts
@@ -1016,6 +1016,7 @@ profile001 = startProfile(sketch001, at = [${roundOff(scale * 69.6)}, ${roundOff
 
     // sketch selection should already have been made.
     // otherwise the cmdbar would be waiting for a selection.
+    await cmdBar.progressCmdBar()
     await cmdBar.expectState({
       stage: 'arguments',
       currentArgKey: 'length',

--- a/e2e/playwright/various.spec.ts
+++ b/e2e/playwright/various.spec.ts
@@ -574,6 +574,7 @@ profile001 = startProfile(sketch002, at = [-12.34, 12.34])
   await page.waitForTimeout(100)
 
   await cmdBar.progressCmdBar()
+  await cmdBar.progressCmdBar()
   await expect(page.getByText('Confirm Extrude')).toBeVisible()
   await cmdBar.progressCmdBar()
 

--- a/src/components/CommandBar/CommandBarSelectionInput.tsx
+++ b/src/components/CommandBar/CommandBarSelectionInput.tsx
@@ -71,6 +71,7 @@ function CommandBarSelectionInput({
 
   useEffect(() => {
     inputRef.current?.focus()
+    setHasSelectionBeenSetHere(true)
   }, [selection, inputRef])
 
   // Show the default planes if the selection type is 'plane'

--- a/src/components/CommandBar/CommandBarSelectionInput.tsx
+++ b/src/components/CommandBar/CommandBarSelectionInput.tsx
@@ -55,6 +55,7 @@ function CommandBarSelectionInput({
   const commandBarState = useCommandBarState()
   const [hasSubmitted, setHasSubmitted] = useState(false)
   const [hasClearedSelection, setHasClearedSelection] = useState(false)
+  const [hasSelectionBeenSetHere, setHasSelectionBeenSetHere] = useState(false)
   const selection = useSelector(arg.machineActor, selectionSelector)
   const selectionsByType = useMemo(() => {
     return getSelectionCountByType(selection)
@@ -107,6 +108,7 @@ function CommandBarSelectionInput({
 
   function handleChange() {
     inputRef.current?.focus()
+    setHasSelectionBeenSetHere(true)
   }
 
   function handleSubmit(e?: React.FormEvent<HTMLFormElement>) {
@@ -158,12 +160,13 @@ function CommandBarSelectionInput({
       if (
         !(arg.clearSelectionFirst && !hasClearedSelection) &&
         canSubmitSelection &&
+        hasSelectionBeenSetHere &&
         resolvedSelection
       ) {
         onSubmit(resolvedSelection)
       }
     }
-  }, [hasClearedSelection])
+  }, [hasClearedSelection, hasSelectionBeenSetHere])
 
   // Set selection filter if needed, and reset it when the component unmounts
   useEffect(() => {

--- a/src/components/CommandBar/CommandBarSelectionInput.tsx
+++ b/src/components/CommandBar/CommandBarSelectionInput.tsx
@@ -55,7 +55,6 @@ function CommandBarSelectionInput({
   const commandBarState = useCommandBarState()
   const [hasSubmitted, setHasSubmitted] = useState(false)
   const [hasClearedSelection, setHasClearedSelection] = useState(false)
-  const [hasSelectionBeenSetHere, setHasSelectionBeenSetHere] = useState(false)
   const selection = useSelector(arg.machineActor, selectionSelector)
   const selectionsByType = useMemo(() => {
     return getSelectionCountByType(selection)
@@ -71,7 +70,6 @@ function CommandBarSelectionInput({
 
   useEffect(() => {
     inputRef.current?.focus()
-    setHasSelectionBeenSetHere(true)
   }, [selection, inputRef])
 
   // Show the default planes if the selection type is 'plane'
@@ -109,7 +107,6 @@ function CommandBarSelectionInput({
 
   function handleChange() {
     inputRef.current?.focus()
-    setHasSelectionBeenSetHere(true)
   }
 
   function handleSubmit(e?: React.FormEvent<HTMLFormElement>) {
@@ -142,8 +139,8 @@ function CommandBarSelectionInput({
         data: {
           selectionType: 'singleCodeCursor',
         },
-      })
-    setHasClearedSelection(true)
+      }) &&
+      setHasClearedSelection(true)
   }, [arg])
 
   // Watch for outside teardowns of this component
@@ -161,13 +158,12 @@ function CommandBarSelectionInput({
       if (
         !(arg.clearSelectionFirst && !hasClearedSelection) &&
         canSubmitSelection &&
-        hasSelectionBeenSetHere &&
         resolvedSelection
       ) {
         onSubmit(resolvedSelection)
       }
     }
-  }, [hasClearedSelection, hasSelectionBeenSetHere])
+  }, [hasClearedSelection])
 
   // Set selection filter if needed, and reset it when the component unmounts
   useEffect(() => {


### PR DESCRIPTION
Fixes #7080

This fixes a double-fire of the clean up callback calling onSubmit.
And we're back to the non-skip behavior on multi profile sweeps before #7047 