### PR TITLE
Nit: Name the various 'upload-artifact' CI steps

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -95,7 +95,8 @@ jobs:
         shell: bash
         run: npm run build:wasm
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload compiled wasm artifacts
+        uses: actions/upload-artifact@v4
         with:
           name: prepared-wasm
           path: |
@@ -176,7 +177,8 @@ jobs:
           CI_SUITE: e2e:snapshots
           TARGET: web
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload playwright report
+        uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: playwright-report-snapshot-${{ github.sha }}
@@ -290,7 +292,8 @@ jobs:
           CI_SUITE: e2e:web
           TARGET: web
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload playwright report
+        uses: actions/upload-artifact@v4
         if: ${{ !cancelled() && (success() || failure()) }}
         with:
           name: playwright-report-web-${{ env.OS_NAME }}-${{ matrix.shardIndex }}-${{ github.sha }}
@@ -415,7 +418,8 @@ jobs:
           CI_SUITE: e2e:desktop
           TARGET: desktop
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-results-desktop-${{ env.OS_NAME }}-${{ matrix.shardIndex }}-${{ github.sha }}
@@ -424,7 +428,8 @@ jobs:
           retention-days: 30
           overwrite: true
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload playwright report
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report-desktop-${{ env.OS_NAME }}-${{ matrix.shardIndex }}-${{ github.sha }}


### PR DESCRIPTION
This makes it easier to read GH actions and find the artifacts you're looking for.