### PR TITLE
Add Vector3D Input Type to CommandBar

### DIFF
--- a/src/components/CommandBar/CommandBarArgument.tsx
+++ b/src/components/CommandBar/CommandBarArgument.tsx
@@ -7,6 +7,7 @@ import CommandBarPathInput from '@src/components/CommandBar/CommandBarPathInput'
 import CommandBarSelectionInput from '@src/components/CommandBar/CommandBarSelectionInput'
 import CommandBarSelectionMixedInput from '@src/components/CommandBar/CommandBarSelectionMixedInput'
 import CommandBarTextareaInput from '@src/components/CommandBar/CommandBarTextareaInput'
+import CommandBarVector3DInput from '@src/components/CommandBar/CommandBarVector3DInput'
 import type { CommandArgument } from '@src/lib/commandTypes'
 import { commandBarActor, useCommandBarState } from '@src/lib/singletons'
 
@@ -123,6 +124,14 @@ function ArgumentInput({
     case 'path':
       return (
         <CommandBarPathInput
+          arg={arg}
+          stepBack={stepBack}
+          onSubmit={onSubmit}
+        />
+      )
+    case 'vector3d':
+      return (
+        <CommandBarVector3DInput
           arg={arg}
           stepBack={stepBack}
           onSubmit={onSubmit}

--- a/src/components/CommandBar/CommandBarVector3DInput.tsx
+++ b/src/components/CommandBar/CommandBarVector3DInput.tsx
@@ -65,9 +65,11 @@ function CommandBarVector3DInput({
     // Submit form when Enter is pressed in the last field
     if (e.key === 'Enter' && !nextInputRef) {
       e.preventDefault()
-      document.getElementById('vector3d-form')?.dispatchEvent(
-        new Event('submit', { cancelable: true, bubbles: true })
-      )
+      document
+        .getElementById('vector3d-form')
+        ?.dispatchEvent(
+          new Event('submit', { cancelable: true, bubbles: true })
+        )
     }
   }
 

--- a/src/components/CommandBar/CommandBarVector3DInput.tsx
+++ b/src/components/CommandBar/CommandBarVector3DInput.tsx
@@ -40,7 +40,7 @@ function CommandBarVector3DInput({
     const zNum = parseFloat(z)
 
     // Basic validation - ensure all values are valid numbers
-    if (isNaN(xNum) || isNaN(yNum) || isNaN(zNum)) {
+    if (window.isNaN(xNum) || window.isNaN(yNum) || window.isNaN(zNum)) {
       return // Don't submit if any value is invalid
     }
 

--- a/src/components/CommandBar/CommandBarVector3DInput.tsx
+++ b/src/components/CommandBar/CommandBarVector3DInput.tsx
@@ -22,6 +22,7 @@ function CommandBarVector3DInput({
   const xInputRef = useRef<HTMLInputElement>(null)
   const yInputRef = useRef<HTMLInputElement>(null)
   const zInputRef = useRef<HTMLInputElement>(null)
+  const formRef = useRef<HTMLFormElement>(null)
 
   useHotkeys('mod + k, mod + /', () => commandBarActor.send({ type: 'Close' }))
 
@@ -65,17 +66,16 @@ function CommandBarVector3DInput({
     // Submit form when Enter is pressed in the last field
     if (e.key === 'Enter' && !nextInputRef) {
       e.preventDefault()
-      document
-        .getElementById('vector3d-form')
-        ?.dispatchEvent(
-          new Event('submit', { cancelable: true, bubbles: true })
-        )
+      formRef.current?.dispatchEvent(
+        new Event('submit', { bubbles: true })
+      )
     }
   }
 
   return (
     <div className="w-full">
       <form
+        ref={formRef}
         id="vector3d-form"
         data-testid="vector3d-form"
         onSubmit={handleSubmit}

--- a/src/components/CommandBar/CommandBarVector3DInput.tsx
+++ b/src/components/CommandBar/CommandBarVector3DInput.tsx
@@ -40,7 +40,7 @@ function CommandBarVector3DInput({
     const zNum = parseFloat(z)
 
     // Basic validation - ensure all values are valid numbers
-    if (Number.isNaN(xNum) || Number.isNaN(yNum) || Number.isNaN(zNum)) {
+    if (isNaN(xNum) || isNaN(yNum) || isNaN(zNum)) {
       return // Don't submit if any value is invalid
     }
 

--- a/src/components/CommandBar/CommandBarVector3DInput.tsx
+++ b/src/components/CommandBar/CommandBarVector3DInput.tsx
@@ -66,9 +66,7 @@ function CommandBarVector3DInput({
     // Submit form when Enter is pressed in the last field
     if (e.key === 'Enter' && !nextInputRef) {
       e.preventDefault()
-      formRef.current?.dispatchEvent(
-        new Event('submit', { bubbles: true })
-      )
+      formRef.current?.dispatchEvent(new Event('submit', { bubbles: true }))
     }
   }
 

--- a/src/components/CommandBar/CommandBarVector3DInput.tsx
+++ b/src/components/CommandBar/CommandBarVector3DInput.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useRef, useState } from 'react'
+import { useHotkeys } from 'react-hotkeys-hook'
+import { commandBarActor } from '@src/lib/singletons'
+import type { CommandArgument } from '@src/lib/commandTypes'
+
+function CommandBarVector3DInput({
+  arg,
+  stepBack,
+  onSubmit,
+}: {
+  arg: CommandArgument<unknown> & {
+    inputType: 'vector3d'
+    name: string
+  }
+  stepBack: () => void
+  onSubmit: (data: [number, number, number]) => void
+}) {
+  const [x, setX] = useState('')
+  const [y, setY] = useState('')
+  const [z, setZ] = useState('')
+
+  const xInputRef = useRef<HTMLInputElement>(null)
+  const yInputRef = useRef<HTMLInputElement>(null)
+  const zInputRef = useRef<HTMLInputElement>(null)
+
+  useHotkeys('mod + k, mod + /', () => commandBarActor.send({ type: 'Close' }))
+
+  // Focus the first input on mount
+  useEffect(() => {
+    if (xInputRef.current) {
+      xInputRef.current.focus()
+    }
+  }, [])
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+
+    const xNum = parseFloat(x)
+    const yNum = parseFloat(y)
+    const zNum = parseFloat(z)
+
+    // Basic validation - ensure all values are valid numbers
+    if (Number.isNaN(xNum) || Number.isNaN(yNum) || Number.isNaN(zNum)) {
+      return // Don't submit if any value is invalid
+    }
+
+    onSubmit([xNum, yNum, zNum])
+  }
+
+  function handleKeyDown(
+    e: React.KeyboardEvent<HTMLInputElement>,
+    nextInputRef?: React.RefObject<HTMLInputElement>
+  ) {
+    if (e.metaKey && e.key === 'k') {
+      commandBarActor.send({ type: 'Close' })
+    }
+    if (e.key === 'Backspace' && e.metaKey) {
+      stepBack()
+    }
+    // Move to next input on Tab or Enter
+    if ((e.key === 'Tab' || e.key === 'Enter') && nextInputRef?.current) {
+      e.preventDefault()
+      nextInputRef.current.focus()
+    }
+  }
+
+  return (
+    <div className="w-full">
+      <form
+        id="vector3d-form"
+        data-testid="vector3d-form"
+        onSubmit={handleSubmit}
+      >
+        <div className="flex items-center mx-4 mt-4 mb-2">
+          <span className="capitalize px-2 py-1 rounded-l bg-chalkboard-100 dark:bg-chalkboard-80 text-chalkboard-10 border-b border-b-chalkboard-100 dark:border-b-chalkboard-80">
+            {arg.displayName || arg.name}
+          </span>
+          <div className="flex flex-1">
+            <input
+              ref={xInputRef}
+              data-testid="vector3d-x-input"
+              type="number"
+              step="any"
+              placeholder="X"
+              value={x}
+              onChange={(e) => setX(e.target.value)}
+              onKeyDown={(e) => handleKeyDown(e, yInputRef)}
+              className="flex-1 px-2 py-1 bg-transparent border-b border-b-chalkboard-100 dark:border-b-chalkboard-80 focus:outline-none text-center"
+            />
+            <input
+              ref={yInputRef}
+              data-testid="vector3d-y-input"
+              type="number"
+              step="any"
+              placeholder="Y"
+              value={y}
+              onChange={(e) => setY(e.target.value)}
+              onKeyDown={(e) => handleKeyDown(e, zInputRef)}
+              className="flex-1 px-2 py-1 bg-transparent border-b border-b-chalkboard-100 dark:border-b-chalkboard-80 focus:outline-none text-center border-l border-l-chalkboard-100 dark:border-l-chalkboard-80"
+            />
+            <input
+              ref={zInputRef}
+              data-testid="vector3d-z-input"
+              type="number"
+              step="any"
+              placeholder="Z"
+              value={z}
+              onChange={(e) => setZ(e.target.value)}
+              onKeyDown={(e) => handleKeyDown(e)}
+              className="flex-1 px-2 py-1 bg-transparent border-b border-b-chalkboard-100 dark:border-b-chalkboard-80 focus:outline-none text-center border-l border-l-chalkboard-100 dark:border-l-chalkboard-80"
+            />
+          </div>
+        </div>
+        <p className="mx-4 mb-4 text-sm text-chalkboard-70 dark:text-chalkboard-40">
+          Enter X, Y, Z coordinates for the 3D vector
+        </p>
+      </form>
+    </div>
+  )
+}
+
+export default CommandBarVector3DInput

--- a/src/components/CommandBar/CommandBarVector3DInput.tsx
+++ b/src/components/CommandBar/CommandBarVector3DInput.tsx
@@ -62,6 +62,13 @@ function CommandBarVector3DInput({
       e.preventDefault()
       nextInputRef.current.focus()
     }
+    // Submit form when Enter is pressed in the last field
+    if (e.key === 'Enter' && !nextInputRef) {
+      e.preventDefault()
+      document.getElementById('vector3d-form')?.dispatchEvent(
+        new Event('submit', { cancelable: true, bubbles: true })
+      )
+    }
   }
 
   return (

--- a/src/components/CommandBar/CommandBarVector3DInput.tsx
+++ b/src/components/CommandBar/CommandBarVector3DInput.tsx
@@ -52,7 +52,7 @@ function CommandBarVector3DInput({
     e: React.KeyboardEvent<HTMLInputElement>,
     nextInputRef?: React.RefObject<HTMLInputElement>
   ) {
-    if (e.metaKey && e.key === 'k') {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
       commandBarActor.send({ type: 'Close' })
     }
     if (e.key === 'Backspace' && e.metaKey) {

--- a/src/lib/commandTypes.ts
+++ b/src/lib/commandTypes.ts
@@ -24,6 +24,7 @@ const _INPUT_TYPES = [
   'selection',
   'selectionMixed',
   'boolean',
+  'vector3d',
 ] as const
 type INPUT_TYPE = typeof _INPUT_TYPES
 export interface KclExpression {
@@ -274,6 +275,23 @@ export type CommandArgumentConfig<
         context: CommandBarContext
       }) => Promise<boolean | string>
     }
+  | {
+      inputType: 'vector3d'
+      defaultValue?:
+        | OutputType
+        | ((
+            commandBarContext: ContextFrom<typeof commandBarMachine>,
+            machineContext?: C
+          ) => OutputType)
+      defaultValueFromContext?: (context: C) => OutputType
+      validation?: ({
+        data,
+        context,
+      }: {
+        data: any
+        context: CommandBarContext
+      }) => Promise<boolean | string>
+    }
 )
 
 export type CommandArgument<
@@ -420,6 +438,22 @@ export type CommandArgument<
     }
   | {
       inputType: 'number'
+      defaultValue?:
+        | OutputType
+        | ((
+            commandBarContext: ContextFrom<typeof commandBarMachine>,
+            machineContext?: ContextFrom<T>
+          ) => OutputType)
+      validation?: ({
+        data,
+        context,
+      }: {
+        data: any
+        context: CommandBarContext
+      }) => Promise<boolean | string>
+    }
+  | {
+      inputType: 'vector3d'
       defaultValue?:
         | OutputType
         | ((


### PR DESCRIPTION
## PR Description
This PR adds a `vector3d` input type to the `CommandBar`. Instead of making users type arrays like [1, 0, 0], you get clear X/Y/Z fields for 3D vector input.

## Changes
- Added 'vector3d' to command input types in `commandTypes.ts`
- New `CommandBarVector3DInput` component with number validation and keyboard nav
- Routed new input type in `CommandBarArgument.tsx`

## Why
- Better UX for 3D vectors - no `[,,]`
- Matches the rest of the CommandBar input patterns

[Follow-up PRs](https://github.com/KittyCAD/modeling-app/issues/8193) will hook up Pattern Circular 3D commands to use these fields.

Closes #8277