### PR TITLE
Set `CurrentValue` arg to `hidden`

### DIFF
--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -917,6 +917,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         inputType: 'text',
         required: false,
         skip: true,
+        hidden: true,
       },
       namedValue: {
         inputType: 'kcl',


### PR DESCRIPTION
We changed the way `hidden`ness is determined in #7506. Fixes #7551 by making this one oddball command arg use that new explicit way.