### PR TITLE
expose relevant file types to python 

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "ezpz",
     "kcl-api",
     "kcl-bumper",
     "kcl-derive-docs",
@@ -13,7 +14,6 @@ members = [
     "kcl-test-server",
     "kcl-to-core",
     "kcl-wasm-lib",
-    "ezpz",
 ]
 
 [workspace.dependencies]

--- a/rust/ezpz/Cargo.toml
+++ b/rust/ezpz/Cargo.toml
@@ -9,7 +9,7 @@ faer = "0.22.6"
 indexmap.workspace = true
 kittycad-modeling-cmds = { workspace = true }
 libm = "0.2.15"
-newton_faer = { git = "https://github.com/adamchalmers/newton-faer", branch="achalmers/fallible" }
+newton_faer = { git = "https://github.com/adamchalmers/newton-faer", branch = "achalmers/fallible" }
 thiserror = "2.0.16"
 
 [dev-dependencies]

--- a/rust/justfile
+++ b/rust/justfile
@@ -58,6 +58,14 @@ test:
     cargo install cargo-nextest
     {{cnr}} --workspace --features=artifact-graph --no-fail-fast
 
+[working-directory: 'kcl-python-bindings']
+python-test:
+    just test
+
+[working-directory: 'kcl-python-bindings']
+python-test-filter name:
+    just test-filter {{name}}
+
 bump-kcl-crate-versions bump='patch':
     # First build the kcl-bumper tool.
     cargo build -p kcl-bumper

--- a/rust/kcl-api/Cargo.toml
+++ b/rust/kcl-api/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 description = "KCL interpreter API"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2.99"
+
 [dependencies]
 indexmap.workspace = true
 kcl-error = { version = "0.1", path = "../kcl-error" }
@@ -16,9 +19,6 @@ ts-rs = { version = "11.0.1", features = [
   "no-serde-warnings",
   "serde-json-impl",
 ] }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "0.2.99"
 
 [lints]
 workspace = true

--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -287,6 +287,16 @@ fn to_py_exception(err: impl std::fmt::Display) -> PyErr {
     PyException::new_err(err.to_string())
 }
 
+/// Get the allowed relevant file extensions (imports + kcl).
+#[pyo3_stub_gen::derive::gen_stub_pyfunction]
+#[pyfunction]
+fn relevant_file_extensions() -> PyResult<Vec<String>> {
+    Ok(kcl_lib::RELEVANT_FILE_EXTENSIONS
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<String>>())
+}
+
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
 #[pyfunction]
 async fn import_and_snapshot_views(
@@ -712,6 +722,7 @@ fn kcl(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(format, m)?)?;
     m.add_function(wrap_pyfunction!(format_dir, m)?)?;
     m.add_function(wrap_pyfunction!(lint, m)?)?;
+    m.add_function(wrap_pyfunction!(relevant_file_extensions, m)?)?;
     Ok(())
 }
 

--- a/rust/kcl-python-bindings/tests/tests.py
+++ b/rust/kcl-python-bindings/tests/tests.py
@@ -317,3 +317,13 @@ async def test_kcl_execute_code_and_export_with_bad_units():
             assert len(str(e)) > 0
             print(e)
             assert "[1:1]" in str(e)
+
+
+def test_relevant_file_extensions():
+    exts = kcl.relevant_file_extensions()
+    assert isinstance(exts, list)
+    assert len(exts) > 0
+    assert len(exts) > 5
+    assert all(isinstance(x, str) and len(x) > 0 for x in exts)
+    # kcl should always be included in the set
+    assert "kcl" in exts


### PR DESCRIPTION
so we can get rid of https://github.com/KittyCAD/text-to-cad/blob/079d2518cf0721c48cf8bcc80137d7018781a0b6/text_to_cad/routes.py#L68