### PR TITLE
Add a bit of space between the scrollbar and the pane resize handle

### DIFF
--- a/src/components/layout/areas/FeatureTreePane.tsx
+++ b/src/components/layout/areas/FeatureTreePane.tsx
@@ -247,7 +247,7 @@ export const FeatureTreePaneContents = () => {
     <div className="relative">
       <section
         data-testid="debug-panel"
-        className="absolute inset-0 p-1 box-border overflow-auto"
+        className="absolute inset-0 p-1 box-border overflow-auto mr-1"
       >
         {kclManager.isExecuting ? (
           <Loading className="h-full" isDummy={true}>

--- a/src/components/layout/areas/KclEditorPane.tsx
+++ b/src/components/layout/areas/KclEditorPane.tsx
@@ -224,7 +224,7 @@ export const KclEditorPaneContents = () => {
       <div
         id="code-mirror-override"
         className={
-          'absolute inset-0 ' + (cursorBlinking.current ? 'blink' : '')
+          'absolute inset-0 pr-1 ' + (cursorBlinking.current ? 'blink' : '')
         }
       >
         <CodeEditor


### PR DESCRIPTION
Closes #8606. I wish I could get the logical side that a scrollbar will appear and apply margin/padding there, but I don't see a clean way to do that, so I'll just do right which will solve the problem for LTR languages, and put the word "i18n" here so that in the future we can see this PR and know it needs properly revisited.

## Demo

https://github.com/user-attachments/assets/0fbc4fc1-857e-4dfd-9cb6-35ee0e4183c4

