### PR TITLE
KCL: Custom snippet values for kcl-in-kcl

### DIFF
--- a/rust/kcl-lib/src/docs/kcl_doc.rs
+++ b/rust/kcl-lib/src/docs/kcl_doc.rs
@@ -743,20 +743,26 @@ impl ArgData {
                                 p.value
                             );
                         }
-                    } else if p.key.name == "snippet_array" {
+                    } else if p.key.name == "snippetArray" {
                         let Expr::ArrayExpression(arr) = &p.value else {
                             panic!(
-                                "Invalid value for `snippet_array`, expected array literal, found {:?}",
+                                "Invalid value for `snippetArray`, expected array literal, found {:?}",
                                 p.value
                             );
                         };
                         let mut items = Vec::new();
                         for s in &arr.elements {
                             let Expr::Literal(lit) = s else {
-                                panic!("Invalid value in `snippet_array`, all items must be string literals but found {:?}", s);
+                                panic!(
+                                    "Invalid value in `snippetArray`, all items must be string literals but found {:?}",
+                                    s
+                                );
                             };
                             let LiteralValue::String(litstr) = &lit.inner.value else {
-                                panic!("Invalid value in `snippet_array`, all items must be string literals but found {:?}", s);
+                                panic!(
+                                    "Invalid value in `snippetArray`, all items must be string literals but found {:?}",
+                                    s
+                                );
                             };
                             items.push(litstr.to_owned());
                         }

--- a/rust/kcl-lib/src/docs/mod.rs
+++ b/rust/kcl-lib/src/docs/mod.rs
@@ -1045,10 +1045,7 @@ mod tests {
             panic!();
         };
         let snippet = circle_fn.to_autocomplete_snippet();
-        assert_eq!(
-            snippet,
-            r#"circle(center = [${0:3.14}, ${1:3.14}], diameter = ${2:3.14})"#
-        );
+        assert_eq!(snippet, r#"circle(center = [${0:0}, ${1:0}], diameter = ${2:3.14})"#);
     }
 
     #[test]

--- a/rust/kcl-lib/src/docs/mod.rs
+++ b/rust/kcl-lib/src/docs/mod.rs
@@ -1045,7 +1045,10 @@ mod tests {
             panic!();
         };
         let snippet = circle_fn.to_autocomplete_snippet();
-        assert_eq!(snippet, r#"circle(center = [${0:0}, ${1:0}], diameter = ${2:3.14})"#);
+        assert_eq!(
+            snippet, r#"circle(center = [${0:0}, ${1:0}], diameter = ${2:3.14})"#,
+            "actual = left, expected = right"
+        );
     }
 
     #[test]

--- a/rust/kcl-lib/std/sketch.kcl
+++ b/rust/kcl-lib/std/sketch.kcl
@@ -33,10 +33,12 @@ export fn circle(
   /// Sketch to extend, or plane or surface to sketch on.
   @sketch_or_surface: Sketch | Plane | Face,
   /// The center of the circle.
+  @(snippet_array = ["0", "0"])
   center: Point2d,
   /// The radius of the circle. Incompatible with `diameter`.
   radius?: number(Length),
   /// The diameter of the circle. Incompatible with `radius`.
+  @(include_in_snippet = true)
   diameter?: number(Length),
   /// Create a new tag which refers to this circle.
   tag?: tag,

--- a/rust/kcl-lib/std/sketch.kcl
+++ b/rust/kcl-lib/std/sketch.kcl
@@ -33,7 +33,7 @@ export fn circle(
   /// Sketch to extend, or plane or surface to sketch on.
   @sketch_or_surface: Sketch | Plane | Face,
   /// The center of the circle.
-  @(snippet_array = ["0", "0"])
+  @(snippetArray = ["0", "0"])
   center: Point2d,
   /// The radius of the circle. Incompatible with `diameter`.
   radius?: number(Length),


### PR DESCRIPTION
In #7156, I allowed KCL to set specific snippet completions for each arg of each function. They're optional -- if you don't set one, it'll fall back to the type-driven defaults.

That PR only worked for KCL stdlib functions defined in Rust. This PR enables the same feature, but for functions defined in KCL.

<img width="421" alt="Screenshot 2025-05-21 at 7 04 48 PM" src="https://github.com/user-attachments/assets/005dd007-665c-4741-b7b2-f3390bc71001" />
