### PR TITLE
Max/pattern circular 3d codemod

### DIFF
--- a/src/lang/modifyAst/pattern3D.test.ts
+++ b/src/lang/modifyAst/pattern3D.test.ts
@@ -1,0 +1,207 @@
+import {
+  type Artifact,
+  assertParse,
+  type CodeRef,
+  recast,
+} from '@src/lang/wasm'
+import type { Selection, Selections } from '@src/lib/selections'
+import { enginelessExecutor } from '@src/lib/testHelpers'
+import { err } from '@src/lib/trap'
+import { addPatternCircular3D } from '@src/lang/modifyAst/pattern3D'
+import { stringToKclExpression } from '@src/lib/kclHelpers'
+
+async function getAstAndArtifactGraph(code: string) {
+  const ast = assertParse(code)
+  if (err(ast)) throw ast
+
+  const { artifactGraph } = await enginelessExecutor(ast)
+  return { ast, artifactGraph }
+}
+
+function createSelectionFromPathArtifact(
+  artifacts: (Artifact & { codeRef: CodeRef })[]
+): Selections {
+  const graphSelections = artifacts.map(
+    (artifact) =>
+      ({
+        codeRef: artifact.codeRef,
+        artifact,
+      }) as Selection
+  )
+  return {
+    graphSelections,
+    otherSelections: [],
+  }
+}
+
+async function getAstAndSolidSelections(code: string) {
+  const { ast, artifactGraph } = await getAstAndArtifactGraph(code)
+  // Filter for sweep artifacts that represent 3D solids
+  const artifacts = [...artifactGraph.values()].filter(
+    (a) => a.type === 'sweep'
+  )
+  if (artifacts.length === 0) {
+    throw new Error('Sweep artifact not found in the graph')
+  }
+  const selections = createSelectionFromPathArtifact(artifacts)
+  return { ast, selections, artifactGraph }
+}
+
+async function getKclCommandValue(value: string) {
+  const result = await stringToKclExpression(value)
+  if (err(result) || 'errors' in result) {
+    throw new Error('Failed to create KCL expression')
+  }
+  return result
+}
+
+describe('Testing addPatternCircular3D', () => {
+  it('should add patternCircular3d with named axis', async () => {
+    const code = `
+exampleSketch = startSketchOn(XZ)
+  |> circle(center = [0, 0], radius = 1)
+
+example = extrude(exampleSketch, length = -5)
+`
+
+    const { ast, selections, artifactGraph } =
+      await getAstAndSolidSelections(code)
+
+    const result = addPatternCircular3D({
+      ast,
+      artifactGraph,
+      solids: selections,
+      instances: await getKclCommandValue('11'),
+      axis: 'X',
+      center: await getKclCommandValue('[10, -20, 0]'),
+      arcDegrees: await getKclCommandValue('360'),
+      rotateDuplicates: true,
+      useOriginal: false,
+    })
+
+    if (err(result)) {
+      throw result
+    }
+
+    const { modifiedAst } = result
+    const newCode = recast(modifiedAst)
+
+    expect(newCode).toContain('patternCircular3d(')
+    expect(newCode).toContain('instances = 11')
+    expect(newCode).toContain('axis = X')
+    expect(newCode).toContain('center = [10, -20, 0]')
+    expect(newCode).toContain('arcDegrees = 360')
+    expect(newCode).toContain('rotateDuplicates = true')
+    expect(newCode).toContain('useOriginal = false')
+  })
+
+  it('should add patternCircular3d with array axis', async () => {
+    const code = `
+exampleSketch = startSketchOn(XZ)
+  |> circle(center = [0, 0], radius = 1)
+
+example = extrude(exampleSketch, length = -5)
+`
+
+    const { ast, selections, artifactGraph } =
+      await getAstAndSolidSelections(code)
+
+    const result = addPatternCircular3D({
+      ast,
+      artifactGraph,
+      solids: selections,
+      instances: await getKclCommandValue('11'),
+      axis: await getKclCommandValue('[1, -1, 0]'),
+      center: await getKclCommandValue('[10, -20, 0]'),
+      arcDegrees: await getKclCommandValue('360'),
+      rotateDuplicates: true,
+    })
+
+    if (err(result)) {
+      throw result
+    }
+
+    const { modifiedAst } = result
+    const newCode = recast(modifiedAst)
+
+    expect(newCode).toContain('patternCircular3d(')
+    expect(newCode).toContain('instances = 11')
+    expect(newCode).toContain('axis = [1, -1, 0]')
+    expect(newCode).toContain('center = [10, -20, 0]')
+    expect(newCode).toContain('arcDegrees = 360')
+    expect(newCode).toContain('rotateDuplicates = true')
+  })
+
+  it('should add patternCircular3d with minimal required parameters', async () => {
+    const code = `
+exampleSketch = startSketchOn(XZ)
+  |> circle(center = [0, 0], radius = 1)
+
+example = extrude(exampleSketch, length = -5)
+`
+
+    const { ast, selections, artifactGraph } =
+      await getAstAndSolidSelections(code)
+
+    const result = addPatternCircular3D({
+      ast,
+      artifactGraph,
+      solids: selections,
+      instances: await getKclCommandValue('5'),
+      axis: 'Z',
+      center: await getKclCommandValue('[0, 0, 0]'),
+    })
+
+    if (err(result)) {
+      throw result
+    }
+
+    const { modifiedAst } = result
+    const newCode = recast(modifiedAst)
+
+    expect(newCode).toContain('patternCircular3d(')
+    expect(newCode).toContain('instances = 5')
+    expect(newCode).toContain('axis = Z')
+    expect(newCode).toContain('center = [0, 0, 0]')
+    expect(newCode).not.toContain('arcDegrees')
+    expect(newCode).not.toContain('rotateDuplicates')
+    expect(newCode).not.toContain('useOriginal')
+  })
+
+  it('should handle variable references for parameters', async () => {
+    const code = `
+myInstances = 8
+myAxis = [0, 0, 1]
+myCenter = [5, 5, 0]
+
+exampleSketch = startSketchOn(XZ)
+  |> circle(center = [0, 0], radius = 1)
+
+example = extrude(exampleSketch, length = -5)
+`
+
+    const { ast, selections, artifactGraph } =
+      await getAstAndSolidSelections(code)
+
+    const result = addPatternCircular3D({
+      ast,
+      artifactGraph,
+      solids: selections,
+      instances: await getKclCommandValue('myInstances'),
+      axis: await getKclCommandValue('myAxis'),
+      center: await getKclCommandValue('myCenter'),
+    })
+
+    if (err(result)) {
+      throw result
+    }
+
+    const { modifiedAst } = result
+    const newCode = recast(modifiedAst)
+
+    expect(newCode).toContain('patternCircular3d(')
+    expect(newCode).toContain('instances = myInstances')
+    expect(newCode).toContain('axis = myAxis')
+    expect(newCode).toContain('center = myCenter')
+  })
+})

