### PR TITLE
Revert back to Ubuntu 22.04 for Linux builds

### DIFF
--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -155,7 +155,7 @@ jobs:
             platform: macos
           - os: namespace-profile-windows-4-cores
             platform: windows
-          - os: namespace-profile-ubuntu-2-cores
+          - os: ubuntu-22.04
             platform: linux
     runs-on: ${{ matrix.os }}
     name: build-apps (${{ matrix.platform }})


### PR DESCRIPTION
A change in https://github.com/KittyCAD/modeling-app/pull/9916 may have impacted the signed release builds: https://github.com/KittyCAD/modeling-app/actions/runs/21634088932/job/62363835658