### PR TITLE
Hide the Bodies Pane on production for now

### DIFF
--- a/src/components/layout/areas/BodiesPane.tsx
+++ b/src/components/layout/areas/BodiesPane.tsx
@@ -22,6 +22,7 @@ import { useMemo } from 'react'
 import toast from 'react-hot-toast'
 import { err } from '@src/lib/trap'
 import { toUtf16 } from '@src/lang/errors'
+import { IS_STAGING_OR_DEBUG } from '@src/routes/utils'
 
 type SolidArtifact = Artifact & { type: 'compositeSolid' | 'sweep' }
 
@@ -45,6 +46,9 @@ export function BodiesPane(props: AreaTypeComponentProps) {
       i++
     }
   }
+
+  // TODO: Remove this early return once bodies support functions and imports
+  if (!IS_STAGING_OR_DEBUG) return null
 
   return (
     <LayoutPanel

--- a/src/lib/layout/defaultAreaLibrary.tsx
+++ b/src/lib/layout/defaultAreaLibrary.tsx
@@ -10,6 +10,7 @@ import type { MouseEventHandler } from 'react'
 import { useCallback, useMemo } from 'react'
 import { togglePaneLayoutNode } from '@src/lib/layout/utils'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
+import { IS_STAGING_OR_DEBUG } from '@src/routes/utils'
 import { ProjectExplorerPane } from '@src/components/layout/areas/ProjectExplorerPane'
 import { KclEditorPane } from '@src/components/layout/areas/KclEditorPane'
 import { MlEphantConversationPaneWrapper } from '@src/components/layout/areas/MlEphantConversationPaneWrapper'
@@ -64,7 +65,8 @@ export const useDefaultAreaLibrary = () => {
           Component: FeatureTreePane,
         },
         bodies: {
-          hide: () => false,
+          // TODO: Enable everywhere once bodies supports functions and imports
+          hide: () => !IS_STAGING_OR_DEBUG,
           Component: BodiesPane,
         },
         modeling: {


### PR DESCRIPTION
It does not yet support functions and imports so we need to hide the UI in order to release.