### PR TITLE
Fix: Lints with non-ASCII characters

### DIFF
--- a/src/lang/KclSingleton.ts
+++ b/src/lang/KclSingleton.ts
@@ -465,7 +465,12 @@ export class KclManager extends EventTarget {
     // Program was not interrupted, setup the scene
     // Do not send send scene commands if the program was interrupted, go to clean up
     if (!isInterrupted) {
-      this.addDiagnostics(await lintAst({ ast: ast }))
+      this.addDiagnostics(
+        await lintAst({
+          ast,
+          sourceCode: this.singletons.codeManager.code,
+        })
+      )
       await setSelectionFilterToDefault(this.engineCommandManager)
     }
 

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -415,10 +415,10 @@ export const errFromErrWithOutputs = (e: any): KCLError => {
 
 export const kclLint = async (ast: Program): Promise<Array<Discovered>> => {
   try {
-    const discovered_findings: Array<Discovered> = await kcl_lint(
+    const discoveredFindings: Array<Discovered> = await kcl_lint(
       JSON.stringify(ast)
     )
-    return discovered_findings
+    return discoveredFindings
   } catch (e: any) {
     return Promise.reject(e)
   }


### PR DESCRIPTION
Non-ASCII characters in KCL source code would be displayed wrong, causing weird visuals or at worst, exceptions.

Before:
<img width="449" alt="Screenshot 2025-06-20 at 2 02 23 PM" src="https://github.com/user-attachments/assets/ecd7eef5-de2c-4176-b83e-6c631d081503" />

After:
<img width="459" alt="Screenshot 2025-06-20 at 2 34 10 PM" src="https://github.com/user-attachments/assets/fba2818e-1536-4482-ae09-7bc5b1754581" />
