### PR TITLE
Always build Wasm for stacked PRs

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -49,9 +49,11 @@ jobs:
       - name: Build Wasm condition
         id: wasm
         run: |
-          set -euox pipefail
-          # Build Wasm if there are Rust changes or downloading from the cache failed
-          if [[ ${{steps.filter.outputs.rust || 'false'}} == 'true' || ${{steps.download-wasm.outcome}} == 'failure' ]]; then
+          # Build Wasm with Rust changes, cache misses, or for stacked PRs
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
+          if [[ ${{ steps.filter.outputs.rust || 'false' }} == 'true' || \
+                ${{ steps.download-wasm.outcome }} == 'failure' || \
+                ( -n "$BASE_REF" && "$BASE_REF" != 'main' ) ]]; then
             echo "should-build-wasm=true" >> $GITHUB_OUTPUT
           else
             echo "should-build-wasm=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
For stacked PRs (base ref is not `main`) we need to build Wasm unconditionally because the filter step's diff against `main` will almost always be inaccurate, not accounting for the changes in the non-default base branch.

Here's the run from this PR where the Wasm cache was used: https://github.com/KittyCAD/modeling-app/actions/runs/21368917869/job/61508098218?pr=9838

Here's a run from a [throwaway PR](https://github.com/KittyCAD/modeling-app/pull/9851) with a non-default `BASE_REF`: https://github.com/KittyCAD/modeling-app/actions/runs/21402089425/job/61615775056?pr=9851