### PR TITLE
Improve feature tree test

### DIFF
--- a/e2e/playwright/sketch-tests.spec.ts
+++ b/e2e/playwright/sketch-tests.spec.ts
@@ -2112,8 +2112,6 @@ profile001 = startProfile(sketch001, at = [127.56, 179.02])
 
     await u.closeDebugPanel()
 
-    ///await page.waitForTimeout(1000)
-
     await toolbar.openFeatureTreePane()
 
     await toolbar.openPane('files')


### PR DESCRIPTION
Added a few delays, it seems after selecting the files it takes more time now for the dom to update..
Changed the file name good.kcl -> correct.kcl so it will be the first in the list, and so opened by default which stabilizes the test by avoiding showing the errors initially.