### PR TITLE
Prefer standard token name for local development

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -4,7 +4,7 @@ NODE_ENV=development
 
 # App
 VITE_KITTYCAD_BASE_DOMAIN=dev.zoo.dev
-#VITE_KITTYCAD_API_TOKEN="required for testing, optional to skip auth in the app"
+#VITE_ZOO_API_TOKEN="required for testing, optional to skip auth in the app"
 #VITE_KITTYCAD_API_WEBSOCKET_URL="optional override for engine websocket URL"
 #VITE_WASM_BASE_URL="optional override of Wasm URL if not on default port 3000"
 FAIL_ON_CONSOLE_ERRORS=true
@@ -13,5 +13,5 @@ FAIL_ON_CONSOLE_ERRORS=true
 RUST_BACKTRACE=1
 PYO3_PYTHON=/usr/local/bin/python3
 ZOO_HOST=https://api.$VITE_KITTYCAD_BASE_DOMAIN
-#KITTYCAD_API_TOKEN=$VITE_KITTYCAD_API_TOKEN
+#ZOO_API_TOKEN=$VITE_ZOO_API_TOKEN
 #ZOO_ENGINE_POOL=pr-1234

--- a/.github/workflows/cargo-bench.yml
+++ b/.github/workflows/cargo-bench.yml
@@ -58,4 +58,4 @@ jobs:
           run: cargo codspeed run
           token: ${{ secrets.CODSPEED_TOKEN }}
         env:
-          KITTYCAD_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
+          ZOO_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -91,7 +91,7 @@ jobs:
             simulation_tests::kcl_samples \
             2>&1 | tee /tmp/github-actions.log
         env:
-          KITTYCAD_API_TOKEN: ${{secrets.ZOO_API_TOKEN}}
+          ZOO_API_TOKEN: ${{secrets.ZOO_API_TOKEN}}
           ZOO_HOST: https://api.dev.zoo.dev
           RUST_BACKTRACE: full
           RUST_MIN_STACK: 10485760000
@@ -121,7 +121,7 @@ jobs:
         env:
           # The default is auto, and insta behaves differently in CI vs. not.
           INSTA_UPDATE: always
-          KITTYCAD_API_TOKEN: ${{secrets.ZOO_API_TOKEN}}
+          ZOO_API_TOKEN: ${{secrets.ZOO_API_TOKEN}}
           ZOO_HOST: https://api.dev.zoo.dev
           # Configure nextest when it's run by insta (via just).
           NEXTEST_PROFILE: ci
@@ -186,7 +186,7 @@ jobs:
           popd
           .github/ci-cd-scripts/upload-results.sh
         env:
-          KITTYCAD_API_TOKEN: ${{secrets.ZOO_API_TOKEN}}
+          ZOO_API_TOKEN: ${{secrets.ZOO_API_TOKEN}}
           ZOO_HOST: https://api.dev.zoo.dev
           RUST_MIN_STACK: 10485760000
           TAB_API_URL: ${{ vars.TAB_API_URL }}
@@ -238,7 +238,7 @@ jobs:
           TWENTY_TWENTY: overwrite
           INSTA_UPDATE: always
           EXPECTORATE: overwrite
-          KITTYCAD_API_TOKEN: ${{secrets.ZOO_API_TOKEN}}
+          ZOO_API_TOKEN: ${{secrets.ZOO_API_TOKEN}}
           ZOO_HOST: https://api.dev.zoo.dev
           RUST_MIN_STACK: 10485760000
           TAB_API_URL: ${{ vars.TAB_API_URL }}
@@ -283,5 +283,5 @@ jobs:
           cd kcl-wasm-lib
           #wasm-pack test --headless --chrome
         env:
-          KITTYCAD_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
+          ZOO_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
           NODE_ENV: development

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -160,7 +160,7 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
         env:
-          VITE_KITTYCAD_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
+          VITE_ZOO_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
           TAB_API_URL: ${{ vars.TAB_API_URL }}
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
@@ -172,7 +172,7 @@ jobs:
         if: failure()
         run: npm run test:snapshots -- --last-failed --update-snapshots
         env:
-          VITE_KITTYCAD_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
+          VITE_ZOO_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
           TAB_API_URL: ${{ vars.TAB_API_URL }}
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
@@ -289,7 +289,7 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
         env:
-          VITE_KITTYCAD_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
+          VITE_ZOO_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
           TAB_API_URL: ${{ vars.TAB_API_URL }}
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
@@ -419,7 +419,7 @@ jobs:
           max_attempts: 9
         env:
           FAIL_ON_CONSOLE_ERRORS: true
