### PR TITLE
[SOLVE] Use light and dark classes for selection box

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -470,6 +470,26 @@ code,
     @apply bg-chalkboard-100 dark:bg-chalkboard-10;
   }
 
+  .border-bg-2 {
+    @apply border-chalkboard-20 dark:border-chalkboard-90;
+  }
+
+  .border-bg-3 {
+    @apply border-chalkboard-30 dark:border-chalkboard-70;
+  }
+
+  .border-bg-4 {
+    @apply border-chalkboard-70 dark:border-chalkboard-30;
+  }
+
+  .border-bg-5 {
+    @apply border-chalkboard-90 dark:border-chalkboard-20;
+  }
+
+  .border-bg-6 {
+    @apply border-chalkboard-100 dark:border-chalkboard-10;
+  }
+
   /*
     This is where your own custom Tailwind utility classes can go,
     which lets you use them with @apply in your CSS, and get

--- a/src/machines/sketchSolve/tools/moveTool/moveTool.ts
+++ b/src/machines/sketchSolve/tools/moveTool/moveTool.ts
@@ -714,7 +714,7 @@ export function setUpOnDragAndSelectionClickCallbacks({
     const [boxDiv, verticalLine, horizontalLine, labelsWrapper] = htmlHelper`
             <div
               ${{ key: 'id', value: 'selection-box' }}
-              class = "border-black/20 dark:border-white/70 bg-black/5 dark:bg-white/10"
+              class = "border-bg-3 bg-black/5 dark:bg-white/10"
               style="
                 position: absolute;
                 pointer-events: none;
@@ -726,7 +726,7 @@ export function setUpOnDragAndSelectionClickCallbacks({
             >
               <div
                 ${{ key: 'id', value: 'vertical-line' }}
-                class="bg-black/20 dark:bg-white/70"
+                class="bg-3"
                 style="
                   position: absolute;
                   pointer-events: none;
@@ -735,7 +735,7 @@ export function setUpOnDragAndSelectionClickCallbacks({
               ></div>
               <div
                 ${{ key: 'id', value: 'horizontal-line' }}
-                class="bg-black/20 dark:bg-white/70"
+                class="bg-3"
                 style="
                   position: absolute;
                   pointer-events: none;
@@ -755,7 +755,7 @@ export function setUpOnDragAndSelectionClickCallbacks({
               >
                 <div
                   ${{ key: 'id', value: 'intersects-label' }}
-                  class="text-black/20 dark:text-white/70"
+                  class="text-3 dark:text-3"
                   style="
                     font-size: 11px;
                     user-select: none;
@@ -767,7 +767,7 @@ export function setUpOnDragAndSelectionClickCallbacks({
                 >Intersects</div>
                 <div
                   ${{ key: 'id', value: 'contains-label' }}
-                  class="text-black/20 dark:text-white/70"
+                  class="text-3 dark:text-3"
                   style="
                     font-size: 11px;
                     user-select: none;


### PR DESCRIPTION
Fixes #9660

https://github.com/user-attachments/assets/9555169f-ebe5-47d0-93e1-17879de9dfbf

The values aren't exactly per the design at https://www.figma.com/design/5UUPOawPLEs3D0Gptf42vy/Designs?node-id=11969-73731&t=o38FUhvGpVidfkO0-4 but close. @franknoirot if you have a way to pull background3 and background4 in those classes I'd love to be more exact
