### PR TITLE
fix: square ratio now for user avatar

### DIFF
--- a/src/components/ExchangeCard.tsx
+++ b/src/components/ExchangeCard.tsx
@@ -73,7 +73,7 @@ export const ExchangeCardStatus = (props: {
 
 export const AvatarUser = (props: { src?: string }) => {
   return (
-    <div className="rounded-sm overflow-hidden">
+    <div className="rounded-sm overflow-hidden h-7 w-7">
       {props.src ? (
         <img
           src={props.src || ''}


### PR DESCRIPTION
closes https://github.com/KittyCAD/modeling-app/issues/8649

# issue

The user avatar rendered at around ~25px by 28px instead of 28px by 28px

# implementation

<img width="522" height="368" alt="image" src="https://github.com/user-attachments/assets/647b87d0-7241-4084-b599-72c7191608a0" />
