### PR TITLE
Fix to return operations and module file names in mock execution

### DIFF
--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -2374,7 +2374,7 @@ profile001 = startProfile(sketch001, at = [0, 0])
         let mock_ctx = ExecutorContext::new_mock(None).await;
         let mock_program = crate::Program::parse_no_errs(code).unwrap();
         let mock_result = mock_ctx.run_mock(mock_program, true).await.unwrap();
-        assert_eq!(mock_result.operations.len(), 0);
+        assert_eq!(mock_result.operations.len(), 1);
 
         let code2 = code.to_owned()
             + r#"

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -587,7 +587,7 @@ impl ExecutorContext {
 
         let mut mem = exec_state.stack().clone();
         let module_infos = exec_state.global.module_infos.clone();
-        let outcome = exec_state.into_mock_exec_outcome(result.0, self).await;
+        let outcome = exec_state.into_exec_outcome(result.0, self).await;
 
         mem.squash_env(result.0);
         cache::write_old_memory((mem, module_infos)).await;

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -170,19 +170,6 @@ impl ExecState {
         }
     }
 
-    pub async fn into_mock_exec_outcome(self, main_ref: EnvironmentRef, ctx: &ExecutorContext) -> ExecOutcome {
-        ExecOutcome {
-            variables: self.mod_local.variables(main_ref),
-            #[cfg(feature = "artifact-graph")]
-            operations: Default::default(),
-            #[cfg(feature = "artifact-graph")]
-            artifact_graph: self.global.artifacts.graph,
-            errors: self.global.errors,
-            filenames: Default::default(),
-            default_planes: ctx.engine.get_default_planes().read().await.clone(),
-        }
-    }
-
     pub(crate) fn stack(&self) -> &Stack {
         &self.mod_local.stack
     }


### PR DESCRIPTION
We weren't returning some of the outcome for mock execution. I don't think there was a good reason for this other than the fact that it wasn't being used.