### PR TITLE
[Fix]: When loading the modeling page the user's settings for camera projection was ignored

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -12,6 +12,7 @@ import type {
   CameraViewState_type,
   UnitLength_type,
 } from '@kittycad/lib/dist/types/src/models'
+import type { CameraProjectionType } from '@rust/kcl-lib/bindings/CameraProjectionType'
 
 export const uuidv4 = v4
 
@@ -622,9 +623,11 @@ export async function engineViewIsometricWithGeometryPresent({
 export async function engineViewIsometricWithoutGeometryPresent({
   engineCommandManager,
   unit,
+  cameraProjection,
 }: {
   engineCommandManager: EngineCommandManager
   unit?: UnitLength_type
+  cameraProjection: CameraProjectionType
 }) {
   // If you load an empty scene with any file unit it will have an eye offset of this
   const MAGIC_ENGINE_EYE_OFFSET = 1378.0057
@@ -644,8 +647,9 @@ export async function engineViewIsometricWithoutGeometryPresent({
     eye_offset: MAGIC_ENGINE_EYE_OFFSET,
     fov_y: 45,
     ortho_scale_factor: 1.4063792,
-    is_ortho: true,
-    ortho_scale_enabled: true,
+    // gotcha: the current value if orthographic won't be written to disk! its default!
+    is_ortho: cameraProjection !== 'perspective',
+    ortho_scale_enabled: cameraProjection !== 'perspective',
     world_coord_system: 'right_handed_up_z',
   }
   await engineCommandManager.sendSceneCommand({

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -647,7 +647,6 @@ export async function engineViewIsometricWithoutGeometryPresent({
     eye_offset: MAGIC_ENGINE_EYE_OFFSET,
     fov_y: 45,
     ortho_scale_factor: 1.4063792,
-    // gotcha: the current value if orthographic won't be written to disk! its default!
     is_ortho: cameraProjection !== 'perspective',
     ortho_scale_enabled: cameraProjection !== 'perspective',
     world_coord_system: 'right_handed_up_z',


### PR DESCRIPTION
# Issue

When loading into the modeling page the user's camera projection setting was completely ignored when I updated the code to use the `view_isometric` endpoint.

# Implementation

Within `resetCameraPosition` I check we are in the user workflow and if the user has `perspective` set and we set the camera to perspective before doing the other camera API calls.

I grab a snapshot of the settings and check what the camera should reset to based on the user settings

# Scenarios

>  `cat ~/.config/zoo-modeling-app/settings.toml ` to see if I have undefined setting

| Has Geometry | User Setting | Does it work (end result) |
|--------|--------|--------|
| No | undefined | orthographic | 
| Yes | undefined | orthographic |
| No | Perspective | Perspective |
| Yes | Perspective | Perspective |
| No | orthographic (actually undefined) | orthographic |
| Yes | orthographic (actually undefined) | orthographic | 

> Note: `orthographic` never gets explicitly written to settings.toml since it is a default settings. It will be `orthographic` in JS memory though. 

# video walkthrough

https://github.com/user-attachments/assets/46191c46-ffdb-42f4-8309-df167937270c


