### PR TITLE
Don't include the current file prompt if there is no current file

### DIFF
--- a/src/components/ModelingSidebar/ModelingPanes/MlEphantConversationPane.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/MlEphantConversationPane.tsx
@@ -61,12 +61,15 @@ export const MlEphantConversationPane = (props: {
       console.warn('theProject is `undefined` - should not be possible')
       return
     }
+    if (props.loaderFile === undefined) {
+      console.warn('loaderFile is `undefined` - should not be possible')
+      return
+    }
 
     const projectFiles = await collectProjectFiles({
       selectedFileContents: props.codeManager.code,
       fileNames: props.kclManager.execState.filenames,
       projectContext: props.theProject,
-      targetFile: props.loaderFile,
     })
 
     // Only on initial project creation do we call the create endpoint, which
@@ -76,6 +79,7 @@ export const MlEphantConversationPane = (props: {
       type: MlEphantManagerTransitions.PromptEditModel,
       prompt: requestedPrompt,
       projectForPromptOutput: props.theProject,
+      applicationProjectDirectory: props.settings.app.projectDirectory.current,
       fileSelectedDuringPrompting: {
         entry: props.loaderFile,
         content: props.codeManager.code,

--- a/src/lib/promptToEdit.tsx
+++ b/src/lib/promptToEdit.tsx
@@ -12,6 +12,7 @@ import type {
   PromptToEditRequest,
   TextToCadErrorResponse,
 } from '@src/lib/promptToEditTypes'
+import { parentPathRelativeToProject } from './paths'
 
 function sourceIndexToLineColumn(
   code: string,
@@ -57,7 +58,10 @@ export async function submitTextToCadMultiFileIterationRequest(
   )
 
   if (!response.ok) {
-    return new Error(`HTTP error! status: ${response.status}`)
+    const errorBody = await response.json()
+    return new Error(
+      `HTTP error! status: ${response.status}, error: ${JSON.stringify(errorBody)}`
+    )
   }
 
   const data = await response.json()
@@ -77,6 +81,7 @@ export function constructMultiFileIterationRequestWithPromptHelpers({
   prompt,
   selections,
   projectFiles,
+  applicationProjectDirectory,
   artifactGraph,
   projectName,
   currentFile,
@@ -84,9 +89,7 @@ export function constructMultiFileIterationRequestWithPromptHelpers({
 }: ConstructRequestArgs): PromptToEditRequest {
   const kclFilesMap: KclFileMetaMap = {}
   const files: KittyCadLibFile[] = []
-  const currentFileMeta = projectFiles.find(
-    (f) => f.type !== 'other' && f.absPath === currentFile.entry?.path
-  )
+
   projectFiles.forEach((file) => {
     let data: Blob
     if (file.type === 'other') {
@@ -104,21 +107,31 @@ export function constructMultiFileIterationRequestWithPromptHelpers({
 
   // Way to patch in supplying the currently-opened file without updating the API.
   // TODO: update the API to support currently-opened files as other parts of the payload
-  const currentFilePrompt: Models['SourceRangePrompt_type'] = {
-    prompt: 'This is the active file',
-    range: convertAppRangeToApiRange(
-      [0, currentFile.content.length, 0],
-      currentFile.content
-    ),
-    file: currentFileMeta?.relPath,
-  }
+  const currentFilePrompt: Models['SourceRangePrompt_type'] | null =
+    currentFile.entry
+      ? {
+          prompt: 'This is the active file',
+          range: convertAppRangeToApiRange(
+            [0, currentFile.content.length, 0],
+            currentFile.content
+          ),
+          file: parentPathRelativeToProject(
+            currentFile.entry?.path,
+            applicationProjectDirectory
+          ),
+        }
+      : null
 
   // If no selection, use whole file
   if (selections === null) {
+    const rangePrompts: Models['SourceRangePrompt_type'][] = []
+    if (currentFilePrompt !== null) {
+      rangePrompts.push(currentFilePrompt)
+    }
     return {
       body: {
         prompt,
-        source_ranges: [currentFilePrompt],
+        source_ranges: rangePrompts,
         project_name:
           projectName !== '' && projectName !== 'browser'
             ? projectName
@@ -261,7 +274,9 @@ See later source ranges for more context. about the sweep`,
       return prompts
     })
   // Push the current file prompt alongside the selection-based prompts
-  ranges.push(currentFilePrompt)
+  if (currentFilePrompt !== null) {
+    ranges.push(currentFilePrompt)
+  }
   let payload = {
     body: {
       prompt,

--- a/src/lib/promptToEditTypes.ts
+++ b/src/lib/promptToEditTypes.ts
@@ -27,6 +27,7 @@ export interface PromptToEditRequest {
 export interface ConstructRequestArgs {
   conversationId?: string
   prompt: string
+  applicationProjectDirectory: string
   selections: Selections | null
   projectFiles: FileMeta[]
   projectName: string

--- a/src/machines/mlEphantManagerMachine.ts
+++ b/src/machines/mlEphantManagerMachine.ts
@@ -81,7 +81,8 @@ export type MlEphantManagerEvents =
       type: MlEphantManagerTransitions.PromptEditModel
       projectForPromptOutput: Project
       prompt: string
-      fileSelectedDuringPrompting: { entry?: FileEntry; content: string }
+      applicationProjectDirectory: string
+      fileSelectedDuringPrompting: { entry: FileEntry; content: string }
       projectFiles: FileMeta[]
       selections: Selections
       artifactGraph: ArtifactGraph
@@ -377,6 +378,7 @@ export const mlEphantManagerMachine = setup({
             conversationId: context.conversationId,
             prompt: event.prompt,
             selections: event.selections,
+            applicationProjectDirectory: event.applicationProjectDirectory,
             projectFiles: event.projectFiles,
             artifactGraph: event.artifactGraph,
             projectName: event.projectForPromptOutput.name,

--- a/src/machines/systemIO/utils.ts
+++ b/src/machines/systemIO/utils.ts
@@ -227,7 +227,6 @@ export const determineProjectFilePathFromPrompt = (
 export const collectProjectFiles = async (args: {
   selectedFileContents: string
   fileNames: ExecState['filenames']
-  targetFile?: FileEntry
   projectContext?: Project
 }) => {
   let projectFiles: FileMeta[] = [


### PR DESCRIPTION
And use more correct utility to get the current file. It was failing in the browser version of the app because the way I got the relative path to the current file was incorrect.