### PR TITLE
Rename build-wasm job

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  npm-build-wasm:
+  build-wasm:
     runs-on: namespace-profile-ubuntu-8-cores
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -57,14 +57,14 @@ jobs:
           CI_SUITE: e2e:desktop
           CI_STEP: setup
 
-  prepare-wasm:
+  build-wasm:
     needs: [track-setup]
     uses: ./.github/workflows/build-wasm.yml
     secrets:
       TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
 
   snapshots:
-    needs: [prepare-wasm]
+    needs: [build-wasm]
 
     runs-on: namespace-profile-ubuntu-8-cores
     name: e2e:snapshots
@@ -188,7 +188,7 @@ jobs:
           CI_STEP: teardown
 
   web:
-    needs: [prepare-wasm]
+    needs: [build-wasm]
 
     strategy:
       fail-fast: false
@@ -290,7 +290,7 @@ jobs:
           CI_STEP: teardown
 
   desktop:
-    needs: [prepare-wasm]
+    needs: [build-wasm]
 
     strategy:
       fail-fast: false

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -27,14 +27,14 @@ jobs:
       - run: npm install
       - run: npm run fmt:check
 
-  npm-build-wasm:
+  build-wasm:
     uses: ./.github/workflows/build-wasm.yml
     secrets:
       TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
 
   npm-tsc:
     runs-on: namespace-profile-ubuntu-2-cores
-    needs: npm-build-wasm
+    needs: build-wasm
 
     steps:
       - uses: actions/checkout@v6
@@ -64,7 +64,7 @@ jobs:
 
   npm-lint:
     runs-on: namespace-profile-ubuntu-2-cores
-    needs: npm-build-wasm
+    needs: build-wasm
 
     steps:
       - uses: actions/checkout@v6
@@ -94,7 +94,7 @@ jobs:
 
   npm-circular-dependencies:
     runs-on: namespace-profile-ubuntu-2-cores
-    needs: npm-build-wasm
+    needs: build-wasm
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,7 +33,7 @@ jobs:
           CI_SUITE: integration
           CI_STEP: setup
 
-  npm-build-wasm:
+  build-wasm:
     needs: [track-setup]
     uses: ./.github/workflows/build-wasm.yml
     secrets:
@@ -71,7 +71,7 @@ jobs:
 
   npm-test-integration:
     runs-on: namespace-profile-ubuntu-2-cores
-    needs: npm-build-wasm
+    needs: build-wasm
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Prefixing this with `npm-` looks strange when this is invoked as a workflow in another project: https://github.com/KittyCAD/text-to-cad/actions/runs/21297539406/job/61307222042 