### PR TITLE
Make current TTC textare transparent like Copilot one

### DIFF
--- a/src/components/MlEphantConversation.tsx
+++ b/src/components/MlEphantConversation.tsx
@@ -150,7 +150,7 @@ export const MlEphantConversationInput = (
               onClick()
             }
           }}
-          className={`outline-none w-full overflow-auto ${isAnimating ? 'hidden' : ''}`}
+          className={`bg-transparent outline-none w-full text-sm overflow-auto ${isAnimating ? 'hidden' : ''}`}
           style={{ height: '2lh' }}
         />
         <div


### PR DESCRIPTION
I converted the `<div>` in `MlEphantConversation.tsx` into a `<textarea>` in #8712 to match the upcoming "copilot" version defined in `MlEphantConversation2.tsx`, but missed the `className` of `bg-transparent` also defined there. Can't wait for there to be one implementation of these components.