### PR TITLE
fix: tsc is broken in main, a cached setup-node had an old npm install

### DIFF
--- a/src/lang/std/sketchConstraints.test.ts
+++ b/src/lang/std/sketchConstraints.test.ts
@@ -353,7 +353,7 @@ describe('testing swapping out sketch calls with xLine/xLineTo while keeping var
         callToSwap: 'angledLine(angle = 217deg, endAbsoluteY = angledLineToYy)',
         constraintType: 'horizontal',
       })
-    await expect(illegalConvert).rejects.toThrowError('no callback helper')
+    await expect(illegalConvert).rejects.toThrow('no callback helper')
   })
 })
 


### PR DESCRIPTION
# Issue

On `main` you will get an error when you run `npm run tsc`.

# Implementation 

This [run](https://github.com/KittyCAD/modeling-app/actions/runs/18062427869/job/51400675531) on this [PR](https://github.com/KittyCAD/modeling-app/pull/8356) had the `npm run tsc` pass. I think this is because of `statci-analysis.yml` caching the `setup-node@v4`. The original PR had a package-lock.json bump but I think the pipeline grabbed an old cache and run `tsc` with that version of `npm install` not the new one.

```
  npm-tsc:
    runs-on: namespace-profile-ubuntu-2-cores
    needs: npm-build-wasm

    steps:
      - uses: actions/checkout@v5
      - uses: actions/setup-node@v4
        with:
          node-version-file: '.nvmrc'
          cache: 'npm'
      - run: npm install
```

I fixed the API called.
```
"@testing-library/jest-dom": "^6.8.0",
```

we were on 
```
"@testing-library/jest-dom": "^5.17.0",
```