### PR TITLE
Keep Text-to-CAD credits for consistency in billing indicator

### DIFF
--- a/src/components/MlEphantConversation2.tsx
+++ b/src/components/MlEphantConversation2.tsx
@@ -194,7 +194,7 @@ function BillingStatusBarItem(props: { billingContext: BillingContext }) {
             hoverOnly
             wrapperClassName="ui-open:!hidden"
           >
-            Zookeeper credits
+            Text-to-CAD credits
           </Tooltip>
         )}
       </Popover.Button>


### PR DESCRIPTION
As reported by @jacebrowning at https://kittycadworkspace.slack.com/archives/C07A80B83FS/p1764857490614469