### PR TITLE
fix: match on project name with seperators to prevent false matches

### DIFF
--- a/src/components/Providers/SystemIOProviderDesktop.tsx
+++ b/src/components/Providers/SystemIOProviderDesktop.tsx
@@ -298,10 +298,16 @@ export function SystemIOMachineLogicListenerDesktop() {
           }
         })
 
+        // Gotcha: below we're gonna look for the index of the project name,
+        // but what if the project name happens to be in the path earlier than the real one?
+        // Let's put separators on either side of it and offset by one, so we know
+        // it matches a whole directory name.
+        const projectNameWithSeparators =
+          window.electron?.sep + promptMeta.project.name + window.electron?.sep
         // I know, it's confusing as hell.
         const targetFilePathWithoutFileAndRelativeToProjectDir =
           promptMeta.targetFile?.path.slice(
-            promptMeta.targetFile?.path.indexOf(promptMeta.project.name) ?? 0
+            promptMeta.targetFile?.path.indexOf(projectNameWithSeparators) ?? 0
           ) ?? ''
 
         const requestedProjectNameNext =


### PR DESCRIPTION
Fixes #8330 by surrounding the project name with OS path separators before searching for it in the requested file path to slice into it and create a project-relative file path. With very short project names—"a" was the example in the bug report—this slice would match early and mangle the path just before the finish line.

## Demo

https://github.com/user-attachments/assets/ccce199f-4db9-4fbd-84a2-4c1167827002


