### PR TITLE
Shift+Enter for line breaks, show them in the prompt outcome box

### DIFF
--- a/src/components/MlEphantConversation.tsx
+++ b/src/components/MlEphantConversation.tsx
@@ -84,11 +84,12 @@ export const MlEphantConversationInput = (
           data-testid="ml-ephant-conversation-input"
           ref={refDiv}
           onKeyDown={(e) => {
-            if (e.key !== 'Enter') {
-              return
+            const isOnlyEnter =
+              e.key === 'Enter' && !(e.shiftKey || e.metaKey || e.ctrlKey)
+            if (isOnlyEnter) {
+              e.preventDefault()
+              onClick()
             }
-            e.preventDefault()
-            onClick()
           }}
           className={`outline-none w-full overflow-auto ${isAnimating ? 'hidden' : ''}`}
           style={{ height: '2lh' }}

--- a/src/components/PromptCard.tsx
+++ b/src/components/PromptCard.tsx
@@ -195,8 +195,8 @@ export const PromptCard = (props: PromptCardProps) => {
 
   const cssPrompt =
     props.status !== 'failed'
-      ? 'select-text break-all shadow-sm bg-2 text-default border b-4 rounded-t-md rounded-bl-md pl-4 pr-4 pt-2 pb-2'
-      : 'select-text break-all shadow-sm bg-2 text-2 border b-4 rounded-t-md rounded-bl-md pl-4 pr-4 pt-2 pb-2'
+      ? 'select-text whitespace-pre-line hyphens-auto shadow-sm bg-2 text-default border b-4 rounded-t-md rounded-bl-md pl-4 pr-4 pt-2 pb-2'
+      : 'select-text whitespace-pre-line hyphens-auto shadow-sm bg-2 text-2 border b-4 rounded-t-md rounded-bl-md pl-4 pr-4 pt-2 pb-2'
 
   return (
     <div className={cssCard}>
@@ -208,7 +208,9 @@ export const PromptCard = (props: PromptCardProps) => {
             disabled={props.disabled}
             onFeedback={(...args) => props.onFeedback?.(...args)}
           />
-          <div className={cssPrompt}>{props.prompt}</div>
+          <div style={{ wordBreak: 'break-word' }} className={cssPrompt}>
+            {props.prompt}
+          </div>
         </div>
         <div className="w-fit-content">
           <AvatarUser src={props.userAvatar} />


### PR DESCRIPTION
- Adds support for newlines in the prompt box with <kbd>Shift+Enter</kbd>
- Makes the past prompts' display with word wrapping and hyphenation, preserving newlines

<img width="1744" height="1744" alt="Screenshot 2025-09-04 at 5 44 12 PM" src="https://github.com/user-attachments/assets/f9bad99c-56c3-45e2-9e75-63431b3f9cb5" />
