### PR TITLE
Disable undo/redo buttons if no depth is available

### DIFF
--- a/src/components/UndoRedoButtons.tsx
+++ b/src/components/UndoRedoButtons.tsx
@@ -1,3 +1,4 @@
+import { redoDepth, undoDepth } from '@codemirror/commands'
 import { CustomIcon } from '@src/components/CustomIcon'
 import Tooltip from '@src/components/Tooltip'
 import type EditorManager from '@src/editor/manager'
@@ -16,41 +17,56 @@ export function UndoRedoButtons({
         keyboardShortcut="mod+z"
         iconName="arrowRotateLeft"
         onClick={() => editorManager.undo()}
+        className="rounded-r-none"
+        disabled={undoDepth(editorManager.editorState) === 0}
       />
       <UndoOrRedoButton
         label="Redo"
         keyboardShortcut="mod+shift+z"
         iconName="arrowRotateRight"
         onClick={() => editorManager.redo()}
+        className="rounded-l-none"
+        disabled={redoDepth(editorManager.editorState) === 0}
       />
     </div>
   )
 }
 
-interface UndoOrRedoButtonProps {
+interface UndoOrRedoButtonProps extends HTMLProps<HTMLButtonElement> {
   label: string
   onClick: MouseEventHandler
   iconName: 'arrowRotateRight' | 'arrowRotateLeft'
   keyboardShortcut: string
+  disabled: boolean
 }
 
-function UndoOrRedoButton(props: UndoOrRedoButtonProps) {
+function UndoOrRedoButton({
+  onClick,
+  disabled,
+  iconName,
+  label,
+  keyboardShortcut,
+  className,
+  ...rest
+}: UndoOrRedoButtonProps) {
   const platform = usePlatform()
   return (
     <button
+      {...rest}
       type="button"
-      onClick={props.onClick}
-      className="p-0 m-0 border-transparent dark:border-transparent focus-visible:border-chalkboard-100"
+      onClick={onClick}
+      className={`p-0 m-0 border-transparent dark:border-transparent focus-visible:b-default disabled:bg-transparent dark:disabled:bg-transparent disabled:border-transparent dark:disabled:border-transparent disabled:text-4 ${className}`}
+      disabled={disabled}
     >
-      <CustomIcon name={props.iconName} className="w-6 h-6" />
+      <CustomIcon name={iconName} className="w-6 h-6" />
       <Tooltip
         position="bottom"
         hoverOnly={true}
         contentClassName="text-sm max-w-none flex items-center gap-4"
       >
-        <span>{props.label}</span>
+        <span>{label}</span>
         <kbd className="hotkey capitalize">
-          {hotkeyDisplay(props.keyboardShortcut, platform)}
+          {hotkeyDisplay(keyboardShortcut, platform)}
         </kbd>
       </Tooltip>
     </button>


### PR DESCRIPTION
Fulfills a request from @JBEmbedded from a little while ago asking for these buttons to be dynamic.