### PR TITLE
Rename "Text-to-CAD Create" command to "Create project using Text-to-CAD"

### DIFF
--- a/e2e/playwright/command-bar-tests.spec.ts
+++ b/e2e/playwright/command-bar-tests.spec.ts
@@ -762,7 +762,7 @@ theta = 45deg
     await homePage.textToCadBtn.click()
     await cmdBar.expectState({
       stage: 'arguments',
-      commandName: 'Text-to-CAD Create',
+      commandName: 'Create Project using Text-to-CAD',
       currentArgKey: 'prompt',
       currentArgValue: '',
       headerArguments: {

--- a/e2e/playwright/text-to-cad-tests.spec.ts
+++ b/e2e/playwright/text-to-cad-tests.spec.ts
@@ -156,10 +156,12 @@ async function sendPromptFromCommandBarAndSetNewProject(
   await page.waitForTimeout(1000)
   await test.step(`Send prompt from command bar: ${promptStr}`, async () => {
     await cmdBar.openCmdBar()
-    await cmdBar.selectOption({ name: 'Text-to-CAD Create' }).click()
+    await cmdBar
+      .selectOption({ name: 'Create Project using Text-to-CAD' })
+      .click()
 
     await cmdBar.expectState({
-      commandName: 'Text-to-CAD Create',
+      commandName: 'Create Project using Text-to-CAD',
       stage: 'arguments',
       currentArgKey: 'method',
       currentArgValue: '',
@@ -172,7 +174,7 @@ async function sendPromptFromCommandBarAndSetNewProject(
     await cmdBar.progressCmdBar()
 
     await cmdBar.expectState({
-      commandName: 'Text-to-CAD Create',
+      commandName: 'Create Project using Text-to-CAD',
       stage: 'arguments',
       currentArgKey: 'newProjectName',
       currentArgValue: '',
@@ -187,7 +189,7 @@ async function sendPromptFromCommandBarAndSetNewProject(
     await cmdBar.progressCmdBar()
 
     await cmdBar.expectState({
-      commandName: 'Text-to-CAD Create',
+      commandName: 'Create Project using Text-to-CAD',
       stage: 'arguments',
       currentArgKey: 'prompt',
       currentArgValue: '',

--- a/src/lib/commandBarConfigs/applicationCommandConfig.ts
+++ b/src/lib/commandBarConfigs/applicationCommandConfig.ts
@@ -142,7 +142,7 @@ export function createApplicationCommands({
   const textToCADCommand: Command = {
     name: 'Text-to-CAD',
     description: 'Generate parts from text prompts.',
-    displayName: 'Text-to-CAD Create',
+    displayName: 'Create Project using Text-to-CAD',
     groupId: 'application',
     needsReview: false,
     status: IS_ML_EXPERIMENTAL ? 'experimental' : 'active',


### PR DESCRIPTION
To better reflect how this command's use has changed after the migration to a conversational-style TTC system in #7542