### PR TITLE
Can't use `useSingletons` in `TutorialRequestToast`

### DIFF
--- a/src/components/HelpMenu.tsx
+++ b/src/components/HelpMenu.tsx
@@ -23,7 +23,7 @@ const HelpMenuDivider = () => (
 )
 
 export function HelpMenu() {
-  const { kclManager, systemIOActor } = useSingletons()
+  const { kclManager, systemIOActor, settingsActor } = useSingletons()
   const navigate = useNavigate()
   const location = useLocation()
   const filePath = useAbsoluteFilePath()
@@ -34,6 +34,7 @@ export function HelpMenu() {
       navigate,
       kclManager,
       systemIOActor,
+      settingsActor,
     }
     acceptOnboarding(props).catch((reason) =>
       catchOnboardingWarnError(reason, props)

--- a/src/components/OpenedProject.tsx
+++ b/src/components/OpenedProject.tsx
@@ -231,6 +231,7 @@ export function OpenedProject() {
             theme: getResolvedTheme(settings.app.theme.current),
             accountUrl: withSiteBaseURL('/account'),
             systemIOActor,
+            settingsActor,
           }),
         {
           id: ONBOARDING_TOAST_ID,
@@ -249,6 +250,7 @@ export function OpenedProject() {
     authToken,
     kclManager,
     systemIOActor,
+    settingsActor,
   ])
 
   // This is, at time of writing, the only spot we need @preact/signals-react,

--- a/src/components/Settings/AllSettingsFields.tsx
+++ b/src/components/Settings/AllSettingsFields.tsx
@@ -71,6 +71,7 @@ export const AllSettingsFields = forwardRef(
         navigate,
         kclManager,
         systemIOActor,
+        settingsActor,
       }
       // We need to navigate out of settings before accepting onboarding
       // in the web

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -248,6 +248,7 @@ const Home = () => {
                       navigate,
                       kclManager,
                       systemIOActor,
+                      settingsActor,
                     }).catch(reportRejection)
                   }}
                   className={`${sidebarButtonClasses} !text-primary flex-1`}

--- a/src/routes/Onboarding/utils.tsx
+++ b/src/routes/Onboarding/utils.tsx
@@ -265,6 +265,7 @@ export interface OnboardingUtilDeps {
   onboardingStatus: OnboardingStatus
   kclManager: KclManager
   systemIOActor: SystemIOActor
+  settingsActor: SettingsActorType
   navigate: NavigateFunction
 }
 
@@ -503,7 +504,6 @@ export async function catchOnboardingWarnError(
 }
 
 export function TutorialWebConfirmationToast(props: OnboardingUtilDeps) {
-  const { settingsActor } = useSingletons()
   function onAccept() {
     toast.dismiss(ONBOARDING_TOAST_ID)
     resetCodeAndAdvanceOnboarding(props).catch(reportRejection)
@@ -531,7 +531,7 @@ export function TutorialWebConfirmationToast(props: OnboardingUtilDeps) {
             }}
             data-negative-button="dismiss"
             name="dismiss"
-            onClick={() => onDismissOnboardingInvite(settingsActor)}
+            onClick={() => onDismissOnboardingInvite(props.settingsActor)}
           >
             I'll save it
           </ActionButton>


### PR DESCRIPTION
This was introduced in #9727, and started making users who had any code in their editor unable to restart their onboarding in the browser. It's unclear why this component could not use `useSingletons`, it is being used in a functional component?? Clearly `tsc` was confused too, as this error is exactly the sort of things that it would normally catch. Here's the error that would emit in the console:

```
react-dom-client.development.js:7597 Uncaught (in promise) Error: Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
1. You might have mismatching versions of React and the renderer (such as React DOM)
2. You might be breaking the Rules of Hooks
3. You might have more than one copy of React in the same app
See https://react.dev/link/invalid-hook-call for tips about how to debug and fix this problem.
    at useSingletons (boot.ts:18:42)
    at TutorialWebConfirmationToast (utils.tsx:506:29)
    at catchOnboardingWarnError (utils.tsx:494:19)
    at HelpMenu.tsx:39:7
```

## Demo
https://github.com/user-attachments/assets/6954b1b8-59ca-4f75-a304-0fc1ba27e3b3

