### PR TITLE
Show error when trying to export at non-top-level

### DIFF
--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -281,7 +281,14 @@ impl ExecutorContext {
 
                     // Track exports.
                     if let ItemVisibility::Export = variable_declaration.visibility {
-                        exec_state.mod_local.module_exports.push(var_name);
+                        if matches!(body_type, BodyType::Root) {
+                            exec_state.mod_local.module_exports.push(var_name);
+                        } else {
+                            exec_state.err(CompilationError::err(
+                                variable_declaration.as_source_range(),
+                                "Exports are only supported at the top-level of a file. Remove `export` or move it to the top-level.",
+                            ));
+                        }
                     }
                     // Variable declaration can be the return value of a module.
                     last_expr = matches!(body_type, BodyType::Root).then_some(value);

--- a/rust/kcl-lib/src/simulation_tests.rs
+++ b/rust/kcl-lib/src/simulation_tests.rs
@@ -1164,6 +1164,27 @@ mod import_foreign {
         super::execute(TEST_NAME, false).await
     }
 }
+mod export_var_only_at_top_level {
+    const TEST_NAME: &str = "export_var_only_at_top_level";
+
+    /// Test parsing KCL.
+    #[test]
+    fn parse() {
+        super::parse(TEST_NAME)
+    }
+
+    /// Test that parsing and unparsing KCL produces the original KCL input.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unparse() {
+        super::unparse(TEST_NAME).await
+    }
+
+    /// Test that KCL is executed correctly.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn kcl_test_execute() {
+        super::execute(TEST_NAME, false).await
+    }
+}
 mod assembly_non_default_units {
     const TEST_NAME: &str = "assembly_non_default_units";
 

--- a/rust/kcl-lib/tests/export_var_only_at_top_level/artifact_commands.snap
+++ b/rust/kcl-lib/tests/export_var_only_at_top_level/artifact_commands.snap
@@ -1,0 +1,5 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Artifact commands export_only_at_top_level.kcl
+---
+[]

--- a/rust/kcl-lib/tests/export_var_only_at_top_level/artifact_graph_flowchart.snap
+++ b/rust/kcl-lib/tests/export_var_only_at_top_level/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Artifact graph flowchart export_only_at_top_level.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/rust/kcl-lib/tests/export_var_only_at_top_level/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/export_var_only_at_top_level/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/rust/kcl-lib/tests/export_var_only_at_top_level/ast.snap
+++ b/rust/kcl-lib/tests/export_var_only_at_top_level/ast.snap
@@ -1,0 +1,148 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Result of parsing export_only_at_top_level.kcl
+---
+{
+  "Ok": {
+    "body": [
+      {
+        "commentStart": 0,
+        "declaration": {
+          "commentStart": 0,
+          "end": 0,
+          "id": {
+            "commentStart": 0,
+            "end": 0,
+            "name": "main",
+            "start": 0,
+            "type": "Identifier"
+          },
+          "init": {
+            "body": {
+              "body": [
+                {
+                  "commentStart": 0,
+                  "declaration": {
+                    "commentStart": 0,
+                    "end": 0,
+                    "id": {
+                      "commentStart": 0,
+                      "end": 0,
+                      "name": "x",
+                      "start": 0,
+                      "type": "Identifier"
+                    },
+                    "init": {
+                      "commentStart": 0,
+                      "end": 0,
+                      "raw": "2",
+                      "start": 0,
+                      "type": "Literal",
+                      "type": "Literal",
+                      "value": {
+                        "value": 2.0,
+                        "suffix": "None"
+                      }
+                    },
+                    "start": 0,
+                    "type": "VariableDeclarator"
+                  },
+                  "end": 0,
+                  "kind": "const",
+                  "start": 0,
+                  "type": "VariableDeclaration",
+                  "type": "VariableDeclaration",
+                  "visibility": "export"
+                },
+                {
+                  "argument": {
+                    "commentStart": 0,
+                    "end": 0,
+                    "raw": "0",
+                    "start": 0,
+                    "type": "Literal",
+                    "type": "Literal",
+                    "value": {
+                      "value": 0.0,
+                      "suffix": "None"
+                    }
+                  },
+                  "commentStart": 0,
+                  "end": 0,
+                  "start": 0,
+                  "type": "ReturnStatement",
+                  "type": "ReturnStatement"
+                }
+              ],
+              "commentStart": 0,
+              "end": 0,
+              "start": 0
+            },
+            "commentStart": 0,
+            "end": 0,
+            "params": [],
+            "start": 0,
+            "type": "FunctionExpression",
+            "type": "FunctionExpression"
+          },
+          "start": 0,
+          "type": "VariableDeclarator"
+        },
+        "end": 0,
+        "kind": "fn",
+        "start": 0,
+        "type": "VariableDeclaration",
+        "type": "VariableDeclaration"
+      },
+      {
+        "commentStart": 0,
+        "end": 0,
+        "expression": {
+          "callee": {
+            "abs_path": false,
+            "commentStart": 0,
+            "end": 0,
+            "name": {
+              "commentStart": 0,
+              "end": 0,
+              "name": "main",
+              "start": 0,
+              "type": "Identifier"
+            },
+            "path": [],
+            "start": 0,
+            "type": "Name"
+          },
+          "commentStart": 0,
+          "end": 0,
+          "start": 0,
+          "type": "CallExpressionKw",
+          "type": "CallExpressionKw",
+          "unlabeled": null
+        },
+        "start": 0,
+        "type": "ExpressionStatement",
+        "type": "ExpressionStatement"
+      }
+    ],
+    "commentStart": 0,
+    "end": 0,
+    "nonCodeMeta": {
+      "nonCodeNodes": {
+        "0": [
+          {
+            "commentStart": 0,
+            "end": 0,
+            "start": 0,
+            "type": "NonCodeNode",
+            "value": {
+              "type": "newLine"
+            }
+          }
+        ]
+      },
+      "startNodes": []
+    },
+    "start": 0
+  }
+}

--- a/rust/kcl-lib/tests/export_var_only_at_top_level/execution_error.snap
+++ b/rust/kcl-lib/tests/export_var_only_at_top_level/execution_error.snap
@@ -1,0 +1,15 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Error from executing export_only_at_top_level.kcl
+---
+KCL Semantic error
+
+  × semantic: Exports are only supported at the top-level of a file. Remove
+  │ `export` or move it to the top-level.
+   ╭─[2:3]
+ 1 │ fn main() {
+ 2 │   export x = 2
+   ·   ──────┬─────
+   ·         ╰── main
+ 3 │   return 0
+   ╰────

--- a/rust/kcl-lib/tests/export_var_only_at_top_level/input.kcl
+++ b/rust/kcl-lib/tests/export_var_only_at_top_level/input.kcl
@@ -1,0 +1,6 @@
+fn main() {
+  export x = 2
+  return 0
+}
+
+main()

--- a/rust/kcl-lib/tests/export_var_only_at_top_level/ops.snap
+++ b/rust/kcl-lib/tests/export_var_only_at_top_level/ops.snap
@@ -1,0 +1,5 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Operations executed export_only_at_top_level.kcl
+---
+[]

--- a/rust/kcl-lib/tests/export_var_only_at_top_level/unparsed.snap
+++ b/rust/kcl-lib/tests/export_var_only_at_top_level/unparsed.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Result of unparsing export_only_at_top_level.kcl
+---
+fn main() {
+  export   x = 2
+  return 0
+}
+
+main()


### PR DESCRIPTION
Resolves #4433.

It's a non-fatal runtime error. Ideally, we'd carry extra context in the parser or have a static analysis phase so that we didn't need to actually execute the `export` to detect it. The bad `export` could be inside a lib function that you don't call.