### PR TITLE
#7828 Don't call onMouseEnter when dragging a segment

### DIFF
--- a/src/clientSideScene/sceneEntities.ts
+++ b/src/clientSideScene/sceneEntities.ts
@@ -3316,7 +3316,7 @@ export class SceneEntities {
 
   mouseEnterLeaveCallbacks() {
     return {
-      onMouseEnter: ({ selected, dragSelected }: OnMouseEnterLeaveArgs) => {
+      onMouseEnter: ({ selected }: OnMouseEnterLeaveArgs) => {
         if ([X_AXIS, Y_AXIS].includes(selected?.userData?.type)) {
           const obj = selected as Mesh
           const mat = obj.material as MeshBasicMaterial
@@ -3348,7 +3348,7 @@ export class SceneEntities {
           if (extraSegmentGroup) {
             extraSegmentGroup.traverse((child) => {
               if (child instanceof Points || child instanceof Mesh) {
-                child.material.opacity = dragSelected ? 0 : 1
+                child.material.opacity = 1
               }
             })
           }

--- a/src/clientSideScene/sceneInfra.ts
+++ b/src/clientSideScene/sceneInfra.ts
@@ -53,7 +53,6 @@ type SendType = ReturnType<typeof useModelingContext>['send']
 
 export interface OnMouseEnterLeaveArgs {
   selected: Object3D<Object3DEventMap>
-  dragSelected?: Object3D<Object3DEventMap>
   mouseEvent: MouseEvent
   /** The intersection of the mouse with the THREEjs raycast plane */
   intersectionPoint?: {
@@ -502,7 +501,7 @@ export class SceneInfra {
       })
     }
 
-    if (intersects[0]) {
+    if (intersects[0] && !this.selected) {
       const firstIntersectObject = intersects[0].object
       const planeIntersectPoint = this.getPlaneIntersectPoint()
       const intersectionPoint = {
@@ -523,15 +522,13 @@ export class SceneInfra {
         this.hoveredObject = firstIntersectObject
         await this.onMouseEnter({
           selected: this.hoveredObject,
-          dragSelected: this.selected?.object,
           mouseEvent: mouseEvent,
           intersectionPoint,
         })
-        if (!this.selected)
-          this.updateMouseState({
-            type: 'isHovering',
-            on: this.hoveredObject,
-          })
+        this.updateMouseState({
+          type: 'isHovering',
+          on: this.hoveredObject,
+        })
       }
     } else {
       if (this.hoveredObject) {
@@ -539,7 +536,6 @@ export class SceneInfra {
         this.hoveredObject = null
         await this.onMouseLeave({
           selected: hoveredObj,
-          dragSelected: this.selected?.object,
           mouseEvent: mouseEvent,
         })
         if (!this.selected) this.updateMouseState({ type: 'idle' })


### PR DESCRIPTION
Small update for dragging performance: no need to call mouseEnter when the user is dragging a segment: this is causing its color to change and also causes some heavy rust functions to be called which is causing dropped frames.

There is a UX question here @franknoirot: when dragging a segment do you prefer to have the yellow (selected) color of the segment or the normal base color? I will update the PR accordingly.