### PR TITLE
Hide Helix arguments that should have been hidden, plus other flow fixes

### DIFF
--- a/e2e/playwright/point-click.spec.ts
+++ b/e2e/playwright/point-click.spec.ts
@@ -1485,9 +1485,8 @@ extrude001 = extrude(profile001, length = 100)
     // One dumb hardcoded screen pixel value
     const testPoint = { x: 620, y: 257 }
     const [clickOnWall] = scene.makeMouseHelpers(testPoint.x, testPoint.y)
-    const expectedOutput = `helix001 = helix(  cylinder = extrude001,  revolutions = 1,  angleStart = 360,  ccw = false,)`
-    const expectedLine = `cylinder = extrude001,`
-    const expectedEditedOutput = `helix001 = helix(  cylinder = extrude001,  revolutions = 1,  angleStart = 360,  ccw = true,)`
+    const expectedOutput = `helix001 = helix(cylinder = extrude001, revolutions = 1, angleStart = 360)`
+    const expectedEditedOutput = `helix001 = helix(cylinder = extrude001, revolutions = 1, angleStart = 10)`
 
     await test.step(`Go through the command bar flow`, async () => {
       await toolbar.helixButton.click()
@@ -1500,7 +1499,6 @@ extrude001 = extrude(profile001, length = 100)
           AngleStart: '',
           Revolutions: '',
           Radius: '',
-          CounterClockWise: '',
         },
         highlightedHeaderArg: 'mode',
         commandName: 'Helix',
@@ -1515,7 +1513,6 @@ extrude001 = extrude(profile001, length = 100)
           Cylinder: '',
           AngleStart: '',
           Revolutions: '',
-          CounterClockWise: '',
         },
         highlightedHeaderArg: 'cylinder',
         commandName: 'Helix',
@@ -1531,18 +1528,17 @@ extrude001 = extrude(profile001, length = 100)
           Cylinder: '1 face',
           AngleStart: '360',
           Revolutions: '1',
-          CounterClockWise: '',
         },
         commandName: 'Helix',
       })
-      await cmdBar.progressCmdBar()
+      await cmdBar.submit()
     })
 
     await test.step(`Confirm code is added to the editor, scene has changed`, async () => {
       await editor.expectEditor.toContain(expectedOutput)
       await editor.expectState({
         diagnostics: [],
-        activeLines: [expectedLine],
+        activeLines: [expectedOutput],
         highlightedCode: '',
       })
     })
@@ -1554,22 +1550,21 @@ extrude001 = extrude(profile001, length = 100)
       await cmdBar.expectState({
         commandName: 'Helix',
         stage: 'arguments',
-        currentArgKey: 'CounterClockWise',
-        currentArgValue: '',
+        currentArgKey: 'angleStart',
+        currentArgValue: '360',
         headerArguments: {
           AngleStart: '360',
           Revolutions: '1',
-          CounterClockWise: '',
         },
-        highlightedHeaderArg: 'CounterClockWise',
+        highlightedHeaderArg: 'angleStart',
       })
-      await cmdBar.selectOption({ name: 'True' }).click()
+      await page.keyboard.insertText('10')
+      await cmdBar.progressCmdBar()
       await cmdBar.expectState({
         stage: 'review',
         headerArguments: {
-          AngleStart: '360',
+          AngleStart: '10',
           Revolutions: '1',
-          CounterClockWise: 'true',
         },
         commandName: 'Helix',
       })

