### PR TITLE
refactor: Remove extra Rust module nesting

### DIFF
--- a/rust/kcl-lib/src/execution/freedom_analysis_tests.rs
+++ b/rust/kcl-lib/src/execution/freedom_analysis_tests.rs
@@ -1,51 +1,48 @@
-#[cfg(test)]
-#[cfg(feature = "artifact-graph")]
-mod test {
-    use std::sync::Arc;
+use std::sync::Arc;
 
-    use crate::{
-        ExecutorContext, ExecutorSettings,
-        engine::conn_mock::EngineConnection,
-        execution::{ContextType, MockConfig},
-        front::{Freedom, ObjectKind},
-        frontend::api::ObjectId,
+use crate::{
+    ExecutorContext, ExecutorSettings,
+    engine::conn_mock::EngineConnection,
+    execution::{ContextType, MockConfig},
+    front::{Freedom, ObjectKind},
+    frontend::api::ObjectId,
+};
+
+async fn run_with_freedom_analysis(kcl: &str) -> Vec<(ObjectId, Freedom)> {
+    let program = crate::Program::parse_no_errs(kcl).unwrap();
+
+    let exec_ctxt = ExecutorContext {
+        engine: Arc::new(Box::new(EngineConnection::new().unwrap())),
+        fs: Arc::new(crate::fs::FileManager::new()),
+        settings: ExecutorSettings::default(),
+        context_type: ContextType::Mock,
     };
 
-    async fn run_with_freedom_analysis(kcl: &str) -> Vec<(ObjectId, Freedom)> {
-        let program = crate::Program::parse_no_errs(kcl).unwrap();
+    let mock_config = MockConfig {
+        freedom_analysis: true,
+        ..Default::default()
+    };
 
-        let exec_ctxt = ExecutorContext {
-            engine: Arc::new(Box::new(EngineConnection::new().unwrap())),
-            fs: Arc::new(crate::fs::FileManager::new()),
-            settings: ExecutorSettings::default(),
-            context_type: ContextType::Mock,
-        };
+    let outcome = exec_ctxt.run_mock(&program, &mock_config).await.unwrap();
 
-        let mock_config = MockConfig {
-            freedom_analysis: true,
-            ..Default::default()
-        };
-
-        let outcome = exec_ctxt.run_mock(&program, &mock_config).await.unwrap();
-
-        let mut point_freedoms = Vec::new();
-        for obj in &outcome.scene_objects {
-            if let ObjectKind::Segment {
-                segment: crate::front::Segment::Point(point),
-            } = &obj.kind
-            {
-                point_freedoms.push((obj.id, point.freedom));
-            }
+    let mut point_freedoms = Vec::new();
+    for obj in &outcome.scene_objects {
+        if let ObjectKind::Segment {
+            segment: crate::front::Segment::Point(point),
+        } = &obj.kind
+        {
+            point_freedoms.push((obj.id, point.freedom));
         }
-        // Sort by object ID for consistent ordering
-        point_freedoms.sort_by_key(|(id, _)| id.0);
-        exec_ctxt.close().await;
-        point_freedoms
     }
+    // Sort by object ID for consistent ordering
+    point_freedoms.sort_by_key(|(id, _)| id.0);
+    exec_ctxt.close().await;
+    point_freedoms
+}
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_freedom_analysis_with_conflicts() {
-        let kcl = r#"
+#[tokio::test(flavor = "multi_thread")]
+async fn test_freedom_analysis_with_conflicts() {
+    let kcl = r#"
 @settings(experimentalFeatures = allow)
 
 sketch(on = YZ) {
@@ -66,33 +63,33 @@ sketch2::distance([line3.start, line3.end]) == 6mm
 }
 "#;
 
-        let point_freedoms = run_with_freedom_analysis(kcl).await;
+    let point_freedoms = run_with_freedom_analysis(kcl).await;
 
-        // Expected: line1 has both ends constrained -> Fixed, Fixed
-        //           line2 has one end constrained -> Fixed, Free (but currently shows Fixed, Conflict - bug)
-        //           line3 has conflicting distance constraints -> Conflict, Conflict (but currently shows Free, Free - bug)
-        // Note: IDs skip every third because segments don't get freedom values
-        // Format: (ObjectId, Freedom)
+    // Expected: line1 has both ends constrained -> Fixed, Fixed
+    //           line2 has one end constrained -> Fixed, Free (but currently shows Fixed, Conflict - bug)
+    //           line3 has conflicting distance constraints -> Conflict, Conflict (but currently shows Free, Free - bug)
+    // Note: IDs skip every third because segments don't get freedom values
+    // Format: (ObjectId, Freedom)
 
-        let expected = vec![
-            (ObjectId(1), Freedom::Fixed),
-            (ObjectId(2), Freedom::Fixed),
-            (ObjectId(4), Freedom::Fixed),
-            (ObjectId(5), Freedom::Free),
-            (ObjectId(7), Freedom::Conflict),
-            (ObjectId(8), Freedom::Conflict),
-        ];
+    let expected = vec![
+        (ObjectId(1), Freedom::Fixed),
+        (ObjectId(2), Freedom::Fixed),
+        (ObjectId(4), Freedom::Fixed),
+        (ObjectId(5), Freedom::Free),
+        (ObjectId(7), Freedom::Conflict),
+        (ObjectId(8), Freedom::Conflict),
+    ];
 
-        // This assertion will fail until the bug is fixed
-        assert_eq!(
-            point_freedoms, expected,
-            "Point freedoms should match expected values. Current behavior shows bugs with conflicts and reordered lines."
-        );
-    }
+    // This assertion will fail until the bug is fixed
+    assert_eq!(
+        point_freedoms, expected,
+        "Point freedoms should match expected values. Current behavior shows bugs with conflicts and reordered lines."
+    );
+}
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_freedom_analysis_without_conflicts() {
-        let kcl = r#"
+#[tokio::test(flavor = "multi_thread")]
+async fn test_freedom_analysis_without_conflicts() {
+    let kcl = r#"
 @settings(experimentalFeatures = allow)
 
 sketch(on = YZ) {
@@ -112,28 +109,28 @@ sketch2::distance([line3.start, line3.end]) == 4mm
 }
 "#;
 
-        let point_freedoms = run_with_freedom_analysis(kcl).await;
+    let point_freedoms = run_with_freedom_analysis(kcl).await;
 
-        // Expected: line1 has both ends constrained -> Fixed, Fixed
-        //           line2 has one end constrained -> Fixed, Free
-        //           line3 has one distance constraint -> Free, Free (both points can move)
+    // Expected: line1 has both ends constrained -> Fixed, Fixed
+    //           line2 has one end constrained -> Fixed, Free
+    //           line3 has one distance constraint -> Free, Free (both points can move)
 
-        // Expected: Fixed, Fixed, Fixed, Free, Free, Free
-        let expected = vec![
-            (ObjectId(1), Freedom::Fixed),
-            (ObjectId(2), Freedom::Fixed),
-            (ObjectId(4), Freedom::Fixed),
-            (ObjectId(5), Freedom::Free),
-            (ObjectId(7), Freedom::Free),
-            (ObjectId(8), Freedom::Free),
-        ];
+    // Expected: Fixed, Fixed, Fixed, Free, Free, Free
+    let expected = vec![
+        (ObjectId(1), Freedom::Fixed),
+        (ObjectId(2), Freedom::Fixed),
+        (ObjectId(4), Freedom::Fixed),
+        (ObjectId(5), Freedom::Free),
+        (ObjectId(7), Freedom::Free),
+        (ObjectId(8), Freedom::Free),
+    ];
 
-        assert_eq!(point_freedoms, expected, "Point freedoms should match expected values");
-    }
+    assert_eq!(point_freedoms, expected, "Point freedoms should match expected values");
+}
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_freedom_analysis_reordered_lines() {
-        let kcl = r#"
+#[tokio::test(flavor = "multi_thread")]
+async fn test_freedom_analysis_reordered_lines() {
+    let kcl = r#"
 @settings(experimentalFeatures = allow)
 
 sketch(on = YZ) {
@@ -154,25 +151,24 @@ line2.start.at[1] == 1
 }
 "#;
 
-        let point_freedoms = run_with_freedom_analysis(kcl).await;
+    let point_freedoms = run_with_freedom_analysis(kcl).await;
 
-        // Expected: line1 has both ends constrained -> Fixed, Fixed
-        //           line3 has conflicting distance constraints -> Conflict, Conflict (but bug shows one Conflict, one Free)
-        //           line2 has one end constrained -> Fixed, Free
+    // Expected: line1 has both ends constrained -> Fixed, Fixed
+    //           line3 has conflicting distance constraints -> Conflict, Conflict (but bug shows one Conflict, one Free)
+    //           line2 has one end constrained -> Fixed, Free
 
-        let expected = vec![
-            (ObjectId(1), Freedom::Fixed),
-            (ObjectId(2), Freedom::Fixed),
-            (ObjectId(4), Freedom::Conflict),
-            (ObjectId(5), Freedom::Conflict),
-            (ObjectId(9), Freedom::Fixed),
-            (ObjectId(10), Freedom::Free),
-        ];
+    let expected = vec![
+        (ObjectId(1), Freedom::Fixed),
+        (ObjectId(2), Freedom::Fixed),
+        (ObjectId(4), Freedom::Conflict),
+        (ObjectId(5), Freedom::Conflict),
+        (ObjectId(9), Freedom::Fixed),
+        (ObjectId(10), Freedom::Free),
+    ];
 
-        // This assertion will fail until the bug is fixed
-        assert_eq!(
-            point_freedoms, expected,
-            "Point freedoms should match expected values. Current behavior shows bug where line3.end is Free instead of Conflict."
-        );
-    }
+    // This assertion will fail until the bug is fixed
+    assert_eq!(
+        point_freedoms, expected,
+        "Point freedoms should match expected values. Current behavior shows bug where line3.end is Free instead of Conflict."
+    );
 }


### PR DESCRIPTION
No functional change. The entire file/Rust module is only compiled in tests.