### PR TITLE
Include metadata for TAB to link back to GitHub Actions runs

### DIFF
--- a/e2e/playwright/lib/api-reporter.ts
+++ b/e2e/playwright/lib/api-reporter.ts
@@ -84,6 +84,7 @@ class APIReporter implements Reporter {
       GITHUB_HEAD_REF: process.env.GITHUB_HEAD_REF || null,
       GITHUB_REF_NAME: process.env.GITHUB_REF_NAME || null,
       GITHUB_REF: process.env.GITHUB_REF || null,
+      GITHUB_RUN_ID: process.env.GITHUB_RUN_ID || null,
       GITHUB_SHA: process.env.GITHUB_SHA || null,
       GITHUB_WORKFLOW: process.env.GITHUB_WORKFLOW || null,
       RUNNER_ARCH: process.env.RUNNER_ARCH || null,


### PR DESCRIPTION


<img width="2144" height="860" alt="download" src="https://github.com/user-attachments/assets/a4c79c5b-e915-4e5b-abea-b4ece7460919" />

---

Depends on https://github.com/KittyCAD/test-analysis-bot/pull/63
