### PR TITLE
chore: Handling on data channel close workflow to improve reconnection to the engine

### DIFF
--- a/src/components/ConnectionStream.tsx
+++ b/src/components/ConnectionStream.tsx
@@ -59,7 +59,7 @@ export const ConnectionStream = (props: {
   const isNetworkOkay =
     overallState === NetworkHealthState.Ok ||
     overallState === NetworkHealthState.Weak
-  const { tryConnecting, isConnecting, numberOfConnectionAtttempts } =
+  const { tryConnecting, isConnecting, numberOfConnectionAttempts } =
     useTryConnect()
   // Stream related refs and data
   const [searchParams] = useSearchParams()
@@ -143,7 +143,7 @@ export const ConnectionStream = (props: {
         videoRef,
         setIsSceneReady,
         isConnecting,
-        numberOfConnectionAtttempts,
+        numberOfConnectionAttempts,
         timeToConnect: 30_000,
         settings: settingsEngine,
         setShowManualConnect,
@@ -188,7 +188,7 @@ export const ConnectionStream = (props: {
         videoRef,
         setIsSceneReady,
         isConnecting,
-        numberOfConnectionAtttempts,
+        numberOfConnectionAttempts,
         timeToConnect: 30_000,
         settings: settingsEngine,
         setShowManualConnect,
@@ -211,7 +211,7 @@ export const ConnectionStream = (props: {
         videoRef,
         setIsSceneReady,
         isConnecting,
-        numberOfConnectionAtttempts,
+        numberOfConnectionAttempts,
         timeToConnect: 30_000,
         settings: settingsEngine,
         setShowManualConnect,
@@ -231,7 +231,7 @@ export const ConnectionStream = (props: {
         videoRef,
         setIsSceneReady,
         isConnecting,
-        numberOfConnectionAtttempts,
+        numberOfConnectionAttempts,
         timeToConnect: 30_000,
         settings: settingsEngine,
         setShowManualConnect,
@@ -251,7 +251,7 @@ export const ConnectionStream = (props: {
         videoRef,
         setIsSceneReady,
         isConnecting,
-        numberOfConnectionAtttempts,
+        numberOfConnectionAttempts,
         timeToConnect: 30_000,
         settings: settingsEngine,
         setShowManualConnect,
@@ -275,7 +275,7 @@ export const ConnectionStream = (props: {
         videoRef,
         setIsSceneReady,
         isConnecting,
-        numberOfConnectionAtttempts,
+        numberOfConnectionAttempts,
         timeToConnect: 30_000,
         settings: settingsEngine,
         setShowManualConnect,
@@ -292,6 +292,7 @@ export const ConnectionStream = (props: {
     kclManager,
     resetCameraPosition,
   })
+
   useOnOfflineToExitSketchMode({
     callback: () => {
       modelingSend({ type: 'Cancel' })
@@ -362,7 +363,7 @@ export const ConnectionStream = (props: {
               videoRef,
               setIsSceneReady,
               isConnecting,
-              numberOfConnectionAtttempts,
+              numberOfConnectionAttempts,
               timeToConnect: 30_000,
               settings: settingsEngine,
               setShowManualConnect,

--- a/src/hooks/network/useOnPeerConnectionClose.tsx
+++ b/src/hooks/network/useOnPeerConnectionClose.tsx
@@ -34,6 +34,11 @@ export function useOnPeerConnectionClose({
       onFailure
     )
 
+    engineCommandManager.addEventListener(
+      EngineCommandManagerEvents.dataChannelClose,
+      onFailure
+    )
+
     return () => {
       engineCommandManager.removeEventListener(
         EngineCommandManagerEvents.peerConnectionClosed,
@@ -47,6 +52,11 @@ export function useOnPeerConnectionClose({
 
       engineCommandManager.removeEventListener(
         EngineCommandManagerEvents.peerConnectionFailed,
+        onFailure
+      )
+
+      engineCommandManager.removeEventListener(
+        EngineCommandManagerEvents.dataChannelClose,
         onFailure
       )
     }

--- a/src/hooks/network/useTryConnect.tsx
+++ b/src/hooks/network/useTryConnect.tsx
@@ -136,7 +136,7 @@ const attemptToConnectToEngine = async ({
  */
 async function tryConnecting({
   isConnecting,
-  numberOfConnectionAtttempts,
+  numberOfConnectionAttempts,
   authToken,
   videoWrapperRef,
   setAppState,
@@ -147,7 +147,7 @@ async function tryConnecting({
   setShowManualConnect,
 }: {
   isConnecting: React.MutableRefObject<boolean>
-  numberOfConnectionAtttempts: React.MutableRefObject<number>
+  numberOfConnectionAttempts: React.MutableRefObject<number>
   authToken: string
   videoWrapperRef: React.RefObject<HTMLDivElement>
   setAppState: (newAppState: Partial<ReturnType<typeof useAppState>>) => void
@@ -174,8 +174,8 @@ async function tryConnecting({
       }, timeToConnect)
 
       async function attempt() {
-        numberOfConnectionAtttempts.current =
-          numberOfConnectionAtttempts.current + 1
+        numberOfConnectionAttempts.current =
+          numberOfConnectionAttempts.current + 1
 
         try {
           await attemptToConnectToEngine({
@@ -190,7 +190,7 @@ async function tryConnecting({
           clearInterval(cancelTimeout)
           isConnecting.current = false
           setAppState({ isStreamAcceptingInput: true })
-          numberOfConnectionAtttempts.current = 0
+          numberOfConnectionAttempts.current = 0
           setShowManualConnect(false)
           EngineDebugger.addLog({
             label: 'tryConnecting',
@@ -202,8 +202,8 @@ async function tryConnecting({
           setAppState({ isStreamAcceptingInput: false })
           engineCommandManager.tearDown()
           // Fail after NUMBER_OF_ENGINE_RETRIES
-          if (numberOfConnectionAtttempts.current >= NUMBER_OF_ENGINE_RETRIES) {
-            numberOfConnectionAtttempts.current = 0
+          if (numberOfConnectionAttempts.current >= NUMBER_OF_ENGINE_RETRIES) {
+            numberOfConnectionAttempts.current = 0
             // Clear if we are going to exit all the attempts
             clearInterval(cancelTimeout)
             return reject(e)
@@ -218,11 +218,11 @@ async function tryConnecting({
 }
 export const useTryConnect = () => {
   const isConnecting = useRef(false)
-  const numberOfConnectionAtttempts = useRef(0)
+  const numberOfConnectionAttempts = useRef(0)
 
   return {
     tryConnecting,
     isConnecting,
-    numberOfConnectionAtttempts,
+    numberOfConnectionAttempts,
   }
 }

--- a/src/network/connection.ts
+++ b/src/network/connection.ts
@@ -478,6 +478,7 @@ export class Connection extends EventTarget {
       connectionPromiseResolve: this.deferredConnection.resolve,
       // don't bind this, it was passed into the class
       handleOnDataChannelMessage: this.handleOnDataChannelMessage,
+      tearDownManager: this.tearDownManager.bind(this),
     })
 
     // Watch out human! The names of the next couple events are really similar!

--- a/src/network/connectionManager.ts
+++ b/src/network/connectionManager.ts
@@ -939,6 +939,10 @@ export class ConnectionManager extends EventTarget {
       this.dispatchEvent(
         new CustomEvent(EngineCommandManagerEvents.peerConnectionFailed, {})
       )
+    } else if (options?.dataChannelClosed) {
+      this.dispatchEvent(
+        new CustomEvent(EngineCommandManagerEvents.dataChannelClose, {})
+      )
     }
 
     if (this.connection) {

--- a/src/network/peerConnection.ts
+++ b/src/network/peerConnection.ts
@@ -311,6 +311,7 @@ export const createOnDataChannel = ({
   startPingPong,
   connectionPromiseResolve,
   handleOnDataChannelMessage,
+  tearDownManager,
 }: {
   setUnreliableDataChannel: (channel: RTCDataChannel) => void
   dispatchEvent: (event: Event) => boolean
@@ -321,6 +322,7 @@ export const createOnDataChannel = ({
   startPingPong: () => void
   connectionPromiseResolve: (value: unknown) => void
   handleOnDataChannelMessage: (event: MessageEvent<any>) => void
+  tearDownManager: (options?: ManagerTearDown) => void
 }) => {
   const onDataChannel = (event: RTCDataChannelEvent) => {
     dispatchEvent(
@@ -349,6 +351,7 @@ export const createOnDataChannel = ({
       onDataChannelOpen,
       onDataChannelError,
       onDataChannelMessage,
+      tearDownManager,
     })
 
     const metaClose = () => {
@@ -470,16 +473,23 @@ export const createOnDataChannelClose = ({
   onDataChannelOpen,
   onDataChannelError,
   onDataChannelMessage,
+  tearDownManager,
 }: {
   unreliableDataChannel: RTCDataChannel
   onDataChannelOpen: (event: Event) => void
   onDataChannelError: (event: Event) => void
   onDataChannelMessage: (event: MessageEvent<any>) => void
+  tearDownManager: (options?: ManagerTearDown) => void
 }) => {
   const onDataChannelClose = () => {
+    EngineDebugger.addLog({
+      label: 'onDataChannelClose',
+      message: 'RTCPeerConnection data channel processed a closed event.',
+    })
     unreliableDataChannel.removeEventListener('open', onDataChannelOpen)
     unreliableDataChannel.removeEventListener('error', onDataChannelError)
     unreliableDataChannel.removeEventListener('message', onDataChannelMessage)
+    tearDownManager({ dataChannelClosed: true })
   }
   return onDataChannelClose
 }

--- a/src/network/utils.ts
+++ b/src/network/utils.ts
@@ -272,6 +272,9 @@ export enum EngineCommandManagerEvents {
   peerConnectionClosed = 'peer-connection-closed',
 
   OnlineRequest = 'online-request',
+
+  // RTCPeerConnection processed a data channel close in createOnDataChannelClose
+  dataChannelClose = 'data-channel-closed',
 }
 
 export interface UnreliableSubscription<T extends UnreliableResponses['type']> {
@@ -322,6 +325,7 @@ export interface ManagerTearDown {
   peerConnectionFailed?: boolean
   peerConnectionDisconnected?: boolean
   peerConnectionClosed?: boolean
+  dataChannelClosed?: boolean
   code?: string
 }
 


### PR DESCRIPTION
# Issue

If you run `engineCommandManager.connection.peerConnection.close()` in the close it will cause a code path that will not recover.  This is because we don't inform the system something went wrong and reconnect we only gracefully cleanup.

# Implementation

Similar to the other `on<>` workflows I've added a new event type for on data channel close and propagated that through the same React workflow for reconnection. RTCPeerConnection already has a hook and I've added the data channel in it because the data channel is a child of the RTCPeerConnection process.

You can test that this automatically connects by running `engineCommandManager.connection.peerConnection.close()` in the console and seeing that you get another engine connection. 

# Diagram
I've updated the excalidraw document. 

# Debugging

```
engineCommandManager.connection.websocket.close()
engineCommandManager.connection.peerConnection.close()
engineCommandManager.connection.unreliableDataChannel.close()
```

^ all 3 of these manually work and will auto reconnect to the engine. 