### PR TITLE
Default backfaces should be reddish

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -318,7 +318,7 @@ export const DEFAULT_BACKFACE_COLOR = {
   a: 1.0,
   b: 0.05,
   g: 0.05,
-  r: 0.05,
+  r: 0.95,
 }
 
 /**


### PR DESCRIPTION
 I notice that the default backface color is set to a dark grey (nearly black). I found it a bit hard to tell which side was the front and which was the back when working with surfaces earlier today.

Should we default it to reddish, like the engine does? I think Rhino also does?