--- a/e2e/playwright/point-click.spec.ts
+++ b/e2e/playwright/point-click.spec.ts
@@ -1275,18 +1275,26 @@ openSketch = startSketchOn(XY)
     {
       selectionType: 'segment',
       testPoint: { x: 513, y: 221 },
+      counterClockWise: false,
       expectedOutput: `helix001 = helix(  axis = seg01,  radius = 1,  revolutions = 20,  angleStart = 0,)`,
       expectedEditedOutput: `helix001 = helix(  axis = seg01,  radius = 5,  revolutions = 20,  angleStart = 0,)`,
     },
     {
       selectionType: 'sweepEdge',
       testPoint: { x: 564, y: 364 },
+      editCounterClockWise: true,
       expectedOutput: `helix001 = helix(  axis =   getOppositeEdge(seg01),  radius = 1,  revolutions = 20,  angleStart = 0,)`,
-      expectedEditedOutput: `helix001 = helix(  axis =   getOppositeEdge(seg01),  radius = 5,  revolutions = 20,  angleStart = 0,)`,
+      expectedEditedOutput: `helix001 = helix(  axis =   getOppositeEdge(seg01),  radius = 5,  revolutions = 20,  angleStart = 0,  ccw = true,)`,
     },
   ]
   helixCases.map(
-    ({ selectionType, testPoint, expectedOutput, expectedEditedOutput }) => {
+    ({
+      selectionType,
+      testPoint,
+      editCounterClockWise,
+      expectedOutput,
+      expectedEditedOutput,
+    }) => {
       test(`Helix point-and-click around ${selectionType}`, async ({
         context,
         page,
@@ -1398,6 +1406,33 @@ openSketch = startSketchOn(XY)
             },
             commandName: 'Helix',
           })
+          if (editCounterClockWise) {
+            await cmdBar.clickOptionalArgument('ccw')
+            await cmdBar.expectState({
+              commandName: 'Helix',
+              stage: 'arguments',
+              currentArgKey: 'CounterClockWise',
+              currentArgValue: '',
+              headerArguments: {
+                AngleStart: '0',
+                Revolutions: '20',
+                Radius: newInput,
+                CounterClockWise: '',
+              },
+              highlightedHeaderArg: 'CounterClockWise',
+            })
+            await cmdBar.selectOption({ name: 'True' }).click()
+            await cmdBar.expectState({
+              stage: 'review',
+              headerArguments: {
+                AngleStart: '0',
+                Revolutions: '20',
+                Radius: newInput,
+                CounterClockWise: '',
+              },
+              commandName: 'Helix',
+            })
+          }
           await cmdBar.submit()
           await toolbar.closePane('feature-tree')
           await toolbar.openPane('code')

--- a/e2e/playwright/point-click.spec.ts
+++ b/e2e/playwright/point-click.spec.ts
@@ -1265,6 +1265,9 @@ openSketch = startSketchOn(XY)
       await page.keyboard.press('Delete')
       await scene.settled(cmdBar)
       await editor.expectEditor.not.toContain('helix')
+      await expect(
+        await toolbar.getFeatureTreeOperation('Helix', 0)
+      ).not.toBeVisible()
     })
   })
 
