### PR TITLE
Finish "KITTYCAD" to "ZOO" rename of environment variables

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -3,16 +3,16 @@
 NODE_ENV=development
 
 # App
-VITE_KITTYCAD_BASE_DOMAIN=dev.zoo.dev
+VITE_ZOO_BASE_DOMAIN=dev.zoo.dev
 #VITE_ZOO_API_TOKEN="required for testing, optional to skip auth in the app"
-#VITE_KITTYCAD_WEBSOCKET_URL="optional override for engine websocket URL"
-#VITE_MLEPHANT_WEBSOCKET_URL="optional override for copilot websocket URL"
+#VITE_KITTYCAD_WEBSOCKET_URL="optional override for engine WebSocket URL"
+#VITE_MLEPHANT_WEBSOCKET_URL="optional override for copilot WebSocket URL"
 #VITE_WASM_BASE_URL="optional override of Wasm URL if not on default port 3000"
 FAIL_ON_CONSOLE_ERRORS=true
 
 # KCL
 RUST_BACKTRACE=1
 PYO3_PYTHON=/usr/local/bin/python3
-ZOO_HOST=https://api.$VITE_KITTYCAD_BASE_DOMAIN
+ZOO_HOST=https://api.$VITE_ZOO_BASE_DOMAIN
 #ZOO_API_TOKEN=$VITE_ZOO_API_TOKEN
 #ZOO_ENGINE_POOL=pr-1234

--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,4 @@
 NODE_ENV=production
 
 # App
-VITE_KITTYCAD_BASE_DOMAIN=zoo.dev
+VITE_ZOO_BASE_DOMAIN=zoo.dev

