### PR TITLE
Release KCL 103

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2231,7 +2231,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-api"
-version = "0.1.9"
+version = "0.1.103"
 dependencies = [
  "indexmap 2.11.4",
  "kcl-error",
@@ -2242,7 +2242,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-bumper"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "anyhow",
  "clap",
@@ -2253,7 +2253,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-derive-docs"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-directory-test-macro"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -2272,7 +2272,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-error"
-version = "0.1.9"
+version = "0.1.103"
 dependencies = [
  "miette",
  "serde",
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-language-server"
-version = "0.2.102"
+version = "0.2.103"
 dependencies = [
  "anyhow",
  "clap",
@@ -2318,7 +2318,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-language-server-release"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "anyhow",
  "clap",
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-lib"
-version = "0.2.102"
+version = "0.2.103"
 dependencies = [
  "anyhow",
  "approx 0.5.1",
@@ -2420,7 +2420,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-python-bindings"
-version = "0.3.102"
+version = "0.3.103"
 dependencies = [
  "anyhow",
  "kcl-lib",
@@ -2436,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-test-server"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "anyhow",
  "hyper 0.14.32",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-to-core"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2463,7 +2463,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-wasm-lib"
-version = "0.1.102"
+version = "0.1.103"
 dependencies = [
  "anyhow",
  "bson",

--- a/rust/kcl-api/Cargo.toml
+++ b/rust/kcl-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-api"
-version = "0.1.9"
+version = "0.1.103"
 edition = "2024"
 description = "KCL interpreter API"
 license = "MIT"

--- a/rust/kcl-bumper/Cargo.toml
+++ b/rust/kcl-bumper/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "kcl-bumper"
-version = "0.1.102"
+version = "0.1.103"
 edition = "2021"
 repository = "https://github.com/KittyCAD/modeling-api"
 rust-version = "1.76"

--- a/rust/kcl-derive-docs/Cargo.toml
+++ b/rust/kcl-derive-docs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-derive-docs"
 description = "A tool for generating documentation from Rust derive macros"
-version = "0.1.102"
+version = "0.1.103"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-directory-test-macro/Cargo.toml
+++ b/rust/kcl-directory-test-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-directory-test-macro"
 description = "A tool for generating tests from a directory of kcl files"
-version = "0.1.102"
+version = "0.1.103"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-error/Cargo.toml
+++ b/rust/kcl-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-error"
-version = "0.1.9"
+version = "0.1.103"
 edition = "2024"
 description = "KCL error definitions"
 license = "MIT"

--- a/rust/kcl-language-server-release/Cargo.toml
+++ b/rust/kcl-language-server-release/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-language-server-release"
-version = "0.1.102"
+version = "0.1.103"
 edition = "2021"
 authors = ["KittyCAD Inc <kcl@kittycad.io>"]
 publish = false

--- a/rust/kcl-language-server/Cargo.toml
+++ b/rust/kcl-language-server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kcl-language-server"
 description = "A language server for KCL."
 authors = ["KittyCAD Inc <kcl@kittycad.io>"]
-version = "0.2.102"
+version = "0.2.103"
 edition = "2021"
 license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust/kcl-lib/Cargo.toml
+++ b/rust/kcl-lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-lib"
 description = "KittyCAD Language implementation and tools"
-version = "0.2.102"
+version = "0.2.103"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-python-bindings/Cargo.toml
+++ b/rust/kcl-python-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-python-bindings"
-version = "0.3.102"
+version = "0.3.103"
 edition = "2021"
 repository = "https://github.com/kittycad/modeling-app"
 exclude = ["tests/*", "files/*", "venv/*"]

--- a/rust/kcl-test-server/Cargo.toml
+++ b/rust/kcl-test-server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-test-server"
 description = "A test server for KCL"
-version = "0.1.102"
+version = "0.1.103"
 edition = "2021"
 license = "MIT"
 

--- a/rust/kcl-to-core/Cargo.toml
+++ b/rust/kcl-to-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-to-core"
 description = "Utility methods to convert kcl to engine core executable tests"
-version = "0.1.102"
+version = "0.1.103"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-wasm-lib/Cargo.toml
+++ b/rust/kcl-wasm-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-wasm-lib"
-version = "0.1.102"
+version = "0.1.103"
 edition = "2021"
 repository = "https://github.com/KittyCAD/modeling-app"
 rust-version = "1.83"


### PR DESCRIPTION
I also bumped kcl-api and kcl-error crates to match the 103 version.