### PR TITLE
Run the KCL tests every hour to detect regressions

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -1,16 +1,22 @@
+name: cargo test
+
 on:
   push:
     branches:
       - main
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: 0 * * * *  # hourly
+
 permissions:
   contents: read
   pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
-name: cargo test
+
 jobs:
   build-test-artifacts:
     name: Build test artifacts
@@ -193,7 +199,7 @@ jobs:
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
           CI_PR_NUMBER: ${{ github.event.pull_request.number }}
-          CI_SUITE: unit:kcl
+          CI_SUITE: e2e:kcl
   run-internal-kcl-samples:
     name: cargo test (internal-kcl-samples)
     runs-on:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,4 +1,5 @@
 name: E2E Tests
+
 on:
   push:
     branches:
@@ -156,7 +157,7 @@ jobs:
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
           CI_PR_NUMBER: ${{ github.event.pull_request.number }}
-          CI_SUITE: snapshots
+          CI_SUITE: e2e:snapshots
           TARGET: web
 
       - name: Update snapshots
@@ -168,7 +169,7 @@ jobs:
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
           CI_PR_NUMBER: ${{ github.event.pull_request.number }}
-          CI_SUITE: snapshots
+          CI_SUITE: e2e:snapshots
           TARGET: web
 
       - uses: actions/upload-artifact@v4
@@ -319,6 +320,7 @@ jobs:
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
           CI_PR_NUMBER: ${{ github.event.pull_request.number }}
+          CI_SUITE: e2e:desktop
           TARGET: desktop
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Here's an example of an engine change that required us to update samples: https://github.com/KittyCAD/modeling-app/pull/7129

It would be good to detect things like this sooner by getting a continuous baseline of results against the `main` branch. This will also help with capturing flakiness metrics.
