### PR TITLE
Bubble up the actual error message in the Text-to-CAD toast message

### DIFF
--- a/src/lib/textToCad.ts
+++ b/src/lib/textToCad.ts
@@ -15,7 +15,7 @@ import {
   SystemIOMachineEvents,
   waitForIdleState,
 } from '@src/machines/systemIO/utils'
-import { reportRejection } from '@src/lib/trap'
+import { err, reportRejection } from '@src/lib/trap'
 import { toSync } from '@src/lib/utils'
 import { getAllSubDirectoriesAtProjectRoot } from '@src/machines/systemIO/snapshotContext'
 import { joinOSPaths } from '@src/lib/paths'
@@ -120,12 +120,15 @@ export async function submitAndAwaitTextToKclSystemIO({
       return value
     })
     .catch((error) => {
-      showFailureToast('Failed to submit to Text-to-CAD API')
+      const message = err(error)
+        ? error.message
+        : 'Failed to submit to Text-to-CAD API'
+      showFailureToast(message)
       return error
     })
 
-  if (textToCadQueued instanceof Error) {
-    showFailureToast('Failed to submit to Text-to-CAD API')
+  if (err(textToCadQueued)) {
+    showFailureToast(textToCadQueued.message)
     return
   }
 

--- a/src/lib/trap.ts
+++ b/src/lib/trap.ts
@@ -29,7 +29,7 @@ export function isErr<T>(value: ExcludeErr<T> | Error): value is Error {
   return value instanceof Error
 }
 
-// Used to bubble errors up
+/** Used to bubble errors up */
 export function err<T>(value: ExcludeErr<T> | Error): value is Error {
   if (!isErr(value)) {
     return false


### PR DESCRIPTION
So that users can see if they're blocked, for example.