-          VITE_KITTYCAD_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
+          VITE_ZOO_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
           TAB_API_URL: ${{ vars.TAB_API_URL }}
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/kcl-python-bindings.yml
+++ b/.github/workflows/kcl-python-bindings.yml
@@ -127,7 +127,7 @@ jobs:
           just setup-uv
           just test
         env:
-          KITTYCAD_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
+          ZOO_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
           ZOO_HOST: https://api.dev.zoo.dev
   sdist:
     name: kcl-python-bindings (sdist)

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -108,7 +108,7 @@ jobs:
           xvfb-run -a npm run test:integration || true # let TAB determine failure
           .github/ci-cd-scripts/upload-results.sh
         env:
-          VITE_KITTYCAD_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
+          VITE_ZOO_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
           TAB_API_URL: ${{ vars.TAB_API_URL }}
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ If you're not a Zoo employee you won't be able to access the dev environment, yo
 
 ### Development environment variables
 
-The Copilot LSP plugin in the editor requires a Zoo API token to run. In production, we authenticate this with a token via cookie in the browser and device auth token in the desktop environment, but this token is inaccessible in the dev browser version because the cookie is considered "cross-site" (from `localhost` to `zoo.dev`). There is an optional environment variable called `VITE_KITTYCAD_API_TOKEN` that you can populate with a dev token in a `.env.development.local` file to not check it into Git, which will use that token instead of other methods for the LSP service.
+The Copilot LSP plugin in the editor requires a Zoo API token to run. In production, we authenticate this with a token via cookie in the browser and device auth token in the desktop environment, but this token is inaccessible in the dev browser version because the cookie is considered "cross-site" (from `localhost` to `zoo.dev`). There is an optional environment variable called `VITE_ZOO_API_TOKEN` that you can populate with a dev token in a `.env.development.local` file to not check it into Git, which will use that token instead of other methods for the LSP service.
 
 ### Developing in Chrome
 
