### PR TITLE
Inform users that Extrude To is only for parallel faces

### DIFF
--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -603,6 +603,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         clearSelectionFirst: true,
         required: false,
         multiple: false,
+        description: 'Note: Only parallel faces are supported for now.',
       },
       symmetric: {
         inputType: 'boolean',


### PR DESCRIPTION
Fixes #8846

That is until https://github.com/KittyCAD/engine/issues/3855

<img width="645" height="227" alt="image" src="https://github.com/user-attachments/assets/eea1088f-78ef-4fb2-86cb-e9b6c200b7e8" />
