### PR TITLE
#8105 Dimensions labels obstruct draft segment position

### DIFF
--- a/src/clientSideScene/sceneInfra.ts
+++ b/src/clientSideScene/sceneInfra.ts
@@ -444,8 +444,11 @@ export class SceneInfra {
   private _lastUnprocessedMouseEvent: MouseEvent | undefined
 
   private updateCurrentMouseVector(event: MouseEvent, target: HTMLElement) {
-    this.currentMouseVector.x = (event.offsetX / target.clientWidth) * 2 - 1
-    this.currentMouseVector.y = -(event.offsetY / target.clientHeight) * 2 + 1
+    const rect = target.getBoundingClientRect()
+    const localX = event.clientX - rect.left
+    const localY = event.clientY - rect.top
+    this.currentMouseVector.x = (localX / rect.width) * 2 - 1
+    this.currentMouseVector.y = -(localY / rect.height) * 2 + 1
   }
 
   onMouseMove = async (mouseEvent: MouseEvent) => {

--- a/src/clientSideScene/sceneInfra.ts
+++ b/src/clientSideScene/sceneInfra.ts
@@ -443,6 +443,11 @@ export class SceneInfra {
   private _processingMouseMove = false
   private _lastUnprocessedMouseEvent: MouseEvent | undefined
 
+  private updateCurrentMouseVector(event: MouseEvent, target: HTMLElement) {
+    this.currentMouseVector.x = (event.offsetX / target.clientWidth) * 2 - 1
+    this.currentMouseVector.y = -(event.offsetY / target.clientHeight) * 2 + 1
+  }
+
   onMouseMove = async (mouseEvent: MouseEvent) => {
     if (!(mouseEvent.currentTarget instanceof HTMLElement)) {
       console.error('unexpected targetless event')
@@ -461,10 +466,7 @@ export class SceneInfra {
       this._processingMouseMove = true
     }
 
-    this.currentMouseVector.x =
-      (mouseEvent.offsetX / mouseEvent.currentTarget.clientWidth) * 2 - 1
-    this.currentMouseVector.y =
-      -(mouseEvent.offsetY / mouseEvent.currentTarget.clientHeight) * 2 + 1
+    this.updateCurrentMouseVector(mouseEvent, mouseEvent.currentTarget)
 
     const planeIntersectPoint = this.getPlaneIntersectPoint()
     const intersects = this.raycastRing()
@@ -640,10 +642,7 @@ export class SceneInfra {
       console.error('unexpected targetless event')
       return
     }
-    this.currentMouseVector.x =
-      (event.offsetX / event.currentTarget.clientWidth) * 2 - 1
-    this.currentMouseVector.y =
-      -(event.offsetY / event.currentTarget.clientHeight) * 2 + 1
+    this.updateCurrentMouseVector(event, event.currentTarget)
 
     const mouseDownVector = this.currentMouseVector.clone()
     const intersect = this.raycastRing()[0]
@@ -665,10 +664,7 @@ export class SceneInfra {
       console.error('unexpected targetless event')
       return
     }
-    this.currentMouseVector.x =
-      (mouseEvent.offsetX / mouseEvent.currentTarget.clientWidth) * 2 - 1
-    this.currentMouseVector.y =
-      -(mouseEvent.offsetY / mouseEvent.currentTarget.clientHeight) * 2 + 1
+    this.updateCurrentMouseVector(mouseEvent, mouseEvent.currentTarget)
     const planeIntersectPoint = this.getPlaneIntersectPoint()
     const intersects = this.raycastRing()
 


### PR DESCRIPTION
Fixes #8105 

The problem was that `event.offsetX` is based on `event.target` not `event.currentTarget`.

Other option would be to disable those dom elements during drafting, but that seemed less robust to me: easy to add new dom elements later that could still lead to a similar issue, this way is more future proof.
(Or using pointer events but it's a bit more complicated.)

Could use a test too if I can add one which is robust and not rely on exact pixel coordinates too much..