### PR TITLE
[Bug Fix]: SKIP_AUTH behaved poorly when using dev credentials. 

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -19,3 +19,5 @@ export const PROD = env.PROD as string | undefined
 export const TEST = env.TEST as string | undefined
 export const DEV = env.DEV as string | undefined
 export const CI = env.CI as string | undefined
+console.log('huh', VITE_KC_SKIP_AUTH, DEV)
+export const SKIP_AUTH = VITE_KC_SKIP_AUTH === 'true' && DEV

--- a/src/lib/desktop.ts
+++ b/src/lib/desktop.ts
@@ -697,7 +697,9 @@ export const readTokenFile = async () => {
 export const writeTokenFile = async (token: string) => {
   const tokenFilePath = await getTokenFilePath()
   if (err(token)) return Promise.reject(token)
-  return window.electron.writeFile(tokenFilePath, token)
+  const result =  window.electron.writeFile(tokenFilePath, token)
+  console.warn(`token written to disk`)
+  return result
 }
 
 export const writeTelemetryFile = async (content: string) => {


### PR DESCRIPTION
# Issue

When going to `.env.developement.local` and setting `VITE_KC_SKIP_AUTH='false'` I was still automatically logged into the system. After hitting logout, I was still actually logged into the system.

# Implementation

When `VITE_KC_SKIP_AUTH='false'` is set, you actually need to login or use the cached credentials (from a login). When you logout it actually logs you out. You will not be logged in, all credentials are cleared.


