### PR TITLE
Pass the query parameters through to sign-in flow

### DIFF
--- a/src/hooks/useAuthNavigation.tsx
+++ b/src/hooks/useAuthNavigation.tsx
@@ -15,7 +15,6 @@ export function useAuthNavigation() {
 
   // Subscribe to the auth state of the app and navigate accordingly.
   useEffect(() => {
-    console.log('authState', authState.value)
     if (
       authState.matches('loggedIn') &&
       location.pathname.includes(PATHS.SIGN_IN)
@@ -25,7 +24,7 @@ export function useAuthNavigation() {
       authState.matches('loggedOut') &&
       !location.pathname.includes(PATHS.SIGN_IN)
     ) {
-      navigate(PATHS.SIGN_IN)
+      navigate(PATHS.SIGN_IN + (location.search || ''))
     }
   }, [authState, location.pathname])
 }

--- a/src/routes/SignIn.tsx
+++ b/src/routes/SignIn.tsx
@@ -59,7 +59,7 @@ const SignIn = () => {
   const signInDesktop = async () => {
     // We want to invoke our command to login via device auth.
     const userCodeToDisplay = await window.electron
-      .startDeviceFlow(VITE_KC_API_BASE_URL)
+      .startDeviceFlow(VITE_KC_API_BASE_URL + location.search)
       .catch(reportError)
     if (!userCodeToDisplay) {
       console.error('No user code received while trying to log in')


### PR DESCRIPTION
So users can return to their invoked command after signing in. This PR also includes a change to not run query param-powered commands if the user is not logged in.