### PR TITLE
make cmd-F etc work on homepage

### DIFF
--- a/src/components/ProjectSearchBar.tsx
+++ b/src/components/ProjectSearchBar.tsx
@@ -41,6 +41,14 @@ export function ProjectSearchBar({
     },
     { enableOnFormTags: true }
   )
+  useHotkeys(
+    'mod+f',
+    (event) => {
+      event.preventDefault()
+      inputRef.current?.focus()
+    },
+    { enableOnFormTags: true }
+  )
 
   return (
     <div className="relative group">


### PR DESCRIPTION
I noticed I had to click into the search bar, paper cut

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves search accessibility by adding a standard find shortcut.
> 
> - Registers `mod+f` via `react-hotkeys-hook` in `ProjectSearchBar` to `focus()` the input (with `enableOnFormTags: true`)
> - Retains existing `Ctrl+.` shortcut; no other logic or UI changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ee5c3b59ca990c82dce947f23a9607dd25f877b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->