### PR TITLE
KCL: write_to method on Name to avoid allocating a string

### DIFF
--- a/rust/kcl-lib/src/parsing/ast/types/mod.rs
+++ b/rust/kcl-lib/src/parsing/ast/types/mod.rs
@@ -2396,6 +2396,28 @@ impl Name {
     }
 }
 
+impl Name {
+    /// Write the full name to the given string.
+    pub fn write_to(&self, buf: &mut String) {
+        if self.abs_path {
+            buf.push_str("::");
+        };
+        for p in &self.path {
+            buf.push_str(&p.name);
+            buf.push_str("::");
+        }
+        buf.push_str(&self.name.name);
+    }
+}
+
+impl fmt::Display for Name {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut buf = String::new();
+        self.write_to(&mut buf);
+        buf.fmt(f)
+    }
+}
+
 impl From<Node<Identifier>> for Node<Name> {
     fn from(value: Node<Identifier>) -> Self {
         let start = value.start;
@@ -2413,19 +2435,6 @@ impl From<Node<Identifier>> for Node<Name> {
             end,
             mod_id,
         )
-    }
-}
-
-impl fmt::Display for Name {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.abs_path {
-            f.write_str("::")?;
-        }
-        for p in &self.path {
-            f.write_str(&p.name)?;
-            f.write_str("::")?;
-        }
-        f.write_str(&self.name.name)
     }
 }
 

--- a/rust/kcl-lib/src/unparser.rs
+++ b/rust/kcl-lib/src/unparser.rs
@@ -349,7 +349,7 @@ impl BinaryPart {
             }
             BinaryPart::Name(name) => match deprecation(&name.inner.name.inner.name, DeprecationKind::Const) {
                 Some(suggestion) => write!(buf, "{suggestion}").no_fail(),
-                None => write!(buf, "{name}").no_fail(),
+                None => name.write_to(buf),
             },
             BinaryPart::BinaryExpression(binary_expression) => {
                 binary_expression.recast(buf, options, indentation_level, ctxt)
@@ -423,7 +423,7 @@ impl CallExpressionKw {
                 options.get_indentation(indentation_level)
             };
             options.write_indentation(buf, smart_indent_level);
-            write!(buf, "{name}").no_fail();
+            name.write_to(buf);
             buf.push('(');
             buf.push('\n');
             write!(buf, "{inner_indentation}").no_fail();
@@ -433,7 +433,7 @@ impl CallExpressionKw {
             buf.push(')');
         } else {
             options.write_indentation(buf, smart_indent_level);
-            write!(buf, "{name}").no_fail();
+            name.write_to(buf);
             buf.push('(');
             write!(buf, "{args}").no_fail();
             buf.push(')');
@@ -546,7 +546,8 @@ impl Literal {
 impl TagDeclarator {
     pub fn recast(&self, buf: &mut String) {
         // TagDeclarators are always prefixed with a dollar sign.
-        write!(buf, "${}", self.name).no_fail()
+        buf.push('$');
+        buf.push_str(&self.name);
     }
 }
 


### PR DESCRIPTION
Speeds up recaster medium 3% on my macbook.