### PR TITLE
KCL: Autocomplete snippets for 'center' should suggest the origin

### DIFF
--- a/rust/kcl-lib/src/docs/mod.rs
+++ b/rust/kcl-lib/src/docs/mod.rs
@@ -1018,7 +1018,7 @@ mod tests {
         let snippet = pattern_fn.to_autocomplete_snippet().unwrap();
         assert_eq!(
             snippet,
-            r#"patternCircular3d(${0:%}, instances = ${1:10}, axis = [${2:3.14}, ${3:3.14}, ${4:3.14}], center = [${5:3.14}, ${6:3.14}, ${7:3.14}])"#
+            r#"patternCircular3d(${0:%}, instances = ${1:10}, axis = [${2:3.14}, ${3:3.14}, ${4:3.14}], center = [${5:0}, ${6:0}, ${7:0}])"#
         );
     }
 

--- a/rust/kcl-lib/src/std/patterns.rs
+++ b/rust/kcl-lib/src/std/patterns.rs
@@ -941,7 +941,7 @@ pub async fn pattern_circular_2d(exec_state: &mut ExecState, args: Args) -> Resu
     args = {
         sketch_set = { docs = "Which sketch(es) to pattern" },
         instances = { docs = "The number of total instances. Must be greater than or equal to 1. This includes the original entity. For example, if instances is 2, there will be two copies -- the original, and one new copy. If instances is 1, this has no effect."},
-        center = { docs = "The center about which to make the pattern. This is a 2D vector."},
+        center = { docs = "The center about which to make the pattern. This is a 2D vector.", snippet_value_array = ["0", "0"]},
         arc_degrees = { docs = "The arc angle (in degrees) to place the repetitions. Must be greater than 0. Defaults to 360."},
         rotate_duplicates= { docs = "Whether or not to rotate the duplicates as they are copied. Defaults to true."},
         use_original= { docs = "If the target was sketched on an extrusion, setting this will use the original sketch as the target, not the entire joined solid. Defaults to false."},
@@ -1083,7 +1083,7 @@ pub async fn pattern_circular_3d(exec_state: &mut ExecState, args: Args) -> Resu
         solids = { docs = "Which solid(s) to pattern" },
         instances = { docs = "The number of total instances. Must be greater than or equal to 1. This includes the original entity. For example, if instances is 2, there will be two copies -- the original, and one new copy. If instances is 1, this has no effect."},
         axis = { docs = "The axis around which to make the pattern. This is a 3D vector"},
-        center = { docs = "The center about which to make the pattern. This is a 3D vector."},
+        center = { docs = "The center about which to make the pattern. This is a 3D vector.", snippet_value_array = ["0", "0", "0"]},
         arc_degrees = { docs = "The arc angle (in degrees) to place the repetitions. Must be greater than 0. Defaults to 360."},
         rotate_duplicates = { docs = "Whether or not to rotate the duplicates as they are copied. Defaults to true."},
         use_original = { docs = "If the target was sketched on an extrusion, setting this will use the original sketch as the target, not the entire joined solid. Defaults to false."},

--- a/rust/kcl-lib/src/std/shapes.rs
+++ b/rust/kcl-lib/src/std/shapes.rs
@@ -328,7 +328,7 @@ pub async fn polygon(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
         sketch_surface_or_group = { docs = "Plane or surface to sketch on" },
         radius = { docs = "The radius of the polygon", include_in_snippet = true },
         num_sides = { docs = "The number of sides in the polygon", include_in_snippet = true },
-        center = { docs = "The center point of the polygon", include_in_snippet = true },
+        center = { docs = "The center point of the polygon", snippet_value_array = ["0", "0"] },
         inscribed = { docs = "Whether the polygon is inscribed (true, the default) or circumscribed (false) about a circle with the specified radius" },
     },
     tags = ["sketch"]


### PR DESCRIPTION
Pattern functions and `polygon` both take a parameter `center` which defaulted to [3.14, 3.14] for silly reasons. They now default to [0, 0].