### PR TITLE
Fix to ignore rust-analyzer target output and restructure ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,20 +29,8 @@ yarn-error.log*
 result
 
 # rust
-rust/target
-rust/kcl-api/bindings
-rust/kcl-error/bindings
-rust/kcl-lib/bindings
-rust/kcl-language-server/server
-public/kcl_wasm_lib_bg.wasm
-rust/lcov.info
-rust/kcl-wasm-lib/pkg
-*.snap.new
-rust/kcl-lib/fuzz/Cargo.lock
-rust/kcl-language-server-release/Cargo.lock
-
-# kcl language server package
-rust/kcl-language-server/dist/
+/target
+/public/kcl_wasm_lib_bg.wasm
 
 # playwright
 e2e/playwright/temp1.png

--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,12 @@
+target
+*.snap.new
+
+/kcl-lib/fuzz/Cargo.lock
+/kcl-language-server-release/Cargo.lock
+/kcl-wasm-lib/pkg
+/lcov.info
+
+# ts-rs
+/kcl-api/bindings
+/kcl-error/bindings
+/kcl-lib/bindings

--- a/rust/kcl-language-server/.gitignore
+++ b/rust/kcl-language-server/.gitignore
@@ -1,0 +1,2 @@
+/dist
+/server


### PR DESCRIPTION
rust-analyzer started using the top-level `/target` directory.

I also moved a bunch of ignores into their respective directories. Rust-specific ignores shouldn't apply in other directories. Having ignores in their respective directories also makes it easier to move or rename the directories.