### PR TITLE
Created a dedicated branch for the Vercel staging environment

### DIFF
--- a/.github/workflows/update-staging.yml
+++ b/.github/workflows/update-staging.yml
@@ -1,0 +1,25 @@
+name: sync-branch
+
+# This is used to sync the `staging` branch with the `main` branch to
+# continuously deploy the pre-production web app to Vercel
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  staging:
+    runs-on: namespace-profile-ubuntu-2-cores
+
+    steps:
+      - uses: actions/checkout@v4
+      - shell: bash
+        run: |
+          git checkout staging || git checkout -b staging
+          git fetch origin
+          git reset --hard origin/main
+          git push --force origin staging

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,8 @@
   "version": 2,
   "git": {
     "deploymentEnabled": {
-      "main": false
+      "main": false,
+      "staging": true
     }
   },
   "headers": [


### PR DESCRIPTION
https://github.com/KittyCAD/modeling-app/pull/8213 disabled the staging deployments, which we don't want.

Vercel insists on associating environments to branches so I'm going to create a new one for this purpose.

---

Contributes to https://github.com/KittyCAD/modeling-app/issues/8161