### PR TITLE
Change code owner of docs directory to kcl

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 * @KittyCAD/frontend
+/docs/ @KittyCAD/kcl
 /src/ @KittyCAD/frontend
 /rust/ @KittyCAD/kcl


### PR DESCRIPTION
The `docs` directory is KCL docs.