### PR TITLE
Bump rust

### DIFF
--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.91"
+channel = "1.91.1"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
explicitly use 1.91.1 in the rust toolchain TOML.