### PR TITLE
Add "Comments" row to Python-KCL cheat sheet

### DIFF
--- a/docs/kcl-lang/python-cheat-sheet.md
+++ b/docs/kcl-lang/python-cheat-sheet.md
@@ -6,6 +6,7 @@ layout: manual
 
 | Feature | **Python** | **KCL** |
 | ------- | ---------- | ------- |
+| **Comments**               | <pre><code># Single line comment<br/><br/>"""<br/>Multi-line comment<br/>"""</code></pre> | <pre><code>// Single line comment<br/><br/>/\*<br/>Multi-line comment<br/>\*/</code></pre> |
 | **Variable Assignment**    | Can be reassigned later.<br/>`x = 42` | Cannot be reassigned once declared.<br/>`x = 42` |
 | **Data Types**             | Numbers, strings, booleans, lists, tuples, dicts, objects, None | Numbers (with units), strings, booleans, arrays, objects |
 | **Immutability**           | Variables can be reassigned. Lists, dicts, and objects are mutable. | Variables cannot be reassigned. Arrays and objects are immutable. |


### PR DESCRIPTION
Adds a demonstration of the difference between comment syntax in Python vs. KCL.

<img width="805" height="418" alt="image" src="https://github.com/user-attachments/assets/95bda7b5-3c98-42ba-86f6-6170968d0a22" />
