### PR TITLE
KCL: Improve autocompletion for fn arguments

### DIFF
--- a/rust/kcl-lib/src/lsp/kcl/mod.rs
+++ b/rust/kcl-lib/src/lsp/kcl/mod.rs
@@ -253,10 +253,17 @@ impl Backend {
                 }),
                 deprecated: None,
                 preselect: None,
-                sort_text: None,
-                filter_text: None,
-                insert_text: None,
-                insert_text_format: None,
+                sort_text: Some(arg_name.to_owned()),
+                filter_text: Some(arg_name.to_owned()),
+                insert_text: {
+                    // let snippet = "${0:x}";
+                    if let Some(snippet) = arg_data.props.get_autocomplete_snippet(0).map(|(_i, snippet)| snippet) {
+                        Some(snippet)
+                    } else {
+                        Some(format!("{arg_name} = "))
+                    }
+                },
+                insert_text_format: Some(InsertTextFormat::SNIPPET),
                 insert_text_mode: None,
                 text_edit: None,
                 additional_text_edits: None,


### PR DESCRIPTION
Before, accepting a completion like `diameter` in the `circle` function would just insert the text `diameter`. You'd then have to write `= 10` or some other appropriate value.

https://github.com/user-attachments/assets/069cd77c-cc8a-4d3a-83ef-2e144052b134

Now, accepting the completion `diameter` will insert `diameter = 10`. This reuses the same "sensible placeholder value" code we already had before, so that for example `center` will be completed to `[0, 0]`.

https://github.com/user-attachments/assets/e5c2173e-edda-44ca-afc8-27e23c388309

