### PR TITLE
Execution refactoring

### DIFF
--- a/rust/kcl-lib/src/execution/artifact.rs
+++ b/rust/kcl-lib/src/execution/artifact.rs
@@ -676,6 +676,7 @@ impl EdgeCut {
 #[serde(rename_all = "camelCase")]
 pub struct ArtifactGraph {
     map: IndexMap<ArtifactId, Artifact>,
+    item_count: usize,
 }
 
 impl ArtifactGraph {
@@ -711,10 +712,10 @@ pub(super) fn build_artifact_graph(
     artifact_commands: &[ArtifactCommand],
     responses: &IndexMap<Uuid, WebSocketResponse>,
     ast: &Node<Program>,
-    cached_body_items: usize,
     exec_artifacts: &mut IndexMap<ArtifactId, Artifact>,
     initial_graph: ArtifactGraph,
 ) -> Result<ArtifactGraph, KclError> {
+    let item_count = initial_graph.item_count;
     let mut map = initial_graph.into_map();
 
     let mut path_to_plane_id_map = FnvHashMap::default();
@@ -725,7 +726,7 @@ pub(super) fn build_artifact_graph(
     for exec_artifact in exec_artifacts.values_mut() {
         // Note: We only have access to the new AST. So if these artifacts
         // somehow came from cached AST, this won't fill in anything.
-        fill_in_node_paths(exec_artifact, ast, cached_body_items);
+        fill_in_node_paths(exec_artifact, ast, item_count);
     }
 
     for artifact_command in artifact_commands {
@@ -752,7 +753,7 @@ pub(super) fn build_artifact_graph(
             &flattened_responses,
             &path_to_plane_id_map,
             ast,
-            cached_body_items,
+            item_count,
             exec_artifacts,
         )?;
         for artifact in artifact_updates {
@@ -765,7 +766,10 @@ pub(super) fn build_artifact_graph(
         merge_artifact_into_map(&mut map, exec_artifact.clone());
     }
 
-    Ok(ArtifactGraph { map })
+    Ok(ArtifactGraph {
+        map,
+        item_count: item_count + ast.body.len(),
+    })
 }
 
 /// These may have been created with placeholder `CodeRef`s because we didn't

--- a/rust/kcl-lib/src/execution/cache.rs
+++ b/rust/kcl-lib/src/execution/cache.rs
@@ -64,7 +64,7 @@ pub struct OldAstState {
     /// The exec state.
     pub exec_state: ExecState,
     /// The last settings used for execution.
-    pub settings: crate::execution::ExecutorSettings,
+    pub settings: ExecutorSettings,
     pub result_env: EnvironmentRef,
 }
 
@@ -146,7 +146,6 @@ pub(super) async fn get_changed_program(old: CacheInformation<'_>, new: CacheInf
         // We know they have the same imports because the ast is the same.
         // If we have no imports, we can skip this.
         if !old.ast.has_import_statements() {
-            println!("No imports, no need to check.");
             return CacheResult::NoAction(reapply_settings);
         }
 

--- a/rust/kcl-lib/src/execution/cache.rs
+++ b/rust/kcl-lib/src/execution/cache.rs
@@ -6,25 +6,31 @@ use itertools::{EitherOrBoth, Itertools};
 use tokio::sync::RwLock;
 
 use crate::{
-    execution::{annotations, memory::Stack, state::ModuleInfoMap, EnvironmentRef, ExecState, ExecutorSettings},
+    execution::{
+        annotations,
+        memory::Stack,
+        state::{self as exec_state, ModuleInfoMap},
+        EnvironmentRef, ExecutorSettings,
+    },
     parsing::ast::types::{Annotation, Node, Program},
     walk::Node as WalkNode,
+    ExecOutcome, ExecutorContext,
 };
 
 lazy_static::lazy_static! {
     /// A static mutable lock for updating the last successful execution state for the cache.
-    static ref OLD_AST: Arc<RwLock<Option<OldAstState>>> = Default::default();
+    static ref OLD_AST: Arc<RwLock<Option<GlobalState>>> = Default::default();
     // The last successful run's memory. Not cleared after an unssuccessful run.
     static ref PREV_MEMORY: Arc<RwLock<Option<(Stack, ModuleInfoMap)>>> = Default::default();
 }
 
 /// Read the old ast memory from the lock.
-pub(crate) async fn read_old_ast() -> Option<OldAstState> {
+pub(super) async fn read_old_ast() -> Option<GlobalState> {
     let old_ast = OLD_AST.read().await;
     old_ast.clone()
 }
 
-pub(super) async fn write_old_ast(old_state: OldAstState) {
+pub(super) async fn write_old_ast(old_state: GlobalState) {
     let mut old_ast = OLD_AST.write().await;
     *old_ast = Some(old_state);
 }
@@ -34,7 +40,7 @@ pub(crate) async fn read_old_memory() -> Option<(Stack, ModuleInfoMap)> {
     old_mem.clone()
 }
 
-pub(super) async fn write_old_memory(mem: (Stack, ModuleInfoMap)) {
+pub(crate) async fn write_old_memory(mem: (Stack, ModuleInfoMap)) {
     let mut old_mem = PREV_MEMORY.write().await;
     *old_mem = Some(mem);
 }
@@ -56,16 +62,73 @@ pub struct CacheInformation<'a> {
     pub settings: &'a ExecutorSettings,
 }
 
-/// The old ast and program memory.
+/// The cached state of the whole program.
 #[derive(Debug, Clone)]
-pub struct OldAstState {
-    /// The ast.
-    pub ast: Node<Program>,
+pub(super) struct GlobalState {
+    pub(super) main: ModuleState,
     /// The exec state.
-    pub exec_state: ExecState,
+    pub(super) exec_state: exec_state::GlobalState,
     /// The last settings used for execution.
-    pub settings: ExecutorSettings,
-    pub result_env: EnvironmentRef,
+    pub(super) settings: ExecutorSettings,
+}
+
+impl GlobalState {
+    pub fn new(
+        state: exec_state::ExecState,
+        settings: ExecutorSettings,
+        ast: Node<Program>,
+        result_env: EnvironmentRef,
+    ) -> Self {
+        Self {
+            main: ModuleState {
+                ast,
+                exec_state: state.mod_local,
+                result_env,
+            },
+            exec_state: state.global,
+            settings,
+        }
+    }
+
+    pub fn with_settings(mut self, settings: ExecutorSettings) -> GlobalState {
+        self.settings = settings;
+        self
+    }
+
+    pub fn reconstitute_exec_state(&self) -> exec_state::ExecState {
+        exec_state::ExecState {
+            global: self.exec_state.clone(),
+            mod_local: self.main.exec_state.clone(),
+        }
+    }
+
+    pub async fn into_exec_outcome(self, ctx: &ExecutorContext) -> ExecOutcome {
+        // Fields are opt-in so that we don't accidentally leak private internal
+        // state when we add more to ExecState.
+        ExecOutcome {
+            variables: self.main.exec_state.variables(self.main.result_env),
+            filenames: self.exec_state.filenames(),
+            #[cfg(feature = "artifact-graph")]
+            operations: self.exec_state.artifacts.operations,
+            #[cfg(feature = "artifact-graph")]
+            artifact_commands: self.exec_state.artifacts.commands,
+            #[cfg(feature = "artifact-graph")]
+            artifact_graph: self.exec_state.artifacts.graph,
+            errors: self.exec_state.errors,
+            default_planes: ctx.engine.get_default_planes().read().await.clone(),
+        }
+    }
+}
+
+/// Per-module cached state
+#[derive(Debug, Clone)]
+pub(super) struct ModuleState {
+    /// The AST of the module.
+    pub(super) ast: Node<Program>,
+    /// The ExecState of the module.
+    pub(super) exec_state: exec_state::ModuleState,
+    /// The memory env for the module.
+    pub(super) result_env: EnvironmentRef,
 }
 
 /// The result of a cache check.
@@ -79,9 +142,6 @@ pub(super) enum CacheResult {
         reapply_settings: bool,
         /// The program that needs to be executed.
         program: Node<Program>,
-        /// The number of body items that were cached and omitted from the
-        /// program that needs to be executed. Used to compute [`crate::NodePath`].
-        cached_body_items: usize,
     },
     /// Check only the imports, and not the main program.
     /// Before sending this we already checked the main program and it is the same.
@@ -193,7 +253,6 @@ pub(super) async fn get_changed_program(old: CacheInformation<'_>, new: CacheInf
             clear_scene: true,
             reapply_settings: true,
             program: new.ast.clone(),
-            cached_body_items: 0,
         };
     }
 
@@ -222,7 +281,6 @@ fn generate_changed_program(old_ast: Node<Program>, mut new_ast: Node<Program>, 
             clear_scene: true,
             reapply_settings,
             program: new_ast,
-            cached_body_items: 0,
         };
     }
 
@@ -243,7 +301,6 @@ fn generate_changed_program(old_ast: Node<Program>, mut new_ast: Node<Program>, 
                 clear_scene: true,
                 reapply_settings,
                 program: new_ast,
-                cached_body_items: 0,
             }
         }
         std::cmp::Ordering::Greater => {
@@ -260,7 +317,6 @@ fn generate_changed_program(old_ast: Node<Program>, mut new_ast: Node<Program>, 
                 clear_scene: false,
                 reapply_settings,
                 program: new_ast,
-                cached_body_items: old_ast.body.len(),
             }
         }
         std::cmp::Ordering::Equal => {
@@ -599,7 +655,6 @@ startSketchOn(XY)
                 clear_scene: true,
                 reapply_settings: true,
                 program: new_program.ast,
-                cached_body_items: 0,
             }
         );
     }
@@ -638,7 +693,6 @@ startSketchOn(XY)
                 clear_scene: true,
                 reapply_settings: true,
                 program: new_program.ast,
-                cached_body_items: 0,
             }
         );
     }

--- a/rust/kcl-lib/src/execution/import_graph.rs
+++ b/rust/kcl-lib/src/execution/import_graph.rs
@@ -31,7 +31,7 @@ pub(crate) type Universe = HashMap<String, DependencyInfo>;
 /// run concurrently. Each "stage" is blocking in this model, which will
 /// change in the future. Don't use this function widely, yet.
 #[allow(clippy::iter_over_hash_type)]
-pub fn import_graph(progs: &Universe, ctx: &ExecutorContext) -> Result<Vec<Vec<String>>, KclError> {
+pub(crate) fn import_graph(progs: &Universe, ctx: &ExecutorContext) -> Result<Vec<Vec<String>>, KclError> {
     let mut graph = Graph::new();
 
     for (name, (_, _, path, repr)) in progs.iter() {
@@ -120,7 +120,7 @@ fn topsort(all_modules: &[&str], graph: Graph) -> Result<Vec<Vec<String>>, KclEr
 
 type ImportDependencies = Vec<(String, AstNode<ImportStatement>, ModulePath)>;
 
-pub(crate) fn import_dependencies(
+fn import_dependencies(
     path: &ModulePath,
     repr: &ModuleRepr,
     ctx: &ExecutorContext,

--- a/rust/kcl-lib/src/simulation_tests.rs
+++ b/rust/kcl-lib/src/simulation_tests.rs
@@ -163,7 +163,7 @@ async fn execute_test(test: &Test, render_to_png: bool, export_step: bool) {
     // Run the program.
     let exec_res = crate::test_server::execute_and_snapshot_ast(ast, Some(test.entry_point.clone()), export_step).await;
     match exec_res {
-        Ok((exec_state, env_ref, png, step)) => {
+        Ok((exec_state, ctx, env_ref, png, step)) => {
             let fail_path = test.output_dir.join("execution_error.snap");
             if std::fs::exists(&fail_path).unwrap() {
                 panic!("This test case is expected to fail, but it passed. If this is intended, and the test should actually be passing now, please delete kcl-lib/{}", fail_path.to_string_lossy())
@@ -181,7 +181,7 @@ async fn execute_test(test: &Test, render_to_png: bool, export_step: bool) {
                     panic!("Step data was empty");
                 }
             }
-            let outcome = exec_state.to_exec_outcome(env_ref).await;
+            let outcome = exec_state.to_exec_outcome(env_ref, &ctx).await;
 
             let mem_result = catch_unwind(AssertUnwindSafe(|| {
                 assert_snapshot(test, "Variables in memory after executing", || {

--- a/rust/kcl-lib/src/test_server.rs
+++ b/rust/kcl-lib/src/test_server.rs
@@ -36,7 +36,16 @@ pub async fn execute_and_snapshot_ast(
     ast: Program,
     current_file: Option<PathBuf>,
     with_export_step: bool,
-) -> Result<(ExecState, EnvironmentRef, image::DynamicImage, Option<Vec<u8>>), ExecErrorWithState> {
+) -> Result<
+    (
+        ExecState,
+        ExecutorContext,
+        EnvironmentRef,
+        image::DynamicImage,
+        Option<Vec<u8>>,
+    ),
+    ExecErrorWithState,
+> {
     let ctx = new_context(true, current_file).await?;
     let (exec_state, env, img) = match do_execute_and_snapshot(&ctx, ast).await {
         Ok((exec_state, env_ref, img)) => (exec_state, env_ref, img),
@@ -64,7 +73,7 @@ pub async fn execute_and_snapshot_ast(
         step = files.into_iter().next().map(|f| f.contents);
     }
     ctx.close().await;
-    Ok((exec_state, env, img, step))
+    Ok((exec_state, ctx, env, img, step))
 }
 
 pub async fn execute_and_snapshot_no_auth(

--- a/rust/kcl-lib/src/walk/mod.rs
+++ b/rust/kcl-lib/src/walk/mod.rs
@@ -3,10 +3,7 @@
 mod ast_node;
 mod ast_visitor;
 mod ast_walk;
-mod import_graph;
 
-pub use ast_node::Node;
-pub use ast_visitor::Visitable;
-pub use ast_walk::walk;
-pub use import_graph::import_graph;
-pub(crate) use import_graph::{import_universe, Universe, UniverseMap};
+pub(crate) use ast_node::Node;
+pub(crate) use ast_visitor::Visitable;
+pub(crate) use ast_walk::walk;


### PR DESCRIPTION
This was going to be preliminary work for more caching stuff, but it's got big enough that I think it is worth landing now. The only interesting bit is that caching splits per-module from global info so that in the future we can cache information about each module more easily. There's a bunch of other stuff to just simplify the code because it's got really messy :-(