### PR TITLE
Add TS lint for invalid void type

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,6 +36,7 @@
     "@typescript-eslint/no-for-in-array": "error",
     "no-implied-eval": "off", // This is wrong; use the @typescript-eslint one instead.
     "@typescript-eslint/no-implied-eval": "error",
+    "@typescript-eslint/no-invalid-void-type": "error",
     "@typescript-eslint/no-misused-new": "error",
     "@typescript-eslint/no-misused-promises": "error",
     "@typescript-eslint/no-namespace": "error",

--- a/e2e/playwright/fixtures/sceneFixture.ts
+++ b/e2e/playwright/fixtures/sceneFixture.ts
@@ -33,13 +33,17 @@ type SceneSerialised = {
   }
 }
 
-type ClickHandler = (clickParams?: MouseParams) => Promise<void | boolean>
-type MoveHandler = (moveParams?: MouseParams) => Promise<void | boolean>
-type DblClickHandler = (clickParams?: MouseParams) => Promise<void | boolean>
-type DragToHandler = (dragParams: MouseDragToParams) => Promise<void | boolean>
+type ClickHandler = (clickParams?: MouseParams) => Promise<undefined | boolean>
+type MoveHandler = (moveParams?: MouseParams) => Promise<undefined | boolean>
+type DblClickHandler = (
+  clickParams?: MouseParams
+) => Promise<undefined | boolean>
+type DragToHandler = (
+  dragParams: MouseDragToParams
+) => Promise<undefined | boolean>
 type DragFromHandler = (
   dragParams: MouseDragFromParams
-) => Promise<void | boolean>
+) => Promise<undefined | boolean>
 
 export class SceneFixture {
   public page: Page
@@ -149,16 +153,16 @@ export class SceneFixture {
             clickParams.pixelDiff
           )
         }
