### PR TITLE
Preserve the original folder for settings in the staging app

### DIFF
--- a/src/lib/desktop.ts
+++ b/src/lib/desktop.ts
@@ -469,9 +469,8 @@ export async function writeProjectSettingsFile(
 let APP_ID = 'dev.zoo.modeling-app'
 if (IS_STAGING) {
   APP_ID = `${APP_ID}-staging`
-}
-if (IS_STAGING_OR_DEBUG) {
-  APP_ID = `${APP_ID}-debug`
+} else if (IS_STAGING_OR_DEBUG) {
+  APP_ID = `${APP_ID}-local`
 }
 
 const getAppFolderName = () => {


### PR DESCRIPTION
Amends https://github.com/KittyCAD/modeling-app/pull/8058 so that folks don't have their **Zoo Design Studio (Staging)** settings reset.