### PR TITLE
Add a button to reset WebSocket overrides to the default

### DIFF
--- a/src/components/environment/Environment.tsx
+++ b/src/components/environment/Environment.tsx
@@ -29,7 +29,7 @@ export function EnvironmentDescription() {
       <div
         className={`flex flex-col p-2 mb-2 rounded-t-sm bg-chalkboard-20 text-chalkboard-100 dark:bg-chalkboard-80 dark:text-chalkboard-10`}
       >
-        <p className="flex flex-row justify-between items-center">
+        <div className="flex flex-row justify-between items-center">
           <h2 className="text-sm font-sans font-normal">Environment</h2>
           <p
             data-testid="environment"
@@ -58,7 +58,7 @@ export function EnvironmentDescription() {
               {fullEnvironmentName}
             </ActionButton>
           </p>
-        </p>
+        </div>
       </div>
       <ul>
         <li className="flex flex-col px-2 py-2 gap-1 last:mb-0 ">

--- a/src/env.ts
+++ b/src/env.ts
@@ -27,7 +27,7 @@ let ENVIRONMENT: EnvironmentConfigurationRuntime | null = null
 /** Update the runtime environment */
 export const updateEnvironment = (environment: string | null) => {
   if (environment === '') {
-    console.log('reject updating environment: value is the empty string.')
+    console.log('reject updating environment: value is the empty string')
     return
   }
 
@@ -42,19 +42,13 @@ export const updateEnvironment = (environment: string | null) => {
       }
     }
   }
-  console.log('updating environment', environment)
+  console.log('updating environment:', environment)
 }
 
 export const updateEnvironmentKittycadWebSocketUrl = (
   environmentName: string,
   kittycadWebSocketUrl: string
 ) => {
-  if (environmentName === '') {
-    console.log(
-      'reject updating kittycadWebSocketUrl, environment: value is the empty string.'
-    )
-    return
-  }
   if (!ENVIRONMENT) return
   if (ENVIRONMENT.domain === environmentName) {
     ENVIRONMENT.kittycadWebSocketUrl = kittycadWebSocketUrl
@@ -65,12 +59,6 @@ export const updateEnvironmentMlephantWebSocketUrl = (
   environmentName: string,
   mlephantWebSocketUrl: string
 ) => {
-  if (environmentName === '') {
-    console.log(
-      'reject updating mlephantWebSocketUrl, environment: value is the empty string.'
-    )
-    return
-  }
   if (!ENVIRONMENT) return
   if (ENVIRONMENT.domain === environmentName) {
     ENVIRONMENT.mlephantWebSocketUrl = mlephantWebSocketUrl

--- a/src/lib/commandBarConfigs/applicationCommandConfig.ts
+++ b/src/lib/commandBarConfigs/applicationCommandConfig.ts
@@ -426,20 +426,23 @@ export function createApplicationCommands({
     name: 'override-engine',
     displayName: 'Override Engine',
     description: 'Connect the scene to a custom Engine WebSocket URL',
-    needsReview: false,
+
     icon: 'gear',
     groupId: 'application',
+    needsReview: true,
+    reviewValidation: async (context) => {
+      const url = context.argumentsToSubmit.url as string | undefined
+      if (url) {
+        try {
+          new URL(url)
+        } catch {
+          return new Error('Invalid Engine WebSocket URL')
+        }
+      }
+    },
     onSubmit: (data) => {
       if (!window.electron) {
         console.error(new Error('No file system present'))
-        return
-      }
-      if (!data?.url) {
-        return
-      }
-      try {
-        new URL(data.url)
-      } catch {
         return
       }
       const environmentName = env().VITE_ZOO_BASE_DOMAIN
@@ -447,10 +450,9 @@ export function createApplicationCommands({
         writeEnvironmentConfigurationKittycadWebSocketUrl(
           window.electron,
           environmentName,
-          data.url
+          data?.url ?? ''
         )
           .then(() => {
-            // Reload the application and it will trigger the correct sign in workflow for the new environment
             window.location.reload()
           })
           .catch(reportRejection)
@@ -458,13 +460,12 @@ export function createApplicationCommands({
     args: {
       url: {
         inputType: 'string',
-        required: true,
+        required: false,
         displayName: 'URL',
         description: `
           Replace **api.${env().VITE_ZOO_BASE_DOMAIN}** with **localhost:8080** for locally-running Engines.
           Alternatively, append **?pr=NUMBER** to connect to a deployed Pull Request.
           Finally, append **?pool=LABEL** for all other variants of deployed Engines.
-          Reset to the default value: **${env().VITE_KITTYCAD_WEBSOCKET_URL}**
         `.trim(),
         defaultValue: () => env().VITE_KITTYCAD_WEBSOCKET_URL ?? '',
       },
@@ -475,20 +476,22 @@ export function createApplicationCommands({
     name: 'override-zookeeper',
     displayName: 'Override Zookeeper',
     description: 'Connect to a custom Zookeeper WebSocket URL',
-    needsReview: false,
     icon: 'gear',
     groupId: 'application',
+    needsReview: true,
+    reviewValidation: async (context) => {
+      const url = context.argumentsToSubmit.url as string | undefined
+      if (url) {
+        try {
+          new URL(url)
+        } catch {
+          return new Error('Invalid Zookeeper WebSocket URL')
+        }
+      }
+    },
     onSubmit: (data) => {
       if (!window.electron) {
         console.error(new Error('No file system present'))
-        return
-      }
-      if (!data?.url) {
-        return
-      }
-      try {
-        new URL(data.url)
-      } catch {
         return
       }
       const environmentName = env().VITE_ZOO_BASE_DOMAIN
@@ -496,10 +499,9 @@ export function createApplicationCommands({
         writeEnvironmentConfigurationMlephantWebSocketUrl(
           window.electron,
           environmentName,
-          data.url
+          data?.url ?? ''
         )
           .then(() => {
-            // Reload the application and it will trigger the correct sign in workflow for the new environment
             window.location.reload()
           })
           .catch(reportRejection)
@@ -507,12 +509,11 @@ export function createApplicationCommands({
     args: {
       url: {
         inputType: 'string',
-        required: true,
+        required: false,
         displayName: 'URL',
         description: `
           Replace **api.${env().VITE_ZOO_BASE_DOMAIN}** with **localhost:8080** for locally-running Zookeeper.
           Alternatively, append **?pr=NUMBER** to connect to a deployed Pull Request.
-          Reset to the default value: **${env().VITE_MLEPHANT_WEBSOCKET_URL}**
         `.trim(),
         defaultValue: () => env().VITE_MLEPHANT_WEBSOCKET_URL ?? '',
       },


### PR DESCRIPTION
This extends https://github.com/KittyCAD/modeling-app/pull/9376 and https://github.com/KittyCAD/modeling-app/pull/9387 to leverage command review validation to reject invalid URLs and provide a button to reset back to the default:

<img width="587" height="158" alt="Screenshot 2025-12-19 at 3 00 24 PM" src="https://github.com/user-attachments/assets/e11b3891-6e2f-4a14-90ac-5a074f095c3a" /><br>

<img width="586" height="308" alt="Screenshot 2025-12-19 at 2 59 40 PM" src="https://github.com/user-attachments/assets/995598b4-87a6-4e30-af03-62196aa82941" />

---

Closes https://github.com/KittyCAD/modeling-app/issues/7524