### PR TITLE
Use the standard API token name

### DIFF
--- a/.github/workflows/cargo-bench.yml
+++ b/.github/workflows/cargo-bench.yml
@@ -58,4 +58,4 @@ jobs:
           run: cargo codspeed run
           token: ${{ secrets.CODSPEED_TOKEN }}
         env:
-          KITTYCAD_API_TOKEN: ${{ secrets.KITTYCAD_API_TOKEN }}
+          KITTYCAD_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -91,7 +91,7 @@ jobs:
             simulation_tests::kcl_samples \
             2>&1 | tee /tmp/github-actions.log
         env:
-          KITTYCAD_API_TOKEN: ${{secrets.KITTYCAD_API_TOKEN_DEV}}
+          KITTYCAD_API_TOKEN: ${{secrets.ZOO_API_TOKEN}}
           ZOO_HOST: https://api.dev.zoo.dev
           RUST_BACKTRACE: full
           RUST_MIN_STACK: 10485760000
@@ -121,7 +121,7 @@ jobs:
         env:
           # The default is auto, and insta behaves differently in CI vs. not.
           INSTA_UPDATE: always
-          KITTYCAD_API_TOKEN: ${{secrets.KITTYCAD_API_TOKEN_DEV}}
+          KITTYCAD_API_TOKEN: ${{secrets.ZOO_API_TOKEN}}
           ZOO_HOST: https://api.dev.zoo.dev
           # Configure nextest when it's run by insta (via just).
           NEXTEST_PROFILE: ci
@@ -186,7 +186,7 @@ jobs:
           popd
           .github/ci-cd-scripts/upload-results.sh
         env:
-          KITTYCAD_API_TOKEN: ${{secrets.KITTYCAD_API_TOKEN_DEV}}
+          KITTYCAD_API_TOKEN: ${{secrets.ZOO_API_TOKEN}}
           ZOO_HOST: https://api.dev.zoo.dev
           RUST_MIN_STACK: 10485760000
           TAB_API_URL: ${{ vars.TAB_API_URL }}
@@ -238,7 +238,7 @@ jobs:
           TWENTY_TWENTY: overwrite
           INSTA_UPDATE: always
           EXPECTORATE: overwrite
-          KITTYCAD_API_TOKEN: ${{secrets.KITTYCAD_API_TOKEN_DEV}}
+          KITTYCAD_API_TOKEN: ${{secrets.ZOO_API_TOKEN}}
           ZOO_HOST: https://api.dev.zoo.dev
           RUST_MIN_STACK: 10485760000
           TAB_API_URL: ${{ vars.TAB_API_URL }}
@@ -283,5 +283,5 @@ jobs:
           cd kcl-wasm-lib
           #wasm-pack test --headless --chrome
         env:
-          KITTYCAD_API_TOKEN: ${{ secrets.KITTYCAD_API_TOKEN_DEV }}
+          KITTYCAD_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
           NODE_ENV: development

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -158,7 +158,7 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
         env:
-          VITE_KITTYCAD_API_TOKEN: ${{ secrets.KITTYCAD_API_TOKEN_DEV }}
+          VITE_KITTYCAD_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
           TAB_API_URL: ${{ vars.TAB_API_URL }}
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
@@ -170,7 +170,7 @@ jobs:
         if: failure()
         run: npm run test:snapshots -- --last-failed --update-snapshots
         env:
-          VITE_KITTYCAD_API_TOKEN: ${{ secrets.KITTYCAD_API_TOKEN_DEV }}
+          VITE_KITTYCAD_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
           TAB_API_URL: ${{ vars.TAB_API_URL }}
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
@@ -285,7 +285,7 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
         env:
-          VITE_KITTYCAD_API_TOKEN: ${{ secrets.KITTYCAD_API_TOKEN_DEV }}
+          VITE_KITTYCAD_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
           TAB_API_URL: ${{ vars.TAB_API_URL }}
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
@@ -411,7 +411,7 @@ jobs:
           max_attempts: 9
         env:
           FAIL_ON_CONSOLE_ERRORS: true
-          VITE_KITTYCAD_API_TOKEN: ${{ secrets.KITTYCAD_API_TOKEN_DEV }}
+          VITE_KITTYCAD_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
           TAB_API_URL: ${{ vars.TAB_API_URL }}
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/kcl-python-bindings.yml
+++ b/.github/workflows/kcl-python-bindings.yml
@@ -128,7 +128,7 @@ jobs:
           just setup-uv
           just test
         env:
-          KITTYCAD_API_TOKEN: ${{ secrets.KITTYCAD_API_TOKEN_DEV }}
+          KITTYCAD_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
           ZOO_HOST: https://api.dev.zoo.dev
   sdist:
     name: kcl-python-bindings (sdist)

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -108,7 +108,7 @@ jobs:
           xvfb-run -a npm run test:integration || true # let TAB determine failure
           .github/ci-cd-scripts/upload-results.sh
         env:
-          VITE_KITTYCAD_API_TOKEN: ${{ secrets.KITTYCAD_API_TOKEN_DEV }}
+          VITE_KITTYCAD_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
           TAB_API_URL: ${{ vars.TAB_API_URL }}
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
This is needed for https://github.com/KittyCAD/engine/pull/3853 to avoid having to add the legacy token name to the secrets on another project.