### PR TITLE
Update E2E test expectation

### DIFF
--- a/e2e/playwright/testing-gizmo.spec.ts
+++ b/e2e/playwright/testing-gizmo.spec.ts
@@ -286,7 +286,7 @@ test.describe(`Testing gizmo, fixture-based`, () => {
     await test.step(`Setup`, async () => {
       await scene.expectState({
         camera: {
-          position: [11796.52, -39216.59, 21103.27],
+          position: [11796.52, -39216.59, 21103.26],
           target: [11796.52, -635, 3201.42],
         },
       })


### PR DESCRIPTION
Updates E2E test expectation after camera changes from KittyCad/engine#3889 (see #8665 for CI test run against preview engine deployment).