### PR TITLE
Release kcl 113

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-api"
-version = "0.1.112"
+version = "0.1.113"
 dependencies = [
  "indexmap 2.12.1",
  "kcl-error",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-bumper"
-version = "0.1.112"
+version = "0.1.113"
 dependencies = [
  "anyhow",
  "clap",
@@ -2125,7 +2125,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-derive-docs"
-version = "0.1.112"
+version = "0.1.113"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-directory-test-macro"
-version = "0.1.112"
+version = "0.1.113"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -2144,7 +2144,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-error"
-version = "0.1.112"
+version = "0.1.113"
 dependencies = [
  "miette",
  "serde",
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-language-server"
-version = "0.2.112"
+version = "0.2.113"
 dependencies = [
  "anyhow",
  "clap",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-language-server-release"
-version = "0.1.112"
+version = "0.1.113"
 dependencies = [
  "anyhow",
  "clap",
@@ -2210,7 +2210,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-lib"
-version = "0.2.112"
+version = "0.2.113"
 dependencies = [
  "anyhow",
  "approx 0.5.1",
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-python-bindings"
-version = "0.3.112"
+version = "0.3.113"
 dependencies = [
  "anyhow",
  "kcl-lib",
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-test-server"
-version = "0.1.112"
+version = "0.1.113"
 dependencies = [
  "anyhow",
  "hyper 0.14.32",
@@ -2321,7 +2321,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-to-core"
-version = "0.1.112"
+version = "0.1.113"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-wasm-lib"
-version = "0.1.112"
+version = "0.1.113"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",

--- a/rust/kcl-api/Cargo.toml
+++ b/rust/kcl-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-api"
-version = "0.1.112"
+version = "0.1.113"
 edition = "2024"
 description = "KCL interpreter API"
 license = "MIT"

--- a/rust/kcl-bumper/Cargo.toml
+++ b/rust/kcl-bumper/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "kcl-bumper"
-version = "0.1.112"
+version = "0.1.113"
 edition = "2021"
 repository = "https://github.com/KittyCAD/modeling-api"
 rust-version = "1.76"

--- a/rust/kcl-derive-docs/Cargo.toml
+++ b/rust/kcl-derive-docs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-derive-docs"
 description = "A tool for generating documentation from Rust derive macros"
-version = "0.1.112"
+version = "0.1.113"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-directory-test-macro/Cargo.toml
+++ b/rust/kcl-directory-test-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-directory-test-macro"
 description = "A tool for generating tests from a directory of kcl files"
-version = "0.1.112"
+version = "0.1.113"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-error/Cargo.toml
+++ b/rust/kcl-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-error"
-version = "0.1.112"
+version = "0.1.113"
 edition = "2024"
 description = "KCL error definitions"
 license = "MIT"

--- a/rust/kcl-language-server-release/Cargo.toml
+++ b/rust/kcl-language-server-release/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-language-server-release"
-version = "0.1.112"
+version = "0.1.113"
 edition = "2021"
 authors = ["KittyCAD Inc <kcl@kittycad.io>"]
 publish = false

--- a/rust/kcl-language-server/Cargo.toml
+++ b/rust/kcl-language-server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kcl-language-server"
 description = "A language server for KCL."
 authors = ["KittyCAD Inc <kcl@kittycad.io>"]
-version = "0.2.112"
+version = "0.2.113"
 edition = "2021"
 license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust/kcl-lib/Cargo.toml
+++ b/rust/kcl-lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-lib"
 description = "KittyCAD Language implementation and tools"
-version = "0.2.112"
+version = "0.2.113"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-python-bindings/Cargo.toml
+++ b/rust/kcl-python-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-python-bindings"
-version = "0.3.112"
+version = "0.3.113"
 edition = "2021"
 repository = "https://github.com/kittycad/modeling-app"
 exclude = ["tests/*", "files/*", "venv/*"]

--- a/rust/kcl-test-server/Cargo.toml
+++ b/rust/kcl-test-server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-test-server"
 description = "A test server for KCL"
-version = "0.1.112"
+version = "0.1.113"
 edition = "2021"
 license = "MIT"
 

--- a/rust/kcl-to-core/Cargo.toml
+++ b/rust/kcl-to-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-to-core"
 description = "Utility methods to convert kcl to engine core executable tests"
-version = "0.1.112"
+version = "0.1.113"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-wasm-lib/Cargo.toml
+++ b/rust/kcl-wasm-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-wasm-lib"
-version = "0.1.112"
+version = "0.1.113"
 edition = "2021"
 repository = "https://github.com/KittyCAD/modeling-app"
 publish = false


### PR DESCRIPTION
 - fixed bug in formatter
 - new KCL samples, "pipe-manifold" and "tube-manifold"
 - better error messages in clone