### PR TITLE
Add TS lint for unnecessary type parameters

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -45,6 +45,7 @@
     "@typescript-eslint/no-this-alias": "warn",
     "@typescript-eslint/no-unnecessary-type-assertion": "error",
     "@typescript-eslint/no-unnecessary-type-constraint": "error",
+    "@typescript-eslint/no-unnecessary-type-parameters": "error",
     "no-unused-vars": "off", // This is wrong; use the @typescript-eslint one instead.
     "@typescript-eslint/no-unused-vars": [
       "error",

--- a/packages/codemirror-lsp-client/src/client/codec/utils.ts
+++ b/packages/codemirror-lsp-client/src/client/codec/utils.ts
@@ -12,6 +12,9 @@ export class Codec {
     return Bytes.encode(delimited)
   }
 
+  // The generic type T is used to assert the return type is T instead of `any`
+  // or `unknown`. This is unsafe!
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
   static decode<T>(data: Uint8Array): T {
     const delimited = Bytes.decode(data)
     const message = Headers.remove(delimited)

--- a/packages/codemirror-lsp-client/src/client/index.ts
+++ b/packages/codemirror-lsp-client/src/client/index.ts
@@ -246,7 +246,7 @@ export class LanguageServerClient {
     return this.client.request(method, params) as Promise<LSPRequestMap[K][1]>
   }
 
-  requestCustom<P, R>(method: string, params: P): Promise<R> {
+  requestCustom<R>(method: string, params: unknown): Promise<R> {
     return this.client.request(method, params) as Promise<R>
   }
 
@@ -257,7 +257,7 @@ export class LanguageServerClient {
     return this.client.notify(method, params)
   }
 
-  notifyCustom<P>(method: string, params: P): void {
+  notifyCustom(method: string, params: unknown): void {
     return this.client.notify(method, params)
   }
 

--- a/rust/kcl-language-server/client/src/config.ts
+++ b/rust/kcl-language-server/client/src/config.ts
@@ -104,6 +104,7 @@ export class Config {
    * ```
    * So this getter handles this quirk by not requiring the caller to use postfix `!`
    */
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
   private get<T>(path: string): T | undefined {
     return prepareVSCodeConfig(this.cfg.get<T>(path))
   }

--- a/src/lang/queryAst.ts
+++ b/src/lang/queryAst.ts
@@ -69,6 +69,9 @@ import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
  * By default it will return the node of the deepest "stopAt" type encountered, or the node at the end of the path if no "stopAt" type is provided.
  * If the "returnEarly" flag is set to true, the function will return as soon as a node of the specified type is found.
  */
+// The generic type T is used to assert the return type is T instead of `any` or
+// `unknown`. This is unsafe!
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
 export function getNodeFromPath<T>(
   node: Program,
   path: PathToNode,
@@ -179,6 +182,9 @@ export function getNodeFromPathCurry(
   node: Program,
   path: PathToNode,
   wasmInstance?: ModuleType
+  // The generic type T is used to assert the return type is T instead of `any`
+  // or `unknown`. This is unsafe!
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
 ): <T>(
   stopAt?: SyntaxType | SyntaxType[],
   returnEarly?: boolean
@@ -188,6 +194,9 @@ export function getNodeFromPathCurry(
       path: PathToNode
     }
   | Error {
+  // The generic type T is used to assert the return type is T instead of `any`
+  // or `unknown`. This is unsafe!
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
   return <T>(stopAt?: SyntaxType | SyntaxType[], returnEarly = false) => {
     const _node1 = getNodeFromPath<T>(
       node,

--- a/src/lib/objectPropertyByPath.ts
+++ b/src/lib/objectPropertyByPath.ts
@@ -23,10 +23,10 @@ export function setPropertyByPath<
   return obj
 }
 
-export function getPropertyByPath<
-  T extends { [key: string]: any },
-  P extends Paths<T, 4>,
->(obj: T, path: P): unknown {
+export function getPropertyByPath<T extends { [key: string]: any }>(
+  obj: T,
+  path: Paths<T, 4>
+): unknown {
   if (typeof path === 'string') {
     return path.split('.').reduce((accumulator, currentValue) => {
       if (accumulator) return accumulator[currentValue]

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -96,10 +96,7 @@ export type Leaves<T, D extends number = 10> = [D] extends [never]
 // https://stackoverflow.com/a/57390160/22753272
 export type AtLeast<T, K extends keyof T> = Partial<T> & Pick<T, K>
 
-export function isEnumMember<T extends Record<string, unknown>>(
-  v: unknown,
-  e: T
-) {
+export function isEnumMember(v: unknown, e: Record<string, unknown>): boolean {
   return Object.values(e).includes(v)
 }
 

--- a/src/machines/utils.ts
+++ b/src/machines/utils.ts
@@ -5,9 +5,7 @@ export enum S {
   Await = 'await',
 }
 
-export const transitions = <T>(
-  list: T[]
-): Record<string, { target: string }> => {
+export function transitions<T>(list: T[]): Record<string, { target: T }> {
   return list.reduce(
     (obj, cur) => ({ ...obj, [String(cur)]: { target: cur } }),
     {}


### PR DESCRIPTION
Part 2 of adding lints. See #8852 for the reason why this lint is good for type safety.

https://typescript-eslint.io/rules/no-unnecessary-type-parameters/

For the ignores where the comment says it's unsafe, the alternative is either a lot of work to change or it would just move the `as` assertion to the call site. Things like `decode` (similar to JSON.parse), we probably want to do it inside the function.