### PR TITLE
Export length unit conversion function

### DIFF
--- a/rust/kcl-lib/src/lib.rs
+++ b/rust/kcl-lib/src/lib.rs
@@ -140,7 +140,9 @@ pub mod native_engine {
 }
 
 pub mod std_utils {
-    pub use crate::std::utils::{TangentialArcInfoInput, get_tangential_arc_to_info, is_points_ccw_wasm};
+    pub use crate::std::utils::{
+        TangentialArcInfoInput, get_tangential_arc_to_info, is_points_ccw_wasm, untyped_point_to_unit,
+    };
 }
 
 pub mod pretty {

--- a/rust/kcl-lib/src/std/utils.rs
+++ b/rust/kcl-lib/src/std/utils.rs
@@ -24,9 +24,13 @@ pub(crate) fn point_to_mm(p: [TyF64; 2]) -> [f64; 2] {
 }
 
 pub(crate) fn untyped_point_to_mm(p: [f64; 2], units: UnitLength) -> [f64; 2] {
+    untyped_point_to_unit(p, units, UnitLength::Millimeters)
+}
+
+pub fn untyped_point_to_unit(point: [f64; 2], from_len_unit: UnitLength, to_len_unit: UnitLength) -> [f64; 2] {
     [
-        crate::execution::types::adjust_length(units, p[0], UnitLength::Millimeters).0,
-        crate::execution::types::adjust_length(units, p[1], UnitLength::Millimeters).0,
+        crate::execution::types::adjust_length(from_len_unit, point[0], to_len_unit).0,
+        crate::execution::types::adjust_length(from_len_unit, point[1], to_len_unit).0,
     ]
 }
 

--- a/rust/kcl-wasm-lib/src/wasm.rs
+++ b/rust/kcl-wasm-lib/src/wasm.rs
@@ -124,6 +124,17 @@ pub fn is_points_ccw(points: &[f64]) -> i32 {
 }
 
 #[wasm_bindgen]
+pub fn point_to_unit(point_json: &str, from_len_unit_json: &str, to_len_unit_json: &str) -> Result<Vec<f64>, String> {
+    console_error_panic_hook::set_once();
+
+    let point: [f64; 2] = serde_json::from_str(point_json).map_err(|e| e.to_string())?;
+    let from_len_unit: UnitLength = serde_json::from_str(from_len_unit_json).map_err(|e| e.to_string())?;
+    let to_len_unit: UnitLength = serde_json::from_str(to_len_unit_json).map_err(|e| e.to_string())?;
+
+    Ok(kcl_lib::std_utils::untyped_point_to_unit(point, from_len_unit, to_len_unit).to_vec())
+}
+
+#[wasm_bindgen]
 pub struct TangentialArcInfoOutputWasm {
     /// The geometric center of the arc x.
     pub center_x: f64,

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -61,6 +61,7 @@ import {
   parse_app_settings,
   parse_project_settings,
   parse_wasm,
+  point_to_unit,
   recast_wasm,
   serialize_configuration,
   serialize_project_configuration,
@@ -515,6 +516,29 @@ export function humanDisplayNumber(
 export function isPointsCCW(points: Coords2d[], instance?: ModuleType): number {
   const is_points_ccw_fn = instance ? instance.is_points_ccw : is_points_ccw
   return is_points_ccw_fn(new Float64Array(points.flat()))
+}
+
+/**
+ * Convert a 2D point from one length unit to another.
+ */
+export function pointToUnit(
+  point: [number, number],
+  fromLenUnit: UnitLength,
+  toLenUnit: UnitLength
+): Coords2d | Error {
+  try {
+    const result = point_to_unit(
+      JSON.stringify(point),
+      JSON.stringify(fromLenUnit),
+      JSON.stringify(toLenUnit)
+    )
+    return [result[0], result[1]]
+  } catch (e: any) {
+    return new Error(
+      `Error converting point to length unit: ${point} with len unit ${fromLenUnit} to len unit ${toLenUnit}`,
+      { cause: e }
+    )
+  }
 }
 
 export function getTangentialArcToInfo({

--- a/src/lib/wasm_lib_wrapper.ts
+++ b/src/lib/wasm_lib_wrapper.ts
@@ -21,6 +21,7 @@ import type {
   import_file_extensions as ImportFileExtensions,
   is_kcl_empty_or_only_settings as IsKclEmptyOrOnlySettings,
   is_points_ccw as IsPointsCcw,
+  point_to_unit as PointToUnit,
   kcl_lint as KclLint,
   kcl_settings as KclSettings,
   node_path_from_range as NodePathFromRange,
@@ -75,6 +76,9 @@ export const node_path_from_range: typeof NodePathFromRange = (...args) => {
 }
 export const is_points_ccw: typeof IsPointsCcw = (...args) => {
   return getModule().is_points_ccw(...args)
+}
+export const point_to_unit: typeof PointToUnit = (...args) => {
+  return getModule().point_to_unit(...args)
 }
 export const get_tangential_arc_to_info: typeof GetTangentialArcToInfo = (
   ...args


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expose a generic `point_to_unit`/`untyped_point_to_unit` API to convert 2D points between length units, wired from Rust through WASM to TypeScript.
> 
> - **Rust std utils**:
>   - Add `untyped_point_to_unit(point, from_len_unit, to_len_unit)` and refactor `untyped_point_to_mm` to use it in `rust/kcl-lib/src/std/utils.rs`.
>   - Re-export `untyped_point_to_unit` via `kcl_lib::std_utils` in `rust/kcl-lib/src/lib.rs`.
> - **WASM bindings** (`rust/kcl-wasm-lib/src/wasm.rs`):
>   - Add `point_to_unit(point_json, from_len_unit_json, to_len_unit_json)` wrapper.
> - **TS wrappers**:
>   - Export `point_to_unit` in `src/lib/wasm_lib_wrapper.ts` and plumb through `src/lang/wasm.ts` with `pointToUnit(point, fromLenUnit, toLenUnit)`.
> - **Misc**:
>   - Keep existing `is_points_ccw` and tangential arc APIs; no behavior changes there.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f13cf8ea2d5dfeb115496ba95fb7dd75435ae736. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->