### PR TITLE
Only attempt to activate flake if nix is installed

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -7,4 +7,7 @@ dotenv .env.development
 # Load optional environment variables overrides
 dotenv_if_exists .env.development.local
 
-use flake .
+# Enable nix development environment if installed
+if has nix; then
+    use flake .
+fi


### PR DESCRIPTION
This will eliminate the warning messages for those not using `nix` (most of the team).