### PR TITLE
Allow unit/integration tests to be dynamically skipped

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -51,12 +51,11 @@ jobs:
           mkdir rust/kcl-lib/bindings
           cp -r prepared-ts-rs-bindings/* rust/kcl-lib/bindings/
 
-      - run: npm run test:unit
+      - name: npm run test:unit
         if: ${{ github.event_name != 'release' && github.event_name != 'schedule' }}
-
-      - name: Upload results
-        if: always()
-        run: .github/ci-cd-scripts/upload-results.sh
+        run: |-
+          npm run test:unit || true # let TAB determine failure
+          .github/ci-cd-scripts/upload-results.sh
         env:
           TAB_API_URL: ${{ vars.TAB_API_URL }}
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
@@ -105,14 +104,11 @@ jobs:
 
       - name: npm run test:integration
         if: ${{ github.event_name != 'release' && github.event_name != 'schedule' }}
-        run: xvfb-run -a npm run test:integration
+        run: |-
+          xvfb-run -a npm run test:integration || true # let TAB determine failure
+          .github/ci-cd-scripts/upload-results.sh
         env:
           VITE_KITTYCAD_API_TOKEN: ${{ secrets.KITTYCAD_API_TOKEN_DEV }}
-
-      - name: Upload results
-        if: always()
-        run: .github/ci-cd-scripts/upload-results.sh
-        env:
           TAB_API_URL: ${{ vars.TAB_API_URL }}
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}

--- a/e2e/playwright/lib/api-reporter.ts
+++ b/e2e/playwright/lib/api-reporter.ts
@@ -89,6 +89,7 @@ class APIReporter implements Reporter {
       // Extra test and result data
       annotations: test.annotations.map((a) => a.type), // e.g. 'fail' or 'fixme'
       id: test.id, // computed file/test/project ID used for reruns
+      logs: logsAsString,
       retry: result.retry,
       tags: test.tags, // e.g. '@snapshot' or '@skipLocalEngine'
       // Extra environment variables
@@ -103,7 +104,6 @@ class APIReporter implements Reporter {
       GITHUB_SHA: process.env.GITHUB_SHA || null,
       GITHUB_WORKFLOW: process.env.GITHUB_WORKFLOW || null,
       RUNNER_ARCH: process.env.RUNNER_ARCH || null,
-      logs: logsAsString,
     }
 
     const request = (async () => {


### PR DESCRIPTION
This matches the [standard setup](https://github.com/KittyCAD/test-analysis-bot?tab=readme-ov-file#unit-tests-cargo-nextest--github) used by other test runners that produce a JUnit XML report, which will let us dynamically skip tests that are broken due to a network dependency being down.