### PR TITLE
App breaks on double click on operations that doesn't have an edit flow

### DIFF
--- a/src/components/layout/areas/FeatureTreePane.tsx
+++ b/src/components/layout/areas/FeatureTreePane.tsx
@@ -490,24 +490,33 @@ const OperationItem = ({
 
   const enterEditFlow = useCallback(() => {
     if (
-      item.type === 'StdLibCall' ||
-      item.type === 'VariableDeclaration' ||
-      item.type === 'SketchSolve'
+      item.type !== 'StdLibCall' &&
+      item.type !== 'VariableDeclaration' &&
+      item.type !== 'SketchSolve'
     ) {
-      const artifact =
-        getArtifactFromRange(
-          item.sourceRange,
-          systemDeps.kclManager.artifactGraph
-        ) ?? undefined
-      prepareEditCommand({
-        artifactGraph: systemDeps.kclManager.artifactGraph,
-        code: systemDeps.kclManager.code,
-        commandBarActor,
-        operation: item,
-        rustContext: systemDeps.rustContext,
-        artifact,
-      }).catch((e) => toast.error(e))
+      return
     }
+
+    if (
+      item.type === 'StdLibCall' &&
+      stdLibMap[item.name]?.prepareToEdit === undefined
+    ) {
+      return
+    }
+
+    const artifact =
+      getArtifactFromRange(
+        item.sourceRange,
+        systemDeps.kclManager.artifactGraph
+      ) ?? undefined
+    prepareEditCommand({
+      artifactGraph: systemDeps.kclManager.artifactGraph,
+      code: systemDeps.kclManager.code,
+      commandBarActor,
+      operation: item,
+      rustContext: systemDeps.rustContext,
+      artifact,
+    }).catch((e) => toast.error(e))
   }, [item])
 
   function enterAppearanceFlow() {


### PR DESCRIPTION
Fixes #9829

To repro on main:
```
sketch001 = startSketchOn(XY)
profile001 = circle(sketch001, center = [0, 0], radius = 3.02)
extrude001 = extrude(profile001, length = 5)
clone001 = clone(extrude001)
```
then double click on the Clone operation