### PR TITLE
Limit settings reset test to just Linux

### DIFF
--- a/e2e/playwright/testing-settings.spec.ts
+++ b/e2e/playwright/testing-settings.spec.ts
@@ -46,72 +46,75 @@ test.describe(
     tag: ['@desktop'],
   },
   () => {
-    test('Stored settings are validated and fall back to defaults', async ({
-      page,
-      homePage,
-      tronApp,
-    }) => {
-      if (!tronApp) throw new Error('tronApp is missing.')
+    test(
+      'Stored settings are validated and fall back to defaults',
+      { tag: ['@macos', '@windows'] },
+      async ({ page, homePage, tronApp }) => {
+        if (!tronApp) throw new Error('tronApp is missing.')
 
-      // Override beforeEach test setup
-      // with corrupted settings
-      await tronApp.cleanProjectDir(
-        TEST_SETTINGS_CORRUPTED as DeepPartial<Settings>
-      )
-
-      await page.setBodyDimensions({ width: 1200, height: 500 })
-
-      // Check the settings were reset
-      const storedSettings = tomlToSettings(
-        await page.evaluate(
-          ({ settingsKey }) => localStorage.getItem(settingsKey) || '',
-          { settingsKey: TEST_SETTINGS_KEY }
+        // Override beforeEach test setup
+        // with corrupted settings
+        await tronApp.cleanProjectDir(
+          TEST_SETTINGS_CORRUPTED as DeepPartial<Settings>
         )
-      )
 
-      expect(storedSettings.settings?.app?.appearance?.theme).toBe('dark')
+        await page.setBodyDimensions({ width: 1200, height: 500 })
 
-      // Check that the invalid settings were changed to good defaults
-      expect(storedSettings.settings?.modeling?.base_unit).toBe('in')
-      expect(storedSettings.settings?.modeling?.mouse_controls).toBe('zoo')
-      // Commenting this out because tests need this to be set to work properly.
-      // expect(storedSettings.settings?.app?.project_directory).toBe('')
-      expect(storedSettings.settings?.project?.default_project_name).toBe(
-        'untitled'
-      )
-    })
+        // Check the settings were reset
+        const storedSettings = tomlToSettings(
+          await page.evaluate(
+            ({ settingsKey }) => localStorage.getItem(settingsKey) || '',
+            { settingsKey: TEST_SETTINGS_KEY }
+          )
+        )
 
-    test('Keybindings display the correct hotkey for Command Palette', async ({
-      page,
-      homePage,
-    }) => {
-      const u = await getUtils(page)
-      await page.setBodyDimensions({ width: 1200, height: 500 })
-      await homePage.goToModelingScene()
-      await u.waitForPageLoad()
+        expect(storedSettings.settings?.app?.appearance?.theme).toBe('dark')
 
-      await test.step('Open keybindings settings', async () => {
-        // Open the settings modal with the keyboard shortcut
-        await page.keyboard.press('ControlOrMeta+,')
+        // Check that the invalid settings were changed to good defaults
+        expect(storedSettings.settings?.modeling?.base_unit).toBe('in')
+        expect(storedSettings.settings?.modeling?.mouse_controls).toBe('zoo')
+        // Commenting this out because tests need this to be set to work properly.
+        // expect(storedSettings.settings?.app?.project_directory).toBe('')
+        expect(storedSettings.settings?.project?.default_project_name).toBe(
+          'untitled'
+        )
+      }
+    )
 
-        // Go to Keybindings tab.
-        const keybindingsTab = page.getByRole('radio', { name: 'Keybindings' })
-        await keybindingsTab.click()
-      })
+    test(
+      'Keybindings display the correct hotkey for Command Palette',
+      { tag: ['@macos', '@windows'] },
+      async ({ page, homePage }) => {
+        const u = await getUtils(page)
+        await page.setBodyDimensions({ width: 1200, height: 500 })
+        await homePage.goToModelingScene()
+        await u.waitForPageLoad()
 
-      // Go to the hotkey for Command Palette.
-      const commandPalette = page.getByText('Toggle Command Palette')
-      await commandPalette.scrollIntoViewIfNeeded()
+        await test.step('Open keybindings settings', async () => {
+          // Open the settings modal with the keyboard shortcut
+          await page.keyboard.press('ControlOrMeta+,')
 
-      // The heading is above it and should be in view now.
-      const commandPaletteHeading = page.getByRole('heading', {
-        name: 'Command Palette',
-      })
-      // The hotkey is in a kbd element next to the heading.
-      const hotkey = commandPaletteHeading.locator('+ div kbd')
-      const text = process.platform === 'darwin' ? 'Command+K' : 'Control+K'
-      await expect(hotkey).toHaveText(text)
-    })
+          // Go to Keybindings tab.
+          const keybindingsTab = page.getByRole('radio', {
+            name: 'Keybindings',
+          })
+          await keybindingsTab.click()
+        })
+
+        // Go to the hotkey for Command Palette.
+        const commandPalette = page.getByText('Toggle Command Palette')
+        await commandPalette.scrollIntoViewIfNeeded()
+
+        // The heading is above it and should be in view now.
+        const commandPaletteHeading = page.getByRole('heading', {
+          name: 'Command Palette',
+        })
+        // The hotkey is in a kbd element next to the heading.
+        const hotkey = commandPaletteHeading.locator('+ div kbd')
+        const text = process.platform === 'darwin' ? 'Command+K' : 'Control+K'
+        await expect(hotkey).toHaveText(text)
+      }
+    )
 
     test('Project and user settings can be reset', async ({
       page,
@@ -214,327 +217,336 @@ test.describe(
       })
     })
 
-    test(`Load desktop app with no settings file`, async ({
-      page,
-    }, testInfo) => {
-      await page.setBodyDimensions({ width: 1200, height: 500 })
-
-      // Selectors and constants
-      const errorHeading = page.getByRole('heading', {
-        name: 'An unexpected error occurred',
-      })
-      const projectDirLink = page.getByText('Loaded from')
-
-      // If the app loads without exploding we're in the clear
-      await expect(errorHeading).not.toBeVisible()
-      await expect(projectDirLink).toBeVisible()
-    })
-
-    test(`Load desktop app with a settings file, but no project directory setting`, async ({
-      page,
-      tronApp,
-    }) => {
-      if (!tronApp) throw new Error('tronApp is missing.')
-
-      await tronApp.cleanProjectDir({
-        modeling: {
-          base_unit: 'in',
-        },
-      })
-
-      await page.setBodyDimensions({ width: 1200, height: 500 })
-
-      // Selectors and constants
-      const errorHeading = page.getByRole('heading', {
-        name: 'An unexpected error occurred',
-      })
-      const projectDirLink = page.getByText('Loaded from')
-
-      // If the app loads without exploding we're in the clear
-      await expect(errorHeading).not.toBeVisible()
-      await expect(projectDirLink).toBeVisible()
-    })
-
-    test('project settings reload on external change', async ({
-      context,
-      page,
-      toolbar,
-    }) => {
-      const { dir: projectDirName } = await context.folderSetupFn(
-        async () => {}
-      )
-
-      await page.setBodyDimensions({ width: 1200, height: 500 })
-
-      const projectDirLink = page.getByText('Loaded from')
-
-      await test.step('Wait for project view', async () => {
-        await expect(projectDirLink).toBeVisible()
-      })
-
-      await createProject({ name: 'project-000', page })
-
-      const changeShowDebugPanelFs = async (show_debug_panel: boolean) => {
-        const tempSettingsFilePath = join(
-          projectDirName,
-          'project-000',
-          PROJECT_SETTINGS_FILE_NAME
-        )
-        await fsp.writeFile(
-          tempSettingsFilePath,
-          settingsToToml({
-            settings: {
-              app: {
-                show_debug_panel,
-              },
-              // TODO: make sure this isn't just working around a bug
-              // where the existing data wouldn't be preserved?
-              meta: {
-                id: '9379bcda-e1e4-4613-851e-a5c4f5c7e83d',
-              },
-            },
-          })
-        )
-      }
-
-      await test.step('Check the body theme is first starting as we expect', async () => {
-        await expect(toolbar.debugPaneBtn).not.toBeAttached()
-      })
-
-      await test.step('Check the theme changed', async () => {
-        await changeShowDebugPanelFs(true)
-        await expect(toolbar.debugPaneBtn).toBeAttached()
-      })
-    })
-
-    test(`Closing settings modal should go back to the original file being viewed`, async ({
-      context,
-      page,
-    }, testInfo) => {
-      await context.folderSetupFn(async (dir) => {
-        const bracketDir = join(dir, 'project-000')
-        await fsp.mkdir(bracketDir, { recursive: true })
-        await fsp.copyFile(
-          executorInputPath('cube.kcl'),
-          join(bracketDir, 'main.kcl')
-        )
-        await fsp.copyFile(
-          executorInputPath('cylinder.kcl'),
-          join(bracketDir, '2.kcl')
-        )
-      })
-      const kclCube = await fsp.readFile(executorInputPath('cube.kcl'), 'utf-8')
-      const kclCylinder = await fsp.readFile(
-        executorInputPath('cylinder.kcl'),
-        'utf8'
-      )
-
-      const {
-        openKclCodePanel,
-        openFilePanel,
-        waitForPageLoad,
-        selectFile,
-        editorTextMatches,
-      } = await getUtils(page, test)
-
-      await page.setBodyDimensions({ width: 1200, height: 500 })
-      page.on('console', console.log)
-
-      await test.step('Precondition: Open to second project file', async () => {
-        await expect(page.getByTestId('home-section')).toBeVisible()
-        await page.getByText('project-000').click()
-        await waitForPageLoad()
-        await openKclCodePanel()
-        await openFilePanel()
-        await editorTextMatches(kclCube)
-
-        await selectFile('2.kcl')
-        await editorTextMatches(kclCylinder)
-      })
-
-      const settingsOpenButton = page.getByRole('link', {
-        name: 'settings Settings',
-      })
-      const settingsCloseButton = page.getByTestId('settings-close-button')
-
-      await test.step('Open and close settings', async () => {
-        await settingsOpenButton.click()
-        await expect(
-          page.getByRole('heading', { name: 'Settings', exact: true })
-        ).toBeVisible()
-        await settingsCloseButton.click()
-      })
-
-      await test.step('Postcondition: Same file content is in editor as before settings opened', async () => {
-        await editorTextMatches(kclCylinder)
-      })
-    })
-
-    test('Changing modeling default unit', async ({ page, homePage }) => {
-      await test.step(`Test setup`, async () => {
+    test(
+      `Load desktop app with no settings file`,
+      { tag: ['@macos', '@windows'] },
+      async ({ page }, testInfo) => {
         await page.setBodyDimensions({ width: 1200, height: 500 })
-        await homePage.goToModelingScene()
-        const toastMessage = page.getByText(
-          `Successfully created "testDefault"`
+
+        // Selectors and constants
+        const errorHeading = page.getByRole('heading', {
+          name: 'An unexpected error occurred',
+        })
+        const projectDirLink = page.getByText('Loaded from')
+
+        // If the app loads without exploding we're in the clear
+        await expect(errorHeading).not.toBeVisible()
+        await expect(projectDirLink).toBeVisible()
+      }
+    )
+
+    test(
+      `Load desktop app with a settings file, but no project directory setting`,
+      { tag: ['@macos', '@windows'] },
+      async ({ page, tronApp }) => {
+        if (!tronApp) throw new Error('tronApp is missing.')
+
+        await tronApp.cleanProjectDir({
+          modeling: {
+            base_unit: 'in',
+          },
+        })
+
+        await page.setBodyDimensions({ width: 1200, height: 500 })
+
+        // Selectors and constants
+        const errorHeading = page.getByRole('heading', {
+          name: 'An unexpected error occurred',
+        })
+        const projectDirLink = page.getByText('Loaded from')
+
+        // If the app loads without exploding we're in the clear
+        await expect(errorHeading).not.toBeVisible()
+        await expect(projectDirLink).toBeVisible()
+      }
+    )
+
+    test(
+      'project settings reload on external change',
+      { tag: ['@macos', '@windows'] },
+      async ({ context, page, toolbar }) => {
+        const { dir: projectDirName } = await context.folderSetupFn(
+          async () => {}
         )
-        await expect(toastMessage).not.toBeVisible()
-        await page
-          .getByRole('button', { name: 'Start Sketch' })
-          .waitFor({ state: 'visible' })
-      })
 
-      // Selectors and constants
-      const userSettingsTab = page.getByRole('radio', { name: 'User' })
-      const projectSettingsTab = page.getByRole('radio', { name: 'Project' })
-      const defaultUnitSection = page.getByText(
-        'default unitRoll back default unitRoll back to match'
-      )
-      const defaultUnitRollbackButton = page.getByRole('button', {
-        name: 'Roll back default unit',
-      })
+        await page.setBodyDimensions({ width: 1200, height: 500 })
 
-      await test.step(`Open the settings modal`, async () => {
-        await page.getByRole('link', { name: 'Settings' }).last().click()
-        await expect(
-          page.getByRole('heading', { name: 'Settings', exact: true })
-        ).toBeVisible()
-      })
+        const projectDirLink = page.getByText('Loaded from')
 
-      await test.step(`Reset unit setting`, async () => {
+        await test.step('Wait for project view', async () => {
+          await expect(projectDirLink).toBeVisible()
+        })
+
+        await createProject({ name: 'project-000', page })
+
+        const changeShowDebugPanelFs = async (show_debug_panel: boolean) => {
+          const tempSettingsFilePath = join(
+            projectDirName,
+            'project-000',
+            PROJECT_SETTINGS_FILE_NAME
+          )
+          await fsp.writeFile(
+            tempSettingsFilePath,
+            settingsToToml({
+              settings: {
+                app: {
+                  show_debug_panel,
+                },
+                // TODO: make sure this isn't just working around a bug
+                // where the existing data wouldn't be preserved?
+                meta: {
+                  id: '9379bcda-e1e4-4613-851e-a5c4f5c7e83d',
+                },
+              },
+            })
+          )
+        }
+
+        await test.step('Check the body theme is first starting as we expect', async () => {
+          await expect(toolbar.debugPaneBtn).not.toBeAttached()
+        })
+
+        await test.step('Check the theme changed', async () => {
+          await changeShowDebugPanelFs(true)
+          await expect(toolbar.debugPaneBtn).toBeAttached()
+        })
+      }
+    )
+
+    test(
+      `Closing settings modal should go back to the original file being viewed`,
+      { tag: ['@macos', '@windows'] },
+      async ({ context, page }, testInfo) => {
+        await context.folderSetupFn(async (dir) => {
+          const bracketDir = join(dir, 'project-000')
+          await fsp.mkdir(bracketDir, { recursive: true })
+          await fsp.copyFile(
+            executorInputPath('cube.kcl'),
+            join(bracketDir, 'main.kcl')
+          )
+          await fsp.copyFile(
+            executorInputPath('cylinder.kcl'),
+            join(bracketDir, '2.kcl')
+          )
+        })
+        const kclCube = await fsp.readFile(
+          executorInputPath('cube.kcl'),
+          'utf-8'
+        )
+        const kclCylinder = await fsp.readFile(
+          executorInputPath('cylinder.kcl'),
+          'utf8'
+        )
+
+        const {
+          openKclCodePanel,
+          openFilePanel,
+          waitForPageLoad,
+          selectFile,
+          editorTextMatches,
+        } = await getUtils(page, test)
+
+        await page.setBodyDimensions({ width: 1200, height: 500 })
+        page.on('console', console.log)
+
+        await test.step('Precondition: Open to second project file', async () => {
+          await expect(page.getByTestId('home-section')).toBeVisible()
+          await page.getByText('project-000').click()
+          await waitForPageLoad()
+          await openKclCodePanel()
+          await openFilePanel()
+          await editorTextMatches(kclCube)
+
+          await selectFile('2.kcl')
+          await editorTextMatches(kclCylinder)
+        })
+
+        const settingsOpenButton = page.getByRole('link', {
+          name: 'settings Settings',
+        })
+        const settingsCloseButton = page.getByTestId('settings-close-button')
+
+        await test.step('Open and close settings', async () => {
+          await settingsOpenButton.click()
+          await expect(
+            page.getByRole('heading', { name: 'Settings', exact: true })
+          ).toBeVisible()
+          await settingsCloseButton.click()
+        })
+
+        await test.step('Postcondition: Same file content is in editor as before settings opened', async () => {
+          await editorTextMatches(kclCylinder)
+        })
+      }
+    )
+
+    test(
+      'Changing modeling default unit',
+      { tag: ['@macos', '@windows'] },
+      async ({ page, homePage }) => {
+        await test.step(`Test setup`, async () => {
+          await page.setBodyDimensions({ width: 1200, height: 500 })
+          await homePage.goToModelingScene()
+          const toastMessage = page.getByText(
+            `Successfully created "testDefault"`
+          )
+          await expect(toastMessage).not.toBeVisible()
+          await page
+            .getByRole('button', { name: 'Start Sketch' })
+            .waitFor({ state: 'visible' })
+        })
+
+        // Selectors and constants
+        const userSettingsTab = page.getByRole('radio', { name: 'User' })
+        const projectSettingsTab = page.getByRole('radio', { name: 'Project' })
+        const defaultUnitSection = page.getByText(
+          'default unitRoll back default unitRoll back to match'
+        )
+        const defaultUnitRollbackButton = page.getByRole('button', {
+          name: 'Roll back default unit',
+        })
+
+        await test.step(`Open the settings modal`, async () => {
+          await page.getByRole('link', { name: 'Settings' }).last().click()
+          await expect(
+            page.getByRole('heading', { name: 'Settings', exact: true })
+          ).toBeVisible()
+        })
+
+        await test.step(`Reset unit setting`, async () => {
+          await settingsSwitchTab(page)('user')
+          await defaultUnitSection.hover()
+          await defaultUnitRollbackButton.click()
+          await projectSettingsTab.hover()
+          await projectSettingsTab.click()
+          await page.waitForTimeout(1000)
+        })
+
+        await test.step('Change modeling default unit within project tab', async () => {
+          const changeUnitOfMeasureInProjectTab = async (
+            unitOfMeasure: string
+          ) => {
+            await test.step(`Set modeling default unit to ${unitOfMeasure}`, async () => {
+              await page
+                .getByTestId('modeling-defaultUnit')
+                .selectOption(`${unitOfMeasure}`)
+              const toastMessage = page.getByText(
+                `Set default unit to "${unitOfMeasure}" for this project`
+              )
+
+              // Assert visibility and disappearance
+              await expect(toastMessage).toBeVisible()
+              await expect(toastMessage).not.toBeVisible()
+            })
+          }
+          await changeUnitOfMeasureInProjectTab('in')
+          await changeUnitOfMeasureInProjectTab('ft')
+          await changeUnitOfMeasureInProjectTab('yd')
+          await changeUnitOfMeasureInProjectTab('cm')
+          await changeUnitOfMeasureInProjectTab('m')
+        })
+
+        // Go to the user tab
+        await userSettingsTab.hover()
         await settingsSwitchTab(page)('user')
-        await defaultUnitSection.hover()
-        await defaultUnitRollbackButton.click()
-        await projectSettingsTab.hover()
-        await projectSettingsTab.click()
         await page.waitForTimeout(1000)
-      })
 
-      await test.step('Change modeling default unit within project tab', async () => {
-        const changeUnitOfMeasureInProjectTab = async (
-          unitOfMeasure: string
-        ) => {
-          await test.step(`Set modeling default unit to ${unitOfMeasure}`, async () => {
-            await page
-              .getByTestId('modeling-defaultUnit')
-              .selectOption(`${unitOfMeasure}`)
+        await test.step('Change modeling default unit within user tab', async () => {
+          const changeUnitOfMeasureInUserTab = async (
+            unitOfMeasure: string
+          ) => {
+            await test.step(`Set modeling default unit to ${unitOfMeasure}`, async () => {
+              await page
+                .getByTestId('modeling-defaultUnit')
+                .selectOption(`${unitOfMeasure}`)
+              const toastMessage = page.getByText(
+                `Set default unit to "${unitOfMeasure}" as a user default`
+              )
+              await expect(toastMessage).toBeVisible()
+              await expect(toastMessage).not.toBeVisible()
+            })
+          }
+          await changeUnitOfMeasureInUserTab('in')
+          await changeUnitOfMeasureInUserTab('ft')
+          await changeUnitOfMeasureInUserTab('yd')
+          await changeUnitOfMeasureInUserTab('mm')
+          await changeUnitOfMeasureInUserTab('cm')
+          await changeUnitOfMeasureInUserTab('m')
+        })
+
+        // Close settings
+        const settingsCloseButton = page.getByTestId('settings-close-button')
+        await settingsCloseButton.click()
+
+        await test.step('Change modeling default unit within command bar', async () => {
+          const commands = page.getByRole('button', { name: 'Commands' })
+          const changeUnitOfMeasureInCommandBar = async (
+            unitOfMeasure: string
+          ) => {
+            // Open command bar
+            await commands.click()
+            const settingsModelingDefaultUnitCommand = page.getByText(
+              'Settings · modeling · default unit'
+            )
+            await settingsModelingDefaultUnitCommand.click()
+
+            const commandOption = page.getByRole('option', {
+              name: unitOfMeasure,
+              exact: true,
+            })
+            await commandOption.click()
+
             const toastMessage = page.getByText(
               `Set default unit to "${unitOfMeasure}" for this project`
             )
-
-            // Assert visibility and disappearance
             await expect(toastMessage).toBeVisible()
-            await expect(toastMessage).not.toBeVisible()
-          })
-        }
-        await changeUnitOfMeasureInProjectTab('in')
-        await changeUnitOfMeasureInProjectTab('ft')
-        await changeUnitOfMeasureInProjectTab('yd')
-        await changeUnitOfMeasureInProjectTab('cm')
-        await changeUnitOfMeasureInProjectTab('m')
-      })
+          }
+          await changeUnitOfMeasureInCommandBar('in')
+          await changeUnitOfMeasureInCommandBar('ft')
+          await changeUnitOfMeasureInCommandBar('yd')
+          await changeUnitOfMeasureInCommandBar('mm')
+          await changeUnitOfMeasureInCommandBar('cm')
+          await changeUnitOfMeasureInCommandBar('m')
+        })
 
-      // Go to the user tab
-      await userSettingsTab.hover()
-      await settingsSwitchTab(page)('user')
-      await page.waitForTimeout(1000)
-
-      await test.step('Change modeling default unit within user tab', async () => {
-        const changeUnitOfMeasureInUserTab = async (unitOfMeasure: string) => {
-          await test.step(`Set modeling default unit to ${unitOfMeasure}`, async () => {
-            await page
-              .getByTestId('modeling-defaultUnit')
-              .selectOption(`${unitOfMeasure}`)
+        await test.step('Change modeling default unit within gizmo', async () => {
+          const changeUnitOfMeasureInGizmo = async (
+            unitOfMeasure: string,
+            copy: string
+          ) => {
+            const gizmo = page.getByTestId('units-menu')
+            await gizmo.click()
+            const button = page.locator('ul').getByRole('button', {
+              name: copy,
+              exact: true,
+            })
+            await button.click()
             const toastMessage = page.getByText(
-              `Set default unit to "${unitOfMeasure}" as a user default`
+              `Updated per-file units to ${unitOfMeasure}`
             )
             await expect(toastMessage).toBeVisible()
-            await expect(toastMessage).not.toBeVisible()
-          })
-        }
-        await changeUnitOfMeasureInUserTab('in')
-        await changeUnitOfMeasureInUserTab('ft')
-        await changeUnitOfMeasureInUserTab('yd')
-        await changeUnitOfMeasureInUserTab('mm')
-        await changeUnitOfMeasureInUserTab('cm')
-        await changeUnitOfMeasureInUserTab('m')
-      })
+          }
 
-      // Close settings
-      const settingsCloseButton = page.getByTestId('settings-close-button')
-      await settingsCloseButton.click()
+          await changeUnitOfMeasureInGizmo('ft', 'Feet')
+          await changeUnitOfMeasureInGizmo('in', 'Inches')
+          await changeUnitOfMeasureInGizmo('yd', 'Yards')
+          await changeUnitOfMeasureInGizmo('cm', 'Centimeters')
+          await changeUnitOfMeasureInGizmo('m', 'Meters')
+          // Must come after 'm' because 'm' will partially match on 'mm'
+          await changeUnitOfMeasureInGizmo('mm', 'Millimeters')
+        })
+      }
+    )
 
-      await test.step('Change modeling default unit within command bar', async () => {
-        const commands = page.getByRole('button', { name: 'Commands' })
-        const changeUnitOfMeasureInCommandBar = async (
-          unitOfMeasure: string
-        ) => {
-          // Open command bar
-          await commands.click()
-          const settingsModelingDefaultUnitCommand = page.getByText(
-            'Settings · modeling · default unit'
-          )
-          await settingsModelingDefaultUnitCommand.click()
-
-          const commandOption = page.getByRole('option', {
-            name: unitOfMeasure,
-            exact: true,
-          })
-          await commandOption.click()
-
-          const toastMessage = page.getByText(
-            `Set default unit to "${unitOfMeasure}" for this project`
-          )
-          await expect(toastMessage).toBeVisible()
-        }
-        await changeUnitOfMeasureInCommandBar('in')
-        await changeUnitOfMeasureInCommandBar('ft')
-        await changeUnitOfMeasureInCommandBar('yd')
-        await changeUnitOfMeasureInCommandBar('mm')
-        await changeUnitOfMeasureInCommandBar('cm')
-        await changeUnitOfMeasureInCommandBar('m')
-      })
-
-      await test.step('Change modeling default unit within gizmo', async () => {
-        const changeUnitOfMeasureInGizmo = async (
-          unitOfMeasure: string,
-          copy: string
-        ) => {
-          const gizmo = page.getByTestId('units-menu')
-          await gizmo.click()
-          const button = page.locator('ul').getByRole('button', {
-            name: copy,
-            exact: true,
-          })
-          await button.click()
-          const toastMessage = page.getByText(
-            `Updated per-file units to ${unitOfMeasure}`
-          )
-          await expect(toastMessage).toBeVisible()
-        }
-
-        await changeUnitOfMeasureInGizmo('ft', 'Feet')
-        await changeUnitOfMeasureInGizmo('in', 'Inches')
-        await changeUnitOfMeasureInGizmo('yd', 'Yards')
-        await changeUnitOfMeasureInGizmo('cm', 'Centimeters')
-        await changeUnitOfMeasureInGizmo('m', 'Meters')
-        // Must come after 'm' because 'm' will partially match on 'mm'
-        await changeUnitOfMeasureInGizmo('mm', 'Millimeters')
-      })
-    })
-
-    test('Changing theme in sketch mode', async ({
-      context,
-      page,
-      homePage,
-      toolbar,
-      scene,
-      cmdBar,
-    }) => {
-      const u = await getUtils(page)
-      await context.addInitScript(() => {
-        localStorage.setItem(
-          'persistCode',
-          `sketch001 = startSketchOn(XZ)
+    test(
+      'Changing theme in sketch mode',
+      { tag: ['@macos', '@windows'] },
+      async ({ context, page, homePage, toolbar, scene, cmdBar }) => {
+        const u = await getUtils(page)
+        await context.addInitScript(() => {
+          localStorage.setItem(
+            'persistCode',
+            `sketch001 = startSketchOn(XZ)
     |> startProfile(at = [0, 0])
     |> line(end = [5, 0])
     |> line(end = [0, 5])
@@ -543,210 +555,211 @@ test.describe(
     |> close()
   extrude001 = extrude(sketch001, length = 5)
   `
-        )
-      })
-      await page.setBodyDimensions({ width: 1200, height: 500 })
-      await homePage.goToModelingScene()
-      await expect(toolbar.startSketchBtn).toBeEnabled({ timeout: 15_000 })
-      await scene.settled(cmdBar)
-      await page.waitForTimeout(1000)
-
-      // Selectors and constants
-      const lineToolButton = page.getByTestId('line')
-      const segmentOverlays = page.getByTestId('segment-overlay')
-      const sketchOriginLocation = { x: 600, y: 250 }
-      const darkThemeSegmentColor: [number, number, number] = [249, 249, 249]
-      const lightThemeSegmentColor: [number, number, number] = [28, 28, 28]
-
-      await test.step(`Get into sketch mode`, async () => {
-        await page.mouse.click(700, 200)
-        await toolbar.editSketch()
-
-        // We use the line tool as a proxy for sketch mode
-        await expect(lineToolButton).toBeVisible()
-        await expect(segmentOverlays).toHaveCount(5)
-        // but we allow more time to pass for animating to the sketch
-        await page.waitForTimeout(1000)
-      })
-
-      await test.step(`Check the sketch line color before`, async () => {
-        await expect
-          .poll(() =>
-            u.getGreatestPixDiff(sketchOriginLocation, darkThemeSegmentColor)
           )
-          .toBeLessThan(15)
-      })
-
-      await test.step(`Change theme to light using command palette`, async () => {
-        await page.keyboard.press('ControlOrMeta+K')
-        await page.getByRole('option', { name: 'theme' }).click()
-        await page.getByRole('option', { name: 'light' }).click()
-        await expect(page.getByText('theme to "light"')).toBeVisible()
-
-        // Make sure we haven't left sketch mode
-        await expect(lineToolButton).toBeVisible()
-      })
-
-      await test.step(`Check the sketch line color after`, async () => {
-        await expect
-          .poll(() =>
-            u.getGreatestPixDiff(sketchOriginLocation, lightThemeSegmentColor)
-          )
-          .toBeLessThan(15)
-      })
-    })
-
-    test(`Changing system theme preferences (via media query) should update UI and stream`, async ({
-      page,
-      homePage,
-      tronApp,
-    }) => {
-      if (!tronApp) throw new Error('tronApp is missing.')
-
-      await tronApp.cleanProjectDir({
-        // Override the settings so that the theme is set to `system`
-        ...TEST_SETTINGS_DEFAULT_THEME,
-      })
-
-      const u = await getUtils(page)
-
-      // Selectors and constants
-      const darkBackgroundCss = 'oklch(0.3012 0 264.48)'
-      const lightBackgroundCss = 'oklch(0.9911 0 264.48)'
-      const darkBackgroundColor: [number, number, number] = [50, 40, 51] // planes are on
-      const lightBackgroundColor: [number, number, number] = [227, 222, 230] // planes are on
-      const streamBackgroundPixelIsColor = async (
-        color: [number, number, number]
-      ) => {
-        return u.getGreatestPixDiff({ x: 1000, y: 200 }, color)
-      }
-      const toolbar = page.locator('menu').filter({ hasText: 'Start Sketch' })
-
-      await test.step(`Test setup`, async () => {
+        })
         await page.setBodyDimensions({ width: 1200, height: 500 })
         await homePage.goToModelingScene()
-        await u.waitForPageLoad()
+        await expect(toolbar.startSketchBtn).toBeEnabled({ timeout: 15_000 })
+        await scene.settled(cmdBar)
         await page.waitForTimeout(1000)
-        await expect(toolbar).toBeVisible()
-      })
 
-      await test.step(`Check the background color is light before`, async () => {
-        await expect(toolbar).toHaveCSS('background-color', lightBackgroundCss)
-        await expect
-          .poll(() => streamBackgroundPixelIsColor(lightBackgroundColor))
-          .toBeLessThan(15)
-      })
+        // Selectors and constants
+        const lineToolButton = page.getByTestId('line')
+        const segmentOverlays = page.getByTestId('segment-overlay')
+        const sketchOriginLocation = { x: 600, y: 250 }
+        const darkThemeSegmentColor: [number, number, number] = [249, 249, 249]
+        const lightThemeSegmentColor: [number, number, number] = [28, 28, 28]
 
-      await test.step(`Change media query preference to dark, emulating dusk with system theme`, async () => {
-        await page.emulateMedia({ colorScheme: 'dark' })
-      })
+        await test.step(`Get into sketch mode`, async () => {
+          await page.mouse.click(700, 200)
+          await toolbar.editSketch()
 
-      await test.step(`Check the background color is dark after`, async () => {
-        await expect(toolbar).toHaveCSS('background-color', darkBackgroundCss)
-        await expect
-          .poll(() => streamBackgroundPixelIsColor(darkBackgroundColor))
-          .toBeLessThan(15)
-      })
-    })
+          // We use the line tool as a proxy for sketch mode
+          await expect(lineToolButton).toBeVisible()
+          await expect(segmentOverlays).toHaveCount(5)
+          // but we allow more time to pass for animating to the sketch
+          await page.waitForTimeout(1000)
+        })
 
-    test(`Change inline units setting`, async ({
-      page,
-      homePage,
-      context,
-      editor,
-    }) => {
-      const initialInlineUnits = 'yd'
-      const editedInlineUnits = { short: 'mm', long: 'Millimeters' }
-      const inlineSettingsString = (s: string) =>
-        `@settings(defaultLengthUnit = ${s})`
-      const unitsIndicator = page.getByTestId('units-menu')
-      const unitsChangeButton = (name: string) =>
-        page.getByRole('button', { name, exact: true })
+        await test.step(`Check the sketch line color before`, async () => {
+          await expect
+            .poll(() =>
+              u.getGreatestPixDiff(sketchOriginLocation, darkThemeSegmentColor)
+            )
+            .toBeLessThan(15)
+        })
 
-      await context.folderSetupFn(async (dir) => {
-        const bracketDir = join(dir, 'project-000')
-        await fsp.mkdir(bracketDir, { recursive: true })
-        await fsp.copyFile(
-          executorInputPath('cube.kcl'),
-          join(bracketDir, 'main.kcl')
-        )
-      })
+        await test.step(`Change theme to light using command palette`, async () => {
+          await page.keyboard.press('ControlOrMeta+K')
+          await page.getByRole('option', { name: 'theme' }).click()
+          await page.getByRole('option', { name: 'light' }).click()
+          await expect(page.getByText('theme to "light"')).toBeVisible()
 
-      await test.step(`Initial units from settings are ignored`, async () => {
-        await homePage.openProject('project-000')
-        await expect(unitsIndicator).toHaveText(
-          'Default units for current filemm'
-        )
-      })
+          // Make sure we haven't left sketch mode
+          await expect(lineToolButton).toBeVisible()
+        })
 
-      await test.step(`Manually write inline settings`, async () => {
-        await editor.openPane()
-        await editor.replaceCode(
-          `fn cube`,
-          `${inlineSettingsString(initialInlineUnits)}
+        await test.step(`Check the sketch line color after`, async () => {
+          await expect
+            .poll(() =>
+              u.getGreatestPixDiff(sketchOriginLocation, lightThemeSegmentColor)
+            )
+            .toBeLessThan(15)
+        })
+      }
+    )
+
+    test(
+      `Changing system theme preferences (via media query) should update UI and stream`,
+      { tag: ['@macos', '@windows'] },
+      async ({ page, homePage, tronApp }) => {
+        if (!tronApp) throw new Error('tronApp is missing.')
+
+        await tronApp.cleanProjectDir({
+          // Override the settings so that the theme is set to `system`
+          ...TEST_SETTINGS_DEFAULT_THEME,
+        })
+
+        const u = await getUtils(page)
+
+        // Selectors and constants
+        const darkBackgroundCss = 'oklch(0.3012 0 264.48)'
+        const lightBackgroundCss = 'oklch(0.9911 0 264.48)'
+        const darkBackgroundColor: [number, number, number] = [50, 40, 51] // planes are on
+        const lightBackgroundColor: [number, number, number] = [227, 222, 230] // planes are on
+        const streamBackgroundPixelIsColor = async (
+          color: [number, number, number]
+        ) => {
+          return u.getGreatestPixDiff({ x: 1000, y: 200 }, color)
+        }
+        const toolbar = page.locator('menu').filter({ hasText: 'Start Sketch' })
+
+        await test.step(`Test setup`, async () => {
+          await page.setBodyDimensions({ width: 1200, height: 500 })
+          await homePage.goToModelingScene()
+          await u.waitForPageLoad()
+          await page.waitForTimeout(1000)
+          await expect(toolbar).toBeVisible()
+        })
+
+        await test.step(`Check the background color is light before`, async () => {
+          await expect(toolbar).toHaveCSS(
+            'background-color',
+            lightBackgroundCss
+          )
+          await expect
+            .poll(() => streamBackgroundPixelIsColor(lightBackgroundColor))
+            .toBeLessThan(15)
+        })
+
+        await test.step(`Change media query preference to dark, emulating dusk with system theme`, async () => {
+          await page.emulateMedia({ colorScheme: 'dark' })
+        })
+
+        await test.step(`Check the background color is dark after`, async () => {
+          await expect(toolbar).toHaveCSS('background-color', darkBackgroundCss)
+          await expect
+            .poll(() => streamBackgroundPixelIsColor(darkBackgroundColor))
+            .toBeLessThan(15)
+        })
+      }
+    )
+
+    test(
+      `Change inline units setting`,
+      { tag: ['@macos', '@windows'] },
+      async ({ page, homePage, context, editor }) => {
+        const initialInlineUnits = 'yd'
+        const editedInlineUnits = { short: 'mm', long: 'Millimeters' }
+        const inlineSettingsString = (s: string) =>
+          `@settings(defaultLengthUnit = ${s})`
+        const unitsIndicator = page.getByTestId('units-menu')
+        const unitsChangeButton = (name: string) =>
+          page.getByRole('button', { name, exact: true })
+
+        await context.folderSetupFn(async (dir) => {
+          const bracketDir = join(dir, 'project-000')
+          await fsp.mkdir(bracketDir, { recursive: true })
+          await fsp.copyFile(
+            executorInputPath('cube.kcl'),
+            join(bracketDir, 'main.kcl')
+          )
+        })
+
+        await test.step(`Initial units from settings are ignored`, async () => {
+          await homePage.openProject('project-000')
+          await expect(unitsIndicator).toHaveText(
+            'Default units for current filemm'
+          )
+        })
+
+        await test.step(`Manually write inline settings`, async () => {
+          await editor.openPane()
+          await editor.replaceCode(
+            `fn cube`,
+            `${inlineSettingsString(initialInlineUnits)}
 fn cube`
-        )
-        await expect(unitsIndicator).toContainText(initialInlineUnits)
-      })
+          )
+          await expect(unitsIndicator).toContainText(initialInlineUnits)
+        })
 
-      await test.step(`Change units setting via lower-right control`, async () => {
-        await unitsIndicator.click()
-        await unitsChangeButton(editedInlineUnits.long).click()
-        await expect(
-          page.getByText(`Updated per-file units to ${editedInlineUnits.short}`)
-        ).toBeVisible()
-      })
-    })
+        await test.step(`Change units setting via lower-right control`, async () => {
+          await unitsIndicator.click()
+          await unitsChangeButton(editedInlineUnits.long).click()
+          await expect(
+            page.getByText(
+              `Updated per-file units to ${editedInlineUnits.short}`
+            )
+          ).toBeVisible()
+        })
+      }
+    )
 
-    test(`Enable and disable inline experimental features`, async ({
-      page,
-      homePage,
-      context,
-      editor,
-      scene,
-      cmdBar,
-      toolbar,
-    }) => {
-      const initialCode = `startSketchOn(XY)`
-      await test.step('Settle the scene', async () => {
-        await context.addInitScript((initialCode) => {
-          localStorage.setItem('persistCode', initialCode)
-        }, initialCode)
-        await homePage.goToModelingScene()
-        await scene.settled(cmdBar)
-        await expect(toolbar.experimentalFeaturesMenu).not.toBeVisible()
-      })
+    test(
+      `Enable and disable inline experimental features`,
+      { tag: ['@macos', '@windows'] },
+      async ({ page, homePage, context, editor, scene, cmdBar, toolbar }) => {
+        const initialCode = `startSketchOn(XY)`
+        await test.step('Settle the scene', async () => {
+          await context.addInitScript((initialCode) => {
+            localStorage.setItem('persistCode', initialCode)
+          }, initialCode)
+          await homePage.goToModelingScene()
+          await scene.settled(cmdBar)
+          await expect(toolbar.experimentalFeaturesMenu).not.toBeVisible()
+        })
 
-      await test.step('Fire command to allow experimental features', async () => {
-        await cmdBar.openCmdBar()
-        await cmdBar.chooseCommand('Set experimental features flag')
-        await cmdBar.selectOption({ name: 'Allow' }).click()
-      })
+        await test.step('Fire command to allow experimental features', async () => {
+          await cmdBar.openCmdBar()
+          await cmdBar.chooseCommand('Set experimental features flag')
+          await cmdBar.selectOption({ name: 'Allow' }).click()
+        })
 
-      await test.step('Check that they are enabled', async () => {
-        await scene.settled(cmdBar)
-        await editor.expectEditor.toContain(
-          `@settings(experimentalFeatures = allow)
+        await test.step('Check that they are enabled', async () => {
+          await scene.settled(cmdBar)
+          await editor.expectEditor.toContain(
+            `@settings(experimentalFeatures = allow)
 ${initialCode}`,
-          { shouldNormalise: true }
-        )
-        await expect(toolbar.experimentalFeaturesMenu).toBeVisible()
-      })
+            { shouldNormalise: true }
+          )
+          await expect(toolbar.experimentalFeaturesMenu).toBeVisible()
+        })
 
-      await test.step('Use the indicator to turn them off', async () => {
-        await toolbar.experimentalFeaturesMenu.click()
-        await page.getByRole('button', { name: 'Deny' }).click()
-      })
+        await test.step('Use the indicator to turn them off', async () => {
+          await toolbar.experimentalFeaturesMenu.click()
+          await page.getByRole('button', { name: 'Deny' }).click()
+        })
 
-      await test.step('Check that they are disabled', async () => {
-        await scene.settled(cmdBar)
-        await editor.expectEditor.toContain(
-          `@settings(experimentalFeatures = deny)
+        await test.step('Check that they are disabled', async () => {
+          await scene.settled(cmdBar)
+          await editor.expectEditor.toContain(
+            `@settings(experimentalFeatures = deny)
 ${initialCode}`,
-          { shouldNormalise: true }
-        )
-        await expect(toolbar.experimentalFeaturesMenu).not.toBeVisible()
-      })
-    })
+            { shouldNormalise: true }
+          )
+          await expect(toolbar.experimentalFeaturesMenu).not.toBeVisible()
+        })
+      }
+    )
   }
 )


### PR DESCRIPTION
Despite no change to the settings logic, this test has been regularly blocking releases: https://test-analysis-bot.corp.zoo.dev/projects/KittyCAD/modeling-app/tests/366?platform=macos

There has been some discussion that this should really just be integration test of `setSettingsAtLevel()` and related functions. Because of that, I think we can stop testing on macOS and Windows.