### PR TITLE
Use the Wasm cache for scheduled runs

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Download Wasm cache
         id: download-wasm
-        if: ${{ github.event_name != 'schedule' && (steps.filter.outputs.rust || 'false') == 'false' }}
+        if: ${{ (steps.filter.outputs.rust || 'false') == 'false' }}
         uses: dawidd6/action-download-artifact@v12
         continue-on-error: true
         with:
@@ -58,9 +58,8 @@ jobs:
         id: wasm
         run: |
           set -euox pipefail
-          # Build Wasm if this is a scheduled run, there are Rust changes, or
-          # downloading from the wasm cache failed.
-          if [[ ${{github.event_name}} == 'schedule' || ${{steps.filter.outputs.rust || 'false'}} == 'true' || ${{steps.download-wasm.outcome}} == 'failure' ]]; then
+          # Build Wasm if there are Rust changes or downloading from the cache failed
+          if [[ ${{steps.filter.outputs.rust || 'false'}} == 'true' || ${{steps.download-wasm.outcome}} == 'failure' ]]; then
             echo "should-build-wasm=true" >> $GITHUB_OUTPUT
           else
             echo "should-build-wasm=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Download Wasm cache
         id: download-wasm
-        if: ${{ github.event_name != 'schedule' && (steps.filter.outputs.rust || 'false') == 'false' }}
+        if: ${{ (steps.filter.outputs.rust || 'false') == 'false' }}
         uses: dawidd6/action-download-artifact@v12
         continue-on-error: true
         with:
@@ -92,9 +92,8 @@ jobs:
         id: wasm
         run: |
           set -euox pipefail
-          # Build Wasm if this is a scheduled run, there are Rust changes, or
-          # downloading from the wasm cache failed.
-          if [[ ${{github.event_name}} == 'schedule' || ${{steps.filter.outputs.rust || 'false'}} == 'true' || ${{steps.download-wasm.outcome}} == 'failure' ]]; then
+          # Build Wasm if there are Rust changes or downloading from the cache failed
+          if [[ ${{steps.filter.outputs.rust || 'false'}} == 'true' || ${{steps.download-wasm.outcome}} == 'failure' ]]; then
             echo "should-build-wasm=true" >> $GITHUB_OUTPUT
           else
             echo "should-build-wasm=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Given that there will be a merge to `main` preceding the next scheduled run, I don't think we need this conditional logic. Removing it should make the scheduled runs ~3 minutes faster. After merge, I'll keep on eye on the schedule jobs.

---

Relates to https://github.com/KittyCAD/modeling-app/issues/9591