### PR TITLE
test: Disable non-deterministic KCL sample

### DIFF
--- a/public/kcl-samples/manifest.json
+++ b/public/kcl-samples/manifest.json
@@ -449,21 +449,6 @@
   },
   {
     "file": "main.kcl",
-    "pathFromProjectDirectoryToFirstFile": "multi-axis-robot/main.kcl",
-    "multipleFiles": true,
-    "title": "Robot Arm",
-    "description": "A 4 axis robotic arm for industrial use. These machines can be used for assembly, packaging, organization of goods, and quality inspection processes",
-    "files": [
-      "globals.kcl",
-      "main.kcl",
-      "robot-arm-base.kcl",
-      "robot-arm-j2.kcl",
-      "robot-arm-j3.kcl",
-      "robot-rotating-base.kcl"
-    ]
-  },
-  {
-    "file": "main.kcl",
     "pathFromProjectDirectoryToFirstFile": "pdu-faceplate/main.kcl",
     "multipleFiles": false,
     "title": "Power Distribution Unit (PDU) faceplate with European plug sockets and switch",

--- a/rust/kcl-lib/src/simulation_tests/kcl_samples.rs
+++ b/rust/kcl-lib/src/simulation_tests/kcl_samples.rs
@@ -12,6 +12,9 @@ use walkdir::WalkDir;
 
 use super::Test;
 
+/// Some samples may be temporarily disabled.
+const DISABLED_SAMPLES: [&str; 2] = ["ball-joint-rod-end", "multi-axis-robot"];
+
 lazy_static::lazy_static! {
     /// The directory containing the KCL samples source.
     static ref INPUTS_DIR: PathBuf = Path::new("../../public/kcl-samples").to_path_buf();
@@ -291,9 +294,6 @@ fn get_kcl_metadata(project_path: &Path, files: &[String]) -> Option<KclMetadata
         files,
     })
 }
-
-// Some samples may be temporarily disabled for various reasons
-const DISABLED_SAMPLES: [&str; 1] = ["ball-joint-rod-end"];
 
 // Function to scan the directory and generate the manifest.json
 fn generate_kcl_manifest(dir: &Path) -> Result<()> {


### PR DESCRIPTION
We don't know why this became non-deterministic. It's causing `main` to fail in CI. Outgoing engine commands are non-deterministic.

Related:

- #7737