### PR TITLE
Remove "credentials missing or invalid" toast

### DIFF
--- a/src/machines/mlEphantManagerMachine.ts
+++ b/src/machines/mlEphantManagerMachine.ts
@@ -169,6 +169,9 @@ export const mlEphantManagerMachine = setup({
     events: {} as MlEphantManagerEvents,
   },
   actions: {
+    consoleError: ({ event }) => {
+      console.error(event)
+    },
     toastError: ({ event }) => {
       console.error(event)
       if ('output' in event && event.output instanceof Error) {
@@ -570,7 +573,7 @@ export const mlEphantManagerMachine = setup({
         // On failure we need correct dependencies still.
         onError: {
           target: MlEphantManagerStates.NeedDependencies,
-          actions: 'toastError',
+          actions: 'consoleError',
         },
       },
     },


### PR DESCRIPTION
Fixes #8690

Moves MlEphantManagerStates.Setup errors from toast to console errors. These errors aren't helpful to the user, but likely still good to keep in the console to help debug. Note that this doesn't seem to apply to `mlEphantManagerMachine2`.

With `npm start` it throws a different error earlier but it should be the same code path. Before:
<img width="1281" height="1409" alt="image" src="https://github.com/user-attachments/assets/f733cbe5-7a52-4ba3-acfd-fecc0c6c22b9" />

---

After:
<img width="1281" height="1409" alt="image" src="https://github.com/user-attachments/assets/f5368d41-4d4a-4c17-85ac-db35ede7becf" />

