### PR TITLE
Fix to not coerce nested arrays to single level when type is any

### DIFF
--- a/rust/kcl-lib/src/execution/types.rs
+++ b/rust/kcl-lib/src/execution/types.rs
@@ -1090,12 +1090,18 @@ impl KclValue {
         exec_state: &mut ExecState,
     ) -> Result<KclValue, CoercionError> {
         match self {
-            KclValue::Tuple { value, .. } if value.len() == 1 && !matches!(ty, RuntimeType::Tuple(..)) => {
+            KclValue::Tuple { value, .. }
+                if value.len() == 1
+                    && !matches!(ty, RuntimeType::Primitive(PrimitiveType::Any) | RuntimeType::Tuple(..)) =>
+            {
                 if let Ok(coerced) = value[0].coerce(ty, convert_units, exec_state) {
                     return Ok(coerced);
                 }
             }
-            KclValue::HomArray { value, .. } if value.len() == 1 && !matches!(ty, RuntimeType::Array(..)) => {
+            KclValue::HomArray { value, .. }
+                if value.len() == 1
+                    && !matches!(ty, RuntimeType::Primitive(PrimitiveType::Any) | RuntimeType::Array(..)) =>
+            {
                 if let Ok(coerced) = value[0].coerce(ty, convert_units, exec_state) {
                     return Ok(coerced);
                 }


### PR DESCRIPTION
Before, when coercing a value like `[[[1]]]` to `any`, we see that the type isn't array but we have an array of length 1, and try to recursively strip the array off.

This PR makes it so that `any` accepts anything, including arrays.