### PR TITLE
Fix to never display negative zero

### DIFF
--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -3455,7 +3455,7 @@ sketch(on = XY) {
 @settings(experimentalFeatures = allow)
 
 sketch(on = XY) {
-  line1 = sketch2::line(start = [var -0mm, var -0mm], end = [var 4.145mm, var 5.32mm])
+  line1 = sketch2::line(start = [var 0mm, var 0mm], end = [var 4.145mm, var 5.32mm])
   line2 = sketch2::line(start = [var 4.145mm, var 5.32mm], end = [var 9mm, var 10mm])
 line1.start.at[0] == 0
 line1.start.at[1] == 0

--- a/rust/kcl-lib/src/frontend/api.rs
+++ b/rust/kcl-lib/src/frontend/api.rs
@@ -199,8 +199,10 @@ impl Number {
     pub fn round(&self, digits: u8) -> Self {
         let factor = 10f64.powi(digits as i32);
         let rounded_value = (self.value * factor).round() / factor;
+        // Don't return negative zero.
+        let value = if rounded_value == -0.0 { 0.0 } else { rounded_value };
         Number {
-            value: rounded_value,
+            value,
             units: self.units,
         }
     }


### PR DESCRIPTION
This is for when sketch mode writes `var` values back to KCL source.