### PR TITLE
Track markdown-rendered elements in ZK to prevent selection clearing

### DIFF
--- a/src/components/ExchangeCard.tsx
+++ b/src/components/ExchangeCard.tsx
@@ -12,6 +12,7 @@ import {
   useState,
   type ReactNode,
   type ComponentProps,
+  useMemo,
 } from 'react'
 import Tooltip from '@src/components/Tooltip'
 import toast from 'react-hot-toast'
@@ -322,8 +323,8 @@ export const ResponsesCard = (props: ResponsesCardProp) => {
 
   const itemsFilteredNulls = items.filter((x: ReactNode | null) => x !== null)
 
-  const deltasAggregatedMarkdown =
-    props.deltasAggregated !== '' ? (
+  const deltasAggregatedMarkdown = useMemo(() => {
+    return props.deltasAggregated !== '' ? (
       <span
         className="parsed-markdown whitespace-normal"
         dangerouslySetInnerHTML={{
@@ -334,6 +335,7 @@ export const ResponsesCard = (props: ResponsesCardProp) => {
         }}
       ></span>
     ) : null
+  }, [props.deltasAggregated])
 
   return (
     <ChatBubble


### PR DESCRIPTION
Fixes #9183

From https://github.com/KittyCAD/modeling-app/issues/9183#issuecomment-3621361254:
> Ok I think I got it: with the introduction of markdown parsing, we have dom elements that get inserted from an html string in deltasAggregatedMarkdown in src/components/ExchangeCard.tsx#L326, and I noticed we have the whole MlEphantConversationPaneWrapper component rerendering with changes on two props (which we will have to investigate, to reproduce just drop a console.log(props) line in the component). Most of the ZK components weren't rerendering since they weren't changing, but since those html-added components from markdown weren't tracked by React, they get a render each time, clearing the selection!
>
> I have a fix with useMemo where were render the React elements from react on prop change, and keep track of that instead of the html string, which keeps us safe from rerenders and doesn't clear the selections.


### How to confirm the fix?

Selecting text in a response is one, otherwise the dev tools should **not** be showing a hearbeat on these DOM elements like here on app.zoo.dev:
<img width="298" height="174" alt="image" src="https://github.com/user-attachments/assets/7f0dcf95-0b6a-4671-a1b5-ac566575443a" />
