### PR TITLE
KCL: stdlib macro should now assume all functions use keywords

### DIFF
--- a/rust/kcl-derive-docs/src/lib.rs
+++ b/rust/kcl-derive-docs/src/lib.rs
@@ -47,14 +47,6 @@ struct ArgMetadata {
     /// Does not do anything if the argument is already required.
     #[serde(default)]
     include_in_snippet: bool,
-
-    /// The snippet should suggest this value for the arg.
-    #[serde(default)]
-    snippet_value: Option<String>,
-
-    /// The snippet should suggest this value for the arg.
-    #[serde(default)]
-    snippet_value_array: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -81,11 +73,6 @@ struct StdlibMetadata {
     /// If false, calls to the function will never be displayed.
     #[serde(default)]
     feature_tree_operation: bool,
-
-    /// If true, expects keyword arguments.
-    /// If false, expects positional arguments.
-    #[serde(default)]
-    keywords: bool,
 
     /// If true, the first argument is unlabeled.
     /// If false, all arguments require labels.
@@ -292,12 +279,6 @@ fn do_stdlib_inner(
         quote! { false }
     };
 
-    let uses_keyword_arguments = if metadata.keywords {
-        quote! { true }
-    } else {
-        quote! { false }
-    };
-
     let docs_crate = get_crate(None);
 
     // When the user attaches this proc macro to a function with the wrong type
@@ -326,10 +307,6 @@ fn do_stdlib_inner(
         }
         .trim_start_matches('_')
         .to_string();
-        // These aren't really KCL args, they're just state that each stdlib function's impl needs.
-        if arg_name == "exec_state" || arg_name == "args" {
-            continue;
-        }
 
         let ty = match arg {
             syn::FnArg::Receiver(pat) => pat.ty.as_ref().into_token_stream(),
@@ -340,24 +317,27 @@ fn do_stdlib_inner(
 
         let ty_string = rust_type_to_openapi_type(&ty_string);
         let required = !ty_ident.to_string().starts_with("Option <");
-        let Some(arg_meta) = metadata.args.get(&arg_name) else {
-            errors.push(Error::new_spanned(arg, format!("arg {arg_name} not found")));
+        let arg_meta = metadata.args.get(&arg_name);
+        let description = if let Some(s) = arg_meta.map(|arg| &arg.docs) {
+            quote! { #s }
+        } else if ty_string != "Args" && ty_string != "ExecState" {
+            errors.push(Error::new_spanned(
+                &arg,
+                "Argument was not documented in the args block",
+            ));
             continue;
+        } else {
+            quote! { String::new() }
         };
-        let description = arg_meta.docs.clone();
-        let include_in_snippet = required || arg_meta.include_in_snippet;
-        let snippet_value = arg_meta.snippet_value.clone();
-        let snippet_value_array = arg_meta.snippet_value_array.clone();
-        if snippet_value.is_some() && snippet_value_array.is_some() {
-            errors.push(Error::new_spanned(arg, format!("arg {arg_name} has set both snippet_value and snippet_value array, but at most one of these may be set. Please delete one of them.")));
-        }
+        let include_in_snippet = required || arg_meta.map(|arg| arg.include_in_snippet).unwrap_or_default();
         let label_required = !(i == 0 && metadata.unlabeled_first);
         let camel_case_arg_name = to_camel_case(&arg_name);
         if ty_string != "ExecState" && ty_string != "Args" {
             let schema = quote! {
                 generator.root_schema_for::<#ty_ident>()
             };
-            let q0 = quote! {
+            arg_types.push(quote! {
+                #docs_crate::StdLibFnArg {
                     name: #camel_case_arg_name.to_string(),
                     type_: #ty_string.to_string(),
                     schema: #schema,
@@ -365,32 +345,6 @@ fn do_stdlib_inner(
                     label_required: #label_required,
                     description: #description.to_string(),
                     include_in_snippet: #include_in_snippet,
-            };
-            let q1 = if let Some(snippet_value) = snippet_value {
-                quote! {
-                    snippet_value: Some(#snippet_value.to_owned()),
-                }
-            } else {
-                quote! {
-                    snippet_value: None,
-                }
-            };
-            let q2 = if let Some(snippet_value_array) = snippet_value_array {
-                quote! {
-                    snippet_value_array: Some(vec![
-                        #(#snippet_value_array.to_owned()),*
-                    ]),
-                }
-            } else {
-                quote! {
-                    snippet_value_array: None,
-                }
-            };
-            arg_types.push(quote! {
-                #docs_crate::StdLibFnArg {
-                #q0
-                #q1
-                #q2
                 }
             });
         }
@@ -454,8 +408,6 @@ fn do_stdlib_inner(
                 label_required: true,
                 description: String::new(),
                 include_in_snippet: true,
-                snippet_value: None,
-                snippet_value_array: None,
             })
         }
     } else {
@@ -520,10 +472,6 @@ fn do_stdlib_inner(
 
             fn tags(&self) -> Vec<String> {
                 vec![#(#tags),*]
-            }
-
-            fn keyword_arguments(&self) -> bool {
-                #uses_keyword_arguments
             }
 
             fn args(&self, inline_subschemas: bool) -> Vec<#docs_crate::StdLibFnArg> {

--- a/rust/kcl-derive-docs/tests/args_with_lifetime.gen
+++ b/rust/kcl-derive-docs/tests/args_with_lifetime.gen
@@ -91,10 +91,6 @@ impl crate::docs::StdLibFn for SomeFn {
         vec![]
     }
 
-    fn keyword_arguments(&self) -> bool {
-        false
-    }
-
     fn args(&self, inline_subschemas: bool) -> Vec<crate::docs::StdLibFnArg> {
         let mut settings = schemars::gen::SchemaSettings::openapi3();
         settings.inline_subschemas = inline_subschemas;

--- a/rust/kcl-derive-docs/tests/args_with_refs.gen
+++ b/rust/kcl-derive-docs/tests/args_with_refs.gen
@@ -91,10 +91,6 @@ impl crate::docs::StdLibFn for SomeFn {
         vec![]
     }
 
-    fn keyword_arguments(&self) -> bool {
-        false
-    }
-
     fn args(&self, inline_subschemas: bool) -> Vec<crate::docs::StdLibFnArg> {
         let mut settings = schemars::gen::SchemaSettings::openapi3();
         settings.inline_subschemas = inline_subschemas;

--- a/rust/kcl-derive-docs/tests/array.gen
+++ b/rust/kcl-derive-docs/tests/array.gen
@@ -92,10 +92,6 @@ impl crate::docs::StdLibFn for Show {
         vec![]
     }
 
-    fn keyword_arguments(&self) -> bool {
-        false
-    }
-
     fn args(&self, inline_subschemas: bool) -> Vec<crate::docs::StdLibFnArg> {
         let mut settings = schemars::gen::SchemaSettings::openapi3();
         settings.inline_subschemas = inline_subschemas;

--- a/rust/kcl-derive-docs/tests/box.gen
+++ b/rust/kcl-derive-docs/tests/box.gen
@@ -92,10 +92,6 @@ impl crate::docs::StdLibFn for Show {
         vec![]
     }
 
-    fn keyword_arguments(&self) -> bool {
-        false
-    }
-
     fn args(&self, inline_subschemas: bool) -> Vec<crate::docs::StdLibFnArg> {
         let mut settings = schemars::gen::SchemaSettings::openapi3();
         settings.inline_subschemas = inline_subschemas;

--- a/rust/kcl-derive-docs/tests/doc_comment_with_code.gen
+++ b/rust/kcl-derive-docs/tests/doc_comment_with_code.gen
@@ -93,10 +93,6 @@ impl crate::docs::StdLibFn for MyFunc {
         vec![]
     }
 
-    fn keyword_arguments(&self) -> bool {
-        false
-    }
-
     fn args(&self, inline_subschemas: bool) -> Vec<crate::docs::StdLibFnArg> {
         let mut settings = schemars::gen::SchemaSettings::openapi3();
         settings.inline_subschemas = inline_subschemas;

--- a/rust/kcl-derive-docs/tests/lineTo.gen
+++ b/rust/kcl-derive-docs/tests/lineTo.gen
@@ -93,10 +93,6 @@ impl crate::docs::StdLibFn for LineTo {
         vec![]
     }
 
-    fn keyword_arguments(&self) -> bool {
-        false
-    }
-
     fn args(&self, inline_subschemas: bool) -> Vec<crate::docs::StdLibFnArg> {
         let mut settings = schemars::gen::SchemaSettings::openapi3();
         settings.inline_subschemas = inline_subschemas;

--- a/rust/kcl-derive-docs/tests/min.gen
+++ b/rust/kcl-derive-docs/tests/min.gen
@@ -92,10 +92,6 @@ impl crate::docs::StdLibFn for Min {
         vec![]
     }
 
-    fn keyword_arguments(&self) -> bool {
-        false
-    }
-
     fn args(&self, inline_subschemas: bool) -> Vec<crate::docs::StdLibFnArg> {
         let mut settings = schemars::gen::SchemaSettings::openapi3();
         settings.inline_subschemas = inline_subschemas;

--- a/rust/kcl-derive-docs/tests/option.gen
+++ b/rust/kcl-derive-docs/tests/option.gen
@@ -92,10 +92,6 @@ impl crate::docs::StdLibFn for Show {
         vec![]
     }
 
-    fn keyword_arguments(&self) -> bool {
-        false
-    }
-
     fn args(&self, inline_subschemas: bool) -> Vec<crate::docs::StdLibFnArg> {
         let mut settings = schemars::gen::SchemaSettings::openapi3();
         settings.inline_subschemas = inline_subschemas;

--- a/rust/kcl-derive-docs/tests/option_input_format.gen
+++ b/rust/kcl-derive-docs/tests/option_input_format.gen
@@ -92,10 +92,6 @@ impl crate::docs::StdLibFn for Import {
         vec![]
     }
 
-    fn keyword_arguments(&self) -> bool {
-        false
-    }
-
     fn args(&self, inline_subschemas: bool) -> Vec<crate::docs::StdLibFnArg> {
         let mut settings = schemars::gen::SchemaSettings::openapi3();
         settings.inline_subschemas = inline_subschemas;

--- a/rust/kcl-derive-docs/tests/return_vec_box_sketch.gen
+++ b/rust/kcl-derive-docs/tests/return_vec_box_sketch.gen
@@ -92,10 +92,6 @@ impl crate::docs::StdLibFn for Import {
         vec![]
     }
 
-    fn keyword_arguments(&self) -> bool {
-        false
-    }
-
     fn args(&self, inline_subschemas: bool) -> Vec<crate::docs::StdLibFnArg> {
         let mut settings = schemars::gen::SchemaSettings::openapi3();
         settings.inline_subschemas = inline_subschemas;

--- a/rust/kcl-derive-docs/tests/return_vec_sketch.gen
+++ b/rust/kcl-derive-docs/tests/return_vec_sketch.gen
@@ -92,10 +92,6 @@ impl crate::docs::StdLibFn for Import {
         vec![]
     }
 
-    fn keyword_arguments(&self) -> bool {
-        false
-    }
-
     fn args(&self, inline_subschemas: bool) -> Vec<crate::docs::StdLibFnArg> {
         let mut settings = schemars::gen::SchemaSettings::openapi3();
         settings.inline_subschemas = inline_subschemas;

--- a/rust/kcl-derive-docs/tests/show.gen
+++ b/rust/kcl-derive-docs/tests/show.gen
@@ -92,10 +92,6 @@ impl crate::docs::StdLibFn for Show {
         vec![]
     }
 
-    fn keyword_arguments(&self) -> bool {
-        false
-    }
-
     fn args(&self, inline_subschemas: bool) -> Vec<crate::docs::StdLibFnArg> {
         let mut settings = schemars::gen::SchemaSettings::openapi3();
         settings.inline_subschemas = inline_subschemas;

--- a/rust/kcl-derive-docs/tests/test_args_with_exec_state.gen
+++ b/rust/kcl-derive-docs/tests/test_args_with_exec_state.gen
@@ -91,10 +91,6 @@ impl crate::docs::StdLibFn for SomeFunction {
         vec![]
     }
 
-    fn keyword_arguments(&self) -> bool {
-        false
-    }
-
     fn args(&self, inline_subschemas: bool) -> Vec<crate::docs::StdLibFnArg> {
         let mut settings = schemars::gen::SchemaSettings::openapi3();
         settings.inline_subschemas = inline_subschemas;

--- a/rust/kcl-lib/src/docs/mod.rs
+++ b/rust/kcl-lib/src/docs/mod.rs
@@ -1039,7 +1039,10 @@ mod tests {
             panic!();
         };
         let snippet = circle_fn.to_autocomplete_snippet();
-        assert_eq!(snippet, r#"circle(center = [${0:0}, ${1:0}], diameter = ${2:3.14})"#);
+        assert_eq!(
+            snippet,
+            r#"circle(center = [${0:3.14}, ${1:3.14}], diameter = ${2:3.14})"#
+        );
     }
 
     #[test]

--- a/rust/kcl-lib/src/docs/mod.rs
+++ b/rust/kcl-lib/src/docs/mod.rs
@@ -78,8 +78,6 @@ pub struct StdLibFnData {
     pub description: String,
     /// The tags of the function.
     pub tags: Vec<String>,
-    /// If this function uses keyword arguments, or positional arguments.
-    pub keyword_arguments: bool,
     /// The args of the function.
     pub args: Vec<StdLibFnArg>,
     /// The return value of the function.
@@ -472,9 +470,6 @@ pub trait StdLibFn: std::fmt::Debug + Send + Sync {
     /// The description of the function.
     fn description(&self) -> String;
 
-    /// Does this use keyword arguments, or positional?
-    fn keyword_arguments(&self) -> bool;
-
     /// The tags of the function.
     fn tags(&self) -> Vec<String>;
 
@@ -509,7 +504,6 @@ pub trait StdLibFn: std::fmt::Debug + Send + Sync {
             summary: self.summary(),
             description: self.description(),
             tags: self.tags(),
-            keyword_arguments: self.keyword_arguments(),
             args: self.args(false),
             return_value: self.return_value(false),
             unpublished: self.unpublished(),
@@ -593,7 +587,7 @@ pub trait StdLibFn: std::fmt::Debug + Send + Sync {
         } else if self.name() == "subtract2D" {
             return Ok("subtract2d(${0:%}, tool = ${1:%})".to_string());
         }
-        let in_keyword_fn = self.keyword_arguments();
+        let in_keyword_fn = true;
         let mut args = Vec::new();
         let mut index = 0;
         for arg in self.args(true).iter() {
@@ -1045,10 +1039,7 @@ mod tests {
             panic!();
         };
         let snippet = circle_fn.to_autocomplete_snippet();
-        assert_eq!(
-            snippet,
-            r#"circle(center = [${0:3.14}, ${1:3.14}], diameter = ${2:3.14})"#
-        );
+        assert_eq!(snippet, r#"circle(center = [${0:0}, ${1:0}], diameter = ${2:3.14})"#);
     }
 
     #[test]

--- a/rust/kcl-lib/src/lsp/kcl/mod.rs
+++ b/rust/kcl-lib/src/lsp/kcl/mod.rs
@@ -1686,31 +1686,29 @@ pub fn get_arg_maps_from_stdlib(
     let combined = stdlib.combined();
 
     for internal_fn in combined.values() {
-        if internal_fn.keyword_arguments() {
-            let arg_map: HashMap<String, String> = internal_fn
-                .args(false)
-                .into_iter()
-                .map(|data| {
-                    let mut tip = "```\n".to_owned();
-                    tip.push_str(&data.name.clone());
-                    if !data.required {
-                        tip.push('?');
-                    }
-                    if !data.type_.is_empty() {
-                        tip.push_str(": ");
-                        tip.push_str(&data.type_);
-                    }
-                    tip.push_str("\n```");
-                    if !data.description.is_empty() {
-                        tip.push_str("\n\n");
-                        tip.push_str(&data.description);
-                    }
-                    (data.name, tip)
-                })
-                .collect();
-            if !arg_map.is_empty() {
-                result.insert(internal_fn.name(), arg_map);
-            }
+        let arg_map: HashMap<String, String> = internal_fn
+            .args(false)
+            .into_iter()
+            .map(|data| {
+                let mut tip = "```\n".to_owned();
+                tip.push_str(&data.name.clone());
+                if !data.required {
+                    tip.push('?');
+                }
+                if !data.type_.is_empty() {
+                    tip.push_str(": ");
+                    tip.push_str(&data.type_);
+                }
+                tip.push_str("\n```");
+                if !data.description.is_empty() {
+                    tip.push_str("\n\n");
+                    tip.push_str(&data.description);
+                }
+                (data.name, tip)
+            })
+            .collect();
+        if !arg_map.is_empty() {
+            result.insert(internal_fn.name(), arg_map);
         }
     }
 

--- a/rust/kcl-lib/src/std/appearance.rs
+++ b/rust/kcl-lib/src/std/appearance.rs
@@ -260,7 +260,6 @@ pub async fn appearance(exec_state: &mut ExecState, args: Args) -> Result<KclVal
 /// ```
 #[stdlib {
     name = "appearance",
-    keywords = true,
     unlabeled_first = true,
     args = {
         solids = { docs = "The solid(s) whose appearance is being set" },

--- a/rust/kcl-lib/src/std/assert.rs
+++ b/rust/kcl-lib/src/std/assert.rs
@@ -49,7 +49,6 @@ pub async fn assert(_exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 /// ```
 #[stdlib{
     name = "assertIs",
-    keywords = true,
     unlabeled_first = true,
     args = {
         actual = { docs = "Value to check. If this is the boolean value true, assert passes. Otherwise it fails." },
@@ -75,7 +74,6 @@ async fn inner_assert_is(actual: bool, error: Option<String>, args: &Args) -> Re
 /// ```
 #[stdlib {
     name = "assert",
-    keywords = true,
     unlabeled_first = true,
     args = {
         actual = { docs = "Value to check. It will be compared with one of the comparison arguments." },

--- a/rust/kcl-lib/src/std/csg.rs
+++ b/rust/kcl-lib/src/std/csg.rs
@@ -106,7 +106,6 @@ pub async fn union(exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 #[stdlib {
     name = "union",
     feature_tree_operation = true,
-    keywords = true,
     unlabeled_first = true,
     args = {
         solids = {docs = "The solids to union."},
@@ -232,7 +231,6 @@ pub async fn intersect(exec_state: &mut ExecState, args: Args) -> Result<KclValu
 #[stdlib {
     name = "intersect",
     feature_tree_operation = true,
-    keywords = true,
     unlabeled_first = true,
     args = {
         solids = {docs = "The solids to intersect."},
@@ -352,7 +350,6 @@ pub async fn subtract(exec_state: &mut ExecState, args: Args) -> Result<KclValue
 #[stdlib {
     name = "subtract",
     feature_tree_operation = true,
-    keywords = true,
     unlabeled_first = true,
     args = {
         solids = {docs = "The solids to use as the base to subtract from."},

--- a/rust/kcl-lib/src/std/edge.rs
+++ b/rust/kcl-lib/src/std/edge.rs
@@ -53,7 +53,6 @@ pub async fn get_opposite_edge(exec_state: &mut ExecState, args: Args) -> Result
 /// ```
 #[stdlib {
     name = "getOppositeEdge",
-    keywords = true,
     unlabeled_first = true,
     args = {
         edge = { docs = "The tag of the edge you want to find the opposite edge of." },
@@ -137,7 +136,6 @@ pub async fn get_next_adjacent_edge(exec_state: &mut ExecState, args: Args) -> R
 /// ```
 #[stdlib {
     name = "getNextAdjacentEdge",
-    keywords = true,
     unlabeled_first = true,
     args = {
         edge = { docs = "The tag of the edge you want to find the next adjacent edge of." },
@@ -230,7 +228,6 @@ pub async fn get_previous_adjacent_edge(exec_state: &mut ExecState, args: Args) 
 /// ```
 #[stdlib {
     name = "getPreviousAdjacentEdge",
-    keywords = true,
     unlabeled_first = true,
     args = {
         edge = { docs = "The tag of the edge you want to find the previous adjacent edge of." },
@@ -318,7 +315,6 @@ pub async fn get_common_edge(exec_state: &mut ExecState, args: Args) -> Result<K
 #[stdlib {
     name = "getCommonEdge",
     feature_tree_operation = false,
-    keywords = true,
     unlabeled_first = false,
     args = {
         faces = { docs = "The tags of the faces you want to find the common edge between" },

--- a/rust/kcl-lib/src/std/extrude.rs
+++ b/rust/kcl-lib/src/std/extrude.rs
@@ -148,7 +148,6 @@ pub async fn extrude(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 #[stdlib {
     name = "extrude",
     feature_tree_operation = true,
-    keywords = true,
     unlabeled_first = true,
     args = {
         sketches = { docs = "Which sketch or sketches should be extruded"},

--- a/rust/kcl-lib/src/std/loft.rs
+++ b/rust/kcl-lib/src/std/loft.rs
@@ -121,7 +121,6 @@ pub async fn loft(exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 #[stdlib {
     name = "loft",
     feature_tree_operation = true,
-    keywords = true,
     unlabeled_first = true,
     args = {
         sketches = {docs = "Which sketches to loft. Must include at least 2 sketches."},

--- a/rust/kcl-lib/src/std/patterns.rs
+++ b/rust/kcl-lib/src/std/patterns.rs
@@ -578,7 +578,6 @@ pub async fn pattern_linear_2d(exec_state: &mut ExecState, args: Args) -> Result
 /// ```
 #[stdlib {
     name = "patternLinear2d",
-    keywords = true,
     unlabeled_first = true,
     args = {
         sketches = { docs = "The sketch(es) to duplicate" },
@@ -742,7 +741,6 @@ pub async fn pattern_linear_3d(exec_state: &mut ExecState, args: Args) -> Result
 #[stdlib {
     name = "patternLinear3d",
     feature_tree_operation = true,
-    keywords = true,
     unlabeled_first = true,
     args = {
         solids = { docs = "The solid(s) to duplicate" },
@@ -939,7 +937,6 @@ pub async fn pattern_circular_2d(exec_state: &mut ExecState, args: Args) -> Resu
 /// ```
 #[stdlib {
     name = "patternCircular2d",
-    keywords = true,
     unlabeled_first = true,
     args = {
         sketch_set = { docs = "Which sketch(es) to pattern" },
@@ -1081,7 +1078,6 @@ pub async fn pattern_circular_3d(exec_state: &mut ExecState, args: Args) -> Resu
 #[stdlib {
     name = "patternCircular3d",
     feature_tree_operation = true,
-    keywords = true,
     unlabeled_first = true,
     args = {
         solids = { docs = "Which solid(s) to pattern" },

--- a/rust/kcl-lib/src/std/segment.rs
+++ b/rust/kcl-lib/src/std/segment.rs
@@ -49,7 +49,6 @@ pub async fn segment_end(exec_state: &mut ExecState, args: Args) -> Result<KclVa
 /// ```
 #[stdlib {
     name = "segEnd",
-    keywords = true,
     unlabeled_first = true,
     args = {
         tag = { docs = "The line segment being queried by its tag"},
@@ -94,7 +93,6 @@ pub async fn segment_end_x(exec_state: &mut ExecState, args: Args) -> Result<Kcl
 /// ```
 #[stdlib {
     name = "segEndX",
-    keywords = true,
     unlabeled_first = true,
     args = {
         tag = { docs = "The line segment being queried by its tag"},
@@ -137,7 +135,6 @@ pub async fn segment_end_y(exec_state: &mut ExecState, args: Args) -> Result<Kcl
 /// ```
 #[stdlib {
     name = "segEndY",
-    keywords = true,
     unlabeled_first = true,
     args = {
         tag = { docs = "The line segment being queried by its tag"},
@@ -191,7 +188,6 @@ pub async fn segment_start(exec_state: &mut ExecState, args: Args) -> Result<Kcl
 /// ```
 #[stdlib {
     name = "segStart",
-    keywords = true,
     unlabeled_first = true,
     args = {
         tag = { docs = "The line segment being queried by its tag"},
@@ -236,7 +232,6 @@ pub async fn segment_start_x(exec_state: &mut ExecState, args: Args) -> Result<K
 /// ```
 #[stdlib {
     name = "segStartX",
-    keywords = true,
     unlabeled_first = true,
     args = {
         tag = { docs = "The line segment being queried by its tag"},
@@ -279,7 +274,6 @@ pub async fn segment_start_y(exec_state: &mut ExecState, args: Args) -> Result<K
 /// ```
 #[stdlib {
     name = "segStartY",
-    keywords = true,
     unlabeled_first = true,
     args = {
         tag = { docs = "The line segment being queried by its tag"},
@@ -322,7 +316,6 @@ pub async fn last_segment_x(exec_state: &mut ExecState, args: Args) -> Result<Kc
 /// ```
 #[stdlib {
     name = "lastSegX",
-    keywords = true,
     unlabeled_first = true,
     args = {
         sketch = { docs = "The sketch whose line segment is being queried"},
@@ -369,7 +362,6 @@ pub async fn last_segment_y(exec_state: &mut ExecState, args: Args) -> Result<Kc
 /// ```
 #[stdlib {
     name = "lastSegY",
-    keywords = true,
     unlabeled_first = true,
     args = {
         sketch = { docs = "The sketch whose line segment is being queried"},
@@ -419,7 +411,6 @@ pub async fn segment_length(exec_state: &mut ExecState, args: Args) -> Result<Kc
 /// ```
 #[stdlib {
     name = "segLen",
-    keywords = true,
     unlabeled_first = true,
     args = {
         tag = { docs = "The line segment being queried by its tag"},
@@ -463,7 +454,6 @@ pub async fn segment_angle(exec_state: &mut ExecState, args: Args) -> Result<Kcl
 /// ```
 #[stdlib {
     name = "segAng",
-    keywords = true,
     unlabeled_first = true,
     args = {
         tag = { docs = "The line segment being queried by its tag"},
@@ -565,7 +555,6 @@ pub async fn tangent_to_end(exec_state: &mut ExecState, args: Args) -> Result<Kc
 /// ```
 #[stdlib {
     name = "tangentToEnd",
-    keywords = true,
     unlabeled_first = true,
     args = {
         tag = { docs = "The line segment being queried by its tag"},

--- a/rust/kcl-lib/src/std/shapes.rs
+++ b/rust/kcl-lib/src/std/shapes.rs
@@ -167,7 +167,6 @@ pub async fn circle_three_point(exec_state: &mut ExecState, args: Args) -> Resul
 /// ```
 #[stdlib {
     name = "circleThreePoint",
-    keywords = true,
     unlabeled_first = true,
     args = {
         sketch_surface_or_group = {docs = "Plane or surface to sketch on."},
@@ -324,7 +323,6 @@ pub async fn polygon(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 /// ```
 #[stdlib {
     name = "polygon",
-    keywords = true,
     unlabeled_first = true,
     args = {
         sketch_surface_or_group = { docs = "Plane or surface to sketch on" },

--- a/rust/kcl-lib/src/std/sketch.rs
+++ b/rust/kcl-lib/src/std/sketch.rs
@@ -133,7 +133,6 @@ fn involute_curve(radius: f64, angle: f64) -> (f64, f64) {
 /// ```
 #[stdlib {
     name = "involuteCircular",
-    keywords = true,
     unlabeled_first = true,
     args = {
         sketch = { docs = "Which sketch should this path be added to?"},
@@ -254,7 +253,6 @@ pub async fn line(exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kc
 /// ```
 #[stdlib {
     name = "line",
-    keywords = true,
     unlabeled_first = true,
     args = {
         sketch = { docs = "Which sketch should this path be added to?"},
@@ -426,7 +424,6 @@ pub async fn x_line(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 /// ```
 #[stdlib {
     name = "xLine",
-    keywords = true,
     unlabeled_first = true,
     args = {
         sketch = { docs = "Which sketch should this path be added to?"},
@@ -492,7 +489,6 @@ pub async fn y_line(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 /// ```
 #[stdlib {
     name = "yLine",
-    keywords = true,
     unlabeled_first = true,
     args = {
         sketch = { docs = "Which sketch should this path be added to?"},
@@ -575,7 +571,6 @@ pub async fn angled_line(exec_state: &mut ExecState, args: Args) -> Result<KclVa
 /// ```
 #[stdlib {
     name = "angledLine",
-    keywords = true,
     unlabeled_first = true,
     args = {
         sketch = { docs = "Which sketch should this path be added to?"},
@@ -874,7 +869,6 @@ pub async fn angled_line_that_intersects(exec_state: &mut ExecState, args: Args)
 /// ```
 #[stdlib {
     name = "angledLineThatIntersects",
-    keywords = true,
     unlabeled_first = true,
     args = {
         sketch = { docs = "Which sketch should this path be added to?"},
@@ -1152,7 +1146,6 @@ pub async fn start_sketch_on(exec_state: &mut ExecState, args: Args) -> Result<K
 #[stdlib {
     name = "startSketchOn",
     feature_tree_operation = true,
-    keywords = true,
     unlabeled_first = true,
     args = {
         plane_or_solid = { docs = "The plane or solid to sketch on"},
@@ -1318,7 +1311,6 @@ pub async fn start_profile(exec_state: &mut ExecState, args: Args) -> Result<Kcl
 /// ```
 #[stdlib {
     name = "startProfile",
-    keywords = true,
     unlabeled_first = true,
     args = {
         sketch_surface = { docs = "What to start the profile on" },
@@ -1461,7 +1453,6 @@ pub async fn profile_start_x(exec_state: &mut ExecState, args: Args) -> Result<K
 /// ```
 #[stdlib {
     name = "profileStartX",
-    keywords = true,
     unlabeled_first = true,
     args = {
         profile = {docs = "Profile whose start is being used"},
@@ -1491,7 +1482,6 @@ pub async fn profile_start_y(exec_state: &mut ExecState, args: Args) -> Result<K
 /// ```
 #[stdlib {
     name = "profileStartY",
-    keywords = true,
     unlabeled_first = true,
     args = {
         profile = {docs = "Profile whose start is being used"},
@@ -1524,7 +1514,6 @@ pub async fn profile_start(exec_state: &mut ExecState, args: Args) -> Result<Kcl
 /// ```
 #[stdlib {
     name = "profileStart",
-    keywords = true,
     unlabeled_first = true,
     args = {
         profile = {docs = "Profile whose start is being used"},
@@ -1569,7 +1558,6 @@ pub async fn close(exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 /// ```
 #[stdlib {
     name = "close",
-    keywords = true,
     unlabeled_first = true,
     args = {
         sketch = { docs = "The sketch you want to close"},
@@ -1679,7 +1667,6 @@ pub async fn arc(exec_state: &mut ExecState, args: Args) -> Result<KclValue, Kcl
 /// ```
 #[stdlib {
     name = "arc",
-    keywords = true,
     unlabeled_first = true,
     args = {
         sketch = { docs = "Which sketch should this path be added to?" },
@@ -1922,7 +1909,6 @@ pub async fn tangential_arc(exec_state: &mut ExecState, args: Args) -> Result<Kc
 /// ```
 #[stdlib {
     name = "tangentialArc",
-    keywords = true,
     unlabeled_first = true,
     args = {
         sketch = { docs = "Which sketch should this path be added to?"},
@@ -2199,7 +2185,6 @@ pub async fn bezier_curve(exec_state: &mut ExecState, args: Args) -> Result<KclV
 /// ```
 #[stdlib {
     name = "bezierCurve",
-    keywords = true,
     unlabeled_first = true,
     args = {
         sketch = { docs = "Which sketch should this path be added to?"},
@@ -2321,7 +2306,6 @@ pub async fn subtract_2d(exec_state: &mut ExecState, args: Args) -> Result<KclVa
 #[stdlib {
     name = "subtract2d",
     feature_tree_operation = true,
-    keywords = true,
     unlabeled_first = true,
     args = {
         sketch = { docs = "Which sketch should this path be added to?" },

--- a/rust/kcl-lib/src/std/sweep.rs
+++ b/rust/kcl-lib/src/std/sweep.rs
@@ -160,7 +160,6 @@ pub async fn sweep(exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 #[stdlib {
     name = "sweep",
     feature_tree_operation = true,
-    keywords = true,
     unlabeled_first = true,
     args = {
         sketches = { docs = "The sketch or set of sketches that should be swept in space" },

--- a/rust/kcl-lib/src/std/transform.rs
+++ b/rust/kcl-lib/src/std/transform.rs
@@ -147,7 +147,6 @@ pub async fn scale(exec_state: &mut ExecState, args: Args) -> Result<KclValue, K
 #[stdlib {
     name = "scale",
     feature_tree_operation = false,
-    keywords = true,
     unlabeled_first = true,
     args = {
         objects = {docs = "The solid, sketch, or set of solids or sketches to scale."},
@@ -378,7 +377,6 @@ pub async fn translate(exec_state: &mut ExecState, args: Args) -> Result<KclValu
 #[stdlib {
     name = "translate",
     feature_tree_operation = false,
-    keywords = true,
     unlabeled_first = true,
     args = {
         objects = {docs = "The solid, sketch, or set of solids or sketches to move."},
@@ -782,7 +780,6 @@ pub async fn rotate(exec_state: &mut ExecState, args: Args) -> Result<KclValue, 
 #[stdlib {
     name = "rotate",
     feature_tree_operation = false,
-    keywords = true,
     unlabeled_first = true,
     args = {
         objects = {docs = "The solid, sketch, or set of solids or sketches to rotate."},


### PR DESCRIPTION
This has been enforced by the parser since #6639, so there's no need for `keywords = true` in every stdlib function anymore.