### PR TITLE
Upgrade to Rust 1.87

### DIFF
--- a/rust/kcl-lib/src/engine/conn.rs
+++ b/rust/kcl-lib/src/engine/conn.rs
@@ -67,6 +67,7 @@ pub struct TcpRead {
 
 /// Occurs when client couldn't read from the WebSocket to the engine.
 // #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum WebSocketReadError {
     /// Could not read a message due to WebSocket errors.
     Read(tokio_tungstenite::tungstenite::Error),

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1327,7 +1327,7 @@ pub(crate) async fn execute_pipe_body(
     // Now that we've evaluated the first child expression in the pipeline, following child expressions
     // should use the previous child expression for %.
     // This means there's no more need for the previous pipe_value from the parent AST node above this one.
-    let previous_pipe_value = std::mem::replace(&mut exec_state.mod_local.pipe_value, Some(output));
+    let previous_pipe_value = exec_state.mod_local.pipe_value.replace(output);
     // Evaluate remaining elements.
     let result = inner_execute_pipe_body(exec_state, body, ctx).await;
     // Restore the previous pipe value.

--- a/rust/kcl-lib/src/execution/geometry.rs
+++ b/rust/kcl-lib/src/execution/geometry.rs
@@ -24,6 +24,7 @@ type Point3D = kcmc::shared::Point3d<f64>;
 #[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(tag = "type")]
+#[allow(clippy::large_enum_variant)]
 pub enum Geometry {
     Sketch(Sketch),
     Solid(Solid),
@@ -52,6 +53,7 @@ impl Geometry {
 #[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(tag = "type")]
+#[allow(clippy::large_enum_variant)]
 pub enum GeometryWithImportedGeometry {
     Sketch(Sketch),
     Solid(Solid),

--- a/rust/kcl-lib/src/parsing/ast/types/mod.rs
+++ b/rust/kcl-lib/src/parsing/ast/types/mod.rs
@@ -454,7 +454,7 @@ impl Node<Program> {
                         alpha: c.a,
                     },
                 };
-                if colors.borrow().iter().any(|c| *c == color) {
+                if colors.borrow().contains(&color) {
                     return;
                 }
                 colors.borrow_mut().push(color);

--- a/rust/kcl-lib/src/std/sweep.rs
+++ b/rust/kcl-lib/src/std/sweep.rs
@@ -21,6 +21,7 @@ use crate::{
 #[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS, JsonSchema)]
 #[ts(export)]
 #[serde(untagged)]
+#[allow(clippy::large_enum_variant)]
 pub enum SweepPath {
     Sketch(Sketch),
     Helix(Box<Helix>),

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.86"
+channel = "1.87"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
I ignored some new clippy lints about large differences between enum variants. We can always revisit these later (the compiler suggests boxing them so that the enum variants are similar size)