### PR TITLE
KCL: Customizable per-arg and per-fn snippet values

### DIFF
--- a/e2e/playwright/editor-tests.spec.ts
+++ b/e2e/playwright/editor-tests.spec.ts
@@ -1001,7 +1001,7 @@ a1 = startSketchOn(offsetPlane(XY, offset = 10))
       await expect(page.locator('.cm-content')).toHaveText(
         `@settings(defaultLengthUnit = in)
 sketch001 = startSketchOn(XZ)
-        |> startProfile(%, at = [3.14, 12])
+        |> startProfile(%, at = [0, 12])
         |> xLine(%, length = 5) // lin`.replaceAll('\n', '')
       )
 
@@ -1076,7 +1076,7 @@ sketch001 = startSketchOn(XZ)
       await expect(page.locator('.cm-content')).toHaveText(
         `@settings(defaultLengthUnit = in)
 sketch001 = startSketchOn(XZ)
-        |> startProfile(%, at = [3.14, 12])
+        |> startProfile(%, at = [0, 12])
         |> xLine(%, length = 5) // lin`.replaceAll('\n', '')
       )
     })

--- a/rust/kcl-derive-docs/src/lib.rs
+++ b/rust/kcl-derive-docs/src/lib.rs
@@ -341,7 +341,7 @@ fn do_stdlib_inner(
             continue;
         };
         let description = arg_meta.docs.clone();
-        let include_in_snippet = arg_meta.include_in_snippet;
+        let include_in_snippet = required || arg_meta.include_in_snippet;
         let snippet_value = arg_meta.snippet_value.clone();
         let label_required = !(i == 0 && metadata.unlabeled_first);
         let camel_case_arg_name = to_camel_case(&arg_name);

--- a/rust/kcl-derive-docs/src/tests.rs
+++ b/rust/kcl-derive-docs/src/tests.rs
@@ -40,6 +40,9 @@ fn test_args_with_refs() {
     let (item, mut errors) = do_stdlib(
         quote! {
             name = "someFn",
+            args = {
+                data = { docs = "The data for this function"},
+            },
         },
         quote! {
             /// Docs
@@ -65,6 +68,9 @@ fn test_args_with_lifetime() {
     let (item, mut errors) = do_stdlib(
         quote! {
             name = "someFn",
+            args = {
+                data = { docs = "Arg for the function" },
+            }
         },
         quote! {
             /// Docs
@@ -117,7 +123,8 @@ fn test_stdlib_line_to() {
         quote! {
             name = "lineTo",
             args = {
-                sketch = { docs = "the sketch you're adding the line to" }
+                data = { docs = "the sketch you're adding the line to" },
+                sketch = { docs = "the sketch you're adding the line to" },
             }
         },
         quote! {

--- a/rust/kcl-derive-docs/tests/args_with_lifetime.gen
+++ b/rust/kcl-derive-docs/tests/args_with_lifetime.gen
@@ -106,7 +106,7 @@ impl crate::docs::StdLibFn for SomeFn {
             required: true,
             label_required: true,
             description: "Arg for the function".to_string(),
-            include_in_snippet: false,
+            include_in_snippet: true,
             snippet_value: None,
         }]
     }

--- a/rust/kcl-derive-docs/tests/args_with_lifetime.gen
+++ b/rust/kcl-derive-docs/tests/args_with_lifetime.gen
@@ -105,8 +105,9 @@ impl crate::docs::StdLibFn for SomeFn {
             schema: generator.root_schema_for::<Foo>(),
             required: true,
             label_required: true,
-            description: String::new().to_string(),
-            include_in_snippet: true,
+            description: "Arg for the function".to_string(),
+            include_in_snippet: false,
+            snippet_value: None,
         }]
     }
 
@@ -123,6 +124,7 @@ impl crate::docs::StdLibFn for SomeFn {
             label_required: true,
             description: String::new(),
             include_in_snippet: true,
+            snippet_value: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/args_with_lifetime.gen
+++ b/rust/kcl-derive-docs/tests/args_with_lifetime.gen
@@ -108,6 +108,7 @@ impl crate::docs::StdLibFn for SomeFn {
             description: "Arg for the function".to_string(),
             include_in_snippet: true,
             snippet_value: None,
+            snippet_value_array: None,
         }]
     }
 
@@ -125,6 +126,7 @@ impl crate::docs::StdLibFn for SomeFn {
             description: String::new(),
             include_in_snippet: true,
             snippet_value: None,
+            snippet_value_array: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/args_with_refs.gen
+++ b/rust/kcl-derive-docs/tests/args_with_refs.gen
@@ -106,7 +106,7 @@ impl crate::docs::StdLibFn for SomeFn {
             required: true,
             label_required: true,
             description: "The data for this function".to_string(),
-            include_in_snippet: false,
+            include_in_snippet: true,
             snippet_value: None,
         }]
     }

--- a/rust/kcl-derive-docs/tests/args_with_refs.gen
+++ b/rust/kcl-derive-docs/tests/args_with_refs.gen
@@ -105,8 +105,9 @@ impl crate::docs::StdLibFn for SomeFn {
             schema: generator.root_schema_for::<str>(),
             required: true,
             label_required: true,
-            description: String::new().to_string(),
-            include_in_snippet: true,
+            description: "The data for this function".to_string(),
+            include_in_snippet: false,
+            snippet_value: None,
         }]
     }
 
