### PR TITLE
Only update snapshots when there are failures

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -165,7 +165,7 @@ jobs:
           TARGET: web
 
       - name: Update snapshots
-        if: always()
+        if: failure()
         run: npm run test:snapshots -- --last-failed --update-snapshots
         env:
           VITE_KITTYCAD_API_TOKEN: ${{ secrets.KITTYCAD_API_TOKEN_DEV }}

--- a/e2e/playwright/snapshot-tests.spec.ts
+++ b/e2e/playwright/snapshot-tests.spec.ts
@@ -9,6 +9,9 @@ import {
 } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 import { KCL_DEFAULT_LENGTH } from '@src/lib/constants'
+import { OVERLAY_TIMEOUT_MS } from '@src/components/ModelingMachineProvider'
+
+const TEST_OVERLAY_TIMEOUT_MS = OVERLAY_TIMEOUT_MS + 500
 
 test.beforeEach(async ({ page, context }) => {
   // Make the user avatar image always 404
@@ -173,7 +176,7 @@ test(
       500 - pixelToUnitRatio * 10
     )
 
-    await page.waitForTimeout(1_500) // modeling machine timeout is 1s
+    await page.waitForTimeout(TEST_OVERLAY_TIMEOUT_MS)
     await expect(page).toHaveScreenshot({
       maxDiffPixels: 100,
       mask: lowerRightMasks(page),
@@ -203,7 +206,7 @@ test(
     await page.waitForTimeout(500)
 
     await endOfTangentMv()
-    await page.waitForTimeout(1_500) // modeling machine timeout is 1s
+    await page.waitForTimeout(TEST_OVERLAY_TIMEOUT_MS)
     await expect(page).toHaveScreenshot({
       maxDiffPixels: 100,
       mask: lowerRightMasks(page),
@@ -214,7 +217,7 @@ test(
     await page.waitForTimeout(500)
     await endOfTangentClk()
     await threePointArcMidPointMv()
-    await page.waitForTimeout(1_500) // modeling machine timeout is 1s
+    await page.waitForTimeout(TEST_OVERLAY_TIMEOUT_MS)
     await expect(page).toHaveScreenshot({
       maxDiffPixels: 100,
       mask: lowerRightMasks(page),
@@ -223,7 +226,7 @@ test(
     await page.waitForTimeout(100)
 
     await threePointArcEndPointMv()
-    await page.waitForTimeout(1_500) // modeling machine timeout is 1s
+    await page.waitForTimeout(TEST_OVERLAY_TIMEOUT_MS)
     await expect(page).toHaveScreenshot({
       maxDiffPixels: 100,
       mask: lowerRightMasks(page),
@@ -243,7 +246,7 @@ test(
     await arcCenterClk()
 
     await arcEndMv()
-    await page.waitForTimeout(1_500) // modeling machine timeout is 1s
+    await page.waitForTimeout(TEST_OVERLAY_TIMEOUT_MS)
     await expect(page).toHaveScreenshot({
       maxDiffPixels: 100,
       mask: lowerRightMasks(page),
@@ -289,7 +292,7 @@ test(
       500 - pixelToUnitRatio * 10,
       { steps: 5 }
     )
-    await page.waitForTimeout(1_500) // modeling machine timeout is 1s
+    await page.waitForTimeout(TEST_OVERLAY_TIMEOUT_MS)
 
     // Ensure the draft rectangle looks the same as it usually does
     await expect(page).toHaveScreenshot({
@@ -333,7 +336,7 @@ test(
       500 - pixelToUnitRatio * 10,
       { steps: 5 }
     )
-    await page.waitForTimeout(1_500) // modeling machine timeout is 1s
+    await page.waitForTimeout(TEST_OVERLAY_TIMEOUT_MS)
 
     // Ensure the draft circle looks the same as it usually does
     await expect(page).toHaveScreenshot({

--- a/e2e/playwright/snapshot-tests.spec.ts
+++ b/e2e/playwright/snapshot-tests.spec.ts
@@ -9,9 +9,8 @@ import {
 } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 import { KCL_DEFAULT_LENGTH } from '@src/lib/constants'
-import { OVERLAY_TIMEOUT_MS } from '@src/components/ModelingMachineProvider'
 
-const TEST_OVERLAY_TIMEOUT_MS = OVERLAY_TIMEOUT_MS + 500
+const TEST_OVERLAY_TIMEOUT_MS = 1_500 // slightly longer than OVERLAY_TIMEOUT_MS in @src/components/ModelingMachineProvider
 
 test.beforeEach(async ({ page, context }) => {
   // Make the user avatar image always 404

--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -106,6 +106,8 @@ import type { SidebarType } from '@src/components/ModelingSidebar/ModelingPanes'
 import { useNetworkContext } from '@src/hooks/useNetworkContext'
 import { resetCameraPosition } from '@src/lib/resetCameraPosition'
 
+export const OVERLAY_TIMEOUT_MS = 1_000
+
 export const ModelingMachineContext = createContext(
   {} as {
     state: StateFrom<typeof modelingMachine>
@@ -200,8 +202,7 @@ export const ModelingMachineProvider = ({
                     pathToNodeString,
                   },
                 })
-                // overlay timeout is 1s
-              }, 1000) as unknown as number
+              }, OVERLAY_TIMEOUT_MS) as unknown as number
               return {
                 ...context.segmentHoverMap,
                 [pathToNodeString]: timeoutId,

--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -106,7 +106,7 @@ import type { SidebarType } from '@src/components/ModelingSidebar/ModelingPanes'
 import { useNetworkContext } from '@src/hooks/useNetworkContext'
 import { resetCameraPosition } from '@src/lib/resetCameraPosition'
 
-export const OVERLAY_TIMEOUT_MS = 1_000
+const OVERLAY_TIMEOUT_MS = 1_000
 
 export const ModelingMachineContext = createContext(
   {} as {


### PR DESCRIPTION
Now that snapshots are more reliable, using the `--last-failed` option actually returns an error when all tests pass.

I also refactored the timeout based on this: https://github.com/KittyCAD/modeling-app/pull/7956#discussion_r2248489307