### PR TITLE
Ban stdlib trig functions

### DIFF
--- a/rust/clippy.toml
+++ b/rust/clippy.toml
@@ -1,0 +1,17 @@
+disallowed-methods = [
+  "f64::sin",
+  "f64::cos",
+  "f64::tan",
+  "f64::asin",
+  "f64::acos",
+  "f64::atan",
+  "f64::atan2",
+  "f32::sin",
+  "f32::cos",
+  "f32::tan",
+  "f32::asin",
+  "f32::acos",
+  "f32::atan",
+  "f32::atan2",
+  # "std::vec::Vec::new",
+]

--- a/rust/kcl-lib/src/parsing/parser.rs
+++ b/rust/kcl-lib/src/parsing/parser.rs
@@ -45,6 +45,7 @@ thread_local! {
 
 pub fn run_parser(i: TokenSlice) -> super::ParseResult {
     let _stats = crate::log::LogPerfStats::new("Parsing");
+    let _q = f64::sin(0.12);
     ParseContext::init();
 
     let result = match program.parse(i) {


### PR DESCRIPTION
Follow-up to https://github.com/KittyCAD/modeling-app/pull/7499, to ensure we never reintroduce stdlib trig.

For some reason this ban isn't actually working. Investigating why.