### PR TITLE
Allow TAB to link back to GitHub Actions for JUnit XML results

### DIFF
--- a/.github/ci-cd-scripts/upload-results.sh
+++ b/.github/ci-cd-scripts/upload-results.sh
@@ -25,6 +25,7 @@ curl --silent --request POST \
   --form "GITHUB_HEAD_REF=${GITHUB_HEAD_REF:-}" \
   --form "GITHUB_REF_NAME=${GITHUB_REF_NAME:-}" \
   --form "GITHUB_REF=${GITHUB_REF:-}" \
+  --form "GITHUB_RUN_ID=${GITHUB_RUN_ID:-}" \
   --form "GITHUB_SHA=${GITHUB_SHA:-}" \
   --form "GITHUB_WORKFLOW=${GITHUB_WORKFLOW:-}" \
   --form "RUNNER_ARCH=${RUNNER_ARCH:-}" \


### PR DESCRIPTION
I meant to include this as part of https://github.com/KittyCAD/modeling-app/pull/7827. With this change the TAB links back to GitHub Actions should show up for all suites.