### PR TITLE
KCL: Fix typo in deleteFace

### DIFF
--- a/rust/kcl-lib/src/std/surfaces.rs
+++ b/rust/kcl-lib/src/std/surfaces.rs
@@ -138,7 +138,7 @@ async fn inner_delete_face(
     // User has to give us SOMETHING to delete.
     if tagged_faces.is_none() && face_indices.is_none() {
         return Err(KclError::new_semantic(KclErrorDetails::new(
-            "You must use either the `faces` or the `face_indices` parameter".to_string(),
+            "You must use either the `faces` or the `faceIndices` parameter".to_string(),
             vec![args.source_range],
         )));
     }


### PR DESCRIPTION
Error message suggested an argument with the wrong case. `face_indices` is the name of the Rust arg but it's not the name of the KCL arg. That is `faceIndices`.