### PR TITLE
Enable optional arguments in point-and-click Revolve

### DIFF
--- a/e2e/playwright/point-click.spec.ts
+++ b/e2e/playwright/point-click.spec.ts
@@ -3912,6 +3912,8 @@ sketch002 = startSketchOn(extrude001, face = rectangleSegmentA001)
 
       // Edit flow
       const newAngle = '270'
+      const newAngle2 = '5'
+      const editedCodeToFind = `revolve001 = revolve(sketch003, angle = ${newAngle}, axis = seg01, bidirectionalAngle = ${newAngle2}, )`
       await toolbar.openPane('feature-tree')
       const operationButton = await toolbar.getFeatureTreeOperation(
         'Revolve',
@@ -3937,11 +3939,33 @@ sketch002 = startSketchOn(extrude001, face = rectangleSegmentA001)
         },
         commandName: 'Revolve',
       })
+      await cmdBar.clickOptionalArgument('bidirectionalAngle')
+      await cmdBar.expectState({
+        commandName: 'Revolve',
+        currentArgKey: 'bidirectionalAngle',
+        currentArgValue: '',
+        headerArguments: {
+          Angle: newAngle,
+          BidirectionalAngle: '',
+        },
+        highlightedHeaderArg: 'bidirectionalAngle',
+        stage: 'arguments',
+      })
+      await page.keyboard.insertText(newAngle2)
       await cmdBar.progressCmdBar()
+      await cmdBar.expectState({
+        stage: 'review',
+        headerArguments: {
+          Angle: newAngle,
+          BidirectionalAngle: newAngle2,
+        },
+        commandName: 'Revolve',
+      })
+      await cmdBar.submit()
       await toolbar.closePane('feature-tree')
-      await editor.expectEditor.toContain(
-        newCodeToFind.replace('angle = 360', 'angle = ' + newAngle)
-      )
+      await editor.expectEditor.toContain(editedCodeToFind, {
+        shouldNormalise: true,
+      })
     })
   })
 

--- a/src/lang/modifyAst/addSweep.ts
+++ b/src/lang/modifyAst/addSweep.ts
@@ -280,6 +280,8 @@ export function addRevolve({
   axisOrEdge,
   axis,
   edge,
+  symmetric,
+  bidirectionalAngle,
   nodeToEdit,
 }: {
   ast: Node<Program>
@@ -288,6 +290,8 @@ export function addRevolve({
   axisOrEdge: 'Axis' | 'Edge'
   axis: string | undefined
   edge: Selections | undefined
+  symmetric?: boolean
+  bidirectionalAngle?: KclCommandValue
   nodeToEdit?: PathToNode
 }):
   | {
@@ -320,15 +324,42 @@ export function addRevolve({
     return new Error('Generated axis selection is missing.')
   }
 
+  // Extra labeled args expressions
+  const symmetricExpr = symmetric
+    ? [createLabeledArg('symmetric', createLiteral(symmetric))]
+    : []
+  const bidirectionalAngleExpr = bidirectionalAngle
+    ? [
+        createLabeledArg(
+          'bidirectionalAngle',
+          valueOrVariable(bidirectionalAngle)
+        ),
+      ]
+    : []
+
   const sketchesExpr = createSketchExpression(sketchesExprList)
   const call = createCallExpressionStdLibKw('revolve', sketchesExpr, [
     createLabeledArg('angle', valueOrVariable(angle)),
     createLabeledArg('axis', getAxisResult.generatedAxis),
+    ...symmetricExpr,
+    ...bidirectionalAngleExpr,
   ])
 
   // Insert variables for labeled arguments if provided
   if ('variableName' in angle && angle.variableName) {
     insertVariableAndOffsetPathToNode(angle, modifiedAst, nodeToEdit)
+  }
+
+  if (
+    bidirectionalAngle &&
+    'variableName' in bidirectionalAngle &&
+    bidirectionalAngle.variableName
+  ) {
+    insertVariableAndOffsetPathToNode(
+      bidirectionalAngle,
+      modifiedAst,
+      nodeToEdit
+    )
   }
 
   // 3. If edit, we assign the new function call declaration to the existing node,

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -101,6 +101,8 @@ export type ModelingCommandSchema = {
     angle: KclCommandValue
     axis: string | undefined
     edge: Selections | undefined
+    symmetric?: boolean
+    bidirectionalAngle?: KclCommandValue
   }
   Shell: {
     // Enables editing workflow
@@ -539,6 +541,18 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         inputType: 'kcl',
         defaultValue: KCL_DEFAULT_DEGREE,
         required: true,
+      },
+      symmetric: {
+        inputType: 'options',
+        required: false,
+        options: [
+          { name: 'False', value: false },
+          { name: 'True', value: true },
+        ],
+      },
+      bidirectionalAngle: {
+        inputType: 'kcl',
+        required: false,
       },
     },
   },

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -976,6 +976,35 @@ const prepareToEditRevolve: PrepareToEditCallback = async ({
     return { reason: 'Error in angle argument retrieval' }
   }
 
+  // symmetric argument from a string to boolean
+  let symmetric: boolean | undefined
+  if ('symmetric' in operation.labeledArgs && operation.labeledArgs.symmetric) {
+    symmetric =
+      codeManager.code.slice(
+        operation.labeledArgs.symmetric.sourceRange[0],
+        operation.labeledArgs.symmetric.sourceRange[1]
+      ) === 'true'
+  }
+
+  // bidirectionalLength argument from a string to a KCL expression
+  let bidirectionalAngle: KclCommandValue | undefined
+  if (
+    'bidirectionalAngle' in operation.labeledArgs &&
+    operation.labeledArgs.bidirectionalAngle
+  ) {
+    const result = await stringToKclExpression(
+      codeManager.code.slice(
+        operation.labeledArgs.bidirectionalAngle.sourceRange[0],
+        operation.labeledArgs.bidirectionalAngle.sourceRange[1]
+      )
+    )
+    if (err(result) || 'errors' in result) {
+      return { reason: "Couldn't retrieve bidirectionalAngle argument" }
+    }
+
+    bidirectionalAngle = result
+  }
+
   // 3. Assemble the default argument values for the command,
   // with `nodeToEdit` set, which will let the actor know
   // to edit the node that corresponds to the StdLibCall.
@@ -985,6 +1014,8 @@ const prepareToEditRevolve: PrepareToEditCallback = async ({
     axis,
     edge,
     angle,
+    symmetric,
+    bidirectionalAngle,
     nodeToEdit: pathToNodeFromRustNodePath(operation.nodePath),
   }
   return {

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -2548,16 +2548,10 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const { nodeToEdit, sketches, angle, axis, edge, axisOrEdge } = input
         const { ast } = kclManager
         const astResult = addRevolve({
           ast,
-          sketches,
-          angle,
-          axisOrEdge,
-          axis,
-          edge,
-          nodeToEdit,
+          ...input,
         })
         if (err(astResult)) {
           return Promise.reject(astResult)


### PR DESCRIPTION
Closes #6923

- Adds `symmetric` and `bidirectionalAngle` KCL args as optional point-and-click args
- Adds e2e test step covering an edit flow with `bidirectionalAngle`