### PR TITLE
Monkey patch for browser translation in web app

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,6 +20,7 @@ import {
 } from '@src/lib/singletons'
 import { reportRejection } from '@src/lib/trap'
 import reportWebVitals from '@src/reportWebVitals'
+import monkeyPatchForBrowserTranslation from '@src/lib/monkeyPatchBrowserTranslate'
 
 markOnce('code/willAuth')
 initializeWindowExceptionHandler()
@@ -41,6 +42,14 @@ initPromise
     })
   })
   .catch(reportRejection)
+
+// Monkey patch to prevent issues in the web app with automated browser translation
+// This mitigates https://github.com/KittyCAD/modeling-app/issues/8667, until
+// we roll out our own i18n solution and can disable browser translation altogether.
+// https://github.com/KittyCAD/modeling-app/issues/4959
+if (!window.electron) {
+  monkeyPatchForBrowserTranslation()
+}
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 

--- a/src/lib/monkeyPatchBrowserTranslate.ts
+++ b/src/lib/monkeyPatchBrowserTranslate.ts
@@ -1,0 +1,41 @@
+// The patch below is adapted from https://github.com/facebook/react/issues/11538#issuecomment-417504600
+export default function monkeyPatchForBrowserTranslation() {
+  if (typeof Node === 'function' && Node.prototype) {
+    const originalRemoveChild = Node.prototype.removeChild
+    Node.prototype.removeChild = function <T extends Node>(
+      this: Node,
+      child: T
+    ): T {
+      if (child.parentNode !== this) {
+        if (console) {
+          console.error(
+            'Cannot remove a child from a different parent',
+            child,
+            this
+          )
+        }
+        return child
+      }
+      return originalRemoveChild.call(this, child) as T
+    }
+
+    const originalInsertBefore = Node.prototype.insertBefore
+    Node.prototype.insertBefore = function <T extends Node>(
+      this: Node,
+      newNode: T,
+      referenceNode: Node | null
+    ): T {
+      if (referenceNode && referenceNode.parentNode !== this) {
+        if (console) {
+          console.error(
+            'Cannot insert before a reference node from a different parent',
+            referenceNode,
+            this
+          )
+        }
+        return newNode
+      }
+      return originalInsertBefore.call(this, newNode, referenceNode) as T
+    }
+  }
+}


### PR DESCRIPTION
Closes #8667, more context in the issue description.

Can verify this by turning on browser translation on app.dev.zoo.dev, run some copilot prompt, get the error.

Same thing on Vercel deploy here should be good.

Also verified that the electron app is untouched.