@@ -1272,14 +1275,14 @@ openSketch = startSketchOn(XY)
     {
       selectionType: 'segment',
       testPoint: { x: 513, y: 221 },
-      expectedOutput: `helix001 = helix(  axis = seg01,  radius = 1,  revolutions = 20,  angleStart = 0,  ccw = false,)`,
-      expectedEditedOutput: `helix001 = helix(  axis = seg01,  radius = 5,  revolutions = 20,  angleStart = 0,  ccw = false,)`,
+      expectedOutput: `helix001 = helix(  axis = seg01,  radius = 1,  revolutions = 20,  angleStart = 0,)`,
+      expectedEditedOutput: `helix001 = helix(  axis = seg01,  radius = 5,  revolutions = 20,  angleStart = 0,)`,
     },
     {
       selectionType: 'sweepEdge',
       testPoint: { x: 564, y: 364 },
-      expectedOutput: `helix001 = helix(  axis =   getOppositeEdge(seg01),  radius = 1,  revolutions = 20,  angleStart = 0,  ccw = false,)`,
-      expectedEditedOutput: `helix001 = helix(  axis =   getOppositeEdge(seg01),  radius = 5,  revolutions = 20,  angleStart = 0,  ccw = false,)`,
+      expectedOutput: `helix001 = helix(  axis =   getOppositeEdge(seg01),  radius = 1,  revolutions = 20,  angleStart = 0,)`,
+      expectedEditedOutput: `helix001 = helix(  axis =   getOppositeEdge(seg01),  radius = 5,  revolutions = 20,  angleStart = 0,)`,
     },
   ]
   helixCases.map(
@@ -1322,7 +1325,6 @@ openSketch = startSketchOn(XY)
             headerArguments: {
               AngleStart: '',
               Mode: '',
-              CounterClockWise: '',
               Radius: '',
               Revolutions: '',
             },
@@ -1334,11 +1336,8 @@ openSketch = startSketchOn(XY)
             .poll(() => page.getByText('Please select one').count())
             .toBe(1)
           await clickOnEdge()
-          await page.waitForTimeout(1000)
           await cmdBar.progressCmdBar()
-          await page.waitForTimeout(1000)
           await cmdBar.argumentInput.focus()
-          await page.waitForTimeout(1000)
           await page.keyboard.insertText('20')
           await cmdBar.progressCmdBar()
           await page.keyboard.insertText('0')
@@ -1354,12 +1353,11 @@ openSketch = startSketchOn(XY)
               AngleStart: '0',
               Revolutions: '20',
               Radius: '1',
-              CounterClockWise: '',
             },
             commandName: 'Helix',
           })
-          await cmdBar.progressCmdBar()
-          await page.waitForTimeout(1000)
+          await cmdBar.submit()
+          await scene.settled(cmdBar)
         })
 
         await test.step(`Confirm code is added to the editor, scene has changed`, async () => {
@@ -1380,23 +1378,16 @@ openSketch = startSketchOn(XY)
           await cmdBar.expectState({
             commandName: 'Helix',
             stage: 'arguments',
-            currentArgKey: 'CounterClockWise',
-            currentArgValue: '',
+            currentArgKey: 'radius',
+            currentArgValue: initialInput,
             headerArguments: {
               AngleStart: '0',
               Revolutions: '20',
               Radius: initialInput,
-              CounterClockWise: '',
             },
-            highlightedHeaderArg: 'CounterClockWise',
+            highlightedHeaderArg: 'radius',
           })
-          await page
-            .getByRole('button', { name: 'radius', exact: false })
-            .click()
-          await expect(cmdBar.currentArgumentInput).toBeVisible()
-          await cmdBar.currentArgumentInput
-            .locator('.cm-content')
-            .fill(newInput)
+          await page.keyboard.insertText(newInput)
           await cmdBar.progressCmdBar()
           await cmdBar.expectState({
             stage: 'review',
@@ -1404,11 +1395,10 @@ openSketch = startSketchOn(XY)
               AngleStart: '0',
               Revolutions: '20',
               Radius: newInput,
-              CounterClockWise: '',
             },
             commandName: 'Helix',
           })
-          await cmdBar.progressCmdBar()
+          await cmdBar.submit()
           await toolbar.closePane('feature-tree')
           await toolbar.openPane('code')
           await editor.expectEditor.toContain(expectedEditedOutput)

--- a/e2e/playwright/point-click.spec.ts
+++ b/e2e/playwright/point-click.spec.ts
@@ -1151,8 +1151,7 @@ openSketch = startSketchOn(XY)
     cmdBar,
   }) => {
     // One dumb hardcoded screen pixel value
-    const testPoint = { x: 620, y: 257 }
-    const expectedOutput = `helix001 = helix(  axis = X,  radius = 5,  length = 5,  revolutions = 1,  angleStart = 270,  ccw = false,)`
+    const expectedOutput = `helix001 = helix(  axis = X,  radius = 5,  length = 5,  revolutions = 1,  angleStart = 270,)`
     const expectedLine = `axis=X,`
 
     await homePage.goToModelingScene()
@@ -1169,7 +1168,6 @@ openSketch = startSketchOn(XY)
           AngleStart: '',
           Revolutions: '',
           Radius: '',
-          CounterClockWise: '',
         },
         highlightedHeaderArg: 'mode',
         commandName: 'Helix',
