### PR TITLE
Fix pausing when camera state command hangs

### DIFF
--- a/src/machines/engineStreamMachine.ts
+++ b/src/machines/engineStreamMachine.ts
@@ -229,7 +229,11 @@ export const engineStreamMachine = setup({
           }
         }
 
-        await rootContext.sceneInfra.camControls.saveRemoteCameraState()
+        try {
+          await rootContext.sceneInfra.camControls.saveRemoteCameraState()
+        } catch (e) {
+          console.warn('Save remote camera state timed out', e)
+        }
 
         // Make sure we're on the next frame for no flickering between canvas
         // and the video elements.


### PR DESCRIPTION
We were hitting a case where someone would leave their computer or the window, but when coming back, would get stuck in the "pausing" routine. The reason for this is majority of OSs will background the application, but that kills the connection in some way usually. The system wanted to pause on return to the window because the timeout fired, but it never could because the request to get the camera state would never resolve.

Now we set a timeout on the camera state call. This is related to a discussion Adam C. and Mike recently had around per-command timeouts. This is a data point where we needed that.

The situation is now resolved. Video shows before and after.


https://github.com/user-attachments/assets/70ba7a72-a670-44b6-90cd-15516f1e8889

