### PR TITLE
Use the file token to fetch feature flags on desktop

### DIFF
--- a/src/lib/settings/initialSettings.tsx
+++ b/src/lib/settings/initialSettings.tsx
@@ -29,7 +29,7 @@ import { reportRejection } from '@src/lib/trap'
 import { isEnumMember } from '@src/lib/types'
 import { capitaliseFC, isArray, toSync } from '@src/lib/utils'
 import { createKCClient, kcCall } from '@src/lib/kcClient'
-import { getTokenFromEnvOrCookie } from '@src/machines/authMachine'
+import { getToken } from '@src/machines/authMachine'
 
 /**
  * A setting that can be set at the user or project level
@@ -152,9 +152,7 @@ function hideWithoutFeatureFlag(
 ): () => Promise<HideOnPlatformValue | null> {
   return async (): Promise<HideOnPlatformValue | null> => {
     try {
-      // Try to get a token - check env first, then cookie for web
-      const token = getTokenFromEnvOrCookie()
-
+      const token = await getToken()
       if (!token) {
         return defaultHide
       }

--- a/src/machines/authMachine.ts
+++ b/src/machines/authMachine.ts
@@ -256,16 +256,26 @@ export function getCookie(): string | null {
   }
 }
 
-/**
- * Get token from environment variable or cookie.
- * This is a synchronous utility function that can be used in both
- * React hooks and non-React contexts (like singleton initialization).
- * @returns The token string, or empty string if neither source has a token
- */
-export function getTokenFromEnvOrCookie(): string {
+function getTokenFromEnvOrCookie(): string {
   const envToken = env().VITE_ZOO_API_TOKEN
   const cookieToken = getCookie()
   return envToken || cookieToken || ''
+}
+
+async function getTokenFromFile(): Promise<string> {
+  const environmentName = env().VITE_ZOO_BASE_DOMAIN
+  if (!window.electron || !environmentName) return ''
+  return readEnvironmentConfigurationToken(window.electron, environmentName)
+}
+
+/**
+ * Get token from environment variable, cookie (web), or file (desktop).
+ * @returns The token string, or empty string if no source has a token
+ */
+export async function getToken(): Promise<string> {
+  const token = getTokenFromEnvOrCookie()
+  if (token) return token
+  return getTokenFromFile()
 }
 
 function getCookieByName(cname: string): string | null {


### PR DESCRIPTION
Fixes https://github.com/KittyCAD/modeling-app/issues/9939

---

# Testing

1. `unset VITE_ZOO_API_TOKEN`
2. `make run-desktop`
3. Log into `dev.zoo.dev`
4. Enable `new_sketch_mode` on the [Admin Dashboard](https://admin-dashboard-dev.hawk-dinosaur.ts.net/app/search?tab=user)
5. Open the User Settings in ZDS

## Before

We never fetch https://api.dev.zoo.dev/user/features and "Use New Sketch Mode" is absent from settings.

## After

The file token is used to fetch the available features flags and the "Use New Sketch Mode" setting is available.