### PR TITLE
Bump private-gemm-x86 from 0.1.18 to 0.1.20

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3382,9 +3382,9 @@ dependencies = [
 
 [[package]]
 name = "private-gemm-x86"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8138b380908e85071bdd6b2841a38b0858ef09848b754a15219d0b9ca90928"
+checksum = "0af8c3e5087969c323f667ccb4b789fa0954f5aa650550e38e81cf9108be21b5"
 dependencies = [
  "defer",
  "interpol",


### PR DESCRIPTION
The version we were using has been yanked. It's a dependency of faer.

The crate maintainer seems to have [yanked all previous versions](https://crates.io/crates/private-gemm-x86/versions), which is uncommon.