### PR TITLE
Remove auto-scroll to end of each new line

### DIFF
--- a/src/components/MlEphantConversation2.tsx
+++ b/src/components/MlEphantConversation2.tsx
@@ -337,28 +337,6 @@ export const MlEphantConversation2 = (props: MlEphantConversationProps) => {
     if (autoScroll === false) {
       return
     }
-    if (refScroll.current === null) {
-      return
-    }
-    if (props.conversation?.exchanges.length === 0) {
-      return
-    }
-
-    setTimeout(() => {
-      if (refScroll.current == null) {
-        return
-      }
-      refScroll.current.scrollTo({
-        top: refScroll.current.scrollHeight,
-        behavior: 'smooth',
-      })
-    })
-  }, [props.conversation?.exchanges, autoScroll])
-
-  useEffect(() => {
-    if (autoScroll === false) {
-      return
-    }
     if (refScroll.current == null) {
       return
     }


### PR DESCRIPTION
Closes #9181

This is removing the forced auto scroll as new line arrive to the bottom of the view: the thesis here is that we need _one_ scroll when the prompt first starts, pointing to the beginning of the response, and then let the user scroll down as they read through it. This works around the "jumping" that happens when on each new line, we scroll down by a line height. 

Please test the Vercel preview at https://modeling-c92522f14.vercel.dev.zoo.dev/ and compare it with https://app.dev.zoo.dev. Thanks!