### PR TITLE
Force the samples manifest to be updated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,10 @@ else
 endif
 
 public/kcl-samples/manifest.json: $(KCL_SOURCES)
+ifndef WINDOWS
 	cd rust/kcl-lib && EXPECTORATE=overwrite cargo test generate_manifest
 	@ touch $@
+endif
 
 .vite/build/main.js: $(REACT_SOURCES) $(TYPESCRIPT_SOURCES) $(VITE_SOURCES)
 	npm run tronb:vite:dev

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ endif
 
 public/kcl-samples/manifest.json: $(KCL_SOURCES)
 	cd rust/kcl-lib && EXPECTORATE=overwrite cargo test generate_manifest
+	@ touch $@
 
 .vite/build/main.js: $(REACT_SOURCES) $(TYPESCRIPT_SOURCES) $(VITE_SOURCES)
 	npm run tronb:vite:dev


### PR DESCRIPTION
This ensures `generate_manifest` is skipped on subsequent runs of `make build`.

It also makes that target a no-op on Windows to avoid non-POSIX paths.