### PR TITLE
Fix Playwright impacting app sidebar layout

### DIFF
--- a/e2e/playwright/fixtures/fixtureSetup.ts
+++ b/e2e/playwright/fixtures/fixtureSetup.ts
@@ -40,8 +40,7 @@ export class AuthenticatedApp {
   }
 
   async initialise(code = '') {
-    const testDir = this.testInfo.outputPath('electron-test-projects-dir')
-    await setup(this.context, this.page, testDir, this.testInfo)
+    await setup(this.context, this.page, this.testInfo)
     const u = await getUtils(this.page)
 
     await this.page.addInitScript(async (code) => {
@@ -208,7 +207,7 @@ export class ElectronZoo {
       app.testProperty['TEST_SETTINGS_FILE_KEY'] = projectDirName
     }, this.projectDirName)
 
-    await setup(this.context, this.page, this.projectDirName, testInfo)
+    await setup(this.context, this.page, testInfo)
 
     await this.cleanProjectDir()
 

--- a/e2e/playwright/test-utils.ts
+++ b/e2e/playwright/test-utils.ts
@@ -911,7 +911,6 @@ export async function tearDown(page: Page, testInfo: TestInfo) {
 export async function setup(
   context: BrowserContext,
   page: Page,
-  testDir: string,
   testInfo?: TestInfo
 ) {
   await page.addInitScript(
@@ -920,7 +919,6 @@ export async function setup(
       settingsKey,
       settings,
       IS_PLAYWRIGHT_KEY,
-      PLAYWRIGHT_TEST_DIR,
       PERSIST_MODELING_CONTEXT,
     }) => {
       localStorage.clear()
@@ -932,7 +930,9 @@ export async function setup(
       )
       localStorage.setItem(settingsKey, settings)
       localStorage.setItem(IS_PLAYWRIGHT_KEY, 'true')
-      localStorage.setItem('PLAYWRIGHT_TEST_DIR', PLAYWRIGHT_TEST_DIR)
+      window.addEventListener('beforeunload', () => {
+        localStorage.removeItem(IS_PLAYWRIGHT_KEY)
+      })
     },
     {
       token,
@@ -955,7 +955,6 @@ export async function setup(
         },
       }),
       IS_PLAYWRIGHT_KEY,
-      PLAYWRIGHT_TEST_DIR: testDir,
       PERSIST_MODELING_CONTEXT,
     }
   )

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -74,9 +74,6 @@ export const TELEMETRY_FILE_NAME = 'boot.txt'
 export const TELEMETRY_RAW_FILE_NAME = 'raw-metrics.txt'
 export const ENVIRONMENT_FILE_NAME = 'environment.txt'
 
-/** localStorage key to determine if we're in Playwright tests */
-export const PLAYWRIGHT_KEY = 'playwright'
-
 /** Custom error message to match when rejectAllModelCommands is called
  * allows us to match if the execution of executeAst was interrupted
  * This needs to be of type WebsocketResponse, so that we can parse it back out


### PR DESCRIPTION
We need to clear the `'playwright'` key from local storage after tests run to prevent them from impacting the production app sidebar layout. I also removed `PLAYWRIGHT_KEY` and `PLAYWRIGHT_TEST_DIR` which no longer seem to serve a purpose.

---

Relates to https://github.com/KittyCAD/modeling-app/issues/7453