### PR TITLE
Adjust onboarding to handle the new toolbar location

### DIFF
--- a/src/routes/Onboarding/BrowserOnboardingRoutes.tsx
+++ b/src/routes/Onboarding/BrowserOnboardingRoutes.tsx
@@ -150,7 +150,7 @@ function Toolbar() {
   useOnboardingPanes()
 
   return (
-    <div className="cursor-not-allowed fixed inset-0 z-[99] grid items-start justify-center p-16">
+    <div className="cursor-not-allowed fixed inset-0 z-[99] grid items-start justify-center p-24">
       <OnboardingCard>
         <h1 className="text-xl font-bold">This is the toolbar</h1>
         <p className="my-4">
@@ -171,7 +171,7 @@ function TextToCad() {
   useOnboardingPanes()
 
   return (
-    <div className="cursor-not-allowed fixed inset-0 z-50 grid items-start justify-center p-16">
+    <div className="cursor-not-allowed fixed inset-0 z-50 grid items-start justify-center p-24">
       <OnboardingCard>
         <h1 className="text-xl font-bold">Text-to-CAD</h1>
         <p className="my-4">
@@ -184,7 +184,7 @@ function TextToCad() {
           <strong>One</strong> Text-to-CAD generation costs{' '}
           <strong>one credit per minute</strong>, rounded up to the nearest
           minute. A large majority of Text-to-CAD generations take under a
-          minute. If you are on the free plan, you get 40 free credits per
+          minute. If you are on the free plan, you get 20 free credits per
           month. With any of our paid plans, you get unlimited Text-to-CAD
           generations.
         </p>
@@ -326,7 +326,7 @@ function PromptToEdit() {
   useAdvanceOnboardingOnFormSubmit(thisOnboardingStatus)
 
   return (
-    <div className="cursor-not-allowed fixed inset-0 z-50 grid items-center justify-center p-16">
+    <div className="cursor-not-allowed fixed inset-0 z-50 grid items-center justify-center p-24">
       <OnboardingCard className="col-start-3 col-span-2">
         <h1 className="text-xl font-bold">Modify with Zoo Text-to-CAD</h1>
         <p className="my-4">
@@ -464,7 +464,7 @@ function OnboardingConclusion() {
   const downloadLink = withSiteBaseURL(`/${APP_DOWNLOAD_PATH}`)
 
   return (
-    <div className="cursor-not-allowed fixed inset-0 z-50 p-16 grid justify-center items-center">
+    <div className="cursor-not-allowed fixed inset-0 z-50 p-24 grid justify-center items-center">
       <OnboardingCard>
         <h1 className="text-xl font-bold">Download the desktop app</h1>
         <p className="my-4">

--- a/src/routes/Onboarding/DesktopOnboardingRoutes.tsx
+++ b/src/routes/Onboarding/DesktopOnboardingRoutes.tsx
@@ -145,7 +145,7 @@ function Toolbar() {
   useOnboardingPanes()
 
   return (
-    <div className="cursor-not-allowed fixed inset-0 z-[99] grid items-start justify-center p-16">
+    <div className="cursor-not-allowed fixed inset-0 z-[99] grid items-start justify-center p-24">
       <OnboardingCard>
         <h1 className="text-xl font-bold">This is the toolbar</h1>
         <p className="my-4">
@@ -166,7 +166,7 @@ function TextToCad() {
   useOnboardingPanes()
 
   return (
-    <div className="cursor-not-allowed fixed inset-0 z-50 grid items-start justify-center p-16">
+    <div className="cursor-not-allowed fixed inset-0 z-50 grid items-start justify-center p-24">
       <OnboardingCard>
         <h1 className="text-xl font-bold">Text-to-CAD</h1>
         <p className="my-4">
@@ -179,7 +179,7 @@ function TextToCad() {
           <strong>One</strong> Text-to-CAD generation costs{' '}
           <strong>one credit per minute</strong>, rounded up to the nearest
           minute. A large majority of Text-to-CAD generations take under a
-          minute. If you are on the free plan, you get 40 free credits per
+          minute. If you are on the free plan, you get 20 free credits per
           month. With any of our paid plans, you get unlimited Text-to-CAD
           generations.
         </p>
@@ -574,7 +574,7 @@ function Imports() {
   useOnboardingPanes()
 
   return (
-    <div className="cursor-not-allowed fixed inset-0 z-50 p-16 flex flex-col gap-8 items-center">
+    <div className="cursor-not-allowed fixed inset-0 z-50 p-24 flex flex-col gap-8 items-center">
       <OnboardingCard>
         <h1 className="text-xl font-bold">Add file(s) to project</h1>
         <p className="my-4">
@@ -605,7 +605,7 @@ function Exports() {
   useOnboardingPanes()
 
   return (
-    <div className="cursor-not-allowed fixed inset-0 z-50 p-16 grid justify-start items-center">
+    <div className="cursor-not-allowed fixed inset-0 z-50 p-24 grid justify-start items-center">
       <OnboardingCard>
         <h1 className="text-xl font-bold">Exporting</h1>
         <p className="my-4">
@@ -633,7 +633,7 @@ function OnboardingConclusion() {
   )
 
   return (
-    <div className="cursor-not-allowed fixed inset-0 z-50 p-16 grid justify-center items-center">
+    <div className="cursor-not-allowed fixed inset-0 z-50 p-24 grid justify-center items-center">
       <OnboardingCard>
         <h1 className="text-xl font-bold">Time to start building</h1>
         <p className="my-4">


### PR DESCRIPTION
Before:

<img width="800" height="299" alt="Screenshot 2025-07-28 at 11 53 18 AM" src="https://github.com/user-attachments/assets/34842efa-7835-480c-8c7b-05b9ba1997de" />


After:

<img width="808" height="350" alt="Screenshot 2025-07-28 at 11 52 25 AM" src="https://github.com/user-attachments/assets/3f92fe6f-2e3f-4a83-a8ce-8ea2fa118e7d" />

---

I also updated the Text-to-CAD credits explainer to reflect the new pricing: https://zoo.dev/design-studio-pricing

Alternatively, we could drop the exact count from that modal and use generic wording like "limited number of free credits".