### PR TITLE
[SOLVE] Setup initial lint for Transpile old sketches

### DIFF
--- a/rust/kcl-lib/src/execution/geometry.rs
+++ b/rust/kcl-lib/src/execution/geometry.rs
@@ -717,7 +717,7 @@ impl ProfileClosed {
 }
 
 /// Has the profile been closed?
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone, Copy, Hash, Ord, PartialOrd, ts_rs::TS)]
+#[derive(Debug, Serialize, Eq, PartialEq, Clone, Copy, Hash, Ord, PartialOrd, ts_rs::TS)]
 #[serde(rename_all = "camelCase")]
 pub enum ProfileClosed {
     /// It's definitely open.
@@ -1016,7 +1016,7 @@ impl EdgeCut {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Clone, Copy, ts_rs::TS)]
+#[derive(Debug, Serialize, PartialEq, Clone, Copy, ts_rs::TS)]
 #[ts(export)]
 pub struct Point2d {
     pub x: f64,
@@ -1380,6 +1380,17 @@ pub enum Path {
         #[serde(flatten)]
         base: BasePath,
     },
+    /// A cubic Bezier curve.
+    Bezier {
+        #[serde(flatten)]
+        base: BasePath,
+        /// First control point (absolute coordinates).
+        #[ts(type = "[number, number]")]
+        control1: [f64; 2],
+        /// Second control point (absolute coordinates).
+        #[ts(type = "[number, number]")]
+        control2: [f64; 2],
+    },
 }
 
 impl Path {
@@ -1397,6 +1408,7 @@ impl Path {
             Path::ArcThreePoint { base, .. } => base.geo_meta.id,
             Path::Ellipse { base, .. } => base.geo_meta.id,
             Path::Conic { base, .. } => base.geo_meta.id,
+            Path::Bezier { base, .. } => base.geo_meta.id,
         }
     }
 
@@ -1414,6 +1426,7 @@ impl Path {
             Path::ArcThreePoint { base, .. } => base.geo_meta.id = id,
             Path::Ellipse { base, .. } => base.geo_meta.id = id,
             Path::Conic { base, .. } => base.geo_meta.id = id,
+            Path::Bezier { base, .. } => base.geo_meta.id = id,
         }
     }
 
@@ -1431,6 +1444,7 @@ impl Path {
             Path::ArcThreePoint { base, .. } => base.tag.clone(),
             Path::Ellipse { base, .. } => base.tag.clone(),
             Path::Conic { base, .. } => base.tag.clone(),
+            Path::Bezier { base, .. } => base.tag.clone(),
         }
     }
 
@@ -1448,6 +1462,7 @@ impl Path {
             Path::ArcThreePoint { base, .. } => base,
             Path::Ellipse { base, .. } => base,
             Path::Conic { base, .. } => base,
+            Path::Bezier { base, .. } => base,
         }
     }
 
@@ -1532,6 +1547,10 @@ impl Path {
                 // Not supported.
                 None
             }
+            Self::Bezier { .. } => {
+                // Not supported - Bezier curve length requires numerical integration.
+                None
+            }
         };
         n.map(|n| TyF64::new(n, self.get_base().units.into()))
     }
@@ -1550,6 +1569,7 @@ impl Path {
             Path::ArcThreePoint { base, .. } => Some(base),
             Path::Ellipse { base, .. } => Some(base),
             Path::Conic { base, .. } => Some(base),
+            Path::Bezier { base, .. } => Some(base),
         }
     }
 
