### PR TITLE
Change to skip asserting the artifact graph for samples

### DIFF
--- a/rust/justfile
+++ b/rust/justfile
@@ -36,20 +36,20 @@ new-sim-test test_name render_to_png="true":
 
 # Run a KCL deterministic simulation test case and accept output.
 overwrite-sim-test-sample test_name:
-    EXPECTORATE=overwrite TWENTY_TWENTY=overwrite {{cita}} {{kcl_lib_flags}} --no-quiet -- simulation_tests::kcl_samples::parse_{{test_name}}
-    EXPECTORATE=overwrite TWENTY_TWENTY=overwrite {{cita}} {{kcl_lib_flags}} --no-quiet -- simulation_tests::kcl_samples::unparse_{{test_name}}
-    EXPECTORATE=overwrite TWENTY_TWENTY=overwrite {{cita}} {{kcl_lib_flags}} --no-quiet -- simulation_tests::kcl_samples::kcl_test_execute_{{test_name}}
-    EXPECTORATE=overwrite TWENTY_TWENTY=overwrite {{cita}} {{kcl_lib_flags}} --no-quiet -- simulation_tests::kcl_samples::test_after_engine
+    ZOO_SIM_UPDATE=always EXPECTORATE=overwrite TWENTY_TWENTY=overwrite {{cita}} {{kcl_lib_flags}} --no-quiet -- simulation_tests::kcl_samples::parse_{{test_name}}
+    ZOO_SIM_UPDATE=always EXPECTORATE=overwrite TWENTY_TWENTY=overwrite {{cita}} {{kcl_lib_flags}} --no-quiet -- simulation_tests::kcl_samples::unparse_{{test_name}}
+    ZOO_SIM_UPDATE=always EXPECTORATE=overwrite TWENTY_TWENTY=overwrite {{cita}} {{kcl_lib_flags}} --no-quiet -- simulation_tests::kcl_samples::kcl_test_execute_{{test_name}}
+    ZOO_SIM_UPDATE=always EXPECTORATE=overwrite TWENTY_TWENTY=overwrite {{cita}} {{kcl_lib_flags}} --no-quiet -- simulation_tests::kcl_samples::test_after_engine
 
 overwrite-sim-test test_name:
-    EXPECTORATE=overwrite TWENTY_TWENTY=overwrite {{cita}} {{kcl_lib_flags}} --no-quiet -- simulation_tests::{{test_name}}::parse
-    EXPECTORATE=overwrite TWENTY_TWENTY=overwrite {{cita}} {{kcl_lib_flags}} --no-quiet -- simulation_tests::{{test_name}}::unparse
-    EXPECTORATE=overwrite TWENTY_TWENTY=overwrite {{cita}} {{kcl_lib_flags}} --no-quiet -- simulation_tests::{{test_name}}::kcl_test_execute
-    [ {{test_name}} != "kcl_samples" ] || EXPECTORATE=overwrite TWENTY_TWENTY=overwrite {{cita}} {{kcl_lib_flags}} --no-quiet -- simulation_tests::{{test_name}}::test_after_engine
+    ZOO_SIM_UPDATE=always EXPECTORATE=overwrite TWENTY_TWENTY=overwrite {{cita}} {{kcl_lib_flags}} --no-quiet -- simulation_tests::{{test_name}}::parse
+    ZOO_SIM_UPDATE=always EXPECTORATE=overwrite TWENTY_TWENTY=overwrite {{cita}} {{kcl_lib_flags}} --no-quiet -- simulation_tests::{{test_name}}::unparse
+    ZOO_SIM_UPDATE=always EXPECTORATE=overwrite TWENTY_TWENTY=overwrite {{cita}} {{kcl_lib_flags}} --no-quiet -- simulation_tests::{{test_name}}::kcl_test_execute
+    [ {{test_name}} != "kcl_samples" ] || ZOO_SIM_UPDATE=always EXPECTORATE=overwrite TWENTY_TWENTY=overwrite {{cita}} {{kcl_lib_flags}} --no-quiet -- simulation_tests::{{test_name}}::test_after_engine
 
 # Regenerate all the simulation test output.
 redo-sim-tests:
-    EXPECTORATE=overwrite TWENTY_TWENTY=overwrite {{cita}} {{kcl_lib_flags}} --no-quiet -- simulation_tests
+    ZOO_SIM_UPDATE=always EXPECTORATE=overwrite TWENTY_TWENTY=overwrite {{cita}} {{kcl_lib_flags}} --no-quiet -- simulation_tests
 
 test:
     cargo install cargo-nextest

--- a/rust/kcl-lib/src/simulation_tests.rs
+++ b/rust/kcl-lib/src/simulation_tests.rs
@@ -28,6 +28,7 @@ struct Test {
     output_dir: PathBuf,
     /// True to skip asserting the artifact graph and only write it. The default
     /// is false and to assert it.
+    #[cfg_attr(not(feature = "artifact-graph"), expect(dead_code))]
     skip_assert_artifact_graph: bool,
 }
 

--- a/rust/kcl-lib/src/simulation_tests/kcl_samples.rs
+++ b/rust/kcl-lib/src/simulation_tests/kcl_samples.rs
@@ -145,6 +145,8 @@ fn test(test_name: &str, entry_point: std::path::PathBuf) -> Test {
         entry_point: entry_point.clone(),
         input_dir: parent.to_path_buf(),
         output_dir: relative_output_dir,
+        // Skip is temporary while we have non-deterministic output.
+        skip_assert_artifact_graph: true,
     }
 }
 


### PR DESCRIPTION
1. The graph output became non-deterministic due to concurrent module execution
2. We started adding a lot more samples
3. Samples tend to be large, so no one looks at the updates anyway. People just accept the changes.

The result is that artifact graph samples tests in the `cargo test` CI job are really flaky with no real benefit.

This PR makes it so that we skip the assertion for samples, but we continue to write the output. As a developer, you should either use the `just` commands or the new environment variable `ZOO_SIM_UPDATE=always`.