### PR TITLE
Quick Zookeeper conversation padding fix

### DIFF
--- a/src/components/ExchangeCard.tsx
+++ b/src/components/ExchangeCard.tsx
@@ -358,7 +358,7 @@ export const ExchangeCard = (props: ExchangeCardProps) => {
 
   const [showFullReasoning, setShowFullReasoning] = useState<boolean>(true)
 
-  const cssCard = `flex flex-col p-2 gap-2 justify-between
+  const cssCard = `flex flex-col px-4 py-2 gap-2 justify-between
     transition-height duration-500 overflow-hidden text-sm
   `
 


### PR DESCRIPTION

After:

<img width="607" height="428" alt="image" src="https://github.com/user-attachments/assets/9802a455-4e01-46cb-b696-a1bc9e80c0da" />


Before:


<img width="597" height="425" alt="image" src="https://github.com/user-attachments/assets/5dd29009-2fe5-49de-95bc-1032450ded34" />
