### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# CODEOWNERS migrated from dependabot reviewers
+*       @adamchalmers @franknoirot @jessfraz @irev-dev


### PR DESCRIPTION
Dependabot is moving away from reviewers flag and CODEOWNERS should be used instead: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

This PR adds people from the dependabot config.

Feel free to close if unwanted.