### PR TITLE
KCL docs update for argument error fix

### DIFF
--- a/docs/kcl-lang/functions.md
+++ b/docs/kcl-lang/functions.md
@@ -28,7 +28,7 @@ total = add(left = 1, right = 2)
 ```
 
 Functions can also declare one *unlabeled* arg. If you do want to declare an unlabeled arg, it must
-be the first arg declared.
+be the first arg declared. When declaring an unlabeled arg, prefix it with @, like here:
 
 ```
 // The @ indicates an argument is used without a label.
@@ -43,4 +43,28 @@ fn add(@x, delta) {
 
 two = increment(1)
 three = add(1, delta = 2)
+```
+
+Below is an example of how the the custom function must be called if it has a labeled argument, and another example with an unlabeled argument:
+
+```
+@settings(defaultLengthUnit = mm)
+
+// All args must be labeled when calling (no @ on first param)
+fn cube1(offsetX, offsetY, radius, length) {
+  return startSketchOn(XY)
+    |> polygon(radius = radius, numSides = 4, center = [offsetX, offsetY])
+    |> extrude(length = length)
+}
+
+// First arg may be unlabeled at call sites (because of @)
+fn cube2(@offsetX, offsetY, radius, length) {
+  return startSketchOn(XY)
+    |> polygon(radius = radius, numSides = 4, center = [offsetX, offsetY])
+    |> extrude(length = length)
+}
+
+// Function Calls
+testCube1 = cube1(offsetX = 0, offsetY = 6, radius = 5, length = 5)  // all labeled
+testCube2 = cube2(0,           offsetY = 10, radius = 5, length = 5)  // first unlabeled works here
 ```


### PR DESCRIPTION
Refer to this TTC PR for background: https://github.com/KittyCAD/text-to-cad/pull/2139
Essentially, this gives TTC more context to reduce occurrences our most frequent non-engine KCL error. 
It should hopefully also be helpful to humans!