### PR TITLE
Ensure that the document has content before scrolling into view in editor Playwright fixture

### DIFF
--- a/e2e/playwright/fixtures/editorFixture.ts
+++ b/e2e/playwright/fixtures/editorFixture.ts
@@ -208,18 +208,17 @@ export class EditorFixture {
       nextLineCount = await this.lines.count()
     } while (nextLineCount !== currLineCount)
   }
-  scrollToText(text: string, placeCursor?: boolean) {
+  async scrollToText(text: string, placeCursor?: boolean) {
+    if (!(await this.checkIfPaneIsOpen())) {
+      await this.openPane()
+    }
+    await expect(this.codeContent).not.toBeEmpty()
     return this.page.evaluate(
       (args: { text: string; placeCursor?: boolean }) => {
         const editorView = window.kclManager.editorView
-        // error TS2339: Property 'docView' does not exist on type 'EditorView'.
-        // Except it does so :shrug:
-        // @ts-ignore
-        const index = editorView.docView.view.state.doc
-          .toString()
-          .indexOf(args.text)
-        editorView?.focus()
-        editorView?.dispatch({
+        const index = editorView.state.doc.toString().indexOf(args.text)
+        editorView.focus()
+        editorView.dispatch({
           selection: window.EditorSelection.create([
             window.EditorSelection.cursor(index),
           ]),


### PR DESCRIPTION
The test "KittyCAD › modeling-app › projects.spec.ts › when code with error first loads you get errors in console" started failing 70% of the time after #9553 merged earlier today.

This is only possible because we initialize `kclManager.editorView` with an empty string and then fill it with the content from `routeLoaders`, and from the other side the test that was failing awaited nothing between navigating to the project and running `page.evaluate`. I could have also fixed this by adding any await to the test, but this helper might be used elsewhere and I don't want weird rules around "oh you must await such and such first" for a helper method.

<img width="1664" height="788" alt="Screenshot 2026-01-12 at 7 38 27 PM" src="https://github.com/user-attachments/assets/77053b5f-c632-4a07-8799-9680e641e070" />