--- a/src/lang/modifyAst/pattern3D.ts
+++ b/src/lang/modifyAst/pattern3D.ts
@@ -1,0 +1,168 @@
+import type { Node } from '@rust/kcl-lib/bindings/Node'
+
+import {
+  createArrayExpression,
+  createCallExpressionStdLibKw,
+  createLabeledArg,
+  createLiteral,
+  createLocalName,
+} from '@src/lang/create'
+import { isArray } from '@src/lib/utils'
+import {
+  getVariableExprsFromSelection,
+  valueOrVariable,
+} from '@src/lang/queryAst'
+import type { ArtifactGraph, PathToNode, Program } from '@src/lang/wasm'
+import { err } from '@src/lib/trap'
+import type { Selections } from '@src/lib/selections'
+import type { KclCommandValue } from '@src/lib/commandTypes'
+import {
+  createVariableExpressionsArray,
+  insertVariableAndOffsetPathToNode,
+  setCallInAst,
+} from '@src/lang/modifyAst'
+import { KCL_DEFAULT_CONSTANT_PREFIXES } from '@src/lib/constants'
+
+export function addPatternCircular3D({
+  ast,
+  artifactGraph,
+  solids,
+  instances,
+  axis,
+  center,
+  arcDegrees,
+  rotateDuplicates,
+  useOriginal,
+  nodeToEdit,
+}: {
+  ast: Node<Program>
+  artifactGraph: ArtifactGraph
+  solids: Selections
+  instances: KclCommandValue
+  axis: KclCommandValue | string // Can be named axis (X, Y, Z) or array [x, y, z]
+  center: KclCommandValue // Point3d [x, y, z]
+  arcDegrees?: KclCommandValue
+  rotateDuplicates?: boolean
+  useOriginal?: boolean
+  nodeToEdit?: PathToNode
+}): Error | { modifiedAst: Node<Program>; pathToNode: PathToNode } {
+  // Clone the AST to avoid mutating the original
+  const modifiedAst = structuredClone(ast)
+
+  // Prepare function arguments from selected solids
+  const lastChildLookup = true
+  const vars = getVariableExprsFromSelection(
+    solids,
+    modifiedAst,
+    nodeToEdit,
+    lastChildLookup,
+    artifactGraph
+  )
+  if (err(vars)) {
+    return vars
+  }
+
+  // Handle axis parameter - can be named axis or Point3d array
+  let axisExpr
+  if (typeof axis === 'string') {
+    // Named axis like 'X', 'Y', 'Z'
+    axisExpr = createLocalName(axis)
+  } else if ('variableName' in axis && axis.variableName) {
+    // Variable reference
+    axisExpr = valueOrVariable(axis)
+  } else if ('value' in axis && isArray(axis.value)) {
+    // Direct array value [x, y, z]
+    const arrayElements = []
+    for (const val of axis.value) {
+      if (
+        typeof val === 'number' ||
+        typeof val === 'string' ||
+        typeof val === 'boolean'
+      ) {
+        arrayElements.push(createLiteral(val))
+      } else {
+        return new Error('Invalid axis value type')
+      }
+    }
+    axisExpr = createArrayExpression(arrayElements)
+  } else {
+    // Fallback to valueOrVariable
+    axisExpr = valueOrVariable(axis)
+  }
+
+  // Handle center parameter - should be Point3d [x, y, z]
+  let centerExpr
+  if ('value' in center && isArray(center.value)) {
+    // Direct array value [x, y, z]
+    const arrayElements = []
+    for (const val of center.value) {
+      if (
+        typeof val === 'number' ||
+        typeof val === 'string' ||
+        typeof val === 'boolean'
+      ) {
+        arrayElements.push(createLiteral(val))
+      } else {
+        return new Error('Invalid center value type')
+      }
+    }
+    centerExpr = createArrayExpression(arrayElements)
+  } else {
+    // Variable reference or other format
+    centerExpr = valueOrVariable(center)
+  }
+
+  // Optional labeled arguments
+  const arcDegreesExpr = arcDegrees
+    ? [createLabeledArg('arcDegrees', valueOrVariable(arcDegrees))]
+    : []
+  const rotateDuplicatesExpr =
+    rotateDuplicates !== undefined
+      ? [createLabeledArg('rotateDuplicates', createLiteral(rotateDuplicates))]
+      : []
+  const useOriginalExpr =
+    useOriginal !== undefined
+      ? [createLabeledArg('useOriginal', createLiteral(useOriginal))]
+      : []
+
+  const solidsExpr = createVariableExpressionsArray(vars.exprs)
+  const call = createCallExpressionStdLibKw('patternCircular3d', solidsExpr, [
+    createLabeledArg('instances', valueOrVariable(instances)),
+    createLabeledArg('axis', axisExpr),
+    createLabeledArg('center', centerExpr),
+    ...arcDegreesExpr,
+    ...rotateDuplicatesExpr,
+    ...useOriginalExpr,
+  ])
+
+  // Insert variables for labeled arguments if provided
+  if ('variableName' in instances && instances.variableName) {
+    insertVariableAndOffsetPathToNode(instances, modifiedAst, nodeToEdit)
+  }
+  if (typeof axis !== 'string' && 'variableName' in axis && axis.variableName) {
+    insertVariableAndOffsetPathToNode(axis, modifiedAst, nodeToEdit)
+  }
+  if ('variableName' in center && center.variableName) {
+    insertVariableAndOffsetPathToNode(center, modifiedAst, nodeToEdit)
+  }
+  if (arcDegrees && 'variableName' in arcDegrees && arcDegrees.variableName) {
+    insertVariableAndOffsetPathToNode(arcDegrees, modifiedAst, nodeToEdit)
+  }
+
+  // Insert the function call into the AST at the appropriate location
+  const pathToNode = setCallInAst({
+    ast: modifiedAst,
+    call,
+    pathToEdit: nodeToEdit,
+    pathIfNewPipe: vars.pathIfPipe,
+    variableIfNewDecl: KCL_DEFAULT_CONSTANT_PREFIXES.SOLID,
+  })
+  if (err(pathToNode)) {
+    return pathToNode
+  }
+
+  return {
+    modifiedAst,
+    pathToNode,
+  }
+}


### PR DESCRIPTION
closes #8192

Codemod to introduce basic Circular Pattern 3D support for the single‑selection flow.
Early step toward the Patterns/Gizmo work in the modeling app