### PR TITLE
Fix unlabeled arg execution order

### DIFF
--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -197,6 +197,17 @@ impl Node<CallExpressionKw> {
         let fn_name = &self.callee;
         let callsite: SourceRange = self.into();
 
+        // Clone the function so that we can use a mutable reference to
+        // exec_state.
+        let func = fn_name.get_result(exec_state, ctx).await?.clone();
+
+        let Some(fn_src) = func.as_function() else {
+            return Err(KclError::new_semantic(KclErrorDetails::new(
+                "cannot call this because it isn't a function".to_string(),
+                vec![callsite],
+            )));
+        };
+
         // Evaluate the unlabeled first param, if any exists.
         let unlabeled = if let Some(ref arg_expr) = self.unlabeled {
             let source_range = SourceRange::from(arg_expr.clone());
@@ -246,17 +257,6 @@ impl Node<CallExpressionKw> {
             ctx.clone(),
             exec_state.pipe_value().map(|v| Arg::new(v.clone(), callsite)),
         );
-
-        // Clone the function so that we can use a mutable reference to
-        // exec_state.
-        let func = fn_name.get_result(exec_state, ctx).await?.clone();
-
-        let Some(fn_src) = func.as_function() else {
-            return Err(KclError::new_semantic(KclErrorDetails::new(
-                "cannot call this because it isn't a function".to_string(),
-                vec![callsite],
-            )));
-        };
 
         let return_value = fn_src
             .call_kw(Some(fn_name.to_string()), exec_state, ctx, args, callsite)

--- a/rust/kcl-lib/tests/var_ref_in_own_def/ast.snap
+++ b/rust/kcl-lib/tests/var_ref_in_own_def/ast.snap
@@ -68,24 +68,58 @@ description: Result of parsing var_ref_in_own_def.kcl
                 "arguments": [
                   {
                     "type": "LabeledArg",
-                    "label": null,
-                    "arg": {
-                      "abs_path": false,
+                    "label": {
                       "commentStart": 0,
                       "end": 0,
                       "moduleId": 0,
-                      "name": {
-                        "commentStart": 0,
-                        "end": 0,
-                        "moduleId": 0,
-                        "name": "sketch001",
-                        "start": 0,
-                        "type": "Identifier"
-                      },
-                      "path": [],
+                      "name": "at",
                       "start": 0,
-                      "type": "Name",
-                      "type": "Name"
+                      "type": "Identifier"
+                    },
+                    "arg": {
+                      "commentStart": 0,
+                      "elements": [
+                        {
+                          "commentStart": 0,
+                          "end": 0,
+                          "moduleId": 0,
+                          "raw": "20",
+                          "start": 0,
+                          "type": "Literal",
+                          "type": "Literal",
+                          "value": {
+                            "value": 20.0,
+                            "suffix": "None"
+                          }
+                        },
+                        {
+                          "argument": {
+                            "commentStart": 0,
+                            "end": 0,
+                            "moduleId": 0,
+                            "raw": "20",
+                            "start": 0,
+                            "type": "Literal",
+                            "type": "Literal",
+                            "value": {
+                              "value": 20.0,
+                              "suffix": "None"
+                            }
+                          },
+                          "commentStart": 0,
+                          "end": 0,
+                          "moduleId": 0,
+                          "operator": "-",
+                          "start": 0,
+                          "type": "UnaryExpression",
+                          "type": "UnaryExpression"
+                        }
+                      ],
+                      "end": 0,
+                      "moduleId": 0,
+                      "start": 0,
+                      "type": "ArrayExpression",
+                      "type": "ArrayExpression"
                     }
                   }
                 ],
@@ -98,7 +132,7 @@ description: Result of parsing var_ref_in_own_def.kcl
                     "commentStart": 0,
                     "end": 0,
                     "moduleId": 0,
-                    "name": "startProfileAt",
+                    "name": "startProfile",
                     "start": 0,
                     "type": "Identifier"
                   },
@@ -113,49 +147,22 @@ description: Result of parsing var_ref_in_own_def.kcl
                 "type": "CallExpressionKw",
                 "type": "CallExpressionKw",
                 "unlabeled": {
+                  "abs_path": false,
                   "commentStart": 0,
-                  "elements": [
-                    {
-                      "commentStart": 0,
-                      "end": 0,
-                      "moduleId": 0,
-                      "raw": "20",
-                      "start": 0,
-                      "type": "Literal",
-                      "type": "Literal",
-                      "value": {
-                        "value": 20.0,
-                        "suffix": "None"
-                      }
-                    },
-                    {
-                      "argument": {
-                        "commentStart": 0,
-                        "end": 0,
-                        "moduleId": 0,
-                        "raw": "20",
-                        "start": 0,
-                        "type": "Literal",
-                        "type": "Literal",
-                        "value": {
-                          "value": 20.0,
-                          "suffix": "None"
-                        }
-                      },
-                      "commentStart": 0,
-                      "end": 0,
-                      "moduleId": 0,
-                      "operator": "-",
-                      "start": 0,
-                      "type": "UnaryExpression",
-                      "type": "UnaryExpression"
-                    }
-                  ],
                   "end": 0,
                   "moduleId": 0,
+                  "name": {
+                    "commentStart": 0,
+                    "end": 0,
+                    "moduleId": 0,
+                    "name": "sketch001",
+                    "start": 0,
+                    "type": "Identifier"
+                  },
+                  "path": [],
                   "start": 0,
-                  "type": "ArrayExpression",
-                  "type": "ArrayExpression"
+                  "type": "Name",
+                  "type": "Name"
                 }
               }
             ],

