### PR TITLE
Switch to explicit target tags in Playwrights tests

### DIFF
--- a/.github/ci-cd-scripts/playwright-electron.sh
+++ b/.github/ci-cd-scripts/playwright-electron.sh
@@ -9,9 +9,9 @@ if [[ ! -f "test-results/.last-run.json" ]]; then
     if [[ "$3" == *ubuntu* ]]; then
         xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test:e2e:desktop -- --shard=$1/$2 || true
     elif [[ "$3" == *windows* ]]; then
-        npm run test:e2e:desktop -- --grep=@windows --shard=$1/$2 || true
+        npm run test:e2e:desktop -- --grep=@windows --grep-invert=@web --shard=$1/$2 || true
     elif [[ "$3" == *macos* ]]; then
-        npm run test:e2e:desktop -- --grep=@macos --shard=$1/$2 || true
+        npm run test:e2e:desktop -- --grep=@macos --grep-invert=@web --shard=$1/$2 || true
     else
         echo "Do not run Playwright. Unable to detect os runtime."
         exit 1
@@ -33,9 +33,9 @@ while [[ $retry -le $max_retries ]]; do
             if [[ "$3" == *ubuntu* ]]; then
                 xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test:e2e:desktop -- --last-failed || true
             elif [[ "$3" == *windows* ]]; then
-                npm run test:e2e:desktop -- --grep=@windows --last-failed || true
+                npm run test:e2e:desktop -- --grep=@windows --grep-invert=@web --last-failed || true
             elif [[ "$3" == *macos* ]]; then
-                npm run test:e2e:desktop -- --grep=@macos --last-failed || true
+                npm run test:e2e:desktop -- --grep=@macos --grep-invert=@web --last-failed || true
             else
                 echo "Do not run playwright. Unable to detect os runtime."
                 exit 1

--- a/e2e/playwright/app-header-tests.spec.ts
+++ b/e2e/playwright/app-header-tests.spec.ts
@@ -2,49 +2,46 @@ import { join } from 'path'
 import { expect, test } from '@e2e/playwright/zoo-test'
 import * as fsp from 'fs/promises'
 
