### PR TITLE
docs: Fix markdown table formatting with pipe character

### DIFF
--- a/docs/kcl-lang/arithmetic.md
+++ b/docs/kcl-lang/arithmetic.md
@@ -15,7 +15,7 @@ KCL supports the usual arithmetic operators on numbers and logic operators on bo
 | `%` | Modulus aka remainder |
 | `^` | Power, e.g., `x ^ 2` means `x` squared |
 | `&` | Logical 'and' |
-| `|` | Logical 'or' |
+| `\|` | Logical 'or' |
 | `!` | Unary logical 'not' |
 
 KCL also supports comparsion operators which operate on numbers and produce booleans:


### PR DESCRIPTION
This is what it looks like on the website now.

<img width="265" height="140" alt="Screenshot 2025-07-28 at 12 11 48 PM" src="https://github.com/user-attachments/assets/d47a7592-60f8-4ad1-8444-088e53e4980e" />
