### PR TITLE
Do not fire re-execution if the code read from disk matches codeManager

### DIFF
--- a/src/components/Explorer/FileExplorer.tsx
+++ b/src/components/Explorer/FileExplorer.tsx
@@ -372,7 +372,9 @@ export const FileExplorerRowElement = ({
         try {
           droppedData = JSON.parse(event.dataTransfer.getData('json'))
           if (!('name' in droppedData) || !('path' in droppedData)) {
-            throw new Error('malformed drop data: ' + JSON.stringify(droppedData))
+            throw new Error(
+              'malformed drop data: ' + JSON.stringify(droppedData)
+            )
           }
         } catch (e) {
           console.error('invalid JSON in drop event', e)

--- a/src/components/RouteProvider.tsx
+++ b/src/components/RouteProvider.tsx
@@ -99,6 +99,9 @@ export function RouteProvider({ children }: { children: ReactNode }) {
           code = normalizeLineEndings(code)
 
           // Don't fire a re-execution if the codeManager already knows about this change
+          // GOTCHA: string comparison is hard! If the code as read by the OS doesn't
+          // match our in-memory representation of it, this will not guard, and user actions livePathsToWatch
+          // point-and-click sketching will be followed by late-firing re-executions.
           if (code !== normalizeLineEndings(codeManager.code)) {
             codeManager.updateCodeStateEditor(code)
             await kclManager.executeCode()

--- a/src/components/RouteProvider.tsx
+++ b/src/components/RouteProvider.tsx
@@ -97,8 +97,12 @@ export function RouteProvider({ children }: { children: ReactNode }) {
           // Your current file is changed, read it from disk and write it into the code manager and execute the AST
           let code = await window.electron.readFile(path, { encoding: 'utf-8' })
           code = normalizeLineEndings(code)
-          codeManager.updateCodeStateEditor(code)
-          await kclManager.executeCode()
+
+          // Don't fire a re-execution if the codeManager already knows about this change
+          if (code !== normalizeLineEndings(codeManager.code)) {
+            codeManager.updateCodeStateEditor(code)
+            await kclManager.executeCode()
+          }
         }
       } else if (
         (isImportedInCurrentFile || isInExecStateFilenames) &&

--- a/src/components/RouteProvider.tsx
+++ b/src/components/RouteProvider.tsx
@@ -1,4 +1,4 @@
-import { normalizeLineEndings } from '@src/lib/codeEditor'
+import { isCodeTheSame } from '@src/lib/codeEditor'
 import type { ReactNode } from 'react'
 import { createContext, useEffect, useState } from 'react'
 import {
@@ -95,14 +95,13 @@ export function RouteProvider({ children }: { children: ReactNode }) {
       if (isCurrentFile && eventType === 'change') {
         if (window.electron) {
           // Your current file is changed, read it from disk and write it into the code manager and execute the AST
-          let code = await window.electron.readFile(path, { encoding: 'utf-8' })
-          code = normalizeLineEndings(code)
+          const code = await window.electron.readFile(path, {
+            encoding: 'utf-8',
+          })
 
-          // Don't fire a re-execution if the codeManager already knows about this change
-          // GOTCHA: string comparison is hard! If the code as read by the OS doesn't
-          // match our in-memory representation of it, this will not guard, and user actions livePathsToWatch
-          // point-and-click sketching will be followed by late-firing re-executions.
-          if (code !== normalizeLineEndings(codeManager.code)) {
+          // Don't fire a re-execution if the codeManager already knows about this change,
+          // which would be evident if we already have matching code there.
+          if (isCodeTheSame(code, codeManager.code)) {
             codeManager.updateCodeStateEditor(code)
             await kclManager.executeCode()
           }

--- a/src/components/RouteProvider.tsx
+++ b/src/components/RouteProvider.tsx
@@ -101,7 +101,7 @@ export function RouteProvider({ children }: { children: ReactNode }) {
 
           // Don't fire a re-execution if the codeManager already knows about this change,
           // which would be evident if we already have matching code there.
-          if (isCodeTheSame(code, codeManager.code)) {
+          if (!isCodeTheSame(code, codeManager.code)) {
             codeManager.updateCodeStateEditor(code)
             await kclManager.executeCode()
           }

--- a/src/lib/codeEditor.ts
+++ b/src/lib/codeEditor.ts
@@ -1,3 +1,17 @@
 export const normalizeLineEndings = (str: string, normalized = '\n') => {
   return str.replace(/\r?\n/g, normalized)
 }
+
+/**
+ * GOTCHA: string comparison is hard! Only use this when comparing two code strings
+ * so that if we discover we're doing it wrong we only need to change this function.
+ *
+ * We use it right now to verify an OS file system "change" event isn't already known
+ * about by our in-memory codeManager.
+ */
+export function isCodeTheSame(left: string, right: string) {
+  const leftBasis = normalizeLineEndings(left)
+  const rightBasis = normalizeLineEndings(right)
+  // any other future logic that we failed to implement that causes a bug
+  return leftBasis === rightBasis
+}


### PR DESCRIPTION
Fixes #7686 by adding a guard against re-firing the full execution pipeline if we receive a "change" event from the file system watcher, but our in-memory codeManager already has the same code that is read off of disk.