### PR TITLE
Set filepicker type when exporting CAD files

### DIFF
--- a/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
+++ b/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
@@ -115,7 +115,8 @@ export const MlEphantConversationMenu = ({
                 void browserSaveFile(
                   blob,
                   `${context.conversationId ?? new Date().toISOString()}.md`,
-                  ''
+                  '',
+                  'md'
                 )
               }}
               className={styles.button}

--- a/src/lib/browserSaveFile.test.ts
+++ b/src/lib/browserSaveFile.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from 'vitest'
 import { getShowSaveFilePickerOptions } from '@src/lib/browserSaveFile'
 
 describe('getShowSaveFilePickerOptions', () => {
-  it('adds extension-constrained picker options when suggestedName has an extension', () => {
-    expect(getShowSaveFilePickerOptions('main.step')).toEqual({
+  it('uses the explicit file type passed by the caller', () => {
+    expect(getShowSaveFilePickerOptions('main.step', 'step')).toEqual({
       suggestedName: 'main.step',
       types: [
         {
@@ -18,9 +18,18 @@ describe('getShowSaveFilePickerOptions', () => {
     })
   })
 
-  it('only sets suggestedName when there is no extension', () => {
-    expect(getShowSaveFilePickerOptions('foo')).toEqual({
+  it('normalizes dotted and uppercase file types', () => {
+    expect(getShowSaveFilePickerOptions('foo', '.STeP')).toEqual({
       suggestedName: 'foo',
+      types: [
+        {
+          description: 'STEP files',
+          accept: {
+            'application/octet-stream': ['.step'],
+          },
+        },
+      ],
+      excludeAcceptAllOption: true,
     })
   })
 })

--- a/src/lib/browserSaveFile.ts
+++ b/src/lib/browserSaveFile.ts
@@ -5,39 +5,29 @@ import toast from 'react-hot-toast'
 
 import { EXPORT_TOAST_MESSAGES } from '@src/lib/constants'
 
-const getSuggestedExtension = (suggestedName: string): `.${string}` | null => {
-  const finalDotIndex = suggestedName.lastIndexOf('.')
-  if (finalDotIndex <= 0 || finalDotIndex === suggestedName.length - 1) {
-    return null
-  }
-
-  const ext = suggestedName.slice(finalDotIndex + 1).toLowerCase()
-  if (!ext) return null
-
-  return `.${ext}`
+const normalizeFileType = (fileType: string): `.${string}` => {
+  const trimmed = fileType.trim().toLowerCase().replace(/^\./, '')
+  const safeExt = trimmed || 'bin'
+  return `.${safeExt}`
 }
 
 export const getShowSaveFilePickerOptions = (
-  suggestedName: string
+  suggestedName: string,
+  fileType: string
 ): SaveFilePickerOptions => {
+  const extension = normalizeFileType(fileType)
   const options: SaveFilePickerOptions = {
     suggestedName,
-  }
-
-  const extension = getSuggestedExtension(suggestedName)
-  if (!extension) {
-    return options
-  }
-
-  options.types = [
-    {
-      description: `${extension.slice(1).toUpperCase()} files`,
-      accept: {
-        'application/octet-stream': [extension],
+    types: [
+      {
+        description: `${extension.slice(1).toUpperCase()} files`,
+        accept: {
+          'application/octet-stream': [extension],
+        },
       },
-    },
-  ]
-  options.excludeAcceptAllOption = true
+    ],
+    excludeAcceptAllOption: true,
+  }
 
   return options
 }
@@ -46,7 +36,8 @@ export const getShowSaveFilePickerOptions = (
 export const browserSaveFile = async (
   blob: Blob,
   suggestedName: string,
-  toastId: string
+  toastId: string,
+  fileType: string
 ) => {
   // Feature detection. The API needs to be supported
   // and the app not run in an iframe.
@@ -68,7 +59,7 @@ export const browserSaveFile = async (
     try {
       // Show the file save dialog.
       const handle = await window.showSaveFilePicker(
-        getShowSaveFilePickerOptions(suggestedName)
+        getShowSaveFilePickerOptions(suggestedName, fileType)
       )
       // Write the blob to the file.
       const writable = await handle.createWritable()

--- a/src/lib/exportDxf.spec.ts
+++ b/src/lib/exportDxf.spec.ts
@@ -188,7 +188,8 @@ describe('DXF Export', () => {
       expect(mockDeps.browserSaveFile).toHaveBeenCalledWith(
         expect.any(Blob),
         'sketch.dxf',
-        'toast-id'
+        'toast-id',
+        'dxf'
       )
     })
 
@@ -572,7 +573,8 @@ describe('DXF Export', () => {
       expect(mockDeps.browserSaveFile).toHaveBeenCalledWith(
         expect.any(Blob),
         'sketch.dxf', // Filename from sketch name, not from selected file
-        'toast-id'
+        'toast-id',
+        'dxf'
       )
     })
   })

--- a/src/lib/exportDxf.ts
+++ b/src/lib/exportDxf.ts
@@ -31,7 +31,8 @@ export async function exportSketchToDxf(
     browserSaveFile: (
       blob: Blob,
       filename: string,
-      toastId: string
+      toastId: string,
+      fileType: string
     ) => Promise<void>
   }
 ): Promise<boolean | Error> {
@@ -256,7 +257,7 @@ export async function exportSketchToDxf(
       const blob = new Blob([decodedData], {
         type: 'application/dxf',
       })
-      await browserSaveFile(blob, fileName, toastId)
+      await browserSaveFile(blob, fileName, toastId, 'dxf')
       return true
     }
   } catch (error: any) {

--- a/src/lib/exportSave.ts
+++ b/src/lib/exportSave.ts
@@ -5,6 +5,11 @@ import { browserSaveFile } from '@src/lib/browserSaveFile'
 import { EXPORT_TOAST_MESSAGES } from '@src/lib/constants'
 import type ModelingAppFile from '@src/lib/modelingAppFile'
 
+const getFileType = (fileName: string): string => {
+  const extension = fileName.split('.').pop()
+  return extension?.toLowerCase() || 'bin'
+}
+
 const save_ = async (file: ModelingAppFile, toastId: string) => {
   try {
     if (window.electron) {
@@ -67,7 +72,7 @@ const save_ = async (file: ModelingAppFile, toastId: string) => {
       // Create a new blob.
       const blob = new Blob([new Uint8Array(file.contents)])
       // Save the file.
-      await browserSaveFile(blob, file.name, toastId)
+      await browserSaveFile(blob, file.name, toastId, getFileType(file.name))
     }
   } catch (e) {
     // TODO: do something real with the error.


### PR DESCRIPTION
Alternate PR to https://github.com/KittyCAD/modeling-app/pull/10043.

Solves the same problem (we have to set a desired filetype on the file picker, when exporting files), but solves it a different way. It adds a new mandatory parameter to `browserSaveFile` function, for the file type.