### PR TITLE
KCL: Fix cryptic error on unexpected tokens in fn call

### DIFF
--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -2072,8 +2072,8 @@ notPipeSub = 1 |> identity(!%))";
             // a runtime error instead.
             parse_execute(code11).await.unwrap_err(),
             KclError::Syntax(KclErrorDetails::new(
-                "Unexpected token: |>".to_owned(),
-                vec![SourceRange::new(44, 46, ModuleId::default())],
+                "There was an unexpected !. Try removing it.".to_owned(),
+                vec![SourceRange::new(56, 57, ModuleId::default())],
             ))
         );
 

--- a/rust/kcl-lib/src/parsing/parser.rs
+++ b/rust/kcl-lib/src/parsing/parser.rs
@@ -4446,8 +4446,8 @@ z(-[["#,
         assert_err(
             r#"z
 (--#"#,
-            "Unexpected token: (",
-            [2, 3],
+            "There was an unexpected -. Try removing it.",
+            [3, 4],
         );
     }
 

--- a/rust/kcl-lib/src/parsing/parser.rs
+++ b/rust/kcl-lib/src/parsing/parser.rs
@@ -3209,7 +3209,6 @@ fn fn_call_kw(i: &mut TokenSlice) -> ModalResult<Node<CallExpressionKw>> {
         Keyword(Token),
     }
     let initial_unlabeled_arg = opt((expression, comma, opt(whitespace)).map(|(arg, _, _)| arg)).parse_next(i)?;
-    println!("Parsing args");
     let args: Vec<_> = repeat(
         0..,
         alt((
@@ -3220,7 +3219,6 @@ fn fn_call_kw(i: &mut TokenSlice) -> ModalResult<Node<CallExpressionKw>> {
         )),
     )
     .parse_next(i)?;
-    println!("Parsed args");
     let (args, non_code_nodes): (Vec<_>, BTreeMap<usize, _>) = args.into_iter().enumerate().try_fold(
         (Vec::new(), BTreeMap::new()),
         |(mut args, mut non_code_nodes), (index, e)| {
@@ -3272,7 +3270,6 @@ fn fn_call_kw(i: &mut TokenSlice) -> ModalResult<Node<CallExpressionKw>> {
     )?;
     ignore_whitespace(i);
     opt(comma_sep).parse_next(i)?;
-    println!("Parsing end paren");
     let end = match close_paren.parse_next(i) {
         Ok(tok) => tok.end,
         Err(e) => {
@@ -3289,7 +3286,6 @@ fn fn_call_kw(i: &mut TokenSlice) -> ModalResult<Node<CallExpressionKw>> {
             }
         }
     };
-    println!("Parsed end paren");
 
     // Validate there aren't any duplicate labels.
     let mut counted_labels = IndexMap::with_capacity(args.len());
@@ -3411,7 +3407,6 @@ mod tests {
         let tokens = crate::parsing::token::lex("f(x = 1)", ModuleId::default()).unwrap();
         let tokens = tokens.as_slice();
         let op = operand.parse(tokens).unwrap();
-        println!("{op:#?}");
     }
 
     #[test]
@@ -5233,7 +5228,6 @@ bar = 1
             let err = match fn_call_kw.parse(tokens.as_slice()) {
                 Err(e) => e,
                 Ok(ast) => {
-                    eprintln!("{ast:#?}");
                     panic!("Expected this to error but it didn't");
                 }
             };

--- a/rust/kcl-lib/src/parsing/parser.rs
+++ b/rust/kcl-lib/src/parsing/parser.rs
@@ -3406,7 +3406,7 @@ mod tests {
     fn kw_call_as_operand() {
         let tokens = crate::parsing::token::lex("f(x = 1)", ModuleId::default()).unwrap();
         let tokens = tokens.as_slice();
-        let op = operand.parse(tokens).unwrap();
+        operand.parse(tokens).unwrap();
     }
 
     #[test]
@@ -5227,7 +5227,7 @@ bar = 1
             let tokens = crate::parsing::token::lex(program, ModuleId::default()).unwrap();
             let err = match fn_call_kw.parse(tokens.as_slice()) {
                 Err(e) => e,
-                Ok(ast) => {
+                Ok(_ast) => {
                     panic!("Expected this to error but it didn't");
                 }
             };


### PR DESCRIPTION
This program:
```kcl
1
|> extrude(
  length=depth,
})
```

was giving this bad error:

```
unexpected token |>
```

Now it gives

```kcl
There was an unexpected }. Try removing it.
```

and it correctly puts the diagnostic on the extra }.

Fixes https://github.com/KittyCAD/modeling-app/issues/6126