### PR TITLE
Adjust Playwright timeouts to match actual needs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -117,7 +117,7 @@ jobs:
         with:
           shell: bash
           command: npm run test:snapshots
-          timeout_minutes: 5
+          timeout_minutes: 15
           max_attempts: 5
         env:
           VITE_ZOO_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
@@ -262,7 +262,7 @@ jobs:
         with:
           shell: bash
           command: npm run test:e2e:web
-          timeout_minutes: 5
+          timeout_minutes: 15
           max_attempts: 5
         env:
           VITE_ZOO_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
@@ -402,8 +402,8 @@ jobs:
         with:
           shell: bash
           command: .github/ci-cd-scripts/playwright-electron.sh ${{matrix.shardIndex}} ${{matrix.shardTotal}} ${{ env.OS_NAME }}
-          timeout_minutes: 30
-          max_attempts: 9
+          timeout_minutes: 15
+          max_attempts: 5
         env:
           FAIL_ON_CONSOLE_ERRORS: true
           VITE_ZOO_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}


### PR DESCRIPTION
We're doing more web end-to-end testing now so that timeout can be increased. The desktop end-to-end timeout/retries is likely excessive based on recent behavior.

---


Relates to https://github.com/KittyCAD/modeling-app/issues/10081