### PR TITLE
Show starter card about blocked account and disable prompting

### DIFF
--- a/src/components/MlEphantConversation2.tsx
+++ b/src/components/MlEphantConversation2.tsx
@@ -38,7 +38,7 @@ export interface MlEphantConversationProps {
   needsReconnect: boolean
   hasPromptCompleted: boolean
   userAvatarSrc?: string
-  userBlocked?: boolean
+  userBlockedOnPayment?: boolean
   defaultPrompt?: string
 }
 
@@ -394,7 +394,7 @@ export const MlEphantConversation2 = (props: MlEphantConversationProps) => {
         <div className="flex flex-col h-full">
           <div className="h-full flex flex-col justify-end overflow-auto">
             <div className="overflow-auto" ref={refScroll}>
-              {props.userBlocked ? (
+              {props.userBlockedOnPayment ? (
                 <StarterCard
                   text={`Zookeeper is unavailable because you have run out of credits for the month. Please check your [account page](${withSiteBaseURL('/account/billing')}) to view usage or upgrade your plan.`}
                 />
@@ -414,7 +414,9 @@ export const MlEphantConversation2 = (props: MlEphantConversationProps) => {
           <div className="border-t b-4">
             <MlEphantConversationInput
               contexts={props.contexts}
-              disabled={props.userBlocked || props.disabled || props.isLoading}
+              disabled={
+                props.userBlockedOnPayment || props.disabled || props.isLoading
+              }
               hasPromptCompleted={props.hasPromptCompleted}
               needsReconnect={props.needsReconnect}
               onProcess={onProcess}

--- a/src/components/layout/areas/MlEphantConversationPane2.tsx
+++ b/src/components/layout/areas/MlEphantConversationPane2.tsx
@@ -283,6 +283,21 @@ export const MlEphantConversationPane2 = (props: {
     }
   }, [searchParams, setSearchParams])
 
+  const userBlockedOnPayment: () => boolean = () => {
+    if (!props.user || !props.user.block) {
+      return false
+    }
+
+    switch (props.user.block) {
+      case 'missing_payment_method':
+      case 'payment_method_failed':
+        return true
+      default:
+        props.user.block satisfies never // exhaustiveness check
+        return false
+    }
+  }
+
   return (
     <MlEphantConversation2
       isLoading={conversation === undefined}
@@ -301,7 +316,7 @@ export const MlEphantConversationPane2 = (props: {
       needsReconnect={needsReconnect}
       hasPromptCompleted={!isProcessing}
       userAvatarSrc={props.user?.image}
-      userBlocked={Boolean(props.user?.block)}
+      userBlockedOnPayment={userBlockedOnPayment()}
       defaultPrompt={defaultPrompt}
     />
   )


### PR DESCRIPTION
Workaround for #9239. 

<img width="419" height="381" alt="image" src="https://github.com/user-attachments/assets/12a97dfc-9355-45bd-a326-08304ee1f8bf" />


### How to get into that state:

Run the following.
```
git checkout pierremtb/issue9239-Zookeeper-chat-fails-to-load-when-users-have-an-amount-due
make build
npm run tronb:package:dev
./out/mac-arm64/Zoo\ Design\ Studio.app/Contents/MacOS/Zoo\ Design\ Studio
```

Then log into **zoo.dev** with a free account that's out of credits.

### Gotcha

Not sure yet if this will end up being annoying having user state and ml machine state. The better fix is a message coming from the websocket itself, as suggested by @iterion. See https://github.com/KittyCAD/api/issues/3121