### PR TITLE
Sketch 2.0 WIP: spawn tool types

### DIFF
--- a/src/machines/sketchSolve/sketchSolveMode.ts
+++ b/src/machines/sketchSolve/sketchSolveMode.ts
@@ -84,6 +84,8 @@ export const sketchSolveMachine = setup({
       data: { tool: null },
     }),
     'spawn tool': assign(({ event, spawn: _spawn, context }) => {
+      // this type-annotation informs spawn tool of the association between the EquipTools type and the machines in equipTools
+      // It's not an type assertion. The TS still checks that _spawn is assignable to SpawnToolActor.
       const spawn: SpawnToolActor = _spawn
       // Determine which tool to spawn based on event type
       let nameOfToolToSpawn: EquipTool

--- a/src/machines/sketchSolve/sketchSolveMode.ts
+++ b/src/machines/sketchSolve/sketchSolveMode.ts
@@ -85,7 +85,7 @@ export const sketchSolveMachine = setup({
     }),
     'spawn tool': assign(({ event, spawn: _spawn, context }) => {
       // this type-annotation informs spawn tool of the association between the EquipTools type and the machines in equipTools
-      // It's not an type assertion. The TS still checks that _spawn is assignable to SpawnToolActor.
+      // It's not an type assertion. TS still checks that _spawn is assignable to SpawnToolActor.
       const spawn: SpawnToolActor = _spawn
       // Determine which tool to spawn based on event type
       let nameOfToolToSpawn: EquipTool

--- a/src/machines/sketchSolve/sketchSolveMode.ts
+++ b/src/machines/sketchSolve/sketchSolveMode.ts
@@ -103,7 +103,7 @@ export const sketchSolveMachine = setup({
       return {
         toolActor: spawn(nameOfToolToSpawn, { id: 'tool' }),
         sketchSolveToolName: nameOfToolToSpawn,
-        pendingTool: undefined, // Clear the pending tool after spawning
+        pendingToolName: undefined, // Clear the pending tool after spawning
       }
     }),
   },

--- a/src/machines/sketchSolve/sketchSolveMode.ts
+++ b/src/machines/sketchSolve/sketchSolveMode.ts
@@ -102,7 +102,7 @@ export const sketchSolveMachine = setup({
 
       return {
         toolActor: spawn(nameOfToolToSpawn, { id: 'tool' }),
-        sketchSolveTool: nameOfToolToSpawn,
+        sketchSolveToolName: nameOfToolToSpawn,
         pendingTool: undefined, // Clear the pending tool after spawning
       }
     }),

--- a/src/machines/sketchSolve/sketchSolveMode.ts
+++ b/src/machines/sketchSolve/sketchSolveMode.ts
@@ -27,7 +27,7 @@ export type EquipTool = keyof typeof equipTools
 // Type for the spawn function used in XState setup actions
 // This provides better type safety by constraining the actor parameter to valid tool names
 // and ensuring the return type matches the specific tool actor
-type SpawnToolActor = <K extends keyof typeof equipTools>(
+type SpawnToolActor = <K extends EquipTool>(
   src: K,
   options?: { id?: string }
 ) => ActorRefFrom<(typeof equipTools)[K]>

--- a/src/machines/sketchSolve/sketchSolveMode.ts
+++ b/src/machines/sketchSolve/sketchSolveMode.ts
@@ -83,10 +83,10 @@ export const sketchSolveMachine = setup({
       type: 'sketch solve tool changed',
       data: { tool: null },
     }),
-    'spawn tool': assign(({ event, spawn: _spawn, context }) => {
+    'spawn tool': assign(({ event, spawn, context }) => {
       // this type-annotation informs spawn tool of the association between the EquipTools type and the machines in equipTools
       // It's not an type assertion. TS still checks that _spawn is assignable to SpawnToolActor.
-      const spawn: SpawnToolActor = _spawn
+      const typedSpawn: SpawnToolActor = spawn
       // Determine which tool to spawn based on event type
       let nameOfToolToSpawn: EquipTool
 
@@ -103,7 +103,7 @@ export const sketchSolveMachine = setup({
       }
 
       return {
-        toolActor: spawn(nameOfToolToSpawn, { id: 'tool' }),
+        toolActor: typedSpawn(nameOfToolToSpawn, { id: 'tool' }),
         sketchSolveToolName: nameOfToolToSpawn,
         pendingToolName: undefined, // Clear the pending tool after spawning
       }


### PR DESCRIPTION
Why the exhaustive `switch` was needed

* With `spawn` is typed for any actors on this machine, TS can’t relate the key to the concrete actor logic/type.
* The exhaustive `switch` narrows `nameOfToolToSpawn` to a string literal in each branch so spawn is able to figure it out.
* The `default` case with `never` enforces exhaustiveness: adding a new tool breaks compilation until you handle it. HOWEVER this is still maintenance pain of having to add a new case to the switch statement when a new tool is added.

Why `SpawnToolActor` type fills the same role

`SpawnToolActor` fixes it by just informing spawn tool of the association between the `EquipTools` type and the machines in  `equipTools`.

Since `const spawn: SpawnToolActor = _spawn` is a type annotation, not a type assertion. The compiler checks that _spawn is assignable to SpawnToolActor.

So I think we're good.

