### PR TITLE
KCL: Try parsing [1, 2, 3] before [1..3]

### DIFF
--- a/rust/kcl-lib/src/parsing/parser.rs
+++ b/rust/kcl-lib/src/parsing/parser.rs
@@ -908,8 +908,8 @@ pub enum NonCodeOr<T> {
 fn array(i: &mut TokenSlice) -> ModalResult<Expr> {
     alt((
         array_empty.map(Box::new).map(Expr::ArrayExpression),
-        array_end_start.map(Box::new).map(Expr::ArrayRangeExpression),
         array_elem_by_elem.map(Box::new).map(Expr::ArrayExpression),
+        array_end_start.map(Box::new).map(Expr::ArrayRangeExpression),
     ))
     .parse_next(i)
 }


### PR DESCRIPTION
Arrays can be either element-by-element or a range. KCL programs use element-by-element more, because that's how points and axes are represented.

We should parse the more common case (elemnt-by-element) before trying the less common case (ranges). This change improves parse speed significantly on my macbook (15-45%):

<img width="1193" height="596" alt="Screenshot 2025-07-20 at 8 24 29 AM" src="https://github.com/user-attachments/assets/d47524d0-0475-4d32-8650-5a1a95a7ec28" />
