### PR TITLE
Add the debug pane to the default layout

### DIFF
--- a/src/lib/layout/configs/default.ts
+++ b/src/lib/layout/configs/default.ts
@@ -99,6 +99,13 @@ export const defaultLayoutConfig: Layout = {
           areaType: AreaType.Logs,
           icon: 'logs',
         },
+        {
+          id: DefaultLayoutPaneID.Debug,
+          label: 'Debug',
+          icon: 'bug',
+          type: LayoutType.Simple,
+          areaType: AreaType.Debug,
+        },
       ],
       actions: [
         {


### PR DESCRIPTION
So that its `hide()` function can respond to the setting. Fixes #8731, but users will have to run the "Reset layout" command to receive the change. In future, I would like us to provide methods to add and remove sidebar panes and other layout nodes during runtime, but I couldn't decide where to place that code and I don't want us to rush it.

## Demo

https://github.com/user-attachments/assets/141cefb5-9e04-43cb-a837-af84fc5cb3d4

