### PR TITLE
Fix the types of electron functions and awaiting rename

### DIFF
--- a/interface.d.ts
+++ b/interface.d.ts
@@ -47,12 +47,14 @@ export interface IElectronAPI {
   writeFile: (
     path: string,
     data: string | Uint8Array
-  ) => ReturnType<fs.writeFile>
-  readdir: (path: string) => ReturnType<fs.readdir>
-  exists: (path: string) => ReturnType<fs.exists>
+  ) => ReturnType<typeof fs.writeFile>
+  readdir: (path: string) => Promise<string[]>
+  // This is synchronous.
+  exists: (path: string) => boolean
   getPath: (name: string) => Promise<string>
   rm: typeof fs.rm
-  stat: (path: string) => ReturnType<fs.stat>
+  // TODO: Use a real return type.
+  stat: (path: string) => Promise<any>
   statIsDirectory: (path: string) => Promise<boolean>
   canReadWriteDirectory: (
     path: string
@@ -61,7 +63,7 @@ export interface IElectronAPI {
   mkdir: typeof fs.mkdir
   join: typeof path.join
   sep: typeof path.sep
-  rename: (prev: string, next: string) => typeof fs.rename
+  rename: (prev: string, next: string) => ReturnType<typeof fs.rename>
   packageJson: {
     name: string
   }

--- a/src/components/FileMachineProvider.tsx
+++ b/src/components/FileMachineProvider.tsx
@@ -294,7 +294,7 @@ export const FileMachineProvider = ({
             }
           }
 
-          window.electron.rename(oldPath, newPath)
+          await window.electron.rename(oldPath, newPath)
 
           if (!file) {
             return Promise.reject(new Error('file is not defined'))

--- a/src/machines/systemIO/systemIOMachineDesktop.ts
+++ b/src/machines/systemIO/systemIOMachineDesktop.ts
@@ -457,7 +457,7 @@ export const systemIOMachineDesktop = systemIOMachine.provide({
           }
         }
 
-        window.electron.rename(oldPath, newPath)
+        await window.electron.rename(oldPath, newPath)
 
         return {
           message: `Successfully renamed folder "${folderName}" to "${requestedFolderName}"`,
@@ -523,7 +523,7 @@ export const systemIOMachineDesktop = systemIOMachine.provide({
           }
         }
 
-        window.electron.rename(oldPath, newPath)
+        await window.electron.rename(oldPath, newPath)
 
         return {
           message: `Successfully renamed file "${fileNameWithExtension}" to "${requestedFileNameWithExtension}"`,


### PR DESCRIPTION
I noticed that the types of some of our electron types are wrong. `ReturnType<foo>` is wrong; it always evaluates to `any`. You need to use `ReturnType<typeof foo>`.

Unfortunately, the type of `fs.stat` doesn't match what we use, so we should fix that in another PR, which seems non-trivial. Our `FileMetadata` type likely needs to get updated.