### PR TITLE
Use an auto-awaiting assertion on E2E test to deflake it

### DIFF
--- a/e2e/playwright/desktop-export.spec.ts
+++ b/e2e/playwright/desktop-export.spec.ts
@@ -63,9 +63,8 @@ test(
       await expect(engineErrorToastMessage).not.toBeVisible()
 
       const successToastMessage = page.getByText(`Exported successfully`)
-      await page.waitForTimeout(1_000)
-      const count = await successToastMessage.count()
-      await expect(count).toBeGreaterThanOrEqual(1)
+      // We only care if one toast popped up, but don't worry if more do.
+      await expect(successToastMessage.first()).toBeVisible()
 
       // Check for the exported file
       const firstFileFullPath = path.resolve(


### PR DESCRIPTION
Our test seems to have run the risk of presenting double toasts to the user so we patched it using the Playwright `count()` assertion. However, this assertion is instantaneous, so the export functionality which can take a variable and unknown amount of time would often not be completed when it was done. This replaces `count` with the normal `.toBeVisible`, while keeping the previous test's lack of care for > 1 toasts by using the `.first()` helper function on the locator.