@@ -1190,7 +1188,6 @@ openSketch = startSketchOn(XY)
           AngleStart: '',
           Length: '',
           Radius: '',
-          CounterClockWise: '',
         },
         commandName: 'Helix',
       })
@@ -1207,11 +1204,10 @@ openSketch = startSketchOn(XY)
           Revolutions: '1',
           Length: '5',
           Radius: '5',
-          CounterClockWise: '',
         },
         commandName: 'Helix',
       })
-      await cmdBar.progressCmdBar()
+      await cmdBar.submit()
     })
 
     await test.step(`Confirm code is added to the editor, scene has changed`, async () => {
@@ -1221,8 +1217,6 @@ openSketch = startSketchOn(XY)
         activeLines: [expectedLine],
         highlightedCode: '',
       })
-      // Red plane is now gone, white helix is there
-      await scene.expectPixelColor([250, 250, 250], testPoint, 15)
     })
 
     await test.step(`Edit helix through the feature tree`, async () => {
@@ -1234,21 +1228,18 @@ openSketch = startSketchOn(XY)
       await cmdBar.expectState({
         commandName: 'Helix',
         stage: 'arguments',
-        currentArgKey: 'CounterClockWise',
-        currentArgValue: '',
+        currentArgKey: 'length',
+        currentArgValue: '5',
         headerArguments: {
           Axis: 'X',
           AngleStart: '270',
           Revolutions: '1',
           Radius: '5',
           Length: initialInput,
-          CounterClockWise: '',
         },
-        highlightedHeaderArg: 'CounterClockWise',
+        highlightedHeaderArg: 'length',
       })
-      await page.keyboard.press('Shift+Backspace')
-      await expect(cmdBar.currentArgumentInput).toBeVisible()
-      await cmdBar.currentArgumentInput.locator('.cm-content').fill(newInput)
+      await page.keyboard.insertText(newInput)
       await cmdBar.progressCmdBar()
       await cmdBar.expectState({
         stage: 'review',
@@ -1258,11 +1249,10 @@ openSketch = startSketchOn(XY)
           Revolutions: '1',
           Radius: '5',
           Length: newInput,
-          CounterClockWise: '',
         },
         commandName: 'Helix',
       })
-      await cmdBar.progressCmdBar()
+      await cmdBar.submit()
       await toolbar.closeFeatureTreePane()
       await editor.openPane()
       await editor.expectEditor.toContain('length = ' + newInput)
@@ -1273,8 +1263,8 @@ openSketch = startSketchOn(XY)
       const operationButton = await toolbar.getFeatureTreeOperation('Helix', 0)
       await operationButton.click({ button: 'left' })
       await page.keyboard.press('Delete')
-      // Red plane is back
-      await scene.expectPixelColor([96, 52, 52], testPoint, 15)
+      await scene.settled(cmdBar)
+      await editor.expectEditor.not.toContain('helix')
     })
   })
 

