### PR TITLE
Use a faster prompt to test Text-to-CAD

### DIFF
--- a/e2e/playwright/text-to-cad-tests.spec.ts
+++ b/e2e/playwright/text-to-cad-tests.spec.ts
@@ -70,15 +70,13 @@ test.describe('Text-to-CAD tests', () => {
     const failureToastMessage = page.getByText(
       `The prompt must clearly describe a CAD model`
     )
-    await expect(failureToastMessage.first()).toBeVisible({ timeout: 30000 })
+    await expect(failureToastMessage.first()).toBeVisible({ timeout: 30_000 })
 
-    // start a new prompt.
-    await toolbar.fireTtcPrompt('a 2x4 lego')
+    // Start a new prompt
+    await toolbar.fireTtcPrompt('create a cube')
 
-    // Make sure the new prompt works.
-    await expect(page.getByText('a 2x4 lego')).toBeVisible()
-    await editor.expectEditor.toContain('startSketchOn', { timeout: 60000 })
-    await scene.settled(cmdBar)
+    // Make sure the new prompt works
+    await editor.expectEditor.toContain('startSketchOn', { timeout: 60_000 })
   })
 
   // TODO: enable once we can do it in the ml elephant pane

--- a/package-lock.json
+++ b/package-lock.json
@@ -2504,7 +2504,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
"a 2x4 lego" is now taking longer than a minute. For this test, the actual prompt is irrelevant as long as it works.