### PR TITLE
Always build Wasm from workflow calls

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -127,6 +127,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: prepared-wasm
+          path: prepared-wasm
 
       - name: Copy prepared Wasm
         run: |
@@ -249,6 +250,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: prepared-wasm
+          path: prepared-wasm
 
       - name: Copy prepared Wasm
         run: |
@@ -365,6 +367,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: prepared-wasm
+          path: prepared-wasm
 
       - name: Copy prepared Wasm
         run: |


### PR DESCRIPTION
Since we can't rely on checking for changed files using `workflow_call` we have to unconditionally build the Wasm dependency.

This was tested here: https://github.com/KittyCAD/engine/pull/3858

---

Amends https://github.com/KittyCAD/modeling-app/pull/8551 for https://github.com/KittyCAD/engine/issues/3852.