### PR TITLE
Suggest a pipe expression after an expression and whitespace

### DIFF
--- a/packages/codemirror-lsp-client/src/plugin/autocomplete.ts
+++ b/packages/codemirror-lsp-client/src/plugin/autocomplete.ts
@@ -3,16 +3,18 @@ import {
   autocompletion,
   clearSnippet,
   closeCompletion,
+  completionStatus,
   hasNextSnippetField,
   moveCompletionSelection,
   nextSnippetField,
   prevSnippetField,
   startCompletion,
 } from '@codemirror/autocomplete'
+import { insertNewlineAndIndent } from '@codemirror/commands'
 import type { CompletionContext } from '@codemirror/autocomplete'
 import { syntaxTree } from '@codemirror/language'
 import type { Extension } from '@codemirror/state'
-import { Prec } from '@codemirror/state'
+import { Prec, Transaction } from '@codemirror/state'
 import type { EditorView, KeyBinding, ViewPlugin } from '@codemirror/view'
 import { keymap } from '@codemirror/view'
 import {
@@ -41,7 +43,36 @@ const lspAutocompleteKeymap: readonly KeyBinding[] = [
   { key: 'ArrowUp', run: moveCompletionSelection(false) },
   { key: 'PageDown', run: moveCompletionSelection(true, 'page') },
   { key: 'PageUp', run: moveCompletionSelection(false, 'page') },
-  { key: 'Enter', run: acceptCompletion },
+  {
+    key: 'Enter',
+    run: (view: EditorView): boolean => {
+      if (completionStatus(view.state) === 'active') {
+        return acceptCompletion(view)
+      }
+
+      if (!insertNewlineAndIndent(view)) {
+        return false
+      }
+
+      // Enter dispatches `input`, but CodeMirror's autocomplete activation
+      // listens for `input.type`. Dispatch a follow-up event so completion
+      // sources can run at the new cursor position.
+      view.dispatch({
+        annotations: Transaction.userEvent.of('input.type'),
+      })
+      return true
+    },
+    shift: (view: EditorView): boolean => {
+      if (!insertNewlineAndIndent(view)) {
+        return false
+      }
+
+      view.dispatch({
+        annotations: Transaction.userEvent.of('input.type'),
+      })
+      return true
+    },
+  },
   {
     key: 'Tab',
     run: (view: EditorView): boolean => {

--- a/packages/codemirror-lsp-client/tsconfig.json
+++ b/packages/codemirror-lsp-client/tsconfig.json
@@ -6,6 +6,7 @@
     "target": "esnext",
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "commonjs",
+    "types": ["node"],
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,


### PR DESCRIPTION
Derived from https://docs.google.com/document/d/1zHn-2M7jDgMawaXtlGA2goXzL9ezuEO9OYUF7qxbmoI/edit?tab=t.0 .
Codex had a hard time figuring out why indentation & newline did not trigger the suggestion. After feeding it CodeMirror repositories, it had no problem.

Total human-time on this was about 20 minutes for initial specification & 20 minutes of additional fixups.

Codex usually finished any request in < 5 minutes.