### PR TITLE
Fix: Follow up Text-to-CAD Edit to fix in browser

### DIFF
--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -1278,12 +1278,12 @@ export const ModelingMachineProvider = ({
               )
             }
           }
-          let filePath = file?.path
-          // When prompt to edit finishes, try to route to the file they were in otherwise go to main.kcl
-          if (filePath && isDesktop()) {
-            filePath = window.electron.path.relative(basePath, filePath)
-          } else {
-            filePath = PROJECT_ENTRYPOINT
+          // route to main.kcl by default for web and desktop
+          let filePath: string = PROJECT_ENTRYPOINT
+          const possibleFileName = file?.path
+          if (possibleFileName && isDesktop()) {
+            // When prompt to edit finishes, try to route to the file they were in otherwise go to main.kcl
+            filePath = window.electron.path.relative(basePath, possibleFileName)
           }
           return await promptToEditFlow({
             projectFiles,

--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -1280,7 +1280,7 @@ export const ModelingMachineProvider = ({
           }
           let filePath = file?.path
           // When prompt to edit finishes, try to route to the file they were in otherwise go to main.kcl
-          if (filePath) {
+          if (filePath && isDesktop()) {
             filePath = window.electron.path.relative(basePath, filePath)
           } else {
             filePath = PROJECT_ENTRYPOINT


### PR DESCRIPTION
The browser version of Text-to-CAD Edit started failing after we implemented a recent change to keep the user in their current file with Text-to-CAD Edit, causing it to start to silently fail. This restores that bespoke behavior in the browser.