### PR TITLE
Include the filename as the jest suite

### DIFF
--- a/jest-component-unit-tests/jest.config.ts
+++ b/jest-component-unit-tests/jest.config.ts
@@ -24,7 +24,8 @@ const jestConfig: Config = {
     "default",
     ["jest-junit", {
       outputDirectory: "test-results",
-      outputName: "junit.xml"
+      outputName: "junit.xml",
+      suiteNameTemplate: "{filename}"
     }]
   ],
 }


### PR DESCRIPTION
Amends https://github.com/KittyCAD/modeling-app/pull/7794 to handle the lack of `describe` blocks.

---

Before:

> jest tests › undefined › Shows the total credits for Unknown subscription

After:

> jest tests › billing.jesttest.tsx › Shows the total credits for Unknown subscription