### PR TITLE
Bump csscolorparser from 0.7.0 to 0.7.2

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -715,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "csscolorparser"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f9a16a848a7fb95dd47ce387ac1ee9a6df879ba784b815537fcd388a1a8288"
+checksum = "5fda6aace1fbef3aa217b27f4c8d7d071ef2a70a5ca51050b1f17d40299d3f16"
 dependencies = [
  "phf",
 ]

--- a/rust/kcl-lib/Cargo.toml
+++ b/rust/kcl-lib/Cargo.toml
@@ -31,7 +31,7 @@ clap = { version = "4.5.36", default-features = false, optional = true, features
     "derive",
 ] }
 convert_case = "0.8.0"
-csscolorparser = "0.7.0"
+csscolorparser = "0.7.2"
 dashmap = { workspace = true }
 dhat = { version = "0.3", optional = true }
 fnv = "1.0.7"

--- a/rust/kcl-lib/src/parsing/ast/types/mod.rs
+++ b/rust/kcl-lib/src/parsing/ast/types/mod.rs
@@ -529,7 +529,7 @@ impl Node<Program> {
         let new_color = csscolorparser::Color::new(color.red, color.green, color.blue, color.alpha);
         Ok(Some(ColorPresentation {
             // The label will be what they replace the color with.
-            label: new_color.to_hex_string(),
+            label: new_color.to_css_hex(),
             text_edit: None,
             additional_text_edits: None,
         }))


### PR DESCRIPTION
https://github.com/mazznoer/csscolorparser-rs/releases/tag/v0.7.2

Unblocking Dependabot.