### PR TITLE
KCL: Better errors when an example fails

### DIFF
--- a/rust/kcl-lib/src/docs/kcl_doc.rs
+++ b/rust/kcl-lib/src/docs/kcl_doc.rs
@@ -1327,7 +1327,9 @@ mod test {
             "std" | "" => "prelude",
             other => other,
         };
-        Path::new(env!("CARGO_MANIFEST_DIR")).join("std").join(format!("{file_stem}.kcl"))
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("std")
+            .join(format!("{file_stem}.kcl"))
     }
 
     #[test]
@@ -1428,10 +1430,8 @@ mod test {
             if i != number {
                 continue;
             }
-            eprintln!(
-                "Testing example {NAME} for {owner_name} in {}",
-                source_path.display()
-            );
+            eprintln!("Testing example {NAME} for {owner_name} in {}", source_path.display());
+            eprintln!("KCL program:\n---\n{}\n---", eg.0.trim_end());
             let result = match crate::test_server::execute_and_snapshot_3d(&eg.0, None).await {
                 Err(crate::errors::ExecError::Kcl(e)) => {
                     panic!(


### PR DESCRIPTION
## Problem

When a KCL example test fails, it's not clear where to find the KCL program that caused it.

## Solution

Print out the failing file and function and example ID when it fails.

## Error message before:

thread 'docs::kcl_doc::test::kcl_test_examples_std_solid_patternTransform_4' (25033957) panicked at kcl-lib/src/docs/kcl_doc.rs:1421:21:
    Error testing example patternTransform4: assert failed: Expected 3 to be equal to 10 but it wasn't

## Error message now:

Testing example std-solid-patternTransform-4 for std::solid::patternTransform in ~/kc-repos/modeling-app/rust/kcl-lib/std/solid.kcl

thread 'docs::kcl_doc::test::kcl_test_examples_std_solid_patternTransform_4' (25030756) panicked at kcl-lib/src/docs/kcl_doc.rs:1437:21:

Error testing example std-solid-patternTransform-4 for std::solid::patternTransform in ~/kc-repos/modeling-app/rust/kcl-lib/std/solid.kcl: assert failed: Expected 3 to be equal to 10 but it wasn't