### PR TITLE
Fix cargo publish warnings about missing docs

### DIFF
--- a/rust/kcl-error/Cargo.toml
+++ b/rust/kcl-error/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.126"
 edition = "2024"
 description = "KCL error definitions"
 license = "MIT"
+repository = "https://github.com/KittyCAD/modeling-app"
 
 [dependencies]
 miette = { workspace = true }

--- a/rust/kcl-test-server/Cargo.toml
+++ b/rust/kcl-test-server/Cargo.toml
@@ -4,6 +4,7 @@ description = "A test server for KCL"
 version = "0.1.126"
 edition = "2021"
 license = "MIT"
+repository = "https://github.com/KittyCAD/modeling-app"
 
 [lib]
 bench = false


### PR DESCRIPTION
The last cargo publish, I got this message.

```
warning: manifest has no documentation, homepage or repository
  |
  = note: see https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info
```