### PR TITLE
Fix array range end exclusive syntax to invalidate execution cache

### DIFF
--- a/rust/kcl-lib/src/parsing/ast/digest.rs
+++ b/rust/kcl-lib/src/parsing/ast/digest.rs
@@ -427,6 +427,7 @@ impl ArrayRangeExpression {
     compute_digest!(|slf, hasher| {
         hasher.update(slf.start_element.compute_digest());
         hasher.update(slf.end_element.compute_digest());
+        hasher.update(if slf.end_inclusive { [1] } else { [0] });
     });
 }
 


### PR DESCRIPTION
Before, changing `[a .. b]` to `[a ..< b]` didn't invalidate the cache.