### PR TITLE
KCL: Better error message when using var in its own definition

### DIFF
--- a/rust/kcl-lib/tests/var_ref_in_own_def/artifact_commands.snap
+++ b/rust/kcl-lib/tests/var_ref_in_own_def/artifact_commands.snap
@@ -28,5 +28,30 @@ description: Artifact commands var_ref_in_own_def.kcl
       "object_id": "[uuid]",
       "hidden": true
     }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [],
+    "command": {
+      "type": "make_plane",
+      "origin": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "x_axis": {
+        "x": 1.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "y_axis": {
+        "x": 0.0,
+        "y": 1.0,
+        "z": 0.0
+      },
+      "size": 60.0,
+      "clobber": false,
+      "hide": true
+    }
   }
 ]

--- a/rust/kcl-lib/tests/var_ref_in_own_def/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/var_ref_in_own_def/artifact_graph_flowchart.snap.md
@@ -1,3 +1,5 @@
 ```mermaid
 flowchart LR
+  1["Plane<br>[95, 112, 0]"]
+    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 0 }]
 ```

--- a/rust/kcl-lib/tests/var_ref_in_own_def/ast.snap
+++ b/rust/kcl-lib/tests/var_ref_in_own_def/ast.snap
@@ -13,47 +13,141 @@ description: Result of parsing var_ref_in_own_def.kcl
           "id": {
             "commentStart": 0,
             "end": 0,
-            "name": "x",
+            "name": "sketch001",
             "start": 0,
             "type": "Identifier"
           },
           "init": {
-            "callee": {
-              "abs_path": false,
-              "commentStart": 0,
-              "end": 0,
-              "name": {
+            "body": [
+              {
+                "callee": {
+                  "abs_path": false,
+                  "commentStart": 0,
+                  "end": 0,
+                  "name": {
+                    "commentStart": 0,
+                    "end": 0,
+                    "name": "startSketchOn",
+                    "start": 0,
+                    "type": "Identifier"
+                  },
+                  "path": [],
+                  "start": 0,
+                  "type": "Name"
+                },
                 "commentStart": 0,
                 "end": 0,
-                "name": "cos",
                 "start": 0,
-                "type": "Identifier"
+                "type": "CallExpressionKw",
+                "type": "CallExpressionKw",
+                "unlabeled": {
+                  "abs_path": false,
+                  "commentStart": 0,
+                  "end": 0,
+                  "name": {
+                    "commentStart": 0,
+                    "end": 0,
+                    "name": "XY",
+                    "start": 0,
+                    "type": "Identifier"
+                  },
+                  "path": [],
+                  "start": 0,
+                  "type": "Name",
+                  "type": "Name"
+                }
               },
-              "path": [],
-              "start": 0,
-              "type": "Name"
-            },
+              {
+                "arguments": [
+                  {
+                    "type": "LabeledArg",
+                    "label": null,
+                    "arg": {
+                      "abs_path": false,
+                      "commentStart": 0,
+                      "end": 0,
+                      "name": {
+                        "commentStart": 0,
+                        "end": 0,
+                        "name": "sketch001",
+                        "start": 0,
+                        "type": "Identifier"
+                      },
+                      "path": [],
+                      "start": 0,
+                      "type": "Name",
+                      "type": "Name"
+                    }
+                  }
+                ],
+                "callee": {
+                  "abs_path": false,
+                  "commentStart": 0,
+                  "end": 0,
+                  "name": {
+                    "commentStart": 0,
+                    "end": 0,
+                    "name": "startProfileAt",
+                    "start": 0,
+                    "type": "Identifier"
+                  },
+                  "path": [],
+                  "start": 0,
+                  "type": "Name"
+                },
+                "commentStart": 0,
+                "end": 0,
+                "start": 0,
+                "type": "CallExpressionKw",
+                "type": "CallExpressionKw",
+                "unlabeled": {
+                  "commentStart": 0,
+                  "elements": [
+                    {
+                      "commentStart": 0,
+                      "end": 0,
+                      "raw": "20",
+                      "start": 0,
+                      "type": "Literal",
+                      "type": "Literal",
+                      "value": {
+                        "value": 20.0,
+                        "suffix": "None"
+                      }
+                    },
+                    {
+                      "argument": {
+                        "commentStart": 0,
+                        "end": 0,
+                        "raw": "20",
+                        "start": 0,
+                        "type": "Literal",
+                        "type": "Literal",
+                        "value": {
+                          "value": 20.0,
+                          "suffix": "None"
+                        }
+                      },
+                      "commentStart": 0,
+                      "end": 0,
+                      "operator": "-",
+                      "start": 0,
+                      "type": "UnaryExpression",
+                      "type": "UnaryExpression"
+                    }
+                  ],
+                  "end": 0,
+                  "start": 0,
+                  "type": "ArrayExpression",
+                  "type": "ArrayExpression"
+                }
+              }
+            ],
             "commentStart": 0,
             "end": 0,
             "start": 0,
-            "type": "CallExpressionKw",
-            "type": "CallExpressionKw",
-            "unlabeled": {
-              "abs_path": false,
-              "commentStart": 0,
-              "end": 0,
-              "name": {
-                "commentStart": 0,
-                "end": 0,
-                "name": "x",
-                "start": 0,
-                "type": "Identifier"
-              },
-              "path": [],
-              "start": 0,
-              "type": "Name",
-              "type": "Name"
-            }
+            "type": "PipeExpression",
+            "type": "PipeExpression"
           },
           "start": 0,
           "type": "VariableDeclarator"
@@ -61,7 +155,7 @@ description: Result of parsing var_ref_in_own_def.kcl
         "end": 0,
         "kind": "const",
         "preComments": [
-          "// This won't work, because `x` is being referenced in its own definition."
+          "// This won't work, because `sketch001` is being referenced in its own definition."
         ],
         "start": 0,
         "type": "VariableDeclaration",

--- a/rust/kcl-lib/tests/var_ref_in_own_def/execution_error.snap
+++ b/rust/kcl-lib/tests/var_ref_in_own_def/execution_error.snap
@@ -4,10 +4,11 @@ description: Error from executing var_ref_in_own_def.kcl
 ---
 KCL UndefinedValue error
 
-  × undefined value: `x` is not defined
-   ╭─[2:9]
- 1 │ // This won't work, because `x` is being referenced in its own definition.
- 2 │ x = cos(x)
-   ·         ┬
-   ·         ╰── tests/var_ref_in_own_def/input.kcl
+  × undefined value: You can't use `sketch001` because you're currently trying
+  │ to define it. Use a different variable here instead.
+   ╭─[3:32]
+ 2 │ sketch001 = startSketchOn(XY)
+ 3 │   |> startProfileAt([20, -20], sketch001)
+   ·                                ────┬────
+   ·                                    ╰── tests/var_ref_in_own_def/input.kcl
    ╰────

--- a/rust/kcl-lib/tests/var_ref_in_own_def/input.kcl
+++ b/rust/kcl-lib/tests/var_ref_in_own_def/input.kcl
@@ -1,2 +1,3 @@
-// This won't work, because `x` is being referenced in its own definition.
-x = cos(x)
+// This won't work, because `sketch001` is being referenced in its own definition.
+sketch001 = startSketchOn(XY)
+  |> startProfileAt([20, -20], sketch001)

--- a/rust/kcl-lib/tests/var_ref_in_own_def/ops.snap
+++ b/rust/kcl-lib/tests/var_ref_in_own_def/ops.snap
@@ -2,4 +2,18 @@
 source: kcl-lib/src/simulation_tests.rs
 description: Operations executed var_ref_in_own_def.kcl
 ---
-[]
+[
+  {
+    "type": "StdLibCall",
+    "name": "startSketchOn",
+    "unlabeledArg": {
+      "value": {
+        "type": "Plane",
+        "artifact_id": "[uuid]"
+      },
+      "sourceRange": []
+    },
+    "labeledArgs": {},
+    "sourceRange": []
+  }
+]

--- a/rust/kcl-lib/tests/var_ref_in_own_def/unparsed.snap
+++ b/rust/kcl-lib/tests/var_ref_in_own_def/unparsed.snap
@@ -2,5 +2,6 @@
 source: kcl-lib/src/simulation_tests.rs
 description: Result of unparsing var_ref_in_own_def.kcl
 ---
-// This won't work, because `x` is being referenced in its own definition.
-x = cos(x)
+// This won't work, because `sketch001` is being referenced in its own definition.
+sketch001 = startSketchOn(XY)
+  |> startProfileAt([20, -20], sketch001)


### PR DESCRIPTION
I thought I did this in https://github.com/KittyCAD/modeling-app/pull/7325, but I forgot to actually set the better message.

Actually forreal fixes https://github.com/KittyCAD/modeling-app/issues/6072 this time.