### PR TITLE
Add useApp hook, rework app.ReactContext to leave useSingletons unaffected

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,7 +14,7 @@ import type { App } from '@src/lib/app'
 import { reportRejection } from '@src/lib/trap'
 import reportWebVitals from '@src/reportWebVitals'
 import monkeyPatchForBrowserTranslation from '@src/lib/monkeyPatchBrowserTranslate'
-import { app } from '@src/lib/boot'
+import { app, AppContext } from '@src/lib/boot'
 
 // Here's the entry-point for the whole app 🚀
 launchApp(app)
@@ -117,7 +117,7 @@ function mountAppToReact(app: App) {
   )
 
   root.render(
-    <app.ReactContext.Provider value={app}>
+    <AppContext.Provider value={app}>
       <HotkeysProvider>
         <AppStreamProvider>
           <Router />
@@ -144,7 +144,7 @@ function mountAppToReact(app: App) {
           <ModalContainer />
         </AppStreamProvider>
       </HotkeysProvider>
-    </app.ReactContext.Provider>
+    </AppContext.Provider>
   )
 
   // If you want to start measuring performance in your app, pass a function

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -51,7 +51,6 @@ import {
 import type { Project } from '@src/lib/project'
 import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
 import type { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
-import React from 'react'
 
 // We set some of our singletons on the window for debugging and E2E tests
 declare global {
@@ -66,11 +65,9 @@ export type SystemIOActor = ActorRefFrom<typeof systemIOMachine>
 
 export class App {
   singletons: ReturnType<typeof this.buildSingletons>
-  ReactContext: React.Context<typeof this>
 
   constructor() {
     this.singletons = this.buildSingletons()
-    this.ReactContext = React.createContext(this)
   }
 
   /**

--- a/src/lib/boot.ts
+++ b/src/lib/boot.ts
@@ -7,6 +7,7 @@ import React from 'react'
  * created anew.
  */
 export const app = new App()
+export const AppContext = React.createContext(app)
 
 /**
  * Hook to gain access to the global app instance's singletons
@@ -14,9 +15,9 @@ export const app = new App()
  * Alternatively, can use `useApp` and peel needed singletons off.
  * `useSingletons` will eventually be deprecated.
  */
-export const useSingletons = () => React.useContext(app.ReactContext).singletons
+export const useSingletons = () => React.useContext(AppContext).singletons
 
 /**
  * Hook to get access to the app instance.
  */
-export const useApp = () => React.useContext(app.ReactContext)
+export const useApp = () => React.useContext(AppContext)


### PR DESCRIPTION
I find myself doing this in basically every refactor branch I've been making, so let's just split it off as a tiny PR. Unused for now, just a slight refactor and a new alternative to (and future replacement for) `useSingletons`.