### PR TITLE
test: Ignore test until engine fix merges

### DIFF
--- a/rust/kcl-lib/src/simulation_tests.rs
+++ b/rust/kcl-lib/src/simulation_tests.rs
@@ -3686,6 +3686,7 @@ mod user_reported_union_2_bug {
     }
 
     /// Test that KCL is executed correctly.
+    #[ignore]
     #[tokio::test(flavor = "multi_thread")]
     async fn kcl_test_execute() {
         super::execute(TEST_NAME, false).await


### PR DESCRIPTION
https://github.com/KittyCAD/engine/pull/3688 will change the output of this. We can re-enable this when it merges.