### PR TITLE
Revert #9098

### DIFF
--- a/src/editor/plugins/lsp/kcl/index.ts
+++ b/src/editor/plugins/lsp/kcl/index.ts
@@ -153,8 +153,6 @@ export class KclPlugin implements PluginValue {
     }
 
     if (!this.client.ready) return
-
-    const clearSelections = true // no reason to keep them after a manual edit
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.kclManager.executeCode(clearSelections)
   }

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -722,7 +722,7 @@ export class KclManager extends EventTarget {
       this._cancelTokens.set(key, true)
     })
   }
-  async executeCode(clearSelections = false): Promise<void> {
+  async executeCode(): Promise<void> {
     const ast = await this.safeParse(this.code)
 
     if (!ast) {
@@ -742,13 +742,6 @@ export class KclManager extends EventTarget {
 
       this.dispatchEvent(new CustomEvent(KclManagerEvents.LongExecution, {}))
     }, this.longExecutionTimeMs)
-
-    if (clearSelections) {
-      this._modelingSend({
-        type: 'Set selection',
-        data: { selection: undefined, selectionType: 'singleCodeCursor' },
-      })
-    }
 
     return this.executeAst({ ast })
   }

--- a/src/lib/selections.ts
+++ b/src/lib/selections.ts
@@ -325,14 +325,6 @@ export function processCodeMirrorRanges({
   for (const { id, range } of idBasedSelections) {
     if (!id) {
       const pathToNode = getNodePathFromSourceRange(ast, range)
-      const invalidPathToNode =
-        pathToNode.length === 1 &&
-        pathToNode[0][0] === 'body' &&
-        pathToNode[0][1] === ''
-      if (invalidPathToNode) {
-        console.warn('Could not find valid pathToNode, found:', pathToNode)
-        continue
-      }
       selections.push({
         codeRef: {
           range,


### PR DESCRIPTION
Clearing the selection also moves the CodeMirror cursor to the end of the file. We should make this not the case, but for now let's revert this cleanly so we can unblock our planned release today.