### PR TITLE
KCL: Fix cryptic error when missing commas between arguments

### DIFF
--- a/rust/kcl-lib/src/parsing/parser.rs
+++ b/rust/kcl-lib/src/parsing/parser.rs
@@ -3214,7 +3214,7 @@ fn fn_call_kw(i: &mut TokenSlice) -> ModalResult<Node<CallExpressionKw>> {
         alt((
             terminated(non_code_node.map(ArgPlace::NonCode), whitespace),
             terminated(any_keyword.map(ArgPlace::Keyword), whitespace),
-            ((labeled_argument, labeled_arg_separator)).map(ArgPlace::LabeledArg),
+            (labeled_argument, labeled_arg_separator).map(ArgPlace::LabeledArg),
             expression.map(ArgPlace::UnlabeledArg),
         )),
     )
@@ -3231,7 +3231,7 @@ fn fn_call_kw(i: &mut TokenSlice) -> ModalResult<Node<CallExpressionKw>> {
                         return Err(ErrMode::Cut(
                             CompilationError::fatal(
                                 bad_token_source_range,
-                                format!("Missing comma between arguments, try adding a comma in"),
+                                "Missing comma between arguments, try adding a comma in",
                             )
                             .into(),
                         ));


### PR DESCRIPTION
Previously, this KCL

```
arc(
    endAbsolute = [0, 50]
    interiorAbsolute = [-50, 0]
)
```

gave the error `This argument has a label, but no value. Put some value after the equals sign`.

Now it gives this much better error, on the whitespace which was missing a comma:

<img width="666" alt="Screenshot 2025-05-30 at 11 50 28 AM" src="https://github.com/user-attachments/assets/aa5035f5-f748-4dab-b918-b81b05733323" />

Thanks for reporting this @benjamaan476 
