### PR TITLE
Add an info popover for "conversation memory coming soon", add a welcome message with prompt tips

### DIFF
--- a/src/components/MlEphantConversation.tsx
+++ b/src/components/MlEphantConversation.tsx
@@ -187,6 +187,13 @@ export const MlEphantConversation = (props: MlEphantConversationProps) => {
     <div className="relative">
       <div className="absolute inset-0">
         <div className="flex flex-col h-full">
+          <div className="bg-ml-green dark:text-chalkboard-100 p-2 flex items-center gap-4">
+            <CustomIcon name="beaker" className="w-5 h-5 flex-none" />
+            <p className="text-xs">
+              Text-to-CAD treats every prompt as separate. Full copilot mode
+              with conversational memory is coming soon.
+            </p>
+          </div>
           <div className="h-full flex flex-col justify-end overflow-auto">
             <div className="overflow-auto" ref={refScroll}>
               {props.isLoading === false ? (

--- a/src/components/MlEphantConversation.tsx
+++ b/src/components/MlEphantConversation.tsx
@@ -129,10 +129,7 @@ const MLEphantConversationStarter = () => {
           Text-to-CAD
         </span>
       </h2>
-      <p className="my-4">
-        Type in prompts to create and edit parts in your project. Here are some
-        tips:
-      </p>
+      <p className="my-4">Here are some tips for effective prompts:</p>
       <ul className="list-disc pl-4">
         <li className="my-4">
           Be as explicit as possible when describing geometry. Use dimensions,

--- a/src/components/MlEphantConversation.tsx
+++ b/src/components/MlEphantConversation.tsx
@@ -120,6 +120,35 @@ export const MlEphantConversationInput = (
   )
 }
 
+const MLEphantConversationStarter = () => {
+  return (
+    <div className="p-8 text-sm">
+      <h2 className="text-lg font-bold">
+        Welcome to{' '}
+        <span className="dark:text-ml-green light:underline decoration-ml-green underline-offset-4">
+          Text-to-CAD
+        </span>
+      </h2>
+      <p className="my-4">
+        Type in prompts to create and edit parts in your project. Here are some
+        tips:
+      </p>
+      <ul className="list-disc pl-4">
+        <li className="my-4">
+          Be as explicit as possible when describing geometry. Use dimensions,
+          use spatial relationships.
+        </li>
+        <li className="my-4">
+          Try using Text-to-CAD to make a model parametric, it's cool.
+        </li>
+        <li className="my-4">
+          Text-to-CAD treats every prompt as a separate instruction.
+        </li>
+      </ul>
+    </div>
+  )
+}
+
 export const MlEphantConversation = (props: MlEphantConversationProps) => {
   const refScroll = useRef<HTMLDivElement>(null)
   const [autoScroll, setAutoScroll] = useState<boolean>(true)
@@ -200,9 +229,7 @@ export const MlEphantConversation = (props: MlEphantConversationProps) => {
                     See more history
                   </div>
                 ) : (
-                  <div className="text-center p-4 text-chalkboard-60 text-md">
-                    The beginning of this project's Text-to-CAD history.
-                  </div>
+                  <MLEphantConversationStarter />
                 )
               ) : (
                 <div className="text-center p-4 text-chalkboard-60 text-md animate-pulse">
@@ -226,8 +253,8 @@ export const MlEphantConversation = (props: MlEphantConversationProps) => {
 
 export const MLEphantConversationPaneMenu = () => (
   <Popover className="relative">
-    <Popover.Button className="p-1 !bg-transparent border-transparent dark:!border-transparent hover:!border-primary dark:hover:!border-chalkboard-70 ui-open:!border-primary dark:ui-open:!border-chalkboard-70 !outline-none">
-      <CustomIcon name="beaker" className="w-4 h-4" />
+    <Popover.Button className="p-0 !bg-transparent border-transparent dark:!border-transparent hover:!border-primary dark:hover:!border-chalkboard-70 ui-open:!border-primary dark:ui-open:!border-chalkboard-70 !outline-none">
+      <CustomIcon name="questionMark" className="w-5 h-5" />
     </Popover.Button>
 
     <Transition
@@ -237,12 +264,17 @@ export const MLEphantConversationPaneMenu = () => (
       as={Fragment}
     >
       <Popover.Panel className="w-max max-w-md z-10 bg-default flex flex-col gap-4 absolute top-full left-auto right-0 mt-1 p-4 border border-solid b-5 rounded shadow-lg">
-        <div className="flex gap-4 items-center">
+        <div className="flex gap-2 items-center">
           <CustomIcon
             name="beaker"
             className="w-5 h-5 bg-ml-green dark:text-chalkboard-100 rounded-sm"
           />
-          <p className="text-base ">Text-to-CAD is experimental</p>
+          <p className="text-base font-bold">
+            <span className="dark:text-ml-green light:underline decoration-ml-green underline-offset-4">
+              Text-to-CAD
+            </span>{' '}
+            is experimental
+          </p>
         </div>
         <p className="text-sm">
           Text-to-CAD treats every prompt as separate. Full copilot mode with

--- a/src/components/MlEphantConversation.tsx
+++ b/src/components/MlEphantConversation.tsx
@@ -1,9 +1,10 @@
 import type { MlEphantManagerContext } from '@src/machines/mlEphantManagerMachine'
 import type { ReactNode } from 'react'
-import { useRef, useEffect, useState } from 'react'
+import { useRef, useEffect, useState, Fragment } from 'react'
 import type { Prompt } from '@src/lib/prompt'
 import { PromptCard } from '@src/components/PromptCard'
 import { CustomIcon } from '@src/components/CustomIcon'
+import { Popover, Transition } from '@headlessui/react'
 
 export interface MlEphantConversationProps {
   isLoading: boolean
@@ -187,13 +188,6 @@ export const MlEphantConversation = (props: MlEphantConversationProps) => {
     <div className="relative">
       <div className="absolute inset-0">
         <div className="flex flex-col h-full">
-          <div className="bg-ml-green dark:text-chalkboard-100 p-2 flex items-center gap-4">
-            <CustomIcon name="beaker" className="w-5 h-5 flex-none" />
-            <p className="text-xs">
-              Text-to-CAD treats every prompt as separate. Full copilot mode
-              with conversational memory is coming soon.
-            </p>
-          </div>
           <div className="h-full flex flex-col justify-end overflow-auto">
             <div className="overflow-auto" ref={refScroll}>
               {props.isLoading === false ? (
@@ -229,3 +223,33 @@ export const MlEphantConversation = (props: MlEphantConversationProps) => {
     </div>
   )
 }
+
+export const MLEphantConversationPaneMenu = () => (
+  <Popover className="relative">
+    <Popover.Button className="p-1 !bg-transparent border-transparent dark:!border-transparent hover:!border-primary dark:hover:!border-chalkboard-70 ui-open:!border-primary dark:ui-open:!border-chalkboard-70 !outline-none">
+      <CustomIcon name="beaker" className="w-4 h-4" />
+    </Popover.Button>
+
+    <Transition
+      enter="duration-100 ease-out"
+      enterFrom="opacity-0 -translate-y-2"
+      enterTo="opacity-100 translate-y-0"
+      as={Fragment}
+    >
+      <Popover.Panel className="w-max max-w-md z-10 bg-default flex flex-col gap-4 absolute top-full left-auto right-0 mt-1 p-4 border border-solid b-5 rounded shadow-lg">
+        <div className="flex gap-4 items-center">
+          <CustomIcon
+            name="beaker"
+            className="w-5 h-5 bg-ml-green dark:text-chalkboard-100 rounded-sm"
+          />
+          <p className="text-base ">Text-to-CAD is experimental</p>
+        </div>
+        <p className="text-sm">
+          Text-to-CAD treats every prompt as separate. Full copilot mode with
+          conversational memory is coming soon. Conversations are not currently
+          shared between computers.
+        </p>
+      </Popover.Panel>
+    </Transition>
+  </Popover>
+)

--- a/src/components/ModelingSidebar/ModelingPanes/index.tsx
+++ b/src/components/ModelingSidebar/ModelingPanes/index.tsx
@@ -51,6 +51,7 @@ import { relevantFileExtensions } from '@src/lang/wasmUtils'
 import toast from 'react-hot-toast'
 import { ToastInsert } from '@src/components/ToastInsert'
 import { isPlaywright } from '@src/lib/isPlaywright'
+import { MLEphantConversationPaneMenu } from '@src/components/MlEphantConversation'
 
 export type SidebarType =
   | 'code'
@@ -133,7 +134,7 @@ const textToCadPane: SidebarPane = {
           id={props.id}
           icon="sparkles"
           title="Text-to-CAD"
-          Menu={null}
+          Menu={MLEphantConversationPaneMenu}
           onClose={props.onClose}
         />
         <MlEphantConversationPane

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -80,6 +80,7 @@ module.exports = {
           return `.${e(`pressed${separator}${className}`)}[aria-pressed='true']`
         })
       })
+      addVariant('light', 'body:not(.dark) &')
     }),
   ],
 }


### PR DESCRIPTION
- adds a popover to the TTC pane that gives some additional info on TTC being experimental and that conversation history memory is coming soon
- adds a welcome message with some prompting tips in the spirit of https://text-to-cad.zoo.dev/
- adds a tailwind utility for light-mode-only styling, which helped me finally start trying to address a styling problem I've had because our ML green color is very nice for text in dark mode but completely unreadable in light mode. I'm trying out making "Text-to-CAD" green in dark mode, and giving it a green underline in light mode instead.

## Dark mode
<img width="1648" height="1696" alt="Screenshot 2025-09-05 at 11 36 43 AM" src="https://github.com/user-attachments/assets/5689fbc7-30ec-48e5-bcc3-24d7be409d5f" />

## Light mode
<img width="1910" height="1764" alt="Screenshot 2025-09-05 at 11 37 03 AM" src="https://github.com/user-attachments/assets/27a2b91d-5bad-4c53-b61d-84529065c46e" />
