### PR TITLE
Fix code persistence on the web

### DIFF
--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -1786,8 +1786,8 @@ export class KclManager extends EventTarget {
     newCode = this.codeSignal.value,
     path = this._currentFilePath
   ) {
-    if (this.isBufferMode || path === null) return
-    if (window.electron) {
+    if (this.isBufferMode) return
+    if (window.electron && path !== null) {
       const electron = window.electron
       // Only write our buffer contents to file once per second. Any faster
       // and file-system watchers which read, will receive empty data during


### PR DESCRIPTION
Follow-up fix to a regression introduced yesterday in #9680. We incorrectly mark `_currentFilePath` as `null` in the browser, so where I placed my null check in that PR led to web users not being sent down the web-special code path within `kclManager.writeToFile`. This is an example of special web-only behavior that I will be thrilled to be rid of soon.