@@ -1602,7 +1622,8 @@ impl Path {
             | Path::ToPoint { .. }
             | Path::Horizontal { .. }
             | Path::AngledLineTo { .. }
-            | Path::Base { .. } => {
+            | Path::Base { .. }
+            | Path::Bezier { .. } => {
                 let base = self.get_base();
                 GetTangentialInfoFromPathsResult::PreviousPoint(base.from)
             }

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -29,6 +29,7 @@ pub use memory::EnvironmentRef;
 pub(crate) use modeling::ModelingCmdMeta;
 use serde::{Deserialize, Serialize};
 pub(crate) use sketch_solve::normalize_to_solver_unit;
+pub use sketch_transpiler::{transpile_old_sketch_to_new, transpile_old_sketch_to_new_with_execution};
 pub(crate) use state::ModuleArtifactState;
 pub use state::{ExecState, MetaSettings};
 use uuid::Uuid;
@@ -68,6 +69,7 @@ pub(crate) mod kcl_value;
 mod memory;
 mod modeling;
 mod sketch_solve;
+mod sketch_transpiler;
 mod state;
 pub mod typed_path;
 pub(crate) mod types;
@@ -629,6 +631,29 @@ impl ExecutorContext {
             settings,
             context_type: ContextType::Mock,
         }
+    }
+
+    /// Create a new mock executor context for WASM LSP servers.
+    /// This is a convenience function that creates a mock engine and FileManager from a FileSystemManager.
+    #[cfg(target_arch = "wasm32")]
+    pub fn new_mock_for_lsp(
+        fs_manager: crate::fs::wasm::FileSystemManager,
+        settings: ExecutorSettings,
+    ) -> Result<Self, String> {
+        use crate::mock_engine;
+
+        let mock_engine = Arc::new(Box::new(
+            mock_engine::EngineConnection::new().map_err(|e| format!("Failed to create mock engine: {:?}", e))?,
+        ) as Box<dyn EngineManager>);
+
+        let fs = Arc::new(FileManager::new(fs_manager));
+
+        Ok(ExecutorContext {
+            engine: mock_engine,
+            fs,
+            settings,
+            context_type: ContextType::Mock,
+        })
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/rust/kcl-lib/src/execution/sketch_transpiler.rs
+++ b/rust/kcl-lib/src/execution/sketch_transpiler.rs
@@ -1,0 +1,786 @@
+//! Transpiler for converting old sketch syntax to new sketch block syntax.
+
+use crate::{
+    Program,
+    errors::{KclError, KclErrorDetails},
+    execution::{
+        ExecOutcome, ExecutorContext, KclValue,
+        geometry::{Path, Sketch, SketchSurface},
+    },
+    frontend::{
+        api::{Expr, Number},
+        ast_name_expr, create_coincident_ast, create_equal_length_ast, create_horizontal_ast, create_line_ast,
+        create_member_expression, create_vertical_ast,
+        sketch::Point2d,
+        to_ast_point2d,
+    },
+    parsing::ast::types as ast,
+};
+
+/// Constraint types that can be applied to segments
+#[derive(Debug, Clone)]
+enum SegmentConstraint {
+    Horizontal,
+    Vertical,
+    EqualLength { other_segment_index: usize },
+}
+
+/// Transpile an old-style sketch to new sketch block syntax.
+///
+/// This function takes a variable name that should contain a Sketch value in
+/// the ExecOutcome's variables, and generates new sketch block code.
+///
+/// # Arguments
+/// * `exec_outcome` - The execution outcome containing the executed sketch
+/// * `program` - The parsed AST program
+/// * `variable_name` - The name of the variable containing the sketch
+///
+/// # Returns
+/// The transpiled code as a string, or an error if the sketch cannot be found
+/// or transpiled.
+pub fn transpile_old_sketch_to_new(
+    exec_outcome: &ExecOutcome,
+    program: &Program,
+    variable_name: &str,
+) -> Result<String, KclError> {
+    // Get the sketch from execution outcome
+    let sketch = get_sketch_from_exec_outcome(exec_outcome, variable_name)?;
+
+    // Get the plane name
+    let plane_name = get_plane_name(&sketch)?;
+
+    // Build the sketch block AST
+    let sketch_block = build_sketch_block_ast(&sketch, &plane_name, program, variable_name)?;
+
+    // Convert AST to string
+    let output = sketch_block.recast_top(&Default::default(), 0);
+    Ok(output)
+}
+
+/// Transpile an old-style sketch to new sketch block syntax by re-executing the program.
+///
+/// This function re-executes the program using the execution cache (which should be very fast
+/// if the program hasn't changed), then extracts the sketch and transpiles it.
+///
+/// # Arguments
+/// * `ctx` - The executor context (must not be mock mode)
+/// * `program` - The parsed AST program
+/// * `variable_name` - The name of the variable containing the sketch
+///
+/// # Returns
+/// The transpiled code as a string, or an error if execution or transpilation fails.
+pub async fn transpile_old_sketch_to_new_with_execution(
+    ctx: &ExecutorContext,
+    program: Program,
+    variable_name: &str,
+) -> Result<String, KclError> {
+    // Re-execute using cache (should be very fast if program hasn't changed)
+    // Both run_mock and run_with_caching use caching, but different types:
+    // - run_mock: uses memory cache (cached variables/state), always re-executes full program
+    // - run_with_caching: uses AST cache, can do incremental execution of changed parts only
+    let exec_outcome = if ctx.is_mock() {
+        // For mock contexts, use run_mock (uses memory cache via read_old_memory/write_old_memory)
+        ctx.run_mock(&program, &crate::execution::MockConfig::default())
+            .await
+            .map_err(|e| {
+                KclError::new_internal(KclErrorDetails::new(
+                    format!("Failed to execute program for transpilation (mock): {:?}", e),
+                    vec![],
+                ))
+            })?
+    } else {
+        ctx.run_with_caching(program.clone()).await.map_err(|e| {
+            KclError::new_internal(KclErrorDetails::new(
+                format!("Failed to execute program for transpilation: {:?}", e),
+                vec![],
+            ))
+        })?
+    };
+
+    // Now transpile using the execution outcome
+    transpile_old_sketch_to_new(&exec_outcome, &program, variable_name)
+}
+
+/// Build the AST for a sketch block from the executed sketch
+fn build_sketch_block_ast(
+    sketch: &Sketch,
+    plane_name: &str,
+    program: &Program,
+    variable_name: &str,
+) -> Result<ast::Node<ast::Program>, KclError> {
+    // Check that all segments are supported types (currently only ToPoint is supported)
+    for (i, path_segment) in sketch.paths.iter().enumerate() {
+        if !matches!(path_segment, Path::ToPoint { .. }) {
+            return Err(KclError::new_internal(KclErrorDetails::new(
+                format!(
+                    "Transpilation not supported: segment {} is not a line segment (ToPoint). Only line segments are currently supported.",
+                    i + 1
+                ),
+                vec![],
+            )));
+        }
+    }
+
+    // Find the pipe expression with startProfile
+    let pipe_expr = find_start_profile_pipe(program, variable_name)?;
+
+    // Map segments to their AST calls using source ranges
+    let segment_ast_calls = map_segments_to_ast_calls(sketch, pipe_expr)?;
+
+    // Detect constraints from AST
+    let constraints = detect_constraints_from_ast(&segment_ast_calls, sketch)?;
+
+    // Create the plane expression
+    let plane_expr = ast::Expr::Name(Box::new(ast::Node::no_src(ast::Name {
+        name: ast::Node::no_src(ast::Identifier {
+            name: plane_name.to_string(),
+            digest: None,
+        }),
+        path: Vec::new(),
+        abs_path: false,
+        digest: None,
+    })));
+
+    // Build sketch block body items
+    let mut body_items = Vec::new();
+    let mut line_names = Vec::new();
+
+    // Start from the start point
+    let mut current_x = sketch.start.from[0];
+    let mut current_y = sketch.start.from[1];
+
+    // Process each path segment
+    for (i, path_segment) in sketch.paths.iter().enumerate() {
+        let line_num = i + 1;
+        let line_name = format!("line{}", line_num);
+        line_names.push(line_name.clone());
+
+        // Get the base path
+        let base = path_segment.get_base();
+
+        // Get start and end coordinates
+        let start_x = current_x;
+        let start_y = current_y;
+        let end_x = base.to[0];
+        let end_y = base.to[1];
+
+        // Update current position for next segment
+        current_x = end_x;
+        current_y = end_y;
+
+        // Create the line AST node using the same pattern as frontend::add_line
+        let line_ast = create_line_ast_from_coords(start_x, start_y, end_x, end_y, sketch.units)?;
+
+        // Create variable declaration for the line
+        let line_var_decl = ast::BodyItem::VariableDeclaration(Box::new(ast::Node::no_src(ast::VariableDeclaration {
+            kind: ast::VariableKind::Const,
+            declaration: ast::Node::no_src(ast::VariableDeclarator {
+                id: ast::Node::no_src(ast::Identifier {
+                    name: line_name.clone(),
+                    digest: None,
+                }),
+                init: line_ast,
+                digest: None,
+            }),
+            visibility: ast::ItemVisibility::Default,
+            digest: None,
+        })));
+
+        body_items.push(line_var_decl);
+
+        // Add coincident constraint between this line and the previous one
+        if line_num > 1 {
+            let prev_line_name = &line_names[line_num - 2];
+            let coincident_ast = create_coincident_ast_from_names(prev_line_name, &line_name);
+            body_items.push(ast::BodyItem::ExpressionStatement(ast::Node::no_src(
+                ast::ExpressionStatement {
+                    expression: coincident_ast,
+                    digest: None,
+                },
+            )));
+        }
+    }
+
+    // Add constraints from AST detection
+    for (i, line_name) in line_names.iter().enumerate() {
+        if let Some(segment_constraints) = constraints.get(i) {
+            for constraint in segment_constraints {
+                match constraint {
+                    SegmentConstraint::Horizontal => {
+                        let horizontal_ast = create_horizontal_ast_from_name(line_name);
+                        body_items.push(ast::BodyItem::ExpressionStatement(ast::Node::no_src(
+                            ast::ExpressionStatement {
+                                expression: horizontal_ast,
+                                digest: None,
+                            },
+                        )));
+                    }
+                    SegmentConstraint::Vertical => {
+                        let vertical_ast = create_vertical_ast_from_name(line_name);
+                        body_items.push(ast::BodyItem::ExpressionStatement(ast::Node::no_src(
+                            ast::ExpressionStatement {
+                                expression: vertical_ast,
+                                digest: None,
+                            },
+                        )));
+                    }
+                    SegmentConstraint::EqualLength { other_segment_index } => {
+                        let other_line_name = &line_names[*other_segment_index];
+                        let equal_length_ast = create_equal_length_ast_from_names(line_name, other_line_name);
+                        body_items.push(ast::BodyItem::ExpressionStatement(ast::Node::no_src(
+                            ast::ExpressionStatement {
+                                expression: equal_length_ast,
+                                digest: None,
+                            },
+                        )));
+                    }
+                }
+            }
+        }
+    }
+
+    // Create the sketch block body (Block)
+    let block = ast::Block {
+        items: body_items,
+        non_code_meta: Default::default(),
+        inner_attrs: Default::default(),
+        digest: None,
+    };
+
+    // Create the sketch block
+    let sketch_block = ast::SketchBlock {
+        arguments: vec![ast::LabeledArg {
+            label: Some(ast::Identifier::new("on")),
+            arg: plane_expr,
+        }],
+        body: ast::Node::no_src(block),
+        is_being_edited: false,
+        non_code_meta: Default::default(),
+        digest: None,
+    };
+
+    // Create a program with just the sketch block
+    let program = ast::Program {
+        body: vec![ast::BodyItem::ExpressionStatement(ast::Node::no_src(
+            ast::ExpressionStatement {
+                expression: ast::Expr::SketchBlock(Box::new(ast::Node::no_src(sketch_block))),
+                digest: None,
+            },
+        ))],
+        shebang: None,
+        non_code_meta: Default::default(),
+        inner_attrs: Default::default(),
+        digest: None,
+    };
+
+    Ok(ast::Node::no_src(program))
+}
+
+/// Convert f64 + UnitLength to Number (rounding to 2 decimal places)
+fn f64_to_number(value: f64, units: kittycad_modeling_cmds::units::UnitLength) -> Number {
+    // Round to 2 decimal places, then convert using From trait
+    let rounded = (value * 100.0).round() / 100.0;
+    (rounded, units).into()
+}
+
+/// Create an AST node for a line call (sketch2::line)
+/// Uses shared helper from frontend.rs
+fn create_line_ast_from_coords(
+    start_x: f64,
+    start_y: f64,
+    end_x: f64,
+    end_y: f64,
+    units: kittycad_modeling_cmds::units::UnitLength,
+) -> Result<ast::Expr, KclError> {
+    // Create Point2d<Expr> with var expressions for start and end points
+    let start_point = Point2d {
+        x: Expr::Var(f64_to_number(start_x, units)),
+        y: Expr::Var(f64_to_number(start_y, units)),
+    };
+
+    let end_point = Point2d {
+        x: Expr::Var(f64_to_number(end_x, units)),
+        y: Expr::Var(f64_to_number(end_y, units)),
+    };
+
+    // Convert to AST using the same function as frontend
+    let start_ast = to_ast_point2d(&start_point).map_err(|e| {
+        KclError::new_internal(KclErrorDetails::new(
+            format!("Failed to convert start point to AST: {}", e),
+            vec![],
+        ))
+    })?;
+
+    let end_ast = to_ast_point2d(&end_point).map_err(|e| {
+        KclError::new_internal(KclErrorDetails::new(
+            format!("Failed to convert end point to AST: {}", e),
+            vec![],
+        ))
+    })?;
+
+    // Use shared helper to create the line AST
+    Ok(create_line_ast(start_ast, end_ast))
+}
+
+// Helper functions below use shared AST creation functions from frontend.rs
+// to ensure consistency between transpiler and frontend code generation.
+
+/// Create an AST node for sketch2::coincident([line1.end, line2.start])
+fn create_coincident_ast_from_names(line1_name: &str, line2_name: &str) -> ast::Expr {
+    let line1_expr = ast_name_expr(line1_name.to_string());
+    let line2_expr = ast_name_expr(line2_name.to_string());
+    let line1_end = create_member_expression(line1_expr, "end");
+    let line2_start = create_member_expression(line2_expr, "start");
+    create_coincident_ast(line1_end, line2_start)
+}
+
+/// Create an AST node for sketch2::horizontal(line)
+fn create_horizontal_ast_from_name(line_name: &str) -> ast::Expr {
+    let line_expr = ast_name_expr(line_name.to_string());
+    create_horizontal_ast(line_expr)
+}
+
+/// Create an AST node for sketch2::vertical(line)
+fn create_vertical_ast_from_name(line_name: &str) -> ast::Expr {
+    let line_expr = ast_name_expr(line_name.to_string());
+    create_vertical_ast(line_expr)
+}
+
+/// Create an AST node for sketch2::equalLength([line1, line2])
+fn create_equal_length_ast_from_names(line1_name: &str, line2_name: &str) -> ast::Expr {
+    let line1_expr = ast_name_expr(line1_name.to_string());
+    let line2_expr = ast_name_expr(line2_name.to_string());
+    create_equal_length_ast(line1_expr, line2_expr)
+}
+
+/// Get the plane name from a sketch
+fn get_plane_name(sketch: &Sketch) -> Result<String, KclError> {
+    match &sketch.on {
+        SketchSurface::Plane(plane) => {
+            // Check plane.kind to determine the base plane type
+            let base_name = match plane.kind {
+                crate::execution::geometry::PlaneKind::XY => "XY",
+                crate::execution::geometry::PlaneKind::XZ => "XZ",
+                crate::execution::geometry::PlaneKind::YZ => "YZ",
+                crate::execution::geometry::PlaneKind::Custom => {
+                    return Err(KclError::new_internal(KclErrorDetails::new(
+                        "Cannot transpile sketch on custom plane".to_string(),
+                        vec![],
+                    )));
+                }
+            };
+
+            // Detect negative orientation by checking x_axis
+            // For XY and XZ planes: negative planes have x_axis.x < 0
+            // For YZ planes: negative planes have x_axis.y < 0
+            let is_negative = match plane.kind {
+                crate::execution::geometry::PlaneKind::XY | crate::execution::geometry::PlaneKind::XZ => {
+                    plane.info.x_axis.x < 0.0
+                }
+                crate::execution::geometry::PlaneKind::YZ => plane.info.x_axis.y < 0.0,
+                crate::execution::geometry::PlaneKind::Custom => {
+                    // Already handled above, but needed for match exhaustiveness
+                    return Err(KclError::new_internal(KclErrorDetails::new(
+                        "Cannot transpile sketch on custom plane".to_string(),
+                        vec![],
+                    )));
+                }
+            };
+
+            let name = if is_negative {
+                format!("-{}", base_name)
+            } else {
+                base_name.to_string()
+            };
+
+            Ok(name)
+        }
+        SketchSurface::Face(_) => Err(KclError::new_internal(KclErrorDetails::new(
+            "Cannot transpile sketch on face".to_string(),
+            vec![],
+        ))),
+    }
+}
+
+/// Get a Sketch value from ExecOutcome's variables.
+fn get_sketch_from_exec_outcome(exec_outcome: &ExecOutcome, variable_name: &str) -> Result<Sketch, KclError> {
+    let value = exec_outcome.variables.get(variable_name).ok_or_else(|| {
+        KclError::new_internal(KclErrorDetails::new(
+            format!("Variable '{}' not found in execution outcome", variable_name),
+            vec![],
+        ))
+    })?;
+
+    match value {
+        KclValue::Sketch { value } => Ok(*value.clone()),
+        _ => Err(KclError::new_internal(KclErrorDetails::new(
+            format!("Variable '{}' is not a Sketch", variable_name),
+            vec![],
+        ))),
+    }
+}
+
+/// Find the pipe expression containing startProfile for the given variable
+/// Uses the same detection logic as the lint (lint_old_sketch_syntax) to ensure consistency
+fn find_start_profile_pipe<'a>(program: &'a Program, variable_name: &str) -> Result<&'a ast::PipeExpression, KclError> {
+    use crate::lint::checks::contains_start_profile;
+
+    // Find the variable declaration
+    for item in &program.ast.body {
+        if let ast::BodyItem::VariableDeclaration(var_decl) = item
+            && var_decl.declaration.id.name == variable_name
+            && let ast::Expr::PipeExpression(pipe) = &var_decl.declaration.init
+            && contains_start_profile(&pipe.inner)
+        {
+            // Use the lint's detection logic as the source of truth
+            // This ensures the transpiler only processes what the lint detects
+            return Ok(&pipe.inner);
+        }
+    }
+
+    Err(KclError::new_internal(KclErrorDetails::new(
+        format!("Could not find startProfile pipe for variable '{}'", variable_name),
+        vec![],
+    )))
+}
+
+/// Map segments to their AST calls using source ranges
+/// Returns a vector of (segment_index, AST call expression)
+fn map_segments_to_ast_calls<'a>(
+    sketch: &Sketch,
+    pipe_expr: &'a ast::PipeExpression,
+) -> Result<Vec<(usize, &'a ast::CallExpressionKw)>, KclError> {
+    let mut result = Vec::new();
+
+    // Get source ranges from segments (skip startProfile, start from first segment)
+    // The pipe body should have: [startProfile, line1, line2, ...]
+    // So segments start at index 1 in the pipe body (skip startProfile)
+    let pipe_segment_calls: Vec<&ast::CallExpressionKw> = pipe_expr
+        .body
+        .iter()
+        .skip(1) // Skip startProfile
+        .filter_map(|expr| {
+            if let ast::Expr::CallExpressionKw(call) = expr {
+                Some(&call.inner)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // Match segments to pipe calls by index (they should be in the same order)
+    // Only match if we have the same number of segments and calls
+    for i in 0..sketch.paths.len().min(pipe_segment_calls.len()) {
+        if let Some(call) = pipe_segment_calls.get(i) {
+            result.push((i, *call));
+        }
+    }
+
+    Ok(result)
+}
+
+/// Detect constraints from AST calls
+fn detect_constraints_from_ast(
+    segment_ast_calls: &[(usize, &ast::CallExpressionKw)],
+    sketch: &Sketch,
+) -> Result<Vec<Vec<SegmentConstraint>>, KclError> {
+    let mut constraints: Vec<Vec<SegmentConstraint>> = vec![Vec::new(); sketch.paths.len()];
+
+    for (segment_index, call) in segment_ast_calls {
+        // Check if it's xLine or yLine
+        // call is &CallExpressionKw, callee is Node<Name>, name is Node<Identifier>
+        let function_name = &call.callee.name.name;
+
+        if function_name == "xLine" {
+            constraints[*segment_index].push(SegmentConstraint::Horizontal);
+        } else if function_name == "yLine" {
+            constraints[*segment_index].push(SegmentConstraint::Vertical);
+        } else if function_name == "angledLine" {
+            // Check for segLen() in the length argument
+            for arg in &call.arguments {
+                if let Some(label) = &arg.label
+                    && label.name == "length"
+                    && let Some(seg_index) = find_seg_len_reference(&arg.arg, segment_ast_calls, sketch)?
+                {
+                    // Check if the arg contains segLen()
+                    constraints[*segment_index].push(SegmentConstraint::EqualLength {
+                        other_segment_index: seg_index,
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(constraints)
+}
+
+/// Find segLen() reference in an expression and return the segment index it refers to
+fn find_seg_len_reference(
+    expr: &ast::Expr,
+    _segment_ast_calls: &[(usize, &ast::CallExpressionKw)],
+    sketch: &Sketch,
+) -> Result<Option<usize>, KclError> {
+    if let ast::Expr::CallExpressionKw(call) = expr
+        && call.callee.name.name == "segLen"
+    {
+        // Check if it's segLen()
+        // Get the argument (should be a tag name like "seg01")
+        // segLen takes the tag name as an unlabeled argument (Name expression)
+        let tag_name_opt = if let Some(unlabeled) = &call.unlabeled {
+            // Check if unlabeled is a Name (tag reference like "seg01")
+            if let ast::Expr::Name(name) = unlabeled {
+                Some(name.name.name.as_str())
+            } else if let ast::Expr::TagDeclarator(tag) = unlabeled {
+                // Also support TagDeclarator for completeness
+                Some(tag.inner.name.as_str())
+            } else {
+                None
+            }
+        } else {
+            // Check labeled arguments for a tag
+            call.arguments.iter().find_map(|arg| {
+                if let Some(label) = &arg.label
+                    && (label.name == "tag" || label.name == "segment")
+                {
+                    if let ast::Expr::Name(name) = &arg.arg {
+                        Some(name.name.name.as_str())
+                    } else if let ast::Expr::TagDeclarator(tag) = &arg.arg {
+                        Some(tag.inner.name.as_str())
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+        };
+
+        if let Some(tag_name) = tag_name_opt {
+            // Find the segment with this tag
+            // Tag format in AST is usually "seg01" (without $)
+            // Tag format in sketch is usually "$seg01" (with $)
+            for (i, path_segment) in sketch.paths.iter().enumerate() {
+                let base = path_segment.get_base();
+                if let Some(segment_tag) = &base.tag {
+                    // Compare tag names - remove $ prefix if present
+                    let segment_tag_name = segment_tag
+                        .inner
+                        .name
+                        .strip_prefix('$')
+                        .unwrap_or(&segment_tag.inner.name);
+                    if segment_tag_name == tag_name {
+                        return Ok(Some(i));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        Program,
+        test_server::{execute_and_snapshot_ast, new_context},
+    };
+
+    #[tokio::test]
+    async fn test_transpile_simple_sketch() {
+        // This test will fail until the transpiler is implemented
+        // It executes the old sketch syntax and then tries to transpile it
+
+        let code = r#"
+sketch001 = startSketchOn(XY)
+profile001 = startProfile(sketch001, at = [-3.71, 5.81])
+  |> line(end = [-3.8, -4.92])
+  |> line(end = [3.47, -5.75])
+  |> xLine(length = 7.68)
+  |> yLine(length = 6.29)
+"#;
+
+        // Parse the code
+        let program = Program::parse_no_errs(code).unwrap();
+
+        // Execute it using the test server
+        let _ctx = new_context(true, None).await.unwrap();
+        let snapshot = execute_and_snapshot_ast(program.clone(), None, false).await.unwrap();
+        let exec_state = snapshot.0;
+        let ctx = snapshot.1;
+        let env_ref = snapshot.2;
+
+        // Convert to ExecOutcome
+        let exec_outcome = exec_state.into_exec_outcome(env_ref, &ctx).await;
+
+        // Expected transpiled output
+        // Note: Coordinates are from actual execution, may have small rounding differences
+        let expected_output = r#"sketch(on = XY) {
+  line1 = sketch2::line(start = [var -3.71mm, var 5.81mm], end = [var -7.51mm, var 0.89mm])
+  line2 = sketch2::line(start = [var -7.51mm, var 0.89mm], end = [var -4.04mm, var -4.86mm])
+  sketch2::coincident([line1.end, line2.start])
+  line3 = sketch2::line(start = [var -4.04mm, var -4.86mm], end = [var 3.64mm, var -4.86mm])
+  sketch2::coincident([line2.end, line3.start])
+  line4 = sketch2::line(start = [var 3.64mm, var -4.86mm], end = [var 3.64mm, var 1.43mm])
+  sketch2::coincident([line3.end, line4.start])
+  sketch2::horizontal(line3)
+  sketch2::vertical(line4)
+}"#;
+
+        // Try to transpile - this should succeed and match the expected output
+        let transpiled =
+            transpile_old_sketch_to_new(&exec_outcome, &program, "profile001").expect("Transpiler should succeed");
+
+        // Normalize whitespace for comparison (trim and normalize line endings)
+        let normalized_transpiled = transpiled.trim().replace("\r\n", "\n");
+        let normalized_expected = expected_output.trim().replace("\r\n", "\n");
+
+        assert_eq!(
+            normalized_transpiled, normalized_expected,
+            "Transpiled output does not match expected output\n\nGot:\n{}\n\nExpected:\n{}",
+            normalized_transpiled, normalized_expected
+        );
+
+        // Clean up
+        ctx.close().await;
+    }
+
+    #[tokio::test]
+    async fn can_convert_equal_length_constraints() {
+        let code = r#"
+sketch001 = startSketchOn(YZ)
+profile001 = startProfile(sketch001, at = [2.25, 4.48])
+  |> line(end = [-7.46, -1.59], tag = $seg01)
+  |> yLine(length = -7.46)
+  |> angledLine(angle = 15deg, length = segLen(seg01))
+"#;
+
+        // Parse the code
+        let program = Program::parse_no_errs(code).unwrap();
+
+        // Execute it using the test server
+        let _ctx = new_context(true, None).await.unwrap();
+        let snapshot = execute_and_snapshot_ast(program.clone(), None, false).await.unwrap();
+        let exec_state = snapshot.0;
+        let ctx = snapshot.1;
+        let env_ref = snapshot.2;
+
+        // Convert to ExecOutcome
+        let exec_outcome = exec_state.into_exec_outcome(env_ref, &ctx).await;
+
+        // Expected transpiled output
+        // Note: Coordinates are from actual execution, may have small rounding differences
+        // Also note: yLine should be vertical on line2, and equalLength should be on line3
+        let expected_output = r#"sketch(on = YZ) {
+  line1 = sketch2::line(start = [var 2.25mm, var 4.48mm], end = [var -5.21mm, var 2.89mm])
+  line2 = sketch2::line(start = [var -5.21mm, var 2.89mm], end = [var -5.21mm, var -4.57mm])
+  sketch2::coincident([line1.end, line2.start])
+  line3 = sketch2::line(start = [var -5.21mm, var -4.57mm], end = [var 2.16mm, var -2.6mm])
+  sketch2::coincident([line2.end, line3.start])
+  sketch2::vertical(line2)
+  sketch2::equalLength([line3, line1])
+}"#;
+
+        // Try to transpile - this should succeed and match the expected output
+        let transpiled =
+            transpile_old_sketch_to_new(&exec_outcome, &program, "profile001").expect("Transpiler should succeed");
+
+        // Normalize whitespace for comparison (trim and normalize line endings)
+        let normalized_transpiled = transpiled.trim().replace("\r\n", "\n");
+        let normalized_expected = expected_output.trim().replace("\r\n", "\n");
+
+        assert_eq!(
+            normalized_transpiled, normalized_expected,
+            "Transpiled output does not match expected output\n\nGot:\n{}\n\nExpected:\n{}",
+            normalized_transpiled, normalized_expected
+        );
+
+        // Clean up
+        ctx.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_transpile_fails_with_unsupported_segments() {
+        // Test that transpilation fails when there are bezier curves
+        let code = r#"
+sketch001 = startSketchOn(XY)
+profile001 = startProfile(sketch001, at = [-3.71, 5.81])
+  |> line(end = [-3.8, -4.92])
+  |> line(end = [3.47, -5.75])
+  |> xLine(length = 7.68)
+  |> yLine(length = 6.29)
+  |> bezierCurve(control1 = [5, 0], control2 = [5, 10], end = [10, 10])
+"#;
+
+        // Parse the code
+        let program = Program::parse_no_errs(code).unwrap();
+
+        // Execute it using the test server
+        let _ctx = new_context(true, None).await.unwrap();
+        let snapshot = execute_and_snapshot_ast(program.clone(), None, false).await.unwrap();
+        let exec_state = snapshot.0;
+        let ctx = snapshot.1;
+        let env_ref = snapshot.2;
+
+        // Convert to ExecOutcome
+        let exec_outcome = exec_state.into_exec_outcome(env_ref, &ctx).await;
+
+        // Try to transpile - this should fail because bezier curves are not supported
+        let result = transpile_old_sketch_to_new(&exec_outcome, &program, "profile001");
+
+        assert!(
+            result.is_err(),
+            "Transpilation should fail when bezier curves are present"
+        );
+
+        // Verify the error message mentions the unsupported segment
+        let error_msg = format!("{:?}", result.unwrap_err());
+        assert!(
+            error_msg.contains("not a line segment") || error_msg.contains("not supported"),
+            "Error message should indicate unsupported segment type. Got: {}",
+            error_msg
+        );
+
+        // Clean up
+        ctx.close().await;
+    }
+
+    #[tokio::test]
+    async fn test_transpile_negative_plane() {
+        // Test that transpilation correctly handles negative planes (e.g., -XY)
+        let code = r#"
+sketch001 = startSketchOn(-XY)
+profile001 = startProfile(sketch001, at = [2.0, 3.0])
+  |> line(end = [5.0, 3.0])
+  |> line(end = [5.0, 6.0])
+"#;
+
+        // Parse the code
+        let program = Program::parse_no_errs(code).unwrap();
+
+        // Execute it using the test server
+        let _ctx = new_context(true, None).await.unwrap();
+        let snapshot = execute_and_snapshot_ast(program.clone(), None, false).await.unwrap();
+        let exec_state = snapshot.0;
+        let ctx = snapshot.1;
+        let env_ref = snapshot.2;
+
+        // Convert to ExecOutcome
+        let exec_outcome = exec_state.into_exec_outcome(env_ref, &ctx).await;
+
+        // Try to transpile - this should succeed and output "-XY" for the plane
+        let transpiled =
+            transpile_old_sketch_to_new(&exec_outcome, &program, "profile001").expect("Transpiler should succeed");
+
+        // Verify that the output contains "-XY" (not just "XY")
+        assert!(
+            transpiled.contains("sketch(on = -XY)"),
+            "Transpiled output should contain '-XY' plane name. Got: {}",
+            transpiled
+        );
+
+        // Clean up
+        ctx.close().await;
+    }
+}

--- a/rust/kcl-lib/src/execution/types.rs
+++ b/rust/kcl-lib/src/execution/types.rs
@@ -1035,6 +1035,19 @@ impl From<UnitAngle> for NumericType {
     }
 }
 
+impl From<UnitLength> for NumericSuffix {
+    fn from(value: UnitLength) -> Self {
+        match value {
+            UnitLength::Millimeters => NumericSuffix::Mm,
+            UnitLength::Centimeters => NumericSuffix::Cm,
+            UnitLength::Meters => NumericSuffix::M,
+            UnitLength::Inches => NumericSuffix::Inch,
+            UnitLength::Feet => NumericSuffix::Ft,
+            UnitLength::Yards => NumericSuffix::Yd,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, ts_rs::TS)]
 pub struct NumericSuffixTypeConvertError;
 
@@ -1044,12 +1057,7 @@ impl TryFrom<NumericType> for NumericSuffix {
     fn try_from(value: NumericType) -> Result<Self, Self::Error> {
         match value {
             NumericType::Known(UnitType::Count) => Ok(NumericSuffix::Count),
-            NumericType::Known(UnitType::Length(UnitLength::Millimeters)) => Ok(NumericSuffix::Mm),
-            NumericType::Known(UnitType::Length(UnitLength::Centimeters)) => Ok(NumericSuffix::Cm),
-            NumericType::Known(UnitType::Length(UnitLength::Meters)) => Ok(NumericSuffix::M),
-            NumericType::Known(UnitType::Length(UnitLength::Inches)) => Ok(NumericSuffix::Inch),
-            NumericType::Known(UnitType::Length(UnitLength::Feet)) => Ok(NumericSuffix::Ft),
-            NumericType::Known(UnitType::Length(UnitLength::Yards)) => Ok(NumericSuffix::Yd),
+            NumericType::Known(UnitType::Length(unit_length)) => Ok(NumericSuffix::from(unit_length)),
             NumericType::Known(UnitType::GenericLength) => Ok(NumericSuffix::Length),
             NumericType::Known(UnitType::Angle(UnitAngle::Degrees)) => Ok(NumericSuffix::Deg),
             NumericType::Known(UnitType::Angle(UnitAngle::Radians)) => Ok(NumericSuffix::Rad),

--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -1710,20 +1710,8 @@ impl FrontendState {
             }
         };
 
-        // Create the coincident() call.
-        let coincident_ast = ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
-            callee: ast::Node::no_src(ast_sketch2_name(COINCIDENT_FN)),
-            unlabeled: Some(ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(
-                ast::ArrayExpression {
-                    elements: vec![seg0_ast, seg1_ast],
-                    digest: None,
-                    non_code_meta: Default::default(),
-                },
-            )))),
-            arguments: Default::default(),
-            digest: None,
-            non_code_meta: Default::default(),
-        })));
+        // Create the coincident() call using shared helper.
+        let coincident_ast = create_coincident_ast(seg0_ast, seg1_ast);
 
         // Add the line to the AST of the sketch block.
         let (sketch_block_range, _) = self.mutate_ast(
@@ -1936,14 +1924,8 @@ impl FrontendState {
         };
         let line_ast = get_or_insert_ast_reference(new_ast, &line_object.source.clone(), "line", None)?;
 
-        // Create the horizontal() call.
-        let horizontal_ast = ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
-            callee: ast::Node::no_src(ast_sketch2_name(HORIZONTAL_FN)),
-            unlabeled: Some(line_ast),
-            arguments: Default::default(),
-            digest: None,
-            non_code_meta: Default::default(),
-        })));
+        // Create the horizontal() call using shared helper.
+        let horizontal_ast = create_horizontal_ast(line_ast);
 
         // Add the line to the AST of the sketch block.
         let (sketch_block_range, _) = self.mutate_ast(
@@ -2002,20 +1984,8 @@ impl FrontendState {
         };
         let line1_ast = get_or_insert_ast_reference(new_ast, &line1_object.source.clone(), "line", None)?;
 
-        // Create the equalLength() call.
-        let equal_length_ast = ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
-            callee: ast::Node::no_src(ast_sketch2_name(EQUAL_LENGTH_FN)),
-            unlabeled: Some(ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(
-                ast::ArrayExpression {
-                    elements: vec![line0_ast, line1_ast],
-                    digest: None,
-                    non_code_meta: Default::default(),
-                },
-            )))),
-            arguments: Default::default(),
-            digest: None,
-            non_code_meta: Default::default(),
-        })));
+        // Create the equalLength() call using shared helper.
+        let equal_length_ast = create_equal_length_ast(line0_ast, line1_ast);
 
         // Add the constraint to the AST of the sketch block.
         let (sketch_block_range, _) = self.mutate_ast(
@@ -2151,14 +2121,8 @@ impl FrontendState {
         };
         let line_ast = get_or_insert_ast_reference(new_ast, &line_object.source.clone(), "line", None)?;
 
-        // Create the vertical() call.
-        let vertical_ast = ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
-            callee: ast::Node::no_src(ast_sketch2_name(VERTICAL_FN)),
-            unlabeled: Some(line_ast),
-            arguments: Default::default(),
-            digest: None,
-            non_code_meta: Default::default(),
-        })));
+        // Create the vertical() call using shared helper.
+        let vertical_ast = create_vertical_ast(line_ast);
 
         // Add the line to the AST of the sketch block.
         let (sketch_block_range, _) = self.mutate_ast(
@@ -2575,14 +2539,7 @@ fn get_or_insert_ast_reference(
         return Ok(var_expr);
     };
 
-    Ok(ast::Expr::MemberExpression(Box::new(ast::Node::no_src(
-        ast::MemberExpression {
-            object: var_expr,
-            property: ast::Expr::Name(Box::new(ast::Name::new(property))),
-            computed: false,
-            digest: None,
-        },
-    ))))
+    Ok(create_member_expression(var_expr, property))
 }
 
 fn mutate_ast_node_by_source_range(
@@ -2982,7 +2939,7 @@ fn source_from_ast(ast: &ast::Node<ast::Program>) -> String {
     ast.recast_top(&Default::default(), 0)
 }
 
-fn to_ast_point2d(point: &Point2d<Expr>) -> anyhow::Result<ast::Expr> {
+pub(crate) fn to_ast_point2d(point: &Point2d<Expr>) -> anyhow::Result<ast::Expr> {
     Ok(ast::Expr::ArrayExpression(Box::new(ast::Node {
         inner: ast::ArrayExpression {
             elements: vec![to_source_expr(&point.x)?, to_source_expr(&point.y)?],
@@ -3042,7 +2999,7 @@ fn to_source_number(number: Number) -> anyhow::Result<ast::NumericLiteral> {
     })
 }
 
-fn ast_name_expr(name: String) -> ast::Expr {
+pub(crate) fn ast_name_expr(name: String) -> ast::Expr {
     ast::Expr::Name(Box::new(ast_name(name)))
 }
 
@@ -3071,7 +3028,7 @@ fn ast_name(name: String) -> ast::Node<ast::Name> {
     }
 }
 
-fn ast_sketch2_name(name: &str) -> ast::Name {
+pub(crate) fn ast_sketch2_name(name: &str) -> ast::Name {
     ast::Name {
         name: ast::Node {
             inner: ast::Identifier {
@@ -3092,6 +3049,106 @@ fn ast_sketch2_name(name: &str) -> ast::Name {
         abs_path: false,
         digest: None,
     }
+}
+
+// Shared AST creation helpers used by both frontend and transpiler to ensure consistency.
+
+/// Create an AST node for sketch2::coincident([expr1, expr2])
+pub(crate) fn create_coincident_ast(expr1: ast::Expr, expr2: ast::Expr) -> ast::Expr {
+    // Create array [expr1, expr2]
+    let array_expr = ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(ast::ArrayExpression {
+        elements: vec![expr1, expr2],
+        digest: None,
+        non_code_meta: Default::default(),
+    })));
+
+    // Create sketch2::coincident([...])
+    ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+        callee: ast::Node::no_src(ast_sketch2_name(COINCIDENT_FN)),
+        unlabeled: Some(array_expr),
+        arguments: Default::default(),
+        digest: None,
+        non_code_meta: Default::default(),
+    })))
+}
+
+/// Create an AST node for sketch2::line(start = [...], end = [...])
+pub(crate) fn create_line_ast(start_ast: ast::Expr, end_ast: ast::Expr) -> ast::Expr {
+    ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+        callee: ast::Node::no_src(ast_sketch2_name(LINE_FN)),
+        unlabeled: None,
+        arguments: vec![
+            ast::LabeledArg {
+                label: Some(ast::Identifier::new(LINE_START_PARAM)),
+                arg: start_ast,
+            },
+            ast::LabeledArg {
+                label: Some(ast::Identifier::new(LINE_END_PARAM)),
+                arg: end_ast,
+            },
+        ],
+        digest: None,
+        non_code_meta: Default::default(),
+    })))
+}
+
+/// Create an AST node for sketch2::horizontal(line)
+pub(crate) fn create_horizontal_ast(line_expr: ast::Expr) -> ast::Expr {
+    ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+        callee: ast::Node::no_src(ast_sketch2_name(HORIZONTAL_FN)),
+        unlabeled: Some(line_expr),
+        arguments: Default::default(),
+        digest: None,
+        non_code_meta: Default::default(),
+    })))
+}
+
+/// Create an AST node for sketch2::vertical(line)
+pub(crate) fn create_vertical_ast(line_expr: ast::Expr) -> ast::Expr {
+    ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+        callee: ast::Node::no_src(ast_sketch2_name(VERTICAL_FN)),
+        unlabeled: Some(line_expr),
+        arguments: Default::default(),
+        digest: None,
+        non_code_meta: Default::default(),
+    })))
+}
+
+/// Create a member expression like object.property (e.g., line1.end)
+pub(crate) fn create_member_expression(object_expr: ast::Expr, property: &str) -> ast::Expr {
+    ast::Expr::MemberExpression(Box::new(ast::Node::no_src(ast::MemberExpression {
+        object: object_expr,
+        property: ast::Expr::Name(Box::new(ast::Node::no_src(ast::Name {
+            name: ast::Node::no_src(ast::Identifier {
+                name: property.to_string(),
+                digest: None,
+            }),
+            path: Vec::new(),
+            abs_path: false,
+            digest: None,
+        }))),
+        computed: false,
+        digest: None,
+    })))
+}
+
+/// Create an AST node for sketch2::equalLength([line1, line2])
+pub(crate) fn create_equal_length_ast(line1_expr: ast::Expr, line2_expr: ast::Expr) -> ast::Expr {
+    // Create array [line1, line2]
+    let array_expr = ast::Expr::ArrayExpression(Box::new(ast::Node::no_src(ast::ArrayExpression {
+        elements: vec![line1_expr, line2_expr],
+        digest: None,
+        non_code_meta: Default::default(),
+    })));
+
+    // Create sketch2::equalLength([...])
+    ast::Expr::CallExpressionKw(Box::new(ast::Node::no_src(ast::CallExpressionKw {
+        callee: ast::Node::no_src(ast_sketch2_name(EQUAL_LENGTH_FN)),
+        unlabeled: Some(array_expr),
+        arguments: Default::default(),
+        digest: None,
+        non_code_meta: Default::default(),
+    })))
 }
 
 #[cfg(test)]

