### PR TITLE
Fix to use updated syntax in error message

### DIFF
--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -744,7 +744,7 @@ fn assign_args_to_params_kw(
             return Err(if args.kw_args.labeled.contains_key(param_name) {
                 KclError::new_argument(KclErrorDetails::new(
                     format!(
-                        "The function does declare a parameter named '{param_name}', but this parameter doesn't use a label. Try removing the `{param_name}:`"
+                        "The function does declare a parameter named '{param_name}', but this parameter doesn't use a label. Try removing the `{param_name} =`"
                     ),
                     source_ranges,
                 ))

--- a/rust/kcl-lib/tests/kw_fn_unlabeled_but_has_label/execution_error.snap
+++ b/rust/kcl-lib/tests/kw_fn_unlabeled_but_has_label/execution_error.snap
@@ -5,7 +5,7 @@ description: Error from executing kw_fn_unlabeled_but_has_label.kcl
 KCL Argument error
 
   × argument: The function does declare a parameter named 'x', but this
-  │ parameter doesn't use a label. Try removing the `x:`
+  │ parameter doesn't use a label. Try removing the `x =`
    ╭─[1:12]
  1 │ ╭─▶ fn add(@x) {
  2 │ │     return x + 1
@@ -19,7 +19,7 @@ KCL Argument error
   ╰─▶ KCL Argument error
       
         × argument: The function does declare a parameter named 'x', but this
-        │ parameter doesn't use a label. Try removing the `x:`
+        │ parameter doesn't use a label. Try removing the `x =`
          ╭─[1:12]
        1 │ ╭─▶ fn add(@x) {
        2 │ │     return x + 1


### PR DESCRIPTION
Error message was using the old `x: value` syntax instead of `x = value`.