### PR TITLE
Impove naming in point-and-click Revolve to convey that axis are relative

### DIFF
--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -478,7 +478,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         required: true,
         defaultValue: 'Axis',
         options: [
-          { name: 'Axis', isCurrent: true, value: 'Axis' },
+          { name: 'Sketch Axis', isCurrent: true, value: 'Axis' },
           { name: 'Edge', isCurrent: false, value: 'Edge' },
         ],
         hidden: (context) => Boolean(context.argumentsToSubmit.nodeToEdit),
@@ -490,8 +490,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
           ),
         inputType: 'options',
         options: [
-          { name: 'X Axis', isCurrent: true, value: 'X' },
-          { name: 'Y Axis', isCurrent: false, value: 'Y' },
+          { name: 'X Axis (relative to sketch)', isCurrent: true, value: 'X' },
+          { name: 'Y Axis (relative to sketch)', isCurrent: false, value: 'Y' },
         ],
         hidden: (context) => Boolean(context.argumentsToSubmit.nodeToEdit),
       },

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -489,9 +489,10 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
             commandContext.argumentsToSubmit.axisOrEdge as string
           ),
         inputType: 'options',
+        displayName: 'Sketch Axis',
         options: [
-          { name: 'X Axis (relative to sketch)', isCurrent: true, value: 'X' },
-          { name: 'Y Axis (relative to sketch)', isCurrent: false, value: 'Y' },
+          { name: 'X Axis', isCurrent: true, value: 'X' },
+          { name: 'Y Axis', isCurrent: false, value: 'Y' },
         ],
         hidden: (context) => Boolean(context.argumentsToSubmit.nodeToEdit),
       },


### PR DESCRIPTION
Fixes #7121

Just trying to be a little more descriptive because this keeps confusing me

<img width="1650" alt="image" src="https://github.com/user-attachments/assets/613de895-3477-46e6-86af-e171610a10b0" />

<img width="1650" alt="image" src="https://github.com/user-attachments/assets/88f7a7fc-c71b-4d24-a658-018928c97659" />

