### PR TITLE
load wasm from custom port

### DIFF
--- a/src/lang/wasmUtils.ts
+++ b/src/lang/wasmUtils.ts
@@ -6,6 +6,12 @@ import { webSafeJoin, webSafePathSplit } from '@src/lib/paths'
 import { init, reloadModule } from '@src/lib/wasm_lib_wrapper'
 
 export const wasmUrl = () => {
+  const wasmFile = '/kcl_wasm_lib_bg.wasm'
+  // Check for test environment override
+  if (typeof process !== 'undefined' && process.env?.VITE_WASM_URL) {
+    return process.env.VITE_WASM_URL + wasmFile
+  }
+
   // For when we're in electron (file based) or web server (network based)
   // For some reason relative paths don't work as expected. Otherwise we would
   // just do /wasm_lib_bg.wasm. In particular, the issue arises when the path
@@ -14,8 +20,7 @@ export const wasmUrl = () => {
     ? document.location.origin + '/kcl_wasm_lib_bg.wasm'
     : document.location.protocol +
       webSafeJoin(webSafePathSplit(document.location.pathname).slice(0, -1)) +
-      '/kcl_wasm_lib_bg.wasm'
-
+      wasmFile
   return fullUrl
 }
 


### PR DESCRIPTION
The background here is I'm find it useful to have a couple instances of the app running at once, and instead of killing and starting process, if I can just leave `npm run start` running on both of them, but use different ports, it's just one less step.

One thing I find peculiar is I could not get `npm run test:unit` to look for the wasm bundle on anything other than port 3000, as ins `document.location` was always port 3000 no matter what changes I made to `vitest.config.ts` so these seemed like an good work around.