### PR TITLE
#8998: Make default_camera_zoom use the unreliable channel

### DIFF
--- a/src/clientSideScene/CameraControls.ts
+++ b/src/clientSideScene/CameraControls.ts
@@ -306,12 +306,9 @@ export class CameraControls {
     type CallBackParam = Parameters<
       (
         | Subscription<
-            | 'default_camera_zoom'
-            | 'camera_drag_end'
-            | 'default_camera_get_settings'
-            | 'zoom_to_fit'
+            'camera_drag_end' | 'default_camera_get_settings' | 'zoom_to_fit'
           >
-        | UnreliableSubscription<'camera_drag_move'>
+        | UnreliableSubscription<'camera_drag_move' | 'default_camera_zoom'>
       )['callback']
     >[0]
 
@@ -374,7 +371,7 @@ export class CameraControls {
         event: 'camera_drag_end',
         callback: cb,
       })
-      this.engineCommandManager.subscribeTo({
+      this.engineCommandManager.subscribeToUnreliable({
         event: 'default_camera_zoom',
         callback: cb,
       })

--- a/src/network/utils.ts
+++ b/src/network/utils.ts
@@ -237,7 +237,7 @@ export const DATACHANNEL_NAME_UMC = 'unreliable_modeling_cmds'
 
 export type UnreliableResponses = Extract<
   OkModelingCmdResponse,
-  { type: 'highlight_set_entity' | 'camera_drag_move' }
+  { type: 'highlight_set_entity' | 'camera_drag_move' | 'default_camera_zoom' }
 >
 
 export enum EngineCommandManagerEvents {


### PR DESCRIPTION
Fixes #8998 

Can be tested with engine preview: `PR-3974` (failed preview deploy) -> `PR-3982`
Or simply here:
https://modeling-c2iyotdwx.vercel.dev.zoo.dev/file/%2Fbrowser%2Fmain.kcl?pool=pr-3982

This should be merged after https://github.com/KittyCAD/engine/pull/3974 although it won't do any harm to merge earlier, the event is not received anyway currently.