-test.describe('Electron app header tests', () => {
-  test(
-    'Open Command Palette button has correct shortcut',
-    { tag: '@desktop' },
-    async ({ page }, testInfo) => {
-      await page.setBodyDimensions({ width: 1200, height: 500 })
+test.describe('Electron app header tests', { tag: '@desktop' }, () => {
+  test('Open Command Palette button has correct shortcut', async ({
+    page,
+  }, testInfo) => {
+    await page.setBodyDimensions({ width: 1200, height: 500 })
 
-      // No space before the shortcut since it checks textContent.
-      let text
-      switch (process.platform) {
-        case 'darwin':
-          text = 'Commands⌘K'
-          break
-        case 'win32':
-          text = 'CommandsCtrl+K'
-          break
-        default: // 'linux' etc.
-          text = 'CommandsCtrl+K'
-          break
-      }
-      const commandsButton = page.getByRole('button', { name: 'Commands' })
-      await expect(commandsButton).toBeVisible()
-      await expect(commandsButton).toHaveText(text)
+    // No space before the shortcut since it checks textContent.
+    let text
+    switch (process.platform) {
+      case 'darwin':
+        text = 'Commands⌘K'
+        break
+      case 'win32':
+        text = 'CommandsCtrl+K'
+        break
+      default: // 'linux' etc.
+        text = 'CommandsCtrl+K'
+        break
     }
-  )
+    const commandsButton = page.getByRole('button', { name: 'Commands' })
+    await expect(commandsButton).toBeVisible()
+    await expect(commandsButton).toHaveText(text)
+  })
 
-  test(
-    'User settings has correct shortcut',
-    { tag: '@desktop' },
-    async ({ page, toolbar }, testInfo) => {
-      await page.setBodyDimensions({ width: 1200, height: 500 })
+  test('User settings has correct shortcut', async ({
+    page,
+    toolbar,
+  }, testInfo) => {
+    await page.setBodyDimensions({ width: 1200, height: 500 })
 
-      // Open the user sidebar menu.
-      await toolbar.userSidebarButton.click()
+    // Open the user sidebar menu.
+    await toolbar.userSidebarButton.click()
 
-      // No space after "User settings" since it's textContent.
-      const text =
-        process.platform === 'darwin' ? 'User settings⌘,' : 'User settingsCtrl,'
-      const userSettingsButton = page.getByTestId('user-settings')
-      await expect(userSettingsButton).toBeVisible()
-      await expect(userSettingsButton).toHaveText(text)
-    }
-  )
+    // No space after "User settings" since it's textContent.
+    const text =
+      process.platform === 'darwin' ? 'User settings⌘,' : 'User settingsCtrl,'
+    const userSettingsButton = page.getByTestId('user-settings')
+    await expect(userSettingsButton).toBeVisible()
+    await expect(userSettingsButton).toHaveText(text)
+  })
 
   test('Share button is disabled when imports are present', async ({
     page,

--- a/e2e/playwright/auth.spec.ts
+++ b/e2e/playwright/auth.spec.ts
@@ -1,57 +1,59 @@
 import { expect, test } from '@e2e/playwright/zoo-test'
 
-test.describe('Authentication tests', () => {
-  test(
-    `The user can sign out and back in`,
-    { tag: ['@desktop'] },
-    async ({ page, homePage, signInPage, toolbar, tronApp }) => {
-      if (!tronApp) throw new Error('tronApp is missing.')
+test.describe('Authentication tests', { tag: '@desktop' }, () => {
+  test(`The user can sign out and back in`, async ({
+    page,
+    homePage,
+    signInPage,
+    toolbar,
+    tronApp,
+  }) => {
+    if (!tronApp) throw new Error('tronApp is missing.')
 
-      await page.setBodyDimensions({ width: 1000, height: 500 })
-      await homePage.projectSection.waitFor()
+    await page.setBodyDimensions({ width: 1000, height: 500 })
+    await homePage.projectSection.waitFor()
 
-      await test.step('Click on sign out and expect sign in page', async () => {
-        await toolbar.userSidebarButton.click()
-        await toolbar.signOutButton.click()
-        await expect(signInPage.signInButton).toBeVisible()
-      })
+    await test.step('Click on sign out and expect sign in page', async () => {
+      await toolbar.userSidebarButton.click()
+      await toolbar.signOutButton.click()
+      await expect(signInPage.signInButton).toBeVisible()
+    })
 
-      await test.step('Click on sign in and cancel, click again and expect different code', async () => {
-        await signInPage.signInButton.click()
-        await expect(signInPage.userCode).toBeVisible()
-        const firstUserCode = await signInPage.userCode.textContent()
-        await signInPage.cancelSignInButton.click()
-        await expect(signInPage.signInButton).toBeVisible()
+    await test.step('Click on sign in and cancel, click again and expect different code', async () => {
+      await signInPage.signInButton.click()
+      await expect(signInPage.userCode).toBeVisible()
+      const firstUserCode = await signInPage.userCode.textContent()
+      await signInPage.cancelSignInButton.click()
+      await expect(signInPage.signInButton).toBeVisible()
 
-        await signInPage.signInButton.click()
-        await expect(signInPage.userCode).toBeVisible()
-        const secondUserCode = await signInPage.userCode.textContent()
-        expect(secondUserCode).not.toEqual(firstUserCode)
-        await signInPage.cancelSignInButton.click()
-      })
+      await signInPage.signInButton.click()
+      await expect(signInPage.userCode).toBeVisible()
+      const secondUserCode = await signInPage.userCode.textContent()
+      expect(secondUserCode).not.toEqual(firstUserCode)
+      await signInPage.cancelSignInButton.click()
+    })
 
-      await test.step('Press back button and remain on home page', async () => {
-        await page.goBack()
-        await expect(homePage.projectSection).not.toBeVisible()
-        await expect(signInPage.signInButton).toBeVisible()
-      })
+    await test.step('Press back button and remain on home page', async () => {
+      await page.goBack()
+      await expect(homePage.projectSection).not.toBeVisible()
+      await expect(signInPage.signInButton).toBeVisible()
+    })
 
-      await test.step('Sign in, activate, and expect home page', async () => {
-        await signInPage.signInButton.click()
-        await expect(signInPage.userCode).toBeVisible()
-        const userCode = await signInPage.userCode.textContent()
-        expect(userCode).not.toBeNull()
-        await signInPage.verifyAndConfirmAuth(userCode!)
+    await test.step('Sign in, activate, and expect home page', async () => {
+      await signInPage.signInButton.click()
+      await expect(signInPage.userCode).toBeVisible()
+      const userCode = await signInPage.userCode.textContent()
+      expect(userCode).not.toBeNull()
+      await signInPage.verifyAndConfirmAuth(userCode!)
 
-        // Longer timeout than usual here for the wait on home page
-        await expect(homePage.projectSection).toBeVisible({ timeout: 10000 })
-      })
+      // Longer timeout than usual here for the wait on home page
+      await expect(homePage.projectSection).toBeVisible({ timeout: 10000 })
+    })
 
-      await test.step('Click on sign out and expect sign in page', async () => {
-        await toolbar.userSidebarButton.click()
-        await toolbar.signOutButton.click()
-        await expect(signInPage.signInButton).toBeVisible()
-      })
-    }
-  )
+    await test.step('Click on sign out and expect sign in page', async () => {
+      await toolbar.userSidebarButton.click()
+      await toolbar.signOutButton.click()
+      await expect(signInPage.signInButton).toBeVisible()
+    })
+  })
 })

--- a/e2e/playwright/benchmark/hot-path.spec.ts
+++ b/e2e/playwright/benchmark/hot-path.spec.ts
@@ -7,7 +7,7 @@ import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
  * mechanical engineers. See .github/CODEOWNERS for more details.
  */
 
-test.describe('Hot path', () => {
+test.describe('Hot path', { tag: '@desktop' }, () => {
   test(`Draw a circle and extrude it`, async ({
     page,
     homePage,
@@ -26,7 +26,9 @@ test.describe('Hot path', () => {
     await toolbar.openPane(DefaultLayoutPaneID.Code)
 
     // Mouse helpers
-    const [clickCenter] = scene.makeMouseHelpers(0.5, 0.5, { format: 'ratio' })
+    const [clickCenter] = scene.makeMouseHelpers(0.5, 0.5, {
+      format: 'ratio',
+    })
     const [clickABitOffCenter] = scene.makeMouseHelpers(0.55, 0.45, {
       format: 'ratio',
     })

--- a/e2e/playwright/boolean.spec.ts
+++ b/e2e/playwright/boolean.spec.ts
@@ -4,137 +4,141 @@ import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 
 import { expect, test } from '@e2e/playwright/zoo-test'
 
-test.describe('Point and click for boolean workflows', () => {
-  // Boolean operations to test
-  const booleanOperations = [
-    {
-      name: 'union',
-      code: 'union([extrude001, extrude006])',
-    },
-    {
-      name: 'subtract',
-      code: 'subtract(extrude001, tools = extrude006)',
-    },
-    {
-      name: 'intersect',
-      code: 'intersect([extrude001, extrude006])',
-    },
-  ] as const
-  for (let i = 0; i < booleanOperations.length; i++) {
-    const operation = booleanOperations[i]
-    const operationName = operation.name
-    const commandName = `Boolean ${
-      operationName.charAt(0).toUpperCase() + operationName.slice(1)
-    }`
-    test(`Create boolean operation -- ${operationName}`, async ({
-      context,
-      homePage,
-      cmdBar,
-      editor,
-      toolbar,
-      scene,
-      page,
-    }) => {
-      const file = await fs.readFile(
-        path.resolve(
-          __dirname,
-          '../../',
-          './rust/kcl-lib/e2e/executor/inputs/boolean-setup-with-sketch-on-faces.kcl'
-        ),
-        'utf-8'
-      )
-      await context.addInitScript((file) => {
-        localStorage.setItem('persistCode', file)
-      }, file)
-      await homePage.goToModelingScene()
-      await scene.settled(cmdBar)
-      await toolbar.closePane(DefaultLayoutPaneID.Code)
+test.describe(
+  'Point and click for boolean workflows',
+  { tag: '@desktop' },
+  () => {
+    // Boolean operations to test
+    const booleanOperations = [
+      {
+        name: 'union',
+        code: 'union([extrude001, extrude006])',
+      },
+      {
+        name: 'subtract',
+        code: 'subtract(extrude001, tools = extrude006)',
+      },
+      {
+        name: 'intersect',
+        code: 'intersect([extrude001, extrude006])',
+      },
+    ] as const
+    for (let i = 0; i < booleanOperations.length; i++) {
+      const operation = booleanOperations[i]
+      const operationName = operation.name
+      const commandName = `Boolean ${
+        operationName.charAt(0).toUpperCase() + operationName.slice(1)
+      }`
+      test(`Create boolean operation -- ${operationName}`, async ({
+        context,
+        homePage,
+        cmdBar,
+        editor,
+        toolbar,
+        scene,
+        page,
+      }) => {
+        const file = await fs.readFile(
+          path.resolve(
+            __dirname,
+            '../../',
+            './rust/kcl-lib/e2e/executor/inputs/boolean-setup-with-sketch-on-faces.kcl'
+          ),
+          'utf-8'
+        )
+        await context.addInitScript((file) => {
+          localStorage.setItem('persistCode', file)
+        }, file)
+        await homePage.goToModelingScene()
+        await scene.settled(cmdBar)
+        await toolbar.closePane(DefaultLayoutPaneID.Code)
 
-      // Test coordinates for selection - these might need adjustment based on actual scene layout
-      const cylinderPoint = { x: 592, y: 174 }
-      const secondObjectPoint = { x: 683, y: 273 }
+        // Test coordinates for selection - these might need adjustment based on actual scene layout
+        const cylinderPoint = { x: 592, y: 174 }
+        const secondObjectPoint = { x: 683, y: 273 }
 
-      // Create mouse helpers for selecting objects
-      const [clickFirstObject] = scene.makeMouseHelpers(
-        cylinderPoint.x,
-        cylinderPoint.y,
-        { steps: 10 }
-      )
-      const [clickSecondObject] = scene.makeMouseHelpers(
-        secondObjectPoint.x,
-        secondObjectPoint.y,
-        { steps: 10 }
-      )
-
-      await test.step(`Test ${operationName} operation`, async () => {
-        // Click the boolean operation button in the toolbar
-        await toolbar.selectBoolean(operationName)
-
-        // Verify command bar is showing the right command
-        await expect(cmdBar.page.getByTestId('command-name')).toContainText(
-          commandName
+        // Create mouse helpers for selecting objects
+        const [clickFirstObject] = scene.makeMouseHelpers(
+          cylinderPoint.x,
+          cylinderPoint.y,
+          { steps: 10 }
+        )
+        const [clickSecondObject] = scene.makeMouseHelpers(
+          secondObjectPoint.x,
+          secondObjectPoint.y,
+          { steps: 10 }
         )
 
-        // Select first object in the scene, expect there to be a pixel diff from the selection color change
-        await clickFirstObject({ pixelDiff: 50 })
-        await page.waitForTimeout(1000)
+        await test.step(`Test ${operationName} operation`, async () => {
+          // Click the boolean operation button in the toolbar
+          await toolbar.selectBoolean(operationName)
 
-        // For subtract, we need to proceed to the next step before selecting the second object
-        if (operationName !== 'subtract') {
-          // should down shift key to select multiple objects
-          await page.keyboard.down('Shift')
-        } else {
+          // Verify command bar is showing the right command
+          await expect(cmdBar.page.getByTestId('command-name')).toContainText(
+            commandName
+          )
+
+          // Select first object in the scene, expect there to be a pixel diff from the selection color change
+          await clickFirstObject({ pixelDiff: 50 })
+          await page.waitForTimeout(1000)
+
+          // For subtract, we need to proceed to the next step before selecting the second object
+          if (operationName !== 'subtract') {
+            // should down shift key to select multiple objects
+            await page.keyboard.down('Shift')
+          } else {
+            await cmdBar.progressCmdBar()
+          }
+
+          // Select second object
+          await clickSecondObject({ pixelDiff: 50 })
+
+          await page.waitForTimeout(1000)
+
+          // Confirm the operation in the command bar
           await cmdBar.progressCmdBar()
-        }
 
-        // Select second object
-        await clickSecondObject({ pixelDiff: 50 })
+          if (operationName === 'union' || operationName === 'intersect') {
+            await cmdBar.expectState({
+              stage: 'review',
+              headerArguments: {
+                Solids: '2 paths',
+              },
+              commandName,
+            })
+          } else if (operationName === 'subtract') {
+            await cmdBar.expectState({
+              stage: 'review',
+              headerArguments: {
+                Solids: '1 path',
+                Tools: '1 path',
+              },
+              commandName,
+            })
+          }
 
-        await page.waitForTimeout(1000)
+          await cmdBar.submit()
+          await scene.settled(cmdBar)
+          await editor.openPane()
+          await editor.scrollToText(operation.code)
+          await editor.expectEditor.toContain(operation.code)
+        })
 
-        // Confirm the operation in the command bar
-        await cmdBar.progressCmdBar()
+        await test.step(`Delete ${operationName} operation via feature tree selection`, async () => {
+          await toolbar.openPane(DefaultLayoutPaneID.FeatureTree)
+          const op = await toolbar.getFeatureTreeOperation('solid001', 0)
+          await op.click({ button: 'right' })
+          await page.getByTestId('context-menu-delete').click()
+          await scene.settled(cmdBar)
+          await toolbar.closePane(DefaultLayoutPaneID.FeatureTree)
 
-        if (operationName === 'union' || operationName === 'intersect') {
-          await cmdBar.expectState({
-            stage: 'review',
-            headerArguments: {
-              Solids: '2 paths',
-            },
-            commandName,
-          })
-        } else if (operationName === 'subtract') {
-          await cmdBar.expectState({
-            stage: 'review',
-            headerArguments: {
-              Solids: '1 path',
-              Tools: '1 path',
-            },
-            commandName,
-          })
-        }
-
-        await cmdBar.submit()
-        await scene.settled(cmdBar)
-        await editor.openPane()
-        await editor.scrollToText(operation.code)
-        await editor.expectEditor.toContain(operation.code)
+          // Expect changes in ft and code
+          await editor.expectEditor.not.toContain(operation.code)
+          await expect(
+            await toolbar.getFeatureTreeOperation(operationName, 0)
+          ).not.toBeVisible()
+        })
       })
-
-      await test.step(`Delete ${operationName} operation via feature tree selection`, async () => {
-        await toolbar.openPane(DefaultLayoutPaneID.FeatureTree)
-        const op = await toolbar.getFeatureTreeOperation('solid001', 0)
-        await op.click({ button: 'right' })
-        await page.getByTestId('context-menu-delete').click()
-        await scene.settled(cmdBar)
-        await toolbar.closePane(DefaultLayoutPaneID.FeatureTree)
-
-        // Expect changes in ft and code
-        await editor.expectEditor.not.toContain(operation.code)
-        await expect(
-          await toolbar.getFeatureTreeOperation(operationName, 0)
-        ).not.toBeVisible()
-      })
-    })
+    }
   }
-})
+)

--- a/e2e/playwright/can-create-sketches-on-all-planes-and-their-back-sides.spec.ts
+++ b/e2e/playwright/can-create-sketches-on-all-planes-and-their-back-sides.spec.ts
@@ -9,267 +9,275 @@ import type { ToolbarFixture } from '@e2e/playwright/fixtures/toolbarFixture'
 import { getUtils } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 
-test.describe('Can create sketches on all planes and their back sides', () => {
-  const sketchOnPlaneAndBackSideTest = async (
-    page: Page,
-    homePage: HomePageFixture,
-    scene: SceneFixture,
-    toolbar: ToolbarFixture,
-    editor: EditorFixture,
-    plane: string,
-    clickCoords: { x: number; y: number }
-  ) => {
-    const u = await getUtils(page)
-    // await page.addInitScript(() => {
-    //   localStorage.setItem('persistCode', '@settings(defaultLengthUnit = in)')
-    // })
-    await page.setBodyDimensions({ width: 1200, height: 500 })
+test.describe(
+  'Can create sketches on all planes and their back sides',
+  { tag: '@desktop' },
+  () => {
+    const sketchOnPlaneAndBackSideTest = async (
+      page: Page,
+      homePage: HomePageFixture,
+      scene: SceneFixture,
+      toolbar: ToolbarFixture,
+      editor: EditorFixture,
+      plane: string,
+      clickCoords: { x: number; y: number }
+    ) => {
+      const u = await getUtils(page)
+      // await page.addInitScript(() => {
+      //   localStorage.setItem('persistCode', '@settings(defaultLengthUnit = in)')
+      // })
+      await page.setBodyDimensions({ width: 1200, height: 500 })
 
-    await homePage.goToModelingScene()
-    // await scene.settled(cmdBar)
-    const XYPlaneRed: [number, number, number] = [46, 36, 34]
-    await scene.expectPixelColor(XYPlaneRed, { x: 700, y: 300 }, 15)
+      await homePage.goToModelingScene()
+      // await scene.settled(cmdBar)
+      const XYPlaneRed: [number, number, number] = [46, 36, 34]
+      await scene.expectPixelColor(XYPlaneRed, { x: 700, y: 300 }, 15)
 
-    await u.openDebugPanel()
-
-    const coord =
-      plane === '-XY' || plane === '-YZ' || plane === 'XZ' ? -100 : 100
-    const camCommand: EngineCommand = {
-      type: 'modeling_cmd_req',
-      cmd_id: uuidv4(),
-      cmd: {
-        type: 'default_camera_look_at',
-        center: { x: 0, y: 0, z: 0 },
-        vantage: { x: coord, y: coord, z: coord },
-        up: { x: 0, y: 0, z: 1 },
-      },
-    }
-    const updateCamCommand: EngineCommand = {
-      type: 'modeling_cmd_req',
-      cmd_id: uuidv4(),
-      cmd: {
-        type: 'default_camera_get_settings',
-      },
-    }
-
-    const code = `@settings(defaultLengthUnit = in)sketch001 = startSketchOn(${plane})profile001 = startProfile(sketch001, at = [`
-
-    await test.step(`Sketch on the ${plane} plane using custom camera commands to orient`, async () => {
       await u.openDebugPanel()
-      await u.clearCommandLogs()
-      await toolbar.startSketchBtn.click()
 
-      await u.sendCustomCmd(camCommand)
-      await page.waitForTimeout(100)
-      await u.sendCustomCmd(updateCamCommand)
+      const coord =
+        plane === '-XY' || plane === '-YZ' || plane === 'XZ' ? -100 : 100
+      const camCommand: EngineCommand = {
+        type: 'modeling_cmd_req',
+        cmd_id: uuidv4(),
+        cmd: {
+          type: 'default_camera_look_at',
+          center: { x: 0, y: 0, z: 0 },
+          vantage: { x: coord, y: coord, z: coord },
+          up: { x: 0, y: 0, z: 1 },
+        },
+      }
+      const updateCamCommand: EngineCommand = {
+        type: 'modeling_cmd_req',
+        cmd_id: uuidv4(),
+        cmd: {
+          type: 'default_camera_get_settings',
+        },
+      }
 
-      await u.closeDebugPanel()
+      const code = `@settings(defaultLengthUnit = in)sketch001 = startSketchOn(${plane})profile001 = startProfile(sketch001, at = [`
 
-      const resolvedCoords = await scene.convertPagePositionToStream(
-        clickCoords.x,
-        clickCoords.y
-      )
-      await page.mouse.click(resolvedCoords.x, resolvedCoords.y)
-      await page.waitForTimeout(600) // wait for animation
+      await test.step(`Sketch on the ${plane} plane using custom camera commands to orient`, async () => {
+        await u.openDebugPanel()
+        await u.clearCommandLogs()
+        await toolbar.startSketchBtn.click()
 
-      await toolbar.waitUntilSketchingReady()
+        await u.sendCustomCmd(camCommand)
+        await page.waitForTimeout(100)
+        await u.sendCustomCmd(updateCamCommand)
 
-      await u.closeDebugPanel()
-      await expect(toolbar.lineBtn).toHaveAttribute('aria-pressed', 'true')
-    })
+        await u.closeDebugPanel()
 
-    const lineCoords = await scene.convertPagePositionToStream(707, 393)
-    await page.mouse.click(lineCoords.x, lineCoords.y)
+        const resolvedCoords = await scene.convertPagePositionToStream(
+          clickCoords.x,
+          clickCoords.y
+        )
+        await page.mouse.click(resolvedCoords.x, resolvedCoords.y)
+        await page.waitForTimeout(600) // wait for animation
 
-    await editor.expectEditor.toContain(code)
+        await toolbar.waitUntilSketchingReady()
+
+        await u.closeDebugPanel()
+        await expect(toolbar.lineBtn).toHaveAttribute('aria-pressed', 'true')
+      })
+
+      const lineCoords = await scene.convertPagePositionToStream(707, 393)
+      await page.mouse.click(lineCoords.x, lineCoords.y)
+
+      await editor.expectEditor.toContain(code)
+    }
+
+    const planeConfigs = [
+      {
+        plane: 'XY',
+        coords: { x: 600, y: 388 },
+        description: 'red plane',
+      },
+      {
+        plane: 'YZ',
+        coords: { x: 700, y: 250 },
+        description: 'green plane',
+      },
+      {
+        plane: 'XZ',
+        coords: { x: 684, y: 427 },
+        description: 'blue plane',
+      },
+      {
+        plane: '-XY',
+        coords: { x: 600, y: 118 },
+        description: 'back of red plane',
+      },
+      {
+        plane: '-YZ',
+        coords: { x: 700, y: 219 },
+        description: 'back of green plane',
+      },
+      {
+        plane: '-XZ',
+        coords: { x: 560, y: 150 },
+        description: 'back of blue plane',
+      },
+    ]
+
+    for (const config of planeConfigs) {
+      test(config.plane, async ({ page, homePage, scene, toolbar, editor }) => {
+        await sketchOnPlaneAndBackSideTest(
+          page,
+          homePage,
+          scene,
+          toolbar,
+          editor,
+          config.plane,
+          config.coords
+        )
+      })
+    }
   }
-
-  const planeConfigs = [
-    {
-      plane: 'XY',
-      coords: { x: 600, y: 388 },
-      description: 'red plane',
-    },
-    {
-      plane: 'YZ',
-      coords: { x: 700, y: 250 },
-      description: 'green plane',
-    },
-    {
-      plane: 'XZ',
-      coords: { x: 684, y: 427 },
-      description: 'blue plane',
-    },
-    {
-      plane: '-XY',
-      coords: { x: 600, y: 118 },
-      description: 'back of red plane',
-    },
-    {
-      plane: '-YZ',
-      coords: { x: 700, y: 219 },
-      description: 'back of green plane',
-    },
-    {
-      plane: '-XZ',
-      coords: { x: 560, y: 150 },
-      description: 'back of blue plane',
-    },
-  ]
-
-  for (const config of planeConfigs) {
-    test(config.plane, async ({ page, homePage, scene, toolbar, editor }) => {
-      await sketchOnPlaneAndBackSideTest(
-        page,
-        homePage,
-        scene,
-        toolbar,
-        editor,
-        config.plane,
-        config.coords
-      )
-    })
-  }
-})
-test.describe('Can create sketches on offset planes and their back sides', () => {
-  const sketchOnPlaneAndBackSideTest = async (
-    page: Page,
-    homePage: HomePageFixture,
-    scene: SceneFixture,
-    toolbar: ToolbarFixture,
-    editor: EditorFixture,
-    plane: string,
-    clickCoords: { x: number; y: number }
-  ) => {
-    const u = await getUtils(page)
-    await page.addInitScript(() => {
-      localStorage.setItem(
-        'persistCode',
-        `@settings(defaultLengthUnit = in)
+)
+test.describe(
+  'Can create sketches on offset planes and their back sides',
+  { tag: '@desktop' },
+  () => {
+    const sketchOnPlaneAndBackSideTest = async (
+      page: Page,
+      homePage: HomePageFixture,
+      scene: SceneFixture,
+      toolbar: ToolbarFixture,
+      editor: EditorFixture,
+      plane: string,
+      clickCoords: { x: number; y: number }
+    ) => {
+      const u = await getUtils(page)
+      await page.addInitScript(() => {
+        localStorage.setItem(
+          'persistCode',
+          `@settings(defaultLengthUnit = in)
 xyPlane = offsetPlane(XY, offset = 0.05)
 xzPlane = offsetPlane(XZ, offset = 0.05)
 yzPlane = offsetPlane(YZ, offset = 0.05)
 `
-      )
-    })
-    await page.setBodyDimensions({ width: 1200, height: 500 })
-    await homePage.goToModelingScene()
-    await u.openDebugPanel()
-
-    const coord =
-      plane === '-XY' || plane === '-YZ' || plane === 'XZ' ? -100 : 100
-    const camCommand: EngineCommand = {
-      type: 'modeling_cmd_req',
-      cmd_id: uuidv4(),
-      cmd: {
-        type: 'default_camera_look_at',
-        center: { x: 0, y: 0, z: 0 },
-        vantage: { x: coord, y: coord, z: coord },
-        up: { x: 0, y: 0, z: 1 },
-      },
-    }
-    const updateCamCommand: EngineCommand = {
-      type: 'modeling_cmd_req',
-      cmd_id: uuidv4(),
-      cmd: {
-        type: 'default_camera_get_settings',
-      },
-    }
-
-    const prefix = plane.length === 3 ? '-' : ''
-    const planeName = plane
-      .slice(plane.length === 3 ? 1 : 0)
-      .toLocaleLowerCase()
-
-    const codeLine1 = `sketch001 = startSketchOn(${prefix}${planeName}Plane)`
-    const codeLine2 = 'profile001 = startProfile(sketch001, at = ['
-
-    await test.step(`Sketch on the ${plane} plane using custom camera commands to orient`, async () => {
+        )
+      })
+      await page.setBodyDimensions({ width: 1200, height: 500 })
+      await homePage.goToModelingScene()
       await u.openDebugPanel()
 
-      await u.clearCommandLogs()
-      await toolbar.startSketchBtn.click()
+      const coord =
+        plane === '-XY' || plane === '-YZ' || plane === 'XZ' ? -100 : 100
+      const camCommand: EngineCommand = {
+        type: 'modeling_cmd_req',
+        cmd_id: uuidv4(),
+        cmd: {
+          type: 'default_camera_look_at',
+          center: { x: 0, y: 0, z: 0 },
+          vantage: { x: coord, y: coord, z: coord },
+          up: { x: 0, y: 0, z: 1 },
+        },
+      }
+      const updateCamCommand: EngineCommand = {
+        type: 'modeling_cmd_req',
+        cmd_id: uuidv4(),
+        cmd: {
+          type: 'default_camera_get_settings',
+        },
+      }
 
-      await u.sendCustomCmd(camCommand)
-      await page.waitForTimeout(100)
-      await u.sendCustomCmd(updateCamCommand)
+      const prefix = plane.length === 3 ? '-' : ''
+      const planeName = plane
+        .slice(plane.length === 3 ? 1 : 0)
+        .toLocaleLowerCase()
 
-      await u.closeDebugPanel()
+      const codeLine1 = `sketch001 = startSketchOn(${prefix}${planeName}Plane)`
+      const codeLine2 = 'profile001 = startProfile(sketch001, at = ['
 
-      // TODO: can we remove these feature tree checks? They seem out of place.
-      await toolbar.openFeatureTreePane()
-      await toolbar.getDefaultPlaneVisibilityButton('XY').click()
-      await toolbar.getDefaultPlaneVisibilityButton('XZ').click()
-      await toolbar.getDefaultPlaneVisibilityButton('YZ').click()
-      await expect(
-        toolbar
-          .getDefaultPlaneVisibilityButton('YZ')
-          .locator('[aria-label="eye crossed out"]')
-      ).toBeVisible()
+      await test.step(`Sketch on the ${plane} plane using custom camera commands to orient`, async () => {
+        await u.openDebugPanel()
 
-      const resolvedCoords = await scene.convertPagePositionToStream(
-        clickCoords.x,
-        clickCoords.y
-      )
-      await page.mouse.click(resolvedCoords.x, resolvedCoords.y)
-      await page.waitForTimeout(600) // wait for animation
+        await u.clearCommandLogs()
+        await toolbar.startSketchBtn.click()
 
-      await toolbar.waitUntilSketchingReady()
+        await u.sendCustomCmd(camCommand)
+        await page.waitForTimeout(100)
+        await u.sendCustomCmd(updateCamCommand)
 
-      await expect(toolbar.lineBtn).toHaveAttribute('aria-pressed', 'true')
-    })
+        await u.closeDebugPanel()
 
-    const lineCoords = await scene.convertPagePositionToStream(707, 393)
-    await page.mouse.click(lineCoords.x, lineCoords.y)
+        // TODO: can we remove these feature tree checks? They seem out of place.
+        await toolbar.openFeatureTreePane()
+        await toolbar.getDefaultPlaneVisibilityButton('XY').click()
+        await toolbar.getDefaultPlaneVisibilityButton('XZ').click()
+        await toolbar.getDefaultPlaneVisibilityButton('YZ').click()
+        await expect(
+          toolbar
+            .getDefaultPlaneVisibilityButton('YZ')
+            .locator('[aria-label="eye crossed out"]')
+        ).toBeVisible()
 
-    await editor.expectEditor.toContain(codeLine1)
-    await editor.expectEditor.toContain(codeLine2)
+        const resolvedCoords = await scene.convertPagePositionToStream(
+          clickCoords.x,
+          clickCoords.y
+        )
+        await page.mouse.click(resolvedCoords.x, resolvedCoords.y)
+        await page.waitForTimeout(600) // wait for animation
+
+        await toolbar.waitUntilSketchingReady()
+
+        await expect(toolbar.lineBtn).toHaveAttribute('aria-pressed', 'true')
+      })
+
+      const lineCoords = await scene.convertPagePositionToStream(707, 393)
+      await page.mouse.click(lineCoords.x, lineCoords.y)
+
+      await editor.expectEditor.toContain(codeLine1)
+      await editor.expectEditor.toContain(codeLine2)
+    }
+
+    const planeConfigs = [
+      {
+        plane: 'XY',
+        coords: { x: 600, y: 388 },
+        description: 'red plane',
+      },
+      {
+        plane: 'YZ',
+        coords: { x: 700, y: 250 },
+        description: 'green plane',
+      },
+      {
+        plane: 'XZ',
+        coords: { x: 684, y: 427 },
+        description: 'blue plane',
+      },
+      {
+        plane: '-XY',
+        coords: { x: 600, y: 118 },
+        description: 'back of red plane',
+      },
+      {
+        plane: '-YZ',
+        coords: { x: 700, y: 219 },
+        description: 'back of green plane',
+      },
+      {
+        plane: '-XZ',
+        coords: { x: 560, y: 150 },
+        description: 'back of blue plane',
+      },
+    ]
+
+    for (const config of planeConfigs) {
+      test(config.plane, async ({ page, homePage, scene, toolbar, editor }) => {
+        await sketchOnPlaneAndBackSideTest(
+          page,
+          homePage,
+          scene,
+          toolbar,
+          editor,
+          config.plane,
+          config.coords
+        )
+      })
+    }
   }
-
-  const planeConfigs = [
-    {
-      plane: 'XY',
-      coords: { x: 600, y: 388 },
-      description: 'red plane',
-    },
-    {
-      plane: 'YZ',
-      coords: { x: 700, y: 250 },
-      description: 'green plane',
-    },
-    {
-      plane: 'XZ',
-      coords: { x: 684, y: 427 },
-      description: 'blue plane',
-    },
-    {
-      plane: '-XY',
-      coords: { x: 600, y: 118 },
-      description: 'back of red plane',
-    },
-    {
-      plane: '-YZ',
-      coords: { x: 700, y: 219 },
-      description: 'back of green plane',
-    },
-    {
-      plane: '-XZ',
-      coords: { x: 560, y: 150 },
-      description: 'back of blue plane',
-    },
-  ]
-
-  for (const config of planeConfigs) {
-    test(config.plane, async ({ page, homePage, scene, toolbar, editor }) => {
-      await sketchOnPlaneAndBackSideTest(
-        page,
-        homePage,
-        scene,
-        toolbar,
-        editor,
-        config.plane,
-        config.coords
-      )
-    })
-  }
-})
+)

--- a/e2e/playwright/code-pane-and-errors.spec.ts
+++ b/e2e/playwright/code-pane-and-errors.spec.ts
@@ -6,7 +6,7 @@ import { executorInputPath, getUtils } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 
-test.describe('Code pane and errors', () => {
+test.describe('Code pane and errors', { tag: '@desktop' }, () => {
   test('Typing KCL errors induces a badge on the code pane button', async ({
     page,
     homePage,
@@ -140,106 +140,104 @@ middle()`)
   })
 })
 
-test(
-  'Opening multiple panes persists when switching projects',
-  { tag: '@desktop' },
-  async ({ context, page }, testInfo) => {
-    // Setup multiple projects.
-    await context.folderSetupFn(async (dir) => {
-      const routerTemplateDir = join(dir, 'router-template-slate')
-      const bracketDir = join(dir, 'bracket')
-      await Promise.all([
-        fsp.mkdir(routerTemplateDir, { recursive: true }),
-        fsp.mkdir(bracketDir, { recursive: true }),
-      ])
-      await Promise.all([
-        fsp.copyFile(
-          executorInputPath('cylinder-inches.kcl'),
-          join(routerTemplateDir, 'main.kcl')
-        ),
-        fsp.copyFile(
-          executorInputPath('e2e-can-sketch-on-chamfer.kcl'),
-          join(bracketDir, 'main.kcl')
-        ),
-      ])
-    })
+test('Opening multiple panes persists when switching projects', async ({
+  context,
+  page,
+}, testInfo) => {
+  // Setup multiple projects.
+  await context.folderSetupFn(async (dir) => {
+    const routerTemplateDir = join(dir, 'router-template-slate')
+    const bracketDir = join(dir, 'bracket')
+    await Promise.all([
+      fsp.mkdir(routerTemplateDir, { recursive: true }),
+      fsp.mkdir(bracketDir, { recursive: true }),
+    ])
+    await Promise.all([
+      fsp.copyFile(
+        executorInputPath('cylinder-inches.kcl'),
+        join(routerTemplateDir, 'main.kcl')
+      ),
+      fsp.copyFile(
+        executorInputPath('e2e-can-sketch-on-chamfer.kcl'),
+        join(bracketDir, 'main.kcl')
+      ),
+    ])
+  })
 
-    const u = await getUtils(page)
-    await page.setBodyDimensions({ width: 1200, height: 500 })
+  const u = await getUtils(page)
+  await page.setBodyDimensions({ width: 1200, height: 500 })
 
-    await test.step('Opening the bracket project should load', async () => {
-      await expect(page.getByText('bracket')).toBeVisible()
+  await test.step('Opening the bracket project should load', async () => {
+    await expect(page.getByText('bracket')).toBeVisible()
 
-      await page.getByText('bracket').click()
+    await page.getByText('bracket').click()
 
-      await u.waitForPageLoad()
-    })
+    await u.waitForPageLoad()
+  })
 
-    // If they're open by default, we're not actually testing anything.
-    await test.step('Pre-condition: panes are not already visible', async () => {
-      await expect(page.locator('#variables-pane')).not.toBeVisible()
-      await expect(page.locator('#logs-pane')).not.toBeVisible()
-    })
+  // If they're open by default, we're not actually testing anything.
+  await test.step('Pre-condition: panes are not already visible', async () => {
+    await expect(page.locator('#variables-pane')).not.toBeVisible()
+    await expect(page.locator('#logs-pane')).not.toBeVisible()
+  })
 
-    await test.step('Open multiple panes', async () => {
-      await u.openKclCodePanel()
-      await u.openVariablesPane()
-      await u.openLogsPane()
-    })
-
-    await test.step('Clicking the logo takes us back to the projects page / home', async () => {
-      await page.getByTestId('app-logo').click()
-
-      await expect(page.getByRole('link', { name: 'bracket' })).toBeVisible()
-      await expect(page.getByText('router-template-slate')).toBeVisible()
-      await expect(page.getByText('Create project')).toBeVisible()
-    })
-
-    await test.step('Opening the router-template project should load', async () => {
-      await expect(page.getByText('router-template-slate')).toBeVisible()
-
-      await page.getByText('router-template-slate').click()
-
-      await u.waitForPageLoad()
-    })
-
-    await test.step('All panes opened before should be visible', async () => {
-      await expect(page.locator('#code-pane')).toBeVisible()
-      await expect(page.locator('#variables-pane')).toBeVisible()
-      await expect(page.locator('#logs-pane')).toBeVisible()
-    })
-  }
-)
-
-test(
-  'external change of file contents are reflected in editor',
-  { tag: '@desktop' },
-  async ({ context, page }, testInfo) => {
-    const PROJECT_DIR_NAME = 'lee-was-here'
-    const { dir: projectsDir } = await context.folderSetupFn(async (dir) => {
-      const aProjectDir = join(dir, PROJECT_DIR_NAME)
-      await fsp.mkdir(aProjectDir, { recursive: true })
-    })
-
-    const u = await getUtils(page)
-    await page.setBodyDimensions({ width: 1200, height: 500 })
-
-    await test.step('Open the project', async () => {
-      await expect(page.getByText(PROJECT_DIR_NAME)).toBeVisible()
-      await page.getByText(PROJECT_DIR_NAME).click()
-      await u.waitForPageLoad()
-    })
-
-    await u.openFilePanel()
+  await test.step('Open multiple panes', async () => {
     await u.openKclCodePanel()
+    await u.openVariablesPane()
+    await u.openLogsPane()
+  })
 
-    await test.step('Write to file externally and check for changed content', async () => {
-      const content = 'ha he ho ho ha blap scap be dap'
-      await fsp.writeFile(
-        join(projectsDir, PROJECT_DIR_NAME, 'main.kcl'),
-        content
-      )
-      await u.editorTextMatches(content)
-    })
-  }
-)
+  await test.step('Clicking the logo takes us back to the projects page / home', async () => {
+    await page.getByTestId('app-logo').click()
+
+    await expect(page.getByRole('link', { name: 'bracket' })).toBeVisible()
+    await expect(page.getByText('router-template-slate')).toBeVisible()
+    await expect(page.getByText('Create project')).toBeVisible()
+  })
+
+  await test.step('Opening the router-template project should load', async () => {
+    await expect(page.getByText('router-template-slate')).toBeVisible()
+
+    await page.getByText('router-template-slate').click()
+
+    await u.waitForPageLoad()
+  })
+
+  await test.step('All panes opened before should be visible', async () => {
+    await expect(page.locator('#code-pane')).toBeVisible()
+    await expect(page.locator('#variables-pane')).toBeVisible()
+    await expect(page.locator('#logs-pane')).toBeVisible()
+  })
+})
+
+test('external change of file contents are reflected in editor', async ({
+  context,
+  page,
+}, testInfo) => {
+  const PROJECT_DIR_NAME = 'lee-was-here'
+  const { dir: projectsDir } = await context.folderSetupFn(async (dir) => {
+    const aProjectDir = join(dir, PROJECT_DIR_NAME)
+    await fsp.mkdir(aProjectDir, { recursive: true })
+  })
+
+  const u = await getUtils(page)
+  await page.setBodyDimensions({ width: 1200, height: 500 })
+
+  await test.step('Open the project', async () => {
+    await expect(page.getByText(PROJECT_DIR_NAME)).toBeVisible()
+    await page.getByText(PROJECT_DIR_NAME).click()
+    await u.waitForPageLoad()
+  })
+
+  await u.openFilePanel()
+  await u.openKclCodePanel()
+
+  await test.step('Write to file externally and check for changed content', async () => {
+    const content = 'ha he ho ho ha blap scap be dap'
+    await fsp.writeFile(
+      join(projectsDir, PROJECT_DIR_NAME, 'main.kcl'),
+      content
+    )
+    await u.editorTextMatches(content)
+  })
+})

--- a/e2e/playwright/command-bar-tests.spec.ts
+++ b/e2e/playwright/command-bar-tests.spec.ts
@@ -6,7 +6,7 @@ import { executorInputPath, getUtils } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 
-test.describe('Command bar tests', () => {
+test.describe('Command bar tests', { tag: '@desktop' }, () => {
   test('Extrude from command bar selects extrude line after', async ({
     page,
     homePage,

--- a/e2e/playwright/debug-pane.spec.ts
+++ b/e2e/playwright/debug-pane.spec.ts
@@ -11,7 +11,7 @@ function countNewlines(input: string): number {
   return count
 }
 
-test.describe('Debug pane', () => {
+test.describe('Debug pane', { tag: '@desktop' }, () => {
   test('Artifact IDs in the artifact graph are stable across code edits', async ({
     page,
     context,

--- a/e2e/playwright/editor-tests.spec.ts
+++ b/e2e/playwright/editor-tests.spec.ts
@@ -54,7 +54,7 @@ profile002 = startProfile(sketch002, at = [-1.0, 0])
   await expect(element).toHaveAttribute('data-overlay-visible', 'true')
 }
 
-test.describe('Editor tests', () => {
+test.describe('Editor tests', { tag: '@desktop' }, () => {
   test('can comment out code with ctrl+/', async ({ page, homePage }) => {
     const u = await getUtils(page)
     await page.setBodyDimensions({ width: 1000, height: 500 })
@@ -1229,42 +1229,43 @@ profile001 = startProfile(sketch001, at = [0, 0])
     await editor.expectEditor.toContain(ogCode, { shouldNormalise: true })
   })
 
-  test(
-    `Can import a local OBJ file`,
-    { tag: '@desktop' },
-    async ({ page, context, scene, cmdBar }, testInfo) => {
-      await context.folderSetupFn(async (dir) => {
-        const bracketDir = join(dir, 'cube')
-        await fsp.mkdir(bracketDir, { recursive: true })
-        await fsp.copyFile(
-          executorInputPath('cube.obj'),
-          join(bracketDir, 'cube.obj')
-        )
-        await fsp.writeFile(join(bracketDir, 'main.kcl'), '')
-      })
+  test(`Can import a local OBJ file`, async ({
+    page,
+    context,
+    scene,
+    cmdBar,
+  }, testInfo) => {
+    await context.folderSetupFn(async (dir) => {
+      const bracketDir = join(dir, 'cube')
+      await fsp.mkdir(bracketDir, { recursive: true })
+      await fsp.copyFile(
+        executorInputPath('cube.obj'),
+        join(bracketDir, 'cube.obj')
+      )
+      await fsp.writeFile(join(bracketDir, 'main.kcl'), '')
+    })
 
-      const viewportSize = { width: 1200, height: 500 }
-      await page.setBodyDimensions(viewportSize)
+    const viewportSize = { width: 1200, height: 500 }
+    await page.setBodyDimensions(viewportSize)
 
-      // Locators and constants
-      const u = await getUtils(page)
-      const projectLink = page.getByRole('link', { name: 'cube' })
-      const errorIndicators = page.locator('.cm-lint-marker-error')
+    // Locators and constants
+    const u = await getUtils(page)
+    const projectLink = page.getByRole('link', { name: 'cube' })
+    const errorIndicators = page.locator('.cm-lint-marker-error')
 
-      await test.step(`Open the empty file`, async () => {
-        await projectLink.click()
-        await scene.settled(cmdBar)
-      })
-      await test.step(`Write the import function line`, async () => {
-        await u.codeLocator.fill(`import 'cube.obj'\ncube`)
-        await page.waitForTimeout(800)
-      })
-      await test.step(`Verify that we see no errors`, async () => {
-        await scene.settled(cmdBar)
-        await expect(errorIndicators).toHaveCount(0)
-      })
-    }
-  )
+    await test.step(`Open the empty file`, async () => {
+      await projectLink.click()
+      await scene.settled(cmdBar)
+    })
+    await test.step(`Write the import function line`, async () => {
+      await u.codeLocator.fill(`import 'cube.obj'\ncube`)
+      await page.waitForTimeout(800)
+    })
+    await test.step(`Verify that we see no errors`, async () => {
+      await scene.settled(cmdBar)
+      await expect(errorIndicators).toHaveCount(0)
+    })
+  })
 
   test('Rectangle tool panning with middle click', async ({
     page,

--- a/e2e/playwright/feature-tree-pane.spec.ts
+++ b/e2e/playwright/feature-tree-pane.spec.ts
@@ -64,114 +64,27 @@ const FEATURE_TREE_FUNCTION_BODY_APPEARANCE_CODE = `export fn cylinder(d, l) {
 test = cylinder(d = 2, l = 10)
 `
 
-test.describe('Feature Tree pane', () => {
-  test(
-    'User can go to definition and go to function definition',
-    { tag: '@desktop' },
-    async ({ context, homePage, scene, editor, toolbar, cmdBar, page }) => {
-      await context.folderSetupFn(async (dir) => {
-        const bracketDir = join(dir, 'test-sample')
-        await fsp.mkdir(bracketDir, { recursive: true })
-        await fsp.writeFile(
-          join(bracketDir, 'main.kcl'),
-          FEATURE_TREE_EXAMPLE_CODE,
-          'utf-8'
-        )
-      })
+test.describe('Feature Tree pane', { tag: '@desktop' }, () => {
+  test('User can go to definition and go to function definition', async ({
+    context,
+    homePage,
+    scene,
+    editor,
+    toolbar,
+    cmdBar,
+    page,
+  }) => {
+    await context.folderSetupFn(async (dir) => {
+      const bracketDir = join(dir, 'test-sample')
+      await fsp.mkdir(bracketDir, { recursive: true })
+      await fsp.writeFile(
+        join(bracketDir, 'main.kcl'),
+        FEATURE_TREE_EXAMPLE_CODE,
+        'utf-8'
+      )
+    })
 
-      await test.step('setup test', async () => {
-        await homePage.expectState({
-          projectCards: [
-            {
-              title: 'test-sample',
-              fileCount: 1,
-            },
-          ],
-          sortBy: 'last-modified-desc',
-        })
-        await homePage.openProject('test-sample')
-        await scene.connectionEstablished()
-        await scene.settled(cmdBar)
-
-        await toolbar.openFeatureTreePane()
-        await expect
-          .poll(() => page.getByText('Feature tree').count())
-          .toBeGreaterThan(1)
-      })
-
-      async function testViewSource({
-        operationName,
-        operationIndex,
-        expectedActiveLine,
-      }: {
-        operationName: string
-        operationIndex: number
-        expectedActiveLine: string
-      }) {
-        await test.step(`Go to definition of the ${operationName}`, async () => {
-          await toolbar.viewSourceOnOperation(operationName, operationIndex)
-          await editor.expectState({
-            highlightedCode: '',
-            diagnostics: [],
-            activeLines: [expectedActiveLine],
-          })
-          await expect(
-            editor.activeLine.first(),
-            `${operationName} code should be scrolled into view`
-          ).toBeVisible()
-        })
-      }
-
-      await testViewSource({
-        operationName: 'plane001',
-        operationIndex: 0,
-        expectedActiveLine: 'plane001 = offsetPlane(XY, offset = 10)',
-      })
-      await testViewSource({
-        operationName: 'extrude001',
-        operationIndex: 0,
-        expectedActiveLine: 'extrude001 = extrude(sketch002, length = 10)',
-      })
-      await testViewSource({
-        operationName: 'revolve001',
-        operationIndex: 0,
-        expectedActiveLine: 'revolve001 = revolve(sketch001, axis = X)',
-      })
-      await testViewSource({
-        operationName: 'Triangle',
-        operationIndex: 0,
-        expectedActiveLine: 'triangle()',
-      })
-
-      await test.step('Go to definition on the triangle function', async () => {
-        await toolbar.goToDefinitionOnOperation('Triangle', 0)
-        await editor.expectState({
-          highlightedCode: '',
-          diagnostics: [],
-          activeLines: ['export fn triangle() {'],
-        })
-        await expect(
-          editor.activeLine.first(),
-          'Triangle function definition should be scrolled into view'
-        ).toBeVisible()
-      })
-    }
-  )
-
-  test(
-    'Set appearance menu works on function-created bodies',
-    { tag: '@desktop' },
-    async ({ context, homePage, scene, toolbar, cmdBar, page, editor }) => {
-      await context.folderSetupFn(async (dir) => {
-        const sampleDir = join(dir, 'test-sample')
-        await fsp.mkdir(sampleDir, { recursive: true })
-        await fsp.writeFile(
-          join(sampleDir, 'main.kcl'),
-          FEATURE_TREE_FUNCTION_BODY_APPEARANCE_CODE,
-          'utf-8'
-        )
-      })
-
+    await test.step('setup test', async () => {
       await homePage.expectState({
         projectCards: [
           {
@@ -182,132 +95,230 @@ test.describe('Feature Tree pane', () => {
         sortBy: 'last-modified-desc',
       })
       await homePage.openProject('test-sample')
+      await scene.connectionEstablished()
       await scene.settled(cmdBar)
+
       await toolbar.openFeatureTreePane()
+      await expect
+        .poll(() => page.getByText('Feature tree').count())
+        .toBeGreaterThan(1)
+    })
 
-      const cylinderOperation = toolbar.featureTreePane
-        .getByRole('button', { name: /test/i })
-        .first()
-      await expect(cylinderOperation).toBeVisible()
-      await cylinderOperation.click({ button: 'right' })
+    async function testViewSource({
+      operationName,
+      operationIndex,
+      expectedActiveLine,
+    }: {
+      operationName: string
+      operationIndex: number
+      expectedActiveLine: string
+    }) {
+      await test.step(`Go to definition of the ${operationName}`, async () => {
+        await toolbar.viewSourceOnOperation(operationName, operationIndex)
+        await editor.expectState({
+          highlightedCode: '',
+          diagnostics: [],
+          activeLines: [expectedActiveLine],
+        })
+        await expect(
+          editor.activeLine.first(),
+          `${operationName} code should be scrolled into view`
+        ).toBeVisible()
+      })
+    }
 
-      const setAppearanceMenuItem = page.getByTestId(
-        'context-menu-set-appearance'
+    await testViewSource({
+      operationName: 'plane001',
+      operationIndex: 0,
+      expectedActiveLine: 'plane001 = offsetPlane(XY, offset = 10)',
+    })
+    await testViewSource({
+      operationName: 'extrude001',
+      operationIndex: 0,
+      expectedActiveLine: 'extrude001 = extrude(sketch002, length = 10)',
+    })
+    await testViewSource({
+      operationName: 'revolve001',
+      operationIndex: 0,
+      expectedActiveLine: 'revolve001 = revolve(sketch001, axis = X)',
+    })
+    await testViewSource({
+      operationName: 'Triangle',
+      operationIndex: 0,
+      expectedActiveLine: 'triangle()',
+    })
+
+    await test.step('Go to definition on the triangle function', async () => {
+      await toolbar.goToDefinitionOnOperation('Triangle', 0)
+      await editor.expectState({
+        highlightedCode: '',
+        diagnostics: [],
+        activeLines: ['export fn triangle() {'],
+      })
+      await expect(
+        editor.activeLine.first(),
+        'Triangle function definition should be scrolled into view'
+      ).toBeVisible()
+    })
+  })
+
+  test('Set appearance menu works on function-created bodies', async ({
+    context,
+    homePage,
+    scene,
+    toolbar,
+    cmdBar,
+    page,
+    editor,
+  }) => {
+    await context.folderSetupFn(async (dir) => {
+      const sampleDir = join(dir, 'test-sample')
+      await fsp.mkdir(sampleDir, { recursive: true })
+      await fsp.writeFile(
+        join(sampleDir, 'main.kcl'),
+        FEATURE_TREE_FUNCTION_BODY_APPEARANCE_CODE,
+        'utf-8'
       )
-      await expect(setAppearanceMenuItem).toBeVisible()
-      await expect(setAppearanceMenuItem).toBeEnabled()
-      await setAppearanceMenuItem.click()
+    })
 
-      await cmdBar.expectState({
-        commandName: 'Appearance',
-        currentArgKey: 'objects',
-        currentArgValue: '',
-        headerArguments: {
-          Objects: '',
-          Color: '',
+    await homePage.expectState({
+      projectCards: [
+        {
+          title: 'test-sample',
+          fileCount: 1,
         },
-        highlightedHeaderArg: 'objects',
-        stage: 'arguments',
+      ],
+      sortBy: 'last-modified-desc',
+    })
+    await homePage.openProject('test-sample')
+    await scene.settled(cmdBar)
+    await toolbar.openFeatureTreePane()
+
+    const cylinderOperation = toolbar.featureTreePane
+      .getByRole('button', { name: /test/i })
+      .first()
+    await expect(cylinderOperation).toBeVisible()
+    await cylinderOperation.click({ button: 'right' })
+
+    const setAppearanceMenuItem = page.getByTestId(
+      'context-menu-set-appearance'
+    )
+    await expect(setAppearanceMenuItem).toBeVisible()
+    await expect(setAppearanceMenuItem).toBeEnabled()
+    await setAppearanceMenuItem.click()
+
+    await cmdBar.expectState({
+      commandName: 'Appearance',
+      currentArgKey: 'objects',
+      currentArgValue: '',
+      headerArguments: {
+        Objects: '',
+        Color: '',
+      },
+      highlightedHeaderArg: 'objects',
+      stage: 'arguments',
+    })
+
+    await cmdBar.progressCmdBar()
+    await cmdBar.expectState({
+      commandName: 'Appearance',
+      currentArgKey: 'color',
+      currentArgValue: '',
+      headerArguments: {
+        Objects: '1 other',
+        Color: '',
+      },
+      highlightedHeaderArg: 'color',
+      stage: 'arguments',
+    })
+
+    // Fill color, submit, and verify code updated
+    await cmdBar.currentArgumentInput.fill('#00ff00')
+    await cmdBar.progressCmdBar()
+    await cmdBar.expectState({
+      commandName: 'Appearance',
+      headerArguments: {
+        Objects: '1 other',
+        Color: '#00ff00',
+      },
+      stage: 'review',
+    })
+    await cmdBar.submit()
+    await scene.settled(cmdBar)
+    await editor.expectEditor.toContain('appearance(test, color = "#00ff00")')
+  })
+
+  test(`User can edit sketch (but not on offset plane yet) from the feature tree`, async ({
+    context,
+    homePage,
+    scene,
+    editor,
+    toolbar,
+    page,
+  }) => {
+    await context.addInitScript((initialCode) => {
+      localStorage.setItem('persistCode', initialCode)
+    }, FEATURE_TREE_SKETCH_CODE)
+    await page.setBodyDimensions({ width: 1000, height: 500 })
+    await homePage.goToModelingScene()
+
+    await test.step('force re-exe', async () => {
+      await page.waitForTimeout(1000)
+      await editor.replaceCode('90', '91')
+      await page.waitForTimeout(1500)
+    })
+
+    await test.step('On a default plane should work', async () => {
+      await (await toolbar.getFeatureTreeOperation('Sketch', 0)).dblclick()
+      await expect(
+        toolbar.exitSketchBtn,
+        'We should be in sketch mode now'
+      ).toBeVisible()
+      await editor.expectState({
+        highlightedCode: '',
+        diagnostics: [],
+        activeLines: ['sketch001 = startSketchOn(XZ)'],
       })
+      await toolbar.exitSketchBtn.click()
+    })
 
-      await cmdBar.progressCmdBar()
-      await cmdBar.expectState({
-        commandName: 'Appearance',
-        currentArgKey: 'color',
-        currentArgValue: '',
-        headerArguments: {
-          Objects: '1 other',
-          Color: '',
-        },
-        highlightedHeaderArg: 'color',
-        stage: 'arguments',
+    await test.step('On an extrude face should *not* work', async () => {
+      // Tooltip is getting in the way of clicking, so I'm first closing the pane
+      await toolbar.closeFeatureTreePane()
+      await page.waitForTimeout(1000)
+      await editor.replaceCode('91', '90')
+      await page.waitForTimeout(2000)
+      await (await toolbar.getFeatureTreeOperation('Sketch', 1)).dblclick()
+
+      await expect(
+        toolbar.exitSketchBtn,
+        'We should be in sketch mode now'
+      ).toBeVisible()
+      await editor.expectState({
+        highlightedCode: '',
+        diagnostics: [],
+        activeLines: [
+          'sketch002=startSketchOn(extrude001,face=rectangleSegmentB001)',
+        ],
       })
+      await toolbar.exitSketchBtn.click()
+    })
 
-      // Fill color, submit, and verify code updated
-      await cmdBar.currentArgumentInput.fill('#00ff00')
-      await cmdBar.progressCmdBar()
-      await cmdBar.expectState({
-        commandName: 'Appearance',
-        headerArguments: {
-          Objects: '1 other',
-          Color: '#00ff00',
-        },
-        stage: 'review',
+    await test.step('On an offset plane should work', async () => {
+      // Tooltip is getting in the way of clicking, so I'm first closing the pane
+      await toolbar.closeFeatureTreePane()
+      await (await toolbar.getFeatureTreeOperation('Sketch', 2)).dblclick()
+      await editor.expectState({
+        highlightedCode: '',
+        diagnostics: [],
+        activeLines: ['sketch003=startSketchOn(plane001)'],
       })
-      await cmdBar.submit()
-      await scene.settled(cmdBar)
-      await editor.expectEditor.toContain('appearance(test, color = "#00ff00")')
-    }
-  )
-
-  test(
-    `User can edit sketch (but not on offset plane yet) from the feature tree`,
-    { tag: '@desktop' },
-    async ({ context, homePage, scene, editor, toolbar, page }) => {
-      await context.addInitScript((initialCode) => {
-        localStorage.setItem('persistCode', initialCode)
-      }, FEATURE_TREE_SKETCH_CODE)
-      await page.setBodyDimensions({ width: 1000, height: 500 })
-      await homePage.goToModelingScene()
-
-      await test.step('force re-exe', async () => {
-        await page.waitForTimeout(1000)
-        await editor.replaceCode('90', '91')
-        await page.waitForTimeout(1500)
-      })
-
-      await test.step('On a default plane should work', async () => {
-        await (await toolbar.getFeatureTreeOperation('Sketch', 0)).dblclick()
-        await expect(
-          toolbar.exitSketchBtn,
-          'We should be in sketch mode now'
-        ).toBeVisible()
-        await editor.expectState({
-          highlightedCode: '',
-          diagnostics: [],
-          activeLines: ['sketch001 = startSketchOn(XZ)'],
-        })
-        await toolbar.exitSketchBtn.click()
-      })
-
-      await test.step('On an extrude face should *not* work', async () => {
-        // Tooltip is getting in the way of clicking, so I'm first closing the pane
-        await toolbar.closeFeatureTreePane()
-        await page.waitForTimeout(1000)
-        await editor.replaceCode('91', '90')
-        await page.waitForTimeout(2000)
-        await (await toolbar.getFeatureTreeOperation('Sketch', 1)).dblclick()
-
-        await expect(
-          toolbar.exitSketchBtn,
-          'We should be in sketch mode now'
-        ).toBeVisible()
-        await editor.expectState({
-          highlightedCode: '',
-          diagnostics: [],
-          activeLines: [
-            'sketch002=startSketchOn(extrude001,face=rectangleSegmentB001)',
-          ],
-        })
-        await toolbar.exitSketchBtn.click()
-      })
-
-      await test.step('On an offset plane should work', async () => {
-        // Tooltip is getting in the way of clicking, so I'm first closing the pane
-        await toolbar.closeFeatureTreePane()
-        await (await toolbar.getFeatureTreeOperation('Sketch', 2)).dblclick()
-        await editor.expectState({
-          highlightedCode: '',
-          diagnostics: [],
-          activeLines: ['sketch003=startSketchOn(plane001)'],
-        })
-        await expect(
-          toolbar.exitSketchBtn,
-          'We should be in sketch mode now'
-        ).toBeVisible()
-      })
-    }
-  )
+      await expect(
+        toolbar.exitSketchBtn,
+        'We should be in sketch mode now'
+      ).toBeVisible()
+    })
+  })
   test(`User can edit an extrude operation from the feature tree`, async ({
     context,
     homePage,

--- a/e2e/playwright/file-tree.spec.ts
+++ b/e2e/playwright/file-tree.spec.ts
@@ -11,179 +11,180 @@ import {
 } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 
-test.describe('integrations tests', () => {
-  test(
-    'Creating a new file or switching file while in sketchMode should exit sketchMode',
-    { tag: '@desktop' },
-    async ({ page, context, homePage, scene, toolbar, cmdBar }) => {
-      await context.folderSetupFn(async (dir) => {
-        const bracketDir = join(dir, 'test-sample')
-        await fsp.mkdir(bracketDir, { recursive: true })
-        await fsp.copyFile(
-          executorInputPath('e2e-can-sketch-on-chamfer.kcl'),
-          join(bracketDir, 'main.kcl')
-        )
-      })
+test.describe('integrations tests', { tag: '@desktop' }, () => {
+  test('Creating a new file or switching file while in sketchMode should exit sketchMode', async ({
+    page,
+    context,
+    homePage,
+    scene,
+    toolbar,
+    cmdBar,
+  }) => {
+    await context.folderSetupFn(async (dir) => {
+      const bracketDir = join(dir, 'test-sample')
+      await fsp.mkdir(bracketDir, { recursive: true })
+      await fsp.copyFile(
+        executorInputPath('e2e-can-sketch-on-chamfer.kcl'),
+        join(bracketDir, 'main.kcl')
+      )
+    })
 
-      await test.step('setup test', async () => {
-        await homePage.expectState({
-          projectCards: [
-            {
-              title: 'test-sample',
-              fileCount: 1,
-            },
-          ],
-          sortBy: 'last-modified-desc',
-        })
-        await homePage.openProject('test-sample')
-        await scene.connectionEstablished()
-        await scene.settled(cmdBar)
+    await test.step('setup test', async () => {
+      await homePage.expectState({
+        projectCards: [
+          {
+            title: 'test-sample',
+            fileCount: 1,
+          },
+        ],
+        sortBy: 'last-modified-desc',
       })
+      await homePage.openProject('test-sample')
+      await scene.connectionEstablished()
+      await scene.settled(cmdBar)
+    })
 
+    await toolbar.editSketch()
+
+    const fileName = 'Untitled.kcl'
+    await test.step('check sketch mode is exited when creating new file', async () => {
+      await toolbar.openPane(DefaultLayoutPaneID.Files)
+      await toolbar.expectFileTreeState(['main.kcl'])
+
+      await toolbar.createFile({ fileName, waitForToastToDisappear: true })
+
+      // check we're out of sketch mode
+      await expect(toolbar.exitSketchBtn).not.toBeVisible()
+      await expect(toolbar.startSketchBtn).toBeVisible()
+    })
+    await test.step('setup for next assertion', async () => {
+      await toolbar.openFile('main.kcl')
+      await page.waitForTimeout(2000)
       await toolbar.editSketch()
+      await toolbar.expectFileTreeState(['main.kcl', fileName])
+    })
+    await test.step('check sketch mode is exited when opening a different file', async () => {
+      await toolbar.openFile(fileName)
 
-      const fileName = 'Untitled.kcl'
-      await test.step('check sketch mode is exited when creating new file', async () => {
-        await toolbar.openPane(DefaultLayoutPaneID.Files)
-        await toolbar.expectFileTreeState(['main.kcl'])
-
-        await toolbar.createFile({ fileName, waitForToastToDisappear: true })
-
-        // check we're out of sketch mode
-        await expect(toolbar.exitSketchBtn).not.toBeVisible()
-        await expect(toolbar.startSketchBtn).toBeVisible()
-      })
-      await test.step('setup for next assertion', async () => {
-        await toolbar.openFile('main.kcl')
-        await page.waitForTimeout(2000)
-        await toolbar.editSketch()
-        await toolbar.expectFileTreeState(['main.kcl', fileName])
-      })
-      await test.step('check sketch mode is exited when opening a different file', async () => {
-        await toolbar.openFile(fileName)
-
-        // check we're out of sketch mode
-        await expect(toolbar.exitSketchBtn).not.toBeVisible()
-        await expect(toolbar.startSketchBtn).toBeVisible()
-      })
-    }
-  )
+      // check we're out of sketch mode
+      await expect(toolbar.exitSketchBtn).not.toBeVisible()
+      await expect(toolbar.startSketchBtn).toBeVisible()
+    })
+  })
 })
-test.describe('when using the file tree to', () => {
+test.describe('when using the file tree to', { tag: '@desktop' }, () => {
   const fromFile = 'main.kcl'
   const toFile = 'hello.kcl'
 
-  test(
-    `rename ${fromFile} to ${toFile}, and doesn't crash on reload and settings load`,
-    { tag: '@desktop' },
-    async ({ page }, testInfo) => {
-      const { panesOpen, pasteCodeInEditor, renameFile, editorTextMatches } =
-        await getUtils(page, test)
+  test(`rename ${fromFile} to ${toFile}, and doesn't crash on reload and settings load`, async ({
+    page,
+  }, testInfo) => {
+    const { panesOpen, pasteCodeInEditor, renameFile, editorTextMatches } =
+      await getUtils(page, test)
 
-      await page.setBodyDimensions({ width: 1200, height: 500 })
-      page.on('console', console.log)
+    await page.setBodyDimensions({ width: 1200, height: 500 })
+    page.on('console', console.log)
 
-      await panesOpen(['files', 'code'])
+    await panesOpen(['files', 'code'])
 
-      await createProject({ name: 'project-000', page })
+    await createProject({ name: 'project-000', page })
 
-      // File the main.kcl with contents
-      const kclCube = await fsp.readFile(
-        'rust/kcl-lib/e2e/executor/inputs/cube.kcl',
-        'utf-8'
-      )
-      await pasteCodeInEditor(kclCube)
+    // File the main.kcl with contents
+    const kclCube = await fsp.readFile(
+      'rust/kcl-lib/e2e/executor/inputs/cube.kcl',
+      'utf-8'
+    )
+    await pasteCodeInEditor(kclCube)
 
-      // TODO: We have a timeout of 1s between edits to write to disk. If you reload the page too quickly it won't write to disk.
-      await page.waitForTimeout(2000)
+    // TODO: We have a timeout of 1s between edits to write to disk. If you reload the page too quickly it won't write to disk.
+    await page.waitForTimeout(2000)
 
-      await renameFile(fromFile, toFile)
-      await page.reload()
+    await renameFile(fromFile, toFile)
+    await page.reload()
 
-      await test.step('Postcondition: editor has same content as before the rename', async () => {
-        await editorTextMatches(kclCube)
+    await test.step('Postcondition: editor has same content as before the rename', async () => {
+      await editorTextMatches(kclCube)
+    })
+
+    await test.step('Postcondition: opening and closing settings works', async () => {
+      const settingsOpenButton = page.getByRole('link', {
+        name: 'settings Settings',
       })
+      const settingsCloseButton = page.getByTestId('settings-close-button')
+      await settingsOpenButton.click()
+      await settingsCloseButton.click()
+    })
+  })
 
-      await test.step('Postcondition: opening and closing settings works', async () => {
-        const settingsOpenButton = page.getByRole('link', {
-          name: 'settings Settings',
-        })
-        const settingsCloseButton = page.getByTestId('settings-close-button')
-        await settingsOpenButton.click()
-        await settingsCloseButton.click()
-      })
-    }
-  )
+  test('create a new file with the same name as an existing file cancels the operation', async ({
+    context,
+    page,
+    homePage,
+    scene,
+    editor,
+    toolbar,
+  }, testInfo) => {
+    const projectName = 'cube'
+    const mainFile = 'main.kcl'
+    const secondFile = 'cylinder.kcl'
+    const kclCube = await fsp.readFile(executorInputPath('cube.kcl'), 'utf-8')
+    const kclCylinder = await fsp.readFile(
+      executorInputPath('cylinder.kcl'),
+      'utf-8'
+    )
 
-  test(
-    'create a new file with the same name as an existing file cancels the operation',
-    { tag: '@desktop' },
-    async ({ context, page, homePage, scene, editor, toolbar }, testInfo) => {
-      const projectName = 'cube'
-      const mainFile = 'main.kcl'
-      const secondFile = 'cylinder.kcl'
-      const kclCube = await fsp.readFile(executorInputPath('cube.kcl'), 'utf-8')
-      const kclCylinder = await fsp.readFile(
+    await context.folderSetupFn(async (dir) => {
+      const cubeDir = join(dir, projectName)
+      await fsp.mkdir(cubeDir, { recursive: true })
+      await fsp.copyFile(executorInputPath('cube.kcl'), join(cubeDir, mainFile))
+      await fsp.copyFile(
         executorInputPath('cylinder.kcl'),
-        'utf-8'
+        join(cubeDir, secondFile)
       )
+    })
 
-      await context.folderSetupFn(async (dir) => {
-        const cubeDir = join(dir, projectName)
-        await fsp.mkdir(cubeDir, { recursive: true })
-        await fsp.copyFile(
-          executorInputPath('cube.kcl'),
-          join(cubeDir, mainFile)
-        )
-        await fsp.copyFile(
-          executorInputPath('cylinder.kcl'),
-          join(cubeDir, secondFile)
-        )
+    const {
+      openFilePanel,
+      renameFile,
+      selectFile,
+      editorTextMatches,
+      waitForPageLoad,
+    } = await getUtils(page, test)
+
+    await test.step(`Setup: Open project and navigate to ${secondFile}`, async () => {
+      await homePage.expectState({
+        projectCards: [
+          {
+            title: projectName,
+            fileCount: 2,
+          },
+        ],
+        sortBy: 'last-modified-desc',
       })
+      await homePage.openProject(projectName)
+      await waitForPageLoad()
+      await openFilePanel()
+      await selectFile(secondFile)
+    })
 
-      const {
-        openFilePanel,
-        renameFile,
-        selectFile,
-        editorTextMatches,
-        waitForPageLoad,
-      } = await getUtils(page, test)
+    await test.step(`Attempt to rename ${secondFile} to ${mainFile}`, async () => {
+      await renameFile(secondFile, mainFile)
+    })
 
-      await test.step(`Setup: Open project and navigate to ${secondFile}`, async () => {
-        await homePage.expectState({
-          projectCards: [
-            {
-              title: projectName,
-              fileCount: 2,
-            },
-          ],
-          sortBy: 'last-modified-desc',
-        })
-        await homePage.openProject(projectName)
-        await waitForPageLoad()
-        await openFilePanel()
-        await selectFile(secondFile)
-      })
+    await test.step(`Postcondition: ${mainFile} still has the original content`, async () => {
+      await selectFile(mainFile)
+      await editorTextMatches(kclCube)
+    })
 
-      await test.step(`Attempt to rename ${secondFile} to ${mainFile}`, async () => {
-        await renameFile(secondFile, mainFile)
-      })
-
-      await test.step(`Postcondition: ${mainFile} still has the original content`, async () => {
-        await selectFile(mainFile)
-        await editorTextMatches(kclCube)
-      })
-
-      await test.step(`Postcondition: ${secondFile} still exists with the original content`, async () => {
-        await selectFile(secondFile)
-        await editorTextMatches(kclCylinder)
-      })
-    }
-  )
+    await test.step(`Postcondition: ${secondFile} still exists with the original content`, async () => {
+      await selectFile(secondFile)
+      await editorTextMatches(kclCylinder)
+    })
+  })
 
   test(
     `create new folders and that doesn't trigger a navigation`,
-    { tag: ['@desktop', '@macos', '@windows'] },
+    { tag: ['@macos', '@windows'] },
     async ({ page, homePage, scene, toolbar, cmdBar }) => {
       await homePage.goToModelingScene()
       await scene.settled(cmdBar)
@@ -201,670 +202,646 @@ test.describe('when using the file tree to', () => {
     }
   )
 
-  test(
-    'deleting all files recreates a default main.kcl with no code',
-    { tag: '@desktop' },
-    async ({ page }, testInfo) => {
-      const { panesOpen, pasteCodeInEditor, deleteFile, editorTextMatches } =
-        await getUtils(page, test)
+  test('deleting all files recreates a default main.kcl with no code', async ({
+    page,
+  }, testInfo) => {
+    const { panesOpen, pasteCodeInEditor, deleteFile, editorTextMatches } =
+      await getUtils(page, test)
 
-      await page.setBodyDimensions({ width: 1200, height: 500 })
-      page.on('console', console.log)
+    await page.setBodyDimensions({ width: 1200, height: 500 })
+    page.on('console', console.log)
 
-      await panesOpen(['files', 'code'])
+    await panesOpen(['files', 'code'])
 
-      await createProject({ name: 'project-000', page })
-      // File the main.kcl with contents
-      const kclCube = await fsp.readFile(
-        'rust/kcl-lib/e2e/executor/inputs/cube.kcl',
-        'utf-8'
-      )
-      await pasteCodeInEditor(kclCube)
+    await createProject({ name: 'project-000', page })
+    // File the main.kcl with contents
+    const kclCube = await fsp.readFile(
+      'rust/kcl-lib/e2e/executor/inputs/cube.kcl',
+      'utf-8'
+    )
+    await pasteCodeInEditor(kclCube)
 
-      const mainFile = 'main.kcl'
+    const mainFile = 'main.kcl'
 
-      await deleteFile(mainFile)
+    await deleteFile(mainFile)
 
-      await test.step(`Postcondition: ${mainFile} is recreated but has no content`, async () => {
-        await editorTextMatches('')
-      })
-    }
-  )
+    await test.step(`Postcondition: ${mainFile} is recreated but has no content`, async () => {
+      await editorTextMatches('')
+    })
+  })
 
-  test(
-    'loading small file, then large, then back to small',
-    {
-      tag: '@desktop',
-    },
-    async ({ page, toolbar }, testInfo) => {
-      const {
-        panesOpen,
-        pasteCodeInEditor,
-        createNewFile,
-        openDebugPanel,
-        closeDebugPanel,
-        expectCmdLog,
-      } = await getUtils(page, test)
+  test('loading small file, then large, then back to small', async ({
+    page,
+    toolbar,
+  }, testInfo) => {
+    const {
+      panesOpen,
+      pasteCodeInEditor,
+      createNewFile,
+      openDebugPanel,
+      closeDebugPanel,
+      expectCmdLog,
+    } = await getUtils(page, test)
 
-      await page.setViewportSize({ width: 1200, height: 500 })
-      page.on('console', console.log)
+    await page.setViewportSize({ width: 1200, height: 500 })
+    page.on('console', console.log)
 
-      await panesOpen(['files', 'code'])
-      await createProject({ name: 'project-000', page })
+    await panesOpen(['files', 'code'])
+    await createProject({ name: 'project-000', page })
 
-      // Create a small file
-      const kclCube = await fsp.readFile(
-        'rust/kcl-lib/e2e/executor/inputs/cube.kcl',
-        'utf-8'
-      )
-      // pasted into main.kcl
-      await pasteCodeInEditor(kclCube)
+    // Create a small file
+    const kclCube = await fsp.readFile(
+      'rust/kcl-lib/e2e/executor/inputs/cube.kcl',
+      'utf-8'
+    )
+    // pasted into main.kcl
+    await pasteCodeInEditor(kclCube)
 
-      // Create a large lego file
-      await createNewFile('lego')
-      const kclLego = await fsp.readFile(
-        'rust/kcl-lib/e2e/executor/inputs/lego.kcl',
-        'utf-8'
-      )
-      await pasteCodeInEditor(kclLego)
+    // Create a large lego file
+    await createNewFile('lego')
+    const kclLego = await fsp.readFile(
+      'rust/kcl-lib/e2e/executor/inputs/lego.kcl',
+      'utf-8'
+    )
+    await pasteCodeInEditor(kclLego)
 
-      await test.step('swap between small and large files', async () => {
-        await openDebugPanel()
-        // Previously created a file so we need to start back at main.kcl
-        await toolbar.openFile('main.kcl')
-        await expectCmdLog('[data-message-type="execution-done"]', 60_000)
-        // Click the large file
-        await toolbar.openFile('lego.kcl')
-        // Once it is building, click back to the smaller file
-        await toolbar.openFile('main.kcl')
-        await expectCmdLog('[data-message-type="execution-done"]', 60_000)
-        await closeDebugPanel()
-      })
-    }
-  )
+    await test.step('swap between small and large files', async () => {
+      await openDebugPanel()
+      // Previously created a file so we need to start back at main.kcl
+      await toolbar.openFile('main.kcl')
+      await expectCmdLog('[data-message-type="execution-done"]', 60_000)
+      // Click the large file
+      await toolbar.openFile('lego.kcl')
+      // Once it is building, click back to the smaller file
+      await toolbar.openFile('main.kcl')
+      await expectCmdLog('[data-message-type="execution-done"]', 60_000)
+      await closeDebugPanel()
+    })
+  })
 })
 
-test.describe('Renaming in the file tree', () => {
-  test(
-    'A file you have open',
-    { tag: '@desktop' },
-    async ({ context, page }, testInfo) => {
-      const { dir } = await context.folderSetupFn(async (dir) => {
-        await fsp.mkdir(join(dir, 'Test Project'), { recursive: true })
-        await fsp.copyFile(
-          executorInputPath('basic_fillet_cube_end.kcl'),
-          join(dir, 'Test Project', 'main.kcl')
-        )
-        await fsp.copyFile(
-          executorInputPath('cylinder.kcl'),
-          join(dir, 'Test Project', 'fileToRename.kcl')
-        )
-      })
-      const u = await getUtils(page)
-      await page.setViewportSize({ width: 1200, height: 500 })
-      page.on('console', console.log)
+test.describe('Renaming in the file tree', { tag: '@desktop' }, () => {
+  test('A file you have open', async ({ context, page }, testInfo) => {
+    const { dir } = await context.folderSetupFn(async (dir) => {
+      await fsp.mkdir(join(dir, 'Test Project'), { recursive: true })
+      await fsp.copyFile(
+        executorInputPath('basic_fillet_cube_end.kcl'),
+        join(dir, 'Test Project', 'main.kcl')
+      )
+      await fsp.copyFile(
+        executorInputPath('cylinder.kcl'),
+        join(dir, 'Test Project', 'fileToRename.kcl')
+      )
+    })
+    const u = await getUtils(page)
+    await page.setViewportSize({ width: 1200, height: 500 })
+    page.on('console', console.log)
 
-      // Constants and locators
-      const projectLink = page.getByText('Test Project')
-      const projectMenuButton = page.getByTestId('project-sidebar-toggle')
-      const checkUnRenamedFS = () => {
-        const filePath = join(dir, 'Test Project', 'fileToRename.kcl')
-        return fs.existsSync(filePath)
-      }
-      const newFileName = 'newFileName'
-      const checkRenamedFS = () => {
-        const filePath = join(dir, 'Test Project', `${newFileName}.kcl`)
-        return fs.existsSync(filePath)
-      }
-      const fileToRename = u.locatorFile('fileToRename.kcl')
-      const renamedFile = u.locatorFile('newFileName.kcl')
-      const renameMenuItem = page.getByRole('button', { name: 'Rename' })
-      const renameInput = page.getByPlaceholder('fileToRename.kcl')
-      const codeLocator = page.locator('.cm-content')
-
-      await test.step('Open project and file pane', async () => {
-        await expect(projectLink).toBeVisible()
-        await projectLink.click()
-        await expect(projectMenuButton).toBeVisible()
-        await expect(projectMenuButton).toContainText('main.kcl')
-
-        await u.openFilePanel()
-        await expect(fileToRename).toBeVisible()
-        expect(checkUnRenamedFS()).toBeTruthy()
-        expect(checkRenamedFS()).toBeFalsy()
-        await fileToRename.click()
-        await expect(projectMenuButton).toContainText('fileToRename.kcl')
-        await u.openKclCodePanel()
-        await expect(codeLocator).toContainText('circle(')
-        await u.closeKclCodePanel()
-      })
-
-      await test.step('Rename the file', async () => {
-        await fileToRename.click({ button: 'right' })
-        await renameMenuItem.click()
-        await expect(renameInput).toBeVisible()
-        await renameInput.fill(newFileName)
-        await page.keyboard.press('Enter')
-      })
-
-      await test.step('Verify the file is renamed', async () => {
-        await expect(fileToRename).not.toBeAttached()
-        await expect(renamedFile).toBeVisible()
-        expect(checkUnRenamedFS()).toBeFalsy()
-        expect(checkRenamedFS()).toBeTruthy()
-      })
-
-      await test.step('Verify we navigated', async () => {
-        await expect(projectMenuButton).toContainText(newFileName + FILE_EXT)
-        const url = page.url()
-        expect(url).toContain(newFileName)
-        await expect(projectMenuButton).not.toContainText('fileToRename.kcl')
-        await expect(projectMenuButton).not.toContainText('main.kcl')
-        expect(url).not.toContain('fileToRename.kcl')
-        expect(url).not.toContain('main.kcl')
-
-        await u.openKclCodePanel()
-        await expect(codeLocator).toContainText('circle(')
-      })
+    // Constants and locators
+    const projectLink = page.getByText('Test Project')
+    const projectMenuButton = page.getByTestId('project-sidebar-toggle')
+    const checkUnRenamedFS = () => {
+      const filePath = join(dir, 'Test Project', 'fileToRename.kcl')
+      return fs.existsSync(filePath)
     }
-  )
-
-  test(
-    'A file you do not have open',
-    { tag: '@desktop' },
-    async ({ context, page }, testInfo) => {
-      const { dir } = await context.folderSetupFn(async (dir) => {
-        await fsp.mkdir(join(dir, 'Test Project'), { recursive: true })
-        await fsp.copyFile(
-          executorInputPath('basic_fillet_cube_end.kcl'),
-          join(dir, 'Test Project', 'main.kcl')
-        )
-        await fsp.copyFile(
-          executorInputPath('cylinder.kcl'),
-          join(dir, 'Test Project', 'fileToRename.kcl')
-        )
-      })
-      const u = await getUtils(page)
-      await page.setViewportSize({ width: 1200, height: 500 })
-      page.on('console', console.log)
-
-      // Constants and locators
-      const newFileName = 'newFileName'
-      const checkUnRenamedFS = () => {
-        const filePath = join(dir, 'Test Project', 'fileToRename.kcl')
-        return fs.existsSync(filePath)
-      }
-      const checkRenamedFS = () => {
-        const filePath = join(dir, 'Test Project', `${newFileName}.kcl`)
-        return fs.existsSync(filePath)
-      }
-      const projectLink = page.getByText('Test Project')
-      const projectMenuButton = page.getByTestId('project-sidebar-toggle')
-      const fileToRename = u.locatorFile('fileToRename.kcl')
-      const renamedFile = u.locatorFile(newFileName + FILE_EXT)
-      const renameMenuItem = page.getByRole('button', { name: 'Rename' })
-      const renameInput = page.getByPlaceholder('fileToRename.kcl')
-      const codeLocator = page.locator('.cm-content')
-
-      await test.step('Open project and file pane', async () => {
-        await expect(projectLink).toBeVisible()
-        await projectLink.click()
-        await expect(projectMenuButton).toBeVisible()
-        await expect(projectMenuButton).toContainText('main.kcl')
-
-        await u.openFilePanel()
-        await expect(fileToRename).toBeVisible()
-        expect(checkUnRenamedFS()).toBeTruthy()
-        expect(checkRenamedFS()).toBeFalsy()
-      })
-
-      await test.step('Rename the file', async () => {
-        await fileToRename.click({ button: 'right' })
-        await renameMenuItem.click()
-        await expect(renameInput).toBeVisible()
-        await renameInput.fill(newFileName)
-        await page.keyboard.press('Enter')
-      })
-
-      await test.step('Verify the file is renamed', async () => {
-        await expect(fileToRename).not.toBeAttached()
-        await expect(renamedFile).toBeVisible()
-        expect(checkUnRenamedFS()).toBeFalsy()
-        expect(checkRenamedFS()).toBeTruthy()
-      })
-
-      await test.step('Verify we have not navigated', async () => {
-        await expect(projectMenuButton).toContainText('main.kcl')
-        await expect(projectMenuButton).not.toContainText(
-          newFileName + FILE_EXT
-        )
-        await expect(projectMenuButton).not.toContainText('fileToRename.kcl')
-
-        const url = page.url()
-        expect(url).toContain('main.kcl')
-        expect(url).not.toContain(newFileName)
-        expect(url).not.toContain('fileToRename.kcl')
-
-        await u.openKclCodePanel()
-        await expect(codeLocator).toContainText('fillet(')
-      })
+    const newFileName = 'newFileName'
+    const checkRenamedFS = () => {
+      const filePath = join(dir, 'Test Project', `${newFileName}.kcl`)
+      return fs.existsSync(filePath)
     }
-  )
+    const fileToRename = u.locatorFile('fileToRename.kcl')
+    const renamedFile = u.locatorFile('newFileName.kcl')
+    const renameMenuItem = page.getByRole('button', { name: 'Rename' })
+    const renameInput = page.getByPlaceholder('fileToRename.kcl')
+    const codeLocator = page.locator('.cm-content')
 
-  test(
-    `A folder you're not inside`,
-    { tag: '@desktop' },
-    async ({ context, page }, testInfo) => {
-      const { dir } = await context.folderSetupFn(async (dir) => {
-        await fsp.mkdir(join(dir, 'Test Project'), { recursive: true })
-        await fsp.mkdir(join(dir, 'Test Project', 'folderToRename'), {
-          recursive: true,
-        })
-        await fsp.copyFile(
-          executorInputPath('basic_fillet_cube_end.kcl'),
-          join(dir, 'Test Project', 'main.kcl')
-        )
-        await fsp.copyFile(
-          executorInputPath('cylinder.kcl'),
-          join(dir, 'Test Project', 'folderToRename', 'someFileWithin.kcl')
-        )
-      })
+    await test.step('Open project and file pane', async () => {
+      await expect(projectLink).toBeVisible()
+      await projectLink.click()
+      await expect(projectMenuButton).toBeVisible()
+      await expect(projectMenuButton).toContainText('main.kcl')
 
-      const u = await getUtils(page)
-      await page.setViewportSize({ width: 1200, height: 500 })
-      page.on('console', console.log)
+      await u.openFilePanel()
+      await expect(fileToRename).toBeVisible()
+      expect(checkUnRenamedFS()).toBeTruthy()
+      expect(checkRenamedFS()).toBeFalsy()
+      await fileToRename.click()
+      await expect(projectMenuButton).toContainText('fileToRename.kcl')
+      await u.openKclCodePanel()
+      await expect(codeLocator).toContainText('circle(')
+      await u.closeKclCodePanel()
+    })
 
-      // Constants and locators
-      const projectLink = page.getByText('Test Project')
-      const projectMenuButton = page.getByTestId('project-sidebar-toggle')
-      const folderToRename = u.locatorFolder('folderToRename')
-      const renamedFolder = u.locatorFolder('newFolderName')
-      const renameMenuItem = page.getByRole('button', { name: 'Rename' })
-      const originalFolderName = 'folderToRename'
-      const renameInput = page.getByPlaceholder(originalFolderName)
-      const newFolderName = 'newFolderName'
-      const checkUnRenamedFolderFS = () => {
-        const folderPath = join(dir, 'Test Project', originalFolderName)
-        return fs.existsSync(folderPath)
-      }
-      const checkRenamedFolderFS = () => {
-        const folderPath = join(dir, 'Test Project', newFolderName)
-        return fs.existsSync(folderPath)
-      }
+    await test.step('Rename the file', async () => {
+      await fileToRename.click({ button: 'right' })
+      await renameMenuItem.click()
+      await expect(renameInput).toBeVisible()
+      await renameInput.fill(newFileName)
+      await page.keyboard.press('Enter')
+    })
 
-      await test.step('Open project and file pane', async () => {
-        await expect(projectLink).toBeVisible()
-        await projectLink.click()
-        await expect(projectMenuButton).toBeVisible()
-        await expect(projectMenuButton).toContainText('main.kcl')
+    await test.step('Verify the file is renamed', async () => {
+      await expect(fileToRename).not.toBeAttached()
+      await expect(renamedFile).toBeVisible()
+      expect(checkUnRenamedFS()).toBeFalsy()
+      expect(checkRenamedFS()).toBeTruthy()
+    })
 
-        const url = page.url()
-        expect(url).toContain('main.kcl')
-        expect(url).not.toContain('folderToRename')
+    await test.step('Verify we navigated', async () => {
+      await expect(projectMenuButton).toContainText(newFileName + FILE_EXT)
+      const url = page.url()
+      expect(url).toContain(newFileName)
+      await expect(projectMenuButton).not.toContainText('fileToRename.kcl')
+      await expect(projectMenuButton).not.toContainText('main.kcl')
+      expect(url).not.toContain('fileToRename.kcl')
+      expect(url).not.toContain('main.kcl')
 
-        await u.openFilePanel()
-        await expect(folderToRename).toBeVisible()
-        expect(checkUnRenamedFolderFS()).toBeTruthy()
-        expect(checkRenamedFolderFS()).toBeFalsy()
-      })
+      await u.openKclCodePanel()
+      await expect(codeLocator).toContainText('circle(')
+    })
+  })
 
-      await test.step('Rename the folder', async () => {
-        await folderToRename.click({ button: 'right' })
-        await expect(renameMenuItem).toBeVisible()
-        await renameMenuItem.click()
-        await expect(renameInput).toBeVisible()
-        await renameInput.fill(newFolderName)
-        await page.keyboard.press('Enter')
-      })
+  test('A file you do not have open', async ({ context, page }, testInfo) => {
+    const { dir } = await context.folderSetupFn(async (dir) => {
+      await fsp.mkdir(join(dir, 'Test Project'), { recursive: true })
+      await fsp.copyFile(
+        executorInputPath('basic_fillet_cube_end.kcl'),
+        join(dir, 'Test Project', 'main.kcl')
+      )
+      await fsp.copyFile(
+        executorInputPath('cylinder.kcl'),
+        join(dir, 'Test Project', 'fileToRename.kcl')
+      )
+    })
+    const u = await getUtils(page)
+    await page.setViewportSize({ width: 1200, height: 500 })
+    page.on('console', console.log)
 
-      await test.step('Verify the folder is renamed, and no navigation occurred', async () => {
-        const url = page.url()
-        expect(url).toContain('main.kcl')
-        expect(url).not.toContain('folderToRename')
-
-        await expect(projectMenuButton).toContainText('main.kcl')
-        await expect(renamedFolder).toBeVisible()
-        await expect(folderToRename).not.toBeAttached()
-        expect(checkUnRenamedFolderFS()).toBeFalsy()
-        expect(checkRenamedFolderFS()).toBeTruthy()
-      })
+    // Constants and locators
+    const newFileName = 'newFileName'
+    const checkUnRenamedFS = () => {
+      const filePath = join(dir, 'Test Project', 'fileToRename.kcl')
+      return fs.existsSync(filePath)
     }
-  )
-
-  test(
-    `A folder you are inside`,
-    { tag: '@desktop' },
-    async ({ page, context }, testInfo) => {
-      const { dir } = await context.folderSetupFn(async (dir) => {
-        await fsp.mkdir(join(dir, 'Test Project'), { recursive: true })
-        await fsp.mkdir(join(dir, 'Test Project', 'folderToRename'), {
-          recursive: true,
-        })
-        await fsp.copyFile(
-          executorInputPath('basic_fillet_cube_end.kcl'),
-          join(dir, 'Test Project', 'main.kcl')
-        )
-        await fsp.copyFile(
-          executorInputPath('cylinder.kcl'),
-          join(dir, 'Test Project', 'folderToRename', 'someFileWithin.kcl')
-        )
-      })
-
-      const u = await getUtils(page)
-      await page.setViewportSize({ width: 1200, height: 500 })
-      page.on('console', console.log)
-
-      // Constants and locators
-      const projectLink = page.getByText('Test Project')
-      const projectMenuButton = page.getByTestId('project-sidebar-toggle')
-      const folderToRename = u.locatorFolder('folderToRename')
-      const renamedFolder = u.locatorFolder('newFolderName')
-      const fileWithinFolder = u.locatorFile('someFileWithin.kcl')
-      const renameMenuItem = page.getByRole('button', { name: 'Rename' })
-      const originalFolderName = 'folderToRename'
-      const renameInput = page.getByPlaceholder(originalFolderName)
-      const newFolderName = 'newFolderName'
-      const checkUnRenamedFolderFS = () => {
-        const folderPath = join(dir, 'Test Project', originalFolderName)
-        return fs.existsSync(folderPath)
-      }
-      const checkRenamedFolderFS = () => {
-        const folderPath = join(dir, 'Test Project', newFolderName)
-        return fs.existsSync(folderPath)
-      }
-
-      await test.step('Open project and navigate into folder', async () => {
-        await expect(projectLink).toBeVisible()
-        await projectLink.click()
-        await expect(projectMenuButton).toBeVisible()
-        await expect(projectMenuButton).toContainText('main.kcl')
-
-        const url = page.url()
-        expect(url).toContain('main.kcl')
-        expect(url).not.toContain('folderToRename')
-
-        await u.openFilePanel()
-        await expect(folderToRename).toBeVisible()
-        await folderToRename.click()
-        await expect(fileWithinFolder).toBeVisible()
-        await fileWithinFolder.click()
-
-        await expect(projectMenuButton).toContainText('someFileWithin.kcl')
-        const newUrl = page.url()
-        expect(newUrl).toContain('folderToRename')
-        expect(newUrl).toContain('someFileWithin.kcl')
-        expect(newUrl).not.toContain('main.kcl')
-        expect(checkUnRenamedFolderFS()).toBeTruthy()
-        expect(checkRenamedFolderFS()).toBeFalsy()
-      })
-
-      await test.step('Rename the folder', async () => {
-        await page.waitForTimeout(1000)
-        await folderToRename.click({ button: 'right' })
-        await expect(renameMenuItem).toBeVisible()
-        await renameMenuItem.click()
-        await expect(renameInput).toBeVisible()
-        await renameInput.fill(newFolderName)
-        await page.keyboard.press('Enter')
-      })
-
-      await test.step('Verify the folder is renamed, and navigated to new path', async () => {
-        const urlSnippet = encodeURIComponent(
-          join(newFolderName, 'someFileWithin.kcl')
-        )
-        await page.waitForURL(new RegExp(urlSnippet))
-        await expect(projectMenuButton).toContainText('someFileWithin.kcl')
-        await expect(renamedFolder).toBeVisible()
-        await expect(folderToRename).not.toBeAttached()
-
-        // URL is synchronous, so we check the other stuff first
-        const url = page.url()
-        expect(url).not.toContain('main.kcl')
-        expect(url).toContain(newFolderName)
-        expect(url).toContain('someFileWithin.kcl')
-        expect(checkUnRenamedFolderFS()).toBeFalsy()
-        expect(checkRenamedFolderFS()).toBeTruthy()
-      })
+    const checkRenamedFS = () => {
+      const filePath = join(dir, 'Test Project', `${newFileName}.kcl`)
+      return fs.existsSync(filePath)
     }
-  )
+    const projectLink = page.getByText('Test Project')
+    const projectMenuButton = page.getByTestId('project-sidebar-toggle')
+    const fileToRename = u.locatorFile('fileToRename.kcl')
+    const renamedFile = u.locatorFile(newFileName + FILE_EXT)
+    const renameMenuItem = page.getByRole('button', { name: 'Rename' })
+    const renameInput = page.getByPlaceholder('fileToRename.kcl')
+    const codeLocator = page.locator('.cm-content')
+
+    await test.step('Open project and file pane', async () => {
+      await expect(projectLink).toBeVisible()
+      await projectLink.click()
+      await expect(projectMenuButton).toBeVisible()
+      await expect(projectMenuButton).toContainText('main.kcl')
+
+      await u.openFilePanel()
+      await expect(fileToRename).toBeVisible()
+      expect(checkUnRenamedFS()).toBeTruthy()
+      expect(checkRenamedFS()).toBeFalsy()
+    })
+
+    await test.step('Rename the file', async () => {
+      await fileToRename.click({ button: 'right' })
+      await renameMenuItem.click()
+      await expect(renameInput).toBeVisible()
+      await renameInput.fill(newFileName)
+      await page.keyboard.press('Enter')
+    })
+
+    await test.step('Verify the file is renamed', async () => {
+      await expect(fileToRename).not.toBeAttached()
+      await expect(renamedFile).toBeVisible()
+      expect(checkUnRenamedFS()).toBeFalsy()
+      expect(checkRenamedFS()).toBeTruthy()
+    })
+
+    await test.step('Verify we have not navigated', async () => {
+      await expect(projectMenuButton).toContainText('main.kcl')
+      await expect(projectMenuButton).not.toContainText(newFileName + FILE_EXT)
+      await expect(projectMenuButton).not.toContainText('fileToRename.kcl')
+
+      const url = page.url()
+      expect(url).toContain('main.kcl')
+      expect(url).not.toContain(newFileName)
+      expect(url).not.toContain('fileToRename.kcl')
+
+      await u.openKclCodePanel()
+      await expect(codeLocator).toContainText('fillet(')
+    })
+  })
+
+  test(`A folder you're not inside`, async ({ context, page }, testInfo) => {
+    const { dir } = await context.folderSetupFn(async (dir) => {
+      await fsp.mkdir(join(dir, 'Test Project'), { recursive: true })
+      await fsp.mkdir(join(dir, 'Test Project', 'folderToRename'), {
+        recursive: true,
+      })
+      await fsp.copyFile(
+        executorInputPath('basic_fillet_cube_end.kcl'),
+        join(dir, 'Test Project', 'main.kcl')
+      )
+      await fsp.copyFile(
+        executorInputPath('cylinder.kcl'),
+        join(dir, 'Test Project', 'folderToRename', 'someFileWithin.kcl')
+      )
+    })
+
+    const u = await getUtils(page)
+    await page.setViewportSize({ width: 1200, height: 500 })
+    page.on('console', console.log)
+
+    // Constants and locators
+    const projectLink = page.getByText('Test Project')
+    const projectMenuButton = page.getByTestId('project-sidebar-toggle')
+    const folderToRename = u.locatorFolder('folderToRename')
+    const renamedFolder = u.locatorFolder('newFolderName')
+    const renameMenuItem = page.getByRole('button', { name: 'Rename' })
+    const originalFolderName = 'folderToRename'
+    const renameInput = page.getByPlaceholder(originalFolderName)
+    const newFolderName = 'newFolderName'
+    const checkUnRenamedFolderFS = () => {
+      const folderPath = join(dir, 'Test Project', originalFolderName)
+      return fs.existsSync(folderPath)
+    }
+    const checkRenamedFolderFS = () => {
+      const folderPath = join(dir, 'Test Project', newFolderName)
+      return fs.existsSync(folderPath)
+    }
+
+    await test.step('Open project and file pane', async () => {
+      await expect(projectLink).toBeVisible()
+      await projectLink.click()
+      await expect(projectMenuButton).toBeVisible()
+      await expect(projectMenuButton).toContainText('main.kcl')
+
+      const url = page.url()
+      expect(url).toContain('main.kcl')
+      expect(url).not.toContain('folderToRename')
+
+      await u.openFilePanel()
+      await expect(folderToRename).toBeVisible()
+      expect(checkUnRenamedFolderFS()).toBeTruthy()
+      expect(checkRenamedFolderFS()).toBeFalsy()
+    })
+
+    await test.step('Rename the folder', async () => {
+      await folderToRename.click({ button: 'right' })
+      await expect(renameMenuItem).toBeVisible()
+      await renameMenuItem.click()
+      await expect(renameInput).toBeVisible()
+      await renameInput.fill(newFolderName)
+      await page.keyboard.press('Enter')
+    })
+
+    await test.step('Verify the folder is renamed, and no navigation occurred', async () => {
+      const url = page.url()
+      expect(url).toContain('main.kcl')
+      expect(url).not.toContain('folderToRename')
+
+      await expect(projectMenuButton).toContainText('main.kcl')
+      await expect(renamedFolder).toBeVisible()
+      await expect(folderToRename).not.toBeAttached()
+      expect(checkUnRenamedFolderFS()).toBeFalsy()
+      expect(checkRenamedFolderFS()).toBeTruthy()
+    })
+  })
+
+  test(`A folder you are inside`, async ({ page, context }, testInfo) => {
+    const { dir } = await context.folderSetupFn(async (dir) => {
+      await fsp.mkdir(join(dir, 'Test Project'), { recursive: true })
+      await fsp.mkdir(join(dir, 'Test Project', 'folderToRename'), {
+        recursive: true,
+      })
+      await fsp.copyFile(
+        executorInputPath('basic_fillet_cube_end.kcl'),
+        join(dir, 'Test Project', 'main.kcl')
+      )
+      await fsp.copyFile(
+        executorInputPath('cylinder.kcl'),
+        join(dir, 'Test Project', 'folderToRename', 'someFileWithin.kcl')
+      )
+    })
+
+    const u = await getUtils(page)
+    await page.setViewportSize({ width: 1200, height: 500 })
+    page.on('console', console.log)
+
+    // Constants and locators
+    const projectLink = page.getByText('Test Project')
+    const projectMenuButton = page.getByTestId('project-sidebar-toggle')
+    const folderToRename = u.locatorFolder('folderToRename')
+    const renamedFolder = u.locatorFolder('newFolderName')
+    const fileWithinFolder = u.locatorFile('someFileWithin.kcl')
+    const renameMenuItem = page.getByRole('button', { name: 'Rename' })
+    const originalFolderName = 'folderToRename'
+    const renameInput = page.getByPlaceholder(originalFolderName)
+    const newFolderName = 'newFolderName'
+    const checkUnRenamedFolderFS = () => {
+      const folderPath = join(dir, 'Test Project', originalFolderName)
+      return fs.existsSync(folderPath)
+    }
+    const checkRenamedFolderFS = () => {
+      const folderPath = join(dir, 'Test Project', newFolderName)
+      return fs.existsSync(folderPath)
+    }
+
+    await test.step('Open project and navigate into folder', async () => {
+      await expect(projectLink).toBeVisible()
+      await projectLink.click()
+      await expect(projectMenuButton).toBeVisible()
+      await expect(projectMenuButton).toContainText('main.kcl')
+
+      const url = page.url()
+      expect(url).toContain('main.kcl')
+      expect(url).not.toContain('folderToRename')
+
+      await u.openFilePanel()
+      await expect(folderToRename).toBeVisible()
+      await folderToRename.click()
+      await expect(fileWithinFolder).toBeVisible()
+      await fileWithinFolder.click()
+
+      await expect(projectMenuButton).toContainText('someFileWithin.kcl')
+      const newUrl = page.url()
+      expect(newUrl).toContain('folderToRename')
+      expect(newUrl).toContain('someFileWithin.kcl')
+      expect(newUrl).not.toContain('main.kcl')
+      expect(checkUnRenamedFolderFS()).toBeTruthy()
+      expect(checkRenamedFolderFS()).toBeFalsy()
+    })
+
+    await test.step('Rename the folder', async () => {
+      await page.waitForTimeout(1000)
+      await folderToRename.click({ button: 'right' })
+      await expect(renameMenuItem).toBeVisible()
+      await renameMenuItem.click()
+      await expect(renameInput).toBeVisible()
+      await renameInput.fill(newFolderName)
+      await page.keyboard.press('Enter')
+    })
+
+    await test.step('Verify the folder is renamed, and navigated to new path', async () => {
+      const urlSnippet = encodeURIComponent(
+        join(newFolderName, 'someFileWithin.kcl')
+      )
+      await page.waitForURL(new RegExp(urlSnippet))
+      await expect(projectMenuButton).toContainText('someFileWithin.kcl')
+      await expect(renamedFolder).toBeVisible()
+      await expect(folderToRename).not.toBeAttached()
+
+      // URL is synchronous, so we check the other stuff first
+      const url = page.url()
+      expect(url).not.toContain('main.kcl')
+      expect(url).toContain(newFolderName)
+      expect(url).toContain('someFileWithin.kcl')
+      expect(checkUnRenamedFolderFS()).toBeFalsy()
+      expect(checkRenamedFolderFS()).toBeTruthy()
+    })
+  })
 })
 
-test.describe('Deleting items from the file pane', () => {
-  test(
-    `delete file when main.kcl exists, navigate to main.kcl`,
-    { tag: '@desktop' },
-    async ({ page, context }, testInfo) => {
-      await context.folderSetupFn(async (dir) => {
-        const testDir = join(dir, 'testProject')
-        await fsp.mkdir(testDir, { recursive: true })
-        await fsp.copyFile(
-          executorInputPath('cylinder.kcl'),
-          join(testDir, 'main.kcl')
-        )
-        await fsp.copyFile(
-          executorInputPath('basic_fillet_cube_end.kcl'),
-          join(testDir, 'fileToDelete.kcl')
-        )
+test.describe('Deleting items from the file pane', { tag: '@desktop' }, () => {
+  test(`delete file when main.kcl exists, navigate to main.kcl`, async ({
+    page,
+    context,
+  }, testInfo) => {
+    await context.folderSetupFn(async (dir) => {
+      const testDir = join(dir, 'testProject')
+      await fsp.mkdir(testDir, { recursive: true })
+      await fsp.copyFile(
+        executorInputPath('cylinder.kcl'),
+        join(testDir, 'main.kcl')
+      )
+      await fsp.copyFile(
+        executorInputPath('basic_fillet_cube_end.kcl'),
+        join(testDir, 'fileToDelete.kcl')
+      )
+    })
+    const u = await getUtils(page)
+    await page.setViewportSize({ width: 1200, height: 500 })
+    page.on('console', console.log)
+
+    // Constants and locators
+    const projectCard = page.getByText('testProject')
+    const projectMenuButton = page.getByTestId('project-sidebar-toggle')
+    const fileToDelete = u.locatorFile('fileToDelete.kcl')
+    const deleteMenuItem = page.getByRole('button', { name: 'Delete' })
+    const deleteConfirmation = page.getByTestId('delete-confirmation')
+
+    await test.step('Open project and navigate to fileToDelete.kcl', async () => {
+      await projectCard.click()
+      await u.waitForPageLoad()
+      await u.openFilePanel()
+
+      await fileToDelete.click()
+      await u.waitForPageLoad()
+      await u.openKclCodePanel()
+      await expect(u.codeLocator).toContainText('getOppositeEdge(thing)')
+      await u.closeKclCodePanel()
+    })
+
+    await test.step('Delete fileToDelete.kcl', async () => {
+      await fileToDelete.click({ button: 'right' })
+      await expect(deleteMenuItem).toBeVisible()
+      await deleteMenuItem.click()
+      await expect(deleteConfirmation).toBeVisible()
+      await deleteConfirmation.click()
+    })
+
+    await test.step('Check deletion and navigation', async () => {
+      await u.waitForPageLoad()
+      await expect(fileToDelete).not.toBeVisible()
+      await u.closeFilePanel()
+      await u.openKclCodePanel()
+      await expect(u.codeLocator).toContainText('circle(')
+      await expect(projectMenuButton).toContainText('main.kcl')
+    })
+  })
+
+  test(`Delete folder we are not in, don't navigate`, async ({
+    context,
+    page,
+  }, testInfo) => {
+    await context.folderSetupFn(async (dir) => {
+      await fsp.mkdir(join(dir, 'Test Project'), { recursive: true })
+      await fsp.mkdir(join(dir, 'Test Project', 'folderToDelete'), {
+        recursive: true,
       })
-      const u = await getUtils(page)
-      await page.setViewportSize({ width: 1200, height: 500 })
-      page.on('console', console.log)
+      await fsp.copyFile(
+        executorInputPath('basic_fillet_cube_end.kcl'),
+        join(dir, 'Test Project', 'main.kcl')
+      )
+      await fsp.copyFile(
+        executorInputPath('cylinder.kcl'),
+        join(dir, 'Test Project', 'folderToDelete', 'someFileWithin.kcl')
+      )
+    })
+    const u = await getUtils(page)
+    await page.setViewportSize({ width: 1200, height: 500 })
+    page.on('console', console.log)
 
-      // Constants and locators
-      const projectCard = page.getByText('testProject')
-      const projectMenuButton = page.getByTestId('project-sidebar-toggle')
-      const fileToDelete = u.locatorFile('fileToDelete.kcl')
-      const deleteMenuItem = page.getByRole('button', { name: 'Delete' })
-      const deleteConfirmation = page.getByTestId('delete-confirmation')
+    // Constants and locators
+    const projectCard = page.getByText('Test Project')
+    const projectMenuButton = page.getByTestId('project-sidebar-toggle')
+    const folderToDelete = u.locatorFolder('folderToDelete')
+    const deleteMenuItem = page.getByRole('button', { name: 'Delete' })
+    const deleteConfirmation = page.getByTestId('delete-confirmation')
 
-      await test.step('Open project and navigate to fileToDelete.kcl', async () => {
-        await projectCard.click()
-        await u.waitForPageLoad()
-        await u.openFilePanel()
+    await test.step('Open project and open project pane', async () => {
+      await projectCard.click()
+      await u.waitForPageLoad()
+      await expect(projectMenuButton).toContainText('main.kcl')
+      await u.closeKclCodePanel()
+      await u.openFilePanel()
+    })
 
-        await fileToDelete.click()
-        await u.waitForPageLoad()
-        await u.openKclCodePanel()
-        await expect(u.codeLocator).toContainText('getOppositeEdge(thing)')
-        await u.closeKclCodePanel()
+    await test.step('Delete folderToDelete', async () => {
+      await folderToDelete.click({ button: 'right' })
+      await expect(deleteMenuItem).toBeVisible()
+      await deleteMenuItem.click()
+      await expect(deleteConfirmation).toBeVisible()
+      await deleteConfirmation.click()
+    })
+
+    await test.step('Check deletion and no navigation', async () => {
+      await expect(folderToDelete).not.toBeAttached()
+      await expect(projectMenuButton).toContainText('main.kcl')
+    })
+  })
+
+  test(`Delete folder we are in, navigate to main.kcl`, async ({
+    context,
+    page,
+  }, testInfo) => {
+    await context.folderSetupFn(async (dir) => {
+      await fsp.mkdir(join(dir, 'Test Project'), { recursive: true })
+      await fsp.mkdir(join(dir, 'Test Project', 'folderToDelete'), {
+        recursive: true,
       })
+      await fsp.copyFile(
+        executorInputPath('basic_fillet_cube_end.kcl'),
+        join(dir, 'Test Project', 'main.kcl')
+      )
+      await fsp.copyFile(
+        executorInputPath('cylinder.kcl'),
+        join(dir, 'Test Project', 'folderToDelete', 'someFileWithin.kcl')
+      )
+    })
+    const u = await getUtils(page)
+    await page.setViewportSize({ width: 1200, height: 500 })
+    page.on('console', console.log)
 
-      await test.step('Delete fileToDelete.kcl', async () => {
-        await fileToDelete.click({ button: 'right' })
-        await expect(deleteMenuItem).toBeVisible()
-        await deleteMenuItem.click()
-        await expect(deleteConfirmation).toBeVisible()
-        await deleteConfirmation.click()
-      })
+    // Constants and locators
+    const projectCard = page.getByText('Test Project')
+    const projectMenuButton = page.getByTestId('project-sidebar-toggle')
+    const folderToDelete = u.locatorFolder('folderToDelete')
+    const fileWithinFolder = u.locatorFile('someFileWithin.kcl')
+    const deleteMenuItem = page.getByRole('button', { name: 'Delete' })
+    const deleteConfirmation = page.getByTestId('delete-confirmation')
 
-      await test.step('Check deletion and navigation', async () => {
-        await u.waitForPageLoad()
-        await expect(fileToDelete).not.toBeVisible()
-        await u.closeFilePanel()
-        await u.openKclCodePanel()
-        await expect(u.codeLocator).toContainText('circle(')
-        await expect(projectMenuButton).toContainText('main.kcl')
-      })
-    }
-  )
+    await test.step('Open project and navigate into folderToDelete', async () => {
+      await projectCard.click()
+      await u.waitForPageLoad()
+      await expect(projectMenuButton).toContainText('main.kcl')
+      await u.closeKclCodePanel()
+      await u.openFilePanel()
 
-  test(
-    `Delete folder we are not in, don't navigate`,
-    { tag: '@desktop' },
-    async ({ context, page }, testInfo) => {
-      await context.folderSetupFn(async (dir) => {
-        await fsp.mkdir(join(dir, 'Test Project'), { recursive: true })
-        await fsp.mkdir(join(dir, 'Test Project', 'folderToDelete'), {
-          recursive: true,
-        })
-        await fsp.copyFile(
-          executorInputPath('basic_fillet_cube_end.kcl'),
-          join(dir, 'Test Project', 'main.kcl')
-        )
-        await fsp.copyFile(
-          executorInputPath('cylinder.kcl'),
-          join(dir, 'Test Project', 'folderToDelete', 'someFileWithin.kcl')
-        )
-      })
-      const u = await getUtils(page)
-      await page.setViewportSize({ width: 1200, height: 500 })
-      page.on('console', console.log)
+      await folderToDelete.click()
+      await expect(fileWithinFolder).toBeVisible()
+      await fileWithinFolder.click()
+      await expect(projectMenuButton).toContainText('someFileWithin.kcl')
+    })
 
-      // Constants and locators
-      const projectCard = page.getByText('Test Project')
-      const projectMenuButton = page.getByTestId('project-sidebar-toggle')
-      const folderToDelete = u.locatorFolder('folderToDelete')
-      const deleteMenuItem = page.getByRole('button', { name: 'Delete' })
-      const deleteConfirmation = page.getByTestId('delete-confirmation')
+    await test.step('Delete folderToDelete', async () => {
+      await folderToDelete.click({ button: 'right' })
+      await expect(deleteMenuItem).toBeVisible()
+      await deleteMenuItem.click()
+      await expect(deleteConfirmation).toBeVisible()
+      await deleteConfirmation.click()
+    })
 
-      await test.step('Open project and open project pane', async () => {
-        await projectCard.click()
-        await u.waitForPageLoad()
-        await expect(projectMenuButton).toContainText('main.kcl')
-        await u.closeKclCodePanel()
-        await u.openFilePanel()
-      })
-
-      await test.step('Delete folderToDelete', async () => {
-        await folderToDelete.click({ button: 'right' })
-        await expect(deleteMenuItem).toBeVisible()
-        await deleteMenuItem.click()
-        await expect(deleteConfirmation).toBeVisible()
-        await deleteConfirmation.click()
-      })
-
-      await test.step('Check deletion and no navigation', async () => {
-        await expect(folderToDelete).not.toBeAttached()
-        await expect(projectMenuButton).toContainText('main.kcl')
-      })
-    }
-  )
-
-  test(
-    `Delete folder we are in, navigate to main.kcl`,
-    { tag: '@desktop' },
-    async ({ context, page }, testInfo) => {
-      await context.folderSetupFn(async (dir) => {
-        await fsp.mkdir(join(dir, 'Test Project'), { recursive: true })
-        await fsp.mkdir(join(dir, 'Test Project', 'folderToDelete'), {
-          recursive: true,
-        })
-        await fsp.copyFile(
-          executorInputPath('basic_fillet_cube_end.kcl'),
-          join(dir, 'Test Project', 'main.kcl')
-        )
-        await fsp.copyFile(
-          executorInputPath('cylinder.kcl'),
-          join(dir, 'Test Project', 'folderToDelete', 'someFileWithin.kcl')
-        )
-      })
-      const u = await getUtils(page)
-      await page.setViewportSize({ width: 1200, height: 500 })
-      page.on('console', console.log)
-
-      // Constants and locators
-      const projectCard = page.getByText('Test Project')
-      const projectMenuButton = page.getByTestId('project-sidebar-toggle')
-      const folderToDelete = u.locatorFolder('folderToDelete')
-      const fileWithinFolder = u.locatorFile('someFileWithin.kcl')
-      const deleteMenuItem = page.getByRole('button', { name: 'Delete' })
-      const deleteConfirmation = page.getByTestId('delete-confirmation')
-
-      await test.step('Open project and navigate into folderToDelete', async () => {
-        await projectCard.click()
-        await u.waitForPageLoad()
-        await expect(projectMenuButton).toContainText('main.kcl')
-        await u.closeKclCodePanel()
-        await u.openFilePanel()
-
-        await folderToDelete.click()
-        await expect(fileWithinFolder).toBeVisible()
-        await fileWithinFolder.click()
-        await expect(projectMenuButton).toContainText('someFileWithin.kcl')
-      })
-
-      await test.step('Delete folderToDelete', async () => {
-        await folderToDelete.click({ button: 'right' })
-        await expect(deleteMenuItem).toBeVisible()
-        await deleteMenuItem.click()
-        await expect(deleteConfirmation).toBeVisible()
-        await deleteConfirmation.click()
-      })
-
-      await test.step('Check deletion and navigation to main.kcl', async () => {
-        await expect(folderToDelete).not.toBeAttached()
-        await expect(fileWithinFolder).not.toBeAttached()
-        await expect(projectMenuButton).toContainText('main.kcl')
-      })
-    }
-  )
+    await test.step('Check deletion and navigation to main.kcl', async () => {
+      await expect(folderToDelete).not.toBeAttached()
+      await expect(fileWithinFolder).not.toBeAttached()
+      await expect(projectMenuButton).toContainText('main.kcl')
+    })
+  })
 
   // Copied from tests above.
-  test(
-    `external deletion of project navigates back home`,
-    { tag: '@desktop' },
-    async ({ context, page }, testInfo) => {
-      const TEST_PROJECT_NAME = 'Test Project'
-      const { dir: projectsDirName } = await context.folderSetupFn(
-        async (dir) => {
-          await fsp.mkdir(join(dir, TEST_PROJECT_NAME), { recursive: true })
-          await fsp.mkdir(join(dir, TEST_PROJECT_NAME, 'folderToDelete'), {
-            recursive: true,
-          })
-          await fsp.copyFile(
-            executorInputPath('basic_fillet_cube_end.kcl'),
-            join(dir, TEST_PROJECT_NAME, 'main.kcl')
-          )
-          await fsp.copyFile(
-            executorInputPath('cylinder.kcl'),
-            join(dir, TEST_PROJECT_NAME, 'folderToDelete', 'someFileWithin.kcl')
-          )
-        }
-      )
-      const u = await getUtils(page)
-      await page.setViewportSize({ width: 1200, height: 500 })
-
-      // Constants and locators
-      const projectCard = page.getByText(TEST_PROJECT_NAME)
-      const projectMenuButton = page.getByTestId('project-sidebar-toggle')
-      const folderToDelete = u.locatorFolder('folderToDelete')
-      const fileWithinFolder = u.locatorFile('someFileWithin.kcl')
-
-      await test.step('Open project and navigate into folderToDelete', async () => {
-        await projectCard.click()
-        await u.waitForPageLoad()
-        await expect(projectMenuButton).toContainText('main.kcl')
-        await u.closeKclCodePanel()
-        await u.openFilePanel()
-
-        await folderToDelete.click()
-        await expect(fileWithinFolder).toBeVisible()
-        await fileWithinFolder.click()
-        await expect(projectMenuButton).toContainText('someFileWithin.kcl')
-      })
-
-      // Point of divergence. Delete the project folder and see if it goes back
-      // to the home view.
-      await test.step('Delete projectsDirName/<project-name> externally', async () => {
-        await fsp.rm(join(projectsDirName, TEST_PROJECT_NAME), {
+  test(`external deletion of project navigates back home`, async ({
+    context,
+    page,
+  }, testInfo) => {
+    const TEST_PROJECT_NAME = 'Test Project'
+    const { dir: projectsDirName } = await context.folderSetupFn(
+      async (dir) => {
+        await fsp.mkdir(join(dir, TEST_PROJECT_NAME), { recursive: true })
+        await fsp.mkdir(join(dir, TEST_PROJECT_NAME, 'folderToDelete'), {
           recursive: true,
-          force: true,
         })
-      })
+        await fsp.copyFile(
+          executorInputPath('basic_fillet_cube_end.kcl'),
+          join(dir, TEST_PROJECT_NAME, 'main.kcl')
+        )
+        await fsp.copyFile(
+          executorInputPath('cylinder.kcl'),
+          join(dir, TEST_PROJECT_NAME, 'folderToDelete', 'someFileWithin.kcl')
+        )
+      }
+    )
+    const u = await getUtils(page)
+    await page.setViewportSize({ width: 1200, height: 500 })
 
-      await test.step('Check the app is back on the home view', async () => {
-        const projectsDirLink = page.getByText('Loaded from')
-        await expect(projectsDirLink).toBeVisible()
+    // Constants and locators
+    const projectCard = page.getByText(TEST_PROJECT_NAME)
+    const projectMenuButton = page.getByTestId('project-sidebar-toggle')
+    const folderToDelete = u.locatorFolder('folderToDelete')
+    const fileWithinFolder = u.locatorFile('someFileWithin.kcl')
+
+    await test.step('Open project and navigate into folderToDelete', async () => {
+      await projectCard.click()
+      await u.waitForPageLoad()
+      await expect(projectMenuButton).toContainText('main.kcl')
+      await u.closeKclCodePanel()
+      await u.openFilePanel()
+
+      await folderToDelete.click()
+      await expect(fileWithinFolder).toBeVisible()
+      await fileWithinFolder.click()
+      await expect(projectMenuButton).toContainText('someFileWithin.kcl')
+    })
+
+    // Point of divergence. Delete the project folder and see if it goes back
+    // to the home view.
+    await test.step('Delete projectsDirName/<project-name> externally', async () => {
+      await fsp.rm(join(projectsDirName, TEST_PROJECT_NAME), {
+        recursive: true,
+        force: true,
       })
-    }
-  )
+    })
+
+    await test.step('Check the app is back on the home view', async () => {
+      const projectsDirLink = page.getByText('Loaded from')
+      await expect(projectsDirLink).toBeVisible()
+    })
+  })
 })
 
-test.describe('Undo and redo do not keep history when navigating between files', () => {
-  test(
-    `open a file, change something, open a different file, hitting undo should do nothing`,
-    { tag: '@desktop' },
-    async ({ context, page }, testInfo) => {
+test.describe(
+  'Undo and redo do not keep history when navigating between files',
+  { tag: '@desktop' },
+  () => {
+    test(`open a file, change something, open a different file, hitting undo should do nothing`, async ({
+      context,
+      page,
+    }, testInfo) => {
       await context.folderSetupFn(async (dir) => {
         const testDir = join(dir, 'testProject')
         await fsp.mkdir(testDir, { recursive: true })
@@ -923,13 +900,12 @@ test.describe('Undo and redo do not keep history when navigating between files',
         await page.waitForTimeout(100)
         await expect(u.codeLocator).toContainText(originalText)
       })
-    }
-  )
+    })
 
-  test(
-    `open a file, change something, undo it, open a different file, hitting redo should do nothing`,
-    { tag: '@desktop' },
-    async ({ context, page }, testInfo) => {
+    test(`open a file, change something, undo it, open a different file, hitting redo should do nothing`, async ({
+      context,
+      page,
+    }, testInfo) => {
       await context.folderSetupFn(async (dir) => {
         const testDir = join(dir, 'testProject')
         await fsp.mkdir(testDir, { recursive: true })
@@ -1021,6 +997,6 @@ test.describe('Undo and redo do not keep history when navigating between files',
         await expect(u.codeLocator).toContainText(originalText)
         await expect(u.codeLocator).not.toContainText(badContent)
       })
-    }
-  )
-})
+    })
+  }
+)

--- a/e2e/playwright/import-ui.spec.ts
+++ b/e2e/playwright/import-ui.spec.ts
@@ -3,11 +3,19 @@ import { expect, test } from '@e2e/playwright/zoo-test'
 import * as fsp from 'fs/promises'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 
-test.describe('Import UI tests', () => {
-  test(
-    'shows toast when trying to sketch on imported face, and hovering over imported geometry should NOT highlight any code',
-    { tag: ['@desktop', '@macos', '@windows'] },
-    async ({ context, page, homePage, toolbar, scene, editor, cmdBar }) => {
+test.describe(
+  'Import UI tests',
+  { tag: ['@desktop', '@macos', '@windows'] },
+  () => {
+    test('shows toast when trying to sketch on imported face, and hovering over imported geometry should NOT highlight any code', async ({
+      context,
+      page,
+      homePage,
+      toolbar,
+      scene,
+      editor,
+      cmdBar,
+    }) => {
       await context.folderSetupFn(async (dir) => {
         const projectDir = path.join(dir, 'import-test')
         await fsp.mkdir(projectDir, { recursive: true })
@@ -104,6 +112,6 @@ sketch002 = startSketchOn(extrude001, face = seg01)`
           page.getByText('Please select this from the files pane to edit')
         ).toBeVisible()
       })
-    }
-  )
-})
+    })
+  }
+)

--- a/e2e/playwright/named-views.spec.ts
+++ b/e2e/playwright/named-views.spec.ts
@@ -62,7 +62,7 @@ function tomlStringMakeTestDataNotAsFragile(toml: string): string {
   return perProjectSettingsToToml(settings)
 }
 
-test.describe('Named view tests', () => {
+test.describe('Named view tests', { tag: '@desktop' }, () => {
   test.fail(runningOnWindows(), 'Windows line endings break snapshot matching')
   test('Verify project.toml is not created', async ({ page }, testInfo) => {
     // Create project and load it

--- a/e2e/playwright/null.spec.ts
+++ b/e2e/playwright/null.spec.ts
@@ -4,7 +4,7 @@
 // Additionally this serves as a nice minimal example.
 import { expect, test } from '@e2e/playwright/zoo-test'
 
-test.describe('Open the application', () => {
+test.describe('Open the application', { tag: '@desktop' }, () => {
   test('see the project view', async ({ page, context }) => {
     await expect(page.getByTestId('home-section')).toBeVisible()
   })

--- a/e2e/playwright/onboarding-tests.spec.ts
+++ b/e2e/playwright/onboarding-tests.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@e2e/playwright/zoo-test'
 
-test.describe('Onboarding tests', () => {
+test.describe('Onboarding tests', { tag: '@desktop' }, () => {
   test('Desktop onboarding flow works', async ({
     page,
     homePage,

--- a/e2e/playwright/point-click-assemblies.spec.ts
+++ b/e2e/playwright/point-click-assemblies.spec.ts
@@ -41,11 +41,11 @@ async function insertPartIntoAssembly(
 }
 
 // test file is for testing point an click code gen functionality that's assemblies related
-test.describe('Point-and-click assemblies tests', () => {
-  test(
-    `Insert kcl parts into assembly as whole module import`,
-    { tag: ['@desktop', '@macos', '@windows'] },
-    async ({
+test.describe(
+  'Point-and-click assemblies tests',
+  { tag: ['@desktop', '@macos', '@windows'] },
+  () => {
+    test(`Insert kcl parts into assembly as whole module import`, async ({
       context,
       page,
       homePage,
@@ -171,13 +171,9 @@ test.describe('Point-and-click assemblies tests', () => {
           { shouldNormalise: true }
         )
       })
-    }
-  )
+    })
 
-  test(
-    `Insert the bracket part into an assembly and transform it`,
-    { tag: ['@desktop', '@macos', '@windows'] },
-    async ({
+    test(`Insert the bracket part into an assembly and transform it`, async ({
       context,
       page,
       homePage,
@@ -429,13 +425,9 @@ test.describe('Point-and-click assemblies tests', () => {
         await editor.expectEditor.not.toContain('scale')
         await editor.expectEditor.not.toContain('rotate')
       })
-    }
-  )
+    })
 
-  test(
-    `Insert foreign parts into assembly and delete them`,
-    { tag: ['@desktop', '@macos', '@windows'] },
-    async ({
+    test(`Insert foreign parts into assembly and delete them`, async ({
       context,
       page,
       homePage,
@@ -563,13 +555,17 @@ test.describe('Point-and-click assemblies tests', () => {
         )
         await toolbar.closePane(DefaultLayoutPaneID.Code)
       })
-    }
-  )
+    })
 
-  test(
-    'Assembly gets reexecuted when imported models are updated externally',
-    { tag: ['@desktop', '@macos', '@windows'] },
-    async ({ context, page, homePage, scene, toolbar, cmdBar, tronApp }) => {
+    test('Assembly gets reexecuted when imported models are updated externally', async ({
+      context,
+      page,
+      homePage,
+      scene,
+      toolbar,
+      cmdBar,
+      tronApp,
+    }) => {
       if (!tronApp) throw new Error('tronApp is missing.')
 
       const projectName = 'assembly'
@@ -648,13 +644,9 @@ foreign
           await toolbar.closePane(DefaultLayoutPaneID.Code)
         })
       })
-    }
-  )
+    })
 
-  test(
-    `Point-and-click clone`,
-    { tag: ['@desktop', '@macos', '@windows'] },
-    async ({
+    test(`Point-and-click clone`, async ({
       context,
       page,
       homePage,
@@ -753,6 +745,6 @@ foreign
           shouldNormalise: true,
         })
       })
-    }
-  )
-})
+    })
+  }
+)

--- a/e2e/playwright/point-click.spec.ts
+++ b/e2e/playwright/point-click.spec.ts
@@ -11,7 +11,7 @@ import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 
 // test file is for testing point an click code gen functionality that's not sketch mode related
 
-test.describe('Point-and-click tests', () => {
+test.describe('Point-and-click tests', { tag: '@desktop' }, () => {
   test('Verify in-pipe extrudes in bracket can be edited', async ({
     tronApp,
     context,

--- a/e2e/playwright/projects.spec.ts
+++ b/e2e/playwright/projects.spec.ts
@@ -574,216 +574,221 @@ test(
   }
 )
 
-test.describe(`Project management commands`, () => {
-  test(
-    `Rename from project page`,
-    { tag: '@desktop' },
-    async ({ context, page, scene, cmdBar }, testInfo) => {
-      const projectName = `my_project_to_rename`
-      await context.folderSetupFn(async (dir) => {
-        await fsp.mkdir(`${dir}/${projectName}`, { recursive: true })
-        await fsp.copyFile(
-          'rust/kcl-lib/e2e/executor/inputs/router-template-slate.kcl',
-          `${dir}/${projectName}/main.kcl`
-        )
-      })
+test.describe(`Project management commands`, { tag: '@desktop' }, () => {
+  test(`Rename from project page`, async ({
+    context,
+    page,
+    scene,
+    cmdBar,
+  }, testInfo) => {
+    const projectName = `my_project_to_rename`
+    await context.folderSetupFn(async (dir) => {
+      await fsp.mkdir(`${dir}/${projectName}`, { recursive: true })
+      await fsp.copyFile(
+        'rust/kcl-lib/e2e/executor/inputs/router-template-slate.kcl',
+        `${dir}/${projectName}/main.kcl`
+      )
+    })
 
-      // Constants and locators
-      const projectHomeLink = page.getByTestId('project-link')
-      const commandButton = page.getByRole('button', { name: 'Commands' })
-      const commandOption = page.getByRole('option', {
-        name: 'rename project',
-      })
-      const projectNameOption = page.getByRole('option', { name: projectName })
-      const projectRenamedName = `untitled`
-      // const projectMenuButton = page.getByTestId('project-sidebar-toggle')
-      const commandContinueButton = page.getByRole('button', {
-        name: 'Continue',
-      })
-      const toastMessage = page.getByText(`Successfully renamed`)
+    // Constants and locators
+    const projectHomeLink = page.getByTestId('project-link')
+    const commandButton = page.getByRole('button', { name: 'Commands' })
+    const commandOption = page.getByRole('option', {
+      name: 'rename project',
+    })
+    const projectNameOption = page.getByRole('option', { name: projectName })
+    const projectRenamedName = `untitled`
+    // const projectMenuButton = page.getByTestId('project-sidebar-toggle')
+    const commandContinueButton = page.getByRole('button', {
+      name: 'Continue',
+    })
+    const toastMessage = page.getByText(`Successfully renamed`)
 
-      await test.step(`Setup`, async () => {
-        await page.setBodyDimensions({ width: 1200, height: 500 })
-        page.on('console', console.log)
+    await test.step(`Setup`, async () => {
+      await page.setBodyDimensions({ width: 1200, height: 500 })
+      page.on('console', console.log)
 
-        await projectHomeLink.click()
-        await scene.settled(cmdBar)
-      })
+      await projectHomeLink.click()
+      await scene.settled(cmdBar)
+    })
 
-      await test.step(`Run rename command via command palette`, async () => {
-        await commandButton.click()
-        await commandOption.click()
-        await projectNameOption.click()
+    await test.step(`Run rename command via command palette`, async () => {
+      await commandButton.click()
+      await commandOption.click()
+      await projectNameOption.click()
 
-        await expect(commandContinueButton).toBeVisible()
-        await commandContinueButton.click()
+      await expect(commandContinueButton).toBeVisible()
+      await commandContinueButton.click()
 
-        await cmdBar.submit()
+      await cmdBar.submit()
 
-        await expect(toastMessage).toBeVisible()
-      })
+      await expect(toastMessage).toBeVisible()
+    })
 
-      // TODO: in future I'd like the behavior to be to
-      // navigate to the new project's page directly,
-      // see ProjectContextProvider.tsx:158
-      await test.step(`Check the project was renamed and we navigated home`, async () => {
-        await expect(projectHomeLink.first()).toBeVisible()
-        await expect(projectHomeLink.first()).toContainText(projectRenamedName)
-      })
-    }
-  )
+    // TODO: in future I'd like the behavior to be to
+    // navigate to the new project's page directly,
+    // see ProjectContextProvider.tsx:158
+    await test.step(`Check the project was renamed and we navigated home`, async () => {
+      await expect(projectHomeLink.first()).toBeVisible()
+      await expect(projectHomeLink.first()).toContainText(projectRenamedName)
+    })
+  })
 
-  test(
-    `Delete from project page`,
-    { tag: '@desktop' },
-    async ({ context, page, scene, cmdBar }, testInfo) => {
-      const projectName = `my_project_to_delete`
-      await context.folderSetupFn(async (dir) => {
-        await fsp.mkdir(`${dir}/${projectName}`, { recursive: true })
-        await fsp.copyFile(
-          'rust/kcl-lib/e2e/executor/inputs/router-template-slate.kcl',
-          `${dir}/${projectName}/main.kcl`
-        )
-      })
+  test(`Delete from project page`, async ({
+    context,
+    page,
+    scene,
+    cmdBar,
+  }, testInfo) => {
+    const projectName = `my_project_to_delete`
+    await context.folderSetupFn(async (dir) => {
+      await fsp.mkdir(`${dir}/${projectName}`, { recursive: true })
+      await fsp.copyFile(
+        'rust/kcl-lib/e2e/executor/inputs/router-template-slate.kcl',
+        `${dir}/${projectName}/main.kcl`
+      )
+    })
 
-      // Constants and locators
-      const projectHomeLink = page.getByTestId('project-link')
-      const commandButton = page.getByRole('button', { name: 'Commands' })
-      const commandOption = page.getByRole('option', {
-        name: 'delete project',
-      })
-      const projectNameOption = page.getByRole('option', { name: projectName })
-      const commandWarning = page.getByText('Are you sure you want to delete?')
-      const toastMessage = page.getByText(`Successfully deleted`)
-      const noProjectsMessage = page.getByText('No projects found')
+    // Constants and locators
+    const projectHomeLink = page.getByTestId('project-link')
+    const commandButton = page.getByRole('button', { name: 'Commands' })
+    const commandOption = page.getByRole('option', {
+      name: 'delete project',
+    })
+    const projectNameOption = page.getByRole('option', { name: projectName })
+    const commandWarning = page.getByText('Are you sure you want to delete?')
+    const toastMessage = page.getByText(`Successfully deleted`)
+    const noProjectsMessage = page.getByText('No projects found')
 
-      await test.step(`Setup`, async () => {
-        await page.setBodyDimensions({ width: 1200, height: 500 })
-        page.on('console', console.log)
+    await test.step(`Setup`, async () => {
+      await page.setBodyDimensions({ width: 1200, height: 500 })
+      page.on('console', console.log)
 
-        await page.waitForTimeout(3000)
+      await page.waitForTimeout(3000)
 
-        await projectHomeLink.click()
-        await scene.settled(cmdBar)
-      })
+      await projectHomeLink.click()
+      await scene.settled(cmdBar)
+    })
 
-      await test.step(`Run delete command via command palette`, async () => {
-        await commandButton.click()
-        await commandOption.click()
-        await projectNameOption.click()
+    await test.step(`Run delete command via command palette`, async () => {
+      await commandButton.click()
+      await commandOption.click()
+      await projectNameOption.click()
 
-        await expect(commandWarning).toBeVisible()
-        await cmdBar.submit()
+      await expect(commandWarning).toBeVisible()
+      await cmdBar.submit()
 
-        await expect(toastMessage).toBeVisible()
-      })
+      await expect(toastMessage).toBeVisible()
+    })
 
-      await test.step(`Check the project was deleted and we navigated home`, async () => {
-        await expect(noProjectsMessage).toBeVisible()
-      })
-    }
-  )
-  test(
-    `Rename from home page`,
-    { tag: '@desktop' },
-    async ({ context, page, homePage, scene, cmdBar }, testInfo) => {
-      const projectName = `my_project_to_rename`
-      await context.folderSetupFn(async (dir) => {
-        await fsp.mkdir(`${dir}/${projectName}`, { recursive: true })
-        await fsp.copyFile(
-          'rust/kcl-lib/e2e/executor/inputs/router-template-slate.kcl',
-          `${dir}/${projectName}/main.kcl`
-        )
-      })
+    await test.step(`Check the project was deleted and we navigated home`, async () => {
+      await expect(noProjectsMessage).toBeVisible()
+    })
+  })
+  test(`Rename from home page`, async ({
+    context,
+    page,
+    homePage,
+    scene,
+    cmdBar,
+  }, testInfo) => {
+    const projectName = `my_project_to_rename`
+    await context.folderSetupFn(async (dir) => {
+      await fsp.mkdir(`${dir}/${projectName}`, { recursive: true })
+      await fsp.copyFile(
+        'rust/kcl-lib/e2e/executor/inputs/router-template-slate.kcl',
+        `${dir}/${projectName}/main.kcl`
+      )
+    })
 
-      // Constants and locators
-      const projectHomeLink = page.getByTestId('project-link')
-      const commandButton = page.getByRole('button', { name: 'Commands' })
-      const commandOption = page.getByRole('option', {
-        name: 'rename project',
-      })
-      const projectNameOption = page.getByRole('option', { name: projectName })
-      const projectRenamedName = `untitled`
-      const commandContinueButton = page.getByRole('button', {
-        name: 'Continue',
-      })
-      const toastMessage = page.getByText(`Successfully renamed`)
+    // Constants and locators
+    const projectHomeLink = page.getByTestId('project-link')
+    const commandButton = page.getByRole('button', { name: 'Commands' })
+    const commandOption = page.getByRole('option', {
+      name: 'rename project',
+    })
+    const projectNameOption = page.getByRole('option', { name: projectName })
+    const projectRenamedName = `untitled`
+    const commandContinueButton = page.getByRole('button', {
+      name: 'Continue',
+    })
+    const toastMessage = page.getByText(`Successfully renamed`)
 
-      await test.step(`Setup`, async () => {
-        await page.setBodyDimensions({ width: 1200, height: 500 })
-        page.on('console', console.log)
-        await homePage.projectsLoaded()
-        await expect(projectHomeLink).toBeVisible()
-      })
+    await test.step(`Setup`, async () => {
+      await page.setBodyDimensions({ width: 1200, height: 500 })
+      page.on('console', console.log)
+      await homePage.projectsLoaded()
+      await expect(projectHomeLink).toBeVisible()
+    })
 
-      await test.step(`Run rename command via command palette`, async () => {
-        await commandButton.click()
-        await commandOption.click()
-        await projectNameOption.click()
+    await test.step(`Run rename command via command palette`, async () => {
+      await commandButton.click()
+      await commandOption.click()
+      await projectNameOption.click()
 
-        await expect(commandContinueButton).toBeVisible()
-        await commandContinueButton.click()
+      await expect(commandContinueButton).toBeVisible()
+      await commandContinueButton.click()
 
-        await cmdBar.submit()
+      await cmdBar.submit()
 
-        await expect(toastMessage).toBeVisible()
-      })
+      await expect(toastMessage).toBeVisible()
+    })
 
-      await test.step(`Check the project was renamed`, async () => {
-        await expect(
-          page.getByRole('link', { name: projectRenamedName })
-        ).toBeVisible()
-        await expect(projectHomeLink).not.toHaveText(projectName)
-      })
-    }
-  )
-  test(
-    `Delete from home page`,
-    { tag: '@desktop' },
-    async ({ context, page, scene, cmdBar }, testInfo) => {
-      const projectName = `my_project_to_delete`
-      await context.folderSetupFn(async (dir) => {
-        await fsp.mkdir(`${dir}/${projectName}`, { recursive: true })
-        await fsp.copyFile(
-          'rust/kcl-lib/e2e/executor/inputs/router-template-slate.kcl',
-          `${dir}/${projectName}/main.kcl`
-        )
-      })
+    await test.step(`Check the project was renamed`, async () => {
+      await expect(
+        page.getByRole('link', { name: projectRenamedName })
+      ).toBeVisible()
+      await expect(projectHomeLink).not.toHaveText(projectName)
+    })
+  })
+  test(`Delete from home page`, async ({
+    context,
+    page,
+    scene,
+    cmdBar,
+  }, testInfo) => {
+    const projectName = `my_project_to_delete`
+    await context.folderSetupFn(async (dir) => {
+      await fsp.mkdir(`${dir}/${projectName}`, { recursive: true })
+      await fsp.copyFile(
+        'rust/kcl-lib/e2e/executor/inputs/router-template-slate.kcl',
+        `${dir}/${projectName}/main.kcl`
+      )
+    })
 
-      // Constants and locators
-      const projectHomeLink = page.getByTestId('project-link')
-      const commandButton = page.getByRole('button', { name: 'Commands' })
-      const commandOption = page.getByRole('option', {
-        name: 'delete project',
-      })
-      const projectNameOption = page.getByRole('option', { name: projectName })
-      const commandWarning = page.getByText('Are you sure you want to delete?')
-      const toastMessage = page.getByText(`Successfully deleted`)
-      const noProjectsMessage = page.getByText('No projects found')
+    // Constants and locators
+    const projectHomeLink = page.getByTestId('project-link')
+    const commandButton = page.getByRole('button', { name: 'Commands' })
+    const commandOption = page.getByRole('option', {
+      name: 'delete project',
+    })
+    const projectNameOption = page.getByRole('option', { name: projectName })
+    const commandWarning = page.getByText('Are you sure you want to delete?')
+    const toastMessage = page.getByText(`Successfully deleted`)
+    const noProjectsMessage = page.getByText('No projects found')
 
-      await test.step(`Setup`, async () => {
-        await page.setBodyDimensions({ width: 1200, height: 500 })
-        page.on('console', console.log)
-        await expect(projectHomeLink).toBeVisible()
-      })
+    await test.step(`Setup`, async () => {
+      await page.setBodyDimensions({ width: 1200, height: 500 })
+      page.on('console', console.log)
+      await expect(projectHomeLink).toBeVisible()
+    })
 
-      await test.step(`Run delete command via command palette`, async () => {
-        await commandButton.click()
-        await commandOption.click()
-        await projectNameOption.click()
+    await test.step(`Run delete command via command palette`, async () => {
+      await commandButton.click()
+      await commandOption.click()
+      await projectNameOption.click()
 
-        await expect(commandWarning).toBeVisible()
-        await cmdBar.submit()
+      await expect(commandWarning).toBeVisible()
+      await cmdBar.submit()
 
-        await expect(toastMessage).toBeVisible()
-      })
+      await expect(toastMessage).toBeVisible()
+    })
 
-      await test.step(`Check the project was deleted`, async () => {
-        await expect(projectHomeLink).not.toBeVisible()
-        await expect(noProjectsMessage).toBeVisible()
-      })
-    }
-  )
+    await test.step(`Check the project was deleted`, async () => {
+      await expect(projectHomeLink).not.toBeVisible()
+      await expect(noProjectsMessage).toBeVisible()
+    })
+  })
   test('Create a new project with a colliding name', async ({
     context,
     homePage,
@@ -1767,12 +1772,12 @@ profile001 = startProfile(sketch001, at = [0, 0])
   }
 )
 
-test.describe('Project id', () => {
+test.describe('Project id', { tag: '@desktop' }, () => {
   // Should work on both web and desktop.
   test(
     'is created on new project',
     {
-      tag: ['@desktop', '@web'],
+      tag: '@web',
     },
     async ({ page, toolbar, context, homePage }, testInfo) => {
       const u = await getUtils(page)
@@ -1795,39 +1800,40 @@ test.describe('Project id', () => {
       })
     }
   )
-  test(
-    'is created on existing project without one',
-    { tag: '@desktop' },
-    async ({ page, toolbar, context, homePage }, testInfo) => {
-      const u = await getUtils(page)
-      await context.folderSetupFn(async (rootDir) => {
-        const projectDir = path.join(rootDir, 'hoohee')
-        await fsp.mkdir(projectDir, { recursive: true })
-        await fsp.writeFile(
-          path.join(projectDir, 'project.toml'),
-          `[settings.app]
+  test('is created on existing project without one', async ({
+    page,
+    toolbar,
+    context,
+    homePage,
+  }, testInfo) => {
+    const u = await getUtils(page)
+    await context.folderSetupFn(async (rootDir) => {
+      const projectDir = path.join(rootDir, 'hoohee')
+      await fsp.mkdir(projectDir, { recursive: true })
+      await fsp.writeFile(
+        path.join(projectDir, 'project.toml'),
+        `[settings.app]
 theme = "dark"
 `
-        )
-      })
+      )
+    })
 
-      await page.setBodyDimensions({ width: 1200, height: 500 })
-      await homePage.goToModelingScene()
-      await u.waitForPageLoad()
+    await page.setBodyDimensions({ width: 1200, height: 500 })
+    await homePage.goToModelingScene()
+    await u.waitForPageLoad()
 
-      const inputProjectId = page.getByTestId('project-id')
+    const inputProjectId = page.getByTestId('project-id')
 
-      await test.step('Open the project settings modal', async () => {
-        await toolbar.projectSidebarToggle.click()
-        await page.getByTestId('project-settings').click()
-        // Give time to system for writing to a persistent store
-        await page.waitForTimeout(1000)
-      })
+    await test.step('Open the project settings modal', async () => {
+      await toolbar.projectSidebarToggle.click()
+      await page.getByTestId('project-settings').click()
+      // Give time to system for writing to a persistent store
+      await page.waitForTimeout(1000)
+    })
 
-      await test.step('Check project id is not the NIL UUID and not empty', async () => {
-        await expect(inputProjectId).not.toHaveValue(uuidNIL)
-        await expect(inputProjectId).toHaveValue(REGEXP_UUIDV4)
-      })
-    }
-  )
+    await test.step('Check project id is not the NIL UUID and not empty', async () => {
+      await expect(inputProjectId).not.toHaveValue(uuidNIL)
+      await expect(inputProjectId).toHaveValue(REGEXP_UUIDV4)
+    })
+  })
 })

--- a/e2e/playwright/regression-tests.spec.ts
+++ b/e2e/playwright/regression-tests.spec.ts
@@ -15,7 +15,7 @@ import {
 import { expect, test } from '@e2e/playwright/zoo-test'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 
-test.describe('Regression tests', () => {
+test.describe('Regression tests', { tag: '@desktop' }, () => {
   // bugs we found that don't fit neatly into other categories
   test('bad model has inline error #3251', async ({
     context,
@@ -538,43 +538,42 @@ extrude002 = extrude(profile002, length = 150)`
     })
   })
 
-  test(
-    `Network health indicator only appears in modeling view`,
-    { tag: '@desktop' },
-    async ({ context, page }) => {
-      await context.folderSetupFn(async (dir) => {
-        const bracketDir = path.join(dir, 'bracket')
-        await fsp.mkdir(bracketDir, { recursive: true })
-        await fsp.copyFile(
-          executorInputPath('cylinder-inches.kcl'),
-          path.join(bracketDir, 'main.kcl')
-        )
-      })
-      await page.setBodyDimensions({ width: 1200, height: 500 })
+  test(`Network health indicator only appears in modeling view`, async ({
+    context,
+    page,
+  }) => {
+    await context.folderSetupFn(async (dir) => {
+      const bracketDir = path.join(dir, 'bracket')
+      await fsp.mkdir(bracketDir, { recursive: true })
+      await fsp.copyFile(
+        executorInputPath('cylinder-inches.kcl'),
+        path.join(bracketDir, 'main.kcl')
+      )
+    })
+    await page.setBodyDimensions({ width: 1200, height: 500 })
 
-      // Locators
-      const projectsHeading = page.getByRole('heading', {
-        name: 'Projects',
-      })
-      const projectLink = page.getByRole('link', { name: 'bracket' })
-      const networkHealthIndicator = page.getByTestId(/network-toggle/)
+    // Locators
+    const projectsHeading = page.getByRole('heading', {
+      name: 'Projects',
+    })
+    const projectLink = page.getByRole('link', { name: 'bracket' })
+    const networkHealthIndicator = page.getByTestId(/network-toggle/)
 
-      await test.step('Check the home page', async () => {
-        await expect(projectsHeading).toBeVisible()
-        await expect(projectLink).toBeVisible()
-        await expect(networkHealthIndicator).not.toBeVisible()
-      })
+    await test.step('Check the home page', async () => {
+      await expect(projectsHeading).toBeVisible()
+      await expect(projectLink).toBeVisible()
+      await expect(networkHealthIndicator).not.toBeVisible()
+    })
 
-      await test.step('Open the project', async () => {
-        await projectLink.click()
-      })
+    await test.step('Open the project', async () => {
+      await projectLink.click()
+    })
 
-      await test.step('Check the modeling view', async () => {
-        await expect(projectsHeading).not.toBeVisible()
-        await expect(networkHealthIndicator).toBeVisible()
-      })
-    }
-  )
+    await test.step('Check the modeling view', async () => {
+      await expect(projectsHeading).not.toBeVisible()
+      await expect(networkHealthIndicator).toBeVisible()
+    })
+  })
 
   test(`View gizmo stays visible even when zoomed out all the way`, async ({
     page,
@@ -862,16 +861,19 @@ s2 = startSketchOn(XY)
     await editor.expectEditor.toContain('s2 = startSketchOn(XY)')
   })
 
-  test(
-    'Interrupting a long-executing file with navigation executes the new file',
-    { tag: '@desktop' },
-    async ({ page, homePage, scene, context, toolbar }) => {
-      await context.folderSetupFn(async (dir) => {
-        const testDir = path.join(dir, 'test')
-        await fsp.mkdir(testDir, { recursive: true })
-        await fsp.writeFile(
-          path.join(testDir, 'sphere.kcl'),
-          `export fn sphere(sphereRadius) {
+  test('Interrupting a long-executing file with navigation executes the new file', async ({
+    page,
+    homePage,
+    scene,
+    context,
+    toolbar,
+  }) => {
+    await context.folderSetupFn(async (dir) => {
+      const testDir = path.join(dir, 'test')
+      await fsp.mkdir(testDir, { recursive: true })
+      await fsp.writeFile(
+        path.join(testDir, 'sphere.kcl'),
+        `export fn sphere(sphereRadius) {
   // build sphere by revolving a semicircular profile (XZ)
   sketch = startSketchOn(XZ)
   profile = sketch
@@ -881,20 +883,20 @@ s2 = startSketchOn(XY)
 
   return profile |> revolve(axis = X)
 }`,
-          'utf-8'
-        )
-        await fsp.writeFile(
-          path.join(testDir, 'main.kcl'),
-          `import sphere from "sphere.kcl"
+        'utf-8'
+      )
+      await fsp.writeFile(
+        path.join(testDir, 'main.kcl'),
+        `import sphere from "sphere.kcl"
 
 export cloud = patternCircular3d(sphere(sphereRadius=2), instances = 10, axis = [1, 1, 0], center = [20, 2, 20])
   |> patternCircular3d(instances = 10, axis = [1, 1, 0], center = [0, 20, 0])
   |> patternCircular3d(instances = 10, axis = [0, 0, 1], center = [100, 10, 10])`,
-          'utf-8'
-        )
-        await fsp.writeFile(
-          path.join(testDir, 'target.kcl'),
-          `sketch001 = startSketchOn(YZ)
+        'utf-8'
+      )
+      await fsp.writeFile(
+        path.join(testDir, 'target.kcl'),
+        `sketch001 = startSketchOn(YZ)
 profile001 = startProfile(sketch001, at = [0, 0])
   |> angledLine(angle = 0deg, length = 16.1, tag = $rectangleSegmentA001)
   |> angledLine(angle = segAng(rectangleSegmentA001) + 90deg, length = 10.72)
@@ -903,22 +905,21 @@ profile001 = startProfile(sketch001, at = [0, 0])
   |> close()
 extrude001 = extrude(profile001, length = 5)
 `,
-          'utf-8'
-        )
-      })
+        'utf-8'
+      )
+    })
 
-      const u = await getUtils(page)
-      await homePage.openProject('test')
-      await toolbar.openPane(DefaultLayoutPaneID.Debug)
-      await toolbar.openPane(DefaultLayoutPaneID.Files)
+    const u = await getUtils(page)
+    await homePage.openProject('test')
+    await toolbar.openPane(DefaultLayoutPaneID.Debug)
+    await toolbar.openPane(DefaultLayoutPaneID.Files)
 
-      await scene.connectionEstablished()
-      await toolbar.openFile('target.kcl')
-      // Extrude is only present in the target file, not main.kcl, so we know the new file has executed
-      // just by navigating
-      await u.waitForCmdReceive('extrude')
-    }
-  )
+    await scene.connectionEstablished()
+    await toolbar.openFile('target.kcl')
+    // Extrude is only present in the target file, not main.kcl, so we know the new file has executed
+    // just by navigating
+    await u.waitForCmdReceive('extrude')
+  })
 })
 
 async function clickExportButton(page: Page, cmdBar: CmdBarFixture) {

--- a/e2e/playwright/sketch-solve-edit.spec.ts
+++ b/e2e/playwright/sketch-solve-edit.spec.ts
@@ -66,7 +66,7 @@ sketch(on = XZ) {
 }
 `
 
-test.describe('Sketch solve edit tests', () => {
+test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
   test("can edit an existing sketch and edit it's segments", async ({
     page,
     context,

--- a/e2e/playwright/sketch-tests.spec.ts
+++ b/e2e/playwright/sketch-tests.spec.ts
@@ -13,78 +13,72 @@ import { expect, test } from '@e2e/playwright/zoo-test'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 
 test.describe('Sketch tests', () => {
-  test('three-point arc closes without disappearing', async ({
-    page,
-    homePage,
-    scene,
-    toolbar,
-    editor,
-    cmdBar,
-  }) => {
-    await page.addInitScript(async () => {
-      localStorage.setItem('persistCode', '')
-    })
+  test(
+    'three-point arc closes without disappearing',
+    { tag: '@desktop' },
+    async ({ page, homePage, scene, toolbar, editor, cmdBar }) => {
+      await page.addInitScript(async () => {
+        localStorage.setItem('persistCode', '')
+      })
 
-    await page.setBodyDimensions({ width: 1200, height: 500 })
+      await page.setBodyDimensions({ width: 1200, height: 500 })
 
-    await homePage.goToModelingScene()
-    await scene.settled(cmdBar)
+      await homePage.goToModelingScene()
+      await scene.settled(cmdBar)
 
-    await toolbar.startSketchPlaneSelection()
-    const [selectXZPlane] = scene.makeMouseHelpers(650, 150)
-    await selectXZPlane()
-    await page.waitForTimeout(600)
-    await editor.expectEditor.toContain('startSketchOn(XZ)')
+      await toolbar.startSketchPlaneSelection()
+      const [selectXZPlane] = scene.makeMouseHelpers(650, 150)
+      await selectXZPlane()
+      await page.waitForTimeout(600)
+      await editor.expectEditor.toContain('startSketchOn(XZ)')
 
-    //await toolbar.lineBtn.click()
-    const [lineStart] = scene.makeMouseHelpers(600, 400)
-    const [lineEnd] = scene.makeMouseHelpers(600, 200)
-    await lineStart()
-    await page.waitForTimeout(300)
-    await lineEnd()
-    await editor.expectEditor.toContain('|> yLine(')
+      //await toolbar.lineBtn.click()
+      const [lineStart] = scene.makeMouseHelpers(600, 400)
+      const [lineEnd] = scene.makeMouseHelpers(600, 200)
+      await lineStart()
+      await page.waitForTimeout(300)
+      await lineEnd()
+      await editor.expectEditor.toContain('|> yLine(')
 
-    await toolbar.selectThreePointArc()
-    await page.waitForTimeout(200)
+      await toolbar.selectThreePointArc()
+      await page.waitForTimeout(200)
 
-    await lineEnd()
-    await page.waitForTimeout(200)
+      await lineEnd()
+      await page.waitForTimeout(200)
 
-    const [arcInteriorMove, arcInterior] = (() => {
-      const [click, move] = scene.makeMouseHelpers(750, 300)
-      return [move, click]
-    })()
-    await arcInteriorMove()
-    await arcInterior()
-    await page.waitForTimeout(200)
+      const [arcInteriorMove, arcInterior] = (() => {
+        const [click, move] = scene.makeMouseHelpers(750, 300)
+        return [move, click]
+      })()
+      await arcInteriorMove()
+      await arcInterior()
+      await page.waitForTimeout(200)
 
-    await lineStart() // close
-    await page.waitForTimeout(300)
+      await lineStart() // close
+      await page.waitForTimeout(300)
 
-    await page.keyboard.press('Escape')
-    await page.waitForTimeout(2000)
+      await page.keyboard.press('Escape')
+      await page.waitForTimeout(2000)
 
-    await editor.expectEditor.toContain('arc(')
-  })
-  test('multi-sketch file shows multiple Edit Sketch buttons', async ({
-    page,
-    context,
-    homePage,
-    scene,
-    cmdBar,
-  }) => {
-    const u = await getUtils(page)
-    const selectionsSnippets = {
-      startProfileAt1:
-        '|> startProfile(at = [-width / 4 + screwRadius, height / 2])',
-      startProfileAt2: '|> startProfile(at = [-width / 2, 0])',
-      startProfileAt3: '|> startProfile(at = [0, thickness])',
+      await editor.expectEditor.toContain('arc(')
     }
-    await context.addInitScript(
-      async ({ startProfileAt1, startProfileAt2, startProfileAt3 }: any) => {
-        localStorage.setItem(
-          'persistCode',
-          `
+  )
+  test(
+    'multi-sketch file shows multiple Edit Sketch buttons',
+    { tag: '@desktop' },
+    async ({ page, context, homePage, scene, cmdBar }) => {
+      const u = await getUtils(page)
+      const selectionsSnippets = {
+        startProfileAt1:
+          '|> startProfile(at = [-width / 4 + screwRadius, height / 2])',
+        startProfileAt2: '|> startProfile(at = [-width / 2, 0])',
+        startProfileAt3: '|> startProfile(at = [0, thickness])',
+      }
+      await context.addInitScript(
+        async ({ startProfileAt1, startProfileAt2, startProfileAt3 }: any) => {
+          localStorage.setItem(
+            'persistCode',
+            `
     width = 20
     height = 10
     thickness = 5
@@ -117,218 +111,209 @@ test.describe('Sketch tests', () => {
   |> close()
   |> extrude(length = -height)
     `
-        )
-      },
-      selectionsSnippets
-    )
-    await page.setBodyDimensions({ width: 1200, height: 500 })
+          )
+        },
+        selectionsSnippets
+      )
+      await page.setBodyDimensions({ width: 1200, height: 500 })
 
-    await homePage.goToModelingScene()
-    await scene.settled(cmdBar)
+      await homePage.goToModelingScene()
+      await scene.settled(cmdBar)
 
-    // wait for execution done
-    await u.openDebugPanel()
-    await u.expectCmdLog('[data-message-type="execution-done"]')
-    await u.closeDebugPanel()
+      // wait for execution done
+      await u.openDebugPanel()
+      await u.expectCmdLog('[data-message-type="execution-done"]')
+      await u.closeDebugPanel()
 
-    await page.getByText(selectionsSnippets.startProfileAt1).click()
-    await expect(
-      page.getByRole('button', { name: 'Edit Sketch' })
-    ).toBeVisible()
+      await page.getByText(selectionsSnippets.startProfileAt1).click()
+      await expect(
+        page.getByRole('button', { name: 'Edit Sketch' })
+      ).toBeVisible()
 
-    await page.getByText(selectionsSnippets.startProfileAt2).click()
-    await expect(
-      page.getByRole('button', { name: 'Edit Sketch' })
-    ).toBeVisible()
+      await page.getByText(selectionsSnippets.startProfileAt2).click()
+      await expect(
+        page.getByRole('button', { name: 'Edit Sketch' })
+      ).toBeVisible()
 
-    await page.getByText(selectionsSnippets.startProfileAt3).click()
-    await expect(
-      page.getByRole('button', { name: 'Edit Sketch' })
-    ).toBeVisible()
-  })
+      await page.getByText(selectionsSnippets.startProfileAt3).click()
+      await expect(
+        page.getByRole('button', { name: 'Edit Sketch' })
+      ).toBeVisible()
+    }
+  )
 
-  test('delete startProfile removes profile statement', async ({
-    page,
-    context,
-    homePage,
-    scene,
-    cmdBar,
-    editor,
-    toolbar,
-  }) => {
-    await page.setBodyDimensions({ width: 1200, height: 600 })
+  test(
+    'delete startProfile removes profile statement',
+    { tag: '@desktop' },
+    async ({ page, context, homePage, scene, cmdBar, editor, toolbar }) => {
+      await page.setBodyDimensions({ width: 1200, height: 600 })
 
-    await context.addInitScript(() => {
-      localStorage.setItem(
-        'persistCode',
-        `sketch001 = startSketchOn(XZ)
+      await context.addInitScript(() => {
+        localStorage.setItem(
+          'persistCode',
+          `sketch001 = startSketchOn(XZ)
 profile001 = startProfile(sketch001, at = [0.0, 0.0])`
-      )
-    })
+        )
+      })
 
-    await homePage.goToModelingScene()
-    await scene.settled(cmdBar)
+      await homePage.goToModelingScene()
+      await scene.settled(cmdBar)
 
-    await editor.expectEditor.toContain('startProfile(')
+      await editor.expectEditor.toContain('startProfile(')
 
-    // Open feature tree and select the first sketch
-    await toolbar.openPane(DefaultLayoutPaneID.FeatureTree)
-    const sketchNode = await toolbar.getFeatureTreeOperation('Sketch', 0)
-    await sketchNode.dblclick()
-    await page.waitForTimeout(600)
-
-    // Select the profile by clicking the origin in the canvas, then press Delete
-    const [clickCenter] = scene.makeMouseHelpers(0.5, 0.5, { format: 'ratio' })
-    await clickCenter()
-
-    await page.waitForTimeout(200)
-
-    await page.keyboard.press('Delete')
-
-    await editor.expectEditor.not.toContain('startProfile(')
-  })
-
-  test('Can exit selection of face', async ({
-    page,
-    homePage,
-    scene,
-    cmdBar,
-    toolbar,
-  }) => {
-    // Load the app with the code panes
-    await page.addInitScript(async () => {
-      localStorage.setItem('persistCode', ``)
-    })
-
-    await page.setBodyDimensions({ width: 1200, height: 500 })
-
-    await homePage.goToModelingScene()
-    await scene.settled(cmdBar)
-
-    await toolbar.startSketchBtn.click()
-    await expect(
-      page.getByRole('button', { name: 'Exit Sketch' })
-    ).toBeVisible()
-
-    await expect(page.getByText('select a plane or face')).toBeVisible()
-
-    await page.keyboard.press('Escape')
-    await expect(toolbar.startSketchBtn).toBeVisible()
-  })
-
-  test('Can select planes in Feature Tree after Start Sketch', async ({
-    page,
-    homePage,
-    toolbar,
-    editor,
-    scene,
-    cmdBar,
-  }) => {
-    // Load the app with empty code
-    await page.addInitScript(async () => {
-      localStorage.setItem(
-        'persistCode',
-        `plane001 = offsetPlane(XZ, offset = 5)`
-      )
-    })
-
-    await page.setBodyDimensions({ width: 1200, height: 500 })
-
-    await homePage.goToModelingScene()
-    await scene.settled(cmdBar)
-
-    await test.step('Click Start Sketch button', async () => {
-      await toolbar.startSketchBtn.click()
-    })
-
-    await test.step('Open feature tree and select Front plane (XZ)', async () => {
-      await toolbar.openFeatureTreePane()
-      await toolbar.selectDefaultPlane('Front plane')
-
+      // Open feature tree and select the first sketch
+      await toolbar.openPane(DefaultLayoutPaneID.FeatureTree)
+      const sketchNode = await toolbar.getFeatureTreeOperation('Sketch', 0)
+      await sketchNode.dblclick()
       await page.waitForTimeout(600)
 
-      await expect(toolbar.lineBtn).toBeEnabled()
-      await editor.expectEditor.toContain('startSketchOn(XZ)')
+      // Select the profile by clicking the origin in the canvas, then press Delete
+      const [clickCenter] = scene.makeMouseHelpers(0.5, 0.5, {
+        format: 'ratio',
+      })
+      await clickCenter()
 
-      await page.getByRole('button', { name: 'Exit Sketch' }).click()
-      await expect(toolbar.startSketchBtn).toBeVisible()
-    })
+      await page.waitForTimeout(200)
 
-    await test.step('Click Start Sketch button again', async () => {
+      await page.keyboard.press('Delete')
+
+      await editor.expectEditor.not.toContain('startProfile(')
+    }
+  )
+
+  test(
+    'Can exit selection of face',
+    { tag: '@desktop' },
+    async ({ page, homePage, scene, cmdBar, toolbar }) => {
+      // Load the app with the code panes
+      await page.addInitScript(async () => {
+        localStorage.setItem('persistCode', ``)
+      })
+
+      await page.setBodyDimensions({ width: 1200, height: 500 })
+
+      await homePage.goToModelingScene()
+      await scene.settled(cmdBar)
+
       await toolbar.startSketchBtn.click()
       await expect(
         page.getByRole('button', { name: 'Exit Sketch' })
       ).toBeVisible()
-    })
 
-    await test.step('Select the offset plane', async () => {
-      await toolbar.openFeatureTreePane()
-      const opButton = await toolbar.getFeatureTreeOperation('plane001', 0)
-      await opButton.click()
+      await expect(page.getByText('select a plane or face')).toBeVisible()
 
-      await page.waitForTimeout(600)
+      await page.keyboard.press('Escape')
+      await expect(toolbar.startSketchBtn).toBeVisible()
+    }
+  )
 
-      await expect(toolbar.lineBtn).toBeEnabled()
-      await editor.expectEditor.toContain('startSketchOn(plane001)')
-    })
-  })
+  test(
+    'Can select planes in Feature Tree after Start Sketch',
+    { tag: '@desktop' },
+    async ({ page, homePage, toolbar, editor, scene, cmdBar }) => {
+      // Load the app with empty code
+      await page.addInitScript(async () => {
+        localStorage.setItem(
+          'persistCode',
+          `plane001 = offsetPlane(XZ, offset = 5)`
+        )
+      })
 
-  test('Can edit a circle center and radius by dragging its handles', async ({
-    page,
-    editor,
-    homePage,
-    scene,
-    cmdBar,
-    toolbar,
-  }) => {
-    await page.addInitScript(async () => {
-      localStorage.setItem(
-        'persistCode',
-        `sketch001 = startSketchOn(XZ)
+      await page.setBodyDimensions({ width: 1200, height: 500 })
+
+      await homePage.goToModelingScene()
+      await scene.settled(cmdBar)
+
+      await test.step('Click Start Sketch button', async () => {
+        await toolbar.startSketchBtn.click()
+      })
+
+      await test.step('Open feature tree and select Front plane (XZ)', async () => {
+        await toolbar.openFeatureTreePane()
+        await toolbar.selectDefaultPlane('Front plane')
+
+        await page.waitForTimeout(600)
+
+        await expect(toolbar.lineBtn).toBeEnabled()
+        await editor.expectEditor.toContain('startSketchOn(XZ)')
+
+        await page.getByRole('button', { name: 'Exit Sketch' }).click()
+        await expect(toolbar.startSketchBtn).toBeVisible()
+      })
+
+      await test.step('Click Start Sketch button again', async () => {
+        await toolbar.startSketchBtn.click()
+        await expect(
+          page.getByRole('button', { name: 'Exit Sketch' })
+        ).toBeVisible()
+      })
+
+      await test.step('Select the offset plane', async () => {
+        await toolbar.openFeatureTreePane()
+        const opButton = await toolbar.getFeatureTreeOperation('plane001', 0)
+        await opButton.click()
+
+        await page.waitForTimeout(600)
+
+        await expect(toolbar.lineBtn).toBeEnabled()
+        await editor.expectEditor.toContain('startSketchOn(plane001)')
+      })
+    }
+  )
+
+  test(
+    'Can edit a circle center and radius by dragging its handles',
+    { tag: '@desktop' },
+    async ({ page, editor, homePage, scene, cmdBar, toolbar }) => {
+      await page.addInitScript(async () => {
+        localStorage.setItem(
+          'persistCode',
+          `sketch001 = startSketchOn(XZ)
   |> circle(center = [0, 0], radius = 0.5)`
-      )
-    })
-
-    await homePage.goToModelingScene()
-    await scene.settled(cmdBar)
-    let prevContent = await editor.getCurrentCode()
-
-    await test.step('enter sketch and expect circle', async () => {
-      await toolbar.editSketch()
-      await expect(page.getByTestId('segment-overlay')).toHaveCount(1)
-    })
-
-    await test.step('drag circle center handle', async () => {
-      const fromPoint = { x: 0.5, y: 0.5 }
-      const toPoint = [fromPoint.x - 0.1, fromPoint.y - 0.1] as const
-      const [dragCenterHandle] = scene.makeDragHelpers(...toPoint, {
-        debug: true,
-        format: 'ratio',
+        )
       })
-      await dragCenterHandle({ fromPoint })
-      await editor.expectEditor.not.toContain(prevContent)
-      prevContent = await editor.getCurrentCode()
-    })
 
-    await test.step('drag circle radius handle', async () => {
-      const magicYOnCircle = 0.68
-      const fromPoint = { x: 0.5, y: magicYOnCircle }
-      const toPoint = [fromPoint.x / 2, magicYOnCircle] as const
-      const [dragRadiusHandle] = scene.makeDragHelpers(...toPoint, {
-        debug: true,
-        format: 'ratio',
+      await homePage.goToModelingScene()
+      await scene.settled(cmdBar)
+      let prevContent = await editor.getCurrentCode()
+
+      await test.step('enter sketch and expect circle', async () => {
+        await toolbar.editSketch()
+        await expect(page.getByTestId('segment-overlay')).toHaveCount(1)
       })
-      await dragRadiusHandle({ fromPoint })
-    })
 
-    await test.step('expect the code to have changed', async () => {
-      await editor.expectEditor.not.toContain(prevContent)
-      await editor.expectEditor.toContain(
-        new RegExp(`sketch001 = startSketchOn(XZ)
+      await test.step('drag circle center handle', async () => {
+        const fromPoint = { x: 0.5, y: 0.5 }
+        const toPoint = [fromPoint.x - 0.1, fromPoint.y - 0.1] as const
+        const [dragCenterHandle] = scene.makeDragHelpers(...toPoint, {
+          debug: true,
+          format: 'ratio',
+        })
+        await dragCenterHandle({ fromPoint })
+        await editor.expectEditor.not.toContain(prevContent)
+        prevContent = await editor.getCurrentCode()
+      })
+
+      await test.step('drag circle radius handle', async () => {
+        const magicYOnCircle = 0.68
+        const fromPoint = { x: 0.5, y: magicYOnCircle }
+        const toPoint = [fromPoint.x / 2, magicYOnCircle] as const
+        const [dragRadiusHandle] = scene.makeDragHelpers(...toPoint, {
+          debug: true,
+          format: 'ratio',
+        })
+        await dragRadiusHandle({ fromPoint })
+      })
+
+      await test.step('expect the code to have changed', async () => {
+        await editor.expectEditor.not.toContain(prevContent)
+        await editor.expectEditor.toContain(
+          new RegExp(`sketch001 = startSketchOn(XZ)
     |> circle\\(center = \\[${NUMBER_REGEXP}, ${NUMBER_REGEXP}\\], radius = ${NUMBER_REGEXP}\\)`)
-      )
-    })
-  })
+        )
+      })
+    }
+  )
   test(
     'Can edit a sketch that has been extruded in the same pipe',
     { tag: '@web' },
@@ -371,60 +356,59 @@ sketch001 = startSketchOn(XZ)
     }
   )
 
-  test('Can add multiple sketches', async ({
-    page,
-    homePage,
-    scene,
-    toolbar,
-    cmdBar,
-    editor,
-  }) => {
-    const viewportSize = { width: 1200, height: 500 }
-    await page.setBodyDimensions(viewportSize)
+  test(
+    'Can add multiple sketches',
+    { tag: '@desktop' },
+    async ({ page, homePage, scene, toolbar, cmdBar, editor }) => {
+      const viewportSize = { width: 1200, height: 500 }
+      await page.setBodyDimensions(viewportSize)
 
-    await homePage.goToModelingScene()
-    await scene.settled(cmdBar)
-    const center = { x: viewportSize.width / 2, y: viewportSize.height / 2 }
-    const { click00r } = getMovementUtils({ center, page })
+      await homePage.goToModelingScene()
+      await scene.settled(cmdBar)
+      const center = { x: viewportSize.width / 2, y: viewportSize.height / 2 }
+      const { click00r } = getMovementUtils({ center, page })
 
-    let codeStr =
-      '@settings(defaultLengthUnit = in)sketch001 = startSketchOn(XY)'
+      let codeStr =
+        '@settings(defaultLengthUnit = in)sketch001 = startSketchOn(XY)'
 
-    await toolbar.startSketchBtn.click()
-    const [clickCenter] = scene.makeMouseHelpers(0.5, 0.5, { format: 'ratio' })
-    await clickCenter()
-    await editor.expectEditor.toContain(codeStr)
+      await toolbar.startSketchBtn.click()
+      const [clickCenter] = scene.makeMouseHelpers(0.5, 0.5, {
+        format: 'ratio',
+      })
+      await clickCenter()
+      await editor.expectEditor.toContain(codeStr)
 
-    await click00r(0, 0)
-    await page.waitForTimeout(100)
-    await editor.expectEditor.toContain(
-      `profile001 = startProfile(sketch001, at =`
-    )
+      await click00r(0, 0)
+      await page.waitForTimeout(100)
+      await editor.expectEditor.toContain(
+        `profile001 = startProfile(sketch001, at =`
+      )
 
-    await click00r(50, 0)
-    await page.waitForTimeout(100)
-    await editor.expectEditor.toContain(`|> xLine(length =`)
+      await click00r(50, 0)
+      await page.waitForTimeout(100)
+      await editor.expectEditor.toContain(`|> xLine(length =`)
 
-    await click00r(0, 50)
-    await editor.expectEditor.toContain(`|> yLine(`)
+      await click00r(0, 50)
+      await editor.expectEditor.toContain(`|> yLine(`)
 
-    // exit the sketch, reset relative clicker
-    await click00r(undefined, undefined)
-    await toolbar.exitSketch()
-    await scene.settled(cmdBar)
+      // exit the sketch, reset relative clicker
+      await click00r(undefined, undefined)
+      await toolbar.exitSketch()
+      await scene.settled(cmdBar)
 
-    // start a new sketch
-    await toolbar.startSketchBtn.click()
-    await clickCenter()
-    await page.waitForTimeout(600) // TODO detect animation ending, or disable animation
-    await editor.expectEditor.toContain(`sketch002 = startSketchOn(XY)`)
+      // start a new sketch
+      await toolbar.startSketchBtn.click()
+      await clickCenter()
+      await page.waitForTimeout(600) // TODO detect animation ending, or disable animation
+      await editor.expectEditor.toContain(`sketch002 = startSketchOn(XY)`)
 
-    await click00r(30, 0)
-    await editor.expectEditor.toContain(
-      `profile002 = startProfile(sketch002, at =`
-    )
-    await toolbar.exitSketch()
-  })
+      await click00r(30, 0)
+      await editor.expectEditor.toContain(
+        `profile002 = startProfile(sketch002, at =`
+      )
+      await toolbar.exitSketch()
+    }
+  )
 
   test.describe('Snap to close works (at any scale)', () => {
     const doSnapAtDifferentScales = async (
@@ -499,57 +483,48 @@ sketch001 = startSketchOn(XZ)
         page.getByRole('button', { name: 'line Line', exact: true })
       ).toHaveAttribute('aria-pressed', 'true')
     }
-    test('[0, 100, 100]', async ({
-      page,
-      homePage,
-      scene,
-      editor,
-      toolbar,
-      cmdBar,
-    }) => {
-      await homePage.goToModelingScene()
-      await scene.settled(cmdBar)
-      await doSnapAtDifferentScales(
-        page,
-        scene,
-        editor,
-        toolbar,
-        [0, 100, 100],
-        0.01
-      )
-    })
+    test(
+      '[0, 100, 100]',
+      { tag: '@desktop' },
+      async ({ page, homePage, scene, editor, toolbar, cmdBar }) => {
+        await homePage.goToModelingScene()
+        await scene.settled(cmdBar)
+        await doSnapAtDifferentScales(
+          page,
+          scene,
+          editor,
+          toolbar,
+          [0, 100, 100],
+          0.01
+        )
+      }
+    )
 
-    test('[0, 10000, 10000]', async ({
-      page,
-      homePage,
-      scene,
-      editor,
-      toolbar,
-      cmdBar,
-    }) => {
-      await homePage.goToModelingScene()
-      await scene.settled(cmdBar)
-      await doSnapAtDifferentScales(
-        page,
-        scene,
-        editor,
-        toolbar,
-        [0, 10000, 10000]
-      )
-    })
+    test(
+      '[0, 10000, 10000]',
+      { tag: '@desktop' },
+      async ({ page, homePage, scene, editor, toolbar, cmdBar }) => {
+        await homePage.goToModelingScene()
+        await scene.settled(cmdBar)
+        await doSnapAtDifferentScales(
+          page,
+          scene,
+          editor,
+          toolbar,
+          [0, 10000, 10000]
+        )
+      }
+    )
   })
-  test('exiting a close extrude, has the extrude button enabled ready to go', async ({
-    page,
-    homePage,
-    cmdBar,
-    toolbar,
-    scene,
-  }) => {
-    // this was a regression https://github.com/KittyCAD/modeling-app/issues/2832
-    await page.addInitScript(async () => {
-      localStorage.setItem(
-        'persistCode',
-        `sketch001 = startSketchOn(XZ)
+  test(
+    'exiting a close extrude, has the extrude button enabled ready to go',
+    { tag: '@desktop' },
+    async ({ page, homePage, cmdBar, toolbar, scene }) => {
+      // this was a regression https://github.com/KittyCAD/modeling-app/issues/2832
+      await page.addInitScript(async () => {
+        localStorage.setItem(
+          'persistCode',
+          `sketch001 = startSketchOn(XZ)
     |> startProfile(at = [-0.45, 0.87])
     |> line(end = [1.32, 0.38])
     |> line(end = [1.02, -1.32], tag = $seg01)
@@ -557,62 +532,59 @@ sketch001 = startSketchOn(XZ)
     |> line(endAbsolute = [profileStartX(%), profileStartY(%)])
   |> close()
   `
-      )
-    })
+        )
+      })
 
-    const u = await getUtils(page)
-    await page.setBodyDimensions({ width: 1200, height: 500 })
+      const u = await getUtils(page)
+      await page.setBodyDimensions({ width: 1200, height: 500 })
 
-    await homePage.goToModelingScene()
-    await scene.settled(cmdBar)
+      await homePage.goToModelingScene()
+      await scene.settled(cmdBar)
 
-    // wait for execution done
-    await u.openDebugPanel()
-    await u.expectCmdLog('[data-message-type="execution-done"]')
-    await u.closeDebugPanel()
+      // wait for execution done
+      await u.openDebugPanel()
+      await u.expectCmdLog('[data-message-type="execution-done"]')
+      await u.closeDebugPanel()
 
-    // click profile in code
-    await page.getByText(`startProfile(at = [-0.45, 0.87])`).click()
-    await page.waitForTimeout(100)
-    await expect(page.getByRole('button', { name: 'Edit Sketch' })).toBeEnabled(
-      { timeout: 10_000 }
-    )
-    // click edit sketch
-    await page.getByRole('button', { name: 'Edit Sketch' }).click()
-    await page.waitForTimeout(600) // wait for animation
+      // click profile in code
+      await page.getByText(`startProfile(at = [-0.45, 0.87])`).click()
+      await page.waitForTimeout(100)
+      await expect(
+        page.getByRole('button', { name: 'Edit Sketch' })
+      ).toBeEnabled({ timeout: 10_000 })
+      // click edit sketch
+      await page.getByRole('button', { name: 'Edit Sketch' }).click()
+      await page.waitForTimeout(600) // wait for animation
 
-    // exit sketch
-    await page.getByRole('button', { name: 'Exit Sketch' }).click()
+      // exit sketch
+      await page.getByRole('button', { name: 'Exit Sketch' }).click()
 
-    // expect extrude button to be enabled
-    await expect(toolbar.extrudeButton).not.toBeDisabled()
+      // expect extrude button to be enabled
+      await expect(toolbar.extrudeButton).not.toBeDisabled()
 
-    // click extrude
-    await toolbar.extrudeButton.click()
+      // click extrude
+      await toolbar.extrudeButton.click()
 
-    // sketch selection should already have been made.
-    // otherwise the cmdbar would be waiting for a selection.
-    await cmdBar.progressCmdBar()
-    await cmdBar.progressCmdBar()
-    await cmdBar.expectState({
-      stage: 'review',
-      headerArguments: { Profiles: '1 profile', Length: '5' },
-      commandName: 'Extrude',
-    })
-  })
-  test("Existing sketch with bad code delete user's code", async ({
-    page,
-    homePage,
-    scene,
-    cmdBar,
-    toolbar,
-    editor,
-  }) => {
-    // this was a regression https://github.com/KittyCAD/modeling-app/issues/2832
-    await page.addInitScript(async () => {
-      localStorage.setItem(
-        'persistCode',
-        `sketch001 = startSketchOn(XZ)
+      // sketch selection should already have been made.
+      // otherwise the cmdbar would be waiting for a selection.
+      await cmdBar.progressCmdBar()
+      await cmdBar.progressCmdBar()
+      await cmdBar.expectState({
+        stage: 'review',
+        headerArguments: { Profiles: '1 profile', Length: '5' },
+        commandName: 'Extrude',
+      })
+    }
+  )
+  test(
+    "Existing sketch with bad code delete user's code",
+    { tag: '@desktop' },
+    async ({ page, homePage, scene, cmdBar, toolbar, editor }) => {
+      // this was a regression https://github.com/KittyCAD/modeling-app/issues/2832
+      await page.addInitScript(async () => {
+        localStorage.setItem(
+          'persistCode',
+          `sketch001 = startSketchOn(XZ)
     |> startProfile(at = [-0.45, 0.87])
     |> line(end = [1.32, 0.38])
     |> line(end = [1.02, -1.32], tag = $seg01)
@@ -621,35 +593,35 @@ sketch001 = startSketchOn(XZ)
     |> close()
   extrude001 = extrude(sketch001, length = 5)
   `
-      )
-    })
-    await homePage.goToModelingScene()
-    await scene.settled(cmdBar)
-    await toolbar.startSketchBtn.click()
+        )
+      })
+      await homePage.goToModelingScene()
+      await scene.settled(cmdBar)
+      await toolbar.startSketchBtn.click()
 
-    // Click the end face of extrude001
-    // await page.mouse.click(622, 355)
-    const [clickOnEndFace] = scene.makeMouseHelpers(0.5, 0.7, {
-      format: 'ratio',
-    })
-    await clickOnEndFace()
+      // Click the end face of extrude001
+      // await page.mouse.click(622, 355)
+      const [clickOnEndFace] = scene.makeMouseHelpers(0.5, 0.7, {
+        format: 'ratio',
+      })
+      await clickOnEndFace()
 
-    // The click should generate a new sketch starting on the end face of extrude001
-    // signified by the implicit 'END' tag for that solid.
-    await page.waitForTimeout(800)
-    await page.getByText(`END)`).click()
-    await page.keyboard.press('End')
-    await page.keyboard.press('Enter')
-    await page.keyboard.type('  |>', { delay: 100 })
-    await page.waitForTimeout(100)
-    await expect(page.locator('.cm-lint-marker-error')).toBeVisible()
+      // The click should generate a new sketch starting on the end face of extrude001
+      // signified by the implicit 'END' tag for that solid.
+      await page.waitForTimeout(800)
+      await page.getByText(`END)`).click()
+      await page.keyboard.press('End')
+      await page.keyboard.press('Enter')
+      await page.keyboard.type('  |>', { delay: 100 })
+      await page.waitForTimeout(100)
+      await expect(page.locator('.cm-lint-marker-error')).toBeVisible()
 
-    await page.getByRole('button', { name: 'Exit Sketch' }).click()
+      await page.getByRole('button', { name: 'Exit Sketch' }).click()
 
-    await expect(toolbar.startSketchBtn).toBeVisible()
+      await expect(toolbar.startSketchBtn).toBeVisible()
 
-    expect((await editor.getCurrentCode()).replace(/\s/g, '')).toBe(
-      `sketch001 = startSketchOn(XZ)
+      expect((await editor.getCurrentCode()).replace(/\s/g, '')).toBe(
+        `sketch001 = startSketchOn(XZ)
     |> startProfile(at = [-0.45, 0.87])
     |> line(end = [1.32, 0.38])
     |> line(end = [1.02, -1.32], tag = $seg01)
@@ -660,22 +632,20 @@ sketch001 = startSketchOn(XZ)
   sketch002 = startSketchOn(extrude001, face = END)
     |>
   `.replace(/\s/g, '')
-    )
-  })
+      )
+    }
+  )
 
-  test('Can attempt to sketch on revolved face', async ({
-    page,
-    homePage,
-    scene,
-    cmdBar,
-    toolbar,
-  }) => {
-    await page.setBodyDimensions({ width: 1200, height: 500 })
+  test(
+    'Can attempt to sketch on revolved face',
+    { tag: '@desktop' },
+    async ({ page, homePage, scene, cmdBar, toolbar }) => {
+      await page.setBodyDimensions({ width: 1200, height: 500 })
 
-    await page.addInitScript(async () => {
-      localStorage.setItem(
-        'persistCode',
-        `lugHeadLength = 0.25
+      await page.addInitScript(async () => {
+        localStorage.setItem(
+          'persistCode',
+          `lugHeadLength = 0.25
       lugDiameter = 0.5
       lugLength = 2
 
@@ -692,36 +662,35 @@ sketch001 = startSketchOn(XZ)
       }
 
       lug(origin = [0, 0], length = 10, diameter = .5, plane = XY)`
-      )
-    })
+        )
+      })
 
-    await homePage.goToModelingScene()
-    await scene.settled(cmdBar)
+      await homePage.goToModelingScene()
+      await scene.settled(cmdBar)
 
-    const [clickCenter] = scene.makeMouseHelpers(0.5, 0.5, { format: 'ratio' })
-    await toolbar.startSketchBtn.click()
-    await page.waitForTimeout(20_000) // Wait for unavoidable animation
-    await clickCenter()
-    await page.waitForTimeout(1000) // Wait for unavoidable animation
+      const [clickCenter] = scene.makeMouseHelpers(0.5, 0.5, {
+        format: 'ratio',
+      })
+      await toolbar.startSketchBtn.click()
+      await page.waitForTimeout(20_000) // Wait for unavoidable animation
+      await clickCenter()
+      await page.waitForTimeout(1000) // Wait for unavoidable animation
 
-    await expect(toolbar.exitSketchBtn).toBeEnabled()
-    await expect(toolbar.lineBtn).toHaveAttribute('aria-pressed', 'true')
-  })
+      await expect(toolbar.exitSketchBtn).toBeEnabled()
+      await expect(toolbar.lineBtn).toHaveAttribute('aria-pressed', 'true')
+    }
+  )
 
-  test('sketch on face of a boolean works', async ({
-    page,
-    homePage,
-    scene,
-    cmdBar,
-    toolbar,
-    editor,
-  }) => {
-    await page.setBodyDimensions({ width: 1000, height: 500 })
+  test(
+    'sketch on face of a boolean works',
+    { tag: '@desktop' },
+    async ({ page, homePage, scene, cmdBar, toolbar, editor }) => {
+      await page.setBodyDimensions({ width: 1000, height: 500 })
 
-    await page.addInitScript(async () => {
-      localStorage.setItem(
-        'persistCode',
-        `@settings(defaultLengthUnit = mm)
+      await page.addInitScript(async () => {
+        localStorage.setItem(
+          'persistCode',
+          `@settings(defaultLengthUnit = mm)
 
 myVar = 50
 sketch001 = startSketchOn(XZ)
@@ -739,79 +708,77 @@ profile002 = startProfile(sketch002, at = [72.2, -52.05])
 extrude002 = extrude(profile002, length = 151)
 solid001 = subtract([extrude001], tools = [extrude002])
 `
-      )
-    })
+        )
+      })
 
-    const [selectChamferFaceClk] = scene.makeMouseHelpers(0.8, 0.5, {
-      format: 'ratio',
-    })
-    const [circleCenterClk] = scene.makeMouseHelpers(0.54, 0.5, {
-      format: 'ratio',
-    })
+      const [selectChamferFaceClk] = scene.makeMouseHelpers(0.8, 0.5, {
+        format: 'ratio',
+      })
+      const [circleCenterClk] = scene.makeMouseHelpers(0.54, 0.5, {
+        format: 'ratio',
+      })
 
-    await test.step('Setup', async () => {
-      await homePage.goToModelingScene()
-      await scene.settled(cmdBar)
+      await test.step('Setup', async () => {
+        await homePage.goToModelingScene()
+        await scene.settled(cmdBar)
 
-      await scene.moveCameraTo(
-        { x: 180, y: -75, z: 116 },
-        { x: 67, y: -114, z: -15 }
-      )
-      await toolbar.waitForFeatureTreeToBeBuilt()
-    })
+        await scene.moveCameraTo(
+          { x: 180, y: -75, z: 116 },
+          { x: 67, y: -114, z: -15 }
+        )
+        await toolbar.waitForFeatureTreeToBeBuilt()
+      })
 
-    await test.step('sketch on chamfer face that is part of a boolean', async () => {
-      await toolbar.startSketchPlaneSelection()
-      await selectChamferFaceClk()
+      await test.step('sketch on chamfer face that is part of a boolean', async () => {
+        await toolbar.startSketchPlaneSelection()
+        await selectChamferFaceClk()
 
-      await expect
-        .poll(async () => {
-          const lineBtn = page.getByRole('button', { name: 'line Line' })
-          return lineBtn.getAttribute('aria-pressed')
-        })
-        .toBe('true')
-
-      await editor.expectEditor.toContain(
-        'startSketchOn(solid001, face = seg01)'
-      )
-    })
-
-    await test.step('verify sketching still works', async () => {
-      await toolbar.circleBtn.click()
-      await expect
-        .poll(async () => {
-          const circleBtn = toolbar.locator.getByRole('button', {
-            name: 'center circle',
+        await expect
+          .poll(async () => {
+            const lineBtn = page.getByRole('button', { name: 'line Line' })
+            return lineBtn.getAttribute('aria-pressed')
           })
-          return circleBtn.getAttribute('aria-pressed')
-        })
-        .toBe('true')
+          .toBe('true')
 
-      await circleCenterClk()
-      await editor.expectEditor.toContain(
-        'profile003 = circle(sketch003, center = ['
-      )
-    })
-  })
+        await editor.expectEditor.toContain(
+          'startSketchOn(solid001, face = seg01)'
+        )
+      })
 
-  test('Can sketch on face when user defined function was used in the sketch', async ({
-    page,
-    homePage,
-    scene,
-    cmdBar,
-    toolbar,
-  }) => {
-    const u = await getUtils(page)
-    await page.setBodyDimensions({ width: 1200, height: 500 })
+      await test.step('verify sketching still works', async () => {
+        await toolbar.circleBtn.click()
+        await expect
+          .poll(async () => {
+            const circleBtn = toolbar.locator.getByRole('button', {
+              name: 'center circle',
+            })
+            return circleBtn.getAttribute('aria-pressed')
+          })
+          .toBe('true')
 
-    // Checking for a regression that performs a sketch when a user defined function
-    // is declared at the top of the file and used in the sketch that is being drawn on.
-    // fn in2mm is declared at the top of the file and used rail which does a an extrusion with the function.
+        await circleCenterClk()
+        await editor.expectEditor.toContain(
+          'profile003 = circle(sketch003, center = ['
+        )
+      })
+    }
+  )
 
-    await page.addInitScript(async () => {
-      localStorage.setItem(
-        'persistCode',
-        `fn in2mm(@inches) {
+  test(
+    'Can sketch on face when user defined function was used in the sketch',
+    { tag: '@desktop' },
+    async ({ page, homePage, scene, cmdBar, toolbar }) => {
+      const u = await getUtils(page)
+      await page.setBodyDimensions({ width: 1200, height: 500 })
+
+      // Checking for a regression that performs a sketch when a user defined function
+      // is declared at the top of the file and used in the sketch that is being drawn on.
+      // fn in2mm is declared at the top of the file and used rail which does a an extrusion with the function.
+
+      await page.addInitScript(async () => {
+        localStorage.setItem(
+          'persistCode',
+          `fn in2mm(@inches) {
     return inches * 25.4
   }
 
@@ -848,104 +815,98 @@ solid001 = subtract([extrude001], tools = [extrude002])
    ])
     |> close()
     |> extrude(length = in2mm(2))`
-      )
-    })
+        )
+      })
 
-    const center = { x: 600, y: 250 }
-    const rectangleSize = 20
-    await homePage.goToModelingScene()
-    await scene.settled(cmdBar)
+      const center = { x: 600, y: 250 }
+      const rectangleSize = 20
+      await homePage.goToModelingScene()
+      await scene.settled(cmdBar)
 
-    // Start a sketch
-    await toolbar.startSketchBtn.click()
+      // Start a sketch
+      await toolbar.startSketchBtn.click()
 
-    // Click the top face of this rail
-    await page.mouse.click(center.x, center.y)
-    await page.waitForTimeout(1000)
+      // Click the top face of this rail
+      await page.mouse.click(center.x, center.y)
+      await page.waitForTimeout(1000)
 
-    // Draw a rectangle
-    // top left
-    await page.mouse.click(center.x - rectangleSize, center.y - rectangleSize)
-    await page.waitForTimeout(250)
-    // top right
-    await page.mouse.click(center.x + rectangleSize, center.y - rectangleSize)
-    await page.waitForTimeout(250)
+      // Draw a rectangle
+      // top left
+      await page.mouse.click(center.x - rectangleSize, center.y - rectangleSize)
+      await page.waitForTimeout(250)
+      // top right
+      await page.mouse.click(center.x + rectangleSize, center.y - rectangleSize)
+      await page.waitForTimeout(250)
 
-    // bottom right
-    await page.mouse.click(center.x + rectangleSize, center.y + rectangleSize)
-    await page.waitForTimeout(250)
+      // bottom right
+      await page.mouse.click(center.x + rectangleSize, center.y + rectangleSize)
+      await page.waitForTimeout(250)
 
-    // bottom left
-    await page.mouse.click(center.x - rectangleSize, center.y + rectangleSize)
-    await page.waitForTimeout(250)
+      // bottom left
+      await page.mouse.click(center.x - rectangleSize, center.y + rectangleSize)
+      await page.waitForTimeout(250)
 
-    // top left
-    await page.mouse.click(center.x - rectangleSize, center.y - rectangleSize)
-    await page.waitForTimeout(250)
+      // top left
+      await page.mouse.click(center.x - rectangleSize, center.y - rectangleSize)
+      await page.waitForTimeout(250)
 
-    // exit sketch
-    await page.getByRole('button', { name: 'Exit Sketch' }).click()
+      // exit sketch
+      await page.getByRole('button', { name: 'Exit Sketch' }).click()
 
-    // Check execution is done
-    await u.openDebugPanel()
-    await u.expectCmdLog('[data-message-type="execution-done"]')
-    await u.closeDebugPanel()
-  })
+      // Check execution is done
+      await u.openDebugPanel()
+      await u.expectCmdLog('[data-message-type="execution-done"]')
+      await u.closeDebugPanel()
+    }
+  )
 
-  test('Can edit a tangentialArc defined by angle and radius', async ({
-    page,
-    homePage,
-    editor,
-    toolbar,
-    scene,
-    cmdBar,
-  }) => {
-    const viewportSize = { width: 1500, height: 750 }
-    await page.setBodyDimensions(viewportSize)
+  test(
+    'Can edit a tangentialArc defined by angle and radius',
+    { tag: '@desktop' },
+    async ({ page, homePage, editor, toolbar, scene, cmdBar }) => {
+      const viewportSize = { width: 1500, height: 750 }
+      await page.setBodyDimensions(viewportSize)
 
-    await page.addInitScript(async () => {
-      localStorage.setItem(
-        'persistCode',
-        `@settings(defaultLengthUnit=in)
+      await page.addInitScript(async () => {
+        localStorage.setItem(
+          'persistCode',
+          `@settings(defaultLengthUnit=in)
 sketch001 = startSketchOn(XZ)
   |> startProfile(at = [-10, -10])
   |> line(end = [20.0, 10.0])
   |> tangentialArc(angle = 60deg, radius=10.0)`
+        )
+      })
+
+      await homePage.goToModelingScene()
+      await toolbar.waitForFeatureTreeToBeBuilt()
+      await scene.settled(cmdBar)
+      await toolbar.editSketch()
+      const [dragToDifferentPoint] = scene.makeDragHelpers(1000, 177, {
+        debug: true,
+      })
+      await dragToDifferentPoint({
+        fromPoint: { x: 1400, y: 177 },
+      })
+
+      await page.waitForTimeout(200)
+      await editor.expectEditor.toContain('tangentialArc(angle = ', {
+        shouldNormalise: true,
+      })
+      await editor.expectEditor.not.toContain(
+        'tangentialArc(angle = 60deg, radius=10.0)'
       )
-    })
+    }
+  )
 
-    await homePage.goToModelingScene()
-    await toolbar.waitForFeatureTreeToBeBuilt()
-    await scene.settled(cmdBar)
-    await toolbar.editSketch()
-    const [dragToDifferentPoint] = scene.makeDragHelpers(1000, 177, {
-      debug: true,
-    })
-    await dragToDifferentPoint({
-      fromPoint: { x: 1400, y: 177 },
-    })
-
-    await page.waitForTimeout(200)
-    await editor.expectEditor.toContain('tangentialArc(angle = ', {
-      shouldNormalise: true,
-    })
-    await editor.expectEditor.not.toContain(
-      'tangentialArc(angle = 60deg, radius=10.0)'
-    )
-  })
-
-  test('Can delete a single segment line with keyboard', async ({
-    page,
-    scene,
-    homePage,
-    cmdBar,
-    editor,
-    toolbar,
-  }) => {
-    await page.addInitScript(async () => {
-      localStorage.setItem(
-        'persistCode',
-        `@settings(defaultLengthUnit = mm)
+  test(
+    'Can delete a single segment line with keyboard',
+    { tag: '@desktop' },
+    async ({ page, scene, homePage, cmdBar, editor, toolbar }) => {
+      await page.addInitScript(async () => {
+        localStorage.setItem(
+          'persistCode',
+          `@settings(defaultLengthUnit = mm)
 sketch001 = startSketchOn(XZ)
 profile001 = startProfile(sketch001, at = [0, 0])
   |> xLine(length = 25.0)
@@ -953,82 +914,80 @@ profile001 = startProfile(sketch001, at = [0, 0])
   |> line(end = [-22.0, 12.0])
   |> line(endAbsolute = [profileStartX(%), profileStartY(%)])
   |> close()`
-      )
-    })
+        )
+      })
 
-    await homePage.goToModelingScene()
-    await scene.settled(cmdBar)
+      await homePage.goToModelingScene()
+      await scene.settled(cmdBar)
 
-    await toolbar.editSketch()
+      await toolbar.editSketch()
 
-    // Select the third line
-    await editor.selectText('line(end = [-22.0, 12.0])')
-    await editor.closePane()
+      // Select the third line
+      await editor.selectText('line(end = [-22.0, 12.0])')
+      await editor.closePane()
 
-    // Delete with backspace
-    await page.keyboard.press('Delete')
+      // Delete with backspace
+      await page.keyboard.press('Delete')
 
-    // Validate the editor code no longer contains the deleted line
-    await editor.expectEditor.toContain(
-      `sketch001 = startSketchOn(XZ)
+      // Validate the editor code no longer contains the deleted line
+      await editor.expectEditor.toContain(
+        `sketch001 = startSketchOn(XZ)
 profile001 = startProfile(sketch001, at = [0, 0])
   |> xLine(length = 25.0)
   |> yLine(length = 5.0)
   |> line(endAbsolute = [profileStartX(%), profileStartY(%)])
   |> close()
 `,
-      { shouldNormalise: true }
-    )
-  })
+        { shouldNormalise: true }
+      )
+    }
+  )
 
-  test('Select-all delete removes segments and circle in sketch mode (seeded code)', async ({
-    page,
-    homePage,
-    scene,
-    cmdBar,
-    toolbar,
-    editor,
-  }) => {
-    await page.setBodyDimensions({ width: 1200, height: 600 })
+  test(
+    'Select-all delete removes segments and circle in sketch mode (seeded code)',
+    { tag: '@desktop' },
+    async ({ page, homePage, scene, cmdBar, toolbar, editor }) => {
+      await page.setBodyDimensions({ width: 1200, height: 600 })
 
-    await page.addInitScript(async () => {
-      localStorage.setItem(
-        'persistCode',
-        `sketch001 = startSketchOn(XZ)
+      await page.addInitScript(async () => {
+        localStorage.setItem(
+          'persistCode',
+          `sketch001 = startSketchOn(XZ)
 profile001 = startProfile(sketch001, at = [-0.26, 0])
   |> xLine(length = 0.11)
   |> line(end = [0.12, -0.11])
 
 profile002 = circle(sketch001, center = [0.03, -0.03], radius = 0.08)
 // testcomment2`
-      )
-    })
+        )
+      })
 
-    await homePage.goToModelingScene()
-    await scene.settled(cmdBar)
+      await homePage.goToModelingScene()
+      await scene.settled(cmdBar)
 
-    // Enter sketch mode on first sketch via Feature Tree
-    await toolbar.openFeatureTreePane()
-    await (await toolbar.getFeatureTreeOperation('Sketch', 0)).dblclick()
-    await page.waitForTimeout(600)
-    await editor.expectEditor.toContain('startSketchOn(XZ)')
-    await editor.expectEditor.toContain('startProfile(')
-    await editor.expectEditor.toContain('circle(')
+      // Enter sketch mode on first sketch via Feature Tree
+      await toolbar.openFeatureTreePane()
+      await (await toolbar.getFeatureTreeOperation('Sketch', 0)).dblclick()
+      await page.waitForTimeout(600)
+      await editor.expectEditor.toContain('startSketchOn(XZ)')
+      await editor.expectEditor.toContain('startProfile(')
+      await editor.expectEditor.toContain('circle(')
 
-    // Select all and delete
-    await page.keyboard.press('ControlOrMeta+A')
-    await page.keyboard.press('Delete')
+      // Select all and delete
+      await page.keyboard.press('ControlOrMeta+A')
+      await page.keyboard.press('Delete')
 
-    // Expect that only the sketch declaration remains
-    await editor.expectEditor.toContain('startSketchOn(XZ)')
-    await editor.expectEditor.not.toContain('startProfile(')
-    await editor.expectEditor.not.toContain('|> xLine(')
-    await editor.expectEditor.not.toContain('circle(')
-    await editor.expectEditor.toContain('testcomment2')
-  })
+      // Expect that only the sketch declaration remains
+      await editor.expectEditor.toContain('startSketchOn(XZ)')
+      await editor.expectEditor.not.toContain('startProfile(')
+      await editor.expectEditor.not.toContain('|> xLine(')
+      await editor.expectEditor.not.toContain('circle(')
+      await editor.expectEditor.toContain('testcomment2')
+    }
+  )
 })
 
-test.describe('multi-profile sketching', () => {
+test.describe('multi-profile sketching', { tag: '@desktop' }, () => {
   test('can enter sketch mode for sketch with no profiles', async ({
     scene,
     toolbar,
@@ -1854,116 +1813,122 @@ loft([profile001, profile002])
 })
 
 // Regression test for https://github.com/KittyCAD/modeling-app/issues/4372
-test.describe('Redirecting to home page and back to the original file should clear sketch DOM elements', () => {
-  test('Can redirect to home page and back to original file and have a cleared DOM', async ({
-    context,
-    page,
-    scene,
-    toolbar,
-    editor,
-    homePage,
-    cmdBar,
-  }) => {
-    // We seed the scene with a single offset plane
-    await context.addInitScript(() => {
-      localStorage.setItem(
-        'persistCode',
-        ` sketch001 = startSketchOn(XZ)
+test.describe(
+  'Redirecting to home page and back to the original file should clear sketch DOM elements',
+  { tag: '@desktop' },
+  () => {
+    test('Can redirect to home page and back to original file and have a cleared DOM', async ({
+      context,
+      page,
+      scene,
+      toolbar,
+      editor,
+      homePage,
+      cmdBar,
+    }) => {
+      // We seed the scene with a single offset plane
+      await context.addInitScript(() => {
+        localStorage.setItem(
+          'persistCode',
+          ` sketch001 = startSketchOn(XZ)
 |> startProfile(at = [256.85, 14.41])
 |> line(endAbsolute = [0, 211.07])
 `
+        )
+      })
+      await homePage.goToModelingScene()
+      await scene.settled(cmdBar)
+
+      const [objClick] = scene.makeMouseHelpers(634, 274)
+      await objClick()
+
+      // Enter sketch mode
+      await toolbar.editSketch()
+
+      await expect(page.getByText('323.49')).toBeVisible()
+
+      // Open navigation side bar
+      await page.getByTestId('project-sidebar-toggle').click()
+      const goToHome = page.getByRole('button', {
+        name: 'Go to Home',
+      })
+
+      await goToHome.click()
+      await homePage.openProject('testDefault')
+      await expect(page.getByText('323.49')).not.toBeVisible()
+    })
+
+    test('Straight line snapping to previous tangent', async ({
+      page,
+      homePage,
+      toolbar,
+      scene,
+      cmdBar,
+      context,
+      editor,
+    }) => {
+      await context.addInitScript(() => {
+        localStorage.setItem('persistCode', `@settings(defaultLengthUnit = mm)`)
+      })
+
+      const viewportSize = { width: 1200, height: 900 }
+      await page.setBodyDimensions(viewportSize)
+      await homePage.goToModelingScene()
+
+      // wait until scene is ready to be interacted with
+      await scene.connectionEstablished()
+      await scene.settled(cmdBar)
+
+      await toolbar.startSketchBtn.click()
+
+      // select an axis plane
+      const [selectPlane] = scene.makeMouseHelpers(0.6, 0.3, {
+        format: 'ratio',
+      })
+      await selectPlane()
+
+      // Needed as we don't yet have a way to get a signal from the engine that the camera has animated to the sketch plane
+      await page.waitForTimeout(3000)
+
+      const center = { x: viewportSize.width / 2, y: viewportSize.height / 2 }
+      const { click00r } = getMovementUtils({ center, page })
+
+      // Draw line
+      await click00r(0, 0)
+      await click00r(200, -200)
+
+      // Draw arc
+      await toolbar.selectTangentialArc()
+      await click00r(0, 0)
+      await click00r(100, 100)
+
+      // Switch back to line
+      await toolbar.selectLine()
+      await click00r(0, 0)
+      await click00r(-100, 100)
+
+      // Draw a 3 point arc
+      await toolbar.selectThreePointArc()
+      await click00r(0, 0)
+      await click00r(0, 100)
+      await click00r(100, 0)
+
+      // draw a line to opposite tangent direction of previous arc
+      await toolbar.selectLine()
+      await click00r(0, 0)
+      await click00r(-200, 200)
+
+      // Check for tangent-related parts only
+      await editor.expectEditor.toContain('tangentialArc')
+      await editor.expectEditor.toContain('tangentToEnd(seg01)')
+      await editor.expectEditor.toContain(
+        'tangentToEnd(seg02) + turns::HALF_TURN'
       )
     })
-    await homePage.goToModelingScene()
-    await scene.settled(cmdBar)
+  }
+)
 
-    const [objClick] = scene.makeMouseHelpers(634, 274)
-    await objClick()
-
-    // Enter sketch mode
-    await toolbar.editSketch()
-
-    await expect(page.getByText('323.49')).toBeVisible()
-
-    // Open navigation side bar
-    await page.getByTestId('project-sidebar-toggle').click()
-    const goToHome = page.getByRole('button', {
-      name: 'Go to Home',
-    })
-
-    await goToHome.click()
-    await homePage.openProject('testDefault')
-    await expect(page.getByText('323.49')).not.toBeVisible()
-  })
-
-  test('Straight line snapping to previous tangent', async ({
-    page,
-    homePage,
-    toolbar,
-    scene,
-    cmdBar,
-    context,
-    editor,
-  }) => {
-    await context.addInitScript(() => {
-      localStorage.setItem('persistCode', `@settings(defaultLengthUnit = mm)`)
-    })
-
-    const viewportSize = { width: 1200, height: 900 }
-    await page.setBodyDimensions(viewportSize)
-    await homePage.goToModelingScene()
-
-    // wait until scene is ready to be interacted with
-    await scene.connectionEstablished()
-    await scene.settled(cmdBar)
-
-    await toolbar.startSketchBtn.click()
-
-    // select an axis plane
-    const [selectPlane] = scene.makeMouseHelpers(0.6, 0.3, { format: 'ratio' })
-    await selectPlane()
-
-    // Needed as we don't yet have a way to get a signal from the engine that the camera has animated to the sketch plane
-    await page.waitForTimeout(3000)
-
-    const center = { x: viewportSize.width / 2, y: viewportSize.height / 2 }
-    const { click00r } = getMovementUtils({ center, page })
-
-    // Draw line
-    await click00r(0, 0)
-    await click00r(200, -200)
-
-    // Draw arc
-    await toolbar.selectTangentialArc()
-    await click00r(0, 0)
-    await click00r(100, 100)
-
-    // Switch back to line
-    await toolbar.selectLine()
-    await click00r(0, 0)
-    await click00r(-100, 100)
-
-    // Draw a 3 point arc
-    await toolbar.selectThreePointArc()
-    await click00r(0, 0)
-    await click00r(0, 100)
-    await click00r(100, 0)
-
-    // draw a line to opposite tangent direction of previous arc
-    await toolbar.selectLine()
-    await click00r(0, 0)
-    await click00r(-200, 200)
-
-    // Check for tangent-related parts only
-    await editor.expectEditor.toContain('tangentialArc')
-    await editor.expectEditor.toContain('tangentToEnd(seg01)')
-    await editor.expectEditor.toContain(
-      'tangentToEnd(seg02) + turns::HALF_TURN'
-    )
-  })
-})
-
-test.describe('manual edits during sketch mode', () => {
+test.describe('manual edits during sketch mode', { tag: '@desktop' }, () => {
   test('Will exit out of sketch mode when all code is nuked', async ({
     page,
     context,

--- a/e2e/playwright/snap-to-grid.spec.ts
+++ b/e2e/playwright/snap-to-grid.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@e2e/playwright/zoo-test'
 
-test.describe('Snap to Grid', () => {
+test.describe('Snap to Grid', { tag: '@desktop' }, () => {
   test('draws a line with snap to grid turned on', async ({
     page,
     homePage,

--- a/e2e/playwright/stress-test.spec.ts
+++ b/e2e/playwright/stress-test.spec.ts
@@ -1,7 +1,7 @@
 import { createProject } from '@e2e/playwright/test-utils'
 import { test } from '@e2e/playwright/zoo-test'
 
-test.describe('Stress test', () => {
+test.describe('Stress test', { tag: '@desktop' }, () => {
   test('Create project and load stress test', async ({
     cmdBar,
     scene,

--- a/e2e/playwright/test-network-and-connection-issues.spec.ts
+++ b/e2e/playwright/test-network-and-connection-issues.spec.ts
@@ -1,7 +1,7 @@
 import { TEST_COLORS, circleMove, getUtils } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 
-test.describe('Test network related behaviors', () => {
+test.describe('Test network related behaviors', { tag: '@desktop' }, () => {
   test(
     'simulate network down and network little widget',
     { tag: '@skipLocalEngine' },
@@ -204,7 +204,7 @@ test.describe('Test network related behaviors', () => {
 
   test(
     'Paused stream freezes view frame, unpause reconnect is seamless to user',
-    { tag: ['@desktop', '@skipLocalEngine'] },
+    { tag: '@skipLocalEngine' },
     async ({ page, homePage, scene, cmdBar, toolbar, tronApp }) => {
       const networkToggle = page.getByTestId(/network-toggle/)
       const networkToggleConnectedText = page.getByText(

--- a/e2e/playwright/testing-camera-movement-touch.spec.ts
+++ b/e2e/playwright/testing-camera-movement-touch.spec.ts
@@ -6,141 +6,145 @@ import { type Page } from '@playwright/test'
 test.use({
   hasTouch: true,
 })
-test.describe('Testing Camera Movement (Touch Only)', () => {
-  /**
-   * DUPLICATED FROM `testing-camera-movement.spec.ts`, might need to become a util.
-   *
-   * hack that we're implemented our own retry instead of using retries built into playwright.
-   * however each of these camera drags can be flaky, because of udp
-   * and so putting them together means only one needs to fail to make this test extra flaky.
-   * this way we can retry within the test
-   * We could break them out into separate tests, but the longest past of the test is waiting
-   * for the stream to start, so it can be good to bundle related things together.
-   */
-  const _bakeInRetries = async ({
-    mouseActions,
-    afterPosition,
-    beforePosition,
-    retryCount = 0,
-    page,
-    scene,
-  }: {
-    mouseActions: () => Promise<void>
-    beforePosition: [number, number, number]
-    afterPosition: [number, number, number]
-    retryCount?: number
-    page: Page
-    scene: SceneFixture
-  }) => {
-    const acceptableCamError = 5
-    const u = await getUtils(page)
+test.describe(
+  'Testing Camera Movement (Touch Only)',
+  { tag: '@desktop' },
+  () => {
+    /**
+     * DUPLICATED FROM `testing-camera-movement.spec.ts`, might need to become a util.
+     *
+     * hack that we're implemented our own retry instead of using retries built into playwright.
+     * however each of these camera drags can be flaky, because of udp
+     * and so putting them together means only one needs to fail to make this test extra flaky.
+     * this way we can retry within the test
+     * We could break them out into separate tests, but the longest past of the test is waiting
+     * for the stream to start, so it can be good to bundle related things together.
+     */
+    const _bakeInRetries = async ({
+      mouseActions,
+      afterPosition,
+      beforePosition,
+      retryCount = 0,
+      page,
+      scene,
+    }: {
+      mouseActions: () => Promise<void>
+      beforePosition: [number, number, number]
+      afterPosition: [number, number, number]
+      retryCount?: number
+      page: Page
+      scene: SceneFixture
+    }) => {
+      const acceptableCamError = 5
+      const u = await getUtils(page)
 
-    await test.step('Set up initial camera position', async () =>
-      await scene.moveCameraTo({
-        x: beforePosition[0],
-        y: beforePosition[1],
-        z: beforePosition[2],
-      }))
+      await test.step('Set up initial camera position', async () =>
+        await scene.moveCameraTo({
+          x: beforePosition[0],
+          y: beforePosition[1],
+          z: beforePosition[2],
+        }))
 
-    await test.step('Do actions and watch for changes', async () =>
-      u.doAndWaitForImageDiff(async () => {
-        await mouseActions()
+      await test.step('Do actions and watch for changes', async () =>
+        u.doAndWaitForImageDiff(async () => {
+          await mouseActions()
 
-        await u.openAndClearDebugPanel()
-        await u.closeDebugPanel()
-        await page.waitForTimeout(100)
-      }, 300))
+          await u.openAndClearDebugPanel()
+          await u.closeDebugPanel()
+          await page.waitForTimeout(100)
+        }, 300))
 
-    await u.openAndClearDebugPanel()
-    await expect(page.getByTestId('cam-x-position')).toBeAttached()
+      await u.openAndClearDebugPanel()
+      await expect(page.getByTestId('cam-x-position')).toBeAttached()
 
-    const vals = await Promise.all([
-      page.getByTestId('cam-x-position').inputValue(),
-      page.getByTestId('cam-y-position').inputValue(),
-      page.getByTestId('cam-z-position').inputValue(),
-    ])
-    const errors = vals.map((v, i) => Math.abs(Number(v) - afterPosition[i]))
-    let shouldRetry = false
+      const vals = await Promise.all([
+        page.getByTestId('cam-x-position').inputValue(),
+        page.getByTestId('cam-y-position').inputValue(),
+        page.getByTestId('cam-z-position').inputValue(),
+      ])
+      const errors = vals.map((v, i) => Math.abs(Number(v) - afterPosition[i]))
+      let shouldRetry = false
 
-    if (errors.some((e) => e > acceptableCamError)) {
-      if (retryCount > 2) {
-        console.log('xVal', vals[0], 'xError', errors[0])
-        console.log('yVal', vals[1], 'yError', errors[1])
-        console.log('zVal', vals[2], 'zError', errors[2])
+      if (errors.some((e) => e > acceptableCamError)) {
+        if (retryCount > 2) {
+          console.log('xVal', vals[0], 'xError', errors[0])
+          console.log('yVal', vals[1], 'yError', errors[1])
+          console.log('zVal', vals[2], 'zError', errors[2])
 
-        throw new Error('Camera position not as expected', {
-          cause: {
-            vals,
-            errors,
-          },
+          throw new Error('Camera position not as expected', {
+            cause: {
+              vals,
+              errors,
+            },
+          })
+        }
+        shouldRetry = true
+      }
+      if (shouldRetry) {
+        await _bakeInRetries({
+          mouseActions,
+          afterPosition: afterPosition,
+          beforePosition: beforePosition,
+          retryCount: retryCount + 1,
+          page,
+          scene,
         })
       }
-      shouldRetry = true
     }
-    if (shouldRetry) {
-      await _bakeInRetries({
-        mouseActions,
-        afterPosition: afterPosition,
-        beforePosition: beforePosition,
-        retryCount: retryCount + 1,
-        page,
-        scene,
-      })
-    }
+    // test(
+    //   'Touch camera controls',
+    //   {
+    //     tag: '@web',
+    //   },
+    //   async ({ page, homePage, scene, cmdBar }) => {
+    //     const u = await getUtils(page)
+    //     const camInitialPosition: [number, number, number] = [0, 85, 85]
+    //
+    //     await homePage.goToModelingScene()
+    //     await scene.settled(cmdBar)
+    //     const stream = page.getByTestId('stream')
+    //
+    //     await u.openAndClearDebugPanel()
+    //     await u.closeKclCodePanel()
+    //
+    //     await test.step('Orbit', async () => {
+    //       await bakeInRetries({
+    //         mouseActions: async () => {
+    //           await panFromCenter(stream, 200, 200)
+    //           await page.waitForTimeout(200)
+    //         },
+    //         afterPosition: [19, 85, 85],
+    //         beforePosition: camInitialPosition,
+    //         page,
+    //         scene,
+    //       })
+    //     })
+    //
+    //     await test.step('Pan', async () => {
+    //       await bakeInRetries({
+    //         mouseActions: async () => {
+    //           await panTwoFingerFromCenter(stream, 200, 200)
+    //           await page.waitForTimeout(200)
+    //         },
+    //         afterPosition: [19, 85, 85],
+    //         beforePosition: camInitialPosition,
+    //         page,
+    //         scene,
+    //       })
+    //     })
+    //
+    //     await test.step('Zoom', async () => {
+    //       await bakeInRetries({
+    //         mouseActions: async () => {
+    //           await pinchFromCenter(stream, 300, -100, 5)
+    //         },
+    //         afterPosition: [0, 118, 118],
+    //         beforePosition: camInitialPosition,
+    //         page,
+    //         scene,
+    //       })
+    //     })
+    //   }
+    //  )
   }
-  // test(
-  //   'Touch camera controls',
-  //   {
-  //     tag: '@web',
-  //   },
-  //   async ({ page, homePage, scene, cmdBar }) => {
-  //     const u = await getUtils(page)
-  //     const camInitialPosition: [number, number, number] = [0, 85, 85]
-  //
-  //     await homePage.goToModelingScene()
-  //     await scene.settled(cmdBar)
-  //     const stream = page.getByTestId('stream')
-  //
-  //     await u.openAndClearDebugPanel()
-  //     await u.closeKclCodePanel()
-  //
-  //     await test.step('Orbit', async () => {
-  //       await bakeInRetries({
-  //         mouseActions: async () => {
-  //           await panFromCenter(stream, 200, 200)
-  //           await page.waitForTimeout(200)
-  //         },
-  //         afterPosition: [19, 85, 85],
-  //         beforePosition: camInitialPosition,
-  //         page,
-  //         scene,
-  //       })
-  //     })
-  //
-  //     await test.step('Pan', async () => {
-  //       await bakeInRetries({
-  //         mouseActions: async () => {
-  //           await panTwoFingerFromCenter(stream, 200, 200)
-  //           await page.waitForTimeout(200)
-  //         },
-  //         afterPosition: [19, 85, 85],
-  //         beforePosition: camInitialPosition,
-  //         page,
-  //         scene,
-  //       })
-  //     })
-  //
-  //     await test.step('Zoom', async () => {
-  //       await bakeInRetries({
-  //         mouseActions: async () => {
-  //           await pinchFromCenter(stream, 300, -100, 5)
-  //         },
-  //         afterPosition: [0, 118, 118],
-  //         beforePosition: camInitialPosition,
-  //         page,
-  //         scene,
-  //       })
-  //     })
-  //   }
-  //  )
-})
+)

--- a/e2e/playwright/testing-camera-movement.spec.ts
+++ b/e2e/playwright/testing-camera-movement.spec.ts
@@ -6,7 +6,7 @@ import { getUtils } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 import type { Page } from '@playwright/test'
 
-test.describe('Testing Camera Movement', () => {
+test.describe('Testing Camera Movement', { tag: '@desktop' }, () => {
   /**
    * hack that we're implemented our own retry instead of using retries built into playwright.
    * however each of these camera drags can be flaky, because of udp

--- a/e2e/playwright/testing-perspective-toggle.spec.ts
+++ b/e2e/playwright/testing-perspective-toggle.spec.ts
@@ -1,3 +1,3 @@
 import { test } from '@e2e/playwright/zoo-test'
 
-test.describe('Test toggling perspective', () => {})
+test.describe('Test toggling perspective', { tag: '@desktop' }, () => {})

--- a/e2e/playwright/testing-samples-loading.spec.ts
+++ b/e2e/playwright/testing-samples-loading.spec.ts
@@ -14,7 +14,7 @@ import {
 import { expect, test } from '@e2e/playwright/zoo-test'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 
-test.describe('Testing loading external models', () => {
+test.describe('Testing loading external models', { tag: '@desktop' }, () => {
   /**
    * Note this test implicitly depends on the KCL sample "parametric-bearing-pillow-block",
    * its title, and its units settings. https://github.com/KittyCAD/kcl-samples/blob/main/parametric-bearing-pillow-block/main.kcl
@@ -80,104 +80,107 @@ test.describe('Testing loading external models', () => {
    * "parametric-bearing-pillow-block": https://github.com/KittyCAD/kcl-samples/blob/main/parametric-bearing-pillow-block/main.kcl
    * "gear-rack": https://github.com/KittyCAD/kcl-samples/blob/main/gear-rack/main.kcl
    */
-  test(
-    'Desktop: should create new file by default, creates a second file with automatic unique name',
-    { tag: '@desktop' },
-    async ({ editor, context, page, scene, cmdBar, toolbar }) => {
-      if (runningOnWindows()) {
-      }
-
-      await context.folderSetupFn(async (dir) => {
-        const bracketDir = join(dir, 'bracket')
-        await fsp.mkdir(bracketDir, { recursive: true })
-        await fsp.writeFile(join(bracketDir, 'main.kcl'), bracket, {
-          encoding: 'utf-8',
-        })
-      })
-      const u = await getUtils(page)
-
-      // Locators and constants
-      const sampleOne = {
-        file: 'ball-bearing' + FILE_EXT,
-        title: 'Ball Bearing',
-        file1: 'ball-bearing-1' + FILE_EXT,
-        folderName: 'ball-bearing',
-        folderName1: 'ball-bearing-1',
-      }
-      const projectCard = page.getByRole('link', { name: 'bracket' })
-      const overwriteWarning = page.getByText(
-        'Overwrite current file with sample?'
-      )
-      const projectMenuButton = page.getByTestId('project-sidebar-toggle')
-      const newlyCreatedFile = (name: string) =>
-        page.getByRole('listitem').filter({
-          has: page.getByRole('button', { name }),
-        })
-      const defaultLoadCmdBarState: CmdBarSerialised = {
-        commandName: 'Add file to project',
-        currentArgKey: 'sample',
-        currentArgValue: '',
-        headerArguments: {
-          Method: 'Existing project',
-          Sample: '',
-          Source: 'kcl-samples',
-          ProjectName: 'bracket',
-        },
-        highlightedHeaderArg: 'sample',
-        stage: 'arguments',
-      }
-
-      await test.step(`Test setup`, async () => {
-        await page.setBodyDimensions({ width: 1200, height: 500 })
-        await projectCard.click()
-        await scene.settled(cmdBar)
-      })
-
-      await test.step(`Precondition: check the initial code`, async () => {
-        await u.openKclCodePanel()
-        await editor.scrollToText(bracket.split('\n')[0])
-        await editor.expectEditor.toContain(bracket.split('\n')[0])
-        await u.openFilePanel()
-
-        await expect(projectMenuButton).toContainText('main.kcl')
-        await expect(newlyCreatedFile(sampleOne.file)).not.toBeVisible()
-      })
-
-      await test.step(`Load a KCL sample with the command palette`, async () => {
-        await toolbar.loadButton.click()
-        await cmdBar.selectOption({ name: 'KCL Samples' }).click()
-        await cmdBar.expectState(defaultLoadCmdBarState)
-        await cmdBar.selectOption({ name: sampleOne.title }).click()
-        await expect(overwriteWarning).not.toBeVisible()
-        await page.waitForTimeout(1000)
-      })
-
-      await test.step(`Ensure we made and opened a new file`, async () => {
-        await editor.expectEditor.toContain('// ' + sampleOne.title)
-        await expect(
-          page.getByTestId('file-tree-item').getByText(sampleOne.folderName)
-        ).toBeVisible()
-        await expect(projectMenuButton).toContainText('main.kcl')
-      })
-
-      await test.step(`Load a KCL sample with the command palette`, async () => {
-        await toolbar.loadButton.click()
-        await cmdBar.selectOption({ name: 'KCL Samples' }).click()
-        await cmdBar.expectState(defaultLoadCmdBarState)
-        await cmdBar.selectOption({ name: sampleOne.title }).click()
-        await expect(overwriteWarning).not.toBeVisible()
-        await page.waitForTimeout(1000)
-      })
-
-      await test.step(`Ensure we made and opened a new file with a unique name`, async () => {
-        await editor.expectEditor.toContain('// ' + sampleOne.title)
-        await expect(
-          page.getByTestId('file-tree-item').getByText(sampleOne.folderName1)
-        ).toBeVisible()
-        await expect(projectMenuButton).toContainText('main.kcl')
-      })
+  test('Desktop: should create new file by default, creates a second file with automatic unique name', async ({
+    editor,
+    context,
+    page,
+    scene,
+    cmdBar,
+    toolbar,
+  }) => {
+    if (runningOnWindows()) {
     }
-  )
+
+    await context.folderSetupFn(async (dir) => {
+      const bracketDir = join(dir, 'bracket')
+      await fsp.mkdir(bracketDir, { recursive: true })
+      await fsp.writeFile(join(bracketDir, 'main.kcl'), bracket, {
+        encoding: 'utf-8',
+      })
+    })
+    const u = await getUtils(page)
+
+    // Locators and constants
+    const sampleOne = {
+      file: 'ball-bearing' + FILE_EXT,
+      title: 'Ball Bearing',
+      file1: 'ball-bearing-1' + FILE_EXT,
+      folderName: 'ball-bearing',
+      folderName1: 'ball-bearing-1',
+    }
+    const projectCard = page.getByRole('link', { name: 'bracket' })
+    const overwriteWarning = page.getByText(
+      'Overwrite current file with sample?'
+    )
+    const projectMenuButton = page.getByTestId('project-sidebar-toggle')
+    const newlyCreatedFile = (name: string) =>
+      page.getByRole('listitem').filter({
+        has: page.getByRole('button', { name }),
+      })
+    const defaultLoadCmdBarState: CmdBarSerialised = {
+      commandName: 'Add file to project',
+      currentArgKey: 'sample',
+      currentArgValue: '',
+      headerArguments: {
+        Method: 'Existing project',
+        Sample: '',
+        Source: 'kcl-samples',
+        ProjectName: 'bracket',
+      },
+      highlightedHeaderArg: 'sample',
+      stage: 'arguments',
+    }
+
+    await test.step(`Test setup`, async () => {
+      await page.setBodyDimensions({ width: 1200, height: 500 })
+      await projectCard.click()
+      await scene.settled(cmdBar)
+    })
+
+    await test.step(`Precondition: check the initial code`, async () => {
+      await u.openKclCodePanel()
+      await editor.scrollToText(bracket.split('\n')[0])
+      await editor.expectEditor.toContain(bracket.split('\n')[0])
+      await u.openFilePanel()
+
+      await expect(projectMenuButton).toContainText('main.kcl')
+      await expect(newlyCreatedFile(sampleOne.file)).not.toBeVisible()
+    })
+
+    await test.step(`Load a KCL sample with the command palette`, async () => {
+      await toolbar.loadButton.click()
+      await cmdBar.selectOption({ name: 'KCL Samples' }).click()
+      await cmdBar.expectState(defaultLoadCmdBarState)
+      await cmdBar.selectOption({ name: sampleOne.title }).click()
+      await expect(overwriteWarning).not.toBeVisible()
+      await page.waitForTimeout(1000)
+    })
+
+    await test.step(`Ensure we made and opened a new file`, async () => {
+      await editor.expectEditor.toContain('// ' + sampleOne.title)
+      await expect(
+        page.getByTestId('file-tree-item').getByText(sampleOne.folderName)
+      ).toBeVisible()
+      await expect(projectMenuButton).toContainText('main.kcl')
+    })
+
+    await test.step(`Load a KCL sample with the command palette`, async () => {
+      await toolbar.loadButton.click()
+      await cmdBar.selectOption({ name: 'KCL Samples' }).click()
+      await cmdBar.expectState(defaultLoadCmdBarState)
+      await cmdBar.selectOption({ name: sampleOne.title }).click()
+      await expect(overwriteWarning).not.toBeVisible()
+      await page.waitForTimeout(1000)
+    })
+
+    await test.step(`Ensure we made and opened a new file with a unique name`, async () => {
+      await editor.expectEditor.toContain('// ' + sampleOne.title)
+      await expect(
+        page.getByTestId('file-tree-item').getByText(sampleOne.folderName1)
+      ).toBeVisible()
+      await expect(projectMenuButton).toContainText('main.kcl')
+    })
+  })
 
   const externalModelCases = [
     {
@@ -192,85 +195,88 @@ test.describe('Testing loading external models', () => {
     },
   ]
   externalModelCases.map(({ modelName, deconflictedModelName, modelPath }) => {
-    test(
-      `Load external models from local drive - ${modelName}`,
-      { tag: ['@desktop'] },
-      async ({ page, homePage, scene, toolbar, cmdBar, tronApp }) => {
-        if (!tronApp) throw new Error('tronApp is missing.')
+    test(`Load external models from local drive - ${modelName}`, async ({
+      page,
+      homePage,
+      scene,
+      toolbar,
+      cmdBar,
+      tronApp,
+    }) => {
+      if (!tronApp) throw new Error('tronApp is missing.')
 
-        await page.setBodyDimensions({ width: 1000, height: 500 })
-        await homePage.goToModelingScene()
-        await scene.settled(cmdBar)
-        const modelFileContent = await fsp.readFile(modelPath, 'utf-8')
-        const { editorTextMatches } = await getUtils(page, test)
+      await page.setBodyDimensions({ width: 1000, height: 500 })
+      await homePage.goToModelingScene()
+      await scene.settled(cmdBar)
+      const modelFileContent = await fsp.readFile(modelPath, 'utf-8')
+      const { editorTextMatches } = await getUtils(page, test)
 
-        async function loadExternalFileThroughCommandBar(tronApp: ElectronZoo) {
-          await toolbar.loadButton.click()
-          await cmdBar.selectOption({ name: 'Local Drive' }).click()
-          await cmdBar.expectState({
-            commandName: 'Add file to project',
-            currentArgKey: 'pathOpen file',
-            currentArgValue: '',
-            headerArguments: {
-              Method: 'Existing project',
-              Path: '',
-              Source: 'local',
-              ProjectName: 'testDefault',
-            },
-            highlightedHeaderArg: 'path',
-            stage: 'arguments',
-          })
-
-          // Mock the file picker selection
-          const handleFile = tronApp.electron.evaluate(
-            async ({ dialog }, filePaths) => {
-              dialog.showOpenDialog = () =>
-                Promise.resolve({ canceled: false, filePaths })
-            },
-            [modelPath]
-          )
-          await page.getByTestId('cmd-bar-arg-file-button').click()
-          await handleFile
-
-          await cmdBar.expectState({
-            commandName: 'Add file to project',
-            currentArgKey: 'pathOpen file',
-            currentArgValue: '',
-            headerArguments: {
-              Method: 'Existing project',
-              Path: '',
-              Source: 'local',
-              ProjectName: 'testDefault',
-            },
-            highlightedHeaderArg: 'path',
-            stage: 'arguments',
-          })
-          await cmdBar.progressCmdBar()
-        }
-
-        await test.step('Load the external model from local drive', async () => {
-          await loadExternalFileThroughCommandBar(tronApp)
-          // TODO: I think the files pane should auto open?
-          await toolbar.openPane(DefaultLayoutPaneID.Files)
-          await toolbar.expectFileTreeState([modelName, 'main.kcl'])
-          if (modelName.endsWith('.kcl')) {
-            await editorTextMatches(modelFileContent)
-          }
+      async function loadExternalFileThroughCommandBar(tronApp: ElectronZoo) {
+        await toolbar.loadButton.click()
+        await cmdBar.selectOption({ name: 'Local Drive' }).click()
+        await cmdBar.expectState({
+          commandName: 'Add file to project',
+          currentArgKey: 'pathOpen file',
+          currentArgValue: '',
+          headerArguments: {
+            Method: 'Existing project',
+            Path: '',
+            Source: 'local',
+            ProjectName: 'testDefault',
+          },
+          highlightedHeaderArg: 'path',
+          stage: 'arguments',
         })
 
-        await test.step('Load the same external model, except deconflicted name', async () => {
-          await loadExternalFileThroughCommandBar(tronApp)
-          await toolbar.openPane(DefaultLayoutPaneID.Files)
-          await toolbar.expectFileTreeState([
-            deconflictedModelName,
-            modelName,
-            'main.kcl',
-          ])
-          if (modelName.endsWith('.kcl')) {
-            await editorTextMatches(modelFileContent)
-          }
+        // Mock the file picker selection
+        const handleFile = tronApp.electron.evaluate(
+          async ({ dialog }, filePaths) => {
+            dialog.showOpenDialog = () =>
+              Promise.resolve({ canceled: false, filePaths })
+          },
+          [modelPath]
+        )
+        await page.getByTestId('cmd-bar-arg-file-button').click()
+        await handleFile
+
+        await cmdBar.expectState({
+          commandName: 'Add file to project',
+          currentArgKey: 'pathOpen file',
+          currentArgValue: '',
+          headerArguments: {
+            Method: 'Existing project',
+            Path: '',
+            Source: 'local',
+            ProjectName: 'testDefault',
+          },
+          highlightedHeaderArg: 'path',
+          stage: 'arguments',
         })
+        await cmdBar.progressCmdBar()
       }
-    )
+
+      await test.step('Load the external model from local drive', async () => {
+        await loadExternalFileThroughCommandBar(tronApp)
+        // TODO: I think the files pane should auto open?
+        await toolbar.openPane(DefaultLayoutPaneID.Files)
+        await toolbar.expectFileTreeState([modelName, 'main.kcl'])
+        if (modelName.endsWith('.kcl')) {
+          await editorTextMatches(modelFileContent)
+        }
+      })
+
+      await test.step('Load the same external model, except deconflicted name', async () => {
+        await loadExternalFileThroughCommandBar(tronApp)
+        await toolbar.openPane(DefaultLayoutPaneID.Files)
+        await toolbar.expectFileTreeState([
+          deconflictedModelName,
+          modelName,
+          'main.kcl',
+        ])
+        if (modelName.endsWith('.kcl')) {
+          await editorTextMatches(modelFileContent)
+        }
+      })
+    })
   })
 })

--- a/e2e/playwright/testing-segment-overlays.spec.ts
+++ b/e2e/playwright/testing-segment-overlays.spec.ts
@@ -7,7 +7,7 @@ import type { EditorFixture } from '@e2e/playwright/fixtures/editorFixture'
 import { deg, getUtils, wiggleMove } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 
-test.describe('Testing segment overlays', () => {
+test.describe('Testing segment overlays', { tag: '@desktop' }, () => {
   test.describe('Hover over a segment should show its overlay, hovering over the input overlays should show its popover, clicking the input overlay should constrain/unconstrain it', () => {
     /**
      * Clicks on an constrained element

--- a/e2e/playwright/testing-selections.spec.ts
+++ b/e2e/playwright/testing-selections.spec.ts
@@ -2,7 +2,7 @@ import { bracket } from '@e2e/playwright/fixtures/bracket'
 import { getUtils } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 
-test.describe('Testing selections', () => {
+test.describe('Testing selections', { tag: '@desktop' }, () => {
   test("Extrude button should be disabled if there's no extrudable geometry when nothing is selected", async ({
     page,
     editor,

--- a/e2e/playwright/testing-settings.spec.ts
+++ b/e2e/playwright/testing-settings.spec.ts
@@ -42,7 +42,7 @@ const settingsSwitchTab = (page: Page) => async (tab: 'user' | 'proj') => {
 test.describe(
   'Testing settings',
   {
-    tag: ['@linux', '@macos', '@windows'],
+    tag: ['@macos', '@windows'],
   },
   () => {
     test('Stored settings are validated and fall back to defaults', async ({

--- a/e2e/playwright/view-controls.spec.ts
+++ b/e2e/playwright/view-controls.spec.ts
@@ -4,7 +4,7 @@ import { TEST_CODE_GIZMO } from '@e2e/playwright/storageStates'
 import { getUtils } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 
-test.describe('Testing Gizmo', () => {
+test.describe('Testing Gizmo', { tag: '@desktop' }, () => {
   const cases = [
     {
       testDescription: 'top view',
@@ -249,7 +249,7 @@ test.describe('Testing Gizmo', () => {
   })
 })
 
-test.describe(`Testing gizmo, fixture-based`, () => {
+test.describe(`Testing gizmo, fixture-based`, { tag: '@desktop' }, () => {
   test('Center on selection from menu, disable interaction in sketch mode', async ({
     context,
     page,

--- a/e2e/playwright/zookeeper.spec.ts
+++ b/e2e/playwright/zookeeper.spec.ts
@@ -8,7 +8,7 @@ import type { ToolbarFixture } from '@e2e/playwright/fixtures/toolbarFixture'
 import type { CmdBarFixture } from '@e2e/playwright/fixtures/cmdBarFixture'
 import type { CopilotFixture } from '@e2e/playwright/fixtures/copilotFixture'
 
-test.describe('Zookeeper tests', () => {
+test.describe('Zookeeper tests', { tag: '@desktop' }, () => {
   async function runCopilotHappyPathTest({
     page,
     editor,
@@ -70,19 +70,23 @@ test.describe('Zookeeper tests', () => {
     }
   )
 
-  test(
-    'Desktop copilot happy path: new project, easy prompt, good result',
-    { tag: ['@desktop'] },
-    async ({ page, editor, homePage, scene, toolbar, cmdBar, copilot }) => {
-      await runCopilotHappyPathTest({
-        page,
-        editor,
-        homePage,
-        scene,
-        toolbar,
-        cmdBar,
-        copilot,
-      })
-    }
-  )
+  test('Desktop copilot happy path: new project, easy prompt, good result', async ({
+    page,
+    editor,
+    homePage,
+    scene,
+    toolbar,
+    cmdBar,
+    copilot,
+  }) => {
+    await runCopilotHappyPathTest({
+      page,
+      editor,
+      homePage,
+      scene,
+      toolbar,
+      cmdBar,
+      copilot,
+    })
+  })
 })

--- a/package.json
+++ b/package.json
@@ -135,10 +135,10 @@
     "test:integration": "vitest run --mode=development --project=integration --sequence.shuffle",
     "test:snapshots": "cross-env TARGET=web NODE_ENV=development playwright test --config=playwright.config.ts --grep=@snapshot",
     "test:e2e:kcl": "(cd rust && just test && just lint)",
-    "test:e2e:web": "cross-env TARGET=web NODE_ENV=development playwright test --config=playwright.config.ts --project=\"Google Chrome\" --grep=@web",
-    "test:e2e:desktop": "cross-env TARGET=desktop playwright test --config=playwright.electron.config.ts --grep-invert=\"@snapshot|@web\"",
-    "test:e2e:desktop:local": "cross-env TARGET=desktop npm run tronb:vite:dev && playwright test --config=playwright.electron.config.ts --grep-invert=\"@snapshot|@web\" --grep-invert=\"$(curl --silent https://test-analysis-bot.hawk-dinosaur.ts.net/projects/KittyCAD/modeling-app/tests/disabled/regex)\"",
-    "test:e2e:desktop:local-engine": "cross-env TARGET=desktop npm run tronb:vite:dev && playwright test --config=playwright.electron.config.ts --grep-invert=\"@snapshot|@web|@skipLocalEngine\" --grep-invert=\"$(curl --silent https://test-analysis-bot.hawk-dinosaur.ts.net/projects/KittyCAD/modeling-app/tests/disabled/regex)\""
+    "test:e2e:web": "cross-env TARGET=web NODE_ENV=development playwright test --config=playwright.config.ts --grep=@web --project=\"Google Chrome\"",
+    "test:e2e:desktop": "cross-env TARGET=desktop playwright test --config=playwright.electron.config.ts --grep=@desktop",
+    "test:e2e:desktop:local": "cross-env TARGET=desktop npm run tronb:vite:dev && playwright test --config=playwright.electron.config.ts --grep=@desktop --grep-invert=\"$(curl --silent https://https://test-analysis-bot.corp.zoo.dev/projects/KittyCAD/modeling-app/tests/disabled/regex)\"",
+    "test:e2e:desktop:local-engine": "cross-env TARGET=desktop npm run tronb:vite:dev && playwright test --config=playwright.electron.config.ts --grep=@desktop --grep-invert=\"@skipLocalEngine\" --grep-invert=\"$(curl --silent https://https://test-analysis-bot.corp.zoo.dev/projects/KittyCAD/modeling-app/tests/disabled/regex)\""
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
# Before

The implicit default target was Desktop (`@desktop`) running on the implicit default platform of Linux (`@linux`).

Some tests explicitly target Web (`@web`) for relevant capabilities (e.g. link sharing) plus a few smoke tests for additional coverage of core features (e.g. Zookeeper).

Some tests explicitly run on the non-default platforms of macOS (`@macos`) or Windows (`@windows`) for capabilities that we expect to behave differently (e.g. networking, filesystems) and require additional coverage.

# After

There is no implicit default target but the implicit default platform continues to be Linux (`@linux`).

All tests targets are explicit opt-ins to Desktop (`@desktop`), Web (`@web`), or both.

The macOS (`@macos`) and Windows (`@windows`) explicit platform selection continues to work as before.


---

For reviewers: The diff looks way bigger than it actually is due to how adding/removing the `tag` option interacts with our code formatter. Unfortunately there's no way around this but hopefully this a one-time thing unless we change the tagging strategy again.

