### PR TITLE
Add a code pane menu item to copy current file's code

### DIFF
--- a/src/components/ModelingSidebar/ModelingPanes/KclEditorMenu.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/KclEditorMenu.tsx
@@ -7,12 +7,24 @@ import { ActionIcon } from '@src/components/ActionIcon'
 import { editorShortcutMeta } from '@src/components/ModelingSidebar/ModelingPanes/KclEditorPane'
 import { useConvertToVariable } from '@src/hooks/useToolbarGuards'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
-import { kclManager } from '@src/lib/singletons'
-import { reportRejection } from '@src/lib/trap'
+import { codeManager, kclManager } from '@src/lib/singletons'
+import { reportRejection, trap } from '@src/lib/trap'
 import { commandBarActor, settingsActor } from '@src/lib/singletons'
 
 import styles from './KclEditorMenu.module.css'
 import { withSiteBaseURL } from '@src/lib/withBaseURL'
+import toast from 'react-hot-toast'
+
+function copyKclCodeToClipboard() {
+  if (globalThis && 'navigator' in globalThis && codeManager.code) {
+    navigator.clipboard
+      .writeText(codeManager.code)
+      .then(() => toast.success(`Copied current file's code to clipboard`))
+      .catch((_e) =>
+        trap(new Error(`Failed to copy current file's code to clipboard`))
+      )
+  }
+}
 
 export const KclEditorMenu = ({ children }: PropsWithChildren) => {
   const { enable: convertToVarEnabled, handleClick: handleConvertToVarClick } =
@@ -50,6 +62,11 @@ export const KclEditorMenu = ({ children }: PropsWithChildren) => {
             >
               <span>Format code</span>
               <small>{editorShortcutMeta.formatCode.display}</small>
+            </button>
+          </Menu.Item>
+          <Menu.Item>
+            <button onClick={copyKclCodeToClipboard} className={styles.button}>
+              <span>Copy code</span>
             </button>
           </Menu.Item>
           {convertToVarEnabled && (


### PR DESCRIPTION
A customer request to make it easier to copy a file's contents. Since we have the menu here it is a very simple addition that shouldn't impact UX for users who don't need it very often.

In the future we should add this into the potential shortcut actions that just aren't assigned a keyboard shortcut by default, so power users can wire it up to a hotkey sequence. Associating that TODO with #3225 