### PR TITLE
chore: update the make clean to remove the out/ folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,7 @@ else
 	rm -rf public/kcl_wasm_lib_bg.wasm
 	rm -rf rust/*/bindings/ rust/*/pkg/ rust/target/
 	rm -rf node_modules/ rust/*/node_modules/
+	rm -rf out/
 endif
 
 .PHONY: help


### PR DESCRIPTION
# issue

When you run `npm run tronb:package:dev` or production it produces built files under `out/`

# Implementation

Updated the `make clean` command to remove `out/`

```
# logs after runnning `npm run tronb:package:dev`
...
  • installing native dependencies  arch=arm64
  • completed installing native dependencies
  • packaging       platform=linux arch=arm64 electron=34.5.1 appOutDir=out/linux-arm64-unpacked
  • building        target=AppImage arch=arm64 file=out/Zoo Design Studio-0.0.0-arm64-linux.AppImage
```

You can see it builds to `out/`