### PR TITLE
#5576 Fix coredump hotkey on linux

### DIFF
--- a/e2e/playwright/editor-tests.spec.ts
+++ b/e2e/playwright/editor-tests.spec.ts
@@ -1617,4 +1617,33 @@ sketch001 = startSketchOn(XZ)
     // Verify error is still visible
     await expect(page.locator('.cm-lint-marker-error')).toHaveCount(1)
   })
+
+  test('Core dump hotkey', async ({ page, scene, cmdBar, homePage }) => {
+    await page.addInitScript(async () => {
+      localStorage.setItem(
+        'persistCode',
+        `sketch001 = startSketchOn(XZ)
+    profile001 = circle(sketch001, center = [-100.0, -100.0], radius = 50.0)
+`
+      )
+    })
+
+    const viewportSize = { width: 1200, height: 800 }
+    await page.setBodyDimensions(viewportSize)
+
+    await homePage.goToModelingScene()
+
+    await scene.connectionEstablished()
+    await scene.settled(cmdBar)
+
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+    await page.keyboard.press(`${modifier}+Shift+.`)
+
+    const toast1 = page.getByText('Starting core dump...')
+    await expect(toast1).toBeVisible()
+
+    const toast2 = page.getByText('Core dump completed')
+    await expect(toast2).toBeVisible()
+  })
 })

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -175,7 +175,7 @@ function CoreDump() {
       ),
     []
   )
-  useHotkeyWrapper(['mod + shift + .'], () => {
+  useHotkeyWrapper(['mod + shift + period'], () => {
     toast
       .promise(
         coreDump(coreDumpManager, true),


### PR DESCRIPTION
Fixes #5576 

I was thinking the combination of `Control + Shift + .` was captured by the OS on Linux or the `Shift + .` part turned into a `>` character..with period it looks to be working on both Linux and Mac. 

Added a test too.