### PR TITLE
Make common avatar style with rounded corners

### DIFF
--- a/src/components/ExchangeCard.tsx
+++ b/src/components/ExchangeCard.tsx
@@ -127,7 +127,7 @@ export const ExchangeCardStatus = (props: {
 
 export const AvatarUser = (props: { src?: string }) => {
   return (
-    <div className="rounded-sm overflow-hidden h-7 w-7">
+    <div className="avatar h-7 w-7">
       {props.src ? (
         <img
           src={props.src || ''}
@@ -275,7 +275,7 @@ export const ResponsesCard = (props: ResponsesCardProp) => {
     <ChatBubble
       side={'left'}
       wfull={true}
-      userAvatar={<div className="h-7 w-7 rounded-sm bg-img-mel" />}
+      userAvatar={<div className="h-7 w-7 avatar bg-img-mel" />}
       dataTestId="ml-response-chat-bubble"
       placeholderTestId="ml-response-chat-bubble-thinking"
     >

--- a/src/components/PromptCard.tsx
+++ b/src/components/PromptCard.tsx
@@ -127,7 +127,7 @@ export const PromptCardStatus = (props: {
 
 export const AvatarUser = (props: { src?: string }) => {
   return (
-    <div className="rounded-full border overflow-hidden">
+    <div className="avatar">
       {props.src ? (
         <img
           src={props.src || ''}

--- a/src/components/UserSidebarMenu.tsx
+++ b/src/components/UserSidebarMenu.tsx
@@ -237,16 +237,16 @@ const UserSidebarMenu = ({ user }: { user?: User }) => {
   return (
     <Popover className="relative grid">
       <Popover.Button
-        className="m-0 relative group border-0 w-fit min-w-max p-0 rounded-l-full rounded-r focus-visible:outline-appForeground"
+        className="m-0 relative group/avatar border-0 w-fit min-w-max p-0 rounded-sm focus-visible:outline-2 hover:bg-transparent"
         data-testid="user-sidebar-toggle"
       >
         <div className="flex items-center">
-          <div className="rounded-full border overflow-hidden">
+          <div className="avatar">
             {user?.image && !imageLoadFailed ? (
               <img
                 src={user?.image || ''}
                 alt={user?.name || ''}
-                className="h-6 w-6 rounded-full"
+                className="h-6 w-6"
                 referrerPolicy="no-referrer"
                 onError={() => setImageLoadFailed(true)}
               />

--- a/src/index.css
+++ b/src/index.css
@@ -238,6 +238,7 @@ code,
   from {
     transform: translateY(0px);
   }
+
   to {
     transform: translateY(-1000px);
   }
@@ -253,6 +254,7 @@ code,
   0% {
     opacity: 0;
   }
+
   100% {
     opacity: 1;
   }
@@ -370,6 +372,12 @@ code,
     @apply grid lg:grid-cols-3 xl:grid-cols-4 gap-4 lg:gap-x-16;
     grid-template-rows: auto 1fr;
   }
+
+  .avatar {
+    @apply grid place-content-center overflow-hidden;
+    @apply border rounded border-chalkboard-30/50 dark:border-chalkboard-80/30;
+    @apply group-hover/avatar:border-chalkboard-30 group-hover/avatar:dark:border-chalkboard-70;
+  }
 }
 
 @layer utilities {
@@ -377,18 +385,23 @@ code,
   .text-default {
     @apply text-chalkboard-100 dark:text-chalkboard-10;
   }
+
   .text-2 {
     @apply text-chalkboard-70 dark:text-chalkboard-30;
   }
+
   .text-3 {
     @apply text-chalkboard-50;
   }
+
   .text-4 {
     @apply text-chalkboard-30 dark:text-chalkboard-70;
   }
+
   .text-5 {
     @apply text-chalkboard-20 dark:text-chalkboard-90;
   }
+
   .text-6 {
     @apply text-chalkboard-10 dark:text-chalkboard-100;
   }
@@ -396,34 +409,63 @@ code,
   .b-default {
     @apply border-chalkboard-100 dark:border-chalkboard-10;
   }
+
   .b-2 {
     @apply border-chalkboard-70 dark:border-chalkboard-30;
   }
+
   .b-3 {
     @apply border-chalkboard-50;
   }
+
   .b-4 {
     @apply border-chalkboard-30 dark:border-chalkboard-80;
   }
+
   .b-5 {
     @apply border-chalkboard-20 dark:border-chalkboard-90;
+  }
+
+  .outline-default {
+    @apply outline-chalkboard-100 dark:outline-chalkboard-10;
+  }
+
+  .outline-2 {
+    @apply outline-chalkboard-70 dark:outline-chalkboard-30;
+  }
+
+  .outline-3 {
+    @apply outline-chalkboard-50;
+  }
+
+  .outline-4 {
+    @apply outline-chalkboard-30 dark:outline-chalkboard-80;
+  }
+
+  .outline-5 {
+    @apply outline-chalkboard-20 dark:outline-chalkboard-90;
   }
 
   .bg-default {
     @apply bg-chalkboard-10 dark:bg-chalkboard-100;
   }
+
   .bg-2 {
     @apply bg-chalkboard-20 dark:bg-chalkboard-90;
   }
+
   .bg-3 {
     @apply bg-chalkboard-30 dark:bg-chalkboard-70;
   }
+
   .bg-4 {
     @apply bg-chalkboard-70 dark:bg-chalkboard-30;
   }
+
   .bg-5 {
     @apply bg-chalkboard-90 dark:bg-chalkboard-20;
   }
+
   .bg-6 {
     @apply bg-chalkboard-100 dark:bg-chalkboard-10;
   }


### PR DESCRIPTION
Some user feedback from @lee-at-zoo-corp that the avatar in the top bar feels a bit bad, either because of the rounding, the border, or both. He made the avatars in the TTC copilot chat have only slightly rounded corners and no border. This makes a common tailwind class that both pull from, and brings back a slight semitransparent border in case an avatar image is close to the background color for legibility.

## Before

<img width="916" height="232" alt="Screenshot 2025-11-13 at 12 43 12 PM" src="https://github.com/user-attachments/assets/7ca455c3-a8ea-4608-a97d-fcfe065b8943" />

## After

<img width="1178" height="370" alt="Screenshot 2025-11-13 at 12 43 36 PM" src="https://github.com/user-attachments/assets/f92500f1-4bb4-4964-8df8-8066906dccb4" />

