### PR TITLE
Skip kcl-sample test execution for fillet radius changes

### DIFF
--- a/rust/kcl-lib/src/simulation_tests/kcl_samples.rs
+++ b/rust/kcl-lib/src/simulation_tests/kcl_samples.rs
@@ -71,6 +71,10 @@ async fn unparse_test(test: &Test) {
 
 #[kcl_directory_test_macro::test_all_dirs("../public/kcl-samples")]
 async fn kcl_test_execute(dir_name: &str, dir_path: &Path) {
+    if DISABLED_SAMPLES.contains(&dir_name) {
+        eprintln!("Skipping disabled sample: {}", dir_name);
+        return;
+    }
     let t = test(dir_name, dir_path.join("main.kcl"));
     super::execute_test(&t, true, true).await;
 }


### PR DESCRIPTION
Follow-up to #7731.

- I made: #7737