--- a/rust/kcl-lib/src/frontend/api.rs
+++ b/rust/kcl-lib/src/frontend/api.rs
@@ -3,6 +3,7 @@
 #![allow(async_fn_in_trait)]
 
 use kcl_error::SourceRange;
+use kittycad_modeling_cmds::units::UnitLength;
 use serde::{Deserialize, Serialize};
 
 pub use crate::ExecutorSettings as Settings;
@@ -204,6 +205,18 @@ impl Number {
         Number {
             value,
             units: self.units,
+        }
+    }
+}
+
+impl From<(f64, UnitLength)> for Number {
+    fn from((value, units): (f64, UnitLength)) -> Self {
+        // Direct conversion from UnitLength to NumericSuffix (never panics)
+        // The From<UnitLength> for NumericSuffix impl is in execution::types
+        let units_suffix = NumericSuffix::from(units);
+        Number {
+            value,
+            units: units_suffix,
         }
     }
 }

--- a/rust/kcl-lib/src/lib.rs
+++ b/rust/kcl-lib/src/lib.rs
@@ -95,7 +95,7 @@ pub use errors::{
 };
 pub use execution::{
     ExecOutcome, ExecState, ExecutorContext, ExecutorSettings, MetaSettings, MockConfig, Point2d, bust_cache,
-    clear_mem_cache, typed_path::TypedPath,
+    clear_mem_cache, transpile_old_sketch_to_new, transpile_old_sketch_to_new_with_execution, typed_path::TypedPath,
 };
 pub use kcl_error::SourceRange;
 pub use lsp::{

--- a/rust/kcl-lib/src/lint/checks/mod.rs
+++ b/rust/kcl-lib/src/lint/checks/mod.rs
@@ -2,8 +2,10 @@ mod camel_case;
 mod chained_profiles;
 mod default_plane;
 mod offset_plane;
+mod old_sketch_syntax;
 
 pub use camel_case::{Z0001, lint_object_properties, lint_variables};
 pub use chained_profiles::{Z0004, lint_profiles_should_not_be_chained};
 pub use default_plane::{Z0002, lint_should_be_default_plane};
 pub use offset_plane::{Z0003, lint_should_be_offset_plane};
+pub use old_sketch_syntax::{Z0005, contains_start_profile, lint_old_sketch_syntax};

--- a/rust/kcl-lib/src/lint/checks/old_sketch_syntax.rs
+++ b/rust/kcl-lib/src/lint/checks/old_sketch_syntax.rs
@@ -1,0 +1,66 @@
+use anyhow::Result;
+
+use crate::{
+    SourceRange,
+    lint::rule::{Discovered, Finding, FindingFamily, def_finding},
+    parsing::ast::types::{Expr, Node as AstNode, PipeExpression, Program},
+    walk::Node,
+};
+
+def_finding!(
+    Z0005,
+    "Old sketch syntax can be converted to new sketch block syntax",
+    "\
+The old sketch syntax using startProfile in a pipe expression can be converted to the new sketch block syntax.
+
+The new syntax is more explicit and easier to understand. For example:
+
+Old: profile001 = startProfile(sketch001, at = [0, 0]) |> line(end = [10, 0]) |> line(end = [10, 10])
+New: profile001 = sketch(on = XY) { line1 = sketch2::line(start = [var 0mm, var 0mm], end = [var 10mm, var 0mm]) ... }
+
+Use the transpile function to convert this to the new format.
+",
+    FindingFamily::Simplify
+);
+
+/// Check if a pipe expression contains startProfile
+/// This is the source of truth for detecting old sketch syntax.
+/// Both the lint and transpiler use this function to ensure consistency.
+pub fn contains_start_profile(pipe_expr: &PipeExpression) -> bool {
+    pipe_expr.body.iter().any(|expr| {
+        if let Expr::CallExpressionKw(call) = expr {
+            call.callee.name.name == "startProfile"
+        } else {
+            false
+        }
+    })
+}
+
+/// Lint that detects old sketch syntax (startProfile in pipe expressions).
+/// This is detection-only - actual transpilation is done via WASM API function.
+pub fn lint_old_sketch_syntax(node: Node, _prog: &AstNode<Program>) -> Result<Vec<Discovered>> {
+    let mut findings = vec![];
+
+    // Only check variable declarations
+    let Node::VariableDeclaration(var_decl) = node else {
+        return Ok(findings);
+    };
+
+    // Check if the variable declaration has a pipe expression with startProfile
+    if let Expr::PipeExpression(pipe) = &var_decl.declaration.init
+        && contains_start_profile(pipe)
+    {
+        let var_name = &var_decl.declaration.id.name;
+        let init_node = &var_decl.declaration.init;
+        let source_range = SourceRange::new(init_node.start(), init_node.end(), init_node.module_id());
+
+        // Just detect - no suggestion since transpilation requires ExecOutcome
+        findings.push(Z0005.at(
+            format!("found old sketch syntax in '{}'", var_name),
+            source_range,
+            None, // No suggestion - use WASM transpile function
+        ));
+    }
+
+    Ok(findings)
+}

--- a/rust/kcl-lib/src/lint/rule.rs
+++ b/rust/kcl-lib/src/lint/rule.rs
@@ -163,7 +163,9 @@ impl IntoDiagnostic for &Discovered {
         vec![Diagnostic {
             range: source_range.to_lsp_range(code),
             severity: Some(self.severity()),
-            code: None,
+            code: Some(tower_lsp::lsp_types::NumberOrString::String(
+                self.finding.code.to_string(),
+            )),
             // TODO: this is neat we can pass a URL to a help page here for this specific error.
             code_description: None,
             source: Some("lint".to_string()),

--- a/rust/kcl-lib/src/parsing/ast/types/mod.rs
+++ b/rust/kcl-lib/src/parsing/ast/types/mod.rs
@@ -347,6 +347,7 @@ impl Node<Program> {
             crate::lint::checks::lint_should_be_default_plane,
             crate::lint::checks::lint_should_be_offset_plane,
             crate::lint::checks::lint_profiles_should_not_be_chained,
+            crate::lint::checks::lint_old_sketch_syntax,
         ];
 
         let mut findings = vec![];

--- a/rust/kcl-lib/src/simulation_tests.rs
+++ b/rust/kcl-lib/src/simulation_tests.rs
@@ -286,7 +286,7 @@ async fn execute_test(test: &Test, render_to_png: bool, export_step: bool) {
             }));
 
             #[cfg(not(feature = "artifact-graph"))]
-            let lint_findings = program_to_lint.lint_all().expect("failed to lint program");
+            let mut lint_findings = program_to_lint.lint_all().expect("failed to lint program");
             #[cfg(feature = "artifact-graph")]
             let mut lint_findings = program_to_lint.lint_all().expect("failed to lint program");
             #[cfg(feature = "artifact-graph")]
@@ -309,6 +309,10 @@ async fn execute_test(test: &Test, render_to_png: bool, export_step: bool) {
                     })
                     .flatten(),
             );