--- a/interface.d.ts
+++ b/interface.d.ts
@@ -76,7 +76,7 @@ export interface IElectronAPI {
   process: {
     env: {
       NODE_ENV: string
-      VITE_KITTYCAD_BASE_DOMAIN: string
+      VITE_ZOO_BASE_DOMAIN: string
       VITE_KITTYCAD_WEBSOCKET_URL: string
       VITE_MLEPHANT_WEBSOCKET_URL: string
       VITE_KITTYCAD_API_TOKEN: string // legacy token name

--- a/src/components/UserSidebarMenu.tsx
+++ b/src/components/UserSidebarMenu.tsx
@@ -28,7 +28,7 @@ const UserSidebarMenu = ({ user }: { user?: User }) => {
   const [imageLoadFailed, setImageLoadFailed] = useState(false)
   const navigate = useNavigate()
   const send = authActor.send
-  const fullEnvironmentName = env().VITE_KITTYCAD_BASE_DOMAIN
+  const fullEnvironmentName = env().VITE_ZOO_BASE_DOMAIN
   const [hasMultipleEnvironments, setHasMultipleEnvironments] = useState(false)
 
   useEffect(() => {
@@ -167,7 +167,7 @@ const UserSidebarMenu = ({ user }: { user?: User }) => {
           Element: 'button',
           children: <span>Change environment</span>,
           onClick: () => {
-            const environment = env().VITE_KITTYCAD_BASE_DOMAIN
+            const environment = env().VITE_ZOO_BASE_DOMAIN
             if (environment) {
               commandBarActor.send({
                 type: 'Find and select command',

--- a/src/components/environment/Environment.tsx
+++ b/src/components/environment/Environment.tsx
@@ -5,7 +5,7 @@ import { commandBarActor } from '@src/lib/singletons'
 import { reportRejection } from '@src/lib/trap'
 
 export function EnvironmentChip() {
-  const shorthand = env().VITE_KITTYCAD_BASE_DOMAIN
+  const shorthand = env().VITE_ZOO_BASE_DOMAIN
   const pool = env().POOL
   return (
     <div className="flex items-center px-2 py-1 text-xs text-chalkboard-80 dark:text-chalkboard-30 rounded-none border-none hover:bg-chalkboard-30 dark:hover:bg-chalkboard-80 focus:bg-chalkboard-30 dark:focus:bg-chalkboard-80 hover:text-chalkboard-100 dark:hover:text-chalkboard-10 focus:text-chalkboard-100 dark:focus:text-chalkboard-10  focus:outline-none focus-visible:ring-2 focus:ring-primary focus:ring-opacity-50">
@@ -17,7 +17,7 @@ export function EnvironmentChip() {
 }
 
 export function EnvironmentDescription() {
-  const fullEnvironmentName = env().VITE_KITTYCAD_BASE_DOMAIN
+  const fullEnvironmentName = env().VITE_ZOO_BASE_DOMAIN
   return (
     <div className="absolute left-2 bottom-full mb-1 flex-col gap-1 align-stretch bg-chalkboard-10 dark:bg-chalkboard-90 rounded shadow-lg border border-solid border-chalkboard-20/50 dark:border-chalkboard-80/50 text-sm">
       <div
@@ -32,7 +32,7 @@ export function EnvironmentDescription() {
             <ActionButton
               Element="button"
               onClick={() => {
-                const environment = env().VITE_KITTYCAD_BASE_DOMAIN
+                const environment = env().VITE_ZOO_BASE_DOMAIN
                 if (environment) {
                   commandBarActor.send({
                     type: 'Find and select command',
@@ -58,13 +58,13 @@ export function EnvironmentDescription() {
         <li className="flex flex-col px-2 py-2 gap-1 last:mb-0 ">
           <p className="text-chalkboard-100 dark:text-chalkboard-10">API</p>{' '}
           <p className="text-chalkboard-60 dark:text-chalkboard-40">
-            {env().VITE_KITTYCAD_API_BASE_URL}
+            {env().VITE_ZOO_API_BASE_URL}
           </p>
         </li>
         <li className="flex flex-col px-2 py-2 gap-1 last:mb-0 ">
           <p className="text-chalkboard-100 dark:text-chalkboard-10">Site</p>{' '}
           <p className="text-chalkboard-60 dark:text-chalkboard-40">
-            {env().VITE_KITTYCAD_SITE_BASE_URL}
+            {env().VITE_ZOO_SITE_BASE_URL}
           </p>
         </li>
         <li className="flex flex-col px-2 py-2 gap-1 last:mb-0 ">
@@ -105,7 +105,7 @@ export function EnvironmentDescription() {
               {env().POOL !== '' && (
                 <ActionButton
                   onClick={() => {
-                    const environment = env().VITE_KITTYCAD_BASE_DOMAIN
+                    const environment = env().VITE_ZOO_BASE_DOMAIN
                     if (environment) {
                       if (!window.electron) {
                         console.error("Can't access electron")

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -13,14 +13,14 @@ describe('@src/env', () => {
       // vite > node.js
       const expected = {
         NODE_ENV: 'place-holder-since-it-will-be-set',
-        VITE_KITTYCAD_BASE_DOMAIN: 'dev.zoo.dev',
-        VITE_KITTYCAD_API_BASE_URL: 'https://api.dev.zoo.dev',
+        VITE_ZOO_BASE_DOMAIN: 'dev.zoo.dev',
+        VITE_ZOO_API_BASE_URL: 'https://api.dev.zoo.dev',
         VITE_KITTYCAD_WEBSOCKET_URL:
           'wss://api.dev.zoo.dev/ws/modeling/commands',
         VITE_MLEPHANT_WEBSOCKET_URL: 'wss://api.dev.zoo.dev/ws/ml/copilot',
         VITE_ZOO_API_TOKEN: 'redacted',
-        VITE_KITTYCAD_SITE_BASE_URL: 'https://dev.zoo.dev',
-        VITE_KITTYCAD_SITE_APP_URL: 'https://app.dev.zoo.dev',
+        VITE_ZOO_SITE_BASE_URL: 'https://dev.zoo.dev',
+        VITE_ZOO_SITE_APP_URL: 'https://app.dev.zoo.dev',
         POOL: '',
       }
       const actual = env()
@@ -39,7 +39,7 @@ describe('@src/env', () => {
       // We only need to match against EnvironmentVariables
       const actual = viteEnv()
       expect(typeof actual.NODE_ENV).toBe('string')
-      expect(typeof actual.VITE_KITTYCAD_BASE_DOMAIN).toBe('string')
+      expect(typeof actual.VITE_ZOO_BASE_DOMAIN).toBe('string')
     })
   })
   describe('windowElectronProcessEnv', () => {
@@ -54,26 +54,26 @@ describe('@src/env', () => {
           process: {
             env: {
               NODE_ENV: 'test',
-              VITE_KITTYCAD_API_BASE_URL: 'https://api.dev.zoo.dev',
+              VITE_ZOO_API_BASE_URL: 'https://api.dev.zoo.dev',
               VITE_KITTYCAD_WEBSOCKET_URL:
                 'wss://api.dev.zoo.dev/ws/modeling/commands',
               VITE_MLEPHANT_WEBSOCKET_URL:
                 'wss://api.dev.zoo.dev/ws/ml/copilot',
               VITE_ZOO_API_TOKEN: 'redacted',
-              VITE_KITTYCAD_SITE_BASE_URL: 'https://dev.zoo.dev',
-              VITE_KITTYCAD_SITE_APP_URL: 'https://app.dev.zoo.dev',
+              VITE_ZOO_SITE_BASE_URL: 'https://dev.zoo.dev',
+              VITE_ZOO_SITE_APP_URL: 'https://app.dev.zoo.dev',
             },
           },
         })
         const expected = {
           NODE_ENV: 'test',
-          VITE_KITTYCAD_API_BASE_URL: 'https://api.dev.zoo.dev',
+          VITE_ZOO_API_BASE_URL: 'https://api.dev.zoo.dev',
           VITE_KITTYCAD_WEBSOCKET_URL:
             'wss://api.dev.zoo.dev/ws/modeling/commands',
           VITE_MLEPHANT_WEBSOCKET_URL: 'wss://api.dev.zoo.dev/ws/ml/copilot',
           VITE_ZOO_API_TOKEN: 'redacted',
-          VITE_KITTYCAD_SITE_BASE_URL: 'https://dev.zoo.dev',
-          VITE_KITTYCAD_SITE_APP_URL: 'https://app.dev.zoo.dev',
+          VITE_ZOO_SITE_BASE_URL: 'https://dev.zoo.dev',
+          VITE_ZOO_SITE_APP_URL: 'https://app.dev.zoo.dev',
         }
         const actual = windowElectronProcessEnv()
         expect(actual).toStrictEqual(expected)
@@ -95,7 +95,7 @@ describe('@src/env', () => {
       const actual = processEnv()
       expect(!!actual).toBe(true)
       expect(typeof actual?.NODE_ENV).toBe('string')
-      expect(typeof actual?.VITE_KITTYCAD_BASE_DOMAIN).toBe('string')
+      expect(typeof actual?.VITE_ZOO_BASE_DOMAIN).toBe('string')
     })
   })
   describe('generateDomainsFromBaseDomain', () => {

--- a/src/env.ts
+++ b/src/env.ts
@@ -12,13 +12,13 @@ export function generateDomainsFromBaseDomain(baseDomain: string) {
 
 export type EnvironmentVariables = {
   readonly NODE_ENV: string | undefined
-  readonly VITE_KITTYCAD_BASE_DOMAIN: string | undefined
-  readonly VITE_KITTYCAD_API_BASE_URL: string | undefined
+  readonly VITE_ZOO_BASE_DOMAIN: string | undefined
+  readonly VITE_ZOO_API_BASE_URL: string | undefined
   readonly VITE_KITTYCAD_WEBSOCKET_URL: string | undefined
   readonly VITE_MLEPHANT_WEBSOCKET_URL: string | undefined
   readonly VITE_ZOO_API_TOKEN: string | undefined
-  readonly VITE_KITTYCAD_SITE_BASE_URL: string | undefined
-  readonly VITE_KITTYCAD_SITE_APP_URL: string | undefined
+  readonly VITE_ZOO_SITE_BASE_URL: string | undefined
+  readonly VITE_ZOO_SITE_APP_URL: string | undefined
   readonly POOL: string | undefined
 }
 
@@ -110,7 +110,7 @@ export default (): EnvironmentVariables => {
   const processEnvOnly = processEnv()
   const env = processEnvOnly || windowElectronProcessEnvOnly || viteOnly
 
-  let BASE_DOMAIN = env.VITE_KITTYCAD_BASE_DOMAIN
+  let BASE_DOMAIN = env.VITE_ZOO_BASE_DOMAIN
   let {
     API_URL,
     SITE_URL,
@@ -160,16 +160,16 @@ export default (): EnvironmentVariables => {
 
   const environmentVariables: EnvironmentVariables = {
     NODE_ENV: (env.NODE_ENV as string) || viteOnly.MODE || undefined,
-    VITE_KITTYCAD_BASE_DOMAIN: BASE_DOMAIN || undefined,
-    VITE_KITTYCAD_API_BASE_URL: API_URL || undefined,
+    VITE_ZOO_BASE_DOMAIN: BASE_DOMAIN || undefined,
+    VITE_ZOO_API_BASE_URL: API_URL || undefined,
     VITE_KITTYCAD_WEBSOCKET_URL: KITTYCAD_WEBSOCKET_URL || undefined,
     VITE_MLEPHANT_WEBSOCKET_URL: MLEPHANT_WEBSOCKET_URL || undefined,
     VITE_ZOO_API_TOKEN:
       (env.VITE_ZOO_API_TOKEN as string) ||
       (env.VITE_KITTYCAD_API_TOKEN as string) ||
       undefined,
-    VITE_KITTYCAD_SITE_BASE_URL: SITE_URL || undefined,
-    VITE_KITTYCAD_SITE_APP_URL: APP_URL || undefined,
+    VITE_ZOO_SITE_BASE_URL: SITE_URL || undefined,
+    VITE_ZOO_SITE_APP_URL: APP_URL || undefined,
     POOL: pool, // TODO: Rename to ENGINE_POOL to be more descriptive
   }
 

--- a/src/lib/commandBarConfigs/applicationCommandConfig.ts
+++ b/src/lib/commandBarConfigs/applicationCommandConfig.ts
@@ -564,7 +564,7 @@ export function createApplicationCommands({
         return
       }
       if (data) {
-        const environmentName = env().VITE_KITTYCAD_BASE_DOMAIN
+        const environmentName = env().VITE_ZOO_BASE_DOMAIN
         if (environmentName)
           writeEnvironmentConfigurationPool(
             window.electron,

--- a/src/lib/kcClient.ts
+++ b/src/lib/kcClient.ts
@@ -8,7 +8,7 @@ export function createKCClient(
   token?: string,
   baseUrlOverride?: string
 ): Client {
-  const baseUrl = baseUrlOverride || env().VITE_KITTYCAD_API_BASE_URL
+  const baseUrl = baseUrlOverride || env().VITE_ZOO_API_BASE_URL
   const injectedFetch = ((input: any, init?: any) => {
     const impl =
       typeof fetch !== 'undefined'

--- a/src/lib/links.test.ts
+++ b/src/lib/links.test.ts
@@ -9,7 +9,7 @@ describe(`link creation tests`, () => {
 
     // Converted with external online tools
     const expectedEncodedCode = `ZXh0cnVzaW9uRGlzdGFuY2UgPSAxMg%3D%3D`
-    const expectedLink = `${env().VITE_KITTYCAD_SITE_APP_URL}/?create-file=true&name=test&code=${expectedEncodedCode}&ask-open-desktop=true`
+    const expectedLink = `${env().VITE_ZOO_SITE_APP_URL}/?create-file=true&name=test&code=${expectedEncodedCode}&ask-open-desktop=true`
 
     const result = createCreateFileUrl({ code, name, isRestrictedToOrg: false })
     expect(result.toString()).toBe(expectedLink)

--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -59,7 +59,7 @@ export async function copyFileShareLink(
  * open the URL in the desktop app.
  */
 export function createCreateFileUrl({ code, name }: FileLinkParams) {
-  let origin = env().VITE_KITTYCAD_SITE_APP_URL
+  let origin = env().VITE_ZOO_SITE_APP_URL
   const searchParams = new URLSearchParams({
     [CREATE_FILE_URL_PARAM]: String(true),
     name,

--- a/src/lib/withBaseURL.ts
+++ b/src/lib/withBaseURL.ts
@@ -1,11 +1,11 @@
 import env from '@src/env'
 
 export function withAPIBaseURL(path: string): string {
-  return env().VITE_KITTYCAD_API_BASE_URL + path
+  return env().VITE_ZOO_API_BASE_URL + path
 }
 
 export function withSiteBaseURL(path: string): string {
-  return env().VITE_KITTYCAD_SITE_BASE_URL + path
+  return env().VITE_ZOO_SITE_BASE_URL + path
 }
 
 export function withWebSocketURL(path: string): string {

--- a/src/machines/authMachine.ts
+++ b/src/machines/authMachine.ts
@@ -174,7 +174,7 @@ async function getUser(input: { token?: string }) {
   if (window.electron) {
     const environment =
       (await readEnvironmentFile(window.electron)) ||
-      env().VITE_KITTYCAD_BASE_DOMAIN ||
+      env().VITE_ZOO_BASE_DOMAIN ||
       ''
     updateEnvironment(environment)
 
@@ -227,7 +227,7 @@ export function getCookie(): string | null {
     return null
   }
 
-  const baseDomain = env().VITE_KITTYCAD_BASE_DOMAIN
+  const baseDomain = env().VITE_ZOO_BASE_DOMAIN
   if (baseDomain === 'zoo.dev' || baseDomain === 'zoogov.dev') {
     return getCookieByName(LEGACY_COOKIE_NAME)
   } else {
@@ -262,7 +262,7 @@ async function getAndSyncStoredToken(input: {
     return localToken
   }
 
-  const environmentName = env().VITE_KITTYCAD_BASE_DOMAIN
+  const environmentName = env().VITE_ZOO_BASE_DOMAIN
 
   // Find possible tokens
   const inputToken = input.token && input.token !== '' ? input.token : ''
@@ -323,7 +323,7 @@ async function logoutEnvironment(requestedDomain?: string) {
   localStorage.removeItem(TOKEN_PERSIST_KEY)
   if (window.electron) {
     try {
-      const domain = requestedDomain || env().VITE_KITTYCAD_BASE_DOMAIN
+      const domain = requestedDomain || env().VITE_ZOO_BASE_DOMAIN
       let token = ''
       if (domain) {
         token = await readEnvironmentConfigurationToken(window.electron, domain)

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,7 +71,7 @@ dotenv.config({ path: [`.env.${NODE_ENV}.local`, `.env.${NODE_ENV}`] })
 process.env.NODE_ENV ??= viteEnv.MODE
 process.env.VITE_KITTYCAD_WEBSOCKET_URL ??= viteEnv.VITE_KITTYCAD_WEBSOCKET_URL
 process.env.VITE_MLEPHANT_WEBSOCKET_URL ??= viteEnv.VITE_MLEPHANT_WEBSOCKET_URL
-process.env.VITE_KITTYCAD_BASE_DOMAIN ??= viteEnv.VITE_KITTYCAD_BASE_DOMAIN
+process.env.VITE_ZOO_BASE_DOMAIN ??= viteEnv.VITE_ZOO_BASE_DOMAIN
 
 // Likely convenient to keep for debugging
 console.log('Environment vars', process.env)

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -289,7 +289,7 @@ contextBridge.exposeInMainWorld('electron', {
       {},
       exposeProcessEnvs([
         'NODE_ENV',
-        'VITE_KITTYCAD_BASE_DOMAIN',
+        'VITE_ZOO_BASE_DOMAIN',
         'VITE_KITTYCAD_WEBSOCKET_URL',
         'VITE_MLEPHANT_WEBSOCKET_URL',
         'VITE_ZOO_API_TOKEN',

--- a/src/routes/SignIn.tsx
+++ b/src/routes/SignIn.tsx
@@ -46,7 +46,7 @@ const SignIn = () => {
 
   // Last saved environment
   // TODO: Reduce this logic
-  const lastSelectedEnvironmentName = env().VITE_KITTYCAD_BASE_DOMAIN || ''
+  const lastSelectedEnvironmentName = env().VITE_ZOO_BASE_DOMAIN || ''
   const [selectedEnvironment, setSelectedEnvironment] = useState(
     lastSelectedEnvironmentName
   )


### PR DESCRIPTION
After this, any environment variable containing `KITTYCAD` (or `MLEPHANT`) are specifically for local development overrides or mocks of that corresponding API offering: https://zoo.dev/design-api and https://zoo.dev/machine-learning-api, respectively.

TODO:

- [x] @jacebrowning to clean up Vercel environment variables after this is merged: https://vercel.com/kittycad/modeling-app/settings/environment-variables