### PR TITLE
Remove nested <button> elements

### DIFF
--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -84,7 +84,7 @@ export const ShareButton = memo(function ShareButton() {
 
   return (
     <Popover className="relative flex">
-      <Popover.Button className="relative group border-0 w-fit min-w-max p-0 rounded-l-full focus-visible:outline-appForeground">
+      <Popover.Group className="relative group border-0 w-fit min-w-max p-0 rounded-l-full focus-visible:outline-appForeground">
         <button
           type="button"
           onClick={onShareClickFreeOrUnknownRestricted}
@@ -110,7 +110,7 @@ export const ShareButton = memo(function ShareButton() {
             )}
           </Tooltip>
         </button>
-      </Popover.Button>
+      </Popover.Group>
       {showOptions && (
         <Popover.Panel
           focus={true}


### PR DESCRIPTION
This is low prio and non-functional, just cleans up the warning in the console coming from nested buttons in the dom:
```
chunk-7I7T2IKX.js?v=b01cdd5b:521 Warning: validateDOMNesting(...): <button> cannot appear as a descendant of <button>.
    at button
    at button
    at Ke3 (http://localhost:5173/node_modules/.vite/deps/@headlessui_react.js?v=b01cdd5b:3094:13)
    at div
    at http://localhost:5173/node_modules/.vite/deps/@headlessui_react.js?v=b01cdd5b:2051:70
    at s9 (http://localhost:5173/node_modules/.vite/deps/@headlessui_react.js?v=b01cdd5b:1366:22)
    at Ue2 (http://localhost:5173/node_modules/.vite/deps/@headlessui_react.js?v=b01cdd5b:3066:21)
    at ShareButton2 (http://localhost:5173/src/components/ShareButton.tsx?t=1748613444382:21:20)
    at div
    at header
    at AppHeader (http://localhost:5173/src/components/AppHeader.tsx:10:3)
```