@@ -123,6 +124,7 @@ impl crate::docs::StdLibFn for SomeFn {
             label_required: true,
             description: String::new(),
             include_in_snippet: true,
+            snippet_value: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/args_with_refs.gen
+++ b/rust/kcl-derive-docs/tests/args_with_refs.gen
@@ -108,6 +108,7 @@ impl crate::docs::StdLibFn for SomeFn {
             description: "The data for this function".to_string(),
             include_in_snippet: true,
             snippet_value: None,
+            snippet_value_array: None,
         }]
     }
 
@@ -125,6 +126,7 @@ impl crate::docs::StdLibFn for SomeFn {
             description: String::new(),
             include_in_snippet: true,
             snippet_value: None,
+            snippet_value_array: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/array.gen
+++ b/rust/kcl-derive-docs/tests/array.gen
@@ -100,15 +100,7 @@ impl crate::docs::StdLibFn for Show {
         let mut settings = schemars::gen::SchemaSettings::openapi3();
         settings.inline_subschemas = inline_subschemas;
         let mut generator = schemars::gen::SchemaGenerator::new(settings);
-        vec![crate::docs::StdLibFnArg {
-            name: "args".to_string(),
-            type_: "[number]".to_string(),
-            schema: generator.root_schema_for::<[f64; 2usize]>(),
-            required: true,
-            label_required: true,
-            description: String::new().to_string(),
-            include_in_snippet: true,
-        }]
+        vec![]
     }
 
     fn return_value(&self, inline_subschemas: bool) -> Option<crate::docs::StdLibFnArg> {
@@ -124,6 +116,7 @@ impl crate::docs::StdLibFn for Show {
             label_required: true,
             description: String::new(),
             include_in_snippet: true,
+            snippet_value: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/array.gen
+++ b/rust/kcl-derive-docs/tests/array.gen
@@ -117,6 +117,7 @@ impl crate::docs::StdLibFn for Show {
             description: String::new(),
             include_in_snippet: true,
             snippet_value: None,
+            snippet_value_array: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/box.gen
+++ b/rust/kcl-derive-docs/tests/box.gen
@@ -117,6 +117,7 @@ impl crate::docs::StdLibFn for Show {
             description: String::new(),
             include_in_snippet: true,
             snippet_value: None,
+            snippet_value_array: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/box.gen
+++ b/rust/kcl-derive-docs/tests/box.gen
@@ -100,15 +100,7 @@ impl crate::docs::StdLibFn for Show {
         let mut settings = schemars::gen::SchemaSettings::openapi3();
         settings.inline_subschemas = inline_subschemas;
         let mut generator = schemars::gen::SchemaGenerator::new(settings);
-        vec![crate::docs::StdLibFnArg {
-            name: "args".to_string(),
-            type_: "number".to_string(),
-            schema: generator.root_schema_for::<f64>(),
-            required: true,
-            label_required: true,
-            description: String::new().to_string(),
-            include_in_snippet: true,
-        }]
+        vec![]
     }
 
     fn return_value(&self, inline_subschemas: bool) -> Option<crate::docs::StdLibFnArg> {
@@ -124,6 +116,7 @@ impl crate::docs::StdLibFn for Show {
             label_required: true,
             description: String::new(),
             include_in_snippet: true,
+            snippet_value: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/doc_comment_with_code.gen
+++ b/rust/kcl-derive-docs/tests/doc_comment_with_code.gen
@@ -101,15 +101,7 @@ impl crate::docs::StdLibFn for MyFunc {
         let mut settings = schemars::gen::SchemaSettings::openapi3();
         settings.inline_subschemas = inline_subschemas;
         let mut generator = schemars::gen::SchemaGenerator::new(settings);
-        vec![crate::docs::StdLibFnArg {
-            name: "args".to_string(),
-            type_: "kittycad::types::InputFormat".to_string(),
-            schema: generator.root_schema_for::<Option<kittycad::types::InputFormat>>(),
-            required: false,
-            label_required: true,
-            description: String::new().to_string(),
-            include_in_snippet: false,
-        }]
+        vec![]
     }
 
     fn return_value(&self, inline_subschemas: bool) -> Option<crate::docs::StdLibFnArg> {
@@ -125,6 +117,7 @@ impl crate::docs::StdLibFn for MyFunc {
             label_required: true,
             description: String::new(),
             include_in_snippet: true,
+            snippet_value: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/doc_comment_with_code.gen
+++ b/rust/kcl-derive-docs/tests/doc_comment_with_code.gen
@@ -118,6 +118,7 @@ impl crate::docs::StdLibFn for MyFunc {
             description: String::new(),
             include_in_snippet: true,
             snippet_value: None,
+            snippet_value_array: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/lineTo.gen
+++ b/rust/kcl-derive-docs/tests/lineTo.gen
@@ -111,6 +111,7 @@ impl crate::docs::StdLibFn for LineTo {
                 description: "the sketch you're adding the line to".to_string(),
                 include_in_snippet: true,
                 snippet_value: None,
+                snippet_value_array: None,
             },
             crate::docs::StdLibFnArg {
                 name: "sketch".to_string(),
@@ -121,6 +122,7 @@ impl crate::docs::StdLibFn for LineTo {
                 description: "the sketch you're adding the line to".to_string(),
                 include_in_snippet: true,
                 snippet_value: None,
+                snippet_value_array: None,
             },
         ]
     }
@@ -139,6 +141,7 @@ impl crate::docs::StdLibFn for LineTo {
             description: String::new(),
             include_in_snippet: true,
             snippet_value: None,
+            snippet_value_array: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/lineTo.gen
+++ b/rust/kcl-derive-docs/tests/lineTo.gen
@@ -108,8 +108,9 @@ impl crate::docs::StdLibFn for LineTo {
                 schema: generator.root_schema_for::<LineToData>(),
                 required: true,
                 label_required: true,
-                description: String::new().to_string(),
-                include_in_snippet: true,
+                description: "the sketch you're adding the line to".to_string(),
+                include_in_snippet: false,
+                snippet_value: None,
             },
             crate::docs::StdLibFnArg {
                 name: "sketch".to_string(),
@@ -118,7 +119,8 @@ impl crate::docs::StdLibFn for LineTo {
                 required: true,
                 label_required: true,
                 description: "the sketch you're adding the line to".to_string(),
-                include_in_snippet: true,
+                include_in_snippet: false,
+                snippet_value: None,
             },
         ]
     }
@@ -136,6 +138,7 @@ impl crate::docs::StdLibFn for LineTo {
             label_required: true,
             description: String::new(),
             include_in_snippet: true,
+            snippet_value: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/lineTo.gen
+++ b/rust/kcl-derive-docs/tests/lineTo.gen
@@ -109,7 +109,7 @@ impl crate::docs::StdLibFn for LineTo {
                 required: true,
                 label_required: true,
                 description: "the sketch you're adding the line to".to_string(),
-                include_in_snippet: false,
+                include_in_snippet: true,
                 snippet_value: None,
             },
             crate::docs::StdLibFnArg {
@@ -119,7 +119,7 @@ impl crate::docs::StdLibFn for LineTo {
                 required: true,
                 label_required: true,
                 description: "the sketch you're adding the line to".to_string(),
-                include_in_snippet: false,
+                include_in_snippet: true,
                 snippet_value: None,
             },
         ]

--- a/rust/kcl-derive-docs/tests/min.gen
+++ b/rust/kcl-derive-docs/tests/min.gen
@@ -100,15 +100,7 @@ impl crate::docs::StdLibFn for Min {
         let mut settings = schemars::gen::SchemaSettings::openapi3();
         settings.inline_subschemas = inline_subschemas;
         let mut generator = schemars::gen::SchemaGenerator::new(settings);
-        vec![crate::docs::StdLibFnArg {
-            name: "args".to_string(),
-            type_: "[number]".to_string(),
-            schema: generator.root_schema_for::<Vec<f64>>(),
-            required: true,
-            label_required: true,
-            description: String::new().to_string(),
-            include_in_snippet: true,
-        }]
+        vec![]
     }
 
     fn return_value(&self, inline_subschemas: bool) -> Option<crate::docs::StdLibFnArg> {
@@ -124,6 +116,7 @@ impl crate::docs::StdLibFn for Min {
             label_required: true,
             description: String::new(),
             include_in_snippet: true,
+            snippet_value: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/min.gen
+++ b/rust/kcl-derive-docs/tests/min.gen
@@ -117,6 +117,7 @@ impl crate::docs::StdLibFn for Min {
             description: String::new(),
             include_in_snippet: true,
             snippet_value: None,
+            snippet_value_array: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/option.gen
+++ b/rust/kcl-derive-docs/tests/option.gen
@@ -100,15 +100,7 @@ impl crate::docs::StdLibFn for Show {
         let mut settings = schemars::gen::SchemaSettings::openapi3();
         settings.inline_subschemas = inline_subschemas;
         let mut generator = schemars::gen::SchemaGenerator::new(settings);
-        vec![crate::docs::StdLibFnArg {
-            name: "args".to_string(),
-            type_: "number".to_string(),
-            schema: generator.root_schema_for::<Option<f64>>(),
-            required: false,
-            label_required: true,
-            description: String::new().to_string(),
-            include_in_snippet: false,
-        }]
+        vec![]
     }
 
     fn return_value(&self, inline_subschemas: bool) -> Option<crate::docs::StdLibFnArg> {
@@ -124,6 +116,7 @@ impl crate::docs::StdLibFn for Show {
             label_required: true,
             description: String::new(),
             include_in_snippet: true,
+            snippet_value: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/option.gen
+++ b/rust/kcl-derive-docs/tests/option.gen
@@ -117,6 +117,7 @@ impl crate::docs::StdLibFn for Show {
             description: String::new(),
             include_in_snippet: true,
             snippet_value: None,
+            snippet_value_array: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/option_input_format.gen
+++ b/rust/kcl-derive-docs/tests/option_input_format.gen
@@ -100,15 +100,7 @@ impl crate::docs::StdLibFn for Import {
         let mut settings = schemars::gen::SchemaSettings::openapi3();
         settings.inline_subschemas = inline_subschemas;
         let mut generator = schemars::gen::SchemaGenerator::new(settings);
-        vec![crate::docs::StdLibFnArg {
-            name: "args".to_string(),
-            type_: "kittycad::types::InputFormat".to_string(),
-            schema: generator.root_schema_for::<Option<kittycad::types::InputFormat>>(),
-            required: false,
-            label_required: true,
-            description: String::new().to_string(),
-            include_in_snippet: false,
-        }]
+        vec![]
     }
 
     fn return_value(&self, inline_subschemas: bool) -> Option<crate::docs::StdLibFnArg> {
@@ -124,6 +116,7 @@ impl crate::docs::StdLibFn for Import {
             label_required: true,
             description: String::new(),
             include_in_snippet: true,
+            snippet_value: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/option_input_format.gen
+++ b/rust/kcl-derive-docs/tests/option_input_format.gen
@@ -117,6 +117,7 @@ impl crate::docs::StdLibFn for Import {
             description: String::new(),
             include_in_snippet: true,
             snippet_value: None,
+            snippet_value_array: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/return_vec_box_sketch.gen
+++ b/rust/kcl-derive-docs/tests/return_vec_box_sketch.gen
@@ -100,15 +100,7 @@ impl crate::docs::StdLibFn for Import {
         let mut settings = schemars::gen::SchemaSettings::openapi3();
         settings.inline_subschemas = inline_subschemas;
         let mut generator = schemars::gen::SchemaGenerator::new(settings);
-        vec![crate::docs::StdLibFnArg {
-            name: "args".to_string(),
-            type_: "kittycad::types::InputFormat".to_string(),
-            schema: generator.root_schema_for::<Option<kittycad::types::InputFormat>>(),
-            required: false,
-            label_required: true,
-            description: String::new().to_string(),
-            include_in_snippet: false,
-        }]
+        vec![]
     }
 
     fn return_value(&self, inline_subschemas: bool) -> Option<crate::docs::StdLibFnArg> {
@@ -124,6 +116,7 @@ impl crate::docs::StdLibFn for Import {
             label_required: true,
             description: String::new(),
             include_in_snippet: true,
+            snippet_value: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/return_vec_box_sketch.gen
+++ b/rust/kcl-derive-docs/tests/return_vec_box_sketch.gen
@@ -117,6 +117,7 @@ impl crate::docs::StdLibFn for Import {
             description: String::new(),
             include_in_snippet: true,
             snippet_value: None,
+            snippet_value_array: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/return_vec_sketch.gen
+++ b/rust/kcl-derive-docs/tests/return_vec_sketch.gen
@@ -100,15 +100,7 @@ impl crate::docs::StdLibFn for Import {
         let mut settings = schemars::gen::SchemaSettings::openapi3();
         settings.inline_subschemas = inline_subschemas;
         let mut generator = schemars::gen::SchemaGenerator::new(settings);
-        vec![crate::docs::StdLibFnArg {
-            name: "args".to_string(),
-            type_: "kittycad::types::InputFormat".to_string(),
-            schema: generator.root_schema_for::<Option<kittycad::types::InputFormat>>(),
-            required: false,
-            label_required: true,
-            description: String::new().to_string(),
-            include_in_snippet: false,
-        }]
+        vec![]
     }
 
     fn return_value(&self, inline_subschemas: bool) -> Option<crate::docs::StdLibFnArg> {
@@ -124,6 +116,7 @@ impl crate::docs::StdLibFn for Import {
             label_required: true,
             description: String::new(),
             include_in_snippet: true,
+            snippet_value: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/return_vec_sketch.gen
+++ b/rust/kcl-derive-docs/tests/return_vec_sketch.gen
@@ -117,6 +117,7 @@ impl crate::docs::StdLibFn for Import {
             description: String::new(),
             include_in_snippet: true,
             snippet_value: None,
+            snippet_value_array: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/show.gen
+++ b/rust/kcl-derive-docs/tests/show.gen
@@ -100,15 +100,7 @@ impl crate::docs::StdLibFn for Show {
         let mut settings = schemars::gen::SchemaSettings::openapi3();
         settings.inline_subschemas = inline_subschemas;
         let mut generator = schemars::gen::SchemaGenerator::new(settings);
-        vec![crate::docs::StdLibFnArg {
-            name: "args".to_string(),
-            type_: "[number]".to_string(),
-            schema: generator.root_schema_for::<Vec<f64>>(),
-            required: true,
-            label_required: true,
-            description: String::new().to_string(),
-            include_in_snippet: true,
-        }]
+        vec![]
     }
 
     fn return_value(&self, inline_subschemas: bool) -> Option<crate::docs::StdLibFnArg> {
@@ -124,6 +116,7 @@ impl crate::docs::StdLibFn for Show {
             label_required: true,
             description: String::new(),
             include_in_snippet: true,
+            snippet_value: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/show.gen
+++ b/rust/kcl-derive-docs/tests/show.gen
@@ -117,6 +117,7 @@ impl crate::docs::StdLibFn for Show {
             description: String::new(),
             include_in_snippet: true,
             snippet_value: None,
+            snippet_value_array: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/test_args_with_exec_state.gen
+++ b/rust/kcl-derive-docs/tests/test_args_with_exec_state.gen
@@ -116,6 +116,7 @@ impl crate::docs::StdLibFn for SomeFunction {
             description: String::new(),
             include_in_snippet: true,
             snippet_value: None,
+            snippet_value_array: None,
         })
     }
 

--- a/rust/kcl-derive-docs/tests/test_args_with_exec_state.gen
+++ b/rust/kcl-derive-docs/tests/test_args_with_exec_state.gen
@@ -115,6 +115,7 @@ impl crate::docs::StdLibFn for SomeFunction {
             label_required: true,
             description: String::new(),
             include_in_snippet: true,
+            snippet_value: None,
         })
     }
 

--- a/rust/kcl-lib/src/docs/mod.rs
+++ b/rust/kcl-lib/src/docs/mod.rs
@@ -114,6 +114,10 @@ pub struct StdLibFnArg {
     /// Snippet should suggest this value for the argument.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub snippet_value: Option<String>,
+    /// Snippet should suggest this value for the argument.
+    /// The suggested value should be an array, with these elements.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub snippet_value_array: Option<Vec<String>>,
     /// Additional information that could be used instead of the type's description.
     /// This is helpful if the type is really basic, like "u32" -- that won't tell the user much about
     /// how this argument is meant to be used.
@@ -168,6 +172,18 @@ impl StdLibFnArg {
         } else {
             ""
         };
+        if let Some(vals) = &self.snippet_value_array {
+            let mut snippet = label.to_owned();
+            snippet.push('[');
+            for (i, val) in vals.iter().enumerate() {
+                snippet.push_str(&format!("${{{}:{}}}", index + i, val));
+                if i != vals.len() - 1 {
+                    snippet.push_str(", ");
+                }
+            }
+            snippet.push(']');
+            return Ok(Some((index + vals.len(), snippet)));
+        }
         if let Some(val) = &self.snippet_value {
             return Ok(Some((index, format!("{label}${{{}:{}}}", index, val))));
         }
@@ -998,7 +1014,7 @@ mod tests {
     fn get_autocomplete_snippet_start_profile() {
         let start_sketch_on_fn: Box<dyn StdLibFn> = Box::new(crate::std::sketch::StartProfile);
         let snippet = start_sketch_on_fn.to_autocomplete_snippet().unwrap();
-        assert_eq!(snippet, r#"startProfile(${0:%}, at = ${1:[0, 0]})"#);
+        assert_eq!(snippet, r#"startProfile(${0:%}, at = [${1:0}, ${2:0}])"#);
     }
 
     #[test]

--- a/rust/kcl-lib/src/docs/mod.rs
+++ b/rust/kcl-lib/src/docs/mod.rs
@@ -172,6 +172,9 @@ impl StdLibFnArg {
         } else {
             ""
         };
+        if let Some(val) = &self.snippet_value {
+            return Ok(Some((index, format!("{label}${{{}:{}}}", index, val))));
+        }
         if (self.type_ == "Sketch"
             || self.type_ == "[Sketch]"
             || self.type_ == "Geometry"
@@ -993,6 +996,13 @@ mod tests {
         let start_sketch_on_fn: Box<dyn StdLibFn> = Box::new(crate::std::sketch::StartSketchOn);
         let snippet = start_sketch_on_fn.to_autocomplete_snippet().unwrap();
         assert_eq!(snippet, r#"startSketchOn(${0:XY})"#);
+    }
+
+    #[test]
+    fn get_autocomplete_snippet_start_profile() {
+        let start_sketch_on_fn: Box<dyn StdLibFn> = Box::new(crate::std::sketch::StartProfile);
+        let snippet = start_sketch_on_fn.to_autocomplete_snippet().unwrap();
+        assert_eq!(snippet, r#"startProfile(${0:%}, at = ${1:[0, 0]})"#);
     }
 
     #[test]

--- a/rust/kcl-lib/src/docs/mod.rs
+++ b/rust/kcl-lib/src/docs/mod.rs
@@ -111,6 +111,9 @@ pub struct StdLibFnArg {
     /// Include this in completion snippets?
     #[serde(default, skip_serializing_if = "is_false")]
     pub include_in_snippet: bool,
+    /// Snippet should suggest this value for the argument.
+    #[serde(default, skip_serializing_if = "is_none")]
+    pub snippet_value: Option<String>,
     /// Additional information that could be used instead of the type's description.
     /// This is helpful if the type is really basic, like "u32" -- that won't tell the user much about
     /// how this argument is meant to be used.
@@ -147,6 +150,10 @@ fn its_true() -> bool {
 
 fn is_false(b: &bool) -> bool {
     !b
+}
+
+fn is_none<T>(o: &Option<T>) -> bool {
+    o.is_none()
 }
 
 impl StdLibFnArg {

--- a/rust/kcl-lib/src/docs/mod.rs
+++ b/rust/kcl-lib/src/docs/mod.rs
@@ -112,7 +112,7 @@ pub struct StdLibFnArg {
     #[serde(default, skip_serializing_if = "is_false")]
     pub include_in_snippet: bool,
     /// Snippet should suggest this value for the argument.
-    #[serde(default, skip_serializing_if = "is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub snippet_value: Option<String>,
     /// Additional information that could be used instead of the type's description.
     /// This is helpful if the type is really basic, like "u32" -- that won't tell the user much about
@@ -150,10 +150,6 @@ fn its_true() -> bool {
 
 fn is_false(b: &bool) -> bool {
     !b
-}
-
-fn is_none<T>(o: &Option<T>) -> bool {
-    o.is_none()
 }
 
 impl StdLibFnArg {

--- a/rust/kcl-lib/src/std/sketch.rs
+++ b/rust/kcl-lib/src/std/sketch.rs
@@ -1322,7 +1322,7 @@ pub async fn start_profile(exec_state: &mut ExecState, args: Args) -> Result<Kcl
     unlabeled_first = true,
     args = {
         sketch_surface = { docs = "What to start the profile on" },
-        at = { docs = "Where to start the profile. An absolute point.", snippet_value = "[0, 0]" },
+        at = { docs = "Where to start the profile. An absolute point.", snippet_value_array = ["0", "0"] },
         tag = { docs = "Tag this first starting point" },
     },
     tags = ["sketch"]

--- a/rust/kcl-lib/src/std/sketch.rs
+++ b/rust/kcl-lib/src/std/sketch.rs
@@ -1322,7 +1322,7 @@ pub async fn start_profile(exec_state: &mut ExecState, args: Args) -> Result<Kcl
     unlabeled_first = true,
     args = {
         sketch_surface = { docs = "What to start the profile on" },
-        at = { docs = "Where to start the profile. An absolute point." },
+        at = { docs = "Where to start the profile. An absolute point.", snippet_value = "[0, 0]" },
         tag = { docs = "Tag this first starting point" },
     },
     tags = ["sketch"]


### PR DESCRIPTION
Before, the LSP snippet for `startProfile` was 

```
startProfile(%, at = [3.14, 3.14])
```

Now it's 

```
startProfile(%, at = [0, 0])
```

This is configured by adding a `snippet_value=` field to the stdlib macro. For example:


```diff
#[stdlib {
    name = "startProfile",
    keywords = true,
    unlabeled_first = true,
    args = {
        sketch_surface = { docs = "What to start the profile on" },
-       at = { docs = "Where to start the profile. An absolute point." },
+       at = { docs = "Where to start the profile. An absolute point.", snippet_value = "[0, 0]" },        tag = { docs = "Tag this first starting point" },
    },
    tags = ["sketch"]
}]
```

## Work for follow-up PRs

 - Make this work for KCL functions defined in KCL, e.g. [`fn circle`](https://github.com/KittyCAD/modeling-app/blob/36c8ad439d4d26b95ba2391ae25dc86cb3e468f0/rust/kcl-lib/std/sketch.kcl#L31-L32) -- something like `@(snippet_value = "[0, 0]")` perhaps
 - Go through the stdlib and change defaults where appropriate