### PR TITLE
Match stream div background to engine's

### DIFF
--- a/src/components/ConnectionStream.tsx
+++ b/src/components/ConnectionStream.tsx
@@ -36,6 +36,7 @@ import { useOnVitestEngineOnline } from '@src/hooks/network/useOnVitestEngineOnl
 import { useOnOfflineToExitSketchMode } from '@src/hooks/network/useOnOfflineToExitSketchMode'
 import { resetCameraPosition } from '@src/lib/resetCameraPosition'
 import { EngineDebugger } from '@src/lib/debugger'
+import { getResolvedTheme, Themes } from '@src/lib/theme'
 
 const TIME_TO_CONNECT = 30_000
 
@@ -333,11 +334,18 @@ export const ConnectionStream = (props: {
     engineCommandManager,
   })
 
+  // Hardcoded engine background color based on theme
+  const backgroundColor =
+    getResolvedTheme(settings.app.theme.current) === Themes.Light
+      ? 'rgb(250, 250, 250)'
+      : 'rgb(30, 30, 30)'
+
   return (
     <div
       role="presentation"
       ref={videoWrapperRef}
       className="absolute inset-[-4px] z-0"
+      style={{ backgroundColor }}
       id="stream"
       data-testid="stream"
       onMouseUp={handleMouseUp}


### PR DESCRIPTION
So that it looks smoother on resize? We still have the black flashes but that's another issue. 

Demo, left is Vercel preview from this branch and right is prod. Mind the edges of the stream while it resizes.

https://github.com/user-attachments/assets/b383ce2d-6990-41a8-8b90-bb9310a2d608


