### PR TITLE
fix: reset camera position on file router staying the same but contents differ

### DIFF
--- a/src/components/RouteProvider.tsx
+++ b/src/components/RouteProvider.tsx
@@ -20,6 +20,7 @@ import { trap } from '@src/lib/trap'
 import type { IndexLoaderData } from '@src/lib/types'
 import { kclEditorActor } from '@src/machines/kclEditorMachine'
 import { useSelector } from '@xstate/react'
+import { resetCameraPosition } from '@src/lib/resetCameraPosition'
 
 export const RouteProviderContext = createContext({})
 
@@ -104,6 +105,7 @@ export function RouteProvider({ children }: { children: ReactNode }) {
           if (!isCodeTheSame(code, codeManager.code)) {
             codeManager.updateCodeStateEditor(code)
             await kclManager.executeCode()
+            await resetCameraPosition()
           }
         }
       } else if (


### PR DESCRIPTION
closes https://github.com/KittyCAD/modeling-app/issues/8254

# issue 
https://github.com/KittyCAD/modeling-app/issues/8254

# implementation

[background](https://github.com/KittyCAD/modeling-app/issues/8254#issuecomment-3434174155) on the debugging process

Awhile back we removed many locations that call `zoom_to_fit` which in the TS land we use the function `resetCameraPosition()`.

A workflow that we missed was when we (behind the scenes in code) route the user from `/file/main.kcl` to `/file/main.kcl`. If the code is different we will call `executeCode()` but that workflow won't reset the camera position because that would happen when the user does point and click or edits the KCL.

The proper implementation is going to the higher level locations and calling `resetCameraPosition()` after an `executeCode()` where it makes sense.

I added this new one because the file contents are different and we want to route them to that file as if they opened it so we need to call `resetCameraPosition`. 