### PR TITLE
Change sketchExecuteMock() to return KCL source

### DIFF
--- a/rust/kcl-lib/src/frontend/sketch.rs
+++ b/rust/kcl-lib/src/frontend/sketch.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ExecOutcome, ExecutorContext,
+    ExecutorContext,
     frontend::api::{
         Expr, FileId, Number, ObjectId, Plane, ProjectId, Result, SceneGraph, SceneGraphDelta, SourceDelta, Version,
     },
@@ -17,7 +17,7 @@ pub trait SketchApi {
         ctx: &ExecutorContext,
         version: Version,
         sketch: ObjectId,
-    ) -> Result<(SceneGraph, ExecOutcome)>;
+    ) -> Result<(SourceDelta, SceneGraphDelta)>;
 
     async fn new_sketch(
         &mut self,

--- a/src/lib/rustContext.ts
+++ b/src/lib/rustContext.ts
@@ -320,21 +320,21 @@ export default class RustContext {
     sketch: ApiObjectId,
     settings: DeepPartial<Configuration>
   ): Promise<{
-    sceneGraph: SceneGraph
-    execOutcome: ExecOutcome
+    kclSource: SourceDelta
+    sceneGraphDelta: SceneGraphDelta
   }> {
     const instance = this._checkInstance()
 
     try {
-      const result: [SceneGraph, ExecOutcome] =
+      const result: [SourceDelta, SceneGraphDelta] =
         await instance.sketch_execute_mock(
           JSON.stringify(version),
           JSON.stringify(sketch),
           JSON.stringify(settings)
         )
       return {
-        sceneGraph: result[0],
-        execOutcome: result[1],
+        kclSource: result[0],
+        sceneGraphDelta: result[1],
       }
     } catch (e: any) {
       // TODO: sketch-api: const err = errFromErrWithOutputs(e)


### PR DESCRIPTION
This changes sketchExecuteMock() to have the same return type as the other API functions.