### PR TITLE
#7455 Last window size improvements: fix full screen on windows

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -154,6 +154,10 @@ const createWindow = (pathToOpen?: string, reuse?: boolean): BrowserWindow => {
       titleBarStyle: 'hiddenInset',
       backgroundColor: nativeTheme.shouldUseDarkColors ? '#1C1C1C' : '#FCFCFC',
     })
+    // This is only needed on windows, but it doesn't do any harm on other platforms.
+    // On windows the initial width, height supplied above cannot be larger than screen resolution which causes
+    // some weird border to appear when the last window size was close to full screen.
+    newWindow.setBounds({x, y, width: windowWidth, height: windowHeight})
   }
 
   newWindow.on('close', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -102,13 +102,9 @@ if (!singleInstanceLock && !IS_PLAYWRIGHT) {
   registerStartupListeners()
 }
 
-const createWindow = (pathToOpen?: string, reuse?: boolean): BrowserWindow => {
+const createWindow = (pathToOpen?: string): BrowserWindow => {
   let newWindow: BrowserWindow | null = null
 
-  if (reuse) {
-    newWindow = mainWindow
-    Menu.setApplicationMenu(null)
-  }
   if (!newWindow) {
     const primaryDisplay = screen.getPrimaryDisplay()
     const { width, height } = primaryDisplay.workAreaSize
@@ -157,7 +153,7 @@ const createWindow = (pathToOpen?: string, reuse?: boolean): BrowserWindow => {
     // This is only needed on windows, but it doesn't do any harm on other platforms.
     // On windows the initial width, height supplied above cannot be larger than screen resolution which causes
     // some weird border to appear when the last window size was close to full screen.
-    newWindow.setBounds({x, y, width: windowWidth, height: windowHeight})
+    newWindow.setBounds({ x, y, width: windowWidth, height: windowHeight })
   }
 
   newWindow.on('close', () => {
@@ -243,9 +239,7 @@ const createWindow = (pathToOpen?: string, reuse?: boolean): BrowserWindow => {
   // Open the DevTools.
   // mainWindow.webContents.openDevTools()
 
-  if (!reuse) {
-    if (!process.env.HEADLESS) newWindow.show()
-  }
+  if (!process.env.HEADLESS) newWindow.show()
 
   return newWindow
 }


### PR DESCRIPTION
Fixes #7455 reported by @jacebrowning 

On windows the initially supplied `width`, `height` was capped at the screen resolution which was still not enough to cover the entire screen. Eg. with my horizontal resolution being 2560 I had to pass 2572 to get the app to cover the screen, 2560 left a ~10px border. 
This seems to work as I expect if I call setBounds on the window so I'm just doing that.
We could go a step further and save if the window was in full screen mode before closing, which is not the same on Windows as resizing it manually to cover the screen - but then we also need to save which display it was on in case the user had multiple.

Removed a seemingly unused `reuse` param too.