### PR TITLE
Fix: remove playwright layout after tests complete

### DIFF
--- a/e2e/playwright/test-utils.ts
+++ b/e2e/playwright/test-utils.ts
@@ -932,7 +932,7 @@ export async function setup(
       localStorage.setItem(IS_PLAYWRIGHT_KEY, 'true')
       window.addEventListener('beforeunload', () => {
         localStorage.removeItem(IS_PLAYWRIGHT_KEY)
-        localStorage.removeItem(`${LAYOUT_PERSIST_PREFIX}default`)
+        localStorage.removeItem(layoutName)
       })
     },
     {


### PR DESCRIPTION
Zoo team users @jacebrowning and @pierremtb  reported a regression of https://github.com/KittyCAD/modeling-app/pull/8235, so that their prod app would present the Playwright testing layout after running E2E tests. This is because the layout is no longer controlled by that flag, but rather by a dedicated persistence key.