### PR TITLE
Chore: rename `deferExecution` to `deferredCallback`

### DIFF
--- a/src/editor/plugins/lsp/copilot/index.ts
+++ b/src/editor/plugins/lsp/copilot/index.ts
@@ -30,7 +30,7 @@ import {
   posToOffset,
 } from '@kittycad/codemirror-lsp-client'
 import { reportRejection } from '@src/lib/trap'
-import { deferExecution } from '@src/lib/utils'
+import { deferredCallback } from '@src/lib/utils'
 
 import type { CopilotAcceptCompletionParams } from '@rust/kcl-lib/bindings/CopilotAcceptCompletionParams'
 import type { CopilotCompletionResponse } from '@rust/kcl-lib/bindings/CopilotCompletionResponse'
@@ -198,7 +198,7 @@ export class CompletionRequester implements PluginValue {
 
   private queuedUids: string[] = []
 
-  private _deffererUserSelect = deferExecution(() => {
+  private _deffererUserSelect = deferredCallback(() => {
     this.rejectSuggestionCommand()
   }, changesDelay)
 

--- a/src/editor/plugins/lsp/kcl/index.ts
+++ b/src/editor/plugins/lsp/kcl/index.ts
@@ -16,7 +16,7 @@ import {
   editorCodeUpdateEvent,
   type KclManager,
 } from '@src/lang/KclManager'
-import { deferExecution } from '@src/lib/utils'
+import { deferredCallback } from '@src/lib/utils'
 import { jsAppSettings } from '@src/lib/settings/settingsUtils'
 
 import type { UpdateCanExecuteParams } from '@rust/kcl-lib/bindings/UpdateCanExecuteParams'
@@ -78,7 +78,7 @@ export class KclPlugin implements PluginValue {
   // document.
   private sendScheduledInput: number | null = null
 
-  private _deffererUserSelect = deferExecution((wasmInstance: ModuleType) => {
+  private _deffererUserSelect = deferredCallback((wasmInstance: ModuleType) => {
     if (this.viewUpdate === null) {
       return
     }

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -38,7 +38,7 @@ import type {
 import { jsAppSettings } from '@src/lib/settings/settingsUtils'
 
 import { err, reportRejection } from '@src/lib/trap'
-import { deferExecution } from '@src/lib/utils'
+import { deferredCallback } from '@src/lib/utils'
 import type { ConnectionManager } from '@src/network/connectionManager'
 
 import { EngineDebugger } from '@src/lib/debugger'
@@ -583,13 +583,13 @@ export class KclManager extends EventTarget {
       // TODO: we wanna remove this logic from xstate, it is racey
       // This defer is bullshit but playwright wants it
       // It was like this in engineConnection.ts already
-      deferExecution((_a?: null) => {
+      deferredCallback((_a?: null) => {
         this.engineCommandManager.modelingSend({
           type: 'Artifact graph populated',
         })
       }, 200)(null)
     } else {
-      deferExecution((_a?: null) => {
+      deferredCallback((_a?: null) => {
         this.engineCommandManager.modelingSend({
           type: 'Artifact graph emptied',
         })
@@ -597,7 +597,7 @@ export class KclManager extends EventTarget {
     }
 
     // Send the 'artifact graph initialized' event for modelingMachine, only once, when default planes are also initialized.
-    deferExecution((_a?: null) => {
+    deferredCallback((_a?: null) => {
       if (this.defaultPlanes) {
         this.engineCommandManager.modelingSend({
           type: 'Artifact graph initialized',

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -169,7 +169,7 @@ export function throttle<T>(
 }
 
 // takes a function and executes it after the wait time, if the function is called again before the wait time is up, the timer is reset
-export function deferExecution<T>(func: (args: T) => any, wait: number) {
+export function deferredCallback<T>(func: (args: T) => any, wait: number) {
   let timeout: ReturnType<typeof setTimeout> | null
   let latestArgs: T
 

--- a/src/machines/sketchSolve/sketchSolveImpl.ts
+++ b/src/machines/sketchSolve/sketchSolveImpl.ts
@@ -28,7 +28,7 @@ import { machine as pointTool } from '@src/machines/sketchSolve/tools/pointTool'
 import { machine as lineTool } from '@src/machines/sketchSolve/tools/lineToolDiagram'
 import { machine as centerArcTool } from '@src/machines/sketchSolve/tools/centerArcToolDiagram'
 import { orthoScale, perspScale } from '@src/clientSideScene/helpers'
-import { deferExecution } from '@src/lib/utils'
+import { deferredCallback } from '@src/lib/utils'
 import {
   SKETCH_LAYER,
   SKETCH_SOLVE_GROUP,
@@ -687,7 +687,7 @@ export function initializeInitialSceneGraph({
 // This allows us to cancel editor updates if a double-click is detected
 // The debounce delay is short (100ms) to minimize perceived lag while still allowing cancellation
 // We store the latest kclManager reference so the debounced function can access it
-const debouncedEditorUpdate = deferExecution(
+const debouncedEditorUpdate = deferredCallback(
   ({ text, kclManager }: { text: string; kclManager: KclManager }) =>
     kclManager.updateCodeEditor(text),
   200


### PR DESCRIPTION
"Execution" refers to something rather specific in our domain; executing KCL code usually. This utility simply debounces a function callback though.

Broken out from https://github.com/KittyCAD/modeling-app/pull/9516 because it's just diff noise and I'm sick of reverting this as part of that.