### PR TITLE
KCL docs: Escape excerpts systematically

### DIFF
--- a/docs/kcl-std/functions/std-solid-isSolid.md
+++ b/docs/kcl-std/functions/std-solid-isSolid.md
@@ -1,11 +1,11 @@
 ---
 title: "isSolid"
 subtitle: "Function in std::solid"
-excerpt: "Given a KCL value that is a 'body' (currently typed as [`Solid`](/docs/kcl-std/types/std-types-Solid)), returns `true` if the value is a solid and `false` otherwise."
+excerpt: "Given a KCL value that is a \"body\" (currently typed as [`Solid`](/docs/kcl-std/types/std-types-Solid)), returns `true` if the value is a solid and `false` otherwise."
 layout: manual
 ---
 
-Given a KCL value that is a 'body' (currently typed as [`Solid`](/docs/kcl-std/types/std-types-Solid)), returns `true` if the value is a solid and `false` otherwise.
+Given a KCL value that is a "body" (currently typed as [`Solid`](/docs/kcl-std/types/std-types-Solid)), returns `true` if the value is a solid and `false` otherwise.
 
 ```kcl
 isSolid(@val: Solid): bool

--- a/rust/kcl-lib/std/solid.kcl
+++ b/rust/kcl-lib/std/solid.kcl
@@ -1400,7 +1400,7 @@ export fn split(
 ): [Solid; 1+] {}
 
 
-/// Given a KCL value that is a 'body' (currently typed as `Solid`), returns `true` if the value is a solid and `false` otherwise. 
+/// Given a KCL value that is a "body" (currently typed as `Solid`), returns `true` if the value is a solid and `false` otherwise. 
 ///
 /// ```kcl
 /// fn square(@plane, origin, side, body_type) {


### PR DESCRIPTION
As Jon correctly pointed out, https://github.com/KittyCAD/modeling-app/pull/9966 was a short-term fix. We should just escape the YAML frontmatter properly for KCL docs.