### PR TITLE
fix: add hole::holes to stdLibMap for feature tree icon

### DIFF
--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -1979,7 +1979,6 @@ export const stdLibMap: Record<string, StdLibCallInfo> = {
   'hole::holes': {
     label: 'Holes',
     icon: 'hole',
-    supportsAppearance: false,
   },
   sketchSolve: {
     label: 'Solve Sketch',


### PR DESCRIPTION
From @jwchmodx. Recreating #10025

> Fixes #9897. Added hole::holes entry to stdLibMap in operations.ts so the Holes operation displays the correct icon in the feature tree.

Note that this allows selection and deletion of the operation in the feature tree. Point-and-click Create and Edit flows for multiple holes should be handled during https://github.com/KittyCAD/modeling-app/issues/9756 as sketch point references become the main way to locate holes.