### PR TITLE
Swap "must" for "should" in identifier casing lint

### DIFF
--- a/e2e/playwright/editor-tests.spec.ts
+++ b/e2e/playwright/editor-tests.spec.ts
@@ -288,7 +288,7 @@ a1 = startSketchOn(offsetPlane(XY, offset = 10))
     // error text on hover
     await page.hover('.cm-lint-marker-info')
     await expect(
-      page.getByText('Identifiers must be lowerCamelCase').first()
+      page.getByText('Identifiers should be lowerCamelCase').first()
     ).toBeVisible()
 
     await page.locator('#code-pane button:first-child').click()
@@ -314,7 +314,7 @@ sketch_001 = startSketchOn(XY)
     // error text on hover
     await page.hover('.cm-lint-marker-info')
     await expect(
-      page.getByText('Identifiers must be lowerCamelCase').first()
+      page.getByText('Identifiers should be lowerCamelCase').first()
     ).toBeVisible()
   })
 
@@ -511,7 +511,7 @@ sketch_001 = startSketchOn(XY)
     // error text on hover
     await page.hover('.cm-lint-marker-info')
     await expect(
-      page.getByText('Identifiers must be lowerCamelCase').first()
+      page.getByText('Identifiers should be lowerCamelCase').first()
     ).toBeVisible()
 
     // focus the editor
@@ -539,7 +539,7 @@ sketch_001 = startSketchOn(XY)
     // error text on hover
     await page.hover('.cm-lint-marker-info')
     await expect(
-      page.getByText('Identifiers must be lowerCamelCase').first()
+      page.getByText('Identifiers should be lowerCamelCase').first()
     ).toBeVisible()
   })
 
@@ -681,7 +681,7 @@ a1 = startSketchOn(offsetPlane(XY, offset = 10))
     // error text on hover
     await page.hover('.cm-lint-marker-info')
     await expect(
-      page.getByText('Identifiers must be lowerCamelCase').first()
+      page.getByText('Identifiers should be lowerCamelCase').first()
     ).toBeVisible()
 
     // select the line that's causing the error and delete it

--- a/rust/kcl-lib/src/lint/checks/camel_case.rs
+++ b/rust/kcl-lib/src/lint/checks/camel_case.rs
@@ -11,10 +11,10 @@ use crate::{
 
 def_finding!(
     Z0001,
-    "Identifiers must be lowerCamelCase",
+    "Identifiers should be lowerCamelCase",
     "\
 By convention, variable names are lowerCamelCase, not snake_case, kebab-case,
-nor CammelCase. 🐪
+nor upper CamelCase (aka PascalCase). 🐪
 
 For instance, a good identifier for the variable representing 'box height'
 would be 'boxHeight', not 'BOX_HEIGHT', 'box_height' nor 'BoxHeight'. For

--- a/rust/kcl-lib/src/lsp/tests.rs
+++ b/rust/kcl-lib/src/lsp/tests.rs
@@ -2359,7 +2359,7 @@ async fn test_kcl_lsp_diagnostic_has_lints() {
             assert_eq!(diagnostics.full_document_diagnostic_report.items.len(), 1);
             assert_eq!(
                 diagnostics.full_document_diagnostic_report.items[0].message,
-                "Identifiers must be lowerCamelCase"
+                "Identifiers should be lowerCamelCase"
             );
         } else {
             panic!("Expected full diagnostics");


### PR DESCRIPTION
From https://github.com/KittyCAD/modeling-app/pull/7546#pullrequestreview-2945780376 and https://github.com/KittyCAD/modeling-app/pull/7546#issuecomment-3000758321

Parametric CAD users are typically used to PascalCase, and hitting 'must' for a lint that's not even an error feels weird to me?

I personally think we should allow PascalCase for non-KCL users, while still nudge KCL users into camelCase, which the current lint does right I believe, except for "must"