### PR TITLE
ci: Add cargo deny workflow

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,0 +1,34 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+permissions:
+  packages: read
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+name: cargo deny
+jobs:
+  cargo-deny:
+    name: cargo deny
+    runs-on: namespace-profile-ubuntu-2-cores
+    steps:
+      - uses: actions/checkout@v6
+      - name: Use correct Rust toolchain
+        shell: bash
+        run: |
+          [ -e rust-toolchain.toml ] || cp rust/rust-toolchain.toml ./
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false # Configured below.
+          rustflags: '' # Use .cargo/config.toml
+
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          manifest-path: rust/Cargo.toml
+          command: check
+          arguments: --all-features
+          command-arguments:  --config rust/deny.toml advisories -D yanked

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -1,0 +1,6 @@
+[advisories]
+ignore = [
+  "RUSTSEC-2024-0320",
+  "RUSTSEC-2024-0436",
+  "RUSTSEC-2023-0089",
+]


### PR DESCRIPTION
https://github.com/EmbarkStudios/cargo-deny
https://github.com/marketplace/actions/cargo-deny

The ignored advisories are unmaintained crates.