### PR TITLE
Remove credits details from onboarding

### DIFF
--- a/src/routes/Onboarding/BrowserOnboardingRoutes.tsx
+++ b/src/routes/Onboarding/BrowserOnboardingRoutes.tsx
@@ -177,12 +177,9 @@ function TextToCad() {
           improving it every day.
         </p>
         <p className="my-4">
-          <strong>One</strong> Text-to-CAD generation costs{' '}
-          <strong>one credit per minute</strong>, rounded up to the nearest
-          minute. A large majority of Text-to-CAD generations take under a
-          minute. If you are on the free plan, you get 20 free credits per
-          month. With any of our paid plans, you get unlimited Text-to-CAD
-          generations.
+          Our free plan includes a limited number of Text-to-CAD generations
+          each month. Upgrade to a paid plan for additional credits. Pro and Org
+          plans come with unlimited Text-to-CAD generations.
         </p>
         <p className="my-4">
           Let’s walk through an example of how to use Text-to-CAD.

--- a/src/routes/Onboarding/DesktopOnboardingRoutes.tsx
+++ b/src/routes/Onboarding/DesktopOnboardingRoutes.tsx
@@ -173,12 +173,9 @@ function TextToCad() {
           improving it every day.
         </p>
         <p className="my-4">
-          <strong>One</strong> Text-to-CAD generation costs{' '}
-          <strong>one credit per minute</strong>, rounded up to the nearest
-          minute. A large majority of Text-to-CAD generations take under a
-          minute. If you are on the free plan, you get 20 free credits per
-          month. With any of our paid plans, you get unlimited Text-to-CAD
-          generations.
+          Our free plan includes a limited number of Text-to-CAD generations
+          each month. Upgrade to a paid plan for additional credits. Pro and Org
+          plans come with unlimited Text-to-CAD generations.
         </p>
         <p className="my-4">
           Let’s walk through an example of how to use Text-to-CAD.


### PR DESCRIPTION
It's too early in the user journey to bring up the specifics of how credits are spent.