### PR TITLE
chore: restrict project creation and renaming to 240 characters or less

### DIFF
--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -88,6 +88,9 @@ function ProjectCard({
     }
   }, [isEditing, inputRef.current])
 
+
+  const projectName = project.name?.replace(FILE_EXT, '')
+
   return (
     <li
       {...props}
@@ -127,10 +130,11 @@ function ProjectCard({
             />
           ) : (
             <h3
-              className="font-sans relative z-0 p-2"
+              className="font-sans relative z-0 p-2 truncate"
               data-testid="project-title"
+              title={projectName}
             >
-              {project.name?.replace(FILE_EXT, '')}
+              {projectName}
             </h3>
           )}
           {project.readWriteAccess && (

--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -88,7 +88,6 @@ function ProjectCard({
     }
   }, [isEditing, inputRef.current])
 
-
   const projectName = project.name?.replace(FILE_EXT, '')
 
   return (
@@ -212,11 +211,11 @@ function ProjectCard({
           }, reportRejection)}
           onDismiss={() => setIsConfirmingDelete(false)}
         >
-          <p className="my-4">
+          <p className="my-4 text-wrap break-words">
             This will permanently delete "{project.name || 'this file'}
             ".
           </p>
-          <p className="my-4">
+          <p className="my-4 text-wrap break-words">
             Are you sure you want to delete "{project.name || 'this file'}
             "? This action cannot be undone.
           </p>

--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -234,33 +234,41 @@ function ProjectMenuPopover({
     ]
   )
 
+  // Breadcrumb for project and file
+  const breadCrumb = {
+    projectName: project?.name || '',
+    sep:'/',
+    filename: isDesktop() && file?.name
+      ? file.name.slice(
+        file.name.lastIndexOf(window.electron.path.sep) + 1
+      )
+      : APP_NAME
+  }
+  const breadCrumbTooltip = `${breadCrumb.projectName}${breadCrumb.sep}${breadCrumb.filename}`
+
   return (
     <Popover className="relative">
       <Popover.Button
         className="gap-1 rounded-sm mr-auto max-h-min min-w-max border-0 py-1 px-2 flex items-center  focus-visible:outline-appForeground dark:hover:bg-chalkboard-90"
         data-testid="project-sidebar-toggle"
       >
-        <div className="flex items-baseline py-0.5 text-sm gap-1">
+        <div className="flex items-baseline py-0.5 text-sm gap-1" title={breadCrumbTooltip}>
           {isDesktop() && project?.name && (
             <>
               <span
-                className="hidden whitespace-nowrap md:block"
+                className="hidden whitespace-nowrap md:block max-w-80 truncate"
                 data-testid="app-header-project-name"
               >
-                {project.name}
+                {breadCrumb.projectName}
               </span>
-              <span className="hidden md:block">/</span>
+              <span className="hidden md:block">{breadCrumb.sep}</span>
             </>
           )}
           <span
             className="text-sm text-chalkboard-110 dark:text-chalkboard-20 whitespace-nowrap"
             data-testid="app-header-file-name"
           >
-            {isDesktop() && file?.name
-              ? file.name.slice(
-                  file.name.lastIndexOf(window.electron.path.sep) + 1
-                )
-              : APP_NAME}
+            {breadCrumb.filename}
           </span>
         </div>
         <CustomIcon

--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -237,12 +237,11 @@ function ProjectMenuPopover({
   // Breadcrumb for project and file
   const breadCrumb = {
     projectName: project?.name || '',
-    sep:'/',
-    filename: isDesktop() && file?.name
-      ? file.name.slice(
-        file.name.lastIndexOf(window.electron.path.sep) + 1
-      )
-      : APP_NAME
+    sep: '/',
+    filename:
+      isDesktop() && file?.name
+        ? file.name.slice(file.name.lastIndexOf(window.electron.path.sep) + 1)
+        : APP_NAME,
   }
   const breadCrumbTooltip = `${breadCrumb.projectName}${breadCrumb.sep}${breadCrumb.filename}`
 
@@ -252,7 +251,10 @@ function ProjectMenuPopover({
         className="gap-1 rounded-sm mr-auto max-h-min min-w-max border-0 py-1 px-2 flex items-center  focus-visible:outline-appForeground dark:hover:bg-chalkboard-90"
         data-testid="project-sidebar-toggle"
       >
-        <div className="flex items-baseline py-0.5 text-sm gap-1" title={breadCrumbTooltip}>
+        <div
+          className="flex items-baseline py-0.5 text-sm gap-1"
+          title={breadCrumbTooltip}
+        >
           {isDesktop() && project?.name && (
             <>
               <span

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -247,3 +247,5 @@ export type EnvironmentConfigurationRuntime = {
 }
 
 export const ENVIRONMENT_CONFIGURATION_FOLDER = 'envs'
+
+export const MAX_PROJECT_NAME_LENGTH = 240

--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -156,8 +156,6 @@ export const systemIOMachine = setup({
         SystemIOMachineEvents.renameProject,
       ])
       const { requestedProjectName } = event.data
-      console.log(requestedProjectName.length)
-      console.log(requestedProjectName.length <= MAX_PROJECT_NAME_LENGTH)
       return requestedProjectName.length <= MAX_PROJECT_NAME_LENGTH
     },
   },
@@ -241,7 +239,10 @@ export const systemIOMachine = setup({
         return { project: event.output.name }
       },
     }),
-  },
+    [SystemIOMachineActions.toastProjectNameTooLong]: ()=>{
+      toast.error(`Project name is too long, must be less than or equal to ${MAX_PROJECT_NAME_LENGTH} characters`)
+    }
+    },
   actors: {
     [SystemIOMachineActors.readFoldersFromProjectDirectory]: fromPromise(
       async ({ input: context }: { input: SystemIOContext }) => {
@@ -433,14 +434,24 @@ export const systemIOMachine = setup({
         [SystemIOMachineEvents.navigateToFile]: {
           actions: [SystemIOMachineActions.setRequestedFileName],
         },
-        [SystemIOMachineEvents.createProject]: {
-          target: SystemIOMachineStates.creatingProject,
-          guard: SystemIOMachineGuards.projectNameIsValidLength,
-        },
-        [SystemIOMachineEvents.renameProject]: {
-          target: SystemIOMachineStates.renamingProject,
-          guard: SystemIOMachineGuards.projectNameIsValidLength,
-        },
+        [SystemIOMachineEvents.createProject]: [
+          {
+            guard:SystemIOMachineGuards.projectNameIsValidLength,
+            target: SystemIOMachineStates.creatingProject,
+          },
+          {
+            actions: [SystemIOMachineActions.toastProjectNameTooLong]
+          }
+        ],
+        [SystemIOMachineEvents.renameProject]: [
+          {
+            target: SystemIOMachineStates.renamingProject,
+            guard: SystemIOMachineGuards.projectNameIsValidLength,
+          },
+          {
+            actions: [SystemIOMachineActions.toastProjectNameTooLong]
+          }
+        ],
         [SystemIOMachineEvents.deleteProject]: {
           target: SystemIOMachineStates.deletingProject,
         },

--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_PROJECT_NAME } from '@src/lib/constants'
+import { DEFAULT_PROJECT_NAME, MAX_PROJECT_NAME_LENGTH } from '@src/lib/constants'
 import type { Project } from '@src/lib/project'
 import type {
   SystemIOContext,
@@ -9,6 +9,7 @@ import {
   SystemIOMachineActions,
   SystemIOMachineActors,
   SystemIOMachineEvents,
+  SystemIOMachineGuards,
   SystemIOMachineStates,
 } from '@src/machines/systemIO/utils'
 import toast from 'react-hot-toast'
@@ -141,6 +142,21 @@ export const systemIOMachine = setup({
             requestedFileName: string
           }
         },
+  },
+  guards: {
+    [SystemIOMachineGuards.projectNameIsValidLength]: ({
+      context,
+      event
+    }) : boolean => {
+      assertEvent(
+        event,
+        [SystemIOMachineEvents.createProject, SystemIOMachineEvents.renameProject]
+      )
+      const {requestedProjectName} = event.data
+      console.log(requestedProjectName.length)
+      console.log(requestedProjectName.length <= MAX_PROJECT_NAME_LENGTH)
+      return requestedProjectName.length <= MAX_PROJECT_NAME_LENGTH
+    }
   },
   actions: {
     [SystemIOMachineActions.setFolders]: assign({
@@ -416,9 +432,11 @@ export const systemIOMachine = setup({
         },
         [SystemIOMachineEvents.createProject]: {
           target: SystemIOMachineStates.creatingProject,
+          guard: SystemIOMachineGuards.projectNameIsValidLength
         },
         [SystemIOMachineEvents.renameProject]: {
           target: SystemIOMachineStates.renamingProject,
+          guard: SystemIOMachineGuards.projectNameIsValidLength
         },
         [SystemIOMachineEvents.deleteProject]: {
           target: SystemIOMachineStates.deletingProject,

--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -1,4 +1,7 @@
-import { DEFAULT_PROJECT_NAME, MAX_PROJECT_NAME_LENGTH } from '@src/lib/constants'
+import {
+  DEFAULT_PROJECT_NAME,
+  MAX_PROJECT_NAME_LENGTH,
+} from '@src/lib/constants'
 import type { Project } from '@src/lib/project'
 import type {
   SystemIOContext,
@@ -146,17 +149,17 @@ export const systemIOMachine = setup({
   guards: {
     [SystemIOMachineGuards.projectNameIsValidLength]: ({
       context,
-      event
-    }) : boolean => {
-      assertEvent(
-        event,
-        [SystemIOMachineEvents.createProject, SystemIOMachineEvents.renameProject]
-      )
-      const {requestedProjectName} = event.data
+      event,
+    }): boolean => {
+      assertEvent(event, [
+        SystemIOMachineEvents.createProject,
+        SystemIOMachineEvents.renameProject,
+      ])
+      const { requestedProjectName } = event.data
       console.log(requestedProjectName.length)
       console.log(requestedProjectName.length <= MAX_PROJECT_NAME_LENGTH)
       return requestedProjectName.length <= MAX_PROJECT_NAME_LENGTH
-    }
+    },
   },
   actions: {
     [SystemIOMachineActions.setFolders]: assign({
@@ -432,11 +435,11 @@ export const systemIOMachine = setup({
         },
         [SystemIOMachineEvents.createProject]: {
           target: SystemIOMachineStates.creatingProject,
-          guard: SystemIOMachineGuards.projectNameIsValidLength
+          guard: SystemIOMachineGuards.projectNameIsValidLength,
         },
         [SystemIOMachineEvents.renameProject]: {
           target: SystemIOMachineStates.renamingProject,
-          guard: SystemIOMachineGuards.projectNameIsValidLength
+          guard: SystemIOMachineGuards.projectNameIsValidLength,
         },
         [SystemIOMachineEvents.deleteProject]: {
           target: SystemIOMachineStates.deletingProject,

--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -239,10 +239,12 @@ export const systemIOMachine = setup({
         return { project: event.output.name }
       },
     }),
-    [SystemIOMachineActions.toastProjectNameTooLong]: ()=>{
-      toast.error(`Project name is too long, must be less than or equal to ${MAX_PROJECT_NAME_LENGTH} characters`)
-    }
+    [SystemIOMachineActions.toastProjectNameTooLong]: () => {
+      toast.error(
+        `Project name is too long, must be less than or equal to ${MAX_PROJECT_NAME_LENGTH} characters`
+      )
     },
+  },
   actors: {
     [SystemIOMachineActors.readFoldersFromProjectDirectory]: fromPromise(
       async ({ input: context }: { input: SystemIOContext }) => {
@@ -436,12 +438,12 @@ export const systemIOMachine = setup({
         },
         [SystemIOMachineEvents.createProject]: [
           {
-            guard:SystemIOMachineGuards.projectNameIsValidLength,
+            guard: SystemIOMachineGuards.projectNameIsValidLength,
             target: SystemIOMachineStates.creatingProject,
           },
           {
-            actions: [SystemIOMachineActions.toastProjectNameTooLong]
-          }
+            actions: [SystemIOMachineActions.toastProjectNameTooLong],
+          },
         ],
         [SystemIOMachineEvents.renameProject]: [
           {
@@ -449,8 +451,8 @@ export const systemIOMachine = setup({
             guard: SystemIOMachineGuards.projectNameIsValidLength,
           },
           {
-            actions: [SystemIOMachineActions.toastProjectNameTooLong]
-          }
+            actions: [SystemIOMachineActions.toastProjectNameTooLong],
+          },
         ],
         [SystemIOMachineEvents.deleteProject]: {
           target: SystemIOMachineStates.deletingProject,

--- a/src/machines/systemIO/utils.ts
+++ b/src/machines/systemIO/utils.ts
@@ -74,6 +74,7 @@ export enum SystemIOMachineActions {
   setReadWriteProjectDirectory = 'set read write project directory',
   setRequestedTextToCadGeneration = 'set requested text to cad generation',
   setLastProjectDeleteRequest = 'set last project delete request',
+  toastProjectNameTooLong = 'toast project name too long'
 }
 
 export enum SystemIOMachineGuards {

--- a/src/machines/systemIO/utils.ts
+++ b/src/machines/systemIO/utils.ts
@@ -76,6 +76,10 @@ export enum SystemIOMachineActions {
   setLastProjectDeleteRequest = 'set last project delete request',
 }
 
+export enum SystemIOMachineGuards {
+  projectNameIsValidLength = 'project name is value length'
+}
+
 export const NO_PROJECT_DIRECTORY = ''
 
 export type SystemIOContext = {

--- a/src/machines/systemIO/utils.ts
+++ b/src/machines/systemIO/utils.ts
@@ -77,7 +77,7 @@ export enum SystemIOMachineActions {
 }
 
 export enum SystemIOMachineGuards {
-  projectNameIsValidLength = 'project name is value length'
+  projectNameIsValidLength = 'project name is value length',
 }
 
 export const NO_PROJECT_DIRECTORY = ''

--- a/src/machines/systemIO/utils.ts
+++ b/src/machines/systemIO/utils.ts
@@ -74,7 +74,7 @@ export enum SystemIOMachineActions {
   setReadWriteProjectDirectory = 'set read write project directory',
   setRequestedTextToCadGeneration = 'set requested text to cad generation',
   setLastProjectDeleteRequest = 'set last project delete request',
-  toastProjectNameTooLong = 'toast project name too long'
+  toastProjectNameTooLong = 'toast project name too long',
 }
 
 export enum SystemIOMachineGuards {


### PR DESCRIPTION
closes https://github.com/KittyCAD/modeling-app/issues/5361

# Issue

Renaming and creating a project over 240 characters is possible.

# Implementation

- Updated systemio macine to have a guard to check the length of the `requestedProjectName`
- Updated a few locations that display the project name to improve the rendering
  - Header bar in the modeling page
  - project card title
  - project name in delete modal