### PR TITLE
Fix conflict between local (debug) and production app settings

### DIFF
--- a/src/lib/desktop.ts
+++ b/src/lib/desktop.ts
@@ -27,7 +27,7 @@ import type { FileEntry, FileMetadata, Project } from '@src/lib/project'
 import { err } from '@src/lib/trap'
 import type { DeepPartial } from '@src/lib/types'
 import { getInVariableCase } from '@src/lib/utils'
-import { IS_STAGING } from '@src/routes/utils'
+import { IS_STAGING, IS_STAGING_OR_DEBUG } from '@src/routes/utils'
 import { withAPIBaseURL } from '@src/lib/withBaseURL'
 
 export async function renameProjectDirectory(
@@ -466,10 +466,13 @@ export async function writeProjectSettingsFile(
 }
 
 // Important for saving settings.
-// TODO: should be pulled from electron-builder.yml
-const APP_ID = IS_STAGING
-  ? 'dev.zoo.modeling-app-staging'
-  : 'dev.zoo.modeling-app'
+let APP_ID = 'dev.zoo.modeling-app'
+if (IS_STAGING) {
+  APP_ID = `${APP_ID}-staging`
+}
+if (IS_STAGING_OR_DEBUG) {
+  APP_ID = `${APP_ID}-debug`
+}
 
 const getAppFolderName = () => {
   if (window.electron.os.isMac || window.electron.os.isWindows) {


### PR DESCRIPTION
# Before

The local desktop app conflicts with the production app usage:

1. Launch  the production **Zoo Design Studio** (ZDS) and log into `zoo.dev`
2. Close the production ZDS
3. `$ make run-desktop` and log into `dev.zoo.dev`
4. Close the local ZDS
5. Launch  the production ZDS again
6. [Bug] Observe that you are logged out and it's defaulting to `dev.zoo.dev`

The production desktop app conflicts with local app development:

1. Set `$VITE_KITTYCAD_API_TOKEN` and `$ make run-desktop` to log into `dev.zoo.dev`
2. Close the local ZDS
3. Launch  the production ZDS and log into `zoo.dev`
4. Close the production ZDS
5. `$ make run-desktop` again
6. [Bug] Observe that `$VITE_KITTYCAD_API_TOKEN` is ignored an it's defaulting to `zoo.dev`

# After

The local and production desktop apps have separate environment settings. This means we can use the production **Zoo Design Studio** as normal while not interrupting our local development environments.