### PR TITLE
#8940 Fix highlight error by ignoring invalid selections

### DIFF
--- a/src/editor/manager.ts
+++ b/src/editor/manager.ts
@@ -197,7 +197,7 @@ export default class EditorManager {
 
     return selection.filter(isTopLevelModule).map((s): [number, number] => {
       const safeEnd = Math.min(s[1], this._editorView?.state.doc.length || s[1])
-      return [s[0], safeEnd]
+      return [Math.min(s[0], safeEnd), safeEnd]
     })
   }
 


### PR DESCRIPTION
Fixes #8940 

I've added a video to the issue where it's reproduced.

It's similar to the kind of issues where we're referring to nodes / selection that are no longer valid in a newly modified codebase, eg.:
```
Failed to stopAt CallExpressionKw, getNodeFromPath > Overlay
```

This time, it's not that we're looking for something in a new `AST` with outdated `NodePath[]`, but that [selectionsWithSafeEnds](https://github.com/KittyCAD/modeling-app/blob/fbe546fa35dbf3974fa9f5ef0691741d09bc4bb3/src/editor/manager.ts#L199) was using `this._editorView?.state.doc.length` which was already updated after the undo (became shorter), and that caused the `to` in the source range to become smaller than `from` which caused a runtime error down the line in codemirror understandably.

`kclManager.ast` was still outdated at this point, so validating the selection against that would have been useless.

This fix simply ignores those invalid selections instead of applying them, but I feel there is a larger architectural overhaul here that we could consider to disallow this kind of behaviour by design..
- We could make it impossible to select / hover stale entities, ie. freeze interaction until the code mode updates are executed and the three.js scene is updated. This can take a lot of time though and that would cause UX to feel janky so I don't like this too much..
- Short of that we need to assume selection / hover data can be invalid and all related code should handle that gracefully without throwing..