### PR TITLE
KCL docs: Fix broken quote

### DIFF
--- a/docs/kcl-std/functions/std-solid-isSolid.md
+++ b/docs/kcl-std/functions/std-solid-isSolid.md
@@ -1,11 +1,11 @@
 ---
 title: "isSolid"
 subtitle: "Function in std::solid"
-excerpt: "Given a KCL value that is a "body" (currently typed as [`Solid`](/docs/kcl-std/types/std-types-Solid)), returns `true` if the value is a solid and `false` otherwise."
+excerpt: "Given a KCL value that is a 'body' (currently typed as [`Solid`](/docs/kcl-std/types/std-types-Solid)), returns `true` if the value is a solid and `false` otherwise."
 layout: manual
 ---
 
-Given a KCL value that is a "body" (currently typed as [`Solid`](/docs/kcl-std/types/std-types-Solid)), returns `true` if the value is a solid and `false` otherwise.
+Given a KCL value that is a 'body' (currently typed as [`Solid`](/docs/kcl-std/types/std-types-Solid)), returns `true` if the value is a solid and `false` otherwise.
 
 ```kcl
 isSolid(@val: Solid): bool

--- a/docs/kcl-std/functions/std-solid-isSurface.md
+++ b/docs/kcl-std/functions/std-solid-isSurface.md
@@ -1,11 +1,11 @@
 ---
 title: "isSurface"
 subtitle: "Function in std::solid"
-excerpt: "Given a KCL value that is a "body" (currently typed as [`Solid`](/docs/kcl-std/types/std-types-Solid)), returns `true` if the value is a surface and `false` otherwise."
+excerpt: "Given a KCL value that is a 'body' (currently typed as [`Solid`](/docs/kcl-std/types/std-types-Solid)), returns `true` if the value is a surface and `false` otherwise."
 layout: manual
 ---
 
-Given a KCL value that is a "body" (currently typed as [`Solid`](/docs/kcl-std/types/std-types-Solid)), returns `true` if the value is a surface and `false` otherwise.
+Given a KCL value that is a 'body' (currently typed as [`Solid`](/docs/kcl-std/types/std-types-Solid)), returns `true` if the value is a surface and `false` otherwise.
 
 ```kcl
 isSurface(@val: Solid): bool

--- a/rust/kcl-lib/std/solid.kcl
+++ b/rust/kcl-lib/std/solid.kcl
@@ -1400,7 +1400,7 @@ export fn split(
 ): [Solid; 1+] {}
 
 
-/// Given a KCL value that is a "body" (currently typed as `Solid`), returns `true` if the value is a solid and `false` otherwise. 
+/// Given a KCL value that is a 'body' (currently typed as `Solid`), returns `true` if the value is a solid and `false` otherwise. 
 ///
 /// ```kcl
 /// fn square(@plane, origin, side, body_type) {
@@ -1445,7 +1445,7 @@ export fn isSolid(
 ): bool {}
 
 
-/// Given a KCL value that is a "body" (currently typed as `Solid`), returns `true` if the value is a surface and `false` otherwise. 
+/// Given a KCL value that is a 'body' (currently typed as `Solid`), returns `true` if the value is a surface and `false` otherwise. 
 ///
 /// ```kcl
 /// fn square(@plane, origin, side, body_type) {


### PR DESCRIPTION
The double-quotes character broke an inline quote in the frontmatter of our docs markdown. See this example:

<img width="734" height="106" alt="Screenshot 2026-02-06 at 11 34 40 AM" src="https://github.com/user-attachments/assets/f4143b50-727a-4fa3-b06b-7b24b23be52f" />

Fix is to use single-quotes in the KCL docstring instead of double-quotes.