### PR TITLE
Fix to disallow engine commands in sketch blocks

### DIFF
--- a/rust/kcl-lib/src/errors.rs
+++ b/rust/kcl-lib/src/errors.rs
@@ -452,6 +452,10 @@ impl KclError {
         KclError::Io { details }
     }
 
+    pub fn new_invalid_expression(details: KclErrorDetails) -> KclError {
+        KclError::InvalidExpression { details }
+    }
+
     pub fn new_engine(details: KclErrorDetails) -> KclError {
         KclError::Engine { details }
     }

--- a/rust/kcl-lib/src/execution/modeling.rs
+++ b/rust/kcl-lib/src/execution/modeling.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 use crate::exec::ArtifactCommand;
 use crate::{
     ExecState, ExecutorContext, KclError, SourceRange,
+    errors::KclErrorDetails,
     exec::{IdGenerator, KclValue},
     execution::Solid,
     std::Args,
@@ -82,7 +83,10 @@ impl ExecState {
         &mut self,
         mut meta: ModelingCmdMeta<'_>,
         cmd: ModelingCmd,
-    ) -> Result<(), crate::errors::KclError> {
+    ) -> Result<(), KclError> {
+        if self.is_in_sketch_block() {
+            return Err(no_modeling_in_sketch_block_error(meta.source_range));
+        }
         let id = meta.id(self.id_generator());
         #[cfg(feature = "artifact-graph")]
         self.push_command(ArtifactCommand {
@@ -99,7 +103,10 @@ impl ExecState {
         &mut self,
         meta: ModelingCmdMeta<'_>,
         cmds: &[ModelingCmdReq],
-    ) -> Result<(), crate::errors::KclError> {
+    ) -> Result<(), KclError> {
+        if self.is_in_sketch_block() {
+            return Err(no_modeling_in_sketch_block_error(meta.source_range));
+        }
         #[cfg(feature = "artifact-graph")]
         for cmd_req in cmds {
             self.push_command(ArtifactCommand {
@@ -118,7 +125,10 @@ impl ExecState {
         &mut self,
         mut meta: ModelingCmdMeta<'_>,
         cmd: ModelingCmd,
-    ) -> Result<(), crate::errors::KclError> {
+    ) -> Result<(), KclError> {
+        if self.is_in_sketch_block() {
+            return Err(no_modeling_in_sketch_block_error(meta.source_range));
+        }
         let id = meta.id(self.id_generator());
         // TODO: The order of the tracking of these doesn't match the order that
         // they're sent to the engine.
@@ -137,6 +147,9 @@ impl ExecState {
         mut meta: ModelingCmdMeta<'_>,
         cmd: ModelingCmd,
     ) -> Result<OkWebSocketResponseData, KclError> {
+        if self.is_in_sketch_block() {
+            return Err(no_modeling_in_sketch_block_error(meta.source_range));
+        }
         let id = meta.id(self.id_generator());
         #[cfg(feature = "artifact-graph")]
         self.push_command(ArtifactCommand {
@@ -153,7 +166,10 @@ impl ExecState {
         &mut self,
         mut meta: ModelingCmdMeta<'_>,
         cmd: &ModelingCmd,
-    ) -> Result<(), crate::errors::KclError> {
+    ) -> Result<(), KclError> {
+        if self.is_in_sketch_block() {
+            return Err(no_modeling_in_sketch_block_error(meta.source_range));
+        }
         let id = meta.id(self.id_generator());
         #[cfg(feature = "artifact-graph")]
         self.push_command(ArtifactCommand {
@@ -172,6 +188,9 @@ impl ExecState {
         // We only do this at the very end of the file.
         batch_end: bool,
     ) -> Result<OkWebSocketResponseData, KclError> {
+        if self.is_in_sketch_block() {
+            return Err(no_modeling_in_sketch_block_error(meta.source_range));
+        }
         meta.ctx.engine.flush_batch(batch_end, meta.source_range).await
     }
 
@@ -181,6 +200,9 @@ impl ExecState {
         meta: ModelingCmdMeta<'_>,
         solids: &[Solid],
     ) -> Result<(), KclError> {
+        if self.is_in_sketch_block() {
+            return Err(no_modeling_in_sketch_block_error(meta.source_range));
+        }
         // Make sure we don't traverse sketches more than once.
         let mut traversed_sketches = Vec::new();
 
@@ -229,4 +251,11 @@ impl ExecState {
 
         Ok(())
     }
+}
+
+fn no_modeling_in_sketch_block_error(range: SourceRange) -> KclError {
+    KclError::new_invalid_expression(KclErrorDetails::new(
+        "Modeling commands communicating with the engine cannot be used inside a sketch block".to_owned(),
+        vec![range],
+    ))
 }

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -320,6 +320,10 @@ impl ExecState {
         self.global.segment_ids_edited.contains(object_id)
     }
 
+    pub(super) fn is_in_sketch_block(&self) -> bool {
+        self.mod_local.sketch_block.is_some()
+    }
+
     pub(crate) fn sketch_block_mut(&mut self) -> Option<&mut SketchBlockState> {
         self.mod_local.sketch_block.as_mut()
     }

--- a/rust/kcl-lib/src/simulation_tests.rs
+++ b/rust/kcl-lib/src/simulation_tests.rs
@@ -4163,6 +4163,27 @@ mod sketch_block_arc_using_center_coincident {
         super::execute(TEST_NAME, true).await
     }
 }
+mod sketch_block_modeling_command_is_error {
+    const TEST_NAME: &str = "sketch_block_modeling_command_is_error";
+
+    /// Test parsing KCL.
+    #[test]
+    fn parse() {
+        super::parse(TEST_NAME)
+    }
+
+    /// Test that parsing and unparsing KCL produces the original KCL input.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unparse() {
+        super::unparse(TEST_NAME).await
+    }
+
+    /// Test that KCL is executed correctly.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn kcl_test_execute() {
+        super::execute(TEST_NAME, false).await
+    }
+}
 mod holes_cube {
     const TEST_NAME: &str = "holes_cube";
 

--- a/rust/kcl-lib/tests/sketch_block_modeling_command_is_error/artifact_commands.snap
+++ b/rust/kcl-lib/tests/sketch_block_modeling_command_is_error/artifact_commands.snap
@@ -1,0 +1,5 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Artifact commands sketch_block_modeling_command_is_error.kcl
+---
+{}

--- a/rust/kcl-lib/tests/sketch_block_modeling_command_is_error/artifact_graph_flowchart.snap
+++ b/rust/kcl-lib/tests/sketch_block_modeling_command_is_error/artifact_graph_flowchart.snap
@@ -1,0 +1,6 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Artifact graph flowchart sketch_block_modeling_command_is_error.kcl
+extension: md
+snapshot_kind: binary
+---

--- a/rust/kcl-lib/tests/sketch_block_modeling_command_is_error/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/sketch_block_modeling_command_is_error/artifact_graph_flowchart.snap.md
@@ -1,0 +1,5 @@
+```mermaid
+flowchart LR
+  1["SketchBlock<br>[41, 80, 0]"]
+    %% [ProgramBodyItem { index: 0 }, ExpressionStatementExpr, SketchBlock]
+```

--- a/rust/kcl-lib/tests/sketch_block_modeling_command_is_error/ast.snap
+++ b/rust/kcl-lib/tests/sketch_block_modeling_command_is_error/ast.snap
@@ -1,0 +1,189 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Result of parsing sketch_block_modeling_command_is_error.kcl
+---
+{
+  "Ok": {
+    "body": [
+      {
+        "commentStart": 0,
+        "end": 0,
+        "expression": {
+          "arguments": [
+            {
+              "type": "LabeledArg",
+              "label": {
+                "commentStart": 0,
+                "end": 0,
+                "moduleId": 0,
+                "name": "on",
+                "start": 0,
+                "type": "Identifier"
+              },
+              "arg": {
+                "abs_path": false,
+                "commentStart": 0,
+                "end": 0,
+                "moduleId": 0,
+                "name": {
+                  "commentStart": 0,
+                  "end": 0,
+                  "moduleId": 0,
+                  "name": "XY",
+                  "start": 0,
+                  "type": "Identifier"
+                },
+                "path": [],
+                "start": 0,
+                "type": "Name",
+                "type": "Name"
+              }
+            }
+          ],
+          "body": {
+            "commentStart": 0,
+            "end": 0,
+            "items": [
+              {
+                "commentStart": 0,
+                "end": 0,
+                "expression": {
+                  "arguments": [],
+                  "callee": {
+                    "abs_path": false,
+                    "commentStart": 0,
+                    "end": 0,
+                    "moduleId": 0,
+                    "name": {
+                      "commentStart": 0,
+                      "end": 0,
+                      "moduleId": 0,
+                      "name": "startSketchOn",
+                      "start": 0,
+                      "type": "Identifier"
+                    },
+                    "path": [],
+                    "start": 0,
+                    "type": "Name"
+                  },
+                  "commentStart": 0,
+                  "end": 0,
+                  "moduleId": 0,
+                  "start": 0,
+                  "type": "CallExpressionKw",
+                  "type": "CallExpressionKw",
+                  "unlabeled": {
+                    "abs_path": false,
+                    "commentStart": 0,
+                    "end": 0,
+                    "moduleId": 0,
+                    "name": {
+                      "commentStart": 0,
+                      "end": 0,
+                      "moduleId": 0,
+                      "name": "XY",
+                      "start": 0,
+                      "type": "Identifier"
+                    },
+                    "path": [],
+                    "start": 0,
+                    "type": "Name",
+                    "type": "Name"
+                  }
+                },
+                "moduleId": 0,
+                "start": 0,
+                "type": "ExpressionStatement",
+                "type": "ExpressionStatement"
+              }
+            ],
+            "moduleId": 0,
+            "start": 0,
+            "type": "Block"
+          },
+          "commentStart": 0,
+          "end": 0,
+          "moduleId": 0,
+          "start": 0,
+          "type": "SketchBlock",
+          "type": "SketchBlock"
+        },
+        "moduleId": 0,
+        "start": 0,
+        "type": "ExpressionStatement",
+        "type": "ExpressionStatement"
+      }
+    ],
+    "commentStart": 0,
+    "end": 0,
+    "innerAttrs": [
+      {
+        "commentStart": 0,
+        "end": 0,
+        "moduleId": 0,
+        "name": {
+          "commentStart": 0,
+          "end": 0,
+          "moduleId": 0,
+          "name": "settings",
+          "start": 0,
+          "type": "Identifier"
+        },
+        "properties": [
+          {
+            "commentStart": 0,
+            "end": 0,
+            "key": {
+              "commentStart": 0,
+              "end": 0,
+              "moduleId": 0,
+              "name": "experimentalFeatures",
+              "start": 0,
+              "type": "Identifier"
+            },
+            "moduleId": 0,
+            "start": 0,
+            "type": "ObjectProperty",
+            "value": {
+              "abs_path": false,
+              "commentStart": 0,
+              "end": 0,
+              "moduleId": 0,
+              "name": {
+                "commentStart": 0,
+                "end": 0,
+                "moduleId": 0,
+                "name": "allow",
+                "start": 0,
+                "type": "Identifier"
+              },
+              "path": [],
+              "start": 0,
+              "type": "Name",
+              "type": "Name"
+            }
+          }
+        ],
+        "start": 0,
+        "type": "Annotation"
+      }
+    ],
+    "moduleId": 0,
+    "nonCodeMeta": {
+      "nonCodeNodes": {},
+      "startNodes": [
+        {
+          "commentStart": 0,
+          "end": 0,
+          "moduleId": 0,
+          "start": 0,
+          "type": "NonCodeNode",
+          "value": {
+            "type": "newLine"
+          }
+        }
+      ]
+    },
+    "start": 0
+  }
+}

--- a/rust/kcl-lib/tests/sketch_block_modeling_command_is_error/execution_error.snap
+++ b/rust/kcl-lib/tests/sketch_block_modeling_command_is_error/execution_error.snap
@@ -1,0 +1,28 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Error from executing sketch_block_modeling_command_is_error.kcl
+---
+KCL InvalidExpression error
+
+  × invalid expression: Modeling commands communicating with the engine cannot
+  │ be used inside a sketch block
+   ╭─[4:3]
+ 3 │ sketch(on = XY) {
+ 4 │   startSketchOn(XY)
+   ·   ────────┬────────┬
+   ·           ╰── tests/sketch_block_modeling_command_is_error/input.kcl
+   ·           ╰── tests/sketch_block_modeling_command_is_error/input.kcl
+ 5 │ }
+   ╰────
+  ╰─▶ KCL InvalidExpression error
+      
+        × invalid expression: Modeling commands communicating with the engine
+        │ cannot be used inside a sketch block
+         ╭─[4:3]
+       3 │ sketch(on = XY) {
+       4 │   startSketchOn(XY)
+         ·   ────────┬────────
+         ·           ╰── tests/sketch_block_modeling_command_is_error/
+      input.kcl
+       5 │ }
+         ╰────

--- a/rust/kcl-lib/tests/sketch_block_modeling_command_is_error/input.kcl
+++ b/rust/kcl-lib/tests/sketch_block_modeling_command_is_error/input.kcl
@@ -1,0 +1,5 @@
+@settings(experimentalFeatures = allow)
+
+sketch(on = XY) {
+  startSketchOn(XY)
+}

--- a/rust/kcl-lib/tests/sketch_block_modeling_command_is_error/ops.snap
+++ b/rust/kcl-lib/tests/sketch_block_modeling_command_is_error/ops.snap
@@ -1,0 +1,267 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Operations executed sketch_block_modeling_command_is_error.kcl
+---
+{
+  "rust/kcl-lib/tests/sketch_block_modeling_command_is_error/input.kcl": [
+    {
+      "type": "StdLibCall",
+      "name": "startSketchOn",
+      "unlabeledArg": {
+        "value": {
+          "type": "Plane",
+          "artifact_id": "[uuid]"
+        },
+        "sourceRange": []
+      },
+      "labeledArgs": {},
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 0
+          },
+          {
+            "type": "ExpressionStatementExpr"
+          },
+          {
+            "type": "SketchBlock"
+          }
+        ]
+      },
+      "sourceRange": [],
+      "isError": true
+    }
+  ],
+  "std::math": [
+    {
+      "type": "VariableDeclaration",
+      "name": "PI",
+      "value": {
+        "type": "Number",
+        "value": 3.141592653589793,
+        "ty": {
+          "type": "Unknown"
+        }
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 1
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "E",
+      "value": {
+        "type": "Number",
+        "value": 2.718281828459045,
+        "ty": {
+          "type": "Known",
+          "type": "Count"
+        }
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 2
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "TAU",
+      "value": {
+        "type": "Number",
+        "value": 6.283185307179586,
+        "ty": {
+          "type": "Known",
+          "type": "Count"
+        }
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 3
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    }
+  ],
+  "std::prelude": [
+    {
+      "type": "VariableDeclaration",
+      "name": "START",
+      "value": {
+        "type": "String",
+        "value": "start"
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 20
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "END",
+      "value": {
+        "type": "String",
+        "value": "end"
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 21
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "NEW",
+      "value": {
+        "type": "String",
+        "value": "new"
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 22
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "MERGE",
+      "value": {
+        "type": "String",
+        "value": "merge"
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 23
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "SOLID",
+      "value": {
+        "type": "String",
+        "value": "solid"
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 24
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    },
+    {
+      "type": "VariableDeclaration",
+      "name": "SURFACE",
+      "value": {
+        "type": "String",
+        "value": "surface"
+      },
+      "visibility": "export",
+      "nodePath": {
+        "steps": [
+          {
+            "type": "ProgramBodyItem",
+            "index": 25
+          },
+          {
+            "type": "VariableDeclarationDeclaration"
+          },
+          {
+            "type": "VariableDeclarationInit"
+          }
+        ]
+      },
+      "sourceRange": []
+    }
+  ]
+}

--- a/rust/kcl-lib/tests/sketch_block_modeling_command_is_error/program_memory.snap
+++ b/rust/kcl-lib/tests/sketch_block_modeling_command_is_error/program_memory.snap
@@ -1,0 +1,5 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Variables in memory after executing sketch_block_modeling_command_is_error.kcl
+---
+{}

--- a/rust/kcl-lib/tests/sketch_block_modeling_command_is_error/unparsed.snap
+++ b/rust/kcl-lib/tests/sketch_block_modeling_command_is_error/unparsed.snap
@@ -1,0 +1,9 @@
+---
+source: kcl-lib/src/simulation_tests.rs
+description: Result of unparsing sketch_block_modeling_command_is_error.kcl
+---
+@settings(experimentalFeatures = allow)
+
+sketch(on = XY) {
+  startSketchOn(XY)
+}


### PR DESCRIPTION
This invariant is a requirement for sketch-solve, so we need to enforce it.