### PR TITLE
KCL: Autocomplete for 'split' should use merge = true

### DIFF
--- a/rust/kcl-lib/src/docs/kcl_doc.rs
+++ b/rust/kcl-lib/src/docs/kcl_doc.rs
@@ -645,6 +645,8 @@ impl FnData {
             return "loft([${0:sketch000}, ${1:sketch001}])".to_owned();
         } else if self.name == "union" {
             return "union([${0:extrude001}, ${1:extrude002}])".to_owned();
+        } else if self.name == "split" {
+            return "split([${0:extrude001}, ${1:extrude002}], merge = ${2:true})".to_owned();
         } else if self.name == "subtract" {
             return "subtract([${0:extrude001}], tools = [${1:extrude002}])".to_owned();
         } else if self.name == "subtract2d" {


### PR DESCRIPTION
The default completion item for bools is 'false',
but split currently only supports merge = true,
so we should put that in the autocomplete.

This is what you get now:

<img width="410" height="103" alt="Screenshot 2026-01-15 at 3 29 10 PM" src="https://github.com/user-attachments/assets/a443b298-3b74-4938-a5df-4972f45e6e16" />
