### PR TITLE
KCL docs: Alt text should properly include fn name.

### DIFF
--- a/docs/kcl-std/functions/std-appearance-hexString.md
+++ b/docs/kcl-std/functions/std-appearance-hexString.md
@@ -37,7 +37,7 @@ startSketchOn(-XZ)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the appearance::hexString function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-appearance-hexString0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -75,7 +75,7 @@ map(
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the appearance::hexString function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-appearance-hexString1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -117,7 +117,7 @@ grid(offset = 0, red = 0)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the appearance::hexString function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-appearance-hexString2_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -164,7 +164,7 @@ map(
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the appearance::hexString function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-appearance-hexString3_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-array-concat.md
+++ b/docs/kcl-std/functions/std-array-concat.md
@@ -47,7 +47,7 @@ assert(count(newArr), isEqualTo = 6, tolerance = 0.00001)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the concat function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-array-concat0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -71,7 +71,7 @@ assert(count(newArr), isEqualTo = 3, tolerance = 0.00001)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the concat function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-array-concat1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-array-count.md
+++ b/docs/kcl-std/functions/std-array-count.md
@@ -35,7 +35,7 @@ assert(count(arr1), isEqualTo = 3)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the count function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-array-count0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-array-map.md
+++ b/docs/kcl-std/functions/std-array-map.md
@@ -48,7 +48,7 @@ circles = map([1..3], f = drawCircle)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the map function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-array-map0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -75,7 +75,7 @@ circles = map(
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the map function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-array-map1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-array-pop.md
+++ b/docs/kcl-std/functions/std-array-pop.md
@@ -53,7 +53,7 @@ assert(
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the pop function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-array-pop0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-array-push.md
+++ b/docs/kcl-std/functions/std-array-push.md
@@ -45,7 +45,7 @@ assert(
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the push function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-array-push0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-array-reduce.md
+++ b/docs/kcl-std/functions/std-array-reduce.md
@@ -66,7 +66,7 @@ assert(
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the reduce function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-array-reduce0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -104,7 +104,7 @@ assert(
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the reduce function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-array-reduce1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -166,7 +166,7 @@ decagon(5.0)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the reduce function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-array-reduce2_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-clone.md
+++ b/docs/kcl-std/functions/std-clone.md
@@ -52,7 +52,7 @@ clonedSketch = clone(exampleSketch)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the clone function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-clone0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -83,7 +83,7 @@ clonedPart = clone(myPart)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the clone function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-clone1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -116,7 +116,7 @@ loft([sketch001, sketch002])
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the clone function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-clone2_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -148,7 +148,7 @@ sketch002 = clone(sketch001)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the clone function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-clone3_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -187,7 +187,7 @@ startSketchOn(sketch002, face = sketchingFace)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the clone function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-clone4_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -233,7 +233,7 @@ clonedMountingPlate = clone(mountingPlate)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the clone function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-clone5_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -270,7 +270,7 @@ sweepedSpring = clone(springSketch)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the clone function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-clone6_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -295,7 +295,7 @@ sketch002 = clone(sketch001)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the clone function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-clone7_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -349,7 +349,7 @@ example001 = revolve(
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the clone function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-clone8_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -377,7 +377,7 @@ clonedCube = clone(myCube)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the clone function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-clone9_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-math-abs.md
+++ b/docs/kcl-std/functions/std-math-abs.md
@@ -44,7 +44,7 @@ baseExtrusion = extrude(sketch001, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the abs function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-math-abs0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-math-acos.md
+++ b/docs/kcl-std/functions/std-math-acos.md
@@ -41,7 +41,7 @@ extrude001 = extrude(sketch001, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the acos function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-math-acos0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-math-asin.md
+++ b/docs/kcl-std/functions/std-math-asin.md
@@ -40,7 +40,7 @@ extrude001 = extrude(sketch001, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the asin function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-math-asin0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-math-atan2.md
+++ b/docs/kcl-std/functions/std-math-atan2.md
@@ -44,7 +44,7 @@ extrude001 = extrude(sketch001, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the atan2 function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-math-atan20_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-math-ceil.md
+++ b/docs/kcl-std/functions/std-math-ceil.md
@@ -41,7 +41,7 @@ extrude001 = extrude(sketch001, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the ceil function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-math-ceil0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-math-cos.md
+++ b/docs/kcl-std/functions/std-math-cos.md
@@ -40,7 +40,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the cos function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-math-cos0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-math-floor.md
+++ b/docs/kcl-std/functions/std-math-floor.md
@@ -41,7 +41,7 @@ extrude001 = extrude(sketch001, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the floor function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-math-floor0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-math-ln.md
+++ b/docs/kcl-std/functions/std-math-ln.md
@@ -41,7 +41,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the ln function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-math-ln0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-math-log.md
+++ b/docs/kcl-std/functions/std-math-log.md
@@ -47,7 +47,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the log function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-math-log0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-math-log10.md
+++ b/docs/kcl-std/functions/std-math-log10.md
@@ -41,7 +41,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the log10 function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-math-log100_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-math-log2.md
+++ b/docs/kcl-std/functions/std-math-log2.md
@@ -41,7 +41,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the log2 function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-math-log20_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-math-max.md
+++ b/docs/kcl-std/functions/std-math-max.md
@@ -40,7 +40,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the max function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-math-max0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-math-min.md
+++ b/docs/kcl-std/functions/std-math-min.md
@@ -40,7 +40,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the min function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-math-min0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-math-polar.md
+++ b/docs/kcl-std/functions/std-math-polar.md
@@ -46,7 +46,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the polar function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-math-polar0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-math-pow.md
+++ b/docs/kcl-std/functions/std-math-pow.md
@@ -44,7 +44,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the pow function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-math-pow0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-math-rem.md
+++ b/docs/kcl-std/functions/std-math-rem.md
@@ -43,7 +43,7 @@ assert(rem(6.5, divisor = 2), isEqualTo = 0.5, error = "remainder is 0.5")
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the rem function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-math-rem0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-math-round.md
+++ b/docs/kcl-std/functions/std-math-round.md
@@ -41,7 +41,7 @@ extrude001 = extrude(sketch001, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the round function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-math-round0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-math-sin.md
+++ b/docs/kcl-std/functions/std-math-sin.md
@@ -40,7 +40,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the sin function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-math-sin0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-math-sqrt.md
+++ b/docs/kcl-std/functions/std-math-sqrt.md
@@ -40,7 +40,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the sqrt function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-math-sqrt0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-math-tan.md
+++ b/docs/kcl-std/functions/std-math-tan.md
@@ -40,7 +40,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the tan function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-math-tan0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-offsetPlane.md
+++ b/docs/kcl-std/functions/std-offsetPlane.md
@@ -51,7 +51,7 @@ loft([squareSketch, circleSketch])
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the offsetPlane function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-offsetPlane0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -82,7 +82,7 @@ loft([squareSketch, circleSketch])
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the offsetPlane function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-offsetPlane1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -113,7 +113,7 @@ loft([squareSketch, circleSketch])
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the offsetPlane function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-offsetPlane2_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -144,7 +144,7 @@ loft([squareSketch, circleSketch])
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the offsetPlane function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-offsetPlane3_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -173,7 +173,7 @@ startSketchOn(offsetPlane(XY, offset = 4))
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the offsetPlane function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-offsetPlane4_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-angledLine.md
+++ b/docs/kcl-std/functions/std-sketch-angledLine.md
@@ -58,7 +58,7 @@ example = extrude(exampleSketch, length = 10)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the angledLine function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-angledLine0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-angledLineThatIntersects.md
+++ b/docs/kcl-std/functions/std-sketch-angledLineThatIntersects.md
@@ -52,7 +52,7 @@ example = extrude(exampleSketch, length = 10)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the angledLineThatIntersects function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-angledLineThatIntersects0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-arc.md
+++ b/docs/kcl-std/functions/std-sketch-arc.md
@@ -62,7 +62,7 @@ example = extrude(exampleSketch, length = 10)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the arc function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-arc0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -85,7 +85,7 @@ example = extrude(exampleSketch, length = 10)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the arc function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-arc1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-bezierCurve.md
+++ b/docs/kcl-std/functions/std-sketch-bezierCurve.md
@@ -58,7 +58,7 @@ example = extrude(exampleSketch, length = 10)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the bezierCurve function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-bezierCurve0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -82,7 +82,7 @@ startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the bezierCurve function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-bezierCurve1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-circle.md
+++ b/docs/kcl-std/functions/std-sketch-circle.md
@@ -47,7 +47,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the circle function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-circle0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -74,7 +74,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the circle function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-circle1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-circleThreePoint.md
+++ b/docs/kcl-std/functions/std-sketch-circleThreePoint.md
@@ -46,7 +46,7 @@ exampleSketch = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the circleThreePoint function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-circleThreePoint0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-close.md
+++ b/docs/kcl-std/functions/std-sketch-close.md
@@ -46,7 +46,7 @@ startSketchOn(XZ)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the close function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-close0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -71,7 +71,7 @@ example = extrude(exampleSketch, length = 10)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the close function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-close1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-conic.md
+++ b/docs/kcl-std/functions/std-sketch-conic.md
@@ -65,7 +65,7 @@ example = extrude(exampleSketch, length = 10)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the conic function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-conic0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-ellipse.md
+++ b/docs/kcl-std/functions/std-sketch-ellipse.md
@@ -51,7 +51,7 @@ exampleSketch = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the ellipse function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-ellipse0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-elliptic.md
+++ b/docs/kcl-std/functions/std-sketch-elliptic.md
@@ -68,7 +68,7 @@ example = extrude(exampleSketch, length = 10)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the elliptic function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-elliptic0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-ellipticPoint.md
+++ b/docs/kcl-std/functions/std-sketch-ellipticPoint.md
@@ -45,7 +45,7 @@ assert(point001[1], isEqualTo = point002[1])
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the ellipticPoint function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-ellipticPoint0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-extrude.md
+++ b/docs/kcl-std/functions/std-sketch-extrude.md
@@ -69,7 +69,7 @@ example = startSketchOn(XZ)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the extrude function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-extrude0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -98,7 +98,7 @@ example = extrude(exampleSketch, length = 10)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the extrude function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-extrude1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -127,7 +127,7 @@ example = extrude(exampleSketch, length = 20, symmetric = true)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the extrude function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-extrude2_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -156,7 +156,7 @@ example = extrude(exampleSketch, length = 10, bidirectionalLength = 50)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the extrude function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-extrude3_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -177,7 +177,7 @@ example = startSketchOn(XZ)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the extrude function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-extrude4_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -213,7 +213,7 @@ translate(cylinder, x = 1)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the extrude function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-extrude5_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-getCommonEdge.md
+++ b/docs/kcl-std/functions/std-sketch-getCommonEdge.md
@@ -53,7 +53,7 @@ commonEdge = getCommonEdge(faces = [chamfer0, end0])
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the getCommonEdge function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-getCommonEdge0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-getNextAdjacentEdge.md
+++ b/docs/kcl-std/functions/std-sketch-getNextAdjacentEdge.md
@@ -44,7 +44,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the getNextAdjacentEdge function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-getNextAdjacentEdge0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-getOppositeEdge.md
+++ b/docs/kcl-std/functions/std-sketch-getOppositeEdge.md
@@ -44,7 +44,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the getOppositeEdge function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-getOppositeEdge0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-getPreviousAdjacentEdge.md
+++ b/docs/kcl-std/functions/std-sketch-getPreviousAdjacentEdge.md
@@ -44,7 +44,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the getPreviousAdjacentEdge function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-getPreviousAdjacentEdge0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-hyperbolic.md
+++ b/docs/kcl-std/functions/std-sketch-hyperbolic.md
@@ -62,7 +62,7 @@ exampleSketch = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the hyperbolic function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-hyperbolic0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-hyperbolicPoint.md
+++ b/docs/kcl-std/functions/std-sketch-hyperbolicPoint.md
@@ -42,7 +42,7 @@ point = hyperbolicPoint(x = 5, semiMajor = 2, semiMinor = 1)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the hyperbolicPoint function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-hyperbolicPoint0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-involuteCircular.md
+++ b/docs/kcl-std/functions/std-sketch-involuteCircular.md
@@ -60,7 +60,7 @@ startSketchOn(XZ)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the involuteCircular function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-involuteCircular0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-lastSegX.md
+++ b/docs/kcl-std/functions/std-sketch-lastSegX.md
@@ -42,7 +42,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the lastSegX function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-lastSegX0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-lastSegY.md
+++ b/docs/kcl-std/functions/std-sketch-lastSegY.md
@@ -42,7 +42,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the lastSegY function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-lastSegY0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-line.md
+++ b/docs/kcl-std/functions/std-sketch-line.md
@@ -61,7 +61,7 @@ box = startSketchOn(XZ)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the line function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-line0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-loft.md
+++ b/docs/kcl-std/functions/std-sketch-loft.md
@@ -64,7 +64,7 @@ loft([triangleSketch, squareSketch])
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the loft function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-loft0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -102,7 +102,7 @@ loft([
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the loft function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-loft1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -146,7 +146,7 @@ loft(
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the loft function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-loft2_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-parabolic.md
+++ b/docs/kcl-std/functions/std-sketch-parabolic.md
@@ -55,7 +55,7 @@ exampleSketch = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the parabolic function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-parabolic0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-parabolicPoint.md
+++ b/docs/kcl-std/functions/std-sketch-parabolicPoint.md
@@ -43,7 +43,7 @@ assert(point001[1], isEqualTo = point002[1])
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the parabolicPoint function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-parabolicPoint0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-patternCircular2d.md
+++ b/docs/kcl-std/functions/std-sketch-patternCircular2d.md
@@ -59,7 +59,7 @@ example = extrude(exampleSketch, length = 1)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the patternCircular2d function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-patternCircular2d0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-patternLinear2d.md
+++ b/docs/kcl-std/functions/std-sketch-patternLinear2d.md
@@ -51,7 +51,7 @@ example = extrude(exampleSketch, length = 1)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the patternLinear2d function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-patternLinear2d0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -77,7 +77,7 @@ example = extrude(exampleSketch, length = 1)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the patternLinear2d function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-patternLinear2d1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-patternTransform2d.md
+++ b/docs/kcl-std/functions/std-sketch-patternTransform2d.md
@@ -50,7 +50,7 @@ sketch001 = startSketchOn(XZ)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the patternTransform2d function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-patternTransform2d0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-planeOf.md
+++ b/docs/kcl-std/functions/std-sketch-planeOf.md
@@ -48,7 +48,7 @@ startSketchOn(offsetPlane(topPlane, offset = 2))
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the planeOf function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-planeOf0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-polygon.md
+++ b/docs/kcl-std/functions/std-sketch-polygon.md
@@ -53,7 +53,7 @@ example = extrude(hex, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the polygon function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-polygon0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -80,7 +80,7 @@ example = extrude(square, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the polygon function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-polygon1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-profileStart.md
+++ b/docs/kcl-std/functions/std-sketch-profileStart.md
@@ -40,7 +40,7 @@ sketch001 = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the profileStart function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-profileStart0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-profileStartX.md
+++ b/docs/kcl-std/functions/std-sketch-profileStartX.md
@@ -38,7 +38,7 @@ sketch001 = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the profileStartX function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-profileStartX0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-profileStartY.md
+++ b/docs/kcl-std/functions/std-sketch-profileStartY.md
@@ -37,7 +37,7 @@ sketch001 = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the profileStartY function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-profileStartY0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-rectangle.md
+++ b/docs/kcl-std/functions/std-sketch-rectangle.md
@@ -45,7 +45,7 @@ exampleSketch = startSketchOn(-XZ)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the rectangle function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-rectangle0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -65,7 +65,7 @@ exampleSketch = startSketchOn(-XZ)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the rectangle function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-rectangle1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-revolve.md
+++ b/docs/kcl-std/functions/std-sketch-revolve.md
@@ -69,7 +69,7 @@ part001 = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the revolve function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-revolve0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -91,7 +91,7 @@ sketch001 = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the revolve function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-revolve1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -120,7 +120,7 @@ part001 = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the revolve function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-revolve2_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -157,7 +157,7 @@ part002 = startSketchOn(part001, face = END)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the revolve function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-revolve3_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -186,7 +186,7 @@ sketch001 = startSketchOn(box, face = END)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the revolve function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-revolve4_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -215,7 +215,7 @@ sketch001 = startSketchOn(box, face = END)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the revolve function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-revolve5_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -244,7 +244,7 @@ sketch001 = startSketchOn(box, face = END)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the revolve function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-revolve6_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -276,7 +276,7 @@ part001 = revolve(
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the revolve function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-revolve7_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -313,7 +313,7 @@ revolve([profile001, profile002], axis = X)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the revolve function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-revolve8_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -344,7 +344,7 @@ sketch001 = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the revolve function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-revolve9_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -373,7 +373,7 @@ sketch001 = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the revolve function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-revolve10_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -402,7 +402,7 @@ sketch001 = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the revolve function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-revolve11_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -431,7 +431,7 @@ sketch001 = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the revolve function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-revolve12_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-segAng.md
+++ b/docs/kcl-std/functions/std-sketch-segAng.md
@@ -44,7 +44,7 @@ example = extrude(exampleSketch, length = 4)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the segAng function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-segAng0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-segEnd.md
+++ b/docs/kcl-std/functions/std-sketch-segEnd.md
@@ -54,7 +54,7 @@ cylinder(radius = 4, tag = line4)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the segEnd function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-segEnd0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-segEndX.md
+++ b/docs/kcl-std/functions/std-sketch-segEndX.md
@@ -42,7 +42,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the segEndX function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-segEndX0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-segEndY.md
+++ b/docs/kcl-std/functions/std-sketch-segEndY.md
@@ -43,7 +43,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the segEndY function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-segEndY0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-segLen.md
+++ b/docs/kcl-std/functions/std-sketch-segLen.md
@@ -41,7 +41,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the segLen function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-segLen0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-segStart.md
+++ b/docs/kcl-std/functions/std-sketch-segStart.md
@@ -54,7 +54,7 @@ cylinder(radius = 4, tag = line4)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the segStart function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-segStart0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-segStartX.md
+++ b/docs/kcl-std/functions/std-sketch-segStartX.md
@@ -42,7 +42,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the segStartX function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-segStartX0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-segStartY.md
+++ b/docs/kcl-std/functions/std-sketch-segStartY.md
@@ -43,7 +43,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the segStartY function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-segStartY0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-startProfile.md
+++ b/docs/kcl-std/functions/std-sketch-startProfile.md
@@ -47,7 +47,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the startProfile function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-startProfile0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -73,7 +73,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the startProfile function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-startProfile1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -99,7 +99,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the startProfile function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-startProfile2_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -133,7 +133,7 @@ squareProfile2 = startProfile(mySketch, at = [20, 0])
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the startProfile function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-startProfile3_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-startSketchOn.md
+++ b/docs/kcl-std/functions/std-sketch-startSketchOn.md
@@ -86,7 +86,7 @@ example003 = extrude(exampleSketch003, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the startSketchOn function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-startSketchOn0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -133,7 +133,7 @@ example003 = extrude(exampleSketch003, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the startSketchOn function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-startSketchOn1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -177,7 +177,7 @@ example003 = extrude(exampleSketch003, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the startSketchOn function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-startSketchOn2_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -216,7 +216,7 @@ example002 = extrude(exampleSketch002, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the startSketchOn function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-startSketchOn3_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -263,7 +263,7 @@ example002 = extrude(exampleSketch002, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the startSketchOn function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-startSketchOn4_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -294,7 +294,7 @@ a1 = startSketchOn({
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the startSketchOn function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-startSketchOn5_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -327,7 +327,7 @@ subtract(cube001, tools = cube002)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the startSketchOn function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-startSketchOn6_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-subtract2d.md
+++ b/docs/kcl-std/functions/std-sketch-subtract2d.md
@@ -47,7 +47,7 @@ example = extrude(exampleSketch, length = 1)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the subtract2d function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-subtract2d0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -79,7 +79,7 @@ example = extrude(exampleSketch, length = 1)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the subtract2d function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-subtract2d1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-sweep.md
+++ b/docs/kcl-std/functions/std-sketch-sweep.md
@@ -73,7 +73,7 @@ sweepSketch = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the sweep function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-sweep0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -107,7 +107,7 @@ springSketch = startSketchOn(XZ)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the sweep function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-sweep1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -145,7 +145,7 @@ sweep([rectangleSketch, circleSketch], path = sweepPath)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the sweep function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-sweep2_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -176,7 +176,7 @@ sweep(circleSketch, path = sweepPath, sectional = true)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the sweep function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-sweep3_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-tangentToEnd.md
+++ b/docs/kcl-std/functions/std-sketch-tangentToEnd.md
@@ -43,7 +43,7 @@ pillExtrude = extrude(pillSketch, length = 10)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the tangentToEnd function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-tangentToEnd0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -71,7 +71,7 @@ pillExtrude = extrude(pillSketch, length = 10)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the tangentToEnd function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-tangentToEnd1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -98,7 +98,7 @@ rectangleExtrude = extrude(rectangleSketch, length = 10)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the tangentToEnd function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-tangentToEnd2_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -121,7 +121,7 @@ bottom = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the tangentToEnd function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-tangentToEnd3_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -147,7 +147,7 @@ triangleSketch = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the tangentToEnd function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-tangentToEnd4_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-tangentialArc.md
+++ b/docs/kcl-std/functions/std-sketch-tangentialArc.md
@@ -59,7 +59,7 @@ example = extrude(exampleSketch, length = 10)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the tangentialArc function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-tangentialArc0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -85,7 +85,7 @@ example = extrude(exampleSketch, length = 10)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the tangentialArc function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-tangentialArc1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -111,7 +111,7 @@ example = extrude(exampleSketch, length = 10)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the tangentialArc function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-tangentialArc2_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-xLine.md
+++ b/docs/kcl-std/functions/std-sketch-xLine.md
@@ -52,7 +52,7 @@ example = extrude(exampleSketch, length = 10)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the xLine function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-xLine0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-sketch-yLine.md
+++ b/docs/kcl-std/functions/std-sketch-yLine.md
@@ -50,7 +50,7 @@ example = extrude(exampleSketch, length = 10)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the yLine function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-sketch-yLine0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-solid-appearance.md
+++ b/docs/kcl-std/functions/std-solid-appearance.md
@@ -52,7 +52,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the appearance function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-appearance0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -75,7 +75,7 @@ sketch001 = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the appearance function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-appearance1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -120,7 +120,7 @@ appearance(
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the appearance function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-appearance2_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -150,7 +150,7 @@ shell(firstSketch, faces = [END], thickness = 0.25)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the appearance function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-appearance3_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -180,7 +180,7 @@ shell(firstSketch, faces = [END], thickness = 0.25)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the appearance function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-appearance4_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -210,7 +210,7 @@ example = extrude(exampleSketch, length = 1)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the appearance function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-appearance5_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -240,7 +240,7 @@ example = extrude(exampleSketch, length = 1)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the appearance function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-appearance6_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -274,7 +274,7 @@ example = extrude(exampleSketch, length = 1)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the appearance function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-appearance7_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -311,7 +311,7 @@ sweepSketch = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the appearance function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-appearance8_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -336,7 +336,7 @@ cube
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the appearance function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-appearance9_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-solid-chamfer.md
+++ b/docs/kcl-std/functions/std-solid-chamfer.md
@@ -66,7 +66,7 @@ mountingPlate = extrude(mountingPlateSketch, length = thickness)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the chamfer function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-chamfer0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -109,7 +109,7 @@ sketch001 = startSketchOn(part001, face = chamfer1)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the chamfer function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-chamfer1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-solid-fillet.md
+++ b/docs/kcl-std/functions/std-solid-fillet.md
@@ -67,7 +67,7 @@ mountingPlate = extrude(mountingPlateSketch, length = thickness)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the fillet function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-fillet0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -108,7 +108,7 @@ mountingPlate = extrude(mountingPlateSketch, length = thickness)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the fillet function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-fillet1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-solid-hollow.md
+++ b/docs/kcl-std/functions/std-solid-hollow.md
@@ -47,7 +47,7 @@ firstSketch = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the hollow function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-hollow0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -74,7 +74,7 @@ firstSketch = startSketchOn(-XZ)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the hollow function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-hollow1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -111,7 +111,7 @@ hollow(case, thickness = 0.5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the hollow function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-hollow2_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-solid-intersect.md
+++ b/docs/kcl-std/functions/std-solid-intersect.md
@@ -58,7 +58,7 @@ intersectedPart = intersect([part001, part002])
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the intersect function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-intersect0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -97,7 +97,7 @@ intersectedPart = part001 & part002
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the intersect function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-intersect1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-solid-patternCircular3d.md
+++ b/docs/kcl-std/functions/std-solid-patternCircular3d.md
@@ -61,7 +61,7 @@ example = extrude(exampleSketch, length = -5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the patternCircular3d function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-patternCircular3d0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -93,7 +93,7 @@ example = extrude(exampleSketch, length = -5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the patternCircular3d function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-patternCircular3d1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-solid-patternLinear3d.md
+++ b/docs/kcl-std/functions/std-solid-patternLinear3d.md
@@ -55,7 +55,7 @@ example = extrude(exampleSketch, length = 1)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the patternLinear3d function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-patternLinear3d0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -85,7 +85,7 @@ example = extrude(exampleSketch, length = 1)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the patternLinear3d function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-patternLinear3d1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -129,7 +129,7 @@ patternLinear3d(
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the patternLinear3d function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-patternLinear3d2_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -169,7 +169,7 @@ patternLinear3d(
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the patternLinear3d function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-patternLinear3d3_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-solid-patternTransform.md
+++ b/docs/kcl-std/functions/std-solid-patternTransform.md
@@ -87,7 +87,7 @@ sketch001 = startSketchOn(XZ)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the patternTransform function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-patternTransform0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -116,7 +116,7 @@ sketch001 = startSketchOn(XZ)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the patternTransform function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-patternTransform1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -171,7 +171,7 @@ myCubes = cube(length = width, center = [100, 0])
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the patternTransform function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-patternTransform2_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -221,7 +221,7 @@ myCubes = cube(length = width, center = [100, 100])
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the patternTransform function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-patternTransform3_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -263,7 +263,7 @@ vase = layer()
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the patternTransform function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-patternTransform4_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -298,7 +298,7 @@ startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the patternTransform function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-patternTransform5_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-solid-shell.md
+++ b/docs/kcl-std/functions/std-solid-shell.md
@@ -50,7 +50,7 @@ shell(firstSketch, faces = [END], thickness = 0.25)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the shell function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-shell0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -79,7 +79,7 @@ shell(firstSketch, faces = [START], thickness = 0.25)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the shell function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-shell1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -108,7 +108,7 @@ shell(firstSketch, faces = [myTag], thickness = 0.25)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the shell function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-shell2_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -137,7 +137,7 @@ shell(firstSketch, faces = [myTag, END], thickness = 0.25)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the shell function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-shell3_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -175,7 +175,7 @@ shell(case, faces = [START], thickness = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the shell function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-shell4_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -213,7 +213,7 @@ shell(thing1, faces = [END], thickness = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the shell function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-shell5_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -254,7 +254,7 @@ shell([thing1, thing2], faces = [END], thickness = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the shell function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-shell6_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-solid-subtract.md
+++ b/docs/kcl-std/functions/std-solid-subtract.md
@@ -61,7 +61,7 @@ subtractedPart = subtract([part001], tools = [part002])
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the subtract function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-subtract0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -100,7 +100,7 @@ subtractedPart = part001 - part002
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the subtract function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-subtract1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-solid-union.md
+++ b/docs/kcl-std/functions/std-solid-union.md
@@ -55,7 +55,7 @@ unionedPart = union([part001, part002])
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the union function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-union0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -94,7 +94,7 @@ unionedPart = part001 + part002
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the union function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-union1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -135,7 +135,7 @@ unionedPart = part001 | part002
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the union function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-solid-union2_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-transform-mirror2d.md
+++ b/docs/kcl-std/functions/std-transform-mirror2d.md
@@ -51,7 +51,7 @@ example = extrude(sketch001, length = 10)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the mirror2d function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-transform-mirror2d0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -77,7 +77,7 @@ example = extrude(sketch001, length = 10)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the mirror2d function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-transform-mirror2d1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -107,7 +107,7 @@ sketch001 = startSketchOn(XZ)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the mirror2d function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-transform-mirror2d2_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -136,7 +136,7 @@ example = extrude(sketch001, length = 10)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the mirror2d function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-transform-mirror2d3_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -170,7 +170,7 @@ shell([sketch002], faces = [END], thickness = .1)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the mirror2d function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-transform-mirror2d4_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-transform-rotate.md
+++ b/docs/kcl-std/functions/std-transform-rotate.md
@@ -92,7 +92,7 @@ sweepSketch = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the rotate function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-transform-rotate0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -130,7 +130,7 @@ sweepSketch = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the rotate function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-transform-rotate1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -168,7 +168,7 @@ sweepSketch = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the rotate function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-transform-rotate2_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -193,7 +193,7 @@ cube
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the rotate function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-transform-rotate3_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -231,7 +231,7 @@ sweepSketch = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the rotate function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-transform-rotate4_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -272,7 +272,7 @@ rotate(parts, axis = [0, 0, 1.0], angle = 90deg)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the rotate function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-transform-rotate5_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -309,7 +309,7 @@ loft([profile001, profile002])
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the rotate function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-transform-rotate6_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-transform-scale.md
+++ b/docs/kcl-std/functions/std-transform-scale.md
@@ -74,7 +74,7 @@ sweepSketch = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the scale function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-transform-scale0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -99,7 +99,7 @@ cube
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the scale function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-transform-scale1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -140,7 +140,7 @@ scale(parts, z = 0.5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the scale function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-transform-scale2_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-transform-translate.md
+++ b/docs/kcl-std/functions/std-transform-translate.md
@@ -69,7 +69,7 @@ sweepSketch = startSketchOn(XY)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the translate function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-transform-translate0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -99,7 +99,7 @@ cube
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the translate function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-transform-translate1_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -129,7 +129,7 @@ cube
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the translate function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-transform-translate2_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -175,7 +175,7 @@ translate(
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the translate function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-transform-translate3_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -214,7 +214,7 @@ square(10)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the translate function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-transform-translate4_output.gltf"
   ar
   environment-image="/moon_1k.hdr"
@@ -251,7 +251,7 @@ loft([profile001, profile002])
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the translate function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-transform-translate5_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-units-toDegrees.md
+++ b/docs/kcl-std/functions/std-units-toDegrees.md
@@ -40,7 +40,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the units::toDegrees function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-units-toDegrees0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-units-toRadians.md
+++ b/docs/kcl-std/functions/std-units-toRadians.md
@@ -40,7 +40,7 @@ example = extrude(exampleSketch, length = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the units::toRadians function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-units-toRadians0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-vector-add.md
+++ b/docs/kcl-std/functions/std-vector-add.md
@@ -43,7 +43,7 @@ assert(v2[2], isEqualTo = 13)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the vector::add function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-vector-add0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-vector-cross.md
+++ b/docs/kcl-std/functions/std-vector-cross.md
@@ -39,7 +39,7 @@ assert(vz[2], isEqualTo = 1)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the vector::cross function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-vector-cross0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-vector-div.md
+++ b/docs/kcl-std/functions/std-vector-div.md
@@ -43,7 +43,7 @@ assert(v2[2], isEqualTo = 3.333, tolerance = 0.01)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the vector::div function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-vector-div0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-vector-dot.md
+++ b/docs/kcl-std/functions/std-vector-dot.md
@@ -41,7 +41,7 @@ assert(dotprod, isEqualTo = 12)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the vector::dot function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-vector-dot0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-vector-magnitude.md
+++ b/docs/kcl-std/functions/std-vector-magnitude.md
@@ -36,7 +36,7 @@ assert(m, isEqualTo = 5)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the vector::magnitude function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-vector-magnitude0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-vector-mul.md
+++ b/docs/kcl-std/functions/std-vector-mul.md
@@ -43,7 +43,7 @@ assert(v2[2], isEqualTo = 30)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the vector::mul function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-vector-mul0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-vector-normalize.md
+++ b/docs/kcl-std/functions/std-vector-normalize.md
@@ -37,7 +37,7 @@ assert(normed[1], isEqualTo = 0.8)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the vector::normalize function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-vector-normalize0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/docs/kcl-std/functions/std-vector-sub.md
+++ b/docs/kcl-std/functions/std-vector-sub.md
@@ -43,7 +43,7 @@ assert(v2[2], isEqualTo = 7)
 
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the  function"
+  alt="Example showing a rendered KCL program that uses the vector::sub function"
   src="/kcl-test-outputs/models/serial_test_example_fn_std-vector-sub0_output.gltf"
   ar
   environment-image="/moon_1k.hdr"

--- a/rust/kcl-lib/src/docs/templates/function.hbs
+++ b/rust/kcl-lib/src/docs/templates/function.hbs
@@ -52,7 +52,7 @@ layout: manual
 {{#if this.gltf_path}}
 <model-viewer
   class="kcl-example"
-  alt="Example showing a rendered KCL program that uses the {{name}} function"
+  alt="Example showing a rendered KCL program that uses the {{@root.name}} function"
   src="{{this.gltf_path}}"
   ar
   environment-image="/moon_1k.hdr"


### PR DESCRIPTION
The problem was that in the handlebars template, `{{name}}` was referring to the property of an
example, when it should have been referring to the top-level property `name`. So I copied how other existing hbs code used that field instead.