### PR TITLE
Remove artifact decoration plugin

### DIFF
--- a/src/editor/plugins/artifacts/index.ts
+++ b/src/editor/plugins/artifacts/index.ts
@@ -35,7 +35,11 @@ export const artifactGraphField = StateField.define<ArtifactGraph>({
   },
 })
 
-/** Decorations field that stores ranges annotated with artifact metadata */
+/**
+ * Decorations field that stores ranges annotated with artifact metadata
+ *
+ * Removed for now as a fix to https://github.com/KittyCAD/modeling-app/issues/9366
+ */
 export const artifactDecorationsField = StateField.define<
   ReturnType<typeof Decoration.set>
 >({
@@ -96,5 +100,5 @@ function buildArtifactDecorations(
 }
 
 export function artifactAnnotationsExtension(): Extension {
-  return [artifactGraphField, artifactDecorationsField]
+  return [artifactGraphField]
 }


### PR DESCRIPTION
Fixes #9366. This Decoration plugin highlights the code with corresponding `artifactGraph` decorations whenever the debug panel is active, and with certain KCL code it can get itself into an infinite loop. This manifests as an internal back-and-forth within CodeMirror's `sync()` methods, which call `super.sync()` and `child.sync()` endlessly without settling. I don't understand why this plugin creates that behavior, but it's not worth debugging fully until we want to turn it back on.

I think this means that I should not advocate for using Decorator plugins for any sort of state lookups or connecting tissue, which makes sense in retrospect. Developers should use the StateFields and calculated Facets to get one state representation they have to one they want.