### PR TITLE
Fix signature helper editor tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,8 @@ run-desktop: install build ## Start the desktop app
 ###############################################################################
 # TEST
 
+PW_ARGS ?=
+
 E2E_GREP ?=
 E2E_WORKERS ?=
 E2E_FAILURES ?= 1
@@ -139,17 +141,17 @@ test-e2e: test-e2e-$(TARGET)
 .PHONY: test-e2e-web
 test-e2e-web: install build ## Run the web e2e tests
 ifdef E2E_GREP
-	npm run test:e2e:web -- --headed --grep="$(E2E_GREP)" --max-failures=$(E2E_FAILURES)
+	npm run test:e2e:web -- --headed --grep="$(E2E_GREP)" --max-failures=$(E2E_FAILURES) $(PW_ARGS)
 else
-	npm run test:e2e:web -- --headed --workers='100%'
+	npm run test:e2e:web -- --headed --workers='100%' $(PW_ARGS)
 endif
 
 .PHONY: test-e2e-desktop
 test-e2e-desktop: install build ## Run the desktop e2e tests
 ifdef E2E_GREP
-	npm run test:e2e:desktop -- --grep="$(E2E_GREP)" --max-failures=$(E2E_FAILURES)
+	npm run test:e2e:desktop -- --grep="$(E2E_GREP)" --max-failures=$(E2E_FAILURES) $(PW_ARGS)
 else
-	npm run test:e2e:desktop -- --workers='100%'
+	npm run test:e2e:desktop -- --workers='100%' $(PW_ARGS)
 endif
 
 .PHONY: test-snapshots

--- a/e2e/playwright/editor-tests.spec.ts
+++ b/e2e/playwright/editor-tests.spec.ts
@@ -625,6 +625,11 @@ a1 = startSketchOn(offsetPlane(XY, offset = 10))
 
     await scene.connectionEstablished()
 
+    // Wait for highlighting to kick in, a good proxy that the LSP is ready.
+    await expect
+      .poll(() => page.evaluate(() => document.querySelector('.ͼu') !== null))
+      .toBe(true)
+
     // Expect the signature help to NOT be visible
     await expect(page.locator('.cm-signature-tooltip')).not.toBeVisible()
 


### PR DESCRIPTION
The test was trying to test if the signature helper modal pops up when the user presses comma in the code editor.