### PR TITLE
Remove defaultAngleUnit from @settings() autocomplete

### DIFF
--- a/docs/kcl-lang/settings.md
+++ b/docs/kcl-lang/settings.md
@@ -41,6 +41,7 @@ Valid properties are:
   - Accepted values: `mm`, `cm`, `m`, `in` (inches), `ft` (feet), `yd` (yards).
 - `defaultAngleUnit`: the default angle unit to use for numbers declared in this file.
   - Accepted values: `deg` (degrees), `rad` (radians).
+  - It's recommended to not use this. Instead, use explicit suffixes for angles, e.g. `180deg`, to avoid ambiguity and receive more helpful error messages.
 - `experimentalFeatures`: how experimental features are handled within this file.
   - Accepted values: `allow` (experimental features can be used freely), `warn` (experimental features
   cause a warning), `deny` (the default, experimental features cause an error).

--- a/rust/kcl-lib/src/execution/annotations.rs
+++ b/rust/kcl-lib/src/execution/annotations.rs
@@ -116,7 +116,7 @@ impl FromStr for Impl {
 }
 
 pub(crate) fn settings_completion_text() -> String {
-    format!("@{SETTINGS}({SETTINGS_UNIT_LENGTH} = mm, {SETTINGS_UNIT_ANGLE} = deg, {SETTINGS_VERSION} = 1.0)")
+    format!("@{SETTINGS}({SETTINGS_UNIT_LENGTH} = mm, {SETTINGS_VERSION} = 1.0)")
 }
 
 pub(super) fn is_significant(attr: &&Node<Annotation>) -> bool {


### PR DESCRIPTION
Follow-up to #8286. Since `defaultAngleUnit` is a warning now, we should not suggest it to users.