### PR TITLE
Fix unbounded performance mark accumulation causing periodic CPU spikes

### DIFF
--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -161,6 +161,7 @@ export async function maybeWriteToDisk(electron: IElectronAPI) {
   if (args.telemetry) {
     setInterval(() => {
       const marks = getMarks()
+      performance.clearMarks()
       const deltaTotalTable = printDeltaTotal(marks)
       writeTelemetryFile(electron, deltaTotalTable.join('\n'))
         .then(() => {})


### PR DESCRIPTION
Clear performance marks after each telemetry flush so the buffer stays bounded. Previously getMarks() returned every mark since app start, making each 5-second tick process and write an ever-growing dataset.

----

Opus has great reasoning why this is more obvious on Windows, but present on all systems. It's Windows Defender looking at massive file writes to the disk. I now know why I didn't see the issue, it's because of my inexperience around the heap analytic tool. While I used it, it was not obvious to spot the massively growing performance mark array.