### PR TITLE
Handle messages from backends when they've been asked to shut down

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@csstools/postcss-oklab-function": "^4.0.12",
         "@headlessui/react": "^1.7.19",
         "@headlessui/tailwindcss": "^0.2.2",
-        "@kittycad/lib": "^3.1.20",
+        "@kittycad/lib": "^3.1.23",
         "@kittycad/react-shared": "^1.1.1",
         "@lezer/highlight": "^1.2.1",
         "@lezer/lr": "^1.4.7",
@@ -4674,12 +4674,12 @@
       "link": true
     },
     "node_modules/@kittycad/lib": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/@kittycad/lib/-/lib-3.1.22.tgz",
-      "integrity": "sha512-Lg5AdUiR3hgq9XgzEwclG6twoThDoeDGjwLqTkKfFHQHqv7toAF1N/K50x1gLKelGsKHMka1UNWXoxPV09lunQ==",
+      "version": "3.1.23",
+      "resolved": "https://registry.npmjs.org/@kittycad/lib/-/lib-3.1.23.tgz",
+      "integrity": "sha512-Yksl+ejOKnOpo/1dV/UUawVyrVIoiJ8bsTimZZU6QkAxuJ2y6ag7VvqQGI2lZPN3A1bat06+7RX1X1kY5trsew==",
       "license": "MIT",
       "dependencies": {
-        "bson": "^6.8.0",
+        "bson": "^7.1.1",
         "cross-fetch": "^4.0.0",
         "openapi-types": "^12.0.0",
         "ts-node": "^10.9.1",
@@ -10532,12 +10532,12 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.10.4",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
-      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.1.1.tgz",
+      "integrity": "sha512-TtJgBB+QyOlWjrbM+8bRgH84VM/xrDjyBFgSgGrfZF4xvt6gbEDtcswm27Tn9F9TWsjQybxT8b8VpCP/oJK4Dw==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.20.1"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/buffer": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@csstools/postcss-oklab-function": "^4.0.12",
     "@headlessui/react": "^1.7.19",
     "@headlessui/tailwindcss": "^0.2.2",
-    "@kittycad/lib": "^3.1.20",
+    "@kittycad/lib": "^3.1.23",
     "@kittycad/react-shared": "^1.1.1",
     "@lezer/highlight": "^1.2.1",
     "@lezer/lr": "^1.4.7",


### PR DESCRIPTION
Wait until nothing is happening, then shut down. Pretty simple. Right now we have a 5 minute timeout on the backend. So, if things take longer than that they could still get interrupted. That threshold is easy to tweak though, and we can start to track how many times we disconnect abruptly with a bit more work on the backends.

We tolerates these messages just fine as it stands, but sometimes switches to indicating that something is happening.

Some internal related work, that enables this:
https://github.com/KittyCAD/api/pull/3259
https://github.com/KittyCAD/api/pull/3262
https://github.com/KittyCAD/text-to-cad/pull/2652