### PR TITLE
KCL: Translate defaults to 0, 0, 0

### DIFF
--- a/rust/kcl-lib/src/docs/kcl_doc.rs
+++ b/rust/kcl-lib/src/docs/kcl_doc.rs
@@ -657,6 +657,8 @@ impl FnData {
             return "hole(${0:holeSketch}, ${1:%})".to_owned();
         } else if self.name == "extrude" {
             return "extrude(length = ${0:10})".to_owned();
+        } else if self.name == "translate" {
+            return "translate(x = ${0:0}, y = ${1:0}, z = ${2:0})".to_owned();
         }
         let mut args = Vec::new();
         let mut index = 0;

--- a/rust/kcl-lib/src/docs/mod.rs
+++ b/rust/kcl-lib/src/docs/mod.rs
@@ -243,7 +243,7 @@ mod tests {
             panic!();
         };
         let snippet = data.to_autocomplete_snippet();
-        assert_eq!(snippet, r#"translate(x = ${0:10}, y = ${1:10}, z = ${2:10})"#);
+        assert_eq!(snippet, r#"translate(x = ${0:0}, y = ${1:0}, z = ${2:0})"#);
     }
 
     #[test]

--- a/rust/kcl-lib/src/std/transform.rs
+++ b/rust/kcl-lib/src/std/transform.rs
@@ -206,6 +206,11 @@ async fn inner_translate(
         Some(OriginType::Local)
     };
 
+    let translation = shared::Point3d {
+        x: LengthUnit(x.as_ref().map(|t| t.to_mm()).unwrap_or_default()),
+        y: LengthUnit(y.as_ref().map(|t| t.to_mm()).unwrap_or_default()),
+        z: LengthUnit(z.as_ref().map(|t| t.to_mm()).unwrap_or_default()),
+    };
     let mut objects = objects.clone();
     for object_id in objects.ids(&args.ctx).await? {
         exec_state
@@ -214,16 +219,7 @@ async fn inner_translate(
                 ModelingCmd::from(mcmd::SetObjectTransform {
                     object_id,
                     transforms: vec![shared::ComponentTransform {
-                        translate: Some(transform_by(
-                            shared::Point3d {
-                                x: LengthUnit(x.as_ref().map(|t| t.to_mm()).unwrap_or_default()),
-                                y: LengthUnit(y.as_ref().map(|t| t.to_mm()).unwrap_or_default()),
-                                z: LengthUnit(z.as_ref().map(|t| t.to_mm()).unwrap_or_default()),
-                            },
-                            false,
-                            !is_global,
-                            origin,
-                        )),
+                        translate: Some(transform_by(translation, false, !is_global, origin)),
                         scale: None,
                         rotate_rpy: None,
                         rotate_angle_axis: None,


### PR DESCRIPTION
Lee suggestion. Currently default of 10,10,10 means the solid jumps around the scene immediately.