### PR TITLE
Fix to display the correct code in Feature Tree Parameters

### DIFF
--- a/e2e/playwright/feature-tree-pane.spec.ts
+++ b/e2e/playwright/feature-tree-pane.spec.ts
@@ -334,6 +334,19 @@ test.describe('Feature Tree pane', () => {
       await cmdBar.progressCmdBar()
       await editor.expectEditor.toContain(editedParameterValue)
     })
+
+    await test.step('Edit the parameter value in the editor', async () => {
+      await editor.replaceCode('23 * 2', '42')
+      await editor.expectEditor.toContain('= 42')
+      // Wait for the code to be executed.
+      await page.waitForTimeout(2000)
+      // The parameter value should be updated in the feature tree.
+      const operationButton = await toolbar.getFeatureTreeOperation(
+        'Parameter',
+        0
+      )
+      await expect(operationButton.getByTestId('value-detail')).toHaveText('42')
+    })
   })
   test(`User can edit an offset plane operation from the feature tree`, async ({
     context,

--- a/src/components/ModelingSidebar/ModelingPanes/FeatureTreePane.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/FeatureTreePane.tsx
@@ -25,6 +25,7 @@ import {
   stdLibMap,
 } from '@src/lib/operations'
 import {
+  codeManager,
   commandBarActor,
   editorManager,
   kclManager,
@@ -173,6 +174,10 @@ export const FeatureTreePane = () => {
       ? kclManager.execState.operations
       : longestErrorOperationList
     : kclManager.lastSuccessfulOperations
+  // We use the code that corresponds to the operations. In case this is an
+  // error on the first run, fall back to whatever is currently in the code
+  // editor.
+  const operationsCode = kclManager.lastSuccessfulCode || codeManager.code
 
   // We filter out operations that are not useful to show in the feature tree
   const operationList = filterOperations(unfilteredOperationList)
@@ -240,6 +245,7 @@ export const FeatureTreePane = () => {
                 <OperationItem
                   key={key}
                   item={operation}
+                  code={operationsCode}
                   send={featureTreeSend}
                   sketchNoFace={sketchNoFace}
                 />
@@ -359,6 +365,7 @@ const OperationItemWrapper = ({
  */
 const OperationItem = (props: {
   item: Operation
+  code: string
   send: Prop<Actor<typeof featureTreeMachine>, 'send'>
   sketchNoFace: boolean
 }) => {
@@ -368,14 +375,14 @@ const OperationItem = (props: {
     () =>
       props.item.type === 'VariableDeclaration'
         ? {
-            display: kclContext.code.slice(
+            display: props.code.slice(
               props.item.sourceRange[0],
               props.item.sourceRange[1]
             ),
             calculated: props.item.value,
           }
         : undefined,
-    [props.item, kclContext.code]
+    [props.item, props.code]
   )
 
   const variableName = useMemo(() => {

--- a/src/components/ModelingSidebar/ModelingPanes/FeatureTreePane.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/FeatureTreePane.tsx
@@ -342,7 +342,10 @@ const OperationItemWrapper = ({
             {customSuffix && customSuffix}
           </div>
           {valueDetail && (
-            <code className="px-1 text-right text-chalkboard-70 dark:text-chalkboard-40 text-xs">
+            <code
+              data-testid="value-detail"
+              className="px-1 text-right text-chalkboard-70 dark:text-chalkboard-40 text-xs"
+            >
               {valueDetail.display}
             </code>
           )}


### PR DESCRIPTION
Operations reference code via CodeRef. We were using whatever code was in KclContext. Weirdly, the KclContext code can get out of sync with CodeManager's code. But that's a red herring. Synchronizing them led to other issues. The real solution was to store the KCL code that was executed so that the Operations refer to what they originated from, regardless of the code editor or KclContext code.

Checklist:

- [x] Test