### PR TITLE
Properly hide settings commands based on hideOnPlatform

### DIFF
--- a/src/components/Settings/SettingsSearchBar.tsx
+++ b/src/components/Settings/SettingsSearchBar.tsx
@@ -10,6 +10,7 @@ import { isDesktop } from '@src/lib/isDesktop'
 import { interactionMap } from '@src/lib/settings/initialKeybindings'
 import type { SettingsLevel } from '@src/lib/settings/settingsTypes'
 import { useSettings } from '@src/lib/singletons'
+import { hiddenOnPlatform } from '@src/lib/settings/settingsUtils'
 
 type ExtendedSettingsLevel = SettingsLevel | 'keybindings'
 
@@ -41,10 +42,7 @@ export function SettingsSearchBar() {
           const s = setting
           return (['project', 'user'] satisfies SettingsLevel[])
             .filter(
-              (l) =>
-                s.hideOnLevel !== l &&
-                s.hideOnPlatform !== 'both' &&
-                s.hideOnPlatform !== (isDesktop() ? 'desktop' : 'web')
+              (l) => s.hideOnLevel !== l && !hiddenOnPlatform(s, isDesktop())
             )
             .map((l) => ({
               category: decamelize(category, { separator: ' ' }),

--- a/src/lib/commandBarConfigs/settingsCommandConfig.ts
+++ b/src/lib/commandBarConfigs/settingsCommandConfig.ts
@@ -18,17 +18,14 @@ import type {
 } from '@src/lib/settings/settingsTypes'
 import type { PathValue } from '@src/lib/types'
 import type { settingsMachine } from '@src/machines/settingsMachine'
+import { hiddenOnPlatform } from '@src/lib/settings/settingsUtils'
 
 // An array of the paths to all of the settings that have commandConfigs
 export const settingsWithCommandConfigs = (s: SettingsType) =>
   Object.entries(s).flatMap(([categoryName, categorySettings]) =>
     Object.entries(categorySettings)
-      .filter(([_, s]) => s.commandConfig !== undefined)
-      .filter(
-        ([_, s]) =>
-          s.hideOnPlatform !== 'both' &&
-          s.hideOnPlatform !== (isDesktop() ? 'desktop' : 'web')
-      )
+      .filter(([_, setting]) => setting.commandConfig !== undefined)
+      .filter(([_, setting]) => !hiddenOnPlatform(setting, isDesktop()))
       .map(([settingName]) => `${categoryName}.${settingName}`)
   ) as SettingsPaths[]
 

--- a/src/lib/settings/settingsUtils.test.ts
+++ b/src/lib/settings/settingsUtils.test.ts
@@ -1,10 +1,11 @@
 import type { Configuration } from '@rust/kcl-lib/bindings/Configuration'
 import type { ProjectConfiguration } from '@rust/kcl-lib/bindings/ProjectConfiguration'
 
-import { createSettings } from '@src/lib/settings/initialSettings'
+import { createSettings, type Setting } from '@src/lib/settings/initialSettings'
 import {
   configurationToSettingsPayload,
   getAllCurrentSettings,
+  hiddenOnPlatform,
   projectConfigurationToSettingsPayload,
   setSettingsAtLevel,
 } from '@src/lib/settings/settingsUtils'
@@ -110,5 +111,31 @@ describe(`testing getAllCurrentSettings`, () => {
     // (see the test "doesn't read theme from project settings")
     expect(allCurrentSettings.app.theme).toBe('dark')
     expect(allCurrentSettings.modeling.defaultUnit).toBe('ft')
+  })
+})
+
+describe('testing hiddenOnPlatform', () => {
+  it('correctly identifies hidden settings on desktop', () => {
+    const setting1 = { hideOnPlatform: 'both' } as Setting<unknown>
+    const setting2 = { hideOnPlatform: 'desktop' } as Setting<unknown>
+    const setting3 = { hideOnPlatform: 'web' } as Setting<unknown>
+    const setting4 = { hideOnPlatform: undefined } as Setting<unknown>
+
+    expect(hiddenOnPlatform(setting1, true)).toBe(true)
+    expect(hiddenOnPlatform(setting2, true)).toBe(true)
+    expect(hiddenOnPlatform(setting3, true)).toBe(false)
+    expect(hiddenOnPlatform(setting4, true)).toBe(false)
+  })
+
+  it('correctly identifies hidden settings on web', () => {
+    const setting1 = { hideOnPlatform: 'both' } as Setting
+    const setting2 = { hideOnPlatform: 'desktop' } as Setting
+    const setting3 = { hideOnPlatform: 'web' } as Setting
+    const setting4 = { hideOnPlatform: undefined } as Setting
+
+    expect(hiddenOnPlatform(setting1, false)).toBe(true)
+    expect(hiddenOnPlatform(setting2, false)).toBe(false)
+    expect(hiddenOnPlatform(setting3, false)).toBe(true)
+    expect(hiddenOnPlatform(setting4, false)).toBe(false)
   })
 })

--- a/src/lib/settings/settingsUtils.ts
+++ b/src/lib/settings/settingsUtils.ts
@@ -713,3 +713,10 @@ export async function jsAppSettings(s: SettingsType | SettingsActorType) {
   const settings = 'send' in s ? getSettingsFromActorContext(s) : s
   return settingsPayloadToConfiguration(getAllCurrentSettings(settings))
 }
+
+export function hiddenOnPlatform(setting: Setting, desktop: boolean) {
+  return (
+    setting.hideOnPlatform === 'both' ||
+    setting.hideOnPlatform === (desktop ? 'desktop' : 'web')
+  )
+}


### PR DESCRIPTION
Closes #9406 

Tested on a local prod build:

<img width="1800" height="1129" alt="image" src="https://github.com/user-attachments/assets/4f290330-b993-4234-87d2-5926d94f6cb9" />

But the still present on the Vercel preview.