### PR TITLE
Scroll to bottom of Zookeeper chat after submitting new message

### DIFF
--- a/src/components/MlEphantConversation.tsx
+++ b/src/components/MlEphantConversation.tsx
@@ -295,21 +295,29 @@ export const MlEphantConversation = (props: MlEphantConversationProps) => {
     props.onProcess(request, mode)
   }
 
+  // Scroll to bottom when:
+  // 1. A new message is added (exchanges length changes)
+  // 2. A prompt completes (hasPromptCompleted becomes true)
   useEffect(() => {
-    if (autoScroll === false) {
-      return
-    }
-    if (refScroll.current == null) {
-      return
-    }
-    if (!props.hasPromptCompleted) {
-      return
-    }
-    refScroll.current.scrollTo({
-      top: refScroll.current.scrollHeight,
-      behavior: 'smooth',
+    const exchangesLength = props.conversation?.exchanges.length ?? 0
+
+    if (autoScroll === false) return
+    if (refScroll.current === null) return
+    if (exchangesLength === 0 && !props.hasPromptCompleted) return
+
+    requestAnimationFrame(() => {
+      if (refScroll.current) {
+        refScroll.current.scrollTo({
+          top: refScroll.current.scrollHeight,
+          behavior: 'smooth',
+        })
+      }
     })
-  }, [props.hasPromptCompleted, autoScroll])
+  }, [
+    props.conversation?.exchanges.length,
+    props.hasPromptCompleted,
+    autoScroll,
+  ])
 
   const exchangeCards = props.conversation?.exchanges.flatMap(
     (exchange: Exchange, exchangeIndex: number, list) => {


### PR DESCRIPTION
This is an improvement based on the ML team's feedback [here](https://kittycadworkspace.slack.com/archives/C061R186RUZ/p1766183528851309):

> The chat UI doesn't autoscroll to show the latest user message upon submission. Noticeable when the vertical space is filled by a few messages.

To test this, open the Vercel preview then:

1. Using Zookeeper, request a simple part like a gear
2. Build up a chat history by changing color or adding teeth
3. Scroll halfway up the chat history
4. Submit another prompt
5. Observe Zookeeper scroll for new submissions and after responses show up