### PR TITLE
Expose allowed file types

### DIFF
--- a/docs/kcl-lang/settings/user.md
+++ b/docs/kcl-lang/settings/user.md
@@ -107,7 +107,7 @@ This setting has the following nested options:
 The default unit to use in modeling dimensions.
 
 
-**Default:** None
+**Default:** `mm`
 
 ##### camera_projection
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2417,9 +2417,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83"
+checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
 dependencies = [
  "rustversion",
 ]
@@ -2824,9 +2824,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.131"
+version = "0.2.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b589ac0110d08e13371ee186c2c49f8bf1fffdf37aa9885fbbf43f2d4b977b7c"
+checksum = "2d15a4a2d5872522582cba15607f7ee5bdc966cbffcc56e6a60d618c7deab7ab"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4010,9 +4010,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-stub-gen"
-version = "0.12.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650d9624b551894664cc95867ccfe4fd814a5a225c8fe3a75194a3ae51caae1d"
+checksum = "b93cd67bcfbf726f81cd5d5f2cc85a69e089b4eaa11bb41a6514ad1783fb9355"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4032,9 +4032,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-stub-gen-derive"
-version = "0.12.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73947c71903f0e3e31a302a350567594063c75ac155031e40519721429898649"
+checksum = "3f2933be64abedb32a666273e843a1c949e957c18071cf52d543daf4adb2b4e9"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -36,6 +36,7 @@ kittycad-modeling-cmds = { version = "0.2.133", features = [
 lazy_static = "1.5.0"
 miette = "7.6.0"
 pyo3 = { version = "0.25.1" }
+# Build with Python >= 3.10 (set PYO3_PYTHON accordingly)
 pyo3-stub-gen = "0.13.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "ezpz",
     "kcl-api",
     "kcl-bumper",
     "kcl-derive-docs",
@@ -13,7 +14,6 @@ members = [
     "kcl-test-server",
     "kcl-to-core",
     "kcl-wasm-lib",
-    "ezpz",
 ]
 
 [workspace.dependencies]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,19 +1,19 @@
 [workspace]
 resolver = "2"
 members = [
-    "ezpz",
-    "kcl-api",
-    "kcl-bumper",
-    "kcl-derive-docs",
-    "kcl-directory-test-macro",
-    "kcl-error",
-    "kcl-language-server",
-    "kcl-language-server-release",
-    "kcl-lib",
-    "kcl-python-bindings",
-    "kcl-test-server",
-    "kcl-to-core",
-    "kcl-wasm-lib",
+  "ezpz",
+  "kcl-api",
+  "kcl-bumper",
+  "kcl-derive-docs",
+  "kcl-directory-test-macro",
+  "kcl-error",
+  "kcl-language-server",
+  "kcl-language-server-release",
+  "kcl-lib",
+  "kcl-python-bindings",
+  "kcl-test-server",
+  "kcl-to-core",
+  "kcl-wasm-lib",
 ]
 
 [workspace.dependencies]
@@ -29,14 +29,14 @@ kittycad = { version = "0.3.37", default-features = false, features = [
   "js",
   "requests",
 ] }
-kittycad-modeling-cmds = { version = "0.2.131", features = [
+kittycad-modeling-cmds = { version = "0.2.133", features = [
   "ts-rs",
   "websocket",
 ] }
 lazy_static = "1.5.0"
 miette = "7.6.0"
 pyo3 = { version = "0.25.1" }
-pyo3-stub-gen = "0.12.2"
+pyo3-stub-gen = "0.13.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 slog = "2.7.0"

--- a/rust/ezpz/Cargo.toml
+++ b/rust/ezpz/Cargo.toml
@@ -9,7 +9,7 @@ faer = "0.22.6"
 indexmap.workspace = true
 kittycad-modeling-cmds = { workspace = true }
 libm = "0.2.15"
-newton_faer = { git = "https://github.com/adamchalmers/newton-faer", branch="achalmers/fallible" }
+newton_faer = { git = "https://github.com/adamchalmers/newton-faer", branch = "achalmers/fallible" }
 thiserror = "2.0.16"
 
 [dev-dependencies]

--- a/rust/justfile
+++ b/rust/justfile
@@ -58,6 +58,14 @@ test:
     cargo install cargo-nextest
     {{cnr}} --workspace --features=artifact-graph --no-fail-fast
 
+[working-directory: 'kcl-python-bindings']
+python-test:
+    just test
+
+[working-directory: 'kcl-python-bindings']
+python-test-filter name:
+    just test-filter {{name}}
+
 bump-kcl-crate-versions bump='patch':
     # First build the kcl-bumper tool.
     cargo build -p kcl-bumper

--- a/rust/kcl-api/Cargo.toml
+++ b/rust/kcl-api/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 description = "KCL interpreter API"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2.99"
+
 [dependencies]
 indexmap.workspace = true
 kcl-error = { version = "0.1", path = "../kcl-error" }
@@ -16,9 +19,6 @@ ts-rs = { version = "11.0.1", features = [
   "no-serde-warnings",
   "serde-json-impl",
 ] }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "0.2.99"
 
 [lints]
 workspace = true

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -606,7 +606,7 @@ impl ExecutorContext {
                     .ok()
                     .flatten()
                     .map(|s| s.default_length_units)
-                    .map(kcmc::units::UnitLength::from),
+                    .map(crate::UnitLength::from),
             )
         } else {
             GridScaleBehavior::ScaleWithZoom
@@ -1106,7 +1106,7 @@ impl ExecutorContext {
                     .ok()
                     .flatten()
                     .map(|s| s.default_length_units)
-                    .map(kcmc::units::UnitLength::from),
+                    .map(crate::UnitLength::from),
             )
         } else {
             GridScaleBehavior::ScaleWithZoom

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -606,7 +606,7 @@ impl ExecutorContext {
                     .ok()
                     .flatten()
                     .map(|s| s.default_length_units)
-                    .map(crate::UnitLength::from),
+                    .map(kcmc::units::UnitLength::from),
             )
         } else {
             GridScaleBehavior::ScaleWithZoom
@@ -1106,7 +1106,7 @@ impl ExecutorContext {
                     .ok()
                     .flatten()
                     .map(|s| s.default_length_units)
-                    .map(crate::UnitLength::from),
+                    .map(kcmc::units::UnitLength::from),
             )
         } else {
             GridScaleBehavior::ScaleWithZoom

--- a/rust/kcl-lib/src/execution/types.rs
+++ b/rust/kcl-lib/src/execution/types.rs
@@ -959,35 +959,34 @@ impl TryFrom<NumericSuffix> for UnitLen {
     }
 }
 
-impl From<crate::UnitLength> for UnitLen {
-    fn from(unit: crate::UnitLength) -> Self {
+impl From<kittycad_modeling_cmds::units::UnitLength> for UnitLen {
+    fn from(unit: kittycad_modeling_cmds::units::UnitLength) -> Self {
         match unit {
-            crate::UnitLength::Centimeters => UnitLen::Cm,
-            crate::UnitLength::Feet => UnitLen::Feet,
-            crate::UnitLength::Inches => UnitLen::Inches,
-            crate::UnitLength::Meters => UnitLen::M,
-            crate::UnitLength::Millimeters => UnitLen::Mm,
-            crate::UnitLength::Yards => UnitLen::Yards,
+            kittycad_modeling_cmds::units::UnitLength::Centimeters => UnitLen::Cm,
+            kittycad_modeling_cmds::units::UnitLength::Feet => UnitLen::Feet,
+            kittycad_modeling_cmds::units::UnitLength::Inches => UnitLen::Inches,
+            kittycad_modeling_cmds::units::UnitLength::Meters => UnitLen::M,
+            kittycad_modeling_cmds::units::UnitLength::Millimeters => UnitLen::Mm,
+            kittycad_modeling_cmds::units::UnitLength::Yards => UnitLen::Yards,
         }
     }
 }
 
-impl From<UnitLen> for crate::UnitLength {
+impl From<UnitLen> for kittycad_modeling_cmds::units::UnitLength {
     fn from(unit: UnitLen) -> Self {
         match unit {
-            UnitLen::Cm => crate::UnitLength::Centimeters,
-            UnitLen::Feet => crate::UnitLength::Feet,
-            UnitLen::Inches => crate::UnitLength::Inches,
-            UnitLen::M => crate::UnitLength::Meters,
-            UnitLen::Mm => crate::UnitLength::Millimeters,
-            UnitLen::Yards => crate::UnitLength::Yards,
+            UnitLen::Cm => kittycad_modeling_cmds::units::UnitLength::Centimeters,
+            UnitLen::Feet => kittycad_modeling_cmds::units::UnitLength::Feet,
+            UnitLen::Inches => kittycad_modeling_cmds::units::UnitLength::Inches,
+            UnitLen::M => kittycad_modeling_cmds::units::UnitLength::Meters,
+            UnitLen::Mm => kittycad_modeling_cmds::units::UnitLength::Millimeters,
+            UnitLen::Yards => kittycad_modeling_cmds::units::UnitLength::Yards,
             UnitLen::Unknown => unreachable!(),
         }
     }
 }
 
-// Note: crate::UnitLength is re-exported from kittycad_modeling_cmds::units::UnitLength
-// so the above impl covers conversion to the external type as well.
+// Conversions are defined directly against kittycad_modeling_cmds::units::UnitLength.
 
 /// A unit of angle.
 #[derive(Debug, Default, Clone, Copy, Deserialize, Serialize, PartialEq, ts_rs::TS, Eq)]

--- a/rust/kcl-lib/src/execution/types.rs
+++ b/rust/kcl-lib/src/execution/types.rs
@@ -962,12 +962,12 @@ impl TryFrom<NumericSuffix> for UnitLen {
 impl From<crate::UnitLength> for UnitLen {
     fn from(unit: crate::UnitLength) -> Self {
         match unit {
-            crate::UnitLength::Cm => UnitLen::Cm,
-            crate::UnitLength::Ft => UnitLen::Feet,
-            crate::UnitLength::In => UnitLen::Inches,
-            crate::UnitLength::M => UnitLen::M,
-            crate::UnitLength::Mm => UnitLen::Mm,
-            crate::UnitLength::Yd => UnitLen::Yards,
+            crate::UnitLength::Centimeters => UnitLen::Cm,
+            crate::UnitLength::Feet => UnitLen::Feet,
+            crate::UnitLength::Inches => UnitLen::Inches,
+            crate::UnitLength::Meters => UnitLen::M,
+            crate::UnitLength::Millimeters => UnitLen::Mm,
+            crate::UnitLength::Yards => UnitLen::Yards,
         }
     }
 }
@@ -975,30 +975,19 @@ impl From<crate::UnitLength> for UnitLen {
 impl From<UnitLen> for crate::UnitLength {
     fn from(unit: UnitLen) -> Self {
         match unit {
-            UnitLen::Cm => crate::UnitLength::Cm,
-            UnitLen::Feet => crate::UnitLength::Ft,
-            UnitLen::Inches => crate::UnitLength::In,
-            UnitLen::M => crate::UnitLength::M,
-            UnitLen::Mm => crate::UnitLength::Mm,
-            UnitLen::Yards => crate::UnitLength::Yd,
+            UnitLen::Cm => crate::UnitLength::Centimeters,
+            UnitLen::Feet => crate::UnitLength::Feet,
+            UnitLen::Inches => crate::UnitLength::Inches,
+            UnitLen::M => crate::UnitLength::Meters,
+            UnitLen::Mm => crate::UnitLength::Millimeters,
+            UnitLen::Yards => crate::UnitLength::Yards,
             UnitLen::Unknown => unreachable!(),
         }
     }
 }
 
-impl From<UnitLen> for kittycad_modeling_cmds::units::UnitLength {
-    fn from(unit: UnitLen) -> Self {
-        match unit {
-            UnitLen::Cm => kittycad_modeling_cmds::units::UnitLength::Centimeters,
-            UnitLen::Feet => kittycad_modeling_cmds::units::UnitLength::Feet,
-            UnitLen::Inches => kittycad_modeling_cmds::units::UnitLength::Inches,
-            UnitLen::M => kittycad_modeling_cmds::units::UnitLength::Meters,
-            UnitLen::Mm => kittycad_modeling_cmds::units::UnitLength::Millimeters,
-            UnitLen::Yards => kittycad_modeling_cmds::units::UnitLength::Yards,
-            UnitLen::Unknown => unreachable!(),
-        }
-    }
-}
+// Note: crate::UnitLength is re-exported from kittycad_modeling_cmds::units::UnitLength
+// so the above impl covers conversion to the external type as well.
 
 /// A unit of angle.
 #[derive(Debug, Default, Clone, Copy, Deserialize, Serialize, PartialEq, ts_rs::TS, Eq)]

--- a/rust/kcl-lib/src/lib.rs
+++ b/rust/kcl-lib/src/lib.rs
@@ -102,7 +102,7 @@ pub use lsp::{
 pub use modules::ModuleId;
 pub use parsing::ast::types::{FormatOptions, NodePath, Step as NodePathStep};
 pub use project::ProjectManager;
-pub use settings::types::{Configuration, UnitLength, project::ProjectConfiguration};
+pub use settings::types::{Configuration, project::ProjectConfiguration};
 #[cfg(not(target_arch = "wasm32"))]
 pub use unparser::{recast_dir, walk_dir};
 

--- a/rust/kcl-lib/src/lsp/kcl/custom_notifications.rs
+++ b/rust/kcl-lib/src/lsp/kcl/custom_notifications.rs
@@ -1,10 +1,10 @@
 //! Custom notifications for the KCL LSP server that are not part of the LSP specification.
 
+use kittycad_modeling_cmds::units::UnitLength;
 use serde::{Deserialize, Serialize};
 use tower_lsp::lsp_types::notification::Notification;
 
 use crate::parsing::ast::types::Node;
-use kittycad_modeling_cmds::units::UnitLength;
 
 /// A notification that the AST has changed.
 #[derive(Debug)]

--- a/rust/kcl-lib/src/lsp/kcl/custom_notifications.rs
+++ b/rust/kcl-lib/src/lsp/kcl/custom_notifications.rs
@@ -3,7 +3,8 @@
 use serde::{Deserialize, Serialize};
 use tower_lsp::lsp_types::notification::Notification;
 
-use crate::{parsing::ast::types::Node, settings::types::UnitLength};
+use crate::parsing::ast::types::Node;
+use kittycad_modeling_cmds::units::UnitLength;
 
 /// A notification that the AST has changed.
 #[derive(Debug)]

--- a/rust/kcl-lib/src/settings/mod.rs
+++ b/rust/kcl-lib/src/settings/mod.rs
@@ -19,23 +19,14 @@ mod tests {
 
     #[test]
     fn toml_default_unit_length_roundtrip_is_mm() {
-        // Inspect how UnitLength::Millimeters serializes in TOML within ModelingSettings.
-        let modeling_default = ModelingSettings::default();
-        let modeling_toml = toml::to_string(&modeling_default).unwrap();
-        eprintln!("ModelingSettings::default() TOML =\n{}", modeling_toml);
-
         // Explicitly setting mm should parse to the default configuration.
         let with_mm = r#"[settings.modeling]
 base_unit = "mm"
 "#;
 
         let parsed = toml::from_str::<Configuration>(with_mm).unwrap();
-        eprintln!(
-            "Parsed base_unit from with_mm: {:?}",
-            parsed.settings.modeling.base_unit
-        );
         assert_eq!(parsed.settings.modeling.base_unit, UnitLength::Millimeters);
-
+        
         // Serializing defaults should omit modeling/base_unit entirely.
         let serialized = toml::to_string(&parsed).unwrap();
         assert_eq!(serialized, "");
@@ -44,10 +35,16 @@ base_unit = "mm"
         let empty_modeling_section = r#"[settings.modeling]
 "#;
         let parsed2 = toml::from_str::<Configuration>(empty_modeling_section).unwrap();
-        eprintln!(
-            "Parsed base_unit from empty section: {:?}",
-            parsed2.settings.modeling.base_unit
-        );
         assert_eq!(parsed2.settings.modeling.base_unit, UnitLength::Millimeters);
+    }
+
+    #[test]
+    fn configuration_default_has_mm() {
+        let cfg = Configuration::default();
+        assert_eq!(cfg.settings.modeling.base_unit, UnitLength::Millimeters);
+
+        // Default config serializes to empty TOML because everything is defaulted/omitted.
+        let serialized = toml::to_string(&cfg).unwrap();
+        assert_eq!(serialized, "");
     }
 }

--- a/rust/kcl-lib/src/settings/mod.rs
+++ b/rust/kcl-lib/src/settings/mod.rs
@@ -4,3 +4,50 @@ pub mod types;
 
 #[cfg(test)]
 mod generate_settings_docs;
+
+#[cfg(test)]
+mod tests {
+    use super::types::{Configuration, ModelingSettings};
+    use kittycad_modeling_cmds::units::UnitLength;
+
+    #[test]
+    fn default_unit_length_is_millimeters() {
+        // Ensure our settings default to millimeters as the base unit.
+        let modeling = ModelingSettings::default();
+        assert_eq!(modeling.base_unit, UnitLength::Millimeters);
+    }
+
+    #[test]
+    fn toml_default_unit_length_roundtrip_is_mm() {
+        // Inspect how UnitLength::Millimeters serializes in TOML within ModelingSettings.
+        let modeling_default = ModelingSettings::default();
+        let modeling_toml = toml::to_string(&modeling_default).unwrap();
+        eprintln!("ModelingSettings::default() TOML =\n{}", modeling_toml);
+
+        // Explicitly setting mm should parse to the default configuration.
+        let with_mm = r#"[settings.modeling]
+base_unit = "mm"
+"#;
+
+        let parsed = toml::from_str::<Configuration>(with_mm).unwrap();
+        eprintln!(
+            "Parsed base_unit from with_mm: {:?}",
+            parsed.settings.modeling.base_unit
+        );
+        assert_eq!(parsed.settings.modeling.base_unit, UnitLength::Millimeters);
+
+        // Serializing defaults should omit modeling/base_unit entirely.
+        let serialized = toml::to_string(&parsed).unwrap();
+        assert_eq!(serialized, "");
+
+        // An empty [settings.modeling] section should still default to mm.
+        let empty_modeling_section = r#"[settings.modeling]
+"#;
+        let parsed2 = toml::from_str::<Configuration>(empty_modeling_section).unwrap();
+        eprintln!(
+            "Parsed base_unit from empty section: {:?}",
+            parsed2.settings.modeling.base_unit
+        );
+        assert_eq!(parsed2.settings.modeling.base_unit, UnitLength::Millimeters);
+    }
+}

--- a/rust/kcl-lib/src/settings/mod.rs
+++ b/rust/kcl-lib/src/settings/mod.rs
@@ -7,8 +7,9 @@ mod generate_settings_docs;
 
 #[cfg(test)]
 mod tests {
-    use super::types::{Configuration, ModelingSettings};
     use kittycad_modeling_cmds::units::UnitLength;
+
+    use super::types::{Configuration, ModelingSettings};
 
     #[test]
     fn default_unit_length_is_millimeters() {
@@ -26,7 +27,7 @@ base_unit = "mm"
 
         let parsed = toml::from_str::<Configuration>(with_mm).unwrap();
         assert_eq!(parsed.settings.modeling.base_unit, UnitLength::Millimeters);
-        
+
         // Serializing defaults should omit modeling/base_unit entirely.
         let serialized = toml::to_string(&parsed).unwrap();
         assert_eq!(serialized, "");

--- a/rust/kcl-lib/src/settings/types/mod.rs
+++ b/rust/kcl-lib/src/settings/types/mod.rs
@@ -3,7 +3,7 @@
 pub mod project;
 
 use anyhow::Result;
-pub use kittycad_modeling_cmds::units::UnitLength;
+use kittycad_modeling_cmds::units::UnitLength;
 use parse_display::{Display, FromStr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};

--- a/rust/kcl-lib/src/settings/types/mod.rs
+++ b/rust/kcl-lib/src/settings/types/mod.rs
@@ -599,7 +599,7 @@ text_wrapping = true"#;
                 },
                 modeling: ModelingSettings {
                     enable_ssao: false.into(),
-                    base_unit: UnitLength::In,
+                    base_unit: UnitLength::Inches,
                     mouse_controls: MouseControlType::Zoo,
                     camera_projection: CameraProjectionType::Perspective,
                     ..Default::default()

--- a/rust/kcl-lib/src/settings/types/mod.rs
+++ b/rust/kcl-lib/src/settings/types/mod.rs
@@ -271,12 +271,12 @@ impl From<AppTheme> for kittycad::types::Color {
 }
 
 /// Settings that affect the behavior while modeling.
-#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema, ts_rs::TS, PartialEq, Eq, Validate)]
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, ts_rs::TS, PartialEq, Eq, Validate)]
 #[serde(rename_all = "snake_case")]
 #[ts(export)]
 pub struct ModelingSettings {
     /// The default unit to use in modeling dimensions.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default = "default_length_unit_millimeters", skip_serializing_if = "is_default")]
     pub base_unit: UnitLength,
     /// The projection mode the camera should use while modeling.
     #[serde(default, skip_serializing_if = "is_default")]
@@ -302,6 +302,26 @@ pub struct ModelingSettings {
     /// Whether or not to show a scale grid in the 3D modeling view
     #[serde(default, skip_serializing_if = "is_default")]
     pub show_scale_grid: bool,
+}
+
+fn default_length_unit_millimeters() -> UnitLength {
+    UnitLength::Millimeters
+}
+
+impl Default for ModelingSettings {
+    fn default() -> Self {
+        Self {
+            base_unit: UnitLength::Millimeters,
+            camera_projection: Default::default(),
+            camera_orbit: Default::default(),
+            mouse_controls: Default::default(),
+            enable_touch_controls: Default::default(),
+            use_new_sketch_mode: Default::default(),
+            highlight_edges: Default::default(),
+            enable_ssao: Default::default(),
+            show_scale_grid: Default::default(),
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone, Deserialize, Serialize, JsonSchema, ts_rs::TS, PartialEq, Eq)]

--- a/rust/kcl-lib/src/settings/types/mod.rs
+++ b/rust/kcl-lib/src/settings/types/mod.rs
@@ -3,6 +3,7 @@
 pub mod project;
 
 use anyhow::Result;
+pub use kittycad_modeling_cmds::units::UnitLength;
 use parse_display::{Display, FromStr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -323,86 +324,6 @@ impl From<DefaultTrue> for bool {
 impl From<bool> for DefaultTrue {
     fn from(b: bool) -> Self {
         Self(b)
-    }
-}
-
-/// The valid types of length units.
-#[derive(
-    Debug, Default, Eq, PartialEq, Copy, Clone, Deserialize, Serialize, JsonSchema, ts_rs::TS, Display, FromStr,
-)]
-#[cfg_attr(
-    feature = "pyo3",
-    pyo3::pyclass(eq, eq_int),
-    pyo3_stub_gen::derive::gen_stub_pyclass_enum
-)]
-#[ts(export)]
-#[serde(rename_all = "lowercase")]
-#[display(style = "lowercase")]
-pub enum UnitLength {
-    /// Centimeters <https://en.wikipedia.org/wiki/Centimeter>
-    Cm,
-    /// Feet <https://en.wikipedia.org/wiki/Foot_(unit)>
-    Ft,
-    /// Inches <https://en.wikipedia.org/wiki/Inch>
-    In,
-    /// Meters <https://en.wikipedia.org/wiki/Meter>
-    M,
-    /// Millimeters <https://en.wikipedia.org/wiki/Millimeter>
-    #[default]
-    Mm,
-    /// Yards <https://en.wikipedia.org/wiki/Yard>
-    Yd,
-}
-
-impl From<kittycad::types::UnitLength> for UnitLength {
-    fn from(unit: kittycad::types::UnitLength) -> Self {
-        match unit {
-            kittycad::types::UnitLength::Cm => UnitLength::Cm,
-            kittycad::types::UnitLength::Ft => UnitLength::Ft,
-            kittycad::types::UnitLength::In => UnitLength::In,
-            kittycad::types::UnitLength::M => UnitLength::M,
-            kittycad::types::UnitLength::Mm => UnitLength::Mm,
-            kittycad::types::UnitLength::Yd => UnitLength::Yd,
-        }
-    }
-}
-
-impl From<UnitLength> for kittycad::types::UnitLength {
-    fn from(unit: UnitLength) -> Self {
-        match unit {
-            UnitLength::Cm => kittycad::types::UnitLength::Cm,
-            UnitLength::Ft => kittycad::types::UnitLength::Ft,
-            UnitLength::In => kittycad::types::UnitLength::In,
-            UnitLength::M => kittycad::types::UnitLength::M,
-            UnitLength::Mm => kittycad::types::UnitLength::Mm,
-            UnitLength::Yd => kittycad::types::UnitLength::Yd,
-        }
-    }
-}
-
-impl From<kittycad_modeling_cmds::units::UnitLength> for UnitLength {
-    fn from(unit: kittycad_modeling_cmds::units::UnitLength) -> Self {
-        match unit {
-            kittycad_modeling_cmds::units::UnitLength::Centimeters => UnitLength::Cm,
-            kittycad_modeling_cmds::units::UnitLength::Feet => UnitLength::Ft,
-            kittycad_modeling_cmds::units::UnitLength::Inches => UnitLength::In,
-            kittycad_modeling_cmds::units::UnitLength::Meters => UnitLength::M,
-            kittycad_modeling_cmds::units::UnitLength::Millimeters => UnitLength::Mm,
-            kittycad_modeling_cmds::units::UnitLength::Yards => UnitLength::Yd,
-        }
-    }
-}
-
-impl From<UnitLength> for kittycad_modeling_cmds::units::UnitLength {
-    fn from(unit: UnitLength) -> Self {
-        match unit {
-            UnitLength::Cm => kittycad_modeling_cmds::units::UnitLength::Centimeters,
-            UnitLength::Ft => kittycad_modeling_cmds::units::UnitLength::Feet,
-            UnitLength::In => kittycad_modeling_cmds::units::UnitLength::Inches,
-            UnitLength::M => kittycad_modeling_cmds::units::UnitLength::Meters,
-            UnitLength::Mm => kittycad_modeling_cmds::units::UnitLength::Millimeters,
-            UnitLength::Yd => kittycad_modeling_cmds::units::UnitLength::Yards,
-        }
     }
 }
 

--- a/rust/kcl-lib/src/settings/types/project.rs
+++ b/rust/kcl-lib/src/settings/types/project.rs
@@ -2,6 +2,7 @@
 
 use anyhow::Result;
 use indexmap::IndexMap;
+use kittycad_modeling_cmds::units::UnitLength;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
@@ -9,7 +10,6 @@ use validator::Validate;
 use crate::settings::types::{
     AppColor, CommandBarSettings, DefaultTrue, OnboardingStatus, TextEditorSettings, is_default,
 };
-use kittycad_modeling_cmds::units::UnitLength;
 
 /// Project specific settings for the app.
 /// These live in `project.toml` in the base of the project directory.

--- a/rust/kcl-lib/src/settings/types/project.rs
+++ b/rust/kcl-lib/src/settings/types/project.rs
@@ -329,7 +329,7 @@ color = 1567.4"#;
                     ]),
                 },
                 modeling: ProjectModelingSettings {
-                    base_unit: UnitLength::Yd,
+                    base_unit: UnitLength::Yards,
                     highlight_edges: Default::default(),
                     enable_ssao: true.into(),
                 },

--- a/rust/kcl-lib/src/settings/types/project.rs
+++ b/rust/kcl-lib/src/settings/types/project.rs
@@ -7,8 +7,9 @@ use serde::{Deserialize, Serialize};
 use validator::Validate;
 
 use crate::settings::types::{
-    AppColor, CommandBarSettings, DefaultTrue, OnboardingStatus, TextEditorSettings, UnitLength, is_default,
+    AppColor, CommandBarSettings, DefaultTrue, OnboardingStatus, TextEditorSettings, is_default,
 };
+use kittycad_modeling_cmds::units::UnitLength;
 
 /// Project specific settings for the app.
 /// These live in `project.toml` in the base of the project directory.

--- a/rust/kcl-python-bindings/kcl.pyi
+++ b/rust/kcl-python-bindings/kcl.pyi
@@ -143,6 +143,102 @@ class InputFormat3d:
 
 class Options:
     r"""
+    Options for importing FBX.
+    """
+    def __new__(cls) -> Options:
+        r"""
+        Set the options to their defaults.
+        """
+
+class Options:
+    r"""
+    Options for importing STEP format.
+    """
+    def __new__(cls) -> Options:
+        r"""
+        Set the options to their defaults.
+        """
+
+class Options:
+    r"""
+    Options for importing PLY.
+    """
+    def __new__(cls) -> Options:
+        r"""
+        Set the options to their defaults.
+        """
+
+class Options:
+    r"""
+    Options for importing SolidWorks parts.
+    """
+    def __new__(cls) -> Options:
+        r"""
+        Set the options to their defaults.
+        """
+
+class Options:
+    r"""
+    Options for exporting STEP format.
+    """
+    def __new__(cls) -> Options:
+        r"""
+        Set the options to their defaults.
+        """
+
+class Options:
+    r"""
+    Options for exporting OBJ.
+    """
+    def __new__(cls) -> Options:
+        r"""
+        Set the options to their defaults.
+        """
+
+class Options:
+    r"""
+    Options for exporting PLY.
+    """
+    def __new__(cls) -> Options:
+        r"""
+        Set the options to their defaults.
+        """
+
+class Options:
+    r"""
+    Options for exporting DXF format.
+    """
+    def __new__(cls) -> Options:
+        r"""
+        Set the options to their defaults.
+        """
+
+class Options:
+    r"""
+    Options for importing OBJ.
+    """
+    def __new__(cls) -> Options:
+        r"""
+        Set the options to their defaults.
+        """
+
+class Options:
+    r"""
+    Options for importing STL.
+    """
+    ...
+
+class Options:
+    r"""
+    Options for exporting FBX.
+    """
+    def __new__(cls) -> Options:
+        r"""
+        Set the options to their defaults.
+        """
+
+class Options:
+    r"""
     Options for exporting glTF 2.0.
     """
     def __new__(cls) -> Options:
@@ -161,103 +257,7 @@ class Options:
 
 class Options:
     r"""
-    Options for exporting PLY.
-    """
-    def __new__(cls) -> Options:
-        r"""
-        Set the options to their defaults.
-        """
-
-class Options:
-    r"""
-    Options for importing STEP format.
-    """
-    def __new__(cls) -> Options:
-        r"""
-        Set the options to their defaults.
-        """
-
-class Options:
-    r"""
-    Options for importing FBX.
-    """
-    def __new__(cls) -> Options:
-        r"""
-        Set the options to their defaults.
-        """
-
-class Options:
-    r"""
-    Options for importing OBJ.
-    """
-    def __new__(cls) -> Options:
-        r"""
-        Set the options to their defaults.
-        """
-
-class Options:
-    r"""
     Options for exporting STL.
-    """
-    def __new__(cls) -> Options:
-        r"""
-        Set the options to their defaults.
-        """
-
-class Options:
-    r"""
-    Options for exporting FBX.
-    """
-    def __new__(cls) -> Options:
-        r"""
-        Set the options to their defaults.
-        """
-
-class Options:
-    r"""
-    Options for importing PLY.
-    """
-    def __new__(cls) -> Options:
-        r"""
-        Set the options to their defaults.
-        """
-
-class Options:
-    r"""
-    Options for importing STL.
-    """
-    ...
-
-class Options:
-    r"""
-    Options for exporting DXF format.
-    """
-    def __new__(cls) -> Options:
-        r"""
-        Set the options to their defaults.
-        """
-
-class Options:
-    r"""
-    Options for importing SolidWorks parts.
-    """
-    def __new__(cls) -> Options:
-        r"""
-        Set the options to their defaults.
-        """
-
-class Options:
-    r"""
-    Options for exporting OBJ.
-    """
-    def __new__(cls) -> Options:
-        r"""
-        Set the options to their defaults.
-        """
-
-class Options:
-    r"""
-    Options for exporting STEP format.
     """
     def __new__(cls) -> Options:
         r"""
@@ -406,12 +406,12 @@ class Storage(Enum):
     Ascii = ...
     r"""
     Plaintext encoding.
-    
-    This is the default setting.
     """
     Binary = ...
     r"""
-    Binary encoding.
+    Binary STL encoding.
+    
+    This is the default setting.
     """
 
 class Storage(Enum):
@@ -443,6 +443,21 @@ class Storage(Enum):
 
 class Storage(Enum):
     r"""
+    Export storage.
+    """
+    Ascii = ...
+    r"""
+    Plaintext encoding.
+    
+    This is the default setting.
+    """
+    Binary = ...
+    r"""
+    Binary encoding.
+    """
+
+class Storage(Enum):
+    r"""
     Describes the storage format of an FBX file.
     """
     Ascii = ...
@@ -452,21 +467,6 @@ class Storage(Enum):
     Binary = ...
     r"""
     Binary FBX encoding.
-    """
-
-class Storage(Enum):
-    r"""
-    Export storage.
-    """
-    Ascii = ...
-    r"""
-    Plaintext encoding.
-    """
-    Binary = ...
-    r"""
-    Binary STL encoding.
-    
-    This is the default setting.
     """
 
 class UnitAngle(Enum):
@@ -724,5 +724,10 @@ async def parse(path:builtins.str) -> builtins.bool:
 def parse_code(code:builtins.str) -> builtins.bool:
     r"""
     Parse the kcl code.
+    """
+
+def relevant_file_extensions() -> builtins.list[builtins.str]:
+    r"""
+    Get the allowed relevant file extensions (imports + kcl).
     """
 

--- a/rust/kcl-python-bindings/kcl.pyi
+++ b/rust/kcl-python-bindings/kcl.pyi
@@ -578,35 +578,6 @@ class UnitLength(Enum):
     Yards <https://en.wikipedia.org/wiki/Yard>
     """
 
-class UnitLength(Enum):
-    r"""
-    The valid types of length units.
-    """
-    Cm = ...
-    r"""
-    Centimeters <https://en.wikipedia.org/wiki/Centimeter>
-    """
-    Ft = ...
-    r"""
-    Feet <https://en.wikipedia.org/wiki/Foot_(unit)>
-    """
-    In = ...
-    r"""
-    Inches <https://en.wikipedia.org/wiki/Inch>
-    """
-    M = ...
-    r"""
-    Meters <https://en.wikipedia.org/wiki/Meter>
-    """
-    Mm = ...
-    r"""
-    Millimeters <https://en.wikipedia.org/wiki/Millimeter>
-    """
-    Yd = ...
-    r"""
-    Yards <https://en.wikipedia.org/wiki/Yard>
-    """
-
 class UnitMass(Enum):
     r"""
     The valid types of mass units.

--- a/rust/kcl-python-bindings/kcl.pyi
+++ b/rust/kcl-python-bindings/kcl.pyi
@@ -34,6 +34,15 @@ class Discovered:
     @property
     def overridden(self) -> builtins.bool: ...
 
+class DxfExportOptions:
+    r"""
+    Options for exporting DXF format.
+    """
+    def __new__(cls) -> DxfExportOptions:
+        r"""
+        Set the options to their defaults.
+        """
+
 class ExportFile:
     r"""
     A file to be exported to the client.
@@ -42,6 +51,24 @@ class ExportFile:
     def contents(self) -> builtins.list[builtins.int]: ...
     @property
     def name(self) -> builtins.str: ...
+
+class FbxExportOptions:
+    r"""
+    Options for exporting FBX.
+    """
+    def __new__(cls) -> FbxExportOptions:
+        r"""
+        Set the options to their defaults.
+        """
+
+class FbxImportOptions:
+    r"""
+    Options for importing FBX.
+    """
+    def __new__(cls) -> FbxImportOptions:
+        r"""
+        Set the options to their defaults.
+        """
 
 class Finding:
     r"""
@@ -56,6 +83,24 @@ class Finding:
     @property
     def experimental(self) -> builtins.bool: ...
 
+class GltfExportOptions:
+    r"""
+    Options for exporting glTF 2.0.
+    """
+    def __new__(cls) -> GltfExportOptions:
+        r"""
+        Set the options to their defaults.
+        """
+
+class GltfImportOptions:
+    r"""
+    Options for importing glTF 2.0.
+    """
+    def __new__(cls) -> GltfImportOptions:
+        r"""
+        Set the options to their defaults.
+        """
+
 class InputFormat3d:
     r"""
     Input format specifier.
@@ -66,8 +111,8 @@ class InputFormat3d:
         """
         __match_args__ = ("_0",)
         @property
-        def _0(self) -> Options: ...
-        def __new__(cls, _0:Options) -> InputFormat3d.Fbx: ...
+        def _0(self) -> FbxImportOptions: ...
+        def __new__(cls, _0:FbxImportOptions) -> InputFormat3d.Fbx: ...
         def __len__(self) -> builtins.int: ...
         def __getitem__(self, key:builtins.int) -> typing.Any: ...
     
@@ -79,8 +124,8 @@ class InputFormat3d:
         """
         __match_args__ = ("_0",)
         @property
-        def _0(self) -> Options: ...
-        def __new__(cls, _0:Options) -> InputFormat3d.Gltf: ...
+        def _0(self) -> GltfImportOptions: ...
+        def __new__(cls, _0:GltfImportOptions) -> InputFormat3d.Gltf: ...
         def __len__(self) -> builtins.int: ...
         def __getitem__(self, key:builtins.int) -> typing.Any: ...
     
@@ -90,8 +135,8 @@ class InputFormat3d:
         """
         __match_args__ = ("_0",)
         @property
-        def _0(self) -> Options: ...
-        def __new__(cls, _0:Options) -> InputFormat3d.Obj: ...
+        def _0(self) -> ObjImportOptions: ...
+        def __new__(cls, _0:ObjImportOptions) -> InputFormat3d.Obj: ...
         def __len__(self) -> builtins.int: ...
         def __getitem__(self, key:builtins.int) -> typing.Any: ...
     
@@ -101,8 +146,8 @@ class InputFormat3d:
         """
         __match_args__ = ("_0",)
         @property
-        def _0(self) -> Options: ...
-        def __new__(cls, _0:Options) -> InputFormat3d.Ply: ...
+        def _0(self) -> PlyImportOptions: ...
+        def __new__(cls, _0:PlyImportOptions) -> InputFormat3d.Ply: ...
         def __len__(self) -> builtins.int: ...
         def __getitem__(self, key:builtins.int) -> typing.Any: ...
     
@@ -112,8 +157,8 @@ class InputFormat3d:
         """
         __match_args__ = ("_0",)
         @property
-        def _0(self) -> Options: ...
-        def __new__(cls, _0:Options) -> InputFormat3d.Sldprt: ...
+        def _0(self) -> SldprtImportOptions: ...
+        def __new__(cls, _0:SldprtImportOptions) -> InputFormat3d.Sldprt: ...
         def __len__(self) -> builtins.int: ...
         def __getitem__(self, key:builtins.int) -> typing.Any: ...
     
@@ -123,8 +168,8 @@ class InputFormat3d:
         """
         __match_args__ = ("_0",)
         @property
-        def _0(self) -> Options: ...
-        def __new__(cls, _0:Options) -> InputFormat3d.Step: ...
+        def _0(self) -> StepImportOptions: ...
+        def __new__(cls, _0:StepImportOptions) -> InputFormat3d.Step: ...
         def __len__(self) -> builtins.int: ...
         def __getitem__(self, key:builtins.int) -> typing.Any: ...
     
@@ -134,132 +179,45 @@ class InputFormat3d:
         """
         __match_args__ = ("_0",)
         @property
-        def _0(self) -> Options: ...
-        def __new__(cls, _0:Options) -> InputFormat3d.Stl: ...
+        def _0(self) -> StlImportOptions: ...
+        def __new__(cls, _0:StlImportOptions) -> InputFormat3d.Stl: ...
         def __len__(self) -> builtins.int: ...
         def __getitem__(self, key:builtins.int) -> typing.Any: ...
     
     ...
 
-class Options:
-    r"""
-    Options for importing FBX.
-    """
-    def __new__(cls) -> Options:
-        r"""
-        Set the options to their defaults.
-        """
-
-class Options:
-    r"""
-    Options for importing STEP format.
-    """
-    def __new__(cls) -> Options:
-        r"""
-        Set the options to their defaults.
-        """
-
-class Options:
-    r"""
-    Options for importing PLY.
-    """
-    def __new__(cls) -> Options:
-        r"""
-        Set the options to their defaults.
-        """
-
-class Options:
-    r"""
-    Options for importing SolidWorks parts.
-    """
-    def __new__(cls) -> Options:
-        r"""
-        Set the options to their defaults.
-        """
-
-class Options:
-    r"""
-    Options for exporting STEP format.
-    """
-    def __new__(cls) -> Options:
-        r"""
-        Set the options to their defaults.
-        """
-
-class Options:
+class ObjExportOptions:
     r"""
     Options for exporting OBJ.
     """
-    def __new__(cls) -> Options:
+    def __new__(cls) -> ObjExportOptions:
         r"""
         Set the options to their defaults.
         """
 
-class Options:
-    r"""
-    Options for exporting PLY.
-    """
-    def __new__(cls) -> Options:
-        r"""
-        Set the options to their defaults.
-        """
-
-class Options:
-    r"""
-    Options for exporting DXF format.
-    """
-    def __new__(cls) -> Options:
-        r"""
-        Set the options to their defaults.
-        """
-
-class Options:
+class ObjImportOptions:
     r"""
     Options for importing OBJ.
     """
-    def __new__(cls) -> Options:
+    def __new__(cls) -> ObjImportOptions:
         r"""
         Set the options to their defaults.
         """
 
-class Options:
+class PlyExportOptions:
     r"""
-    Options for importing STL.
+    Options for exporting PLY.
     """
-    ...
-
-class Options:
-    r"""
-    Options for exporting FBX.
-    """
-    def __new__(cls) -> Options:
+    def __new__(cls) -> PlyExportOptions:
         r"""
         Set the options to their defaults.
         """
 
-class Options:
+class PlyImportOptions:
     r"""
-    Options for exporting glTF 2.0.
+    Options for importing PLY.
     """
-    def __new__(cls) -> Options:
-        r"""
-        Set the options to their defaults.
-        """
-
-class Options:
-    r"""
-    Options for importing glTF 2.0.
-    """
-    def __new__(cls) -> Options:
-        r"""
-        Set the options to their defaults.
-        """
-
-class Options:
-    r"""
-    Options for exporting STL.
-    """
-    def __new__(cls) -> Options:
+    def __new__(cls) -> PlyImportOptions:
         r"""
         Set the options to their defaults.
         """
@@ -281,6 +239,15 @@ class RawFile:
     @property
     def name(self) -> builtins.str: ...
 
+class SldprtImportOptions:
+    r"""
+    Options for importing SolidWorks parts.
+    """
+    def __new__(cls) -> SldprtImportOptions:
+        r"""
+        Set the options to their defaults.
+        """
+
 class SnapshotOptions:
     r"""
     Customize a snapshot.
@@ -294,6 +261,39 @@ class SnapshotOptions:
         r"""
         Takes a padding number.
         """
+
+class StepExportOptions:
+    r"""
+    Options for exporting STEP format.
+    """
+    def __new__(cls) -> StepExportOptions:
+        r"""
+        Set the options to their defaults.
+        """
+
+class StepImportOptions:
+    r"""
+    Options for importing STEP format.
+    """
+    def __new__(cls) -> StepImportOptions:
+        r"""
+        Set the options to their defaults.
+        """
+
+class StlExportOptions:
+    r"""
+    Options for exporting STL.
+    """
+    def __new__(cls) -> StlExportOptions:
+        r"""
+        Set the options to their defaults.
+        """
+
+class StlImportOptions:
+    r"""
+    Options for importing STL.
+    """
+    ...
 
 class System:
     r"""
@@ -335,6 +335,34 @@ class Direction(Enum):
     Negative = ...
     r"""
     Decreasing numbers.
+    """
+
+class DxfStorage(Enum):
+    r"""
+    Export storage.
+    """
+    Ascii = ...
+    r"""
+    Plaintext encoding.
+    
+    This is the default setting.
+    """
+    Binary = ...
+    r"""
+    Binary encoding.
+    """
+
+class FbxStorage(Enum):
+    r"""
+    Describes the storage format of an FBX file.
+    """
+    Ascii = ...
+    r"""
+    ASCII FBX encoding.
+    """
+    Binary = ...
+    r"""
+    Binary FBX encoding.
     """
 
 class FileExportFormat(Enum):
@@ -386,35 +414,7 @@ class FileExportFormat(Enum):
     The STL file format. <https://en.wikipedia.org/wiki/STL_(file_format)>
     """
 
-class ImageFormat(Enum):
-    r"""
-    Enum containing the variety of image formats snapshots may be exported to.
-    """
-    Png = ...
-    r"""
-    .png format
-    """
-    Jpeg = ...
-    r"""
-    .jpeg format
-    """
-
-class Storage(Enum):
-    r"""
-    Export storage.
-    """
-    Ascii = ...
-    r"""
-    Plaintext encoding.
-    """
-    Binary = ...
-    r"""
-    Binary STL encoding.
-    
-    This is the default setting.
-    """
-
-class Storage(Enum):
+class GltfStorage(Enum):
     r"""
     Describes the storage format of a glTF 2.0 scene.
     """
@@ -441,32 +441,49 @@ class Storage(Enum):
     This is the default setting.
     """
 
-class Storage(Enum):
+class ImageFormat(Enum):
+    r"""
+    Enum containing the variety of image formats snapshots may be exported to.
+    """
+    Png = ...
+    r"""
+    .png format
+    """
+    Jpeg = ...
+    r"""
+    .jpeg format
+    """
+
+class PlyStorage(Enum):
+    r"""
+    The storage for the output PLY file.
+    """
+    Ascii = ...
+    r"""
+    Write numbers in their ascii representation (e.g. -13, 6.28, etc.). Properties are separated by spaces and elements are separated by line breaks.
+    """
+    BinaryLittleEndian = ...
+    r"""
+    Encode payload as binary using little endian.
+    """
+    BinaryBigEndian = ...
+    r"""
+    Encode payload as binary using big endian.
+    """
+
+class StlStorage(Enum):
     r"""
     Export storage.
     """
     Ascii = ...
     r"""
     Plaintext encoding.
+    """
+    Binary = ...
+    r"""
+    Binary STL encoding.
     
     This is the default setting.
-    """
-    Binary = ...
-    r"""
-    Binary encoding.
-    """
-
-class Storage(Enum):
-    r"""
-    Describes the storage format of an FBX file.
-    """
-    Ascii = ...
-    r"""
-    ASCII FBX encoding.
-    """
-    Binary = ...
-    r"""
-    Binary FBX encoding.
     """
 
 class UnitAngle(Enum):

--- a/rust/kcl-python-bindings/pyproject.toml
+++ b/rust/kcl-python-bindings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "zoo-kcl"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 classifiers = [
   "Programming Language :: Rust",
   "Programming Language :: Python :: Implementation :: CPython",

--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -287,6 +287,16 @@ fn to_py_exception(err: impl std::fmt::Display) -> PyErr {
     PyException::new_err(err.to_string())
 }
 
+/// Get the allowed relevant file extensions (imports + kcl).
+#[pyo3_stub_gen::derive::gen_stub_pyfunction]
+#[pyfunction]
+fn relevant_file_extensions() -> PyResult<Vec<String>> {
+    Ok(kcl_lib::RELEVANT_FILE_EXTENSIONS
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<Vec<String>>())
+}
+
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
 #[pyfunction]
 async fn import_and_snapshot_views(
@@ -712,6 +722,7 @@ fn kcl(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(format, m)?)?;
     m.add_function(wrap_pyfunction!(format_dir, m)?)?;
     m.add_function(wrap_pyfunction!(lint, m)?)?;
+    m.add_function(wrap_pyfunction!(relevant_file_extensions, m)?)?;
     Ok(())
 }
 

--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -654,7 +654,7 @@ fn lint(code: String) -> PyResult<Vec<Discovered>> {
 
 /// The kcl python module.
 #[pymodule]
-fn kcl(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn kcl(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Add our types to the module.
     m.add_class::<ImageFormat>()?;
     m.add_class::<RawFile>()?;

--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -2,10 +2,11 @@
 use anyhow::Result;
 use kcl_lib::{
     lint::{checks, Discovered},
-    ExecutorContext, UnitLength,
+    ExecutorContext,
 };
 use kittycad_modeling_cmds::{
-    self as kcmc, format::InputFormat3d, shared::FileExportFormat, websocket::RawFile, ImageFormat, ImportFile,
+    self as kcmc, format::InputFormat3d, shared::FileExportFormat, units::UnitLength, websocket::RawFile, ImageFormat,
+    ImportFile,
 };
 use pyo3::{
     exceptions::PyException, prelude::PyModuleMethods, pyclass, pyfunction, pymethods, pymodule, types::PyModule,
@@ -41,7 +42,7 @@ fn into_miette_for_parse(filename: &str, input: &str, error: kcl_lib::KclError) 
 
 fn get_output_format(
     format: &FileExportFormat,
-    src_unit: kittycad_modeling_cmds::units::UnitLength,
+    src_unit: UnitLength,
 ) -> kittycad_modeling_cmds::format::OutputFormat3d {
     // Zoo co-ordinate system.
     //

--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -666,44 +666,18 @@ fn kcl(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<bridge::CameraLookAt>()?;
     m.add_class::<kcmc::format::InputFormat3d>()?;
 
-    let step_import = PyModule::new(py, "step_import")?;
-    step_import.add_class::<kcmc::format::step::import::Options>()?;
-    m.add_submodule(&step_import)?;
-    let step_export = PyModule::new(py, "step_export")?;
-    step_export.add_class::<kcmc::format::step::export::Options>()?;
-    m.add_submodule(&step_export)?;
-
-    let gltf_import = PyModule::new(py, "gltf_import")?;
-    gltf_import.add_class::<kcmc::format::gltf::import::Options>()?;
-    m.add_submodule(&gltf_import)?;
-    let gltf_export = PyModule::new(py, "gltf_export")?;
-    gltf_export.add_class::<kcmc::format::gltf::export::Options>()?;
-    m.add_submodule(&gltf_export)?;
-
-    let obj_import = PyModule::new(py, "obj_import")?;
-    obj_import.add_class::<kcmc::format::obj::import::Options>()?;
-    m.add_submodule(&obj_import)?;
-    let obj_export = PyModule::new(py, "obj_export")?;
-    obj_export.add_class::<kcmc::format::obj::export::Options>()?;
-    m.add_submodule(&obj_export)?;
-
-    let ply_import = PyModule::new(py, "ply_import")?;
-    ply_import.add_class::<kcmc::format::ply::import::Options>()?;
-    m.add_submodule(&ply_import)?;
-    let ply_export = PyModule::new(py, "ply_export")?;
-    ply_export.add_class::<kcmc::format::ply::export::Options>()?;
-    m.add_submodule(&ply_export)?;
-
-    let stl_import = PyModule::new(py, "stl_import")?;
-    stl_import.add_class::<kcmc::format::stl::import::Options>()?;
-    m.add_submodule(&stl_import)?;
-    let stl_export = PyModule::new(py, "stl_export")?;
-    stl_export.add_class::<kcmc::format::stl::export::Options>()?;
-    m.add_submodule(&stl_export)?;
-
-    let sldprt_import = PyModule::new(py, "sldprt_import")?;
-    sldprt_import.add_class::<kcmc::format::sldprt::import::Options>()?;
-    m.add_submodule(&sldprt_import)?;
+    // These are fine to add top level since we rename them in pyo3 derives.
+    m.add_class::<kcmc::format::step::import::Options>()?;
+    m.add_class::<kcmc::format::step::export::Options>()?;
+    m.add_class::<kcmc::format::gltf::import::Options>()?;
+    m.add_class::<kcmc::format::gltf::export::Options>()?;
+    m.add_class::<kcmc::format::obj::import::Options>()?;
+    m.add_class::<kcmc::format::obj::export::Options>()?;
+    m.add_class::<kcmc::format::ply::import::Options>()?;
+    m.add_class::<kcmc::format::ply::export::Options>()?;
+    m.add_class::<kcmc::format::stl::import::Options>()?;
+    m.add_class::<kcmc::format::stl::export::Options>()?;
+    m.add_class::<kcmc::format::sldprt::import::Options>()?;
 
     // Add our functions to the module.
     m.add_function(wrap_pyfunction!(parse, m)?)?;

--- a/rust/kcl-python-bindings/tests/tests.py
+++ b/rust/kcl-python-bindings/tests/tests.py
@@ -218,7 +218,7 @@ async def test_import_and_snapshots():
         kcl.SnapshotOptions(camera=None, padding=0),
     ]
     # Read from a file.
-    step_options = kcl.step_import.Options()
+    step_options = kcl.StepImportOptions()
     input_format = kcl.InputFormat3d.Step(step_options)
     print(cube_step_file)
     images = await kcl.import_and_snapshot_views(
@@ -234,7 +234,7 @@ async def test_import_and_snapshots():
 @pytest.mark.asyncio
 async def test_import_and_snapshots_single():
     # Read from a file.
-    step_options = kcl.step_import.Options()
+    step_options = kcl.StepImportOptions()
     input_format = kcl.InputFormat3d.Step(step_options)
     print(cube_step_file)
     image_bytes = await kcl.import_and_snapshot(

--- a/rust/kcl-python-bindings/tests/tests.py
+++ b/rust/kcl-python-bindings/tests/tests.py
@@ -317,3 +317,13 @@ async def test_kcl_execute_code_and_export_with_bad_units():
             assert len(str(e)) > 0
             print(e)
             assert "[1:1]" in str(e)
+
+
+def test_relevant_file_extensions():
+    exts = kcl.relevant_file_extensions()
+    assert isinstance(exts, list)
+    assert len(exts) > 0
+    assert len(exts) > 5
+    assert all(isinstance(x, str) and len(x) > 0 for x in exts)
+    # kcl should always be included in the set
+    assert "kcl" in exts


### PR DESCRIPTION
so we can get rid of https://github.com/KittyCAD/text-to-cad/blob/079d2518cf0721c48cf8bcc80137d7018781a0b6/text_to_cad/routes.py#L68

removed duplicate UnitLength and fixes the default to mm and adds a bunch of tests for it