### PR TITLE
Disable subtract_regression08 artifact graph test

### DIFF
--- a/rust/kcl-lib/src/simulation_tests.rs
+++ b/rust/kcl-lib/src/simulation_tests.rs
@@ -321,7 +321,10 @@ fn assert_common_snapshots(
                 // Change the snapshot suffix so that it is rendered as a Markdown file
                 // in GitHub.
                 // Ignore the cpu cooler for now because its being a little bitch.
-                if test.name != "cpu-cooler" && test.name != "subtract_regression10" {
+                if test.name != "cpu-cooler"
+                    && test.name != "subtract_regression08"
+                    && test.name != "subtract_regression10"
+                {
                     insta::assert_binary_snapshot!("artifact_graph_flowchart.md", flowchart.as_bytes().to_owned());
                 }
             })


### PR DESCRIPTION
This has been very flaky since the output is non-deterministic. The issue has been updated.