### PR TITLE
Fix generation of documentation PRs

### DIFF
--- a/.github/workflows/generate-website-docs.yml
+++ b/.github/workflows/generate-website-docs.yml
@@ -71,7 +71,7 @@ jobs:
           gh pr create --title "Update KCL docs" \
               --body "Applies the latest changes from: ${{ github.server_url }}/${{ github.repository }} cc @KittyCAD/kcl" \
               --head "$NEW_BRANCH" \
-              --base main
+              --base main || echo "PR already exists, updated via force push"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
Closes https://github.com/KittyCAD/modeling-app/issues/8868 with some permission updates to the [GitHub App](https://github.com/organizations/KittyCAD/settings/apps/modeling-app-github-app) via @iterion.

Here's an example of what this generates: https://github.com/KittyCAD/documentation/pull/698