### PR TITLE
Stabilize test: "Can edit a sketch with multiple profiles, dragging segments to edit them, and adding one new profile"

### DIFF
--- a/e2e/playwright/sketch-tests.spec.ts
+++ b/e2e/playwright/sketch-tests.spec.ts
@@ -2362,7 +2362,7 @@ profile004 = circleThreePoint(sketch001, p1 = [13.44, -6.8], p2 = [13.39, -2.07]
 
     await test.step('add new profile', async () => {
       await toolbar.rectangleBtn.click()
-      await page.waitForTimeout(100)
+      await page.waitForTimeout(200)
       await rectStart()
       await editor.expectEditor.toContain(
         `profile005 = startProfile(sketch001, at = [15.68, -3.84])`


### PR DESCRIPTION
I ran this test 10 times on main and got 5 failures, ran it with [this PR](https://github.com/KittyCAD/modeling-app/pull/7276)’s changes reverted and got similar results (sometimes 5, sometimes 6 fails, seems around 50%).

What I found is that changing the timeout here from 100ms to 200ms makes the test pass 10/10 for me locally, with or without my PR’s changes:
https://github.com/KittyCAD/modeling-app/blob/b47b9c961307494b9562a022c210c11c4a547bd1/e2e/playwright/sketch-tests.spec.ts#L2365
It looks like clicking the rectangle button and starting the rectangle just 100ms after is sometimes not enough time..why that changed recently is a good question.
