### PR TITLE
feat: add app font size setting

### DIFF
--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -224,6 +224,10 @@ export class App {
               context.textEditor.blinkingCursor.current
             )
           },
+          setAppFontSize: ({ context }) => {
+            const multiplier = context.app.appFontSize.current
+            document.documentElement.style.fontSize = `${multiplier * 100}%`
+          },
           setEngineHighlightEdges: ({ context }) => {
             engineCommandManager
               .setHighlightEdges(context.modeling.highlightEdges.current)

--- a/src/lib/settings/initialSettings.tsx
+++ b/src/lib/settings/initialSettings.tsx
@@ -334,6 +334,36 @@ export function createSettings() {
           )
         },
       }),
+      /**
+       * A multiplier for the app's base font size.
+       * 1.0 is the default; values like 1.25 or 1.5 make text larger,
+       * while 0.8 makes it smaller. Useful for users who need larger
+       * text without zooming the entire UI.
+       */
+      appFontSize: new Setting<number>({
+        defaultValue: 1.0,
+        description:
+          'A multiplier for the base font size of the app (e.g. 1.25 = 25% larger)',
+        validate: (v) =>
+          typeof v === 'number' && v >= 0.5 && v <= 3.0,
+        commandConfig: {
+          inputType: 'options',
+          defaultValueFromContext: (context) =>
+            context.app.appFontSize.current,
+          options: (cmdContext, settingsContext) =>
+            [0.5, 0.75, 0.875, 1.0, 1.125, 1.25, 1.5, 1.75, 2.0].map(
+              (v) => ({
+                name: `${v}x${v === 1.0 ? ' (default)' : ''}`,
+                value: v,
+                isCurrent:
+                  v ===
+                  settingsContext.app.appFontSize[
+                    cmdContext.argumentsToSubmit.level as SettingsLevel
+                  ],
+              })
+            ),
+        },
+      }),
       namedViews: new Setting<{ [key in string]: NamedView }>({
         defaultValue: {},
         validate: (_v) => true,

--- a/src/machines/settingsMachine.ts
+++ b/src/machines/settingsMachine.ts
@@ -234,6 +234,12 @@ export const settingsMachine = setup({
     setCursorBlinking: ({ context, self }) => {
       // Implementation moved to singletons.ts to provide necessary singletons.
     },
+    /**
+     * Update the root font-size based on the app.appFontSize multiplier.
+     */
+    setAppFontSize: ({ context }) => {
+      // Implementation moved to singletons.ts to provide necessary singletons.
+    },
     /** Unload the project-level setting values from memory */
     clearProjectSettings: assign(({ context }) => {
       // Peel off all non-settings context
@@ -412,6 +418,11 @@ export const settingsMachine = setup({
 
           actions: ['setSettingAtLevel', 'toastSuccess'],
         },
+        'set.app.appFontSize': {
+          target: 'persisting settings',
+
+          actions: ['setSettingAtLevel', 'setAppFontSize', 'toastSuccess'],
+        },
 
         'set.app.allowOrbitInSketchMode': {
           target: 'persisting settings',
@@ -454,6 +465,7 @@ export const settingsMachine = setup({
             'setEngineHighlightEdges',
             'setEditorLineWrapping',
             'setCursorBlinking',
+            'setAppFontSize',
             'setAllowOrbitInSketchMode',
             'sendThemeToWatcher',
             sendTo('registerCommands', ({ context }) => ({
@@ -474,6 +486,7 @@ export const settingsMachine = setup({
             'setEngineHighlightEdges',
             'setEditorLineWrapping',
             'setCursorBlinking',
+            'setAppFontSize',
             'setAllowOrbitInSketchMode',
             'sendThemeToWatcher',
             sendTo('registerCommands', ({ context }) => ({
@@ -555,6 +568,7 @@ export const settingsMachine = setup({
             'setEngineHighlightEdges',
             'setEditorLineWrapping',
             'setCursorBlinking',
+            'setAppFontSize',
             'setAllowOrbitInSketchMode',
             'sendThemeToWatcher',
             sendTo('registerCommands', ({ context }) => ({
@@ -592,6 +606,7 @@ export const settingsMachine = setup({
             'setEngineHighlightEdges',
             'setEditorLineWrapping',
             'setCursorBlinking',
+            'setAppFontSize',
             'setAllowOrbitInSketchMode',
             'sendThemeToWatcher',
             sendTo('registerCommands', ({ context }) => ({


### PR DESCRIPTION
Fixes #8077. Added `app.appFontSize` setting that allows users to adjust the application font size via the command palette. Supports scales from 0.5x to 2.0x.