### PR TITLE
Use explicit units for angles in autocomplete

### DIFF
--- a/rust/kcl-lib/src/docs/kcl_doc.rs
+++ b/rust/kcl-lib/src/docs/kcl_doc.rs
@@ -814,7 +814,16 @@ impl ArgData {
         }
         match self.ty.as_deref() {
             Some("Sketch") if self.kind == ArgKind::Special => None,
-            Some(s) if s.starts_with("number") => Some((index, format!(r#"{label}${{{index}:10}}"#))),
+            Some(s) if s.starts_with("number") => {
+                let value = match &*self.name {
+                    "angleStart" => "0",
+                    "angleEnd" => "180deg",
+                    "angle" => "180deg",
+                    "arcDegrees" => "360deg",
+                    _ => "10",
+                };
+                Some((index, format!(r#"{label}${{{index}:{value}}}"#)))
+            }
             Some("Point2d") => Some((index + 1, format!(r#"{label}[${{{}:0}}, ${{{}:0}}]"#, index, index + 1))),
             Some("Point3d") => Some((
                 index + 2,

--- a/rust/kcl-lib/src/docs/mod.rs
+++ b/rust/kcl-lib/src/docs/mod.rs
@@ -106,7 +106,7 @@ mod tests {
         let snippet = data.to_autocomplete_snippet();
         assert_eq!(
             snippet,
-            r#"arc(angleStart = ${0:10}, angleEnd = ${1:10}, diameter = ${2:10})"#
+            r#"arc(angleStart = ${0:0}, angleEnd = ${1:180deg}, diameter = ${2:10})"#
         );
     }
 
@@ -172,7 +172,7 @@ mod tests {
         let snippet = helix_fn.to_autocomplete_snippet();
         assert_eq!(
             snippet,
-            r#"helix(revolutions = ${0:10}, angleStart = ${1:10}, radius = ${2:10}, axis = ${3:X}, length = ${4:10})"#
+            r#"helix(revolutions = ${0:10}, angleStart = ${1:0}, radius = ${2:10}, axis = ${3:X}, length = ${4:10})"#
         );
     }
 


### PR DESCRIPTION
Uses better default values for and explicit units for angle arguments.

Pulled out of https://github.com/KittyCAD/modeling-app/pull/7502