### PR TITLE
[SOLVE] Clean up sketch solve in teardown

### DIFF
--- a/src/clientSideScene/ClientSideSceneComp.tsx
+++ b/src/clientSideScene/ClientSideSceneComp.tsx
@@ -46,6 +46,7 @@ import {
   transformAstSketchLines,
 } from '@src/lang/std/sketchcombos'
 import { getSketchSolveToolIconMap } from '@src/lib/toolbar'
+import { cleanupSketchSolveGroup } from '@src/machines/sketchSolve/sketchSolveImpl'
 
 function useShouldHideScene(): { hideClient: boolean; hideServer: boolean } {
   const [isCamMoving, setIsCamMoving] = useState(false)
@@ -147,6 +148,7 @@ export const ClientSideScene = ({
       container.removeEventListener('mousedown', sceneInfra.onMouseDown)
       container.removeEventListener('mouseup', onMouseUp)
       sceneEntitiesManager.tearDownSketch({ removeAxis: true })
+      cleanupSketchSolveGroup(sceneInfra)
 
       observer.disconnect()
       media.removeEventListener('change', handleChange)

--- a/src/machines/sketchSolve/sketchSolveDiagram.ts
+++ b/src/machines/sketchSolve/sketchSolveDiagram.ts
@@ -150,7 +150,9 @@ export const sketchSolveMachine = setup({
     'initialize initial scene graph': assign(initializeInitialSceneGraph),
     setUpOnDragAndSelectionClickCallbacks,
     'clear hover callbacks': clearHoverCallbacks,
-    'cleanup sketch solve group': cleanupSketchSolveGroup,
+    'cleanup sketch solve group': ({ context }) => {
+      cleanupSketchSolveGroup(context.sceneInfra)
+    },
     'send unequip to tool': ({ context }) => {
       // Use the actor reference directly - optional chaining handles missing actor gracefully
       context.childTool?.send({ type: 'unequip' })

--- a/src/machines/sketchSolve/sketchSolveImpl.ts
+++ b/src/machines/sketchSolve/sketchSolveImpl.ts
@@ -628,9 +628,8 @@ export function clearHoverCallbacks({ self, context }: SolveActionArgs) {
   }
 }
 
-export function cleanupSketchSolveGroup({ context }: SolveActionArgs) {
-  const sketchSegments =
-    context.sceneInfra.scene.getObjectByName(SKETCH_SOLVE_GROUP)
+export function cleanupSketchSolveGroup(sceneInfra: SceneInfra) {
+  const sketchSegments = sceneInfra.scene.getObjectByName(SKETCH_SOLVE_GROUP)
   if (!sketchSegments || !(sketchSegments instanceof Group)) {
     // no segments to clean
     return


### PR DESCRIPTION
A super small fix, I noticed this problem during working with new sketch mode: 

If you are in sketch mode and leave by clicking the Zoo icon instead of "Exit sketch", the three.js meshes are still getting rendered when opening a new (even empty) project:
<img width="191" height="95" alt="Screenshot 2026-01-26 at 10 09 39" src="https://github.com/user-attachments/assets/eeafa6a1-788c-411c-9d03-5897e7b605d3" />
