### PR TITLE
Release KCL 85

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-bumper"
-version = "0.1.84"
+version = "0.1.85"
 dependencies = [
  "anyhow",
  "clap",
@@ -1836,7 +1836,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-derive-docs"
-version = "0.1.84"
+version = "0.1.85"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-directory-test-macro"
-version = "0.1.84"
+version = "0.1.85"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-language-server"
-version = "0.2.84"
+version = "0.2.85"
 dependencies = [
  "anyhow",
  "clap",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-language-server-release"
-version = "0.1.84"
+version = "0.1.85"
 dependencies = [
  "anyhow",
  "clap",
@@ -1896,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-lib"
-version = "0.2.84"
+version = "0.2.85"
 dependencies = [
  "anyhow",
  "approx 0.5.1",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-python-bindings"
-version = "0.3.84"
+version = "0.3.85"
 dependencies = [
  "anyhow",
  "kcl-lib",
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-test-server"
-version = "0.1.84"
+version = "0.1.85"
 dependencies = [
  "anyhow",
  "hyper 0.14.32",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-to-core"
-version = "0.1.84"
+version = "0.1.85"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-wasm-lib"
-version = "0.1.84"
+version = "0.1.85"
 dependencies = [
  "anyhow",
  "bson",

--- a/rust/kcl-bumper/Cargo.toml
+++ b/rust/kcl-bumper/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "kcl-bumper"
-version = "0.1.84"
+version = "0.1.85"
 edition = "2021"
 repository = "https://github.com/KittyCAD/modeling-api"
 rust-version = "1.76"

--- a/rust/kcl-derive-docs/Cargo.toml
+++ b/rust/kcl-derive-docs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-derive-docs"
 description = "A tool for generating documentation from Rust derive macros"
-version = "0.1.84"
+version = "0.1.85"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-directory-test-macro/Cargo.toml
+++ b/rust/kcl-directory-test-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-directory-test-macro"
 description = "A tool for generating tests from a directory of kcl files"
-version = "0.1.84"
+version = "0.1.85"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-language-server-release/Cargo.toml
+++ b/rust/kcl-language-server-release/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-language-server-release"
-version = "0.1.84"
+version = "0.1.85"
 edition = "2021"
 authors = ["KittyCAD Inc <kcl@kittycad.io>"]
 publish = false

--- a/rust/kcl-language-server/Cargo.toml
+++ b/rust/kcl-language-server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kcl-language-server"
 description = "A language server for KCL."
 authors = ["KittyCAD Inc <kcl@kittycad.io>"]
-version = "0.2.84"
+version = "0.2.85"
 edition = "2021"
 license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust/kcl-lib/Cargo.toml
+++ b/rust/kcl-lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-lib"
 description = "KittyCAD Language implementation and tools"
-version = "0.2.84"
+version = "0.2.85"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-python-bindings/Cargo.toml
+++ b/rust/kcl-python-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-python-bindings"
-version = "0.3.84"
+version = "0.3.85"
 edition = "2021"
 repository = "https://github.com/kittycad/modeling-app"
 exclude = ["tests/*", "files/*", "venv/*"]

--- a/rust/kcl-test-server/Cargo.toml
+++ b/rust/kcl-test-server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-test-server"
 description = "A test server for KCL"
-version = "0.1.84"
+version = "0.1.85"
 edition = "2021"
 license = "MIT"
 

--- a/rust/kcl-to-core/Cargo.toml
+++ b/rust/kcl-to-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-to-core"
 description = "Utility methods to convert kcl to engine core executable tests"
-version = "0.1.84"
+version = "0.1.85"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-wasm-lib/Cargo.toml
+++ b/rust/kcl-wasm-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-wasm-lib"
-version = "0.1.84"
+version = "0.1.85"
 edition = "2021"
 repository = "https://github.com/KittyCAD/modeling-app"
 rust-version = "1.83"


### PR DESCRIPTION
 - New stdlib `planeOf` function to find the plane of a face
 - Planes now have a `zAxis` property (planes are always right-handed)
 - Experimental support for conic curves, hyperbolic curves, and ellipses
 - Stdlib `translate` function has a new optional argument, `xyz` which lets you specify all axes at once. For example, `translate(xyz = [1, 3.2, 0.5])`
 - New stdlib `concat()` and `count()` functions for arrays
 - New stdlib `vector` module, with `add`, `sub`, `mul` and `div` component-wise arithmetic. Also `cross`, `dot`, `magnitude` and `normalize` functions.