### PR TITLE
KCL: Mostly reuse one string buffer in recaster

### DIFF
--- a/rust/kcl-lib/src/lib.rs
+++ b/rust/kcl-lib/src/lib.rs
@@ -256,11 +256,11 @@ impl Program {
 
     pub fn recast(&self) -> String {
         // Use the default options until we integrate into the UI the ability to change them.
-        self.ast.recast(&Default::default(), 0)
+        self.ast.recast_top(&Default::default(), 0)
     }
 
     pub fn recast_with_options(&self, options: &FormatOptions) -> String {
-        self.ast.recast(options, 0)
+        self.ast.recast_top(options, 0)
     }
 
     /// Create an empty program.

--- a/rust/kcl-lib/src/lint/checks/camel_case.rs
+++ b/rust/kcl-lib/src/lint/checks/camel_case.rs
@@ -35,7 +35,7 @@ fn lint_lower_camel_case_var(decl: &VariableDeclarator, prog: &AstNode<Program>)
 
         let mut prog = prog.clone();
         prog.rename_symbol(&new_name, ident.start);
-        let recast = prog.recast(&Default::default(), 0);
+        let recast = prog.recast_top(&Default::default(), 0);
 
         let suggestion = Suggestion {
             title: format!("rename '{name}' to '{new_name}'"),

--- a/rust/kcl-lib/src/lsp/kcl/mod.rs
+++ b/rust/kcl-lib/src/lsp/kcl/mod.rs
@@ -860,7 +860,7 @@ impl Backend {
         // Now let's perform the rename on the ast.
         ast.rename_symbol(new_name, pos);
         // Now recast it.
-        let recast = ast.recast(&Default::default(), 0);
+        let recast = ast.recast_top(&Default::default(), 0);
 
         Ok(Some((current_code.to_string(), recast)))
     }
@@ -1480,7 +1480,7 @@ impl LanguageServer for Backend {
             return Ok(None);
         };
         // Now recast it.
-        let recast = ast.recast(
+        let recast = ast.recast_top(
             &crate::parsing::ast::types::FormatOptions {
                 tab_size: params.options.tab_size as usize,
                 insert_final_newline: params.options.insert_final_newline.unwrap_or(false),

--- a/rust/kcl-lib/src/parsing/ast/types/mod.rs
+++ b/rust/kcl-lib/src/parsing/ast/types/mod.rs
@@ -3500,13 +3500,13 @@ impl FunctionExpression {
             signature.push_str("()");
         } else if self.params.len() == 1 {
             signature.push('(');
-            signature.push_str(&self.params[0].recast(&FormatOptions::default(), 0));
+            self.params[0].recast(&mut signature, &FormatOptions::default(), 0);
             signature.push(')');
         } else {
             signature.push('(');
             for a in &self.params {
                 signature.push_str("\n  ");
-                signature.push_str(&a.recast(&FormatOptions::default(), 0));
+                a.recast(&mut signature, &FormatOptions::default(), 0);
                 signature.push(',');
             }
             signature.push('\n');

--- a/rust/kcl-lib/src/parsing/ast/types/mod.rs
+++ b/rust/kcl-lib/src/parsing/ast/types/mod.rs
@@ -3591,7 +3591,8 @@ impl FormatOptions {
     /// Get the indentation string for the given level.
     pub fn write_indentation(&self, buf: &mut String, times: usize) {
         let ind = if self.use_tabs { '\t' } else { ' ' };
-        for _ in 0..times {
+        let n = if self.use_tabs { 1 } else { self.tab_size };
+        for _ in 0..(times * n) {
             buf.push(ind);
         }
     }

--- a/rust/kcl-lib/src/simulation_tests.rs
+++ b/rust/kcl-lib/src/simulation_tests.rs
@@ -183,7 +183,7 @@ async fn unparse_test(test: &Test) {
     let ast = crate::parsing::parse_tokens(tokens).unwrap();
 
     // Check recasting.
-    let actual = ast.recast(&Default::default(), 0);
+    let actual = ast.recast_top(&Default::default(), 0);
     let input_result = catch_unwind(AssertUnwindSafe(|| {
         assert_snapshot(test, "Result of unparsing", || {
             insta::assert_snapshot!("unparsed", actual);

--- a/rust/kcl-lib/src/unparser.rs
+++ b/rust/kcl-lib/src/unparser.rs
@@ -866,7 +866,7 @@ impl IfExpression {
 
 impl Node<PipeExpression> {
     fn recast(&self, buf: &mut String, options: &FormatOptions, indentation_level: usize) {
-        options.write_indentation(buf, indentation_level);
+        // options.write_indentation(buf, indentation_level);
         for (index, statement) in self.body.iter().enumerate() {
             statement.recast(buf, options, indentation_level + 1, ExprContext::Pipe);
             let non_code_meta = &self.non_code_meta;

--- a/rust/kcl-lib/src/unparser.rs
+++ b/rust/kcl-lib/src/unparser.rs
@@ -82,7 +82,9 @@ impl Program {
                         .recast(&mut result, options, indentation_level, ExprContext::Other)
                 }
                 BodyItem::VariableDeclaration(variable_declaration) => {
+                    dbg!(&result);
                     variable_declaration.recast(&mut result, options, indentation_level);
+                    dbg!(&result);
                 }
                 BodyItem::TypeDeclaration(ty_declaration) => ty_declaration.recast(&mut result),
                 BodyItem::ReturnStatement(return_statement) => {
@@ -2972,6 +2974,19 @@ x = 360
 fn myFn() {
 }
 ";
+        let ast = crate::parsing::top_level_parse(code).unwrap();
+        let recasted = ast.recast_top(&FormatOptions::new(), 0);
+        let expected = code;
+        assert_eq!(recasted, expected);
+    }
+
+    #[test]
+    fn simple_assignment_in_fn() {
+        let code = "\
+fn function001() {
+  extrude002 = extrude()
+}\n";
+
         let ast = crate::parsing::top_level_parse(code).unwrap();
         let recasted = ast.recast_top(&FormatOptions::new(), 0);
         let expected = code;

--- a/rust/kcl-lib/src/unparser.rs
+++ b/rust/kcl-lib/src/unparser.rs
@@ -33,12 +33,9 @@ impl Program {
         let indentation = options.get_indentation(indentation_level);
 
         if let Some(sh) = self.shebang.as_ref() {
-            dbg!(&buf);
             write!(buf, "{}\n\n", sh.inner.content).no_fail();
-            dbg!(&buf);
         }
 
-        dbg!(&self.non_code_meta);
         if self
             .non_code_meta
             .start_nodes
@@ -46,23 +43,16 @@ impl Program {
             .any(|noncode| !matches!(noncode.value, NonCodeValue::NewLine))
         {
             for start in &self.non_code_meta.start_nodes {
-                dbg!(&buf);
                 let noncode_recast = start.recast(options, indentation_level);
-                dbg!(&noncode_recast);
                 buf.push_str(&noncode_recast);
-                dbg!(&buf);
             }
         }
         for attr in &self.inner_attrs {
-            dbg!(&buf);
             options.write_indentation(buf, indentation_level);
             attr.recast(buf, options, indentation_level);
-            dbg!(&buf);
         }
         if !self.inner_attrs.is_empty() {
-            dbg!(&buf);
             buf.push('\n');
-            dbg!(&buf);
         }
 
         let body_item_lines = self.body.iter().map(|body_item| {
@@ -506,7 +496,7 @@ impl TypeDeclaration {
         }
         if let Some(alias) = &self.alias {
             buf.push_str(" = ");
-            write!(buf, "{}", alias).no_fail();
+            write!(buf, "{alias}").no_fail();
         }
     }
 }
@@ -932,7 +922,7 @@ impl FunctionExpression {
             None => String::new(),
         };
 
-        write!(buf, "({param_list}){return_type} {{\n").no_fail();
+        writeln!(buf, "({param_list}){return_type} {{").no_fail();
         self.body.recast(buf, &new_options, indentation_level + 1);
         buf.push('\n');
         options.write_indentation(buf, indentation_level);

--- a/rust/kcl-lib/src/unparser.rs
+++ b/rust/kcl-lib/src/unparser.rs
@@ -477,17 +477,17 @@ impl TypeDeclaration {
 
         if let Some(args) = &self.args {
             buf.push('(');
-            for a in args {
-                if buf.len() > 1 {
+            for (i, a) in args.iter().enumerate() {
+                buf.push_str(&a.name);
+                if i < args.len() - 1 {
                     buf.push_str(", ");
                 }
-                buf.push_str(&a.name);
             }
             buf.push(')');
         }
         if let Some(alias) = &self.alias {
             buf.push_str(" = ");
-            buf.push_str(&alias.to_string());
+            write!(buf, "{}", alias).no_fail();
         }
     }
 }
@@ -647,10 +647,6 @@ impl ArrayRangeExpression {
         buf.push(']');
         // Assume a range expression fits on one line.
     }
-}
-
-fn trim_end(buf: &mut String) {
-    *buf = buf.trim_end().to_owned()
 }
 
 fn trim(buf: &mut String) {

--- a/rust/kcl-lib/src/unparser.rs
+++ b/rust/kcl-lib/src/unparser.rs
@@ -39,10 +39,19 @@ impl Program {
         }
 
         dbg!(&self.non_code_meta);
-        for start in &self.non_code_meta.start_nodes {
-            dbg!(&buf);
-            buf.push_str(&start.recast(options, indentation_level));
-            dbg!(&buf);
+        if self
+            .non_code_meta
+            .start_nodes
+            .iter()
+            .any(|noncode| !matches!(noncode.value, NonCodeValue::NewLine))
+        {
+            for start in &self.non_code_meta.start_nodes {
+                dbg!(&buf);
+                let noncode_recast = start.recast(options, indentation_level);
+                dbg!(&noncode_recast);
+                buf.push_str(&noncode_recast);
+                dbg!(&buf);
+            }
         }
         for attr in &self.inner_attrs {
             dbg!(&buf);

--- a/rust/kcl-lib/src/unparser.rs
+++ b/rust/kcl-lib/src/unparser.rs
@@ -40,6 +40,7 @@ impl Program {
             buf.push_str(&start.recast(options, indentation_level));
         }
         for attr in &self.inner_attrs {
+            options.write_indentation(buf, indentation_level);
             attr.recast(buf, options, indentation_level);
         }
         if !self.inner_attrs.is_empty() {
@@ -1068,10 +1069,11 @@ mod tests {
 
     #[test]
     fn test_recast_annotations_in_function_body_without_items() {
-        let input = r#"fn myFunc() {
+        let input = "\
+fn myFunc() {
   @meta(yes = true)
 }
-"#;
+";
         let program = crate::parsing::top_level_parse(input).unwrap();
         let output = program.recast_top(&Default::default(), 0);
         assert_eq!(output, input);

--- a/rust/kcl-lib/src/unparser.rs
+++ b/rust/kcl-lib/src/unparser.rs
@@ -564,7 +564,7 @@ impl ArrayExpression {
                 let el = elems.next().unwrap();
                 let mut s = String::new();
                 el.recast(&mut s, options, 0, ExprContext::Other);
-                s.push(',');
+                s.push_str(", ");
                 format_items.push(s);
             }
         }
@@ -674,7 +674,7 @@ impl ObjectExpression {
             return self.recast_multi_line(buf, options, indentation_level, ctxt);
         }
         let mut flat_recast_buf = String::new();
-        flat_recast_buf.push('{');
+        flat_recast_buf.push_str("{ ");
         for (i, prop) in self.properties.iter().enumerate() {
             write!(flat_recast_buf, "{} = ", prop.key.name,).no_fail();
             prop.value
@@ -684,7 +684,7 @@ impl ObjectExpression {
                 flat_recast_buf.push_str(", ");
             }
         }
-        flat_recast_buf.push('}');
+        flat_recast_buf.push_str(" }");
         let max_array_length = 40;
         let needs_multiple_lines = flat_recast_buf.len() > max_array_length;
         if !needs_multiple_lines {

--- a/rust/kcl-lib/src/unparser.rs
+++ b/rust/kcl-lib/src/unparser.rs
@@ -327,6 +327,8 @@ impl AscribedExpression {
             buf.push('(');
             self.expr.recast(buf, options, indentation_level, ctxt);
             buf.push(')');
+        } else {
+            self.expr.recast(buf, options, indentation_level, ctxt);
         }
         buf.push_str(": ");
         write!(buf, "{}", self.ty).no_fail();
@@ -915,8 +917,6 @@ impl FunctionExpression {
 
         write!(buf, "({param_list}){return_type} {{\n").no_fail();
         self.body.recast(buf, &new_options, indentation_level + 1);
-        // let mut body_buf = String::new();
-        // self.body.recast(&mut body_buf, &new_options, indentation_level + 1);
         buf.push('\n');
         options.write_indentation(buf, indentation_level);
         buf.push('}');
@@ -2632,14 +2632,15 @@ sketch002 = startSketchOn({
 
     #[test]
     fn unparse_fn_unnamed() {
-        let input = r#"squares_out = reduce(
+        let input = "\
+squares_out = reduce(
   arr,
   n = 0: number,
   f = fn(@i, accum) {
     return 1
   },
 )
-"#;
+";
         let ast = crate::parsing::top_level_parse(input).unwrap();
         let actual = ast.recast_top(&FormatOptions::new(), 0);
         assert_eq!(actual, input);

--- a/rust/kcl-lib/src/unparser.rs
+++ b/rust/kcl-lib/src/unparser.rs
@@ -56,8 +56,10 @@ impl Program {
         }
 
         let body_item_lines = self.body.iter().map(|body_item| {
+            dbg!("Parsing body item");
             let mut result = String::with_capacity(256);
             for comment in body_item.get_comments() {
+                dbg!(&comment);
                 if !comment.is_empty() {
                     result.push_str(&indentation);
                     result.push_str(comment);
@@ -69,6 +71,7 @@ impl Program {
             for attr in body_item.get_attrs() {
                 attr.recast(&mut result, options, indentation_level);
             }
+            dbg!(&result);
             match body_item {
                 BodyItem::ImportStatement(stmt) => {
                     result.push_str(&stmt.recast(options, indentation_level));
@@ -79,7 +82,9 @@ impl Program {
                         .recast(&mut result, options, indentation_level, ExprContext::Other)
                 }
                 BodyItem::VariableDeclaration(variable_declaration) => {
-                    variable_declaration.recast(&mut result, options, indentation_level)
+                    // dbg!(&result);
+                    variable_declaration.recast(&mut result, options, indentation_level);
+                    // dbg!(&result);
                 }
                 BodyItem::TypeDeclaration(ty_declaration) => ty_declaration.recast(&mut result),
                 BodyItem::ReturnStatement(return_statement) => {
@@ -94,6 +99,7 @@ impl Program {
             result
         });
         for (index, recast_str) in body_item_lines.enumerate() {
+            dbg!(&recast_str);
             write!(buf, "{recast_str}").no_fail();
 
             // determine the value of the end string
@@ -186,6 +192,7 @@ impl Node<Annotation> {
         let indentation = options.get_indentation(indentation_level);
         let mut result = String::new();
         for comment in &self.pre_comments {
+            dbg!(&comment);
             if !comment.is_empty() {
                 result.push_str(&indentation);
                 result.push_str(comment);
@@ -2965,9 +2972,8 @@ x = 2 * y % 2
         let code = "\
 x = 360
 
-// Comment
+// Watermelon
 fn myFn() {
-  return 1
 }
 ";
         let ast = crate::parsing::top_level_parse(code).unwrap();

--- a/rust/kcl-lib/src/unparser.rs
+++ b/rust/kcl-lib/src/unparser.rs
@@ -670,10 +670,10 @@ impl ObjectExpression {
         let mut flat_recast_buf = String::new();
         flat_recast_buf.push_str("{ ");
         for (i, prop) in self.properties.iter().enumerate() {
-            write!(flat_recast_buf, "{} = ", prop.key.name,).no_fail();
+            let obj_key = &prop.key.name;
+            write!(flat_recast_buf, "{obj_key} = ").no_fail();
             prop.value
-                .recast(&mut flat_recast_buf, options, indentation_level + 1, ctxt);
-            trim_end(&mut flat_recast_buf);
+                .recast(&mut flat_recast_buf, options, indentation_level, ctxt);
             if i < self.properties.len() - 1 {
                 flat_recast_buf.push_str(", ");
             }

--- a/rust/kcl-lib/src/unparser.rs
+++ b/rust/kcl-lib/src/unparser.rs
@@ -94,13 +94,11 @@ impl Program {
             result
         });
         for (index, recast_str) in body_item_lines.enumerate() {
+            write!(buf, "{recast_str}").no_fail();
+
             // determine the value of the end string
             // basically if we are inside a nested function we want to end with a new line
-            let maybe_line_break: String = if index == self.body.len() - 1 && indentation_level == 0 {
-                String::new()
-            } else {
-                "\n".to_string()
-            };
+            let needs_line_break = !(index == self.body.len() - 1 && indentation_level == 0);
 
             let custom_white_space_or_comment = match self.non_code_meta.non_code_nodes.get(&index) {
                 Some(noncodes) => noncodes
@@ -121,13 +119,14 @@ impl Program {
                     .collect::<String>(),
                 None => String::new(),
             };
-            let end_string = if custom_white_space_or_comment.is_empty() {
-                maybe_line_break
-            } else {
-                custom_white_space_or_comment
-            };
 
-            write!(buf, "{recast_str}{end_string}").no_fail();
+            if custom_white_space_or_comment.is_empty() {
+                if needs_line_break {
+                    buf.push('\n')
+                }
+            } else {
+                write!(buf, "{custom_white_space_or_comment}").no_fail();
+            };
         }
         trim(buf);
 

--- a/rust/kcl-lib/src/unparser.rs
+++ b/rust/kcl-lib/src/unparser.rs
@@ -2959,4 +2959,22 @@ x = 2 * y % 2
         let recasted = ast.recast_top(&FormatOptions::new(), 0);
         assert_eq!(recasted, expected);
     }
+
+    #[test]
+    fn gap_between_body_item_and_documented_fn() {
+        let code = "\
+x = 360
+
+// Comment
+fn myFn() {
+  return 1
+}
+";
+        let ast = crate::parsing::top_level_parse(code).unwrap();
+        dbg!(&ast);
+        let recasted = ast.recast_top(&FormatOptions::new(), 0);
+        let expected = code;
+        dbg!(&recasted);
+        assert_eq!(recasted, expected);
+    }
 }

--- a/rust/kcl-lib/src/unparser.rs
+++ b/rust/kcl-lib/src/unparser.rs
@@ -78,7 +78,7 @@ impl Program {
                     }
                     BodyItem::TypeDeclaration(ty_declaration) => ty_declaration.recast(&mut result),
                     BodyItem::ReturnStatement(return_statement) => {
-                        write!(&mut result, "{}return ", indentation).no_fail();
+                        write!(&mut result, "{indentation}return ").no_fail();
                         return_statement
                             .argument
                             .recast(&mut result, options, indentation_level, ExprContext::Other);
@@ -306,7 +306,7 @@ impl Expr {
             Expr::CallExpressionKw(call_exp) => call_exp.recast(buf, options, indentation_level, ctxt),
             Expr::Name(name) => {
                 let result = &name.inner.name.inner.name;
-                match deprecation(&result, DeprecationKind::Const) {
+                match deprecation(result, DeprecationKind::Const) {
                     Some(suggestion) => buf.push_str(suggestion),
                     None => buf.push_str(result),
                 }
@@ -351,7 +351,7 @@ impl BinaryPart {
                 literal.recast(buf);
             }
             BinaryPart::Name(name) => match deprecation(&name.inner.name.inner.name, DeprecationKind::Const) {
-                Some(suggestion) => write!(buf, "{}", suggestion).no_fail(),
+                Some(suggestion) => write!(buf, "{suggestion}").no_fail(),
                 None => write!(buf, "{name}").no_fail(),
             },
             BinaryPart::BinaryExpression(binary_expression) => {
@@ -426,19 +426,19 @@ impl CallExpressionKw {
                 options.get_indentation(indentation_level)
             };
             options.write_indentation(buf, smart_indent_level);
-            write!(buf, "{}", name).no_fail();
+            write!(buf, "{name}").no_fail();
             buf.push('(');
             buf.push('\n');
-            write!(buf, "{}", inner_indentation).no_fail();
-            write!(buf, "{}", args).no_fail();
+            write!(buf, "{inner_indentation}").no_fail();
+            write!(buf, "{args}").no_fail();
             buf.push('\n');
-            write!(buf, "{}", end_indent).no_fail();
+            write!(buf, "{end_indent}").no_fail();
             buf.push(')');
         } else {
             options.write_indentation(buf, smart_indent_level);
-            write!(buf, "{}", name).no_fail();
+            write!(buf, "{name}").no_fail();
             buf.push('(');
-            write!(buf, "{}", args).no_fail();
+            write!(buf, "{args}").no_fail();
             buf.push(')');
         }
     }

--- a/rust/kcl-lib/src/unparser.rs
+++ b/rust/kcl-lib/src/unparser.rs
@@ -521,7 +521,7 @@ impl Literal {
             }
             LiteralValue::String(ref s) => {
                 if let Some(suggestion) = deprecation(s, DeprecationKind::String) {
-                    write!(buf, "{suggestion}").unwrap();
+                    return write!(buf, "{suggestion}").unwrap();
                 }
                 let quote = if self.raw.trim().starts_with('"') { '"' } else { '\'' };
                 write(buf, quote);

--- a/rust/kcl-lib/src/unparser.rs
+++ b/rust/kcl-lib/src/unparser.rs
@@ -119,10 +119,8 @@ impl Program {
                 for to_write in custom {
                     write!(buf, "{to_write}").no_fail();
                 }
-            } else {
-                if needs_line_break {
-                    buf.push('\n')
-                }
+            } else if needs_line_break {
+                buf.push('\n')
             }
         }
         trim(buf);

--- a/rust/kcl-lib/src/unparser.rs
+++ b/rust/kcl-lib/src/unparser.rs
@@ -19,31 +19,34 @@ use crate::{
 #[allow(dead_code)]
 pub fn fmt(input: &str) -> Result<String, KclError> {
     let program = crate::parsing::parse_str(input, ModuleId::default()).parse_errs_as_err()?;
-    Ok(program.recast(&Default::default(), 0))
+    Ok(program.recast_top(&Default::default(), 0))
 }
 
 impl Program {
-    pub fn recast(&self, options: &FormatOptions, indentation_level: usize) -> String {
+    pub fn recast_top(&self, options: &FormatOptions, indentation_level: usize) -> String {
+        let mut buf = String::new();
+        self.recast(&mut buf, options, indentation_level);
+        buf
+    }
+
+    pub fn recast(&self, buf: &mut String, options: &FormatOptions, indentation_level: usize) {
         let indentation = options.get_indentation(indentation_level);
 
-        let mut result = self
-            .shebang
-            .as_ref()
-            .map(|sh| format!("{}\n\n", sh.inner.content))
-            .unwrap_or_default();
+        if let Some(sh) = self.shebang.as_ref() {
+            write!(buf, "{}\n\n", sh.inner.content).no_fail();
+        }
 
         for start in &self.non_code_meta.start_nodes {
-            result.push_str(&start.recast(options, indentation_level));
+            buf.push_str(&start.recast(options, indentation_level));
         }
         for attr in &self.inner_attrs {
-            result.push_str(&attr.recast(options, indentation_level));
+            attr.recast(buf, options, indentation_level);
         }
         if !self.inner_attrs.is_empty() {
-            result.push('\n');
+            buf.push('\n');
         }
 
-        let result = result; // Remove mutation.
-        let result = self
+        for (index, recast_str) in self
             .body
             .iter()
             .map(|body_item| {
@@ -58,87 +61,81 @@ impl Program {
                     }
                 }
                 for attr in body_item.get_attrs() {
-                    result.push_str(&attr.recast(options, indentation_level));
+                    &attr.recast(&mut result, options, indentation_level);
                 }
-                result.push_str(&match body_item {
-                    BodyItem::ImportStatement(stmt) => stmt.recast(options, indentation_level),
-                    BodyItem::ExpressionStatement(expression_statement) => {
-                        expression_statement
-                            .expression
-                            .recast(options, indentation_level, ExprContext::Other)
+                match body_item {
+                    BodyItem::ImportStatement(stmt) => {
+                        result.push_str(&stmt.recast(options, indentation_level));
                     }
+                    BodyItem::ExpressionStatement(expression_statement) => expression_statement.expression.recast(
+                        &mut result,
+                        options,
+                        indentation_level,
+                        ExprContext::Other,
+                    ),
                     BodyItem::VariableDeclaration(variable_declaration) => {
-                        variable_declaration.recast(options, indentation_level)
+                        variable_declaration.recast(&mut result, options, indentation_level)
                     }
-                    BodyItem::TypeDeclaration(ty_declaration) => ty_declaration.recast(),
+                    BodyItem::TypeDeclaration(ty_declaration) => ty_declaration.recast(&mut result),
                     BodyItem::ReturnStatement(return_statement) => {
-                        format!(
-                            "{}return {}",
-                            indentation,
-                            return_statement
-                                .argument
-                                .recast(options, indentation_level, ExprContext::Other)
-                                .trim_start()
-                        )
+                        write!(&mut result, "{}return ", indentation,);
+                        return_statement
+                            .argument
+                            .recast(&mut result, options, indentation_level, ExprContext::Other);
                     }
-                });
+                };
                 result
             })
             .enumerate()
-            .fold(result, |mut output, (index, recast_str)| {
-                let start_string =
-                    if index == 0 && self.non_code_meta.start_nodes.is_empty() && self.inner_attrs.is_empty() {
-                        // We need to indent.
-                        indentation.to_string()
-                    } else {
-                        // Do nothing, we already applied the indentation elsewhere.
-                        String::new()
-                    };
+        {
+            let start_string = if index == 0 && self.non_code_meta.start_nodes.is_empty() && self.inner_attrs.is_empty()
+            {
+                // We need to indent.
+                indentation.to_string()
+            } else {
+                // Do nothing, we already applied the indentation elsewhere.
+                String::new()
+            };
 
-                // determine the value of the end string
-                // basically if we are inside a nested function we want to end with a new line
-                let maybe_line_break: String = if index == self.body.len() - 1 && indentation_level == 0 {
-                    String::new()
-                } else {
-                    "\n".to_string()
-                };
+            // determine the value of the end string
+            // basically if we are inside a nested function we want to end with a new line
+            let maybe_line_break: String = if index == self.body.len() - 1 && indentation_level == 0 {
+                String::new()
+            } else {
+                "\n".to_string()
+            };
 
-                let custom_white_space_or_comment = match self.non_code_meta.non_code_nodes.get(&index) {
-                    Some(noncodes) => noncodes
-                        .iter()
-                        .enumerate()
-                        .map(|(i, custom_white_space_or_comment)| {
-                            let formatted = custom_white_space_or_comment.recast(options, indentation_level);
-                            if i == 0 && !formatted.trim().is_empty() {
-                                if let NonCodeValue::BlockComment { .. } = custom_white_space_or_comment.value {
-                                    format!("\n{formatted}")
-                                } else {
-                                    formatted
-                                }
+            let custom_white_space_or_comment = match self.non_code_meta.non_code_nodes.get(&index) {
+                Some(noncodes) => noncodes
+                    .iter()
+                    .enumerate()
+                    .map(|(i, custom_white_space_or_comment)| {
+                        let formatted = custom_white_space_or_comment.recast(options, indentation_level);
+                        if i == 0 && !formatted.trim().is_empty() {
+                            if let NonCodeValue::BlockComment { .. } = custom_white_space_or_comment.value {
+                                format!("\n{formatted}")
                             } else {
                                 formatted
                             }
-                        })
-                        .collect::<String>(),
-                    None => String::new(),
-                };
-                let end_string = if custom_white_space_or_comment.is_empty() {
-                    maybe_line_break
-                } else {
-                    custom_white_space_or_comment
-                };
+                        } else {
+                            formatted
+                        }
+                    })
+                    .collect::<String>(),
+                None => String::new(),
+            };
+            let end_string = if custom_white_space_or_comment.is_empty() {
+                maybe_line_break
+            } else {
+                custom_white_space_or_comment
+            };
 
-                let _ = write!(output, "{start_string}{recast_str}{end_string}");
-                output
-            })
-            .trim()
-            .to_string();
+            write!(buf, "{start_string}{recast_str}{end_string}").no_fail();
+        }
 
         // Insert a final new line if the user wants it.
-        if options.insert_final_newline && !result.is_empty() {
-            format!("{result}\n")
-        } else {
-            result
+        if options.insert_final_newline && !buf.is_empty() {
+            buf.push('\n');
         }
     }
 }
@@ -193,7 +190,7 @@ impl Node<NonCodeNode> {
 }
 
 impl Node<Annotation> {
-    fn recast(&self, options: &FormatOptions, indentation_level: usize) -> String {
+    fn recast(&self, buf: &mut String, options: &FormatOptions, indentation_level: usize) {
         let indentation = options.get_indentation(indentation_level);
         let mut result = String::new();
         for comment in &self.pre_comments {
@@ -215,13 +212,10 @@ impl Node<Annotation> {
                 &properties
                     .iter()
                     .map(|prop| {
-                        format!(
-                            "{} = {}",
-                            prop.key.name,
-                            prop.value
-                                .recast(options, indentation_level + 1, ExprContext::Other)
-                                .trim()
-                        )
+                        let mut temp = format!("{} = ", prop.key.name);
+                        prop.value
+                            .recast(&mut temp, options, indentation_level + 1, ExprContext::Other);
+                        temp.trim().to_owned()
                     })
                     .collect::<Vec<String>>()
                     .join(", "),
@@ -230,7 +224,7 @@ impl Node<Annotation> {
             result.push('\n');
         }
 
-        result
+        buf.push_str(&result)
     }
 }
 
@@ -280,7 +274,13 @@ pub(crate) enum ExprContext {
 }
 
 impl Expr {
-    pub(crate) fn recast(&self, options: &FormatOptions, indentation_level: usize, mut ctxt: ExprContext) -> String {
+    pub(crate) fn recast(
+        &self,
+        buf: &mut String,
+        options: &FormatOptions,
+        indentation_level: usize,
+        mut ctxt: ExprContext,
+    ) {
         let is_decl = matches!(ctxt, ExprContext::Decl);
         if is_decl {
             // Just because this expression is being bound to a variable, doesn't mean that every child
@@ -289,41 +289,39 @@ impl Expr {
             ctxt = ExprContext::Other;
         }
         match &self {
-            Expr::BinaryExpression(bin_exp) => bin_exp.recast(options, indentation_level, ctxt),
-            Expr::ArrayExpression(array_exp) => array_exp.recast(options, indentation_level, ctxt),
-            Expr::ArrayRangeExpression(range_exp) => range_exp.recast(options, indentation_level, ctxt),
-            Expr::ObjectExpression(obj_exp) => obj_exp.recast(options, indentation_level, ctxt),
-            Expr::MemberExpression(mem_exp) => mem_exp.recast(options, indentation_level, ctxt),
+            Expr::BinaryExpression(bin_exp) => bin_exp.recast(buf, options, indentation_level, ctxt),
+            Expr::ArrayExpression(array_exp) => array_exp.recast(buf, options, indentation_level, ctxt),
+            Expr::ArrayRangeExpression(range_exp) => range_exp.recast(buf, options, indentation_level, ctxt),
+            Expr::ObjectExpression(obj_exp) => obj_exp.recast(buf, options, indentation_level, ctxt),
+            Expr::MemberExpression(mem_exp) => mem_exp.recast(buf, options, indentation_level, ctxt),
             Expr::Literal(literal) => {
-                let mut s = String::new();
-                literal.recast(&mut s);
-                s
+                literal.recast(buf);
             }
             Expr::FunctionExpression(func_exp) => {
-                let mut result = if is_decl { String::new() } else { "fn".to_owned() };
-                result += &func_exp.recast(options, indentation_level);
-                result
+                if !is_decl {
+                    buf.push_str("fn");
+                }
+                &func_exp.recast(buf, options, indentation_level);
             }
-            Expr::CallExpressionKw(call_exp) => call_exp.recast(options, indentation_level, ctxt),
+            Expr::CallExpressionKw(call_exp) => call_exp.recast(buf, options, indentation_level, ctxt),
             Expr::Name(name) => {
-                let result = name.to_string();
+                let result = &name.inner.name.inner.name;
                 match deprecation(&result, DeprecationKind::Const) {
-                    Some(suggestion) => suggestion.to_owned(),
-                    None => result,
+                    Some(suggestion) => buf.push_str(suggestion),
+                    None => buf.push_str(result),
                 }
             }
-            Expr::TagDeclarator(tag) => tag.recast(),
-            Expr::PipeExpression(pipe_exp) => pipe_exp.recast(options, indentation_level),
-            Expr::UnaryExpression(unary_exp) => unary_exp.recast(options, indentation_level, ctxt),
-            Expr::IfExpression(e) => e.recast(options, indentation_level, ctxt),
-            Expr::PipeSubstitution(_) => crate::parsing::PIPE_SUBSTITUTION_OPERATOR.to_string(),
+            Expr::TagDeclarator(tag) => tag.recast(buf),
+            Expr::PipeExpression(pipe_exp) => pipe_exp.recast(buf, options, indentation_level),
+            Expr::UnaryExpression(unary_exp) => unary_exp.recast(buf, options, indentation_level, ctxt),
+            Expr::IfExpression(e) => e.recast(buf, options, indentation_level, ctxt),
+            Expr::PipeSubstitution(_) => buf.push_str(crate::parsing::PIPE_SUBSTITUTION_OPERATOR),
             Expr::LabelledExpression(e) => {
-                let mut result = e.expr.recast(options, indentation_level, ctxt);
-                result += " as ";
-                result += &e.label.name;
-                result
+                e.expr.recast(buf, options, indentation_level, ctxt);
+                buf.push_str(" as ");
+                buf.push_str(&e.label.name);
             }
-            Expr::AscribedExpression(e) => e.recast(options, indentation_level, ctxt),
+            Expr::AscribedExpression(e) => e.recast(buf, options, indentation_level, ctxt),
             Expr::None(_) => {
                 unimplemented!("there is no literal None, see https://github.com/KittyCAD/modeling-app/issues/1115")
             }
@@ -332,50 +330,47 @@ impl Expr {
 }
 
 impl AscribedExpression {
-    fn recast(&self, options: &FormatOptions, indentation_level: usize, ctxt: ExprContext) -> String {
-        let mut result = self.expr.recast(options, indentation_level, ctxt);
+    fn recast(&self, buf: &mut String, options: &FormatOptions, indentation_level: usize, ctxt: ExprContext) {
         if matches!(
             self.expr,
             Expr::BinaryExpression(..) | Expr::PipeExpression(..) | Expr::UnaryExpression(..)
         ) {
-            result = format!("({result})");
+            buf.push('(');
+            self.expr.recast(buf, options, indentation_level, ctxt);
+            buf.push(')');
         }
-        result += ": ";
-        result += &self.ty.to_string();
-        result
+        buf.push_str(": ");
+        write!(buf, "{}", self.ty).no_fail();
     }
 }
 
 impl BinaryPart {
-    fn recast(&self, options: &FormatOptions, indentation_level: usize, ctxt: ExprContext) -> String {
+    fn recast(&self, buf: &mut String, options: &FormatOptions, indentation_level: usize, ctxt: ExprContext) {
         match &self {
             BinaryPart::Literal(literal) => {
-                let mut s = String::new();
-                literal.recast(&mut s);
-                s
+                literal.recast(buf);
             }
-            BinaryPart::Name(name) => {
-                let result = name.to_string();
-                match deprecation(&result, DeprecationKind::Const) {
-                    Some(suggestion) => suggestion.to_owned(),
-                    None => result,
-                }
-            }
+            BinaryPart::Name(name) => match deprecation(&name.inner.name.inner.name, DeprecationKind::Const) {
+                Some(suggestion) => write!(buf, "{}", suggestion).no_fail(),
+                None => write!(buf, "{name}").no_fail(),
+            },
             BinaryPart::BinaryExpression(binary_expression) => {
-                binary_expression.recast(options, indentation_level, ctxt)
+                binary_expression.recast(buf, options, indentation_level, ctxt)
             }
             BinaryPart::CallExpressionKw(call_expression) => {
-                call_expression.recast(options, indentation_level, ExprContext::Other)
+                call_expression.recast(buf, options, indentation_level, ExprContext::Other)
             }
-            BinaryPart::UnaryExpression(unary_expression) => unary_expression.recast(options, indentation_level, ctxt),
+            BinaryPart::UnaryExpression(unary_expression) => {
+                unary_expression.recast(buf, options, indentation_level, ctxt)
+            }
             BinaryPart::MemberExpression(member_expression) => {
-                member_expression.recast(options, indentation_level, ctxt)
+                member_expression.recast(buf, options, indentation_level, ctxt)
             }
-            BinaryPart::ArrayExpression(e) => e.recast(options, indentation_level, ctxt),
-            BinaryPart::ArrayRangeExpression(e) => e.recast(options, indentation_level, ctxt),
-            BinaryPart::ObjectExpression(e) => e.recast(options, indentation_level, ctxt),
-            BinaryPart::IfExpression(e) => e.recast(options, indentation_level, ExprContext::Other),
-            BinaryPart::AscribedExpression(e) => e.recast(options, indentation_level, ExprContext::Other),
+            BinaryPart::ArrayExpression(e) => e.recast(buf, options, indentation_level, ctxt),
+            BinaryPart::ArrayRangeExpression(e) => e.recast(buf, options, indentation_level, ctxt),
+            BinaryPart::ObjectExpression(e) => e.recast(buf, options, indentation_level, ctxt),
+            BinaryPart::IfExpression(e) => e.recast(buf, options, indentation_level, ExprContext::Other),
+            BinaryPart::AscribedExpression(e) => e.recast(buf, options, indentation_level, ExprContext::Other),
         }
     }
 }
@@ -383,27 +378,30 @@ impl BinaryPart {
 impl CallExpressionKw {
     fn recast_args(&self, options: &FormatOptions, indentation_level: usize, ctxt: ExprContext) -> Vec<String> {
         let mut arg_list = if let Some(first_arg) = &self.unlabeled {
-            vec![first_arg.recast(options, indentation_level, ctxt).trim().to_owned()]
+            let mut first = String::new();
+            first_arg.recast(&mut first, options, indentation_level, ctxt);
+            vec![first.trim().to_owned()]
         } else {
             Vec::with_capacity(self.arguments.len())
         };
-        arg_list.extend(
-            self.arguments
-                .iter()
-                .map(|arg| arg.recast(options, indentation_level, ctxt)),
-        );
+        arg_list.extend(self.arguments.iter().map(|arg| {
+            let mut buf = String::new();
+            arg.recast(&mut buf, options, indentation_level, ctxt);
+            buf
+        }));
         arg_list
     }
-    fn recast(&self, options: &FormatOptions, indentation_level: usize, ctxt: ExprContext) -> String {
-        let indent = if ctxt == ExprContext::Pipe {
-            "".to_string()
+    fn recast(&self, buf: &mut String, options: &FormatOptions, indentation_level: usize, ctxt: ExprContext) {
+        let smart_indent_level = if ctxt == ExprContext::Pipe {
+            0
         } else {
-            options.get_indentation(indentation_level)
+            indentation_level
         };
-        let name = self.callee.to_string();
+        let name = &self.callee;
 
-        if let Some(suggestion) = deprecation(&name, DeprecationKind::Function) {
-            return format!("{indent}{suggestion}");
+        if let Some(suggestion) = deprecation(&name.inner.name.inner.name, DeprecationKind::Function) {
+            options.write_indentation(buf, smart_indent_level);
+            return write!(buf, "{suggestion}").no_fail();
         }
 
         let arg_list = self.recast_args(options, indentation_level, ctxt);
@@ -427,74 +425,79 @@ impl CallExpressionKw {
             } else {
                 options.get_indentation(indentation_level)
             };
-            format!("{indent}{name}(\n{inner_indentation}{args}\n{end_indent})")
+            options.write_indentation(buf, smart_indent_level);
+            write!(buf, "{}", name).no_fail();
+            buf.push('(');
+            buf.push('\n');
+            write!(buf, "{}", inner_indentation).no_fail();
+            write!(buf, "{}", args).no_fail();
+            buf.push('\n');
+            write!(buf, "{}", end_indent).no_fail();
+            buf.push(')');
         } else {
-            format!("{indent}{name}({args})")
+            options.write_indentation(buf, smart_indent_level);
+            write!(buf, "{}", name).no_fail();
+            buf.push('(');
+            write!(buf, "{}", args).no_fail();
+            buf.push(')');
         }
     }
 }
 
 impl LabeledArg {
-    fn recast(&self, options: &FormatOptions, indentation_level: usize, ctxt: ExprContext) -> String {
-        let mut result = String::new();
+    fn recast(&self, buf: &mut String, options: &FormatOptions, indentation_level: usize, ctxt: ExprContext) {
         if let Some(l) = &self.label {
-            result.push_str(&l.name);
-            result.push_str(" = ");
+            buf.push_str(&l.name);
+            buf.push_str(" = ");
         }
-        result.push_str(&self.arg.recast(options, indentation_level, ctxt));
-        result
+        &self.arg.recast(buf, options, indentation_level, ctxt);
     }
 }
 
 impl VariableDeclaration {
-    pub fn recast(&self, options: &FormatOptions, indentation_level: usize) -> String {
-        let indentation = options.get_indentation(indentation_level);
-        let mut output = match self.visibility {
-            ItemVisibility::Default => String::new(),
-            ItemVisibility::Export => "export ".to_owned(),
+    pub fn recast(&self, buf: &mut String, options: &FormatOptions, indentation_level: usize) {
+        options.write_indentation(buf, indentation_level);
+        match self.visibility {
+            ItemVisibility::Default => {}
+            ItemVisibility::Export => buf.push_str("export "),
         };
 
         let (keyword, eq) = match self.kind {
             VariableKind::Fn => ("fn ", ""),
             VariableKind::Const => ("", " = "),
         };
-        let _ = write!(
-            output,
-            "{}{keyword}{}{eq}{}",
-            indentation,
-            self.declaration.id.name,
-            self.declaration
-                .init
-                .recast(options, indentation_level, ExprContext::Decl)
-                .trim()
-        );
-        output
+        buf.push_str(keyword);
+        buf.push_str(&self.declaration.id.name);
+        buf.push_str(eq);
+        self.declaration
+            .init
+            .recast(buf, options, indentation_level, ExprContext::Decl);
     }
 }
 
 impl TypeDeclaration {
-    pub fn recast(&self) -> String {
-        let vis = match self.visibility {
-            ItemVisibility::Default => String::new(),
-            ItemVisibility::Export => "export ".to_owned(),
+    pub fn recast(&self, buf: &mut String) {
+        match self.visibility {
+            ItemVisibility::Default => {}
+            ItemVisibility::Export => buf.push_str("export "),
         };
+        buf.push_str("type ");
+        buf.push_str(&self.name.name);
 
-        let mut arg_str = String::new();
         if let Some(args) = &self.args {
-            arg_str.push('(');
+            buf.push('(');
             for a in args {
-                if arg_str.len() > 1 {
-                    arg_str.push_str(", ");
+                if buf.len() > 1 {
+                    buf.push_str(", ");
                 }
-                arg_str.push_str(&a.name);
+                buf.push_str(&a.name);
             }
-            arg_str.push(')');
+            buf.push(')');
         }
         if let Some(alias) = &self.alias {
-            arg_str.push_str(" = ");
-            arg_str.push_str(&alias.to_string());
+            buf.push_str(" = ");
+            buf.push_str(&alias.to_string());
         }
-        format!("{}type {}{}", vis, self.name.name, arg_str)
     }
 }
 
@@ -536,14 +539,14 @@ impl Literal {
 }
 
 impl TagDeclarator {
-    pub fn recast(&self) -> String {
+    pub fn recast(&self, buf: &mut String) {
         // TagDeclarators are always prefixed with a dollar sign.
-        format!("${}", self.name)
+        write!(buf, "${}", self.name).no_fail()
     }
 }
 
 impl ArrayExpression {
-    fn recast(&self, options: &FormatOptions, indentation_level: usize, ctxt: ExprContext) -> String {
+    fn recast(&self, buf: &mut String, options: &FormatOptions, indentation_level: usize, ctxt: ExprContext) {
         // Reconstruct the order of items in the array.
         // An item can be an element (i.e. an expression for a KCL value),
         // or a non-code item (e.g. a comment)
@@ -559,7 +562,9 @@ impl ArrayExpression {
                 }));
             } else {
                 let el = elems.next().unwrap();
-                let s = format!("{}, ", el.recast(options, 0, ExprContext::Other));
+                let mut s = String::new();
+                el.recast(&mut s, options, 0, ExprContext::Other);
+                s.write_char(',');
                 format_items.push(s);
             }
         }
@@ -580,25 +585,26 @@ impl ArrayExpression {
         let max_array_length = 40;
         let multi_line = flat_recast.len() > max_array_length || found_line_comment;
         if !multi_line {
-            return flat_recast;
+            buf.push_str(&flat_recast);
+            return;
         }
 
         // Otherwise, we format a multi-line representation.
-        let mut output = "[\n".to_owned();
+        buf.push_str("[\n");
         let inner_indentation = if ctxt == ExprContext::Pipe {
             options.get_indentation_offset_pipe(indentation_level + 1)
         } else {
             options.get_indentation(indentation_level + 1)
         };
         for format_item in format_items {
-            output.push_str(&inner_indentation);
-            output.push_str(if let Some(x) = format_item.strip_suffix(" ") {
+            buf.push_str(&inner_indentation);
+            buf.push_str(if let Some(x) = format_item.strip_suffix(" ") {
                 x
             } else {
                 &format_item
             });
             if !format_item.ends_with('\n') {
-                output.push('\n')
+                buf.push('\n')
             }
         }
         let end_indent = if ctxt == ExprContext::Pipe {
@@ -606,9 +612,8 @@ impl ArrayExpression {
         } else {
             options.get_indentation(indentation_level)
         };
-        output.push_str(&end_indent);
-        output.push(']');
-        output
+        buf.push_str(&end_indent);
+        buf.push(']');
     }
 }
 
@@ -620,61 +625,77 @@ fn expr_is_trivial(expr: &Expr) -> bool {
     )
 }
 
+trait CannotActuallyFail {
+    fn no_fail(self);
+}
+
+impl CannotActuallyFail for std::fmt::Result {
+    fn no_fail(self) {
+        self.expect("writing to a string cannot fail, there's no IO happening")
+    }
+}
+
 impl ArrayRangeExpression {
-    fn recast(&self, options: &FormatOptions, _: usize, _: ExprContext) -> String {
-        let s1 = self.start_element.recast(options, 0, ExprContext::Other);
-        let s2 = self.end_element.recast(options, 0, ExprContext::Other);
+    fn recast(&self, buf: &mut String, options: &FormatOptions, _: usize, _: ExprContext) {
+        buf.push('[');
+        self.start_element.recast(buf, options, 0, ExprContext::Other);
 
         let range_op = if self.end_inclusive { ".." } else { "..<" };
-
         // Format these items into a one-line array. Put spaces around the `..` if either expression
         // is non-trivial. This is a bit arbitrary but people seem to like simple ranges to be formatted
         // tightly, but this is a misleading visual representation of the precedence if the range
         // components are compound expressions.
-        if expr_is_trivial(&self.start_element) && expr_is_trivial(&self.end_element) {
-            format!("[{s1}{range_op}{s2}]")
+        let no_spaces = expr_is_trivial(&self.start_element) && expr_is_trivial(&self.end_element);
+        if no_spaces {
+            write!(buf, "{range_op}").no_fail()
         } else {
-            format!("[{s1} {range_op} {s2}]")
+            write!(buf, " {range_op} ").no_fail()
         }
-
+        self.end_element.recast(buf, options, 0, ExprContext::Other);
+        buf.push(']');
         // Assume a range expression fits on one line.
     }
 }
 
 impl ObjectExpression {
-    fn recast(&self, options: &FormatOptions, indentation_level: usize, ctxt: ExprContext) -> String {
+    fn recast(&self, buf: &mut String, options: &FormatOptions, indentation_level: usize, ctxt: ExprContext) {
         if self
             .non_code_meta
             .non_code_nodes
             .values()
             .any(|nc| nc.iter().any(|nc| nc.value.should_cause_array_newline()))
         {
-            return self.recast_multi_line(options, indentation_level, ctxt);
+            return self.recast_multi_line(buf, options, indentation_level, ctxt);
         }
-        let flat_recast = format!(
-            "{{ {} }}",
-            self.properties
-                .iter()
-                .map(|prop| {
-                    format!(
-                        "{} = {}",
-                        prop.key.name,
-                        prop.value.recast(options, indentation_level + 1, ctxt).trim()
-                    )
-                })
-                .collect::<Vec<String>>()
-                .join(", ")
-        );
+        let mut flat_recast_buf = String::new();
+        flat_recast_buf.push('{');
+        for (i, prop) in self.properties.iter().enumerate() {
+            write!(flat_recast_buf, "{} = ", prop.key.name,).no_fail();
+            prop.value
+                .recast(&mut flat_recast_buf, options, indentation_level + 1, ctxt);
+            flat_recast_buf.trim();
+            if i < self.properties.len() - 1 {
+                flat_recast_buf.push_str(", ");
+            }
+        }
+        flat_recast_buf.push('}');
         let max_array_length = 40;
-        let needs_multiple_lines = flat_recast.len() > max_array_length;
+        let needs_multiple_lines = flat_recast_buf.len() > max_array_length;
         if !needs_multiple_lines {
-            return flat_recast;
+            buf.push_str(&flat_recast_buf);
+        } else {
+            self.recast_multi_line(buf, options, indentation_level, ctxt);
         }
-        self.recast_multi_line(options, indentation_level, ctxt)
     }
 
     /// Recast, but always outputs the object with newlines between each property.
-    fn recast_multi_line(&self, options: &FormatOptions, indentation_level: usize, ctxt: ExprContext) -> String {
+    fn recast_multi_line(
+        &self,
+        buf: &mut String,
+        options: &FormatOptions,
+        indentation_level: usize,
+        ctxt: ExprContext,
+    ) {
         let inner_indentation = if ctxt == ExprContext::Pipe {
             options.get_indentation_offset_pipe(indentation_level + 1)
         } else {
@@ -690,12 +711,10 @@ impl ObjectExpression {
                     let prop = props.next().unwrap();
                     // Use a comma unless it's the last item
                     let comma = if i == num_items - 1 { "" } else { ",\n" };
-                    let s = format!(
-                        "{} = {}{comma}",
-                        prop.key.name,
-                        prop.value.recast(options, indentation_level + 1, ctxt).trim()
-                    );
-                    vec![s]
+                    let mut s = String::new();
+                    prop.value.recast(&mut s, options, indentation_level + 1, ctxt);
+                    // TODO: Get rid of this vector allocation
+                    vec![format!("{} = {}{comma}", prop.key.name, s.trim())]
                 }
             })
             .collect();
@@ -704,66 +723,72 @@ impl ObjectExpression {
         } else {
             options.get_indentation(indentation_level)
         };
-        format!(
+        write!(
+            buf,
             "{{\n{inner_indentation}{}\n{end_indent}}}",
             format_items.join(&inner_indentation),
         )
+        .no_fail();
     }
 }
 
 impl MemberExpression {
-    fn recast(&self, options: &FormatOptions, indentation_level: usize, ctxt: ExprContext) -> String {
-        let key_str = if self.computed {
-            let node_fmt = self.property.recast(options, indentation_level, ctxt);
-            format!("[{node_fmt}]")
+    fn recast(&self, buf: &mut String, options: &FormatOptions, indentation_level: usize, ctxt: ExprContext) {
+        // The object
+        self.object.recast(buf, options, indentation_level, ctxt);
+        // The key
+        if self.computed {
+            buf.push('[');
+            self.property.recast(buf, options, indentation_level, ctxt);
+            buf.push(']');
         } else {
-            let node_fmt = self.property.recast(options, indentation_level, ctxt);
-            format!(".{node_fmt}")
+            buf.push('.');
+            self.property.recast(buf, options, indentation_level, ctxt);
         };
-        self.object.recast(options, indentation_level, ctxt) + key_str.as_str()
     }
 }
 
 impl BinaryExpression {
-    fn recast(&self, options: &FormatOptions, _indentation_level: usize, ctxt: ExprContext) -> String {
-        let maybe_wrap_it = |a: String, doit: bool| -> String { if doit { format!("({a})") } else { a } };
+    fn recast(&self, buf: &mut String, options: &FormatOptions, _indentation_level: usize, ctxt: ExprContext) {
+        todo!()
+        // let maybe_wrap_it = |a: String, doit: bool| -> String { if doit { format!("({a})") } else { a } };
 
-        // It would be better to always preserve the user's parentheses but since we've dropped that
-        // info from the AST, we bracket expressions as necessary.
-        let should_wrap_left = match &self.left {
-            BinaryPart::BinaryExpression(bin_exp) => {
-                self.precedence() > bin_exp.precedence()
-                    || ((self.precedence() == bin_exp.precedence())
-                        && (!(self.operator.associative() && self.operator == bin_exp.operator)
-                            && self.operator.associativity() == Associativity::Right))
-            }
-            _ => false,
-        };
+        // // It would be better to always preserve the user's parentheses but since we've dropped that
+        // // info from the AST, we bracket expressions as necessary.
+        // let should_wrap_left = match &self.left {
+        //     BinaryPart::BinaryExpression(bin_exp) => {
+        //         self.precedence() > bin_exp.precedence()
+        //             || ((self.precedence() == bin_exp.precedence())
+        //                 && (!(self.operator.associative() && self.operator == bin_exp.operator)
+        //                     && self.operator.associativity() == Associativity::Right))
+        //     }
+        //     _ => false,
+        // };
 
-        let should_wrap_right = match &self.right {
-            BinaryPart::BinaryExpression(bin_exp) => {
-                self.precedence() > bin_exp.precedence()
-                    // These two lines preserve previous reformatting behaviour.
-                    || self.operator == BinaryOperator::Sub
-                    || self.operator == BinaryOperator::Div
-                    || ((self.precedence() == bin_exp.precedence())
-                        && (!(self.operator.associative() && self.operator == bin_exp.operator)
-                            && self.operator.associativity() == Associativity::Left))
-            }
-            _ => false,
-        };
+        // let should_wrap_right = match &self.right {
+        //     BinaryPart::BinaryExpression(bin_exp) => {
+        //         self.precedence() > bin_exp.precedence()
+        //             // These two lines preserve previous reformatting behaviour.
+        //             || self.operator == BinaryOperator::Sub
+        //             || self.operator == BinaryOperator::Div
+        //             || ((self.precedence() == bin_exp.precedence())
+        //                 && (!(self.operator.associative() && self.operator == bin_exp.operator)
+        //                     && self.operator.associativity() == Associativity::Left))
+        //     }
+        //     _ => false,
+        // };
 
-        format!(
-            "{} {} {}",
-            maybe_wrap_it(self.left.recast(options, 0, ctxt), should_wrap_left),
-            self.operator,
-            maybe_wrap_it(self.right.recast(options, 0, ctxt), should_wrap_right)
-        )
+        // format!(
+        //     "{} {} {}",
+        //     maybe_wrap_it(self.left.recast(options, 0, ctxt), should_wrap_left),
+        //     self.operator,
+        //     maybe_wrap_it(self.right.recast(options, 0, ctxt), should_wrap_right)
+        // )
     }
 }
 
 impl UnaryExpression {
-    fn recast(&self, options: &FormatOptions, _indentation_level: usize, ctxt: ExprContext) -> String {
+    fn recast(&self, buf: &mut String, options: &FormatOptions, _indentation_level: usize, ctxt: ExprContext) {
         match self.argument {
             BinaryPart::Literal(_)
             | BinaryPart::Name(_)
@@ -774,86 +799,62 @@ impl UnaryExpression {
             | BinaryPart::IfExpression(_)
             | BinaryPart::AscribedExpression(_)
             | BinaryPart::CallExpressionKw(_) => {
-                format!("{}{}", &self.operator, self.argument.recast(options, 0, ctxt))
+                write!(buf, "{}", self.operator).no_fail();
+                self.argument.recast(buf, options, 0, ctxt)
             }
             BinaryPart::BinaryExpression(_) | BinaryPart::UnaryExpression(_) => {
-                format!("{}({})", &self.operator, self.argument.recast(options, 0, ctxt))
+                write!(buf, "{}", self.operator).no_fail();
+                buf.push('(');
+                self.argument.recast(buf, options, 0, ctxt);
+                buf.push(')');
             }
         }
     }
 }
 
 impl IfExpression {
-    fn recast(&self, options: &FormatOptions, indentation_level: usize, ctxt: ExprContext) -> String {
-        // We can calculate how many lines this will take, so let's do it and avoid growing the vec.
-        // Total lines = starting lines, else-if lines, ending lines.
-        let n = 2 + (self.else_ifs.len() * 2) + 3;
-        let mut lines = Vec::with_capacity(n);
-
-        let cond = self.cond.recast(options, indentation_level, ctxt);
-        lines.push((0, format!("if {cond} {{")));
-        lines.push((1, self.then_val.recast(options, indentation_level + 1)));
-        for else_if in &self.else_ifs {
-            let cond = else_if.cond.recast(options, indentation_level, ctxt);
-            lines.push((0, format!("}} else if {cond} {{")));
-            lines.push((1, else_if.then_val.recast(options, indentation_level + 1)));
-        }
-        lines.push((0, "} else {".to_owned()));
-        lines.push((1, self.final_else.recast(options, indentation_level + 1)));
-        lines.push((0, "}".to_owned()));
-        lines
-            .into_iter()
-            .map(|(ind, line)| format!("{}{}", options.get_indentation(indentation_level + ind), line.trim()))
-            .collect::<Vec<_>>()
-            .join("\n")
+    fn recast(&self, buf: &mut String, options: &FormatOptions, indentation_level: usize, ctxt: ExprContext) {
+        todo!()
     }
 }
 
 impl Node<PipeExpression> {
-    fn recast(&self, options: &FormatOptions, indentation_level: usize) -> String {
-        let pipe = self
-            .body
-            .iter()
-            .enumerate()
-            .map(|(index, statement)| {
-                let indentation = options.get_indentation(indentation_level + 1);
-                let mut s = statement.recast(options, indentation_level + 1, ExprContext::Pipe);
-                let non_code_meta = &self.non_code_meta;
-                if let Some(non_code_meta_value) = non_code_meta.non_code_nodes.get(&index) {
-                    for val in non_code_meta_value {
-                        let formatted = if val.end == self.end {
-                            val.recast(options, indentation_level)
-                                .trim_end_matches('\n')
-                                .to_string()
-                        } else {
-                            val.recast(options, indentation_level + 1)
-                                .trim_end_matches('\n')
-                                .to_string()
-                        };
-                        if let NonCodeValue::BlockComment { .. } = val.value {
-                            s += "\n";
-                            s += &formatted;
-                        } else {
-                            s += &formatted;
-                        }
+    fn recast(&self, buf: &mut String, options: &FormatOptions, indentation_level: usize) {
+        options.write_indentation(buf, indentation_level);
+        for (index, statement) in self.body.iter().enumerate() {
+            statement.recast(buf, options, indentation_level + 1, ExprContext::Pipe);
+            let non_code_meta = &self.non_code_meta;
+            if let Some(non_code_meta_value) = non_code_meta.non_code_nodes.get(&index) {
+                for val in non_code_meta_value {
+                    // TODO: Remove allocation here by switching val.recast to accept buf.
+                    let formatted = if val.end == self.end {
+                        val.recast(options, indentation_level)
+                            .trim_end_matches('\n')
+                            .to_string()
+                    } else {
+                        val.recast(options, indentation_level + 1)
+                            .trim_end_matches('\n')
+                            .to_string()
+                    };
+                    if let NonCodeValue::BlockComment { .. } = val.value {
+                        buf.push('\n');
                     }
+                    buf.push_str(&formatted);
                 }
+            }
 
-                if index != self.body.len() - 1 {
-                    s += "\n";
-                    s += &indentation;
-                    s += PIPE_OPERATOR;
-                    s += " ";
-                }
-                s
-            })
-            .collect::<String>();
-        format!("{}{}", options.get_indentation(indentation_level), pipe)
+            if index != self.body.len() - 1 {
+                buf.push('\n');
+                options.write_indentation(buf, indentation_level + 1);
+                buf.push_str(PIPE_OPERATOR);
+                buf.push(' ');
+            }
+        }
     }
 }
 
 impl FunctionExpression {
-    pub fn recast(&self, options: &FormatOptions, indentation_level: usize) -> String {
+    pub fn recast(&self, buf: &mut String, options: &FormatOptions, indentation_level: usize) {
         // We don't want to end with a new line inside nested functions.
         let mut new_options = options.clone();
         new_options.insert_final_newline = false;
@@ -869,9 +870,10 @@ impl FunctionExpression {
             Some(rt) => format!(": {rt}"),
             None => String::new(),
         };
-        let body = self.body.recast(&new_options, indentation_level + 1);
 
-        format!("({param_list}){return_type} {{\n{tab1}{body}\n{tab0}}}")
+        write!(buf, "({param_list}){return_type} {{\n{tab1}").no_fail();
+        self.body.recast(buf, &new_options, indentation_level + 1);
+        write!(buf, "\n{tab0}}}").no_fail();
     }
 }
 
@@ -1005,7 +1007,7 @@ mod tests {
         let input = r#"@settings(defaultLengthUnit = in)
 "#;
         let program = crate::parsing::top_level_parse(input).unwrap();
-        let output = program.recast(&Default::default(), 0);
+        let output = program.recast_top(&Default::default(), 0);
         assert_eq!(output, input);
     }
 
@@ -1018,7 +1020,7 @@ mod tests {
 }
 "#;
         let program = crate::parsing::top_level_parse(input).unwrap();
-        let output = program.recast(&Default::default(), 0);
+        let output = program.recast_top(&Default::default(), 0);
         assert_eq!(output, input);
     }
 
@@ -1029,7 +1031,7 @@ mod tests {
 }
 "#;
         let program = crate::parsing::top_level_parse(input).unwrap();
-        let output = program.recast(&Default::default(), 0);
+        let output = program.recast_top(&Default::default(), 0);
         assert_eq!(output, input);
     }
 
@@ -1048,7 +1050,7 @@ foo = 42
 bar = 0
 "#;
         let program = crate::parsing::top_level_parse(input).unwrap();
-        let output = program.recast(&Default::default(), 0);
+        let output = program.recast_top(&Default::default(), 0);
         assert_eq!(output, input);
     }
 
@@ -1062,7 +1064,7 @@ sdfsdfsdfs */
 foo = 42
 "#;
         let program = crate::parsing::top_level_parse(input).unwrap();
-        let output = program.recast(&Default::default(), 0);
+        let output = program.recast_top(&Default::default(), 0);
         assert_eq!(output, input);
     }
 
@@ -1077,7 +1079,7 @@ foo = 42
 }
 "#;
         let program = crate::parsing::top_level_parse(input).unwrap();
-        let output = program.recast(&Default::default(), 0);
+        let output = program.recast_top(&Default::default(), 0);
         assert_eq!(output, input);
     }
 
@@ -1090,7 +1092,7 @@ foo = 42
 }
 "#;
         let program = crate::parsing::top_level_parse(input).unwrap();
-        let output = program.recast(&Default::default(), 0);
+        let output = program.recast_top(&Default::default(), 0);
         assert_eq!(output, input);
     }
 
@@ -1111,7 +1113,7 @@ export import a as aaa, b from "a.kcl"
 export import a, b as bbb from "a.kcl"
 "#;
         let program = crate::parsing::top_level_parse(input).unwrap();
-        let output = program.recast(&Default::default(), 0);
+        let output = program.recast_top(&Default::default(), 0);
         assert_eq!(output, input);
     }
 
@@ -1120,7 +1122,7 @@ export import a, b as bbb from "a.kcl"
         let input = r#"import a as a from "a.kcl"
 "#;
         let program = crate::parsing::top_level_parse(input).unwrap();
-        let output = program.recast(&Default::default(), 0);
+        let output = program.recast_top(&Default::default(), 0);
         let expected = r#"import a from "a.kcl"
 "#;
         assert_eq!(output, expected);
@@ -1133,7 +1135,7 @@ export import a, b as bbb from "a.kcl"
 }
 "#;
         let program = crate::parsing::top_level_parse(input).unwrap();
-        let output = program.recast(&Default::default(), 0);
+        let output = program.recast_top(&Default::default(), 0);
         assert_eq!(output, input);
     }
 
@@ -1260,7 +1262,7 @@ zoo(x = zoo_x, y = zoo_y)
 "#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(recasted, some_program_string);
     }
 
@@ -1330,7 +1332,7 @@ outsideRevolve = startSketchOn(XZ)
   |> revolve(axis = Y)"#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
             recasted,
             r#"// Ball Bearing
@@ -1401,7 +1403,7 @@ myNestedVar = [{ prop = callExp(bing.yo) }]
 "#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(recasted, some_program_string);
     }
 
@@ -1412,7 +1414,7 @@ myNestedVar = [callExp(bing.yo)]
 "#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(recasted, some_program_string);
     }
 
@@ -1424,7 +1426,7 @@ bar = [0 + 1 .. ten]
 "#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(recasted, some_program_string);
     }
 
@@ -1438,7 +1440,7 @@ thing ( 1 )
 "#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
             recasted,
             r#"fn thing(x) {
@@ -1458,7 +1460,7 @@ thing(1)
 "#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(recasted, some_program_string);
     }
 
@@ -1474,7 +1476,7 @@ f = [1, 2, 3]: [number; 3+]
 "#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(recasted, some_program_string);
     }
 
@@ -1489,7 +1491,7 @@ myNestedVar = [
 "#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
             recasted,
             r#"bing = { yo = 55 }
@@ -1507,7 +1509,7 @@ myNestedVar = [
         let some_program_string = r#""#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         // Its VERY important this comes back with zero new lines.
         assert_eq!(recasted, r#""#);
     }
@@ -1518,7 +1520,7 @@ myNestedVar = [
 "#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         // Its VERY important this comes back with zero new lines.
         assert_eq!(recasted, r#""#);
     }
@@ -1536,7 +1538,7 @@ part001 = startSketchOn(XY)
 
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
             recasted,
             r#"#!/usr/local/env zoo kcl
@@ -1567,7 +1569,7 @@ part001 = startSketchOn(XY)
 
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
             recasted,
             r#"#!/usr/local/env zoo kcl
@@ -1597,7 +1599,7 @@ part001 = startSketchOn(XY)
 
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
             recasted,
             r#"#!/usr/local/env zoo kcl
@@ -1621,7 +1623,7 @@ part001 = startSketchOn(XY)
 "#;
 
         let program = crate::parsing::top_level_parse(input).unwrap();
-        let output = program.recast(&Default::default(), 0);
+        let output = program.recast_top(&Default::default(), 0);
         assert_eq!(output, input);
     }
 
@@ -1744,7 +1746,7 @@ tabs_l = startSketchOn({
 "#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         // Its VERY important this comes back with zero new lines.
         assert_eq!(
             recasted,
@@ -1876,7 +1878,7 @@ tabs_l = startSketchOn({
 }"#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
             recasted,
             r#"fn cube(pos, scale) {
@@ -1910,7 +1912,7 @@ cube(pos = 0, scale = 0) as cub
 "#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(recasted, some_program_string,);
     }
 
@@ -1922,7 +1924,7 @@ cube(pos = 0, scale = 0) as cub
     |> line(end = [0.6804562304, 0.9087880491])"#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
             recasted,
             r#"part001 = startSketchOn(XY)
@@ -1941,7 +1943,7 @@ cube(pos = 0, scale = 0) as cub
     |> line(end = [0.6804562304, 0.9087880491])"#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
             recasted,
             r#"part001 = startSketchOn(XY)
@@ -1960,7 +1962,7 @@ cube(pos = 0, scale = 0) as cub
     |> line(end = [0.6804562304, 0.9087880491])"#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
             recasted,
             r#"part001 = startSketchOn(XY)
@@ -1985,7 +1987,7 @@ cube(pos = 0, scale = 0) as cub
 }"#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
             recasted,
             r#"fn myFn() {
@@ -2009,7 +2011,7 @@ thing = 'foo'
 "#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
             recasted,
             r#"key = 'c'
@@ -2030,7 +2032,7 @@ thing = 'foo'
 "#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
             recasted,
             r#"// hello world
@@ -2058,7 +2060,7 @@ foo = 'bar' //
 "#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
             recasted,
             r#"// hello world
@@ -2084,7 +2086,7 @@ thing = 'foo'
 "#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
             recasted,
             r#"key = 'c'
@@ -2101,7 +2103,7 @@ thing = 'foo'
 "#;
         let program = crate::parsing::top_level_parse(code).unwrap();
 
-        assert_eq!(program.recast(&Default::default(), 0), code);
+        assert_eq!(program.recast_top(&Default::default(), 0), code);
     }
 
     #[test]
@@ -2113,7 +2115,7 @@ mySk1 = startSketchOn(XY)
   |> startProfile(at = [0, 0])"#;
         let program = crate::parsing::top_level_parse(test_program).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
             recasted,
             r#"/* comment at start */
@@ -2144,7 +2146,7 @@ mySk1 = startSketchOn(XY)
 // one more for good measure"#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
             recasted,
             r#"// comment at start
@@ -2177,7 +2179,7 @@ mySk1 = startSketchOn(XY)
 }"#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(recasted.trim(), some_program_string);
     }
 
@@ -2201,7 +2203,7 @@ yo = [
 "#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(recasted, some_program_string);
     }
 
@@ -2217,7 +2219,7 @@ things = "things"
 // this is also a comment"#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         let expected = some_program_string.trim();
         // Currently new parser removes an empty line
         let actual = recasted.trim();
@@ -2236,7 +2238,7 @@ things = "things"
 }"#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(recasted.trim(), some_program_string.trim());
     }
 
@@ -2254,7 +2256,7 @@ part001 = startSketchOn(XY)
   |> angledLine(angle = -bar(x = seg01, y = myVar, z = %), length = myVar) // ln-lineTo-yAbsolute should use angleToMatchLengthY helper"#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(recasted.trim(), some_program_string);
     }
 
@@ -2273,7 +2275,7 @@ part001 = startSketchOn(XY)
 "#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(
+        let recasted = program.recast_top(
             &FormatOptions {
                 tab_size: 3,
                 use_tabs: false,
@@ -2303,7 +2305,7 @@ fn ghi(part001) {
         let mut program = crate::parsing::top_level_parse(some_program_string).unwrap();
         program.rename_symbol("mySuperCoolPart", 6);
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
             recasted,
             r#"mySuperCoolPart = startSketchOn(XY)
@@ -2331,7 +2333,7 @@ fn ghi(part001) {
         let mut program = crate::parsing::top_level_parse(some_program_string).unwrap();
         program.rename_symbol("newName", 7);
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
             recasted,
             r#"fn ghi(newName, y, z) {
@@ -2352,7 +2354,7 @@ fn ghi(part001) {
   })"#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
             recasted,
             r#"startSketchOn(XY)
@@ -2382,7 +2384,7 @@ firstExtrude = startSketchOn(XY)
 "#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
             recasted,
             r#"w = 20
@@ -2419,7 +2421,7 @@ firstExtrude = startSketchOn(XY)
 "#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(
             recasted,
             r#"w = 20
@@ -2445,7 +2447,7 @@ firstExtrude = startSketchOn(XY)
         let some_program_string = r#"myVar = -5 + 6"#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(recasted.trim(), some_program_string);
     }
 
@@ -2462,7 +2464,7 @@ startSketchOn(XY)
   |> line(end = [0, -(-5 - 1)])"#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(recasted.trim(), some_program_string);
     }
 
@@ -2476,7 +2478,7 @@ width = 20
 thickness = sqrt(distance * p * FOS * 6 / (sigmaAllow * width))"#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(recasted.trim(), some_program_string);
     }
 
@@ -2485,7 +2487,7 @@ thickness = sqrt(distance * p * FOS * 6 / (sigmaAllow * width))"#;
         let some_program_string = r#"distance = 5"#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
 
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(recasted.trim(), some_program_string);
     }
 
@@ -2500,7 +2502,7 @@ type baz = Foo | Bar
 type UnionOfArrays = [Foo] | [Bar] | Foo | { a: T, b: Foo | Bar | [Baz] }
 "#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         assert_eq!(recasted, some_program_string);
     }
 
@@ -2512,7 +2514,7 @@ type UnionOfArrays = [Foo] | [Bar] | Foo | { a: T, b: Foo | Bar | [Baz] }
 }
 }"#;
         let program = crate::parsing::top_level_parse(some_program_string).unwrap();
-        let recasted = program.recast(&Default::default(), 0);
+        let recasted = program.recast_top(&Default::default(), 0);
         let expected = "\
 fn f() {
   return fn() {
@@ -2578,7 +2580,7 @@ sketch002 = startSketchOn({
 })
 "#;
         let ast = crate::parsing::top_level_parse(input).unwrap();
-        let actual = ast.recast(&FormatOptions::new(), 0);
+        let actual = ast.recast_top(&FormatOptions::new(), 0);
         assert_eq!(actual, expected);
     }
 
@@ -2593,7 +2595,7 @@ sketch002 = startSketchOn({
 )
 "#;
         let ast = crate::parsing::top_level_parse(input).unwrap();
-        let actual = ast.recast(&FormatOptions::new(), 0);
+        let actual = ast.recast_top(&FormatOptions::new(), 0);
         assert_eq!(actual, input);
     }
 
@@ -2604,7 +2606,7 @@ sketch002 = startSketchOn({
 }
 "#;
         let ast = crate::parsing::top_level_parse(input).unwrap();
-        let actual = ast.recast(&FormatOptions::new(), 0);
+        let actual = ast.recast_top(&FormatOptions::new(), 0);
         assert_eq!(actual, input);
     }
 
@@ -2616,7 +2618,7 @@ sketch002 = startSketchOn({
 }
 "#;
         let ast = crate::parsing::top_level_parse(input).unwrap();
-        let actual = ast.recast(&FormatOptions::new(), 0);
+        let actual = ast.recast_top(&FormatOptions::new(), 0);
         assert_eq!(actual, input);
     }
 
@@ -2637,7 +2639,7 @@ type foo = fn([fn])
 type foo = fn(fn, f: fn(number(_))): [fn([any]): string]
 "#;
         let ast = crate::parsing::top_level_parse(input).unwrap();
-        let actual = ast.recast(&FormatOptions::new(), 0);
+        let actual = ast.recast_top(&FormatOptions::new(), 0);
         assert_eq!(actual, input);
     }
 
@@ -2655,7 +2657,7 @@ type foo = fn(fn, f: fn(number(_))): [fn([any]): string]
 }
 "#;
         let ast = crate::parsing::top_level_parse(input).unwrap();
-        let actual = ast.recast(&FormatOptions::new(), 0);
+        let actual = ast.recast_top(&FormatOptions::new(), 0);
         assert_eq!(actual, input);
     }
 
@@ -2677,7 +2679,7 @@ type foo = fn(fn, f: fn(number(_))): [fn([any]): string]
 }
 "#;
         let ast = crate::parsing::top_level_parse(input).unwrap();
-        let actual = ast.recast(&FormatOptions::new(), 0);
+        let actual = ast.recast_top(&FormatOptions::new(), 0);
         assert_eq!(actual, input);
     }
 
@@ -2705,9 +2707,10 @@ type foo = fn(fn, f: fn(number(_))): [fn([any]): string]
             let tokens = crate::parsing::token::lex(input, ModuleId::default()).unwrap();
             crate::parsing::parser::print_tokens(tokens.as_slice());
             let expr = crate::parsing::parser::object.parse(tokens.as_slice()).unwrap();
+            let mut actual = String::new();
+            expr.recast(&mut actual, &FormatOptions::new(), 0, ExprContext::Other);
             assert_eq!(
-                expr.recast(&FormatOptions::new(), 0, ExprContext::Other),
-                expected,
+                actual, expected,
                 "failed test {i}, which is testing that recasting {reason}"
             );
         }
@@ -2804,9 +2807,10 @@ type foo = fn(fn, f: fn(number(_))): [fn([any]): string]
             let expr = crate::parsing::parser::array_elem_by_elem
                 .parse(tokens.as_slice())
                 .unwrap();
+            let mut actual = String::new();
+            expr.recast(&mut actual, &FormatOptions::new(), 0, ExprContext::Other);
             assert_eq!(
-                expr.recast(&FormatOptions::new(), 0, ExprContext::Other),
-                expected,
+                actual, expected,
                 "failed test {i}, which is testing that recasting {reason}"
             );
         }
@@ -2822,7 +2826,7 @@ comment */
 yo = 'bing'
 "#;
         let ast = crate::parsing::top_level_parse(code).unwrap();
-        let recasted = ast.recast(&FormatOptions::new(), 0);
+        let recasted = ast.recast_top(&FormatOptions::new(), 0);
         assert_eq!(recasted, code);
     }
 
@@ -2839,7 +2843,7 @@ yo = 'bing'
 }
 "#;
         let ast = crate::parsing::top_level_parse(code).unwrap();
-        let recasted = ast.recast(&FormatOptions::new(), 0);
+        let recasted = ast.recast_top(&FormatOptions::new(), 0);
         assert_eq!(recasted, code);
     }
 
@@ -2847,7 +2851,7 @@ yo = 'bing'
     fn array_range_end_exclusive() {
         let code = "myArray = [0..<4]\n";
         let ast = crate::parsing::top_level_parse(code).unwrap();
-        let recasted = ast.recast(&FormatOptions::new(), 0);
+        let recasted = ast.recast_top(&FormatOptions::new(), 0);
         assert_eq!(recasted, code);
     }
 
@@ -2879,7 +2883,7 @@ x = 2 % y * 2
 x = 2 * y % 2
 "#;
         let ast = crate::parsing::top_level_parse(code).unwrap();
-        let recasted = ast.recast(&FormatOptions::new(), 0);
+        let recasted = ast.recast_top(&FormatOptions::new(), 0);
         assert_eq!(recasted, expected);
     }
 }

--- a/rust/kcl-lib/tests/export_var_only_at_top_level/unparsed.snap
+++ b/rust/kcl-lib/tests/export_var_only_at_top_level/unparsed.snap
@@ -1,9 +1,9 @@
 ---
 source: kcl-lib/src/simulation_tests.rs
-description: Result of unparsing export_only_at_top_level.kcl
+description: Result of unparsing export_var_only_at_top_level.kcl
 ---
 fn main() {
-  export   x = 2
+  export x = 2
   return 0
 }
 


### PR DESCRIPTION
On my Macbook, this speeds up benchmarks by 2x to 2.7x

Before this PR, most of the recast functions looked like this 

```
fn recast(&self, options, indentation_level) -> String
```

In other words, when they ran, they allocated and returned a string. This mean every function would perform at least 1 allocation.

Now they generally look like this:
```
fn recast(&self, buf: &mut String, options, indentation_level)
```

In other words, they usually accept a string from the caller and append to it, rather than allocating a new one. This reduces allocations (because generally the same single string can be shared across recasts) which saves time (because a huge portion of recast time was just allocating strings, appending their contents to some other string, then dropping it).