### PR TITLE
Track how long it takes before integration tests run

### DIFF
--- a/.github/ci-cd-scripts/track-step.sh
+++ b/.github/ci-cd-scripts/track-step.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ -z "${TAB_API_URL:-}" ] || [ -z "${TAB_API_KEY:-}" ]; then
+    echo "WARNING: TAB_API_URL and TAB_API_KEY must be set to analyze results"
+    exit 0
+fi
+
+project="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+suite="${CI_SUITE:-unit}"
+branch="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-}}"
+commit="${CI_COMMIT_SHA:-${GITHUB_SHA:-}}"
+step="${CI_STEP}"
+
+echo "Tracking step:"
+curl --silent --request POST \
+  --header "X-API-Key: ${TAB_API_KEY}" \
+  --form "project=${project}" \
+  --form "suite=${suite}" \
+  --form "branch=${branch}" \
+  --form "commit=${commit}" \
+  --form "step=${step}" \
+  --form "CI_COMMIT_SHA=${CI_COMMIT_SHA:-}" \
+  --form "CI_PR_NUMBER=${CI_PR_NUMBER:-}" \
+  --form "GITHUB_BASE_REF=${GITHUB_BASE_REF:-}" \
+  --form "GITHUB_EVENT_NAME=${GITHUB_EVENT_NAME:-}" \
+  --form "GITHUB_HEAD_REF=${GITHUB_HEAD_REF:-}" \
+  --form "GITHUB_REF_NAME=${GITHUB_REF_NAME:-}" \
+  --form "GITHUB_REF=${GITHUB_REF:-}" \
+  --form "GITHUB_RUN_ID=${GITHUB_RUN_ID:-}" \
+  --form "GITHUB_SHA=${GITHUB_SHA:-}" \
+  --form "GITHUB_WORKFLOW=${GITHUB_WORKFLOW:-}" \
+  --form "RUNNER_ARCH=${RUNNER_ARCH:-}" \
+  ${TAB_API_URL}/api/track
+echo

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -2,6 +2,9 @@ name: Build WASM
 
 on:
   workflow_call:
+    secrets:
+      TAB_API_KEY:
+        required: false
 
 permissions:
   contents: read
@@ -11,6 +14,16 @@ jobs:
     runs-on: namespace-profile-ubuntu-8-cores
     steps:
       - uses: actions/checkout@v6
+
+      - name: Track setup
+        run: .github/ci-cd-scripts/track-step.sh
+        env:
+          TAB_API_URL: ${{ vars.TAB_API_URL }}
+          TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
+          CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+          CI_PR_NUMBER: ${{ github.event.pull_request.number }}
+          CI_SUITE: integration
+          CI_STEP: setup
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -29,6 +29,8 @@ jobs:
 
   npm-build-wasm:
     uses: ./.github/workflows/build-wasm.yml
+    secrets:
+      TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
 
   npm-tsc:
     runs-on: namespace-profile-ubuntu-2-cores

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,6 +20,8 @@ permissions:
 jobs:
   npm-build-wasm:
     uses: ./.github/workflows/build-wasm.yml
+    secrets:
+      TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
 
   npm-test-unit:
     runs-on: namespace-profile-ubuntu-2-cores
@@ -83,6 +85,16 @@ jobs:
           mkdir rust/kcl-lib/bindings
           cp -r prepared-ts-rs-bindings/* rust/kcl-lib/bindings/
 
+      - name: Track start
+        run: .github/ci-cd-scripts/track-step.sh
+        env:
+          TAB_API_URL: ${{ vars.TAB_API_URL }}
+          TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
+          CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+          CI_PR_NUMBER: ${{ github.event.pull_request.number }}
+          CI_SUITE: integration
+          CI_STEP: start
+
       - name: npm run test:integration
         if: ${{ github.event_name != 'release' }}
         run: |-
@@ -95,3 +107,13 @@ jobs:
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
           CI_PR_NUMBER: ${{ github.event.pull_request.number }}
           CI_SUITE: integration
+
+      - name: Track teardown
+        run: .github/ci-cd-scripts/track-step.sh
+        env:
+          TAB_API_URL: ${{ vars.TAB_API_URL }}
+          TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
+          CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+          CI_PR_NUMBER: ${{ github.event.pull_request.number }}
+          CI_SUITE: integration
+          CI_STEP: teardown


### PR DESCRIPTION
This test suite seems to be the "long pole in the tent" in terms of the feedback cycle so it makes sense to measure this one first. I'll likely instrument some of the e2e suites next as those also have long build steps.

You can see the type of metrics this will be collecting in the admin: https://test-analysis-bot.corp.zoo.dev/admin/projects/run/?suite__name=integration


---


Relates to https://github.com/KittyCAD/test-analysis-bot/issues/211