+
+            // Filter out Z0005 (old sketch syntax) from test snapshots
+            // TODO: Remove this filter once the transpiler is complete and all tests are updated
+            lint_findings.retain(|finding| finding.finding.code != "Z0005");
 
             let (outcome, module_state) = exec_state.into_test_exec_outcome(env_ref, &ctx, &test.input_dir).await;
 

--- a/rust/kcl-lib/src/std/extrude.rs
+++ b/rust/kcl-lib/src/std/extrude.rs
@@ -680,7 +680,7 @@ fn surface_of(path: &Path, actual_face_id: Uuid) -> Option<ExtrudeSurface> {
             });
             Some(extrude_surface)
         }
-        Path::Base { .. } | Path::ToPoint { .. } | Path::Horizontal { .. } | Path::AngledLineTo { .. } => {
+        Path::Base { .. } | Path::ToPoint { .. } | Path::Horizontal { .. } | Path::AngledLineTo { .. } | Path::Bezier { .. } => {
             let extrude_surface = ExtrudeSurface::ExtrudePlane(crate::execution::ExtrudePlane {
                 face_id: actual_face_id,
                 tag: path.get_base().tag.clone(),
@@ -725,7 +725,7 @@ fn clone_surface_of(path: &Path, clone_path_id: Uuid, actual_face_id: Uuid) -> O
             });
             Some(extrude_surface)
         }
-        Path::Base { .. } | Path::ToPoint { .. } | Path::Horizontal { .. } | Path::AngledLineTo { .. } => {
+        Path::Base { .. } | Path::ToPoint { .. } | Path::Horizontal { .. } | Path::AngledLineTo { .. } | Path::Bezier { .. } => {
             let extrude_surface = ExtrudeSurface::ExtrudePlane(crate::execution::ExtrudePlane {
                 face_id: actual_face_id,
                 tag: path.get_base().tag.clone(),

--- a/rust/kcl-lib/tests/elliptic_curve_inches_regression/program_memory.snap
+++ b/rust/kcl-lib/tests/elliptic_curve_inches_regression/program_memory.snap
@@ -176,6 +176,14 @@ description: Variables in memory after executing elliptic_curve_inches_regressio
             "id": "[uuid]",
             "sourceRange": []
           },
+          "control1": [
+            -75.651309,
+            35.31668
+          ],
+          "control2": [
+            -58.29019,
+            31.196099999999998
+          ],
           "from": [
             -90.658755,
             60.855171
@@ -185,7 +193,7 @@ description: Variables in memory after executing elliptic_curve_inches_regressio
             -40.454074999999996,
             34.182681
           ],
-          "type": "ToPoint",
+          "type": "Bezier",
           "units": "in"
         },
         {
@@ -193,6 +201,14 @@ description: Variables in memory after executing elliptic_curve_inches_regressio
             "id": "[uuid]",
             "sourceRange": []
           },
+          "control1": [
+            -22.617959999999997,
+            37.169262
+          ],
+          "control2": [
+            -4.306847999999995,
+            47.263005
+          ],
           "from": [
             -40.454074999999996,
             34.182681
@@ -202,7 +218,7 @@ description: Variables in memory after executing elliptic_curve_inches_regressio
             13.334875000000004,
             47.374937
           ],
-          "type": "ToPoint",
+          "type": "Bezier",
           "units": "in"
         },
         {
@@ -210,6 +226,14 @@ description: Variables in memory after executing elliptic_curve_inches_regressio
             "id": "[uuid]",
             "sourceRange": []
           },
+          "control1": [
+            30.976598000000003,
+            47.486869000000006
+          ],
+          "control2": [
+            47.948933000000004,
+            37.616992
+          ],
           "from": [
             13.334875000000004,
             47.374937
@@ -219,7 +243,7 @@ description: Variables in memory after executing elliptic_curve_inches_regressio
             61.470926000000006,
             36.332651
           ],
-          "type": "ToPoint",
+          "type": "Bezier",
           "units": "in"
         },
         {
@@ -227,6 +251,14 @@ description: Variables in memory after executing elliptic_curve_inches_regressio
             "id": "[uuid]",
             "sourceRange": []
           },
+          "control1": [
+            74.992919,
+            35.04831
+          ],
+          "control2": [
+            85.06457,
+            42.349506999999996
+          ],
           "from": [
             61.470926000000006,
             36.332651
@@ -236,7 +268,7 @@ description: Variables in memory after executing elliptic_curve_inches_regressio
             90.65875500000001,
             60.85517
           ],
-          "type": "ToPoint",
+          "type": "Bezier",
           "units": "in"
         },
         {

--- a/rust/kcl-lib/tests/kcl_samples/french-press/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/french-press/program_memory.snap
@@ -10891,6 +10891,14 @@ description: Variables in memory after executing french-press.kcl
               "id": "[uuid]",
               "sourceRange": []
             },
