### PR TITLE
[SOLVE]: Stop cursor jump in sketch mode

### DIFF
--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -1486,8 +1486,13 @@ export class KclManager extends EventTarget {
    */
   updateCodeEditor(code: string, clearHistory?: boolean): void {
     // If the code hasn't changed, skip the update to preserve cursor position
+    // However, if clearHistory is true, we still need to clear the history
     const currentCode = this.editorState.doc.toString()
     if (currentCode === code) {
+      if (clearHistory) {
+        // Code is the same but we need to clear history (e.g., opening a new file with same content)
+        clearCodeMirrorHistory(this)
+      }
       return
     }
 


### PR DESCRIPTION
Editing directly in the editor while in sketch solve mode, would have the cursor jump to the top of the file whenever the defered execution kicked in which is super annoying.

But you might notice that this fix is general, not specific to sketch solve mode, and that's just because I thought this was a better approach, but interested in @franknoirot thoughts.

Normal flow is:
User edits → deferredExecution → executeCode() → NO editor update

Sketch solve mode flow is a bit different:
User edits → deferredExecution → sends 'update sketch outcome' → 
updateSketchOutcome() → updateCodeEditor() → CURSOR JUMPS ❌

Sketch solve mode syncs the editor with Rust state, which triggers updateCodeEditor() and causes the cursor jump.

which is why is was happening, but like I said, it can be fixed generally.

Resolves #9282 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves editor update behavior to stop cursor/selection jumps during external updates (e.g., sketch sync).
> 
> - `updateCodeEditor` now no-ops when incoming `code` matches current doc; still supports `clearHistory`
> - Preserves current selection/cursor by mapping/clamping ranges when replacing the entire doc and applying via `selection: EditorSelection.create(...)`
> - Retains ability to clear CodeMirror history with `clearCodeMirrorHistory`, and controls history recording with `Transaction.addToHistory`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5e13b7d73bb7b75805378b7e26327c2534fae33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->