### PR TITLE
Link to the new download page

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@ Compared to other CAD software, getting Zoo Design Studio up and running is quic
 
 ## Windows
 
-1. Download the [Zoo Design Studio installer](https://zoo.dev/modeling-app/download) for Windows and for your processor type.
+1. Download the [Zoo Design Studio installer](https://zoo.dev/design-studio) for Windows and for your processor type.
 
 2. Once downloaded, run the installer `Zoo Design Studio-{version}-{arch}-win.exe` which should take a few seconds.
 
@@ -12,16 +12,16 @@ Compared to other CAD software, getting Zoo Design Studio up and running is quic
 
 ## macOS
 
-1. Download the [Zoo Design Studio installer](https://zoo.dev/modeling-app/download) for macOS and for your processor type.
+1. Download the [Zoo Design Studio installer](https://zoo.dev/design-studio) for macOS and for your processor type.
 
 2. Once downloaded, open the disk image `Zoo Design Studio-{version}-{arch}-mac.dmg` and drag the applications to your `Applications` directory.
 
 3. You can then open your `Applications` directory and double-click on `Zoo Design Studio` to open.
 
 
-## Linux 
+## Linux
 
-1. Download the [Zoo Design Studio installer](https://zoo.dev/modeling-app/download) for Linux and for your processor type.
+1. Download the [Zoo Design Studio installer](https://zoo.dev/design-studio) for Linux and for your processor type.
 
 2. Install the dependencies needed to run the [AppImage format](https://appimage.org/).
     -  On Ubuntu, install the FUSE library with these commands in a terminal.
@@ -29,7 +29,7 @@ Compared to other CAD software, getting Zoo Design Studio up and running is quic
        sudo apt update
        sudo apt install libfuse2
        ```
-    - Optionally, follow [these steps](https://github.com/probonopd/go-appimage/blob/master/src/appimaged/README.md#initial-setup) to install `appimaged`. It is a daemon that makes interacting with AppImage files more seamless. 
+    - Optionally, follow [these steps](https://github.com/probonopd/go-appimage/blob/master/src/appimaged/README.md#initial-setup) to install `appimaged`. It is a daemon that makes interacting with AppImage files more seamless.
     - Once installed, copy the downloaded `Zoo Design Studio-{version}-{arch}-linux.AppImage` to the directory of your choice, for instance `~/Applications`.
 
    - `appimaged` should automatically find it and make it executable. If not, run:

--- a/public/announce_release.py
+++ b/public/announce_release.py
@@ -27,7 +27,7 @@ if len(modified_release_body) > max_length:
 # Message to send to Discord
 data = {
     "content": textwrap.dedent(f'''
-        **{release_version}** is now available! Check out the latest features and improvements here: <https://zoo.dev/modeling-app/download>
+        **{release_version}** is now available! Check out the latest features and improvements here: <https://zoo.dev/design-studio>
 
         {modified_release_body}
     '''),

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -3,7 +3,7 @@ import type { Models } from '@kittycad/lib/dist/types/src'
 import type { UnitAngle, UnitLength } from '@rust/kcl-lib/bindings/ModelingCmd'
 
 export const APP_NAME = 'Design Studio'
-export const APP_DOWNLOAD_PATH = 'modeling-app/download'
+export const APP_DOWNLOAD_PATH = 'design-studio'
 /** Search string in new project names to increment as an index */
 export const INDEX_IDENTIFIER = '$n'
 /** The maximum number of 0's to pad a default project name's index with */


### PR DESCRIPTION
https://zoo.dev/modeling-app/download will eventually turn into a redirect.