### PR TITLE
Fix CSP

### DIFF
--- a/vite.base.config.ts
+++ b/vite.base.config.ts
@@ -123,7 +123,7 @@ export function indexHtmlCsp(enabled: boolean): Plugin {
     // Allow inline styles and styles from the same origin. This is how we use CSS rightnow.
     "style-src 'self' 'unsafe-inline'",
     // Allow images from any source and inline images. We fetch user profile images from any origin.
-    "img-src * blob: 'unsafe-inline'",
+    "img-src * blob: data: 'unsafe-inline'",
     // Allow WebSocket connections and fetches to our API.
     "connect-src 'self' https://plausible.corp.zoo.dev https://api.zoo.dev wss://api.zoo.dev https://api.dev.zoo.dev wss://api.dev.zoo.dev https://api.zoogov.dev wss://api.zoogov.dev",
     // Disallow legacy stuff


### PR DESCRIPTION
Fixes:

```
index-Dlgm-ieD.js:29540 Refused to load the image 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="6" height="3">%3Cpath%20d%3D%22m0%202.5%20l2%20-1.5%20l1%200%20l2%201.5%20l1%200%22%20stroke%3D%22%23999%22%20fill%3D%22none%22%20stroke-width%3D%22.7%22%2F%3E</svg>' because it violates the following Content Security Policy directive: "img-src * blob: 'unsafe-inline'". Note that '*' matches only URLs with network schemes ('http', 'https', 'ws', 'wss'), or URLs whose scheme matches `self`'s scheme. The scheme 'data:' must be added explicitly.
```