### PR TITLE
Use the same OS images for web and desktop e2e

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -217,7 +217,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: "runs-on=${{ github.run_id }}/family=i7ie.2xlarge/image=ubuntu22-full-x64"
+          - os: namespace-profile-macos-8-cores
+          - os: windows-latest-8-cores
     runs-on: ${{ matrix.os }}
     name: e2e:web (${{ contains(matrix.os, 'ubuntu') && 'ubuntu' || (contains(matrix.os, 'windows') && 'windows' || 'macos') }})
     env:


### PR DESCRIPTION
I've seen a few cases of Vector failing to start on the default macOS runners.

Contributes to #6773 