### PR TITLE
Fix sketch on face with a hole in it

### DIFF
--- a/src/lib/selections.ts
+++ b/src/lib/selections.ts
@@ -18,6 +18,7 @@ import { showUnsupportedSelectionToast } from '@src/components/ToastUnsupportedS
 import {
   findAllChildrenAndOrderByPlaceInCode,
   getEdgeCutMeta,
+  getLastVariable,
   getNodeFromPath,
   isSingleCursorInPipe,
 } from '@src/lang/queryAst'
@@ -41,7 +42,6 @@ import type {
   ArtifactGraph,
   CallExpressionKw,
   Expr,
-  PathToNode,
   Program,
   SourceRange,
 } from '@src/lang/wasm'
@@ -1089,17 +1089,18 @@ export async function selectionBodyFace(
     )
   }
 
-  const lastChild =
-    findAllChildrenAndOrderByPlaceInCode(
-      { type: 'sweep', ...extrusion },
-      kclManager.artifactGraph
-    )[0] || null
-  const lastChildCodeRef: PathToNode | null =
-    lastChild?.type === 'compositeSolid' ? lastChild.codeRef.pathToNode : null
-
-  const extrudePathToNode = !err(extrusion)
-    ? lastChildCodeRef || extrusion.codeRef.pathToNode
-    : []
+  const children = findAllChildrenAndOrderByPlaceInCode(
+    { type: 'sweep', ...extrusion },
+    kclManager.artifactGraph
+  )
+  const lastChildVariable = getLastVariable(children, kclManager.ast, [
+    'sweep',
+    'compositeSolid',
+  ])
+  const extrudePathToNode =
+    lastChildVariable && !err(lastChildVariable)
+      ? lastChildVariable.pathToNode
+      : []
 
   return {
     type: 'extrudeFace',


### PR DESCRIPTION
Fixes #8851

### Changes

While adding debugging statements and figuring out where the issue was, I noticed that this part of `selectionBodyFace` to recover `ExtrudePlaneFace` wasn't properly returning the last item, in our case here hole001. 

https://github.com/KittyCAD/modeling-app/blob/3d82b5a53547c55978b594994d953213f15bd764/src/lib/selections.ts#L1092-L1102

Other places in the codebase use `getLastVariable` instead of direct indexing after calls to `findAllChildrenAndOrderByPlaceInCode`, so I did that and it seems to fix the issue for me!

### Demo

https://github.com/user-attachments/assets/0a9c0658-b2b7-47a5-9287-4e136cb96c4c

