### PR TITLE
Use proper envs for Rust functions

### DIFF
--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -401,7 +401,7 @@ impl FunctionDefinition<'_> {
 impl FunctionBody<'_> {
     fn prep_mem(&self, exec_state: &mut ExecState) {
         match self {
-            FunctionBody::Rust(_) => exec_state.mut_stack().push_new_env_for_rust_call(),
+            FunctionBody::Rust(_) => exec_state.mut_stack().push_new_root_env(true),
             FunctionBody::Kcl(_, memory) => exec_state.mut_stack().push_new_env_for_call(*memory),
         }
     }

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -1921,6 +1921,22 @@ shape = layer() |> patternTransform(instances = 10, transform = transform)
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn pass_std_to_std() {
+        let ast = r#"sketch001 = startSketchOn(XY)
+profile001 = circle(sketch001, center = [0, 0], radius = 2)
+extrude001 = extrude(profile001, length = 5)
+extrudes = patternLinear3d(
+  extrude001,
+  instances = 3,
+  distance = 5,
+  axis = [1, 1, 0],
+)
+clone001 = map(extrudes, f = clone)
+"#;
+        parse_execute(ast).await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_zero_param_fn() {
         let ast = r#"sigmaAllow = 35000 // psi
 leg1 = 5 // inches


### PR DESCRIPTION
Closes #7588

We use a stack for memory management. When a function is called we push a new frame onto the stack (aka a root environment). For efficiency and perhaps to catch some bugs, when we call a Rust function (i.e., a std lib function), we don't push a new frame and set the frame 'pointer' to a dummy value. However, when we call map or similar higher-order functions, the Rust definition calls other functions. This should be OK because we'll push a fresh stack frame for the callee if it is a KCL function and if it is a Rust function, it doesn't need a stack frame. However, when we type check the function call we might need to look up names in memory for which we need a real stack frame.

To fix this issue I considered working around this by special-casing the Rust envs, but it increased complexity for an unproven optimisation (since most Rust calls are leaf functions we mostly only save a single stack frame which is pretty lightweight). Instead I removed the Rust function special case and now we do create a stack frame for all functions, Rust or KCL. This is a simplification and we can optimise if it's shown to be slow.