### PR TITLE
Track the last message type to avoid deltas re-executing other crap

### DIFF
--- a/src/machines/mlEphantManagerMachine2.ts
+++ b/src/machines/mlEphantManagerMachine2.ts
@@ -32,6 +32,8 @@ export enum MlEphantSetupErrors {
   NoRefParentSend = 'no ref parent send',
 }
 
+type TypeVariant<T, U = T> = U extends T ? keyof U : never
+
 type MlCopilotClientMessageUser<T = MlCopilotClientMessage> = T extends {
   type: 'user'
 }
@@ -130,6 +132,7 @@ export interface MlEphantManagerContext2 {
   conversation?: Conversation
   conversationId?: string
   lastMessageId?: number
+  lastMessageType?: TypeVariant<MlCopilotServerMessage>
   fileFocusedOnInEditor?: FileEntry
   projectNameCurrentlyOpened?: string
   cachedSetup?: {
@@ -148,6 +151,7 @@ export const mlEphantDefaultContext2 = (args: {
   abruptlyClosed: false,
   conversation: undefined,
   lastMessageId: undefined,
+  lastMessageType: undefined,
   fileFocusedOnInEditor: undefined,
   projectNameCurrentlyOpened: undefined,
 })
@@ -618,9 +622,28 @@ export const mlEphantManagerMachine2 = setup({
                       lastExchange.responses.push(event.response)
                     }
 
+                    // This sucks but must be done because we can't
+                    // enumerate the message types.
+                    const r = event.response
+                    const ts: TypeVariant<MlCopilotServerMessage>[] = [
+                      'info',
+                      'error',
+                      'end_of_stream',
+                      'session_data',
+                      'conversation_id',
+                      'delta',
+                      'tool_output',
+                      'reasoning',
+                      'replay',
+                    ]
+                    const lastMessageType:
+                      | TypeVariant<MlCopilotServerMessage>
+                      | undefined = ts.find((t) => t in r)
+
                     return {
                       conversation,
                       lastMessageId,
+                      lastMessageType,
                     }
                   }),
                 ],

--- a/src/machines/systemIO/hooks.ts
+++ b/src/machines/systemIO/hooks.ts
@@ -186,6 +186,8 @@ export const useWatchForNewFileRequestsFromMlEphant = (
       if (next.context.lastMessageId === lastId) return
       lastId = next.context.lastMessageId
 
+      if (next.context.lastMessageType === 'delta') return
+
       const exchanges = next.context.conversation?.exchanges ?? []
       const lastExchange = exchanges[exchanges.length - 1]
       if (lastExchange === undefined) return


### PR DESCRIPTION
This was causing the SystemIO subscriber to re-execute the file creation for each delta coming in, since deltas are not recorded in the responses anymore for optimization reasons.
