### PR TITLE
fix- Starting planes hide imported geometry #7011

### DIFF
--- a/src/clientSideScene/sceneEntities.ts
+++ b/src/clientSideScene/sceneEntities.ts
@@ -382,10 +382,14 @@ export class SceneEntities {
     const xAxisMaterial = new MeshBasicMaterial({
       color: baseXColor,
       depthTest: false,
+      transparent: true,
+      opacity: 0.5,
     })
     const yAxisMaterial = new MeshBasicMaterial({
       color: baseYColor,
       depthTest: false,
+      transparent: true,
+      opacity: 0.5,
     })
     const xAxisMesh = new Mesh(xAxisGeometry, xAxisMaterial)
     const yAxisMesh = new Mesh(yAxisGeometry, yAxisMaterial)


### PR DESCRIPTION
Add transparency to the grid to fix the issue.
![image](https://github.com/user-attachments/assets/ee0595db-d544-4464-b83a-a7f6b1d91c8f)
