### PR TITLE
Don't access `id` when editing a shell without a `VariableDeclaration`

### DIFF
--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -2803,7 +2803,10 @@ export const modelingMachine = setup({
             nodeToEdit,
             'VariableDeclaration'
           )
-          if (err(variableNode)) {
+          if (
+            err(variableNode) ||
+            variableNode.node.type !== 'VariableDeclaration'
+          ) {
             console.error('Error extracting name')
           } else {
             variableName = variableNode.node.declaration.id.name


### PR DESCRIPTION
The type on `getNodeFromPath` is doing us a disservice here, lying to us when we actually don't have a `VariableDeclaration` in cases like the one in `rust/kcl-lib/tests/fillet-and-shell/input.kcl`, which was causing an error when attempting to edit via point-and-click. Now it bails out of that, and falls back to giving that node a variable declaration.