### PR TITLE
Fix edit_sketch when there's an execution error

### DIFF
--- a/rust/kcl-lib/src/errors.rs
+++ b/rust/kcl-lib/src/errors.rs
@@ -1,17 +1,23 @@
+#[cfg(feature = "artifact-graph")]
+use std::collections::BTreeMap;
+
 use indexmap::IndexMap;
 pub use kcl_error::{CompilationError, Severity, Suggestion, Tag};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
 
-#[cfg(feature = "artifact-graph")]
-use crate::execution::{ArtifactCommand, ArtifactGraph, Operation};
 use crate::{
     ModuleId, SourceRange,
     exec::KclValue,
     execution::DefaultPlanes,
     lsp::{IntoDiagnostic, ToLspRange},
     modules::{ModulePath, ModuleSource},
+};
+#[cfg(feature = "artifact-graph")]
+use crate::{
+    execution::{ArtifactCommand, ArtifactGraph, Operation},
+    front::{Number, Object, ObjectId},
 };
 
 mod details;
@@ -152,6 +158,16 @@ pub struct KclErrorWithOutputs {
     pub _artifact_commands: Vec<ArtifactCommand>,
     #[cfg(feature = "artifact-graph")]
     pub artifact_graph: ArtifactGraph,
+    #[cfg(feature = "artifact-graph")]
+    #[serde(skip)]
+    pub scene_objects: Vec<Object>,
+    #[cfg(feature = "artifact-graph")]
+    #[serde(skip)]
+    pub source_range_to_object: BTreeMap<SourceRange, ObjectId>,
+    #[cfg(feature = "artifact-graph")]
+    #[serde(skip)]
+    pub var_solutions: Vec<(SourceRange, Number)>,
+    pub scene_graph: Option<crate::front::SceneGraph>,
     pub filenames: IndexMap<ModuleId, ModulePath>,
     pub source_files: IndexMap<ModuleId, ModuleSource>,
     pub default_planes: Option<DefaultPlanes>,
@@ -166,6 +182,9 @@ impl KclErrorWithOutputs {
         #[cfg(feature = "artifact-graph")] operations: Vec<Operation>,
         #[cfg(feature = "artifact-graph")] artifact_commands: Vec<ArtifactCommand>,
         #[cfg(feature = "artifact-graph")] artifact_graph: ArtifactGraph,
+        #[cfg(feature = "artifact-graph")] scene_objects: Vec<Object>,
+        #[cfg(feature = "artifact-graph")] source_range_to_object: BTreeMap<SourceRange, ObjectId>,
+        #[cfg(feature = "artifact-graph")] var_solutions: Vec<(SourceRange, Number)>,
         filenames: IndexMap<ModuleId, ModulePath>,
         source_files: IndexMap<ModuleId, ModuleSource>,
         default_planes: Option<DefaultPlanes>,
@@ -180,6 +199,13 @@ impl KclErrorWithOutputs {
             _artifact_commands: artifact_commands,
             #[cfg(feature = "artifact-graph")]
             artifact_graph,
+            #[cfg(feature = "artifact-graph")]
+            scene_objects,
+            #[cfg(feature = "artifact-graph")]
+            source_range_to_object,
+            #[cfg(feature = "artifact-graph")]
+            var_solutions,
+            scene_graph: Default::default(),
             filenames,
             source_files,
             default_planes,
@@ -196,6 +222,13 @@ impl KclErrorWithOutputs {
             _artifact_commands: Default::default(),
             #[cfg(feature = "artifact-graph")]
             artifact_graph: Default::default(),
+            #[cfg(feature = "artifact-graph")]
+            scene_objects: Default::default(),
+            #[cfg(feature = "artifact-graph")]
+            source_range_to_object: Default::default(),
+            #[cfg(feature = "artifact-graph")]
+            var_solutions: Default::default(),
+            scene_graph: Default::default(),
             filenames: Default::default(),
             source_files: Default::default(),
             default_planes: Default::default(),

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -568,6 +568,12 @@ impl ExecState {
             Default::default(),
             #[cfg(feature = "artifact-graph")]
             self.global.artifacts.graph.clone(),
+            #[cfg(feature = "artifact-graph")]
+            self.global.root_module_artifacts.scene_objects.clone(),
+            #[cfg(feature = "artifact-graph")]
+            self.global.root_module_artifacts.source_range_to_object.clone(),
+            #[cfg(feature = "artifact-graph")]
+            self.global.root_module_artifacts.var_solutions.clone(),
             module_id_to_module_path,
             self.global.id_to_source.clone(),
             default_planes,

--- a/rust/kcl-lib/src/frontend/api.rs
+++ b/rust/kcl-lib/src/frontend/api.rs
@@ -19,7 +19,7 @@ pub trait LifecycleApi {
     async fn refresh(&self, project: ProjectId) -> Result<()>;
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, ts_rs::TS)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, ts_rs::TS)]
 #[ts(export, export_to = "FrontendApi.ts")]
 pub struct SceneGraph {
     pub project: ProjectId,

--- a/rust/kcl-lib/src/lib.rs
+++ b/rust/kcl-lib/src/lib.rs
@@ -157,7 +157,7 @@ pub mod front {
     pub(crate) use crate::frontend::modify::{find_defined_names, next_free_name_using_max};
     // Re-export trim module items
     pub use crate::frontend::{
-        FrontendState,
+        FrontendState, SetProgramOutcome,
         api::{
             Error, Expr, Face, File, FileId, LifecycleApi, Number, Object, ObjectId, ObjectKind, Plane, ProjectId,
             Result, SceneGraph, SceneGraphDelta, Settings, SourceDelta, SourceRef, Version,

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -583,33 +583,40 @@ export class KclManager extends EventTarget {
       try {
         if (this.modelingState?.matches('sketchSolveMode')) {
           await this.executeCode(newCode)
-          const { sceneGraph, execOutcome } =
+          const setProgramOutcome =
             await this.singletons.rustContext.hackSetProgram(
               this.ast,
               await jsAppSettings(this.singletons.rustContext.settingsActor)
             )
 
-          // Convert SceneGraph to SceneGraphDelta and send to sketch solve machine
-          // Always invalidate IDs for direct edits since we don't know what the user changed
-          const sceneGraphDelta: SceneGraphDelta = {
-            new_graph: sceneGraph,
-            new_objects: [],
-            invalidates_ids: true,
-            exec_outcome: execOutcome,
-          }
+          if (setProgramOutcome.type === 'Success') {
+            // Convert SceneGraph to SceneGraphDelta and send to sketch solve machine
+            // Always invalidate IDs for direct edits since we don't know what the user changed
+            const sceneGraphDelta: SceneGraphDelta = {
+              new_graph: setProgramOutcome.sceneGraph,
+              new_objects: [],
+              invalidates_ids: true,
+              exec_outcome: setProgramOutcome.execOutcome,
+            }
 
-          const kclSource: SourceDelta = {
-            text: newCode,
-          }
+            const kclSource: SourceDelta = {
+              text: newCode,
+            }
 
-          // Send event to sketch solve machine via modeling machine
-          this.sendModelingEvent({
-            type: 'update sketch outcome',
-            data: {
-              kclSource,
-              sceneGraphDelta,
-            },
-          })
+            // Send event to sketch solve machine via modeling machine
+            this.sendModelingEvent({
+              type: 'update sketch outcome',
+              data: {
+                kclSource,
+                sceneGraphDelta,
+              },
+            })
+          } else {
+            console.debug(
+              'Error when executing after user edit:',
+              setProgramOutcome
+            )
+          }
         } else {
           await this.executeCode(newCode)
           if (shouldResetCamera) {

--- a/src/lib/rustContext.ts
+++ b/src/lib/rustContext.ts
@@ -14,9 +14,9 @@ import type {
   ApiProjectId,
   ApiVersion,
   ExistingSegmentCtor,
-  SceneGraph,
   SceneGraphDelta,
   SegmentCtor,
+  SetProgramOutcome,
   SketchCtor,
   SourceDelta,
 } from '@rust/kcl-lib/bindings/FrontendApi'
@@ -38,7 +38,6 @@ import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 
 import type { ConnectionManager } from '@src/network/connectionManager'
 import { Signal } from '@src/lib/signal'
-import type { ExecOutcome } from '@rust/kcl-lib/bindings/ExecOutcome'
 import type { SettingsActorType } from '@src/machines/settingsMachine'
 
 export default class RustContext {
@@ -295,21 +294,15 @@ export default class RustContext {
   async hackSetProgram(
     program_ast: Node<Program>,
     settings: DeepPartial<Configuration>
-  ): Promise<{
-    sceneGraph: SceneGraph
-    execOutcome: ExecOutcome
-  }> {
+  ): Promise<SetProgramOutcome> {
     const instance = await this._checkContextInstance()
 
     try {
-      const result: [SceneGraph, ExecOutcome] = await instance.hack_set_program(
+      const result: SetProgramOutcome = await instance.hack_set_program(
         JSON.stringify(program_ast),
         JSON.stringify(settings)
       )
-      return {
-        sceneGraph: result[0],
-        execOutcome: result[1],
-      }
+      return result
     } catch (e: any) {
       // TODO: sketch-api: const err = errFromErrWithOutputs(e)
       const err = { message: e }

--- a/src/machines/sketchSolve/tools/trimToolImpl.spec.ts
+++ b/src/machines/sketchSolve/tools/trimToolImpl.spec.ts
@@ -131,17 +131,19 @@ async function executeTrimFlow({
 }): Promise<{ sourceDelta: { text: string } } | Error> {
   // Parse and execute initial KCL code
   const ast = assertParse(kclCode, instanceInThisFile)
-  const { sceneGraph, execOutcome } =
-    await rustContextInThisFile.hackSetProgram(
-      ast,
-      await jsAppSettings(rustContextInThisFile.settingsActor)
-    )
+  const setProgramOutcome = await rustContextInThisFile.hackSetProgram(
+    ast,
+    await jsAppSettings(rustContextInThisFile.settingsActor)
+  )
+  if (setProgramOutcome.type !== 'Success') {
+    return new Error(setProgramOutcome.error.error.details.msg)
+  }
 
   const initialSceneGraphDelta: SceneGraphDelta = {
-    new_graph: sceneGraph,
+    new_graph: setProgramOutcome.sceneGraph,
     new_objects: [],
     invalidates_ids: false,
-    exec_outcome: execOutcome,
+    exec_outcome: setProgramOutcome.execOutcome,
   }
 
   // Track the last result to return it


### PR DESCRIPTION
Fixes #10015.

The frontend calls `hackSetProgram()` and then `editSketch()`. Setting the program must execute the program. Currently, if there's an execution error, it can't run `editSketch()`.

Before, when we did an engine execution, we only cached previous memory on success. With this PR, we always cache as much as we can so that scene objects are available for sketch mode (mock) execution afterwards. I'm not sure if there are unintended consequences of this.

The new contract of `hackSetProgram()` is that an execution error isn't fatal. It still returns a value if it was able to do its best to update state based on the new program.