### PR TITLE
Remove Owners font from the modeling app

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,6 @@
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
     <link rel="stylesheet" href="./inter/inter.css" />
-    <link rel="stylesheet" href="https://use.typekit.net/zzv8rvm.css" />
     <script
       defer
       data-domain="app.zoo.dev"

--- a/src/index.css
+++ b/src/index.css
@@ -33,7 +33,7 @@ h3,
 h4,
 h5,
 h6 {
-  @apply font-display;
+  @apply font-sans;
 }
 
 .body-bg {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -40,9 +40,6 @@ module.exports = {
         ...themeColors,
       },
       fontFamily: {
-        display: `'owners', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-        'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-        sans-serif`,
         sans: `'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
         'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
         sans-serif`,


### PR DESCRIPTION
Our team started getting *rate limited* with access to the font, which meant the app wasn't loading for them 😱. I don't want us to risk any user being rate limited because of a font ever.

Here are some examples of the impact of this change in the UI. We use Owners in some headings and display text as a nod to the marketing site currently.

## Sign-in
![Screenshot 2025-05-23 at 11 43 49 AM](https://github.com/user-attachments/assets/d0b2f777-5b37-4690-95ad-35667706d972)
![Screenshot 2025-05-23 at 11 43 53 AM](https://github.com/user-attachments/assets/add36dc6-668c-4455-b699-01b44c163fe5)

## Settings
![Screenshot 2025-05-23 at 11 42 36 AM](https://github.com/user-attachments/assets/f2096e73-c1dd-468d-ba3a-81bf4f5af924)
![Screenshot 2025-05-23 at 11 49 44 AM](https://github.com/user-attachments/assets/6d21c67a-47c1-469f-8887-fbe671a01a75)
