### PR TITLE
Fix open KCL sample via URL query param in browser

### DIFF
--- a/src/lib/commandBarConfigs/applicationCommandConfig.ts
+++ b/src/lib/commandBarConfigs/applicationCommandConfig.ts
@@ -333,6 +333,7 @@ export function createApplicationCommands({
           isDesktop() &&
           commandsContext.argumentsToSubmit.method === 'existingProject',
         skip: true,
+        defaultValue: isDesktop() ? undefined : 'browser',
         options: (_, _context) => {
           const { folders } = systemIOActor.getSnapshot().context
           const options: CommandArgumentOption<string>[] = []


### PR DESCRIPTION
There is now a `projectName` that isn't included in the query params I was using and wasn't including in the URLs I was building.