### PR TITLE
#8401 Fix infinite grid distortion on closing panes

### DIFF
--- a/src/clientSideScene/ClientSideSceneComp.tsx
+++ b/src/clientSideScene/ClientSideSceneComp.tsx
@@ -119,6 +119,7 @@ export const ClientSideScene = ({
       // This is called initially too, not just on resize
       sceneInfra.onCanvasResized()
       sceneInfra.camControls.onWindowResize()
+      sceneEntitiesManager.onCamChange()
     })
     observer.observe(container)
 

--- a/src/clientSideScene/sceneEntities.ts
+++ b/src/clientSideScene/sceneEntities.ts
@@ -203,8 +203,6 @@ export class SceneEntities {
 
   getSettings: (() => SettingsType) | null = null
 
-  private canvasResizeObserver: ResizeObserver
-
   constructor(
     engineCommandManager: EngineCommandManager,
     sceneInfra: SceneInfra,
@@ -225,12 +223,6 @@ export class SceneEntities {
 
     this.sceneInfra.camControls.cameraChange.add(this.onCamChange)
     this.sceneInfra.baseUnitChange.add(this.onCamChange)
-
-    const canvas = this.sceneInfra.renderer.domElement
-    this.canvasResizeObserver = new ResizeObserver(() => {
-      this.onCamChange()
-    })
-    this.canvasResizeObserver.observe(canvas)
   }
 
   onCamChange = () => {


### PR DESCRIPTION
Fixes #8401 

Gets rid of the second ResizeObserver, easier to have only one.