### PR TITLE
Revert "KCL: Disable pattern_into_union test (#8571)"

### DIFF
--- a/rust/kcl-lib/src/simulation_tests.rs
+++ b/rust/kcl-lib/src/simulation_tests.rs
@@ -2807,27 +2807,27 @@ mod intersect_cubes {
     }
 }
 
-// mod pattern_into_union {
-//     const TEST_NAME: &str = "pattern_into_union";
+mod pattern_into_union {
+    const TEST_NAME: &str = "pattern_into_union";
 
-//     /// Test parsing KCL.
-//     #[test]
-//     fn parse() {
-//         super::parse(TEST_NAME)
-//     }
+    /// Test parsing KCL.
+    #[test]
+    fn parse() {
+        super::parse(TEST_NAME)
+    }
 
-//     /// Test that parsing and unparsing KCL produces the original KCL input.
-//     #[tokio::test(flavor = "multi_thread")]
-//     async fn unparse() {
-//         super::unparse(TEST_NAME).await
-//     }
+    /// Test that parsing and unparsing KCL produces the original KCL input.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unparse() {
+        super::unparse(TEST_NAME).await
+    }
 
-//     /// Test that KCL is executed correctly.
-//     #[tokio::test(flavor = "multi_thread")]
-//     async fn kcl_test_execute() {
-//         super::execute(TEST_NAME, true).await
-//     }
-// }
+    /// Test that KCL is executed correctly.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn kcl_test_execute() {
+        super::execute(TEST_NAME, true).await
+    }
+}
 mod subtract_doesnt_need_brackets {
     const TEST_NAME: &str = "subtract_doesnt_need_brackets";
 


### PR DESCRIPTION
This reverts commit f425a9db9e70ac3eafbbe5beac92277a4ce0d8b5.

We prefer to disable in TAB so that it can be tracked and dynamically re-enabled without a code change.

Reverts #8571.
Related #8572.