### PR TITLE
Avoid backtracking when parsing function call expressions

### DIFF
--- a/rust/kcl-lib/benches/compiler_benchmark_criterion.rs
+++ b/rust/kcl-lib/benches/compiler_benchmark_criterion.rs
@@ -10,6 +10,7 @@ pub fn bench_parse(c: &mut Criterion) {
         ("math", MATH_PROGRAM),
         ("mike_stress_test", MIKE_STRESS_TEST_PROGRAM),
         ("koch snowflake", LSYSTEM_KOCH_SNOWFLAKE_PROGRAM),
+        ("nested function calls", NESTED_FN_CALLS),
     ] {
         c.bench_function(&format!("parse_{name}"), move |b| {
             b.iter(move || {
@@ -74,3 +75,20 @@ const MATH_PROGRAM: &str = include_str!("../e2e/executor/inputs/math.kcl");
 const MEDIUM_SKETCH: &str = include_str!("../e2e/executor/inputs/medium_sketch.kcl");
 const MIKE_STRESS_TEST_PROGRAM: &str = include_str!("../tests/mike_stress_test/input.kcl");
 const LSYSTEM_KOCH_SNOWFLAKE_PROGRAM: &str = include_str!("../e2e/executor/inputs/lsystem.kcl");
+// Previously had O(c^n) behaviour due to excessive backtracking in the parser, https://github.com/KittyCAD/modeling-app/issues/7866
+const NESTED_FN_CALLS: &str = "extrude(
+ close(
+  xLine(
+    yLine(
+      xLine(
+        yLine(
+          startProfile(at)
+        ),
+        length = 10
+      ),
+      length = 10
+    ),
+    length = 10
+  )
+ )
+)";

--- a/rust/kcl-lib/src/parsing/ast/types/mod.rs
+++ b/rust/kcl-lib/src/parsing/ast/types/mod.rs
@@ -125,7 +125,7 @@ impl<T> Node<T> {
         }
     }
 
-    pub fn boxed(inner: T, start: usize, end: usize, module_id: ModuleId) -> BoxNode<T> {
+    pub fn boxed(start: usize, end: usize, module_id: ModuleId, inner: T) -> BoxNode<T> {
         Box::new(Node {
             inner,
             start,

--- a/rust/kcl-lib/src/parsing/math.rs
+++ b/rust/kcl-lib/src/parsing/math.rs
@@ -28,20 +28,17 @@ fn evaluate(rpn: Vec<BinaryExpressionToken>) -> Result<Node<BinaryExpression>, C
                 let Some(left) = operand_stack.pop() else {
                     return Err(e);
                 };
-                let start = left.start();
-                let end = right.end();
-                let module_id = left.module_id();
 
                 BinaryPart::BinaryExpression(Node::boxed(
+                    left.start(),
+                    right.end(),
+                    left.module_id(),
                     BinaryExpression {
                         operator,
                         left,
                         right,
                         digest: None,
                     },
-                    start,
-                    end,
-                    module_id,
                 ))
             }
             BinaryExpressionToken::Operand(o) => o,
@@ -162,15 +159,15 @@ mod tests {
                 lit(2).into(),
                 BinaryOperator::Div.into(),
                 BinaryPart::BinaryExpression(Node::boxed(
+                    0,
+                    0,
+                    ModuleId::default(),
                     BinaryExpression {
                         operator: BinaryOperator::Sub,
                         left: lit(1),
                         right: lit(5),
                         digest: None,
                     },
-                    0,
-                    0,
-                    ModuleId::default(),
                 ))
                 .into(),
                 BinaryOperator::Pow.into(),


### PR DESCRIPTION
Fixes https://github.com/KittyCAD/modeling-app/issues/7866

This PR fixes two instances of unnecessary backtracking - one in the single unlabelled argument case of parsing function calls and one in pipeline/non-pipeline expression distinction which combined led to exponential blowup when parsing nested function calls. For the particular example in #7866 this changes non-termination in a reasonable time into practically instant.