### PR TITLE
Refactor: Rename App component to `StudioEditor`

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -8,7 +8,7 @@ import {
   redirect,
 } from 'react-router-dom'
 
-import { OpenedProject } from '@src/OpenedProject'
+import { OpenedProject } from '@src/components/OpenedProject'
 import RootLayout from '@src/Root'
 import { CommandBar } from '@src/components/CommandBar/CommandBar'
 import { ErrorPage } from '@src/components/ErrorPage'

--- a/src/components/OpenedProject.tsx
+++ b/src/components/OpenedProject.tsx
@@ -81,7 +81,7 @@ if (window.electron) {
     .catch(reportRejection)
 }
 
-export function StudioEditor() {
+export function OpenedProject() {
   const { state: modelingState } = useModelingContext()
   useQueryParamEffects(kclManager)
   const loaderData = useLoaderData<IndexLoaderData>()


### PR DESCRIPTION
Just a little thing that's been around forever. This isn't the app, it just used to be way way back in the day.