### PR TITLE
Only show loading indicator on last response

### DIFF
--- a/src/components/ExchangeCard.tsx
+++ b/src/components/ExchangeCard.tsx
@@ -211,6 +211,7 @@ export const ChatBubble = (props: {
   dataTestId?: string
   placeholderTestId?: string
   className?: string
+  showCancelledInsteadOfPlaceholder?: boolean
 }) => {
   const cssRequest =
     `${props.wfull ? 'w-full ' : ''} select-text whitespace-pre-line hyphens-auto shadow-sm ${props.side === 'left' ? '' : 'border b-4'} bg-2 text-default rounded-t-md pl-4 pr-4 ${props.className} ` +
@@ -225,6 +226,8 @@ export const ChatBubble = (props: {
         <div style={{ wordBreak: 'break-word' }} className={cssRequest}>
           {hasVisibleChildren(props.children) ? (
             props.children
+          ) : props.showCancelledInsteadOfPlaceholder ? (
+            <span>Message canceled.</span>
           ) : (
             <PlaceholderLine data-testid={props.placeholderTestId} />
           )}
@@ -263,6 +266,7 @@ export const Delta = (props: { children: ReactNode }) => {
 type ResponsesCardProp = {
   items: Exchange['responses']
   deltasAggregated: Exchange['deltasAggregated']
+  isLastResponse: boolean
 }
 
 const MaybeError = (props: { maybeError?: MlCopilotServerMessageError }) =>
@@ -316,6 +320,7 @@ export const ResponsesCard = (props: ResponsesCardProp) => {
       dataTestId="ml-response-chat-bubble"
       placeholderTestId="ml-response-chat-bubble-thinking"
       className="py-4"
+      showCancelledInsteadOfPlaceholder={!props.isLastResponse}
     >
       {[
         itemsFilteredNulls.length > 0 ? itemsFilteredNulls : null,
@@ -415,18 +420,21 @@ export const ExchangeCard = (props: ExchangeCardProps) => {
               )}
             </button>
           </div>
-          <ExchangeCardStatus
-            maybeError={maybeError}
-            responses={props.responses}
-            onlyShowImmediateThought={true}
-            startedAt={startedAt}
-            updatedAt={updatedAt}
-          />
+          {props.isLastResponse && (
+            <ExchangeCardStatus
+              maybeError={maybeError}
+              responses={props.responses}
+              onlyShowImmediateThought={true}
+              startedAt={startedAt}
+              updatedAt={updatedAt}
+            />
+          )}
         </div>
       )}
       <ResponsesCard
         items={props.responses}
         deltasAggregated={props.deltasAggregated}
+        isLastResponse={props.isLastResponse}
       />
       <ResponseCardToolBar
         responses={props.responses}

--- a/src/components/Thinking.tsx
+++ b/src/components/Thinking.tsx
@@ -327,7 +327,7 @@ export const NothingInParticular = (props: {
     <ThoughtContainer
       heading={
         <ThoughtHeader icon={<CustomIcon name="brain" className="w-6 h-6" />}>
-          <span className="animate-shimmer">Thinking</span>
+          <span>Thinking</span>
         </ThoughtHeader>
       }
     >


### PR DESCRIPTION
Frontend patch towards #9765, as part of the issue is service-size with broken out cancelled `info` responses.

**There's no reason for us to show loading indicators on prompts that aren't last in the conversation**, so this PR does that. But there is something to be fixed service-side to properly close the intent behind the bug ticket I believe, cc @greg-kcio. See https://kittycadworkspace.slack.com/archives/C07A80B83FS/p1769613080497789?thread_ts=1769528986.784049&cid=C07A80B83FS

### How to reproduce:
- Cancel two prompts in a row
- Reload the app

### Screenshots

Before, from the issue:

<img width="918" height="548" alt="image" src="https://github.com/user-attachments/assets/47caa9b0-269f-47ff-b319-c846adc79f3b" />


After:

<img width="854" height="1402" alt="image" src="https://github.com/user-attachments/assets/68367eb8-7fd4-4845-b23e-3df170a33c2a" />
