### PR TITLE
Try to deflake settings rest E2E test by removing interactions

### DIFF
--- a/e2e/playwright/testing-settings.spec.ts
+++ b/e2e/playwright/testing-settings.spec.ts
@@ -21,7 +21,7 @@ import {
 } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 import type { Page } from '@playwright/test'
-import { UnitLength } from '@kittycad/lib/dist/types/src'
+import type { UnitLength } from '@kittycad/lib/dist/types/src'
 import { uuidv4 } from '@src/lib/utils'
 
 const settingsSwitchTab = (page: Page) => async (tab: 'user' | 'proj') => {


### PR DESCRIPTION
I suspect that this E2E test is so unreliable because it attempts to very rapidly set settings through the UI at the user level, the project level, then the user level again. We do not have a good file write queue system yet, so that kind of faster-than-human interaction, can lead to conflicting writes if timed just right (our file system watcher loop is 1 second at the moment). This avoids that issue in the test by removing all unnecessary manipulations of the settings, leaving mostly reads.

I ended up splitting the test in two and loading settings in before the test so that fewer interactions were needed, but there is still a flake somewhere. It seems that reseting the setting at each level can truly just not take effect sometimes, and needs to be reworked. I would believe that, since I made them dumb XState actions. 9/100 of the two tests failed locally, still improving quite a bit by my estimate.
<img width="2736" height="686" alt="Screenshot 2026-02-17 at 12 34 48 PM" src="https://github.com/user-attachments/assets/4aa2aa1f-fbb3-4835-a9fb-c57b370b2980" />
