### PR TITLE
Hardcode repository to fix workflow calls

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: namespace-profile-ubuntu-8-cores
     steps:
       - uses: actions/checkout@v6
+        with:
+          repository: kittycad/modeling-app # required for 'workflow_call'
 
       - id: filter
         name: Check for Rust changes


### PR DESCRIPTION
Amends https://github.com/KittyCAD/modeling-app/pull/9803 to fix the `workflow_call` invocation of the shared job: https://github.com/KittyCAD/text-to-cad/actions/runs/21296625156/job/61304490786