--- a/rust/kcl-lib/tests/var_ref_in_own_def/execution_error.snap
+++ b/rust/kcl-lib/tests/var_ref_in_own_def/execution_error.snap
@@ -6,9 +6,9 @@ KCL UndefinedValue error
 
   × undefined value: You can't use `sketch001` because you're currently trying
   │ to define it. Use a different variable here instead.
-   ╭─[3:32]
+   ╭─[3:19]
  2 │ sketch001 = startSketchOn(XY)
- 3 │   |> startProfileAt([20, -20], sketch001)
-   ·                                ────┬────
-   ·                                    ╰── tests/var_ref_in_own_def/input.kcl
+ 3 │   |> startProfile(sketch001, at = [20, -20])
+   ·                   ────┬────
+   ·                       ╰── tests/var_ref_in_own_def/input.kcl
    ╰────

--- a/rust/kcl-lib/tests/var_ref_in_own_def/input.kcl
+++ b/rust/kcl-lib/tests/var_ref_in_own_def/input.kcl
@@ -1,3 +1,3 @@
 // This won't work, because `sketch001` is being referenced in its own definition.
 sketch001 = startSketchOn(XY)
-  |> startProfileAt([20, -20], sketch001)
+  |> startProfile(sketch001, at = [20, -20])

--- a/rust/kcl-lib/tests/var_ref_in_own_def/unparsed.snap
+++ b/rust/kcl-lib/tests/var_ref_in_own_def/unparsed.snap
@@ -4,4 +4,4 @@ description: Result of unparsing var_ref_in_own_def.kcl
 ---
 // This won't work, because `sketch001` is being referenced in its own definition.
 sketch001 = startSketchOn(XY)
-  |> startProfileAt([20, -20], sketch001)
+  |> startProfile(sketch001, at = [20, -20])


### PR DESCRIPTION
```
foo(one(), x = two(), y = three())
```

Before, unlabeled args like `one()` would get executed after labeled arguments `two()` and `three()`. Execution order was:

1. `two()`
2. `three()`
3. `one()`
4. `foo`

This PR makes it in left-to-right order.

1. `foo`
2. `one()`
3. `two()`
4. `three()`

This is a breaking change due to things like #2728, but I don't think many KCL programs rely on the current behavior. I think it's worth it to change.