### PR TITLE
KCL: Improve error messages for var referenced in own definition

### DIFF
--- a/rust/kcl-lib/src/simulation_tests.rs
+++ b/rust/kcl-lib/src/simulation_tests.rs
@@ -3525,3 +3525,24 @@ mod ascription_unknown_type {
         super::execute(TEST_NAME, true).await
     }
 }
+mod var_ref_in_own_def_decl {
+    const TEST_NAME: &str = "var_ref_in_own_def_decl";
+
+    /// Test parsing KCL.
+    #[test]
+    fn parse() {
+        super::parse(TEST_NAME)
+    }
+
+    /// Test that parsing and unparsing KCL produces the original KCL input.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unparse() {
+        super::unparse(TEST_NAME).await
+    }
+
+    /// Test that KCL is executed correctly.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn kcl_test_execute() {
+        super::execute(TEST_NAME, true).await
+    }
+}

--- a/rust/kcl-lib/tests/var_ref_in_own_def_decl/artifact_commands.snap
+++ b/rust/kcl-lib/tests/var_ref_in_own_def_decl/artifact_commands.snap
@@ -1,0 +1,32 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Artifact commands var_ref_in_own_def_decl.kcl
+---
+[
+  {
+    "cmdId": "[uuid]",
+    "range": [],
+    "command": {
+      "type": "edge_lines_visible",
+      "hidden": false
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [],
+    "command": {
+      "type": "object_visible",
+      "object_id": "[uuid]",
+      "hidden": true
+    }
+  },
+  {
+    "cmdId": "[uuid]",
+    "range": [],
+    "command": {
+      "type": "object_visible",
+      "object_id": "[uuid]",
+      "hidden": true
+    }
+  }
+]

--- a/rust/kcl-lib/tests/var_ref_in_own_def_decl/artifact_graph_flowchart.snap
+++ b/rust/kcl-lib/tests/var_ref_in_own_def_decl/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Artifact graph flowchart var_ref_in_own_def_decl.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/rust/kcl-lib/tests/var_ref_in_own_def_decl/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/var_ref_in_own_def_decl/artifact_graph_flowchart.snap.md
@@ -1,0 +1,3 @@
+```mermaid
+flowchart LR
+```

--- a/rust/kcl-lib/tests/var_ref_in_own_def_decl/ast.snap
+++ b/rust/kcl-lib/tests/var_ref_in_own_def_decl/ast.snap
@@ -1,0 +1,189 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Result of parsing var_ref_in_own_def_decl.kcl
+---
+{
+  "Ok": {
+    "body": [
+      {
+        "commentStart": 0,
+        "declaration": {
+          "commentStart": 0,
+          "end": 0,
+          "id": {
+            "commentStart": 0,
+            "end": 0,
+            "name": "declare",
+            "start": 0,
+            "type": "Identifier"
+          },
+          "init": {
+            "body": {
+              "body": [
+                {
+                  "commentStart": 0,
+                  "declaration": {
+                    "commentStart": 0,
+                    "end": 0,
+                    "id": {
+                      "commentStart": 0,
+                      "end": 0,
+                      "name": "x",
+                      "start": 0,
+                      "type": "Identifier"
+                    },
+                    "init": {
+                      "commentStart": 0,
+                      "end": 0,
+                      "raw": "0",
+                      "start": 0,
+                      "type": "Literal",
+                      "type": "Literal",
+                      "value": {
+                        "value": 0.0,
+                        "suffix": "None"
+                      }
+                    },
+                    "start": 0,
+                    "type": "VariableDeclarator"
+                  },
+                  "end": 0,
+                  "kind": "const",
+                  "start": 0,
+                  "type": "VariableDeclaration",
+                  "type": "VariableDeclaration"
+                },
+                {
+                  "argument": {
+                    "abs_path": false,
+                    "commentStart": 0,
+                    "end": 0,
+                    "name": {
+                      "commentStart": 0,
+                      "end": 0,
+                      "name": "x",
+                      "start": 0,
+                      "type": "Identifier"
+                    },
+                    "path": [],
+                    "start": 0,
+                    "type": "Name",
+                    "type": "Name"
+                  },
+                  "commentStart": 0,
+                  "end": 0,
+                  "start": 0,
+                  "type": "ReturnStatement",
+                  "type": "ReturnStatement"
+                }
+              ],
+              "commentStart": 0,
+              "end": 0,
+              "start": 0
+            },
+            "commentStart": 0,
+            "end": 0,
+            "params": [],
+            "start": 0,
+            "type": "FunctionExpression",
+            "type": "FunctionExpression"
+          },
+          "start": 0,
+          "type": "VariableDeclarator"
+        },
+        "end": 0,
+        "kind": "fn",
+        "start": 0,
+        "type": "VariableDeclaration",
+        "type": "VariableDeclaration"
+      },
+      {
+        "commentStart": 0,
+        "declaration": {
+          "commentStart": 0,
+          "end": 0,
+          "id": {
+            "commentStart": 0,
+            "end": 0,
+            "name": "x",
+            "start": 0,
+            "type": "Identifier"
+          },
+          "init": {
+            "commentStart": 0,
+            "end": 0,
+            "left": {
+              "abs_path": false,
+              "commentStart": 0,
+              "end": 0,
+              "name": {
+                "commentStart": 0,
+                "end": 0,
+                "name": "x",
+                "start": 0,
+                "type": "Identifier"
+              },
+              "path": [],
+              "start": 0,
+              "type": "Name",
+              "type": "Name"
+            },
+            "operator": "+",
+            "right": {
+              "callee": {
+                "abs_path": false,
+                "commentStart": 0,
+                "end": 0,
+                "name": {
+                  "commentStart": 0,
+                  "end": 0,
+                  "name": "declare",
+                  "start": 0,
+                  "type": "Identifier"
+                },
+                "path": [],
+                "start": 0,
+                "type": "Name"
+              },
+              "commentStart": 0,
+              "end": 0,
+              "start": 0,
+              "type": "CallExpressionKw",
+              "type": "CallExpressionKw",
+              "unlabeled": null
+            },
+            "start": 0,
+            "type": "BinaryExpression",
+            "type": "BinaryExpression"
+          },
+          "start": 0,
+          "type": "VariableDeclarator"
+        },
+        "end": 0,
+        "kind": "const",
+        "start": 0,
+        "type": "VariableDeclaration",
+        "type": "VariableDeclaration"
+      }
+    ],
+    "commentStart": 0,
+    "end": 0,
+    "nonCodeMeta": {
+      "nonCodeNodes": {
+        "0": [
+          {
+            "commentStart": 0,
+            "end": 0,
+            "start": 0,
+            "type": "NonCodeNode",
+            "value": {
+              "type": "newLine"
+            }
+          }
+        ]
+      },
+      "startNodes": []
+    },
+    "start": 0
+  }
+}

--- a/rust/kcl-lib/tests/var_ref_in_own_def_decl/execution_error.snap
+++ b/rust/kcl-lib/tests/var_ref_in_own_def_decl/execution_error.snap
@@ -1,0 +1,14 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Error from executing var_ref_in_own_def_decl.kcl
+---
+KCL UndefinedValue error
+
+  × undefined value: You can't use `x` because you're currently trying to
+  │ define it. Use a different variable here instead.
+   ╭─[6:5]
+ 5 │ 
+ 6 │ x = x + declare()
+   ·     ┬
+   ·     ╰── tests/var_ref_in_own_def_decl/input.kcl
+   ╰────

--- a/rust/kcl-lib/tests/var_ref_in_own_def_decl/input.kcl
+++ b/rust/kcl-lib/tests/var_ref_in_own_def_decl/input.kcl
@@ -1,0 +1,6 @@
+fn declare() {
+  x = 0
+  return x
+}
+
+x = x + declare()

--- a/rust/kcl-lib/tests/var_ref_in_own_def_decl/ops.snap
+++ b/rust/kcl-lib/tests/var_ref_in_own_def_decl/ops.snap
@@ -1,0 +1,5 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Operations executed var_ref_in_own_def_decl.kcl
+---
+[]

--- a/rust/kcl-lib/tests/var_ref_in_own_def_decl/unparsed.snap
+++ b/rust/kcl-lib/tests/var_ref_in_own_def_decl/unparsed.snap
@@ -1,0 +1,10 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Result of unparsing var_ref_in_own_def_decl.kcl
+---
+fn declare() {
+  x = 0
+  return x
+}
+
+x = x + declare()


### PR DESCRIPTION
Jon pointed out that my new error message wasn't showing up in some cases, and it should store/restore the previous var being defined.