### PR TITLE
chore: patching diagnostics kcl lsp error

### DIFF
--- a/src/lang/KclSingleton.ts
+++ b/src/lang/KclSingleton.ts
@@ -234,8 +234,20 @@ export class KclManager extends EventTarget {
   }
 
   setDiagnosticsForCurrentErrors() {
-    this.singletons.editorManager?.setDiagnostics(this.diagnostics)
-    this._diagnosticsCallback(this.diagnostics)
+    let diagnostics = this.diagnostics
+    const codeIsEmptyString = this.singletons.codeManager.code.trim() === ''
+    if (codeIsEmptyString && diagnostics.length > 0) {
+      /**
+       * If the current code is the empty string, why would there be diagnostics on an empty string?
+       * The entire editor should be cleared. It cannot have diagnostics for '' since we do not
+       * tell the user if the editor is completely blank.
+       */
+      console.error('attempted diagnostics:', this.diagnostics)
+      diagnostics = []
+    }
+
+    this.singletons.editorManager?.setDiagnostics(diagnostics)
+    this._diagnosticsCallback(diagnostics)
   }
 
   get isExecuting() {


### PR DESCRIPTION
related https://github.com/KittyCAD/modeling-app/issues/7256

# Issue

When you `CRTL+A` and delete the entire KCL Editor for your file the system can keep the engine scene because the execute code will not finish.

# Debugging but cannot find exact root cause

```
chunk-JEVQZFNC.js?v=99604e51:780 Uncaught (in promise) RangeError: Position 112 is out of range for changeset of length 0
    at _ChangeSet.mapPos (chunk-JEVQZFNC.js?v=99604e51:780:13)
    at findSharedChunks (chunk-JEVQZFNC.js?v=99604e51:3076:49)
    at _RangeSet.compare (chunk-JEVQZFNC.js?v=99604e51:2871:24)
    at findChangedDeco (chunk-HHQTB6RG.js?v=99604e51:3349:12)
    at DocView.update (chunk-HHQTB6RG.js?v=99604e51:2828:20)
    at _EditorView.update (chunk-HHQTB6RG.js?v=99604e51:7203:30)
    at _EditorView.dispatchTransactions (chunk-HHQTB6RG.js?v=99604e51:7114:145)
    at _EditorView.dispatch (chunk-HHQTB6RG.js?v=99604e51:7136:10)
    at EditorManager.setDiagnostics (manager.ts:259:22)
    at KclManager.setDiagnosticsForCurrentErrors (KclSingleton.ts:237:36)
```

<img width="1007" height="288" alt="image" src="https://github.com/user-attachments/assets/b4d10f93-bd45-4208-a775-024a120f33cc" />

# Implementation

When a user does `CRTL+A` and deletes all the code it needs to `executeCode` on the empty string. The `setDiagnostics` is keeping an old diagnostics around which will try to be applied to the empty code which will crash during runtime and then won't actually execute the code because `safeParse` fails before executing the code.

e.g. The code and diagnostics are desynced for some reason. I am not able to figure out why they are desynced. 

I check if the current code is the empty string and if the any diagnostics are present. There is no way that this is possible. I rewrite them to the `[]` to prevent the code from bricking.

I still `console.error` if this happens. 

Anyone have other suggestions? I was able to reproduce this issue a few times with `CRTL+A` and `backspace` but it isn't easy. I know for a fact if you hard code some bad diagnostics into this workflow manually it will break so it is a workflow that is problematic. I just don't know where the root cause is to have these two things desync. 