@@ -96,7 +96,7 @@ To package the app for your platform with electron-builder, run `npm run tronb:p
 
 Prepare these system dependencies:
 
-- Set `$VITE_KITTYCAD_API_TOKEN` from https://zoo.dev/account/api-tokens
+- Set `$VITE_ZOO_API_TOKEN` from https://zoo.dev/account/api-tokens
 
 #### Desktop tests (Electron on all platforms)
 
@@ -202,7 +202,7 @@ Which will run our suite of [Vitest unit](https://vitest.dev/) and [React Testin
 
 Prepare these system dependencies:
 
-- Set `$KITTYCAD_API_TOKEN` from https://zoo.dev/account/api-tokens
+- Set `$ZOO_API_TOKEN` from https://zoo.dev/account/api-tokens
 - Install `just` following [these instructions](https://just.systems/man/en/packages.html)
 
 then run tests that target the KCL language:

--- a/e2e/playwright/test-utils.ts
+++ b/e2e/playwright/test-utils.ts
@@ -17,7 +17,8 @@ import { PNG } from 'pngjs'
 
 const NODE_ENV = process.env.NODE_ENV || 'development'
 dotenv.config({ path: [`.env.${NODE_ENV}.local`, `.env.${NODE_ENV}`] })
-export const token = process.env.VITE_KITTYCAD_API_TOKEN || ''
+export const token =
+  process.env.VITE_ZOO_API_TOKEN || process.env.VITE_KITTYCAD_API_TOKEN || ''
 
 /** A string version of a RegExp to get a number that may include a decimal point */
 export const NUMBER_REGEXP = '((-)?\\d+(\\.\\d+)?)'

--- a/interface.d.ts
+++ b/interface.d.ts
@@ -78,7 +78,8 @@ export interface IElectronAPI {
       NODE_ENV: string
       VITE_KITTYCAD_BASE_DOMAIN: string
       VITE_KITTYCAD_API_WEBSOCKET_URL: string
-      VITE_KITTYCAD_API_TOKEN: string
+      VITE_KITTYCAD_API_TOKEN: string // legacy token name
+      VITE_ZOO_API_TOKEN: string
     }
   }
   kittycad: (access: string, args: any) => any

--- a/rust/kcl-lib/README.md
+++ b/rust/kcl-lib/README.md
@@ -14,7 +14,7 @@ We've built a lot of tooling to make contributing to KCL easier. If you are inte
 6. A `stdlib` macro providing the name that will need to be written by KCL users to use the function (this is usually a camelCase version of your Rust implementation, which is named with snake_case)
 7. An inner function that is published only to the crate
 8. Add your new standard library function to [the long list of CORE_FNS in mod.rs](https://github.com/KittyCAD/modeling-app/blob/main/rust/kcl-lib/src/std/mod.rs#L42)
-9. Get a production Zoo dev token and run `export KITTYCAD_API_TOKEN=your-token-here` in a terminal
+9. Get a production Zoo dev token and run `export ZOO_API_TOKEN=your-token-here` in a terminal
 10. Run `TWENTY_TWENTY=overwrite cargo nextest run --workspace --no-fail-fast` to take snapshot tests of your example code running in the engine
 11. Run `just redo-kcl-stdlib-docs` to generate new Markdown documentation for your function that will be used [to generate docs on our website](https://zoo.dev/docs/kcl).
 12. Create a PR in GitHub.

--- a/rust/kcl-lib/src/coredump/local.rs
+++ b/rust/kcl-lib/src/coredump/local.rs
@@ -23,7 +23,9 @@ impl Default for CoreDumper {
 #[async_trait::async_trait(?Send)]
 impl CoreDump for CoreDumper {
     fn token(&self) -> Result<String> {
-        Ok(std::env::var("KITTYCAD_API_TOKEN").unwrap_or_default())
+        Ok(std::env::var("ZOO_API_TOKEN")
+            .or_else(|_| std::env::var("KITTYCAD_API_TOKEN"))
+            .unwrap_or_default())
     }
 
     fn base_api_url(&self) -> Result<String> {

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -17,14 +17,14 @@ describe('@src/env', () => {
         VITE_KITTYCAD_API_BASE_URL: 'https://api.dev.zoo.dev',
         VITE_KITTYCAD_API_WEBSOCKET_URL:
           'wss://api.dev.zoo.dev/ws/modeling/commands',
-        VITE_KITTYCAD_API_TOKEN: 'redacted',
+        VITE_ZOO_API_TOKEN: 'redacted',
         VITE_KITTYCAD_SITE_BASE_URL: 'https://dev.zoo.dev',
         VITE_KITTYCAD_SITE_APP_URL: 'https://app.dev.zoo.dev',
         POOL: '',
       }
       const actual = env()
       //@ts-ignore I do not want this token in our logs for any reason.
-      actual.VITE_KITTYCAD_API_TOKEN = 'redacted'
+      actual.VITE_ZOO_API_TOKEN = 'redacted'
       expect(actual).toStrictEqual(expected)
     })
   })
@@ -52,7 +52,7 @@ describe('@src/env', () => {
               VITE_KITTYCAD_API_BASE_URL: 'https://api.dev.zoo.dev',
               VITE_KITTYCAD_API_WEBSOCKET_URL:
                 'wss://api.dev.zoo.dev/ws/modeling/commands',
-              VITE_KITTYCAD_API_TOKEN: 'redacted',
+              VITE_ZOO_API_TOKEN: 'redacted',
               VITE_KITTYCAD_SITE_BASE_URL: 'https://dev.zoo.dev',
               VITE_KITTYCAD_SITE_APP_URL: 'https://app.dev.zoo.dev',
             },
@@ -63,7 +63,7 @@ describe('@src/env', () => {
           VITE_KITTYCAD_API_BASE_URL: 'https://api.dev.zoo.dev',
           VITE_KITTYCAD_API_WEBSOCKET_URL:
             'wss://api.dev.zoo.dev/ws/modeling/commands',
-          VITE_KITTYCAD_API_TOKEN: 'redacted',
+          VITE_ZOO_API_TOKEN: 'redacted',
           VITE_KITTYCAD_SITE_BASE_URL: 'https://dev.zoo.dev',
           VITE_KITTYCAD_SITE_APP_URL: 'https://app.dev.zoo.dev',
         }

--- a/src/env.ts
+++ b/src/env.ts
@@ -14,7 +14,7 @@ export type EnvironmentVariables = {
   readonly VITE_KITTYCAD_BASE_DOMAIN: string | undefined
   readonly VITE_KITTYCAD_API_BASE_URL: string | undefined
   readonly VITE_KITTYCAD_API_WEBSOCKET_URL: string | undefined
-  readonly VITE_KITTYCAD_API_TOKEN: string | undefined
+  readonly VITE_ZOO_API_TOKEN: string | undefined
   readonly VITE_KITTYCAD_SITE_BASE_URL: string | undefined
   readonly VITE_KITTYCAD_SITE_APP_URL: string | undefined
   readonly POOL: string | undefined
@@ -149,8 +149,10 @@ export default (): EnvironmentVariables => {
     VITE_KITTYCAD_BASE_DOMAIN: BASE_DOMAIN || undefined,
     VITE_KITTYCAD_API_BASE_URL: API_URL || undefined,
     VITE_KITTYCAD_API_WEBSOCKET_URL: WEBSOCKET_URL || undefined,
-    VITE_KITTYCAD_API_TOKEN:
-      (env.VITE_KITTYCAD_API_TOKEN as string) || undefined,
+    VITE_ZOO_API_TOKEN:
+      (env.VITE_ZOO_API_TOKEN as string) ||
+      (env.VITE_KITTYCAD_API_TOKEN as string) ||
+      undefined,
     VITE_KITTYCAD_SITE_BASE_URL: SITE_URL || undefined,
     VITE_KITTYCAD_SITE_APP_URL: APP_URL || undefined,
     POOL: pool, // TODO: Rename to ENGINE_POOL to be more descriptive

--- a/src/integration.spec.ts
+++ b/src/integration.spec.ts
@@ -123,7 +123,7 @@ beforeAll(async () => {
   await new Promise((resolve) => {
     engineCommandManager
       .start({
-        token: env().VITE_KITTYCAD_API_TOKEN || '',
+        token: env().VITE_ZOO_API_TOKEN || '',
         width: 256,
         height: 256,
         setStreamIsReady: () => {

--- a/src/machines/authMachine.ts
+++ b/src/machines/authMachine.ts
@@ -48,7 +48,7 @@ export const TOKEN_PERSIST_KEY = 'TOKEN_PERSIST_KEY'
  * Determine which token do we have persisted to initialize the auth machine
  */
 const persistedCookie = getCookie()
-const persistedDevToken = env().VITE_KITTYCAD_API_TOKEN
+const persistedDevToken = env().VITE_ZOO_API_TOKEN
 export const persistedToken = persistedDevToken || persistedCookie || ''
 console.log('Initial persisted token')
 console.table([
@@ -198,7 +198,7 @@ async function getUser(input: { token?: string }) {
    * We do not want to store a token or a user since the developer is running
    * the application and dependencies locally. They know what they are doing.
    */
-  if (env().VITE_KITTYCAD_API_TOKEN === 'localhost') {
+  if (env().VITE_ZOO_API_TOKEN === 'localhost') {
     return {
       user: undefined,
       token: 'localhost',
@@ -254,12 +254,12 @@ function getCookieByName(cname: string): string | null {
 async function getAndSyncStoredToken(input: {
   token?: string
 }): Promise<string> {
-  // dev mode
-  const VITE_KITTYCAD_API_TOKEN = env().VITE_KITTYCAD_API_TOKEN
-  if (VITE_KITTYCAD_API_TOKEN) {
+  // Local mode
+  const localToken = env().VITE_ZOO_API_TOKEN
+  if (localToken) {
     console.log('Token used for authentication')
-    console.table([['api token', !!VITE_KITTYCAD_API_TOKEN]])
-    return VITE_KITTYCAD_API_TOKEN
+    console.table([['api token', !!localToken]])
+    return localToken
   }
 
   const environmentName = env().VITE_KITTYCAD_BASE_DOMAIN
@@ -281,7 +281,7 @@ async function getAndSyncStoredToken(input: {
   console.table([
     ['persisted token', !!inputToken],
     ['cookie', !!cookieToken],
-    ['api token', !!VITE_KITTYCAD_API_TOKEN],
+    ['api token', !!localToken],
     ['file token', !!fileToken],
   ])
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -291,7 +291,7 @@ contextBridge.exposeInMainWorld('electron', {
         'NODE_ENV',
         'VITE_KITTYCAD_BASE_DOMAIN',
         'VITE_KITTYCAD_API_WEBSOCKET_URL',
-        'VITE_KITTYCAD_API_TOKEN',
+        'VITE_ZOO_API_TOKEN',
       ])
     ),
   },


### PR DESCRIPTION
This is a followup to https://github.com/KittyCAD/modeling-app/pull/8529 to make the local development environment use the standard `ZOO_API_TOKEN` name, matching what is already set in CI.

`KITTYCAD_API_TOKEN` will continue to work as a fallback, so updates to `.env.development.local` are _encouraged_ but not required at this time.