### PR TITLE
Don't pass an Error object into `toast.error` everything breaks

### DIFF
--- a/src/components/layout/areas/FeatureTreePane.tsx
+++ b/src/components/layout/areas/FeatureTreePane.tsx
@@ -506,7 +506,7 @@ const OperationItem = ({
         operation: item,
         rustContext: systemDeps.rustContext,
         artifact,
-      }).catch((e) => toast.error(e))
+      }).catch((e) => toast.error(err(e) ? e.message : JSON.stringify(e)))
     }
   }, [item])
 


### PR DESCRIPTION
Alternative fix to #9830 that keeps the toast behavior while still fixing #9829. Thanks for catching this @pierremtb 