### PR TITLE
Fix layout shift by changing ZK credits tooltip position

### DIFF
--- a/src/components/ZookeeperCreditsMenu.tsx
+++ b/src/components/ZookeeperCreditsMenu.tsx
@@ -28,7 +28,7 @@ function BillingStatusBarItem(props: { billingContext: BillingContext }) {
         />
         {!props.billingContext.error && (
           <Tooltip
-            position="left"
+            position="top"
             contentClassName="text-xs"
             hoverOnly
             wrapperClassName="ui-open:!hidden"


### PR DESCRIPTION
Quick fix to close #9332 back down, follow-up to https://github.com/KittyCAD/modeling-app/pull/9373 after testing on staging.

<img width="319" height="134" alt="image" src="https://github.com/user-attachments/assets/9e3838de-5acb-4260-96bf-8a1c7ec15a22" />

Before that fix it's sitting on the left side and causing a layout shift due to some padding in the container

<img width="836" height="436" alt="image" src="https://github.com/user-attachments/assets/9f532bae-6984-47d3-a369-e11b95a49a0a" />