+            "control1": [
+              2.085,
+              7.74
+            ],
+            "control2": [
+              2.8259999999999996,
+              8.74
+            ],
             "from": [
               2.385,
               7.74
@@ -10900,7 +10908,7 @@ description: Variables in memory after executing french-press.kcl
               0.07999999999999963,
               8.74
             ],
-            "type": "ToPoint",
+            "type": "Bezier",
             "units": "in"
           },
           {

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -881,6 +881,7 @@ export class KclManager extends EventTarget {
           ast,
           sourceCode: this.code,
           instance: await this._wasmInstancePromise,
+          rustContext: this.singletons.rustContext,
         })
       )
       if (this._sceneEntitiesManager) {
@@ -1446,6 +1447,7 @@ export class KclManager extends EventTarget {
     if (!this._editorView) return
     // Clear out any existing diagnostics that are the same.
     diagnostics = this.makeUniqueDiagnostics(diagnostics)
+
     this._editorView.dispatch({
       effects: [setDiagnosticsEffect.of(diagnostics)],
       annotations: [

--- a/src/lang/langHelpers.ts
+++ b/src/lang/langHelpers.ts
@@ -176,16 +176,43 @@ export async function lintAst({
   ast,
   sourceCode,
   instance,
+  rustContext,
 }: {
   ast: Program
   sourceCode: string
   instance: ModuleType
+  rustContext?: RustContext
 }): Promise<Array<Diagnostic>> {
   try {
-    const discovered_findings = await kclLint(ast, instance)
-    return discovered_findings.map((lint) => {
+    let discovered_findings = await kclLint(ast, instance)
+
+    // Filter out Z0005 if new sketch mode is not enabled
+    // Only show Z0005 when useNewSketchMode setting is enabled
+    let shouldShowZ0005 = false
+    if (rustContext) {
+      try {
+        const settings = await jsAppSettings(rustContext.settingsActor)
+        shouldShowZ0005 =
+          settings?.settings?.modeling?.use_new_sketch_mode === true
+      } catch {
+        // If we can't get settings, no-op since shouldShowZ0005 defaults false
+      }
+    }
+
+    if (!shouldShowZ0005) {
+      discovered_findings = discovered_findings.filter(
+        (lint) => lint.finding.code !== 'Z0005'
+      )
+    }
+
+    // Process findings - for Z0005 without suggestion, we'll create actions async
+    const diagnosticsPromises = discovered_findings.map(async (lint) => {
       let actions
+      const transpilationFailMessage =
+        'Deprecated sketch syntax. This sketch cannot be converted to new sketch block syntax at this time.'
+      let message = lint.finding.title
       const suggestion = lint.suggestion
+
       if (suggestion) {
         actions = [
           {
@@ -202,15 +229,113 @@ export async function lintAst({
             },
           },
         ]
+      } else if (
+        lint.finding.code === 'Z0005' &&
+        rustContext &&
+        shouldShowZ0005
+      ) {
+        // For Z0005 without suggestion, try to transpile using WASM
+        // Extract variable name from the AST at the lint position
+        try {
+          const lintStart = lint.pos[0]
+          const lintEnd = lint.pos[1]
+
+          // Find the variable declaration that contains this range
+          let variableName: string | null = null
+          for (const item of ast.body) {
+            if (item.type === 'VariableDeclaration') {
+              const varDecl = item.declaration
+
+              // Check if lint range is within this variable's init expression
+              if (
+                lintStart >= varDecl.init.start &&
+                lintEnd <= varDecl.init.end
+              ) {
+                variableName = varDecl.id.name
+                break
+              }
+            }
+          }
+
+          if (variableName) {
+            // Create a temporary context for transpilation
+            // Note: This creates a new context each time, but transpile_old_sketch
+            // uses the execution cache, so it should be fast
+            // The ExecutorContext inside transpile_old_sketch is closed automatically,
+            // but we still need to ensure the WASM Context reference is released
+            let ctx: Awaited<
+              ReturnType<typeof rustContext.createNewContext>
+            > | null = null
+            try {
+              const settings = await jsAppSettings(rustContext.settingsActor)
+
+              ctx = await rustContext.createNewContext()
+
+              const transpiledCodeResult = await ctx.transpile_old_sketch(
+                JSON.stringify(ast),
+                variableName,
+                null, // path
+                JSON.stringify(settings)
+              )
+
+              const transpiledCode =
+                typeof transpiledCodeResult === 'string'
+                  ? transpiledCodeResult
+                  : String(transpiledCodeResult)
+
+              if (transpiledCode?.trim()) {
+                actions = [
+                  {
+                    name: `convert '${variableName}' to new sketch block syntax`,
+                    apply: (view: EditorView, from: number, to: number) => {
+                      view.dispatch({
+                        changes: {
+                          from: toUtf16(lint.pos[0], sourceCode),
+                          to: toUtf16(lint.pos[1], sourceCode),
+                          insert: transpiledCode.trim(),
+                        },
+                        annotations: [lspCodeActionEvent],
+                      })
+                    },
+                  },
+                ]
+              } else {
+                // Transpilation returned empty result - update message
+                message = transpilationFailMessage
+                console.warn(
+                  '[lintAst] Z0005 transpilation returned empty result'
+                )
+              }
+            } catch (transpileError) {
+              // Transpilation failed - update message
+              message = transpilationFailMessage
+              console.warn(
+                '[lintAst] Z0005 transpilation failed:',
+                transpileError
+              )
+            } finally {
+              // Explicitly clear the context reference to help GC
+              // The ExecutorContext inside transpile_old_sketch is already closed by Rust code
+              ctx = null
+            }
+          }
+        } catch (e) {
+          console.warn('[lintAst] Error processing Z0005:', e)
+        }
       }
-      return {
+
+      const diagnostic = {
         from: toUtf16(lint.pos[0], sourceCode),
         to: toUtf16(lint.pos[1], sourceCode),
-        message: lint.finding.title,
+        message,
         severity: 'info',
         actions,
-      }
+      } as const
+
+      return diagnostic
     })
+
+    return await Promise.all(diagnosticsPromises)
   } catch (e: any) {
     console.log(e)
     return []

--- a/src/lib/rustContext.ts
+++ b/src/lib/rustContext.ts
@@ -89,6 +89,12 @@ export default class RustContext {
     return ctxInstance
   }
 
+  /** Create a new Context instance for operations that need a separate context (e.g., transpilation) */
+  async createNewContext(): Promise<Context> {
+    const instance = await this._wasmInstancePromise
+    return new instance.Context(this.engineCommandManager, projectFsManager)
+  }
+
   get wasmInstancePromise() {
     return this._wasmInstancePromise
   }


### PR DESCRIPTION
First step for #9278



https://github.com/user-attachments/assets/68478967-e5cb-40cb-932c-940d5796de02





Adds a lint (Z0005) that detects old sketch syntax (`startProfile` in pipe expressions) and provides an automatic refactor to convert it to the new sketch block syntax. The transpiler is a work in progress and will continue to be for a while as we handle more edge cases and and add more features to the sketch block syntax will all more old sketches to be transpiled. This PR establishes the foundation for how the lint appears in the app and how users can update their code.

- Detection happens in Rust via `lint_old_sketch_syntax()` which checks for `startProfile` in pipe expressions. The detection logic is shared between the lint and transpiler via `contains_start_profile()` to ensure consistency. This can be expanded later to cover circle, rectangle.

- Transpilation uses program memory to get the data for where the segments are using execution as the source of truth, so this is without anything to do with the AST.

- What the AST is used for is to find constraints, for example so far it's just xLine mean Horizontal constraint. Coincident constraints are implicit with old profiles. More needs to be implemented in future.

- Since `ExecOutcome` is not stored on the Rust side, but is needed for transpilation, it does a cached requires re-execution. The frontend detects Z0005 findings without suggestions, then calls the WASM `transpile_old_sketch()` function which re-executes the program. This is fast because execution uses cached data when the code hasn't changed. This approach was taken somewhat as a work around to leave ExecOutcome as not stored in rust, it had a lot of knock on effects for this implementation, so if  you disagree with this approach let me know before doing too thorough of a review, and I can refactor it.

- The lint is gated behind the `useNewSketchMode` setting so regular users don't see it.

- Z0005 findings are filtered out from simulation test snapshots and LSP diagnostics to prevent test failures. This filter can be removed once the transpiler is complete and all tests are updated.

- The transpiler uses the execution cache (memory cache for mock contexts, AST cache for live contexts) to make re-execution fast.

- Code actions are created in `lintAst()` on the frontend when Z0005 is detected, providing a button that applies the transpiled code when clicked. This is the only path that handles Z0005 transpilation - the LSP `code_action` handler does not process Z0005 since these diagnostics are filtered out from LSP diagnostics (see line 445 in `lsp/kcl/mod.rs`).

- Added a separate `Path::Bezier` type because the transpiler relies on execution and paths in program memory, where types must accurately represent the underlying path. Previously, Bezier curves were incorrectly represented as `Path::ToPoint`, which caused the transpiler to incorrectly think it could transpile them. The Bezier type may not implement all helper functions 100% correctly(e.g., tangent implementations) completely, but this is acceptable since it's primarily for old sketch mode and not expected to be used extensively. Having the correct type representation is valuable for transpilation accuracy.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Establishes end-to-end support to detect and refactor old `startProfile` pipe-based sketches into new sketch block syntax, plus foundational geometry updates.
> 
> - **Lint (Z0005)**: Detects old sketch syntax via `lint_old_sketch_syntax()` (shared detection in `contains_start_profile`). Filtered from LSP diagnostics and simulation snapshots until complete.
> - **Transpiler**: New `execution/sketch_transpiler.rs` with `transpile_old_sketch_to_new(_with_execution)`; re-executes using caches, maps segments/constraints, and generates sketch block AST. Exposed via `kcl-lib` and WASM `transpile_old_sketch` API.
> - **LSP/Frontend integration**: LSP uses mock execution in WASM, avoids emitting Z0005; frontend `lintAst()` gates Z0005 behind `useNewSketchMode` and provides a one-click code action to apply transpiled code.
> - **Geometry/Execution**: Add `Path::Bezier` (with control points) and thread through ID/tag/getters, length (unsupported), tangential info, and extrude handling. Minor derives/visibility tweaks and numeric/unit helpers.
> - **AST helpers**: Centralize shared creators (`create_line_ast`, `create_coincident_ast`, etc.) and expose utility functions used by frontend and transpiler.
> - **WASM/LSP context**: `ExecutorContext::new_mock_for_lsp` to support transpilation/code actions in WASM LSP.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7701651dbc0225612a5be1de65c2371a4af75520. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->