### PR TITLE
KCL: Set sensible defaults for pattern 'axis' arg

### DIFF
--- a/docs/kcl-std/patternLinear3d.md
+++ b/docs/kcl-std/patternLinear3d.md
@@ -26,7 +26,7 @@ patternLinear3d(
 | `solids` | [`[Solid]`](/docs/kcl-std/types/std-types-Solid) | The solid(s) to duplicate | Yes |
 | `instances` | [`number`](/docs/kcl-std/types/std-types-number) | The number of total instances. Must be greater than or equal to 1. This includes the original entity. For example, if instances is 2, there will be two copies -- the original, and one new copy. If instances is 1, this has no effect. | Yes |
 | `distance` | [`number`](/docs/kcl-std/types/std-types-number) | Distance between each repetition. Also known as 'spacing'. | Yes |
-| `axis` | [`Point3d`](/docs/kcl-std/types/std-types-Point3d) | The axis of the pattern. A 2D vector. | Yes |
+| `axis` | [`Point3d`](/docs/kcl-std/types/std-types-Point3d) | The axis of the pattern. A 3D vector. | Yes |
 | `useOriginal` | [`bool`](/docs/kcl-std/types/std-types-bool) | If the target was sketched on an extrusion, setting this will use the original sketch as the target, not the entire joined solid. Defaults to false. | No |
 
 ### Returns

--- a/rust/kcl-lib/src/docs/mod.rs
+++ b/rust/kcl-lib/src/docs/mod.rs
@@ -180,7 +180,7 @@ impl StdLibFnArg {
                 }
             }
             snippet.push(']');
-            return Ok(Some((index + vals.len(), snippet)));
+            return Ok(Some((index + vals.len() - 1, snippet)));
         }
         if let Some(val) = &self.snippet_value {
             return Ok(Some((index, format!("{label}${{{}:{}}}", index, val))));
@@ -1018,7 +1018,7 @@ mod tests {
         let snippet = pattern_fn.to_autocomplete_snippet().unwrap();
         assert_eq!(
             snippet,
-            r#"patternCircular3d(${0:%}, instances = ${1:10}, axis = [${2:3.14}, ${3:3.14}, ${4:3.14}], center = [${5:0}, ${6:0}, ${7:0}])"#
+            r#"patternCircular3d(${0:%}, instances = ${1:10}, axis = [${2:1}, ${3:0}, ${4:0}], center = [${5:0}, ${6:0}, ${7:0}])"#
         );
     }
 
@@ -1071,7 +1071,7 @@ mod tests {
         let snippet = pattern_fn.to_autocomplete_snippet().unwrap();
         assert_eq!(
             snippet,
-            r#"patternLinear2d(${0:%}, instances = ${1:10}, distance = ${2:3.14}, axis = [${3:3.14}, ${4:3.14}])"#
+            r#"patternLinear2d(${0:%}, instances = ${1:10}, distance = ${2:3.14}, axis = [${3:1}, ${4:0}])"#
         );
     }
 

--- a/rust/kcl-lib/src/std/patterns.rs
+++ b/rust/kcl-lib/src/std/patterns.rs
@@ -583,7 +583,7 @@ pub async fn pattern_linear_2d(exec_state: &mut ExecState, args: Args) -> Result
         sketches = { docs = "The sketch(es) to duplicate" },
         instances = { docs = "The number of total instances. Must be greater than or equal to 1. This includes the original entity. For example, if instances is 2, there will be two copies -- the original, and one new copy. If instances is 1, this has no effect." },
         distance = { docs = "Distance between each repetition. Also known as 'spacing'."},
-        axis = { docs = "The axis of the pattern. A 2D vector." },
+        axis = { docs = "The axis of the pattern. A 2D vector.", snippet_value_array = ["1", "0"] },
         use_original = { docs = "If the target was sketched on an extrusion, setting this will use the original sketch as the target, not the entire joined solid. Defaults to false." },
     }
 }]
@@ -746,7 +746,7 @@ pub async fn pattern_linear_3d(exec_state: &mut ExecState, args: Args) -> Result
         solids = { docs = "The solid(s) to duplicate" },
         instances = { docs = "The number of total instances. Must be greater than or equal to 1. This includes the original entity. For example, if instances is 2, there will be two copies -- the original, and one new copy. If instances is 1, this has no effect." },
         distance = { docs = "Distance between each repetition. Also known as 'spacing'."},
-        axis = { docs = "The axis of the pattern. A 2D vector." },
+        axis = { docs = "The axis of the pattern. A 3D vector.", snippet_value_array = ["1", "0", "0"] },
         use_original = { docs = "If the target was sketched on an extrusion, setting this will use the original sketch as the target, not the entire joined solid. Defaults to false." },
     },
     tags = ["solid"]
@@ -1082,7 +1082,7 @@ pub async fn pattern_circular_3d(exec_state: &mut ExecState, args: Args) -> Resu
     args = {
         solids = { docs = "Which solid(s) to pattern" },
         instances = { docs = "The number of total instances. Must be greater than or equal to 1. This includes the original entity. For example, if instances is 2, there will be two copies -- the original, and one new copy. If instances is 1, this has no effect."},
-        axis = { docs = "The axis around which to make the pattern. This is a 3D vector"},
+        axis = { docs = "The axis around which to make the pattern. This is a 3D vector", snippet_value_array = ["1", "0", "0"]},
         center = { docs = "The center about which to make the pattern. This is a 3D vector.", snippet_value_array = ["0", "0", "0"]},
         arc_degrees = { docs = "The arc angle (in degrees) to place the repetitions. Must be greater than 0. Defaults to 360."},
         rotate_duplicates = { docs = "Whether or not to rotate the duplicates as they are copied. Defaults to true."},


### PR DESCRIPTION
`[3.14, 3.14]` is not a sensible default axis for a pattern. 