--- a/src/lang/modifyAst.ts
+++ b/src/lang/modifyAst.ts
@@ -590,7 +590,7 @@ export function addHelix({
   angleStart: Expr
   radius?: Expr
   length?: Expr
-  ccw: boolean
+  ccw?: boolean
   insertIndex?: number
   variableName?: string
 }): { modifiedAst: Node<Program>; pathToNode: PathToNode } {
@@ -610,6 +610,9 @@ export function addHelix({
     )
   }
 
+  // Extra labeled args expressions
+  const ccwExpr = ccw ? [createLabeledArg('ccw', createLiteral(ccw))] : []
+
   const variable = createVariableDeclaration(
     name,
     createCallExpressionStdLibKw(
@@ -619,7 +622,7 @@ export function addHelix({
         ...modeArgs,
         createLabeledArg('revolutions', revolutions),
         createLabeledArg('angleStart', angleStart),
-        createLabeledArg('ccw', createLiteral(ccw)),
+        ...ccwExpr,
       ]
     )
   )

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -690,14 +690,15 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       },
       axis: {
         inputType: 'options',
-        required: (commandContext) =>
-          ['Axis'].includes(commandContext.argumentsToSubmit.mode as string),
         options: [
           { name: 'X Axis', value: 'X' },
           { name: 'Y Axis', value: 'Y' },
           { name: 'Z Axis', value: 'Z' },
         ],
-        hidden: false, // for consistency here, we can actually edit here since it's not a selection
+        required: (context) =>
+          ['Axis'].includes(context.argumentsToSubmit.mode as string),
+        hidden: (context) =>
+          !['Axis'].includes(context.argumentsToSubmit.mode as string),
       },
       edge: {
         inputType: 'selection',
@@ -732,34 +733,30 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       radius: {
         inputType: 'kcl',
         defaultValue: KCL_DEFAULT_LENGTH,
-        required: (commandContext) =>
-          !['Cylinder'].includes(
-            commandContext.argumentsToSubmit.mode as string
-          ),
+        required: (context) =>
+          !['Cylinder'].includes(context.argumentsToSubmit.mode as string),
+        hidden: (context) =>
+          ['Cylinder'].includes(context.argumentsToSubmit.mode as string),
       },
       length: {
         inputType: 'kcl',
         defaultValue: KCL_DEFAULT_LENGTH,
         required: (commandContext) =>
           ['Axis'].includes(commandContext.argumentsToSubmit.mode as string),
+        // No need for hidden here, as it works with all modes
       },
       ccw: {
         inputType: 'options',
-        skip: true,
-        required: true,
-        defaultValue: false,
-        valueSummary: (value) => String(value),
+        required: false,
         displayName: 'CounterClockWise',
-        options: (commandContext) => [
+        options: [
           {
             name: 'False',
             value: false,
-            isCurrent: !Boolean(commandContext.argumentsToSubmit.ccw),
           },
           {
             name: 'True',
             value: true,
-            isCurrent: Boolean(commandContext.argumentsToSubmit.ccw),
           },
         ],
       },

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -700,22 +700,24 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         hidden: false, // for consistency here, we can actually edit here since it's not a selection
       },
       edge: {
-        required: (commandContext) =>
-          ['Edge'].includes(commandContext.argumentsToSubmit.mode as string),
         inputType: 'selection',
         selectionTypes: ['segment', 'sweepEdge'],
         multiple: false,
-        hidden: (context) => Boolean(context.argumentsToSubmit.nodeToEdit),
+        required: (context) =>
+          ['Edge'].includes(context.argumentsToSubmit.mode as string),
+        hidden: (context) =>
+          Boolean(context.argumentsToSubmit.nodeToEdit) ||
+          !['Edge'].includes(context.argumentsToSubmit.mode as string),
       },
       cylinder: {
-        required: (commandContext) =>
-          ['Cylinder'].includes(
-            commandContext.argumentsToSubmit.mode as string
-          ),
         inputType: 'selection',
         selectionTypes: ['wall'],
         multiple: false,
-        hidden: (context) => Boolean(context.argumentsToSubmit.nodeToEdit),
+        required: (context) =>
+          ['Cylinder'].includes(context.argumentsToSubmit.mode as string),
+        hidden: (context) =>
+          Boolean(context.argumentsToSubmit.nodeToEdit) ||
+          !['Cylinder'].includes(context.argumentsToSubmit.mode as string),
       },
       revolutions: {
         inputType: 'kcl',


### PR DESCRIPTION
Fixes #7589

Notes:
- Sets `hidden` on fields that didn't have it before as it was relying on the former behavior of `required`, should have been addressed during #7506 
- Makes `ccw` a true optional arg in the new sense
- Cleans up helix tests (no more runtime map and less reliance on px testing) and add test step for `ccw` as optional arg