### PR TITLE
Add editing lines via their end points and fix to preserve constructors

### DIFF
--- a/rust/kcl-lib/src/execution/geometry.rs
+++ b/rust/kcl-lib/src/execution/geometry.rs
@@ -18,7 +18,7 @@ use crate::{
         ArtifactId, ExecState, ExecutorContext, Metadata, TagEngineInfo, TagIdentifier,
         types::{NumericType, adjust_length},
     },
-    front::{Freedom, ObjectId},
+    front::{Freedom, LineCtor, ObjectId, PointCtor},
     parsing::ast::types::{Node, NodeRef, TagDeclarator, TagNode},
     std::{args::TyF64, sketch::PlaneData},
 };
@@ -1718,10 +1718,12 @@ pub struct UnsolvedSegment {
 pub enum UnsolvedSegmentKind {
     Point {
         position: [UnsolvedExpr; 2],
+        ctor: Box<PointCtor>,
     },
     Line {
         start: [UnsolvedExpr; 2],
         end: [UnsolvedExpr; 2],
+        ctor: Box<LineCtor>,
     },
 }
 
@@ -1740,11 +1742,13 @@ pub struct Segment {
 pub enum SegmentKind {
     Point {
         position: [TyF64; 2],
+        ctor: Box<PointCtor>,
         freedom: Freedom,
     },
     Line {
         start: [TyF64; 2],
         end: [TyF64; 2],
+        ctor: Box<LineCtor>,
         start_freedom: Freedom,
         end_freedom: Freedom,
     },

--- a/rust/kcl-lib/src/execution/kcl_value.rs
+++ b/rust/kcl-lib/src/execution/kcl_value.rs
@@ -694,6 +694,20 @@ impl KclValue {
         }
     }
 
+    pub fn to_sketch_expr(&self) -> Option<crate::front::Expr> {
+        match self {
+            KclValue::Number { value, ty, .. } => Some(crate::front::Expr::Number(crate::front::Number {
+                value: *value,
+                units: (*ty).try_into().ok()?,
+            })),
+            KclValue::SketchVar { value, .. } => Some(crate::front::Expr::Var(crate::front::Number {
+                value: value.initial_value,
+                units: value.ty.try_into().ok()?,
+            })),
+            _ => None,
+        }
+    }
+
     pub fn as_str(&self) -> Option<&str> {
         match self {
             KclValue::String { value, .. } => Some(value),


### PR DESCRIPTION
Before, we didn't preserve the constructor past the `point()` or `line()` call, so we couldn't correctly mod code with `var`s. Now we can.