### PR TITLE
[SOLVE]: Fix rect sketch outcome payload and type it

### DIFF
--- a/src/machines/sketchSolve/tools/rectTool.ts
+++ b/src/machines/sketchSolve/tools/rectTool.ts
@@ -137,10 +137,15 @@ export const machine = setup({
                 })
               }
 
-              self._parent?.send({
+              const sendData: SketchSolveMachineEvent = {
                 type: 'update sketch outcome',
-                data: { ...result, writeToDisk: false },
-              })
+                data: {
+                  sourceDelta: result.kclSource,
+                  sceneGraphDelta: result.sceneGraphDelta,
+                  writeToDisk: false,
+                },
+              }
+              self._parent?.send(sendData)
               await new Promise((resolve) => requestAnimationFrame(resolve))
             } catch (err) {
               console.error('failed to edit segment', err)
@@ -397,7 +402,10 @@ export const machine = setup({
         finalize: {
           actions: [
             ({ self }) => {
-              self._parent?.send({ type: 'clear draft entities' })
+              const sendData: SketchSolveMachineEvent = {
+                type: 'clear draft entities',
+              }
+              self._parent?.send(sendData)
             },
             assign({
               origin: [0, 0],


### PR DESCRIPTION
Type parent sends with `SketchSolveMachineEvent` in sketch solve tools. Use a typed variable before `_parent?.send(...)` so event type changes surface as TSC errors at the send site (since `_parent?.send` is untyped).

- `rectTool.ts`: two sends updated — "update sketch outcome" in add second point listener (typed `sendData` with `sourceDelta`/`sceneGraphDelta` from result) and "clear draft entities" in awaiting third point finalize.
- Already using the pattern: `trimToolDiagram.ts`, `pointTool.ts`, `lineToolImpl.ts`, `lineToolDiagram.ts`, `centerArcToolImpl.ts`, `centerArcToolDiagram.ts`.

