### PR TITLE
KCL: Parser should allow space after negative

### DIFF
--- a/rust/kcl-lib/src/parsing/parser.rs
+++ b/rust/kcl-lib/src/parsing/parser.rs
@@ -2526,6 +2526,7 @@ fn unary_expression(i: &mut TokenSlice) -> ModalResult<Node<UnaryExpression>> {
         })
         .context(expected("a unary expression, e.g. -x or -3"))
         .parse_next(i)?;
+    ignore_whitespace(i);
     let argument = operand.parse_next(i)?;
     Ok(Node::new_node(
         op_token.start,
@@ -5582,6 +5583,7 @@ my14 = 4 ^ 2 - 3 ^ 2 * 2
         r#"incl = [1..10]
         excl = [0..<10]"#
     );
+    snapshot_test!(space_between_unary_and_operand, r#"x = - 1"#);
 }
 
 #[allow(unused)]

--- a/rust/kcl-lib/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__space_between_unary_and_operand.snap
+++ b/rust/kcl-lib/src/parsing/snapshots/kcl_lib__parsing__parser__snapshot_tests__space_between_unary_and_operand.snap
@@ -1,0 +1,58 @@
+---
+source: kcl-lib/src/parsing/parser.rs
+expression: actual
+---
+{
+  "body": [
+    {
+      "commentStart": 0,
+      "declaration": {
+        "commentStart": 0,
+        "end": 7,
+        "id": {
+          "commentStart": 0,
+          "end": 1,
+          "moduleId": 0,
+          "name": "x",
+          "start": 0,
+          "type": "Identifier"
+        },
+        "init": {
+          "argument": {
+            "commentStart": 6,
+            "end": 7,
+            "moduleId": 0,
+            "raw": "1",
+            "start": 6,
+            "type": "Literal",
+            "type": "Literal",
+            "value": {
+              "value": 1.0,
+              "suffix": "None"
+            }
+          },
+          "commentStart": 4,
+          "end": 7,
+          "moduleId": 0,
+          "operator": "-",
+          "start": 4,
+          "type": "UnaryExpression",
+          "type": "UnaryExpression"
+        },
+        "moduleId": 0,
+        "start": 0,
+        "type": "VariableDeclarator"
+      },
+      "end": 7,
+      "kind": "const",
+      "moduleId": 0,
+      "start": 0,
+      "type": "VariableDeclaration",
+      "type": "VariableDeclaration"
+    }
+  ],
+  "commentStart": 0,
+  "end": 7,
+  "moduleId": 0,
+  "start": 0
+}


### PR DESCRIPTION
`x = - 1` didn't parse previously. Now it does.