### PR TITLE
Fix enter key loop in sweep commands

### DIFF
--- a/e2e/playwright/fixtures/cmdBarFixture.ts
+++ b/e2e/playwright/fixtures/cmdBarFixture.ts
@@ -105,14 +105,19 @@ export class CmdBarFixture {
   expectState = async (expected: CmdBarSerialised) => {
     return expect.poll(() => this._serialiseCmdBar()).toEqual(expected)
   }
-  /** The method will use buttons OR press enter randomly to progress the cmdbar,
-   * this could have unexpected results depending on what's focused
-   *
-   * TODO: This method assumes the user has a valid input to the current stage,
+  /**
+   * This method is used to progress the command bar to the next step, defaulting to clicking the next button.
+   * Optionally, with the `shouldUseKeyboard` parameter, it will hit `Enter` to progress.
+   * * TODO: This method assumes the user has a valid input to the current stage,
    * and assumes we are past the `pickCommand` step.
    */
-  progressCmdBar = async (shouldFuzzProgressMethod = true) => {
+  progressCmdBar = async (shouldUseKeyboard = false) => {
     await this.page.waitForTimeout(2000)
+    if (shouldUseKeyboard) {
+      await this.page.keyboard.press('Enter')
+      return
+    }
+
     const arrowButton = this.page.getByRole('button', {
       name: 'arrow right Continue',
     })

--- a/e2e/playwright/point-click.spec.ts
+++ b/e2e/playwright/point-click.spec.ts
@@ -1855,7 +1855,11 @@ sketch002 = startSketchOn(XZ)
           },
           stage: 'review',
         })
-        await cmdBar.progressCmdBar()
+        // Confirm we can submit from the review step with just `Enter`
+        await cmdBar.progressCmdBar(true)
+        await cmdBar.expectState({
+          stage: 'commandBarClosed',
+        })
       })
 
       await test.step(`Confirm code is added to the editor, scene has changed`, async () => {
@@ -1995,7 +1999,7 @@ profile001 = ${circleCode}`
         },
         stage: 'review',
       })
-      await cmdBar.progressCmdBar()
+      await cmdBar.progressCmdBar(true)
       await editor.expectEditor.toContain(sweepDeclaration)
     })
 

--- a/src/components/CommandBar/CommandBarHeader.tsx
+++ b/src/components/CommandBar/CommandBarHeader.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useState } from 'react'
+import type React from 'react'
+import { useMemo, useEffect, useRef, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 
 import { ActionButton } from '@src/components/ActionButton'
@@ -121,6 +122,7 @@ function CommandBarHeader({ children }: React.PropsWithChildren<object>) {
                     data-is-current-arg={
                       argName === currentArgument?.name ? 'true' : 'false'
                     }
+                    type="button"
                     disabled={!isReviewing && currentArgument?.name === argName}
                     onClick={() => {
                       commandBarActor.send({
@@ -244,13 +246,20 @@ function CommandBarHeader({ children }: React.PropsWithChildren<object>) {
 
 type ButtonProps = { bgClassName?: string; iconClassName?: string }
 function ReviewingButton({ bgClassName, iconClassName }: ButtonProps) {
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  useEffect(() => {
+    if (buttonRef.current) {
+      buttonRef.current.focus()
+    }
+  }, [])
   return (
     <ActionButton
       Element="button"
-      autoFocus
+      ref={buttonRef}
       type="submit"
       form="review-form"
-      className="w-fit !p-0 rounded-sm hover:shadow"
+      className="w-fit !p-0 rounded-sm hover:shadow focus:outline-current"
+      tabIndex={0}
       data-testid="command-bar-submit"
       iconStart={{
         icon: 'checkmark',
@@ -269,7 +278,8 @@ function GatheringArgsButton({ bgClassName, iconClassName }: ButtonProps) {
       Element="button"
       type="submit"
       form="arg-form"
-      className="w-fit !p-0 rounded-sm hover:shadow"
+      className="w-fit !p-0 rounded-sm hover:shadow focus:outline-current"
+      tabIndex={0}
       data-testid="command-bar-continue"
       iconStart={{
         icon: 'arrowRight',


### PR DESCRIPTION
Fixes #7026. The Submit button in the command palette was not being focused for two reasons:
- in #4469 we set all `ActionButton`s to have `tabIndex={1}` making them unfocusable. I want to change this as it has caused a few keyboard use issues like this. For now, I made the `ReviewingButton` and the `GatheringArgsButton` both have `tabIndex={0}` so they become focusable without undoing the work done in that PR to make tooltips and outlines behave better.
- I discovered why the `autoFocus` attribute on this button was not having an impact on these buttons. As a Headless UI Dialog element, the first focusable element is coerced to get focus from that component, and the only static way to override that is by [passing a ref to `initialFocus`](https://headlessui.com/v1/react/dialog#managing-initial-focus). We do not have an easy way to do that with the way our components are arranged, so instead I imperatively focus the `ReviewingButton` on mount.

I adjusted the Sweep point-and-click tests to submit their command flows with the <kbd>Enter</kbd> key.