### PR TITLE
Fix sketch mode exec to always use previous memory

### DIFF
--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -1301,10 +1301,10 @@ impl FrontendState {
 
         // Execute.
         let mock_config = MockConfig {
-            use_prev_memory: !is_delete,
             freedom_analysis: is_delete,
             #[cfg(feature = "artifact-graph")]
             segment_ids_edited,
+            ..Default::default()
         };
         let outcome = ctx.run_mock(&truncated_program, &mock_config).await.map_err(|err| {
             // TODO: sketch-api: Yeah, this needs to change. We need to


### PR DESCRIPTION
The only reason we didn't use previous memory during a deletion was because of a misunderstanding. We should always use previous memory. This isn't super important right now, but it will be critical for partial execution #9434.

The TypeScript code uses `usePrevMemory: false` when deleting a segment to check for dependencies. We're not trying to do that here.