### PR TITLE
Add camera matrix helpers

### DIFF
--- a/src/clientSideScene/CameraControls.ts
+++ b/src/clientSideScene/CameraControls.ts
@@ -1931,9 +1931,9 @@ function toQuaternion(obj: { w: number; x: number; y: number; z: number }) {
 }
 
 /**
- * Creates a projection matrix from the given CameraViewState in a way that is consistent with engine
+ * Creates a view matrix from the given CameraViewState in a way that is consistent with engine
  */
-export function createProjectionMatrix(cam: CameraViewState): Matrix4 {
+export function createViewMatrix(cam: CameraViewState): Matrix4 {
   const invRot = new Matrix4()
   invRot.makeRotationFromQuaternion(
     toQuaternion(cam.pivot_rotation).conjugate()
@@ -1949,9 +1949,9 @@ export function createProjectionMatrix(cam: CameraViewState): Matrix4 {
 }
 
 /**
- * Creates a view matrix from the given CameraViewState in a way that is consistent with engine
+ * Creates a projection matrix from the given CameraViewState in a way that is consistent with engine
  */
-export function createViewMatrix(
+export function createProjectionMatrix(
   camera: CameraViewState,
   aspectRatio: number,
   nearClip: number,


### PR DESCRIPTION
Adds some helper functions for creating camera matrices from `CameraViewState` that are consistent with what's used in engine. Hoping this helps correct some of the inconsistencies we're seeing in #8737.
