### PR TITLE
Don't error when editing via feature tree if no `angle` arg is present in revolve, use `360deg`

### DIFF
--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -868,7 +868,7 @@ const prepareToEditRevolve: PrepareToEditCallback = async ({
           operation.labeledArgs.angle.sourceRange[0],
           operation.labeledArgs.angle.sourceRange[1]
         )
-      : '360'
+      : '360deg'
   )
   if (err(angle) || 'errors' in angle) {
     return { reason: 'Error in angle argument retrieval' }

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -861,14 +861,14 @@ const prepareToEditRevolve: PrepareToEditCallback = async ({
   }
 
   // angle kcl arg
-  if (!('angle' in operation.labeledArgs) || !operation.labeledArgs.angle) {
-    return { reason: "Couldn't find angle argument" }
-  }
+  // Default to '360' if not present
   const angle = await stringToKclExpression(
-    codeManager.code.slice(
-      operation.labeledArgs.angle.sourceRange[0],
-      operation.labeledArgs.angle.sourceRange[1]
-    )
+    'angle' in operation.labeledArgs && operation.labeledArgs.angle
+      ? codeManager.code.slice(
+          operation.labeledArgs.angle.sourceRange[0],
+          operation.labeledArgs.angle.sourceRange[1]
+        )
+      : '360'
   )
   if (err(angle) || 'errors' in angle) {
     return { reason: 'Error in angle argument retrieval' }


### PR DESCRIPTION
KCL uses a default value if the keyword argument isn't present, so the feature tree edit flow should do the same. In the future these should flow from the same source of truth so that the feature tree doesn't have to duplicate default arg values like this.