### PR TITLE
Fix the vertical alignment on the temporary workspace label

### DIFF
--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -394,7 +394,7 @@ export function Toolbar({
       <div className="flex flex-col items-center absolute top-full left-1/2 -translate-x-1/2">
         {isInTemporaryWorkspace && (
           <div className="flex flex-row gap-2 justify-center">
-            <div className="mt-2 py-1 animate-pulse w-fit uppercase text-xs rounded-full ml-2 px-2 py-1 border border-chalkboard-40 dark:text-chalkboard-40 bg-chalkboard-10 dark:bg-chalkboard-90 shadow-lg flex items-center">
+            <div className="mt-2 animate-pulse w-fit uppercase text-xs rounded-full ml-2 px-2 py-1 border border-chalkboard-40 dark:text-chalkboard-40 bg-chalkboard-10 dark:bg-chalkboard-90 shadow-lg flex items-center">
               Temporary workspace
             </div>
             <button

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -394,7 +394,7 @@ export function Toolbar({
       <div className="flex flex-col items-center absolute top-full left-1/2 -translate-x-1/2">
         {isInTemporaryWorkspace && (
           <div className="flex flex-row gap-2 justify-center">
-            <div className="mt-2 py-1 animate-pulse w-fit uppercase text-xs rounded-full ml-2 px-2 py-1 border border-chalkboard-40 dark:text-chalkboard-40 bg-chalkboard-10 dark:bg-chalkboard-90 shadow-lg">
+            <div className="mt-2 py-1 animate-pulse w-fit uppercase text-xs rounded-full ml-2 px-2 py-1 border border-chalkboard-40 dark:text-chalkboard-40 bg-chalkboard-10 dark:bg-chalkboard-90 shadow-lg flex items-center">
               Temporary workspace
             </div>
             <button


### PR DESCRIPTION
Before:

    
<img width="343" alt="Screenshot 2025-06-27 at 5 25 09 PM" src="https://github.com/user-attachments/assets/6a610bf1-4140-44a4-a211-01d5da75e55d" />


After:

    
<img width="363" alt="Screenshot 2025-06-27 at 5 27 39 PM" src="https://github.com/user-attachments/assets/20a4584b-c627-4eb9-b6f5-87b1aaf2657f" />
