### PR TITLE
Fix to use modern bash on macOS

### DIFF
--- a/scripts/build-wasm-dev.sh
+++ b/scripts/build-wasm-dev.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 rm -rf rust/kcl-wasm-lib/pkg

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 rm -rf rust/kcl-wasm-lib/pkg

--- a/scripts/diff-circular-deps.sh
+++ b/scripts/diff-circular-deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 npm run circular-deps | sed '$d' > /tmp/circular-deps.txt

--- a/scripts/diff-url-checker.sh
+++ b/scripts/diff-url-checker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 npm run url-checker > /tmp/urls.txt

--- a/scripts/flip-files-to-staging.sh
+++ b/scripts/flip-files-to-staging.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 COMMIT=$(git rev-parse --short HEAD)
 TITLE=$(git show -s --format=%s $COMMIT)

--- a/scripts/get-latest-wasm-bundle.sh
+++ b/scripts/get-latest-wasm-bundle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Set the repository owner and name
 REPO_OWNER="KittyCAD"

--- a/scripts/invalidate-files-bucket.sh
+++ b/scripts/invalidate-files-bucket.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 base_dir="/releases/design-studio"
 if [[ $1 = "--staging" ]]; then
     base_dir="/releases/design-studio/staging"

--- a/scripts/set-files-notes.sh
+++ b/scripts/set-files-notes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 yq -i '.releaseNotes = strenv(NOTES)' out/latest-linux-arm64.yml
 yq -i '.releaseNotes = strenv(NOTES)' out/latest-linux.yml

--- a/scripts/set-windows-codesign-config.sh
+++ b/scripts/set-windows-codesign-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 if [ -z "$WINDOWS_CERTIFICATE_THUMBPRINT" ]; then

--- a/scripts/url-checker.sh
+++ b/scripts/url-checker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 trap 'echo "$BASH_COMMAND"' ERR
 


### PR DESCRIPTION
On one of my macs, I kept getting this error doing the wasm build. It's because it wasn't picking up the environment variable correctly. The version of bash built-in to mac is extremely old. No one should be using it.

> error: The "wasm_js" backend requires the `wasm_js` feature for `getrandom`. For more information see: https://docs.rs/getrandom/0.3.4/#webassembly-support