### PR TITLE
Update PRINCIPLES.md regarding WASM method use

### DIFF
--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -3,7 +3,7 @@ These are principles we try to follow as a team working on this product. Anyone 
 ## 0. Application architecture
 1. Use React as a thin view layer unless absolutely necessary, presenting state that is defined outside of React.
 
-2. Reduce the usage of the global `initPromise()` workflow of globally importing and initializing the WASM instance.
+2. Never directly import a method from the WASM module (although it is tempting!). Always pass in our WASM instance as a dependency instead. This anti-pattern was removed in #9415.
 
 3. Reduce the usage of circular dependencies in src/lib/singletons.ts.
 


### PR DESCRIPTION
Principle 2 used to advise us to "reduce usage of initPromise" but as of #9308 that's no longer an issue, since it isn't exported ✨.

Instead, I'd like to use the slot to remind us to never repeat the pattern of importing methods from the WASM wrapper module directly. We create an instance of that module at runtime, and manage its lifecycle, potentially reloading it if it breaks. But it is confusing, because it's "just another JS module" that can be imported from while developing. Before #9415 we had helper methods that would import the methods directly, and take an instance of the module only optionally if at all. This could lead to unknown behavior if WASM needs reloaded or more.