### PR TITLE
Remove `deferredWriteToFile`, we already defer within `writeToFile` itself

### DIFF
--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -1792,8 +1792,9 @@ export class KclManager extends EventTarget {
           time: Date.now(),
         }
         this.timeoutWriter = setTimeout(() => {
-          if (!this._currentFilePath)
+          if (!path) {
             return reject(new Error('currentFilePath not set'))
+          }
           // Wait one event loop to give a chance for params to be set
           // Save the file to disk
           this.writeCausedByAppCheckedInFileTreeFileSystemWatcher = true


### PR DESCRIPTION
I added the new `deferredWriteToFile` property in #9553, without realizing that `kclManager.writeToFile` which it wraps already has its own deferment via a `setTimeout`. I am suspicious of this double delay causing some of the more sporadic weird behavior we've been seeing lately where KCL is not saved in hard-to-reproduce instances.