### PR TITLE
Increase hook timeout for integration tests

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -53,12 +53,12 @@ export default defineConfig(({ command, mode }) => {
       mockReset: true,
       reporters: process.env.GITHUB_ACTIONS
         ? ['dot', 'github-actions']
-        : // Gotcha: 'hanging-process' is very noisey, turn off by default on localhost
+        : // Gotcha: 'hanging-process' is very noisy, turn off by default on localhost
           // : ['verbose', 'hanging-process'],
           ['verbose'],
-      testTimeout: 2000,
-      hookTimeout: 1000,
-      teardownTimeout: 1000,
+      testTimeout: 2_000,
+      hookTimeout: 1_000,
+      teardownTimeout: 1_000,
       retry: 5,
     },
     build: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
         test: {
           name: 'integration',
           include: ['src/**/*.spec.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+          hookTimeout: 30_000,
         },
       },
     ],


### PR DESCRIPTION
The default of 10s may not be long enough to get engine connections: https://test-analysis-bot.hawk-dinosaur.ts.net/projects/KittyCAD/modeling-app/tests/10429/results/30921491