### PR TITLE
Use nightly rustfmt in CI

### DIFF
--- a/.github/workflows/cargo-fmt.yml
+++ b/.github/workflows/cargo-fmt.yml
@@ -31,15 +31,15 @@ jobs:
       - name: Use correct Rust toolchain
         shell: bash
         run: |
-          [ -e rust-toolchain.toml ] || cp rust/rust-toolchain.toml ./
+          cp .github/workflows/nightly-rust-toolchain.toml rust-toolchain.toml
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-workspaces: rust
           components: rustfmt
 
-      - name: Run cargo fmt
+      - name: Run nightly cargo fmt
         run: |
           cd rust
-          cargo fmt -- --check
+          cargo +nightly fmt -- --check
         shell: bash

--- a/.github/workflows/nightly-rust-toolchain.toml
+++ b/.github/workflows/nightly-rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+components = ["rustfmt"]

--- a/rust/kcl-lib/src/execution/kcl_value.rs
+++ b/rust/kcl-lib/src/execution/kcl_value.rs
@@ -668,9 +668,8 @@ impl From<GeometryWithImportedGeometry> for KclValue {
 
 #[cfg(test)]
 mod tests {
-    use crate::exec::UnitType;
-
     use super::*;
+    use crate::exec::UnitType;
 
     #[test]
     fn test_human_friendly_type() {


### PR DESCRIPTION
Resolves #6780.

The first commit verified that it fails in CI without nightly formatting.