### PR TITLE
Allow multiple unlabelled arguments if the input arg is an array

### DIFF
--- a/rust/kcl-error/src/source_range.rs
+++ b/rust/kcl-error/src/source_range.rs
@@ -92,6 +92,22 @@ impl SourceRange {
         Self::default()
     }
 
+    pub fn merge(mut ranges: impl Iterator<Item = SourceRange>) -> Self {
+        let mut result = ranges.next().unwrap_or_default();
+
+        for r in ranges {
+            debug_assert!(r.0[2] == result.0[2], "Merging source ranges from different files");
+            if r.0[0] < result.0[0] {
+                result.0[0] = r.0[0]
+            }
+            if r.0[1] > result.0[1] {
+                result.0[1] = r.0[1];
+            }
+        }
+
+        result
+    }
+
     /// True if this is a source range that doesn't correspond to any source
     /// code.
     pub fn is_synthetic(&self) -> bool {

--- a/rust/kcl-lib/src/execution/cad_op.rs
+++ b/rust/kcl-lib/src/execution/cad_op.rs
@@ -8,6 +8,7 @@ use crate::{ModuleId, NodePath, SourceRange, parsing::ast::types::ItemVisibility
 
 /// A CAD modeling operation for display in the feature tree, AKA operations
 /// timeline.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize, PartialEq, ts_rs::TS)]
 #[ts(export_to = "Operation.ts")]
 #[serde(tag = "type")]

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1210,7 +1210,7 @@ impl Node<BinaryExpression> {
         // Then check if we have solids.
         if self.operator == BinaryOperator::Add || self.operator == BinaryOperator::Or {
             if let (KclValue::Solid { value: left }, KclValue::Solid { value: right }) = (&left_value, &right_value) {
-                let args = Args::new(Default::default(), self.into(), ctx.clone(), None);
+                let args = Args::new_no_args(self.into(), ctx.clone());
                 let result = crate::std::csg::inner_union(
                     vec![*left.clone(), *right.clone()],
                     Default::default(),
@@ -1223,7 +1223,7 @@ impl Node<BinaryExpression> {
         } else if self.operator == BinaryOperator::Sub {
             // Check if we have solids.
             if let (KclValue::Solid { value: left }, KclValue::Solid { value: right }) = (&left_value, &right_value) {
-                let args = Args::new(Default::default(), self.into(), ctx.clone(), None);
+                let args = Args::new_no_args(self.into(), ctx.clone());
                 let result = crate::std::csg::inner_subtract(
                     vec![*left.clone()],
                     vec![*right.clone()],
@@ -1237,7 +1237,7 @@ impl Node<BinaryExpression> {
         } else if self.operator == BinaryOperator::And {
             // Check if we have solids.
             if let (KclValue::Solid { value: left }, KclValue::Solid { value: right }) = (&left_value, &right_value) {
-                let args = Args::new(Default::default(), self.into(), ctx.clone(), None);
+                let args = Args::new_no_args(self.into(), ctx.clone());
                 let result = crate::std::csg::inner_intersect(
                     vec![*left.clone(), *right.clone()],
                     Default::default(),

--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -17,48 +17,83 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
-pub struct Args {
-    /// Positional args.
-    pub args: Vec<Arg>,
-    /// Keyword arguments
-    pub kw_args: KwArgs,
+pub struct Args<Status: ArgsStatus = Desugared> {
+    /// Unlabeled keyword args. Currently only the first formal arg can be unlabeled.
+    /// If the argument was a local variable, then the first element of the tuple is its name
+    /// which may be used to treat this arg as a labelled arg.
+    pub unlabeled: Vec<(Option<String>, Arg)>,
+    /// Labeled args.
+    pub labeled: IndexMap<String, Arg>,
     pub source_range: SourceRange,
     pub ctx: ExecutorContext,
     /// If this call happens inside a pipe (|>) expression, this holds the LHS of that |>.
     /// Otherwise it's None.
     pub pipe_value: Option<Arg>,
+    _status: std::marker::PhantomData<Status>,
 }
 
-impl Args {
-    pub fn new(args: Vec<Arg>, source_range: SourceRange, ctx: ExecutorContext, pipe_value: Option<Arg>) -> Self {
-        Self {
-            args,
-            kw_args: Default::default(),
+pub trait ArgsStatus: std::fmt::Debug + Clone {}
+
+#[derive(Debug, Clone)]
+pub struct Sugary;
+impl ArgsStatus for Sugary {}
+
+// Invariants guaranteed by the `Desugared` status:
+// - There is either 0 or 1 unlabeled arguments
+// - Any lableled args are in the labeled map, and not the unlabeled Vec.
+// - The arguments match the type signature of the function exactly
+// - pipe_value.is_none()
+#[derive(Debug, Clone)]
+pub struct Desugared;
+impl ArgsStatus for Desugared {}
+
+impl Args<Sugary> {
+    /// Collect the given keyword arguments.
+    pub fn new(
+        labeled: IndexMap<String, Arg>,
+        unlabeled: Vec<(Option<String>, Arg)>,
+        source_range: SourceRange,
+        exec_state: &mut ExecState,
+        ctx: ExecutorContext,
+    ) -> Args<Sugary> {
+        Args {
+            labeled,
+            unlabeled,
             source_range,
             ctx,
-            pipe_value,
+            pipe_value: exec_state.pipe_value().map(|v| Arg::new(v.clone(), source_range)),
+            _status: std::marker::PhantomData,
         }
     }
+}
 
-    /// Collect the given keyword arguments.
-    pub fn new_kw(kw_args: KwArgs, source_range: SourceRange, ctx: ExecutorContext, pipe_value: Option<Arg>) -> Self {
-        Self {
-            args: Default::default(),
-            kw_args,
+impl<Status: ArgsStatus> Args<Status> {
+    /// How many arguments are there?
+    pub fn len(&self) -> usize {
+        self.labeled.len() + self.unlabeled.len()
+    }
+
+    /// Are there no arguments?
+    pub fn is_empty(&self) -> bool {
+        self.labeled.is_empty() && self.unlabeled.is_empty()
+    }
+}
+
+impl Args<Desugared> {
+    pub fn new_no_args(source_range: SourceRange, ctx: ExecutorContext) -> Args {
+        Args {
+            unlabeled: Default::default(),
+            labeled: Default::default(),
             source_range,
             ctx,
-            pipe_value,
+            pipe_value: None,
+            _status: std::marker::PhantomData,
         }
     }
 
     /// Get the unlabeled keyword argument. If not set, returns None.
     pub(crate) fn unlabeled_kw_arg_unconverted(&self) -> Option<&Arg> {
-        self.kw_args
-            .unlabeled
-            .as_ref()
-            .map(|(_, a)| a)
-            .or(self.args.first())
-            .or(self.pipe_value.as_ref())
+        self.unlabeled.first().map(|(_, a)| a)
     }
 }
 
@@ -84,28 +119,6 @@ impl Arg {
 
     pub fn source_ranges(&self) -> Vec<SourceRange> {
         vec![self.source_range]
-    }
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct KwArgs {
-    /// Unlabeled keyword args. Currently only the first arg can be unlabeled.
-    /// If the argument was a local variable, then the first element of the tuple is its name
-    /// which may be used to treat this arg as a labelled arg.
-    pub unlabeled: Option<(Option<String>, Arg)>,
-    /// Labeled args.
-    pub labeled: IndexMap<String, Arg>,
-    pub errors: Vec<Arg>,
-}
-
-impl KwArgs {
-    /// How many arguments are there?
-    pub fn len(&self) -> usize {
-        self.labeled.len() + if self.unlabeled.is_some() { 1 } else { 0 }
-    }
-    /// Are there no arguments?
-    pub fn is_empty(&self) -> bool {
-        self.labeled.len() == 0 && self.unlabeled.is_none()
     }
 }
 
@@ -199,7 +212,7 @@ impl Node<CallExpressionKw> {
 
         // Clone the function so that we can use a mutable reference to
         // exec_state.
-        let func = fn_name.get_result(exec_state, ctx).await?.clone();
+        let func: KclValue = fn_name.get_result(exec_state, ctx).await?.clone();
 
         let Some(fn_src) = func.as_function() else {
             return Err(KclError::new_semantic(KclErrorDetails::new(
@@ -208,8 +221,12 @@ impl Node<CallExpressionKw> {
             )));
         };
 
+        // Build a hashmap from argument labels to the final evaluated values.
+        let mut fn_args = IndexMap::with_capacity(self.arguments.len());
+        let mut unlabeled = Vec::new();
+
         // Evaluate the unlabeled first param, if any exists.
-        let unlabeled = if let Some(ref arg_expr) = self.unlabeled {
+        if let Some(ref arg_expr) = self.unlabeled {
             let source_range = SourceRange::from(arg_expr.clone());
             let metadata = Metadata { source_range };
             let value = ctx
@@ -218,14 +235,9 @@ impl Node<CallExpressionKw> {
 
             let label = arg_expr.ident_name().map(str::to_owned);
 
-            Some((label, Arg::new(value, source_range)))
-        } else {
-            None
-        };
+            unlabeled.push((label, Arg::new(value, source_range)))
+        }
 
-        // Build a hashmap from argument labels to the final evaluated values.
-        let mut fn_args = IndexMap::with_capacity(self.arguments.len());
-        let mut errors = Vec::new();
         for arg_expr in &self.arguments {
             let source_range = SourceRange::from(arg_expr.arg.clone());
             let metadata = Metadata { source_range };
@@ -238,25 +250,12 @@ impl Node<CallExpressionKw> {
                     fn_args.insert(l.name.clone(), arg);
                 }
                 None => {
-                    if let Some(id) = arg_expr.arg.ident_name() {
-                        fn_args.insert(id.to_owned(), arg);
-                    } else {
-                        errors.push(arg);
-                    }
+                    unlabeled.push((arg_expr.arg.ident_name().map(str::to_owned), arg));
                 }
             }
         }
 
-        let args = Args::new_kw(
-            KwArgs {
-                unlabeled,
-                labeled: fn_args,
-                errors,
-            },
-            self.into(),
-            ctx.clone(),
-            exec_state.pipe_value().map(|v| Arg::new(v.clone(), callsite)),
-        );
+        let args = Args::new(fn_args, unlabeled, callsite, exec_state, ctx.clone());
 
         let return_value = fn_src
             .call_kw(Some(fn_name.to_string()), exec_state, ctx, args, callsite)
@@ -294,7 +293,7 @@ impl FunctionDefinition<'_> {
         fn_name: Option<String>,
         exec_state: &mut ExecState,
         ctx: &ExecutorContext,
-        mut args: Args,
+        args: Args<Sugary>,
         callsite: SourceRange,
     ) -> Result<Option<KclValue>, KclError> {
         if self.deprecated {
@@ -322,14 +321,13 @@ impl FunctionDefinition<'_> {
             );
         }
 
-        type_check_params_kw(fn_name.as_deref(), self, &mut args.kw_args, exec_state)?;
+        let args = type_check_params_kw(fn_name.as_deref(), self, args, exec_state)?;
 
         // Don't early return until the stack frame is popped!
         self.body.prep_mem(exec_state);
 
         let op = if self.include_in_feature_tree {
             let op_labeled_args = args
-                .kw_args
                 .labeled
                 .iter()
                 .map(|(k, arg)| (k.clone(), OpArg::new(OpKclValue::from(&arg.value), arg.source_range)))
@@ -352,10 +350,8 @@ impl FunctionDefinition<'_> {
                         name: fn_name.clone(),
                         function_source_range: self.as_source_range().unwrap(),
                         unlabeled_arg: args
-                            .kw_args
-                            .unlabeled
-                            .as_ref()
-                            .map(|arg| OpArg::new(OpKclValue::from(&arg.1.value), arg.1.source_range)),
+                            .unlabeled_kw_arg_unconverted()
+                            .map(|arg| OpArg::new(OpKclValue::from(&arg.value), arg.source_range)),
                         labeled_args: op_labeled_args,
                     },
                     node_path: NodePath::placeholder(),
@@ -433,7 +429,7 @@ impl FunctionSource {
         fn_name: Option<String>,
         exec_state: &mut ExecState,
         ctx: &ExecutorContext,
-        args: Args,
+        args: Args<Sugary>,
         callsite: SourceRange,
     ) -> Result<Option<KclValue>, KclError> {
         let def: FunctionDefinition = self.into();
@@ -593,67 +589,124 @@ fn type_err_str(expected: &Type, found: &KclValue, source_range: &SourceRange, e
 fn type_check_params_kw(
     fn_name: Option<&str>,
     fn_def: &FunctionDefinition<'_>,
-    args: &mut KwArgs,
+    mut args: Args<Sugary>,
     exec_state: &mut ExecState,
-) -> Result<(), KclError> {
+) -> Result<Args<Desugared>, KclError> {
+    let mut result = Args::new_no_args(args.source_range, args.ctx);
+
     // If it's possible the input arg was meant to be labelled and we probably don't want to use
     // it as the input arg, then treat it as labelled.
-    if let Some((Some(label), _)) = &args.unlabeled
-        && (fn_def.input_arg.is_none() || exec_state.pipe_value().is_some())
+    if let Some((Some(label), _)) = args.unlabeled.first()
+        && args.unlabeled.len() == 1
+        && (fn_def.input_arg.is_none() || args.pipe_value.is_some())
         && fn_def.named_args.iter().any(|p| p.0 == label)
         && !args.labeled.contains_key(label)
     {
-        let (label, arg) = args.unlabeled.take().unwrap();
+        let (label, arg) = args.unlabeled.pop().unwrap();
         args.labeled.insert(label.unwrap(), arg);
     }
 
-    for (label, arg) in &mut args.labeled {
-        match fn_def.named_args.get(label) {
-            Some((def, ty)) => {
-                // For optional args, passing None should be the same as not passing an arg.
-                if !(def.is_some() && matches!(arg.value, KclValue::KclNone { .. }))
-                    && let Some(ty) = ty
-                {
-                    let rty = RuntimeType::from_parsed(ty.clone(), exec_state, arg.source_range)
-                        .map_err(|e| KclError::new_semantic(e.into()))?;
-                    arg.value = arg
-                            .value
-                            .coerce(
-                                &rty,
-                                true,
-                                exec_state,
-                            )
-                            .map_err(|e| {
-                                let mut message = format!(
-                                    "{label} requires {}",
-                                    type_err_str(ty, &arg.value, &arg.source_range, exec_state),
-                                );
-                                if let Some(ty) = e.explicit_coercion {
-                                    // TODO if we have access to the AST for the argument we could choose which example to suggest.
-                                    message = format!("{message}\n\nYou may need to add information about the type of the argument, for example:\n  using a numeric suffix: `42{ty}`\n  or using type ascription: `foo(): {ty}`");
-                                }
-                                KclError::new_argument(KclErrorDetails::new(
-                                    message,
-                                    vec![arg.source_range],
-                                ))
-                            })?;
-                }
-            }
-            None => {
+    // Apply the `a == a: a` shorthand by desugaring unlabeled args into labeled ones.
+    let (labeled_unlabeled, unlabeled_unlabeled) = args.unlabeled.into_iter().partition(|(l, _)| {
+        if let Some(l) = l
+            && fn_def.named_args.contains_key(l)
+            && !args.labeled.contains_key(l)
+        {
+            true
+        } else {
+            false
+        }
+    });
+    args.unlabeled = unlabeled_unlabeled;
+    for (l, arg) in labeled_unlabeled {
+        let previous = args.labeled.insert(l.unwrap(), arg);
+        debug_assert!(previous.is_none());
+    }
+
+    if let Some((name, ty)) = &fn_def.input_arg {
+        // Expecting an input arg
+
+        if args.unlabeled.is_empty() {
+            // No args provided
+
+            if let Some(pipe) = args.pipe_value {
+                // But there is a pipeline
+                result.unlabeled = vec![(None, pipe)];
+            } else if let Some(arg) = args.labeled.swap_remove(name) {
+                // Mistakenly labelled
                 exec_state.err(CompilationError::err(
                     arg.source_range,
                     format!(
-                        "`{label}` is not an argument of {}",
+                        "{} expects an unlabeled first argument (`@{name}`), but it is labelled in the call. You might try removing the `{name} = `",
                         fn_name
-                            .map(|n| format!("`{n}`"))
-                            .unwrap_or_else(|| "this function".to_owned()),
+                            .map(|n| format!("The function `{n}`"))
+                            .unwrap_or_else(|| "This function".to_owned()),
                     ),
                 ));
+                result.unlabeled = vec![(Some(name.clone()), arg)];
+            } else {
+                // Just missing
+                return Err(KclError::new_argument(KclErrorDetails::new(
+                    "This function expects an unlabeled first parameter, but you haven't passed it one.".to_owned(),
+                    fn_def.as_source_range().into_iter().collect(),
+                )));
+            }
+        } else if args.unlabeled.len() == 1 {
+            let mut arg = args.unlabeled.pop().unwrap().1;
+            if let Some(ty) = ty {
+                let rty = RuntimeType::from_parsed(ty.clone(), exec_state, arg.source_range)
+                    .map_err(|e| KclError::new_semantic(e.into()))?;
+                arg.value = arg.value.coerce(&rty, true, exec_state).map_err(|_| {
+                    KclError::new_argument(KclErrorDetails::new(
+                        format!(
+                            "The input argument of {} requires {}",
+                            fn_name
+                                .map(|n| format!("`{n}`"))
+                                .unwrap_or_else(|| "this function".to_owned()),
+                            type_err_str(ty, &arg.value, &arg.source_range, exec_state),
+                        ),
+                        vec![arg.source_range],
+                    ))
+                })?;
+            }
+            result.unlabeled = vec![(None, arg)]
+        } else {
+            // Multiple unlabelled args
+
+            // Try to un-spread args into an array
+            if let Some(Type::Array { len, .. }) = ty {
+                if len.satisfied(args.unlabeled.len(), false).is_none() {
+                    exec_state.err(CompilationError::err(
+                        args.source_range,
+                        format!(
+                            "{} expects an array input argument with {} elements",
+                            fn_name
+                                .map(|n| format!("The function `{n}`"))
+                                .unwrap_or_else(|| "This function".to_owned()),
+                            len.human_friendly_type(),
+                        ),
+                    ));
+                }
+
+                let source_range = SourceRange::merge(args.unlabeled.iter().map(|(_, a)| a.source_range));
+                exec_state.warn_experimental("array input arguments", source_range);
+                result.unlabeled = vec![(
+                    None,
+                    Arg {
+                        source_range,
+                        value: KclValue::HomArray {
+                            value: args.unlabeled.drain(..).map(|(_, a)| a.value).collect(),
+                            ty: RuntimeType::any(),
+                        },
+                    },
+                )]
             }
         }
     }
 
-    if !args.errors.is_empty() {
+    // Either we didn't move the arg above, or we're not expecting one.
+    if !args.unlabeled.is_empty() {
+        // Not expecting an input arg, but found one or more
         let actuals = args.labeled.keys();
         let formals: Vec<_> = fn_def
             .named_args
@@ -673,9 +726,9 @@ fn type_check_params_kw(
             format!("; suggested labels: {}", formals.join(", "))
         };
 
-        let mut errors = args.errors.iter().map(|e| {
+        let mut errors = args.unlabeled.iter().map(|(_, arg)| {
             CompilationError::err(
-                e.source_range,
+                arg.source_range,
                 format!("This argument needs a label, but it doesn't have one{suggestion}"),
             )
         });
@@ -686,43 +739,59 @@ fn type_check_params_kw(
         return Err(KclError::new_argument(first.into()));
     }
 
-    if let Some(arg) = &mut args.unlabeled {
-        if let Some((_, Some(ty))) = &fn_def.input_arg {
-            let rty = RuntimeType::from_parsed(ty.clone(), exec_state, arg.1.source_range)
-                .map_err(|e| KclError::new_semantic(e.into()))?;
-            arg.1.value = arg.1.value.coerce(&rty, true, exec_state).map_err(|_| {
-                KclError::new_argument(KclErrorDetails::new(
+    for (label, mut arg) in args.labeled {
+        match fn_def.named_args.get(&label) {
+            Some((def, ty)) => {
+                // For optional args, passing None should be the same as not passing an arg.
+                if !(def.is_some() && matches!(arg.value, KclValue::KclNone { .. })) {
+                    if let Some(ty) = ty {
+                        let rty = RuntimeType::from_parsed(ty.clone(), exec_state, arg.source_range)
+                            .map_err(|e| KclError::new_semantic(e.into()))?;
+                        arg.value = arg
+                                .value
+                                .coerce(
+                                    &rty,
+                                    true,
+                                    exec_state,
+                                )
+                                .map_err(|e| {
+                                    let mut message = format!(
+                                        "{label} requires {}",
+                                        type_err_str(ty, &arg.value, &arg.source_range, exec_state),
+                                    );
+                                    if let Some(ty) = e.explicit_coercion {
+                                        // TODO if we have access to the AST for the argument we could choose which example to suggest.
+                                        message = format!("{message}\n\nYou may need to add information about the type of the argument, for example:\n  using a numeric suffix: `42{ty}`\n  or using type ascription: `foo(): {ty}`");
+                                    }
+                                    KclError::new_argument(KclErrorDetails::new(
+                                        message,
+                                        vec![arg.source_range],
+                                    ))
+                                })?;
+                    }
+                    result.labeled.insert(label, arg);
+                }
+            }
+            None => {
+                exec_state.err(CompilationError::err(
+                    arg.source_range,
                     format!(
-                        "The input argument of {} requires {}",
+                        "`{label}` is not an argument of {}",
                         fn_name
                             .map(|n| format!("`{n}`"))
                             .unwrap_or_else(|| "this function".to_owned()),
-                        type_err_str(ty, &arg.1.value, &arg.1.source_range, exec_state),
                     ),
-                    vec![arg.1.source_range],
-                ))
-            })?;
+                ));
+            }
         }
-    } else if let Some((name, _)) = &fn_def.input_arg
-        && let Some(arg) = args.labeled.get(name)
-    {
-        exec_state.err(CompilationError::err(
-            arg.source_range,
-            format!(
-                "{} expects an unlabeled first argument (`@{name}`), but it is labelled in the call",
-                fn_name
-                    .map(|n| format!("The function `{n}`"))
-                    .unwrap_or_else(|| "This function".to_owned()),
-            ),
-        ));
     }
 
-    Ok(())
+    Ok(result)
 }
 
 fn assign_args_to_params_kw(
     fn_def: &FunctionDefinition<'_>,
-    args: Args,
+    args: Args<Desugared>,
     exec_state: &mut ExecState,
 ) -> Result<(), KclError> {
     // Add the arguments to the memory.  A new call frame should have already
@@ -730,7 +799,7 @@ fn assign_args_to_params_kw(
     let source_ranges = fn_def.as_source_range().into_iter().collect();
 
     for (name, (default, _)) in fn_def.named_args.iter() {
-        let arg = args.kw_args.labeled.get(name);
+        let arg = args.labeled.get(name);
         match arg {
             Some(arg) => {
                 exec_state.mut_stack().add(
@@ -757,22 +826,12 @@ fn assign_args_to_params_kw(
     }
 
     if let Some((param_name, _)) = &fn_def.input_arg {
-        let unlabelled = args.unlabeled_kw_arg_unconverted();
-
-        let Some(unlabeled) = unlabelled else {
-            return Err(if args.kw_args.labeled.contains_key(param_name) {
-                KclError::new_argument(KclErrorDetails::new(
-                    format!(
-                        "The function does declare a parameter named '{param_name}', but this parameter doesn't use a label. Try removing the `{param_name} =`"
-                    ),
-                    source_ranges,
-                ))
-            } else {
-                KclError::new_argument(KclErrorDetails::new(
-                    "This function expects an unlabeled first parameter, but you haven't passed it one.".to_owned(),
-                    source_ranges,
-                ))
-            });
+        let Some(unlabeled) = args.unlabeled_kw_arg_unconverted() else {
+            debug_assert!(false, "Bad args");
+            return Err(KclError::new_internal(KclErrorDetails::new(
+                "Desugared arguments are inconsistent".to_owned(),
+                source_ranges,
+            )));
         };
         exec_state.mut_stack().add(
             param_name.clone(),
@@ -946,16 +1005,15 @@ mod test {
             let mut exec_state = ExecState::new(&exec_ctxt);
             exec_state.mod_local.stack = Stack::new_for_tests();
 
-            let args = Args::new_kw(
-                KwArgs {
-                    unlabeled: None,
-                    labeled,
-                    errors: Vec::new(),
-                },
-                SourceRange::default(),
-                exec_ctxt,
-                None,
-            );
+            let args = Args {
+                labeled,
+                unlabeled: Vec::new(),
+                source_range: SourceRange::default(),
+                ctx: exec_ctxt,
+                pipe_value: None,
+                _status: std::marker::PhantomData,
+            };
+
             let actual = assign_args_to_params_kw(&(&func_src).into(), args, &mut exec_state)
                 .map(|_| exec_state.mod_local.stack);
             assert_eq!(
@@ -978,5 +1036,14 @@ msg2 = makeMessage(prefix = 1, suffix = 3)"#;
             err.message(),
             "prefix requires a value with type `string`, but found a value with type `number`.\nThe found value is a number but has incomplete units information. You can probably fix this error by specifying the units using type ascription, e.g., `len: mm` or `(a * b): deg`."
         )
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn array_input_arg() {
+        let ast = r#"fn f(@input: [mm]) { return 1 }
+f([1, 2, 3])
+f(1, 2, 3)
+"#;
+        parse_execute(ast).await.unwrap();
     }
 }

--- a/rust/kcl-lib/src/execution/types.rs
+++ b/rust/kcl-lib/src/execution/types.rs
@@ -367,11 +367,22 @@ impl ArrayLen {
     }
 
     /// True if the length constraint is satisfied by the supplied length.
-    fn satisfied(self, len: usize, allow_shrink: bool) -> Option<usize> {
+    pub fn satisfied(self, len: usize, allow_shrink: bool) -> Option<usize> {
         match self {
             ArrayLen::None => Some(len),
             ArrayLen::Minimum(s) => (len >= s).then_some(len),
             ArrayLen::Known(s) => (if allow_shrink { len >= s } else { len == s }).then_some(s),
+        }
+    }
+
+    pub fn human_friendly_type(self) -> String {
+        match self {
+            ArrayLen::None | ArrayLen::Minimum(0) => "any number of elements".to_owned(),
+            ArrayLen::Minimum(1) => "at least 1 element".to_owned(),
+            ArrayLen::Minimum(n) => format!("at least {n} elements"),
+            ArrayLen::Known(0) => "no elements".to_owned(),
+            ArrayLen::Known(1) => "exactly 1 element".to_owned(),
+            ArrayLen::Known(n) => format!("exactly {n} elements"),
         }
     }
 }

--- a/rust/kcl-lib/src/std/args.rs
+++ b/rust/kcl-lib/src/std/args.rs
@@ -100,7 +100,7 @@ impl Args {
     where
         T: for<'a> FromKclValue<'a>,
     {
-        match self.kw_args.labeled.get(label) {
+        match self.labeled.get(label) {
             None => return Ok(None),
             Some(a) => {
                 if let KclValue::KclNone { .. } = &a.value {
@@ -116,7 +116,7 @@ impl Args {
     where
         T: for<'a> FromKclValue<'a>,
     {
-        let Some(arg) = self.kw_args.labeled.get(label) else {
+        let Some(arg) = self.labeled.get(label) else {
             return Err(KclError::new_semantic(KclErrorDetails::new(
                 format!("This function requires a keyword argument `{label}`"),
                 vec![self.source_range],
@@ -168,7 +168,7 @@ impl Args {
         &self,
         label: &str,
     ) -> Result<Vec<(EdgeReference, SourceRange)>, KclError> {
-        let Some(arg) = self.kw_args.labeled.get(label) else {
+        let Some(arg) = self.labeled.get(label) else {
             let err = KclError::new_semantic(KclErrorDetails::new(
                 format!("This function requires a keyword argument '{label}'"),
                 vec![self.source_range],

--- a/rust/kcl-lib/src/std/array.rs
+++ b/rust/kcl-lib/src/std/array.rs
@@ -5,7 +5,7 @@ use crate::{
     errors::{KclError, KclErrorDetails},
     execution::{
         ExecState,
-        fn_call::{Arg, Args, KwArgs},
+        fn_call::{Arg, Args},
         kcl_value::{FunctionSource, KclValue},
         types::RuntimeType,
     },
@@ -43,16 +43,12 @@ async fn call_map_closure(
     exec_state: &mut ExecState,
     ctxt: &ExecutorContext,
 ) -> Result<KclValue, KclError> {
-    let kw_args = KwArgs {
-        unlabeled: Some((None, Arg::new(input, source_range))),
-        labeled: Default::default(),
-        errors: Vec::new(),
-    };
-    let args = Args::new_kw(
-        kw_args,
+    let args = Args::new(
+        Default::default(),
+        vec![(None, Arg::new(input, source_range))],
         source_range,
+        exec_state,
         ctxt.clone(),
-        exec_state.pipe_value().map(|v| Arg::new(v.clone(), source_range)),
     );
     let output = map_fn.call_kw(None, exec_state, ctxt, args, source_range).await?;
     let source_ranges = vec![source_range];
@@ -99,16 +95,12 @@ async fn call_reduce_closure(
     // Call the reduce fn for this repetition.
     let mut labeled = IndexMap::with_capacity(1);
     labeled.insert("accum".to_string(), Arg::new(accum, source_range));
-    let kw_args = KwArgs {
-        unlabeled: Some((None, Arg::new(elem, source_range))),
+    let reduce_fn_args = Args::new(
         labeled,
-        errors: Vec::new(),
-    };
-    let reduce_fn_args = Args::new_kw(
-        kw_args,
+        vec![(None, Arg::new(elem, source_range))],
         source_range,
+        exec_state,
         ctxt.clone(),
-        exec_state.pipe_value().map(|v| Arg::new(v.clone(), source_range)),
     );
     let transform_fn_return = reduce_fn
         .call_kw(None, exec_state, ctxt, reduce_fn_args, source_range)

--- a/rust/kcl-lib/src/std/patterns.rs
+++ b/rust/kcl-lib/src/std/patterns.rs
@@ -20,7 +20,7 @@ use crate::{
     errors::{KclError, KclErrorDetails},
     execution::{
         ExecState, Geometries, Geometry, KclObjectFields, KclValue, Sketch, Solid,
-        fn_call::{Arg, Args, KwArgs},
+        fn_call::{Arg, Args},
         kcl_value::FunctionSource,
         types::{NumericType, PrimitiveType, RuntimeType},
     },
@@ -203,16 +203,12 @@ async fn make_transform<T: GeometryTrait>(
         ty: NumericType::count(),
         meta: vec![source_range.into()],
     };
-    let kw_args = KwArgs {
-        unlabeled: Some((None, Arg::new(repetition_num, source_range))),
-        labeled: Default::default(),
-        errors: Vec::new(),
-    };
-    let transform_fn_args = Args::new_kw(
-        kw_args,
+    let transform_fn_args = Args::new(
+        Default::default(),
+        vec![(None, Arg::new(repetition_num, source_range))],
         source_range,
+        exec_state,
         ctxt.clone(),
-        exec_state.pipe_value().map(|v| Arg::new(v.clone(), source_range)),
     );
     let transform_fn_return = transform
         .call_kw(None, exec_state, ctxt, transform_fn_args, source_range)

--- a/rust/kcl-lib/tests/helix_ccw/ops.snap
+++ b/rust/kcl-lib/tests/helix_ccw/ops.snap
@@ -88,15 +88,7 @@ description: Operations executed helix_ccw.kcl
     {
       "type": "StdLibCall",
       "name": "helix",
-      "unlabeledArg": {
-        "value": {
-          "type": "Solid",
-          "value": {
-            "artifactId": "[uuid]"
-          }
-        },
-        "sourceRange": []
-      },
+      "unlabeledArg": null,
       "labeledArgs": {
         "angleStart": {
           "value": {

--- a/rust/kcl-lib/tests/kw_fn_unlabeled_but_has_label/execution_error.snap
+++ b/rust/kcl-lib/tests/kw_fn_unlabeled_but_has_label/execution_error.snap
@@ -2,28 +2,13 @@
 source: kcl-lib/src/simulation_tests.rs
 description: Error from executing kw_fn_unlabeled_but_has_label.kcl
 ---
-KCL Argument error
+KCL Semantic error
 
-  × argument: The function does declare a parameter named 'x', but this
-  │ parameter doesn't use a label. Try removing the `x =`
-   ╭─[1:12]
- 1 │ ╭─▶ fn add(@x) {
- 2 │ │     return x + 1
- 3 │ ├─▶ }
-   · ╰──── tests/kw_fn_unlabeled_but_has_label/input.kcl
- 4 │     
- 5 │     two = add(x = 1)
-   ·           ─────┬────
-   ·                ╰── tests/kw_fn_unlabeled_but_has_label/input.kcl
+  × semantic: The function `add` expects an unlabeled first argument (`@x`),
+  │ but it is labelled in the call. You might try removing the `x = `
+   ╭─[5:15]
+ 4 │ 
+ 5 │ two = add(x = 1)
+   ·               ┬
+   ·               ╰── main
    ╰────
-  ╰─▶ KCL Argument error
-      
-        × argument: The function does declare a parameter named 'x', but this
-        │ parameter doesn't use a label. Try removing the `x =`
-         ╭─[1:12]
-       1 │ ╭─▶ fn add(@x) {
-       2 │ │     return x + 1
-       3 │ ├─▶ }
-         · ╰──── tests/kw_fn_unlabeled_but_has_label/input.kcl
-       4 │
-         ╰────

--- a/rust/kcl-lib/tests/kw_fn_unlabeled_but_has_label/ops.snap
+++ b/rust/kcl-lib/tests/kw_fn_unlabeled_but_has_label/ops.snap
@@ -10,26 +10,60 @@ description: Operations executed kw_fn_unlabeled_but_has_label.kcl
         "type": "FunctionCall",
         "name": "add",
         "functionSourceRange": [],
-        "unlabeledArg": null,
-        "labeledArgs": {
-          "x": {
-            "value": {
-              "type": "Number",
-              "value": 1.0,
-              "ty": {
-                "type": "Default",
-                "len": {
-                  "type": "Mm"
-                },
-                "angle": {
-                  "type": "Degrees"
-                }
+        "unlabeledArg": {
+          "value": {
+            "type": "Number",
+            "value": 1.0,
+            "ty": {
+              "type": "Default",
+              "len": {
+                "type": "Mm"
+              },
+              "angle": {
+                "type": "Degrees"
               }
-            },
-            "sourceRange": []
+            }
+          },
+          "sourceRange": []
+        },
+        "labeledArgs": {}
+      },
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 1
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "GroupEnd"
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "two",
+      "value": {
+        "type": "Number",
+        "value": 2.0,
+        "ty": {
+          "type": "Default",
+          "len": {
+            "type": "Mm"
+          },
+          "angle": {
+            "type": "Degrees"
           }
         }
       },
+      "visibility": "default",
       "nodePath": {
         "steps": [
           {

--- a/rust/kcl-lib/tests/kw_fn_unlabeled_but_has_label/program_memory.snap
+++ b/rust/kcl-lib/tests/kw_fn_unlabeled_but_has_label/program_memory.snap
@@ -2,9 +2,4 @@
 source: kcl-lib/src/simulation_tests.rs
 description: Variables in memory after executing kw_fn_unlabeled_but_has_label.kcl
 ---
-{
-  "add": {
-    "type": "Function",
-    "value": null
-  }
-}
+{}


### PR DESCRIPTION
This is required for constraints/sketch 2.0 and can improve ergonomics of some other functions. Marked as experimental and (deliberately) undocumented (for now).