### PR TITLE
#7741 Use devicePixelRatio to calculate canvas resolution

### DIFF
--- a/src/clientSideScene/ClientSideSceneComp.tsx
+++ b/src/clientSideScene/ClientSideSceneComp.tsx
@@ -95,6 +95,7 @@ export const ClientSideScene = ({
     const canvas = canvasRef.current
     canvas.appendChild(sceneInfra.renderer.domElement)
     canvas.appendChild(sceneInfra.labelRenderer.domElement)
+    sceneInfra.onWindowResize()
     sceneInfra.animate()
     canvas.addEventListener(
       'mousemove',

--- a/src/clientSideScene/sceneInfra.ts
+++ b/src/clientSideScene/sceneInfra.ts
@@ -278,16 +278,17 @@ export class SceneInfra {
 
     // RENDERER
     this.renderer = new WebGLRenderer({ antialias: true, alpha: true }) // Enable transparency
-    this.renderer.setSize(window.innerWidth, window.innerHeight)
     this.renderer.setClearColor(0x000000, 0) // Set clear color to black with 0 alpha (fully transparent)
 
     // LABEL RENDERER
     this.labelRenderer = new CSS2DRenderer()
-    this.labelRenderer.setSize(window.innerWidth, window.innerHeight)
     this.labelRenderer.domElement.style.position = 'absolute'
     this.labelRenderer.domElement.style.top = '0px'
     this.labelRenderer.domElement.style.pointerEvents = 'none'
+    this.renderer.domElement.style.width = '100%'
+    this.renderer.domElement.style.height = '100%'
     this.labelRenderer.domElement.className = 'z-sketchSegmentIndicators'
+
     window.addEventListener('resize', this.onWindowResize)
 
     this.camControls = new CameraControls(
@@ -343,9 +344,22 @@ export class SceneInfra {
     axisGroup?.name === 'gridHelper' && axisGroup.scale.set(scale, scale, scale)
   }
 
+  // Called after canvas is attached to the DOM and on each resize.
+  // Note: would be better to use ResizeObserver instead of window.onresize
+  // See:
+  // https://webglfundamentals.org/webgl/lessons/webgl-resizing-the-canvas.html
   onWindowResize = () => {
-    this.renderer.setSize(window.innerWidth, window.innerHeight)
-    this.labelRenderer.setSize(window.innerWidth, window.innerHeight)
+    const cssSize = [
+      this.renderer.domElement.clientWidth,
+      this.renderer.domElement.clientHeight,
+    ]
+    // Note: could cap the resolution on mobile devices if needed.
+    const canvasResolution = [
+      Math.round(cssSize[0] * window.devicePixelRatio),
+      Math.round(cssSize[1] * window.devicePixelRatio),
+    ]
+    this.renderer.setSize(canvasResolution[0], canvasResolution[1], false)
+    this.labelRenderer.setSize(cssSize[0], cssSize[1])
   }
 
   animate = () => {


### PR DESCRIPTION
Fixes #7741 



We could put a size limit / disable on mobile devices where it's typical that the screen is high density but the GPU is weak.
Could also add it as a setting if this causes performance degradations, but since sketches are mostly just lines it shouldn't have a big impact, our current bottleneck is not three.js rendering anyway.

I think this looks much nicer and is worth it but probably better to test it on a bunch of bigger screens as well.

Regardless of this change:

The canvas is 100% of the screen even though the app header covers the top part of it, so that area is rendered unnecessarily. That could be changed so the canvas is only as large as what's visible on it. Since the new UI design is coming it may not be worth fixing that before that.
We should eventually switch to ResizeObserver, especially with the new panel system where the canvas area will be manually resizable if I'm correct (?)