### PR TITLE
KCL: More accurate benchmark for sketch mode perf

### DIFF
--- a/rust/kcl-lib/benches/compiler_benchmark_criterion.rs
+++ b/rust/kcl-lib/benches/compiler_benchmark_criterion.rs
@@ -27,9 +27,9 @@ pub fn bench_mock(c: &mut Criterion) {
         let program = kcl_lib::Program::parse_no_errs(black_box(file)).unwrap();
         c.bench_function(&format!("mock_execute_{name}"), move |b| {
             let rt = tokio::runtime::Runtime::new().unwrap();
+            let ctx = rt.block_on(async { kcl_lib::ExecutorContext::new_mock(None).await });
             b.iter(|| {
                 if let Err(err) = rt.block_on(async {
-                    let ctx = kcl_lib::ExecutorContext::new_mock(None).await;
                     ctx.run_mock(black_box(&program), false).await?;
                     ctx.close().await;
                     Ok::<(), anyhow::Error>(())


### PR DESCRIPTION
The latency being discussed in https://github.com/KittyCAD/modeling-app/pull/7812 is actually latency of running a mock execution _with usePreviousMemory_ set to true. This means that the KCL prelude is only evaluated once. It's basically running with a "warm cache". So let's correct the benchmark, so it more accurately measures the interactive latency when users are dragging points around.