### PR TITLE
Upgrade to rust toolchain 1.93.0

### DIFF
--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.93.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
https://blog.rust-lang.org/2026/01/22/Rust-1.93.0/