### PR TITLE
Update project thumbnails after successful execution

### DIFF
--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -119,6 +119,8 @@ import {
   type TransactionSpecNoChanges,
 } from '@src/editor/HistoryView'
 import { fsHistoryExtension } from '@src/editor/plugins/fs'
+import { createThumbnailPNGOnDesktop } from '@src/lib/screenshot'
+import { projectFsManager } from '@src/lang/std/fileSystemManager'
 
 interface ExecuteArgs {
   ast?: Node<Program>
@@ -953,6 +955,13 @@ export class KclManager extends EventTarget {
 
     this._cancelTokens.delete(currentExecutionId)
     markOnce('code/endExecuteAst')
+
+    // Update project thumbnail after successful execution
+    if (!isInterrupted && errors.length === 0 && projectFsManager.dir) {
+      createThumbnailPNGOnDesktop({
+        projectDirectoryWithoutEndingSlash: projectFsManager.dir,
+      })
+    }
   }
 
   /**


### PR DESCRIPTION
To test this:

1. `make run-desktop`
2. Create a simple colored object
3. Return to the home page
4. Open that project again
5. Change the color
6. Return to the home page

Before, the preview image would be stale but now it always reflects the updated model.

Note that this functionality will be further improved once https://github.com/KittyCAD/modeling-app/issues/9762 is fixed as it's currently possible for Zookeeper edits leave the camera in a bad state. Reopening the project is the workaround until that Zookeeper bug is fixed.

---

Fixes https://github.com/KittyCAD/modeling-app/issues/9294