-        return clickParams?.shouldDbClick
-          ? this.page.mouse.dblclick(resolvedPoint.x, resolvedPoint.y, {
+        clickParams?.shouldDbClick
+          ? await this.page.mouse.dblclick(resolvedPoint.x, resolvedPoint.y, {
               delay: clickParams?.delay || 0,
             })
           : clickParams?.shouldRightClick
-            ? this.page.mouse.click(resolvedPoint.x, resolvedPoint.y, {
+            ? await this.page.mouse.click(resolvedPoint.x, resolvedPoint.y, {
                 button: 'right',
                 delay: clickParams?.delay || 0,
               })
-            : this.page.mouse.click(resolvedPoint.x, resolvedPoint.y, {
+            : await this.page.mouse.click(resolvedPoint.x, resolvedPoint.y, {
                 delay: clickParams?.delay || 0,
               })
       },
@@ -176,7 +180,7 @@ export class SceneFixture {
             moveParams.pixelDiff
           )
         }
-        return this.page.mouse.move(resolvedPoint.x, resolvedPoint.y, { steps })
+        await this.page.mouse.move(resolvedPoint.x, resolvedPoint.y, { steps })
       },
       async (clickParams?: MouseParams) => {
         const resolvedPoint = await this.convertPagePositionToStream(
@@ -191,7 +195,7 @@ export class SceneFixture {
             clickParams.pixelDiff
           )
         }
-        return this.page.mouse.dblclick(resolvedPoint.x, resolvedPoint.y)
+        await this.page.mouse.dblclick(resolvedPoint.x, resolvedPoint.y)
       },
     ] as const
   makeDragHelpers = (
@@ -244,7 +248,7 @@ export class SceneFixture {
             dragToParams.pixelDiff
           )
         }
-        return this.page.dragAndDrop('#stream', '#stream', {
+        await this.page.dragAndDrop('#stream', '#stream', {
           sourcePosition: resolvedFromPoint,
           targetPosition: resolvedToPoint,
         })
@@ -282,7 +286,7 @@ export class SceneFixture {
             dragFromParams.pixelDiff
           )
         }
-        return this.page.dragAndDrop('#stream', '#stream', {
+        await this.page.dragAndDrop('#stream', '#stream', {
           sourcePosition: resolvedFromPoint,
           targetPosition: resolvedToPoint,
         })

--- a/src/lang/modelingWorkflows.ts
+++ b/src/lang/modelingWorkflows.ts
@@ -25,7 +25,7 @@ import { err, reject } from '@src/lib/trap'
 export async function mockExecAstAndReportErrors(
   ast: Node<Program>,
   rustContext: RustContext
-): Promise<void | Error> {
+): Promise<undefined | Error> {
   const { errors } = await executeAstMock({ ast, rustContext })
   if (errors.length > 0) {
     return new Error(errors.map((e) => e.message).join('\n'))

--- a/src/lang/modifyAst.ts
+++ b/src/lang/modifyAst.ts
@@ -678,7 +678,7 @@ export function deleteSegmentOrProfileFromPipeExpression(
 export function deleteTopLevelStatement(
   ast: Node<Program>,
   pathToNode: PathToNode
-): Error | void {
+): Error | undefined {
   const pathStep = pathToNode[1]
   if (!isArray(pathStep) || typeof pathStep[0] !== 'number') {
     return new Error(

--- a/src/lang/modifyAst/deleteNodeInExtrudePipe.ts
+++ b/src/lang/modifyAst/deleteNodeInExtrudePipe.ts
@@ -7,7 +7,7 @@ import { err } from '@src/lib/trap'
 export function deleteNodeInExtrudePipe(
   ast: Node<Program>,
   node: PathToNode
-): Error | void {
+): Error | undefined {
   const pipeIndex = node.findIndex(([_, type]) => type === 'PipeExpression') + 1
   if (!(node[pipeIndex][0] && typeof node[pipeIndex][0] === 'number')) {
     return new Error("Couldn't find node to delete in ast")

--- a/src/lang/modifyAst/deleteSelection.ts
+++ b/src/lang/modifyAst/deleteSelection.ts
@@ -17,7 +17,7 @@ export const deletionErrorMessage =
 
 export async function deleteSelectionPromise(
   selection: Selection
-): Promise<Error | void> {
+): Promise<Error | undefined> {
   let ast = kclManager.ast
 
   const modifiedAst = await deleteFromSelection(

--- a/src/lib/commandTypes.ts
+++ b/src/lib/commandTypes.ts
@@ -78,7 +78,7 @@ export type Command<
   reviewMessage?:
     | ReactNode
     | ((commandBarContext: CommandBarContext) => ReactNode)
-  reviewValidation?: (context: CommandBarContext) => Promise<void | Error>
+  reviewValidation?: (context: CommandBarContext) => Promise<undefined | Error>
   machineActor?: Actor<T>
   onSubmit: (data?: CommandSchema) => void
   onCancel?: () => void

--- a/src/lib/layout/types.ts
+++ b/src/lib/layout/types.ts
@@ -47,7 +47,7 @@ export enum ActionType {
 }
 
 export type ActionTypeDefinition = {
-  execute: () => void | (() => Promise<void>)
+  execute: () => void
   /** A custom hook for the Action to detect if it should be enabled */
   useDisabled?: () => string | undefined
   shortcut?: string

--- a/src/lib/textToCad.ts
+++ b/src/lib/textToCad.ts
@@ -8,16 +8,18 @@ export async function textToCadPromptFeedback(
     id: TextToCad['id']
     feedback: TextToCad['feedback']
   }
-): Promise<void | Error> {
+): Promise<undefined | Error> {
   if (!args.feedback) return
   const client = createKCClient(token)
   const fb = args.feedback
   const data = await kcCall(() =>
-    ml.create_text_to_cad_part_feedback({
-      client,
-      id: args.id,
-      feedback: fb,
-    })
+    ml
+      .create_text_to_cad_part_feedback({
+        client,
+        id: args.id,
+        feedback: fb,
+      })
+      .then(() => undefined)
   )
 
   return data

--- a/src/lib/trap.ts
+++ b/src/lib/trap.ts
@@ -73,7 +73,7 @@ export function report(
  * Report a promise rejection.  The type of reason is `any` so that it matches
  * Promise.prototype.catch.
  */
-export function reportRejection(reason: any) {
+export function reportRejection(reason: any): undefined {
   report((reason ?? 'Unknown promise rejection').toString())
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -203,9 +203,7 @@ export function deferExecution<T>(func: (args: T) => any, wait: number) {
  */
 export function toSync<F extends AsyncFn<F>>(
   fn: F,
-  onReject: (
-    reason: any
-  ) => void | PromiseLike<void | null | undefined> | null | undefined
+  onReject: (reason: any) => PromiseLike<null | undefined> | null | undefined
 ): (...args: Parameters<F>) => void {
   return (...args: Parameters<F>) => {
     void fn(...args).catch((...args) => {

--- a/src/machines/settingsMachine.ts
+++ b/src/machines/settingsMachine.ts
@@ -83,7 +83,7 @@ export const settingsMachine = setup({
   },
   actors: {
     persistSettings: fromPromise<
-      void,
+      undefined,
       {
         doNotPersist: boolean
         context: SettingsMachineContext
@@ -98,17 +98,18 @@ export const settingsMachine = setup({
       input.rootContext.codeManager.writeCausedByAppCheckedInFileTreeFileSystemWatcher = true
       const { currentProject, ...settings } = input.context
 
-      const val = await saveSettings(settings, currentProject?.path)
+      await saveSettings(settings, currentProject?.path)
 
       if (input.toastCallback) {
         input.toastCallback()
       }
-      return val
     }),
-    loadUserSettings: fromPromise<SettingsMachineContext, void>(async () => {
-      const { settings } = await loadAndValidateSettings()
-      return settings
-    }),
+    loadUserSettings: fromPromise<SettingsMachineContext, undefined>(
+      async () => {
+        const { settings } = await loadAndValidateSettings()
+        return settings
+      }
+    ),
     loadProjectSettings: fromPromise<
       SettingsMachineContext,
       { project?: Project }

--- a/src/network/connectionManager.ts
+++ b/src/network/connectionManager.ts
@@ -1152,7 +1152,7 @@ export class ConnectionManager extends EventTarget {
     rangeStr: string,
     commandStr: string,
     idToRangeStr: string
-  ): void | Error {
+  ): undefined | Error {
     if (this.connection === undefined) {
       return new Error('this.connection is undefined')
     }
@@ -1196,7 +1196,7 @@ export class ConnectionManager extends EventTarget {
     rangeStr: string,
     commandStr: string,
     idToRangeStr: string
-  ): Promise<Uint8Array | void> {
+  ): Promise<Uint8Array | undefined> {
     if (this.connection === undefined) {
       return Promise.reject(new Error('this.connection is undefined'))
     }

--- a/src/network/utils.ts
+++ b/src/network/utils.ts
@@ -33,7 +33,8 @@ export function isHighlightSetEntity_type(
 
 export type Value<T, U> = U extends undefined
   ? { type: T; value: U }
-  : U extends void
+  : // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+    U extends void
     ? { type: T }
     : { type: T; value: U }
 


### PR DESCRIPTION
See article explaining why void in a union is so bad: https://wolfgirl.dev/blog/2025-10-22-4-unconventional-ways-to-cast-in-typescript/

At least one other lint from the article will be incoming in a follow-up PR.