### PR TITLE
Increase the vitest timeout from 1s to 2s

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -55,7 +55,7 @@ export default defineConfig(({ command, mode }) => {
         : // Gotcha: 'hanging-process' is very noisey, turn off by default on localhost
           // : ['verbose', 'hanging-process'],
           ['verbose'],
-      testTimeout: 1000,
+      testTimeout: 2000,
       hookTimeout: 1000,
       teardownTimeout: 1000,
       retry: 5,


### PR DESCRIPTION
A small percentage of the tests take longer that 1s on average: https://test-analysis-bot.hawk-dinosaur.ts.net/projects/KittyCAD/modeling-app?search=vitest&enabled=true&sort=-average_duration