### PR TITLE
Try opening the files pane first to reduce flakes

### DIFF
--- a/e2e/playwright/sketch-tests.spec.ts
+++ b/e2e/playwright/sketch-tests.spec.ts
@@ -2070,10 +2070,9 @@ profile001 = startProfile(sketch001, at = [127.56, 179.02])
 
     await u.closeDebugPanel()
 
-    await toolbar.openFeatureTreePane()
     await toolbar.openPane('files')
-
     await toolbar.openFile('good.kcl')
+    await toolbar.openFeatureTreePane()
 
     await expect(
       toolbar.featureTreePane.getByRole('button', { name: 'Sketch' })


### PR DESCRIPTION
Based on logs like this:

```
TimeoutError: locator.click: Timeout 30000ms exceeded.
Call log:
  - waiting for getByTestId('files-pane-button')
    - locator resolved to <button align="right" aria-pressed="false" name="Project Files" aria-disabled="false" data-testid="files-pane-button" class="group pointer-events-auto flex items-center justify-center border-0 rounded-none border-transparent dark:border-transparent p-[8px] pl-[9px] pr-[7px] m-0 !outline-0  ">…</button>
  - attempting click action
    2 × waiting for element to be visible, enabled and stable
      - element is visible, enabled and stable
      - scrolling into view if needed
      - done scrolling
      - <span>x</span> from <p id="files-badge" title="Project files have runtime errors" class="absolute m-0 p-0 bottom-4 left-4 min-w-3 h-3 flex items-center justify-center text-[9px] font-semibold text-white bg-primary hue-rotate-90 rounded-full border border-chalkboard-10 dark:border-chalkboard-80 z-50 hover:cursor-pointer hover:scale-[2] transition-transform duration-200">…</p> subtree intercepts pointer events
    - retrying click action
    - waiting 20ms
    2 × waiting for element to be visible, enabled and stable
      - element is visible, enabled and stable
      - scrolling into view if needed
      - done scrolling
     ...
 ```

it's possible Playwright is going too fast and trying to click on an element while the layout is shifting.

---

https://test-analysis-bot.hawk-dinosaur.ts.net/projects/KittyCAD/modeling-app/tests/2412?branch=fix-file-panes-flake