### PR TITLE
Make TTC pane button green, change keyboard shortcut to `Ctrl+T`

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -45,7 +45,7 @@ export const AppHeader = ({
       >
         {projectMenuChildren}
       </ProjectSidebarMenu>
-      <div className="flex items-center gap-2 py-1 ml-auto">
+      <div className="flex items-center gap-2 py-1.5 ml-auto">
         {/* If there are children, show them, otherwise show User menu */}
         {children || <CommandBarOpenButton />}
         <UserSidebarMenu user={user} />

--- a/src/components/ModelingSidebar/ModelingPanes/index.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/index.tsx
@@ -80,6 +80,11 @@ interface PaneCallbackProps {
   platform: 'web' | 'desktop'
 }
 
+export type SidebarCssOverrides = Partial<{
+  button: string
+  // Could add pane, etc here
+}>
+
 export type SidebarPane = {
   id: SidebarType
   sidebarName: string
@@ -88,6 +93,7 @@ export type SidebarPane = {
   Content: React.FC<{ id: SidebarType; onClose: () => void }>
   hide?: boolean | ((props: PaneCallbackProps) => boolean)
   showBadge?: BadgeInfo
+  cssClassOverrides?: SidebarCssOverrides
 }
 
 export type SidebarAction = {
@@ -100,6 +106,7 @@ export type SidebarAction = {
   action: () => void
   hide?: boolean | ((props: PaneCallbackProps) => boolean)
   disable?: () => string | undefined
+  cssClassOverrides?: SidebarCssOverrides
 }
 
 // For now a lot of icons are the same but the reality is they could totally
@@ -110,6 +117,10 @@ const textToCadPane: SidebarPane = {
   icon: 'sparkles',
   keybinding: 'Ctrl + T',
   sidebarName: 'Text-to-CAD',
+  cssClassOverrides: {
+    button:
+      'bg-ml-green pressed:bg-transparent dark:!text-chalkboard-100 hover:dark:!text-inherit dark:pressed:!text-inherit',
+  },
   Content: (props) => {
     const settings = useSettings()
     const user = useUser()

--- a/src/components/ModelingSidebar/ModelingPanes/index.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/index.tsx
@@ -108,7 +108,7 @@ export type SidebarAction = {
 const textToCadPane: SidebarPane = {
   id: 'text-to-cad',
   icon: 'sparkles',
-  keybinding: 'Shift + E',
+  keybinding: 'Ctrl + T',
   sidebarName: 'Text-to-CAD',
   Content: (props) => {
     const settings = useSettings()

--- a/src/components/ModelingSidebar/ModelingSidebar.tsx
+++ b/src/components/ModelingSidebar/ModelingSidebar.tsx
@@ -20,6 +20,7 @@ import { MachineManagerContext } from '@src/components/MachineManagerProvider'
 import { ModelingPane } from '@src/components/ModelingSidebar/ModelingPane'
 import type {
   SidebarAction,
+  SidebarCssOverrides,
   SidebarPane,
   SidebarType,
 } from '@src/components/ModelingSidebar/ModelingPanes'
@@ -452,6 +453,7 @@ interface ModelingPaneButtonProps
     keybinding: string
     iconClassName?: string
     iconSize?: 'sm' | 'md' | 'lg'
+    cssClassOverrides?: SidebarCssOverrides
   }
   align: Alignment
   onClick: () => void
@@ -478,11 +480,12 @@ function ModelingPaneButton({
   return (
     <div
       id={paneConfig.id + '-button-holder'}
-      className="relative py-[1px]"
+      className="relative"
       data-onboarding-id={`${paneConfig.id}-pane-button`}
     >
       <button
-        className={`group pointer-events-auto flex items-center justify-center border-0 rounded-none border-transparent dark:border-transparent p-2 m-0 !outline-0 ${paneIsOpen ? ' !border-primary' : ''}`}
+        className={`group pointer-events-auto flex items-center justify-center border-0 rounded-none border-transparent dark:border-transparent p-2 m-0 !outline-0 ${paneIsOpen ? ' !border-primary' : ''} ${paneConfig.cssClassOverrides?.button ?? ''}`}
+        aria-pressed={paneIsOpen}
         style={{
           [tooltipPosition === 'left' ? 'borderLeft' : 'borderRight']:
             'solid 2px transparent',

--- a/src/components/UserSidebarMenu.tsx
+++ b/src/components/UserSidebarMenu.tsx
@@ -248,14 +248,14 @@ const UserSidebarMenu = ({ user }: { user?: User }) => {
               <img
                 src={user?.image || ''}
                 alt={user?.name || ''}
-                className="h-7 w-7 rounded-full"
+                className="h-6 w-6 rounded-full"
                 referrerPolicy="no-referrer"
                 onError={() => setImageLoadFailed(true)}
               />
             ) : (
               <CustomIcon
                 name="person"
-                className="w-7 h-7 text-chalkboard-70 dark:text-chalkboard-40 bg-chalkboard-20 dark:bg-chalkboard-80"
+                className="w-6 h-6 text-chalkboard-70 dark:text-chalkboard-40 bg-chalkboard-20 dark:bg-chalkboard-80"
               />
             )}
           </div>


### PR DESCRIPTION
>[!NOTE]
> If the padding tweaks mess with our E2E tests I'm gonna be real mad.

1. Sidestep user issue of a character being typed when keyboard shortcut is used by using a non-character combination
2. Highlight the TTC pane button in MLephant brand green

## Light mode
<img width="1834" height="1758" alt="Screenshot 2025-09-04 at 11 17 15 AM" src="https://github.com/user-attachments/assets/686c1736-b9a4-470a-a345-c2eab3f80e7f" />
<img width="1770" height="1756" alt="Screenshot 2025-09-04 at 11 17 27 AM" src="https://github.com/user-attachments/assets/30f6068d-3fa7-4c69-bcc0-06d31a1c674f" />

## Dark mode
<img width="1990" height="1760" alt="Screenshot 2025-09-04 at 11 17 03 AM" src="https://github.com/user-attachments/assets/bf746fa4-6710-4447-83e7-4276d617c9da" />
<img width="1704" height="1766" alt="Screenshot 2025-09-04 at 11 19 34 AM" src="https://github.com/user-attachments/assets/e7eca824-5ff0-4de3-8d2c-e684e93998bc" />
