### PR TITLE
WIP - function overloading

### DIFF
--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -753,7 +753,7 @@ impl ExecutorContext {
                     if let ModulePath::Std { value: std_path } = &exec_state.mod_local.path {
                         let (func, props) = crate::std::std_fn(std_path, statement_kind.expect_name());
                         KclValue::Function {
-                            value: Box::new(FunctionSource::rust(func, function_expression.clone(), props, attrs)),
+                            value: vec![FunctionSource::rust(func, function_expression.clone(), props, attrs)],
                             meta: vec![metadata.to_owned()],
                         }
                     } else {
@@ -767,11 +767,11 @@ impl ExecutorContext {
                     // over variables. Variables defined lexically later shouldn't
                     // be available to the function body.
                     KclValue::Function {
-                        value: Box::new(FunctionSource::kcl(
+                        value: vec![FunctionSource::kcl(
                             function_expression.clone(),
                             exec_state.mut_stack().snapshot(),
                             matches!(&exec_state.mod_local.path, ModulePath::Std { .. }),
-                        )),
+                        )],
                         meta: vec![metadata.to_owned()],
                     }
                 }

--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -174,7 +174,8 @@ impl Node<CallExpressionKw> {
 
         let args = Args::new(fn_args, unlabeled, callsite, exec_state, ctx.clone());
 
-        let return_value = fn_src
+        // TODO check functions
+        let return_value = fn_src[0]
             .call_kw(Some(fn_name.to_string()), exec_state, ctx, args, callsite)
             .await
             .map_err(|e| {

--- a/rust/kcl-lib/src/lsp/kcl/mod.rs
+++ b/rust/kcl-lib/src/lsp/kcl/mod.rs
@@ -1044,9 +1044,10 @@ impl LanguageServer for Backend {
                 let (sig, docs) = if let Some(Some(result)) = with_cached_var(&name, |value| {
                     match value {
                         // User-defined function
-                        KclValue::Function { value, .. } if !value.is_std => {
+                        KclValue::Function { value, .. } if !value[0].1.is_std => {
+                            let sigs: Vec<_> = value.iter().map(|v| v.1.ast.signature()).collect();
                             // TODO get docs from comments
-                            Some((value.ast.signature(), ""))
+                            Some((sigs.join("\n---\n"), ""))
                         }
                         _ => None,
                     }

--- a/rust/kcl-lib/src/std/args.rs
+++ b/rust/kcl-lib/src/std/args.rs
@@ -1167,7 +1167,11 @@ impl<'a> FromKclValue<'a> for Box<Solid> {
 
 impl<'a> FromKclValue<'a> for FunctionSource {
     fn from_kcl_val(arg: &'a KclValue) -> Option<Self> {
-        arg.as_function().cloned()
+        let f = arg.as_function()?;
+        if f.len() != 1 {
+            return None;
+        }
+        Some(f[0].clone())
     }
 }
 


### PR DESCRIPTION
This is a WIP progress, the basic shape is there, but there are some issues to resolve. Essentially a function value in memory gets a Vec of function definitions rather than a single one.

The motivation is to have a nice way to handle functions like `line` and `arc` for both sketch mode 1 and 2. In theory, which you get could depend on the sketch if that was the first argument, but in practice an even easier overloading is that we distinguish between there being an input argument and there not being one (sketch mode 1 has one, v2 does not).

The complications are: handling multiple function definitions in our docs and for IDE stuff like hover and autocomplete, also since we're doing mutation of the value in memory, we need to interact with the epoch systems of program memory and check that function is defined at the point of call. These are both definitely solvable, but make this solution harder than otherwise.

I think, on balance, it is probably not worth finishing this work and a more ad-hoc versioning thing might be easier (e.g., special-casing the sketch2 module inside sketch blocks). But I'm sharing this branch in case y'all decide this is the best approach.