### PR TITLE
Run integration tests on an hourly schedule

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    - cron: 0 * * * *  # hourly
+    - cron: 0 * * * * # hourly
 
 permissions:
   contents: read

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: 0 * * * * # hourly
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -97,7 +99,7 @@ jobs:
           cp -r prepared-ts-rs-bindings/* rust/kcl-lib/bindings/
 
       - name: npm run test:integration
-        if: ${{ github.event_name != 'release' && github.event_name != 'schedule' }}
+        if: ${{ github.event_name != 'release' }}
         run: |-
           xvfb-run -a npm run test:integration || true # let TAB determine failure
           .github/ci-cd-scripts/upload-results.sh


### PR DESCRIPTION
Some of these tests seem to be failing intermittently on PRs so I'd like to collect more data on `main` to evaluate which tests need attention and/or test-level retries via Vitest.