### PR TITLE
fix: add hole::holes to stdLibMap for feature tree icon

### DIFF
--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -1976,6 +1976,11 @@ export const stdLibMap: Record<string, StdLibCallInfo> = {
     supportsAppearance: false,
     supportsTransform: true,
   },
+  'hole::holes': {
+    label: 'Holes',
+    icon: 'hole',
+    supportsAppearance: false,
+  },
   sketchSolve: {
     label: 'Solve Sketch',
     icon: 'sketch',


### PR DESCRIPTION
Fixes #9897. Added `hole::holes` entry to `stdLibMap` in `operations.ts` so the Holes operation displays the correct icon in the feature tree.