### PR TITLE
#8030 Sketch mode navigation improvements

### DIFF
--- a/src/clientSideScene/CameraControls.ts
+++ b/src/clientSideScene/CameraControls.ts
@@ -7,8 +7,7 @@ import { isArray } from '@src/lib/utils'
 import type { EngineStreamActor } from '@src/machines/engineStreamMachine'
 import * as TWEEN from '@tweenjs/tween.js'
 import Hammer from 'hammerjs'
-import type {
-  Camera} from 'three';
+import type { Camera } from 'three'
 import {
   Euler,
   MathUtils,


### PR DESCRIPTION
Fixes #8030

- [x] Keep focus under the mouse when zooming
- [x] Keep point under the mouse when panning
- [ ] Allow panning outside of electron window

Also, I think we could add support for zooming with a trackpad by default, the current behaviour of needing to switch to Trackpad friendly + using option + shift + left click is buried too deep and seems inconvenient (?)   