### PR TITLE
Revert "Migrate `settings` items out of singletons, into `app.settings`"

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -45,10 +45,13 @@ const createRouter = isDesktop() ? createHashRouter : createBrowserRouter
  * @returns RouterProvider
  */
 export const Router = () => {
-  const { settings } = useApp()
-  const { engineCommandManager, kclManager, rustContext, systemIOActor } =
-    useSingletons()
-  const settingsActor = settings.actor
+  const {
+    engineCommandManager,
+    kclManager,
+    rustContext,
+    settingsActor,
+    systemIOActor,
+  } = useSingletons()
   const networkStatus = useNetworkStatus(engineCommandManager)
   const router = useMemo(
     () =>

--- a/src/clientSideScene/CameraControls.ts
+++ b/src/clientSideScene/CameraControls.ts
@@ -166,12 +166,7 @@ export class CameraControls {
     return ndc.unproject(camera || this.camera)
   }
 
-  get engineCameraProjection(): CameraProjectionType {
-    return this.camera instanceof OrthographicCamera
-      ? 'orthographic'
-      : 'perspective'
-  }
-  set engineCameraProjection(projection: CameraProjectionType) {
+  setEngineCameraProjection(projection: CameraProjectionType) {
     if (projection === 'orthographic') {
       this.useOrthographicCamera()
     } else {

--- a/src/components/CommandBar/CommandBarKclInput.tsx
+++ b/src/components/CommandBar/CommandBarKclInput.tsx
@@ -70,14 +70,14 @@ function CommandBarKclInput({
   stepBack: () => void
   onSubmit: (event: unknown) => void
 }) {
-  const { commands, settings } = useApp()
-  const { kclManager, rustContext } = useSingletons()
+  const { commands } = useApp()
+  const { kclManager, rustContext, useSettings } = useSingletons()
   const wasmInstance = use(kclManager.wasmInstancePromise)
   const commandBarState = commands.useState()
   const previouslySetValue = commandBarState.context.argumentsToSubmit[
     arg.name
   ] as KclCommandValue | undefined
-  const settingsValues = settings.useSettings()
+  const settings = useSettings()
   const {
     context: { selectionRanges },
   } = useModelingContext()
@@ -239,10 +239,10 @@ function CommandBarKclInput({
   useEffect(() => {
     miniEditor.dispatch({
       effects: themeCompartment.reconfigure(
-        editorTheme[getResolvedTheme(settingsValues.app.theme.current)]
+        editorTheme[getResolvedTheme(settings.app.theme.current)]
       ),
     })
-  }, [settingsValues.app.theme])
+  }, [settings.app.theme])
 
   useEffect(() => {
     if (editorRef.current) {

--- a/src/components/ConnectionStream.tsx
+++ b/src/components/ConnectionStream.tsx
@@ -1,7 +1,7 @@
 import type { MouseEventHandler } from 'react'
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { ClientSideScene } from '@src/clientSideScene/ClientSideSceneComp'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useSingletons } from '@src/lib/boot'
 import { ViewControlContextMenu } from '@src/components/ViewControlMenu'
 import { btnName } from '@src/lib/cameraControls'
 import { err, reportRejection } from '@src/lib/trap'
@@ -36,12 +36,12 @@ const TIME_TO_CONNECT = 30_000
 export const ConnectionStream = (props: {
   authToken: string | undefined
 }) => {
-  const { settings } = useApp()
-  const { engineCommandManager, kclManager, sceneInfra } = useSingletons()
+  const { engineCommandManager, kclManager, sceneInfra, useSettings } =
+    useSingletons()
   const [showManualConnect, setShowManualConnect] = useState(false)
   const isIdle = useRef(false)
   const [isSceneReady, setIsSceneReady] = useState(false)
-  const settingsValues = settings.useSettings()
+  const settings = useSettings()
   const { setAppState } = useAppState()
   const { overallState } = useNetworkContext()
   const { state: modelingMachineState, send: modelingSend } =
@@ -60,22 +60,22 @@ export const ConnectionStream = (props: {
     useTryConnect()
   const settingsEngine: SettingsViaQueryString = useMemo(
     () => ({
-      theme: settingsValues.app.theme.current,
-      enableSSAO: settingsValues.modeling.enableSSAO.current,
-      highlightEdges: settingsValues.modeling.highlightEdges.current,
-      showScaleGrid: settingsValues.modeling.showScaleGrid.current,
-      cameraProjection: settingsValues.modeling.cameraProjection.current,
-      cameraOrbit: settingsValues.modeling.cameraOrbit.current,
+      theme: settings.app.theme.current,
+      enableSSAO: settings.modeling.enableSSAO.current,
+      highlightEdges: settings.modeling.highlightEdges.current,
+      showScaleGrid: settings.modeling.showScaleGrid.current,
+      cameraProjection: settings.modeling.cameraProjection.current,
+      cameraOrbit: settings.modeling.cameraOrbit.current,
       backfaceColor: DEFAULT_BACKFACE_COLOR,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
-      settingsValues.app.theme.current,
-      settingsValues.modeling.enableSSAO.current,
-      settingsValues.modeling.highlightEdges.current,
-      settingsValues.modeling.showScaleGrid.current,
-      settingsValues.modeling.cameraProjection.current,
-      settingsValues.modeling.cameraOrbit.current,
+      settings.app.theme.current,
+      settings.modeling.enableSSAO.current,
+      settings.modeling.highlightEdges.current,
+      settings.modeling.showScaleGrid.current,
+      settings.modeling.cameraProjection.current,
+      settings.modeling.cameraOrbit.current,
     ]
   )
   const safariObjectFitClass = useMemo(() => {
@@ -407,12 +407,12 @@ export const ConnectionStream = (props: {
   const style = useMemo(
     () => ({
       backgroundColor:
-        getResolvedTheme(settingsValues.app.theme.current) === Themes.Light
+        getResolvedTheme(settings.app.theme.current) === Themes.Light
           ? 'rgb(250, 250, 250)'
           : 'rgb(30, 30, 30)',
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [settingsValues.app.theme.current]
+    [settings.app.theme.current]
   )
 
   const viewControlContextMenuGuard: (e: MouseEvent) => boolean = useCallback(
@@ -453,10 +453,8 @@ export const ConnectionStream = (props: {
         No canvas support
       </canvas>
       <ClientSideScene
-        cameraControls={settingsValues.modeling.mouseControls.current}
-        enableTouchControls={
-          settingsValues.modeling.enableTouchControls.current
-        }
+        cameraControls={settings.modeling.mouseControls.current}
+        enableTouchControls={settings.modeling.enableTouchControls.current}
       />
       <ViewControlContextMenu
         event="mouseup"

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -34,7 +34,7 @@ import {
   toArchivePath,
 } from '@src/lib/paths'
 import type { FileEntry, Project } from '@src/lib/project'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useSingletons } from '@src/lib/boot'
 import type { MaybePressOrBlur } from '@src/lib/types'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -181,12 +181,10 @@ export const ProjectExplorer = ({
   canNavigate: boolean
   overrideApplicationProjectDirectory?: string
 }) => {
-  const { settings } = useApp()
-  const { kclManager, systemIOActor } = useSingletons()
+  const { kclManager, systemIOActor, useSettings } = useSingletons()
   const errors = kclManager.errorsSignal.value
-  const settingsValues = settings.useSettings()
-  const applicationProjectDirectory =
-    settingsValues.app.projectDirectory.current
+  const settings = useSettings()
+  const applicationProjectDirectory = settings.app.projectDirectory.current
 
   /**
    * Read the file you are loading into and open all of the parent paths to that file

--- a/src/components/HelpMenu.tsx
+++ b/src/components/HelpMenu.tsx
@@ -7,7 +7,7 @@ import { isDesktop } from '@src/lib/isDesktop'
 import { onboardingStartPath } from '@src/lib/onboardingPaths'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
 import { PATHS } from '@src/lib/paths'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useSingletons } from '@src/lib/boot'
 import { reportRejection } from '@src/lib/trap'
 import { withSiteBaseURL } from '@src/lib/withBaseURL'
 import type { WebContentSendPayload } from '@src/menu/channels'
@@ -23,8 +23,7 @@ const HelpMenuDivider = () => (
 )
 
 export function HelpMenu() {
-  const { settings } = useApp()
-  const { kclManager, systemIOActor } = useSingletons()
+  const { kclManager, systemIOActor, settingsActor } = useSingletons()
   const navigate = useNavigate()
   const location = useLocation()
   const filePath = useAbsoluteFilePath()
@@ -35,7 +34,7 @@ export function HelpMenu() {
       navigate,
       kclManager,
       systemIOActor,
-      settingsActor: settings.actor,
+      settingsActor,
     }
     acceptOnboarding(props).catch((reason) =>
       catchOnboardingWarnError(reason, props)

--- a/src/components/KclInput.tsx
+++ b/src/components/KclInput.tsx
@@ -8,7 +8,7 @@ import { Compartment, EditorState } from '@codemirror/state'
 import { use, useEffect, useRef } from 'react'
 import { editorTheme } from '@src/editor/plugins/theme'
 import { getResolvedTheme } from '@src/lib/theme'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useSingletons } from '@src/lib/boot'
 import { parse, resultIsOk } from '@src/lang/wasm'
 import { err } from '@src/lib/trap'
 import { varMentions } from '@src/lib/varCompletionExtension'
@@ -23,9 +23,8 @@ export function KclInput(props: {
   onCancel: () => void
   style?: React.CSSProperties
 }) {
-  const { settings: settingsSystem } = useApp()
-  const { rustContext, kclManager } = useSingletons()
-  const settings = settingsSystem.useSettings()
+  const { useSettings, rustContext, kclManager } = useSingletons()
+  const settings = useSettings()
   const wasmInstance = use(rustContext.wasmInstancePromise)
 
   const variables = kclManager.variablesSignal.value

--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -61,7 +61,7 @@ export const ModelingMachineProvider = ({
 }: {
   children: React.ReactNode
 }) => {
-  const { commands, settings } = useApp()
+  const { commands } = useApp()
   const {
     engineCommandManager,
     getLayout,
@@ -70,8 +70,9 @@ export const ModelingMachineProvider = ({
     sceneEntitiesManager,
     sceneInfra,
     setLayout,
+    settingsActor,
+    useSettings,
   } = useSingletons()
-  const settingsActor = settings.actor
   const systemDeps = useMemo(
     () => ({
       sceneInfra,
@@ -82,7 +83,6 @@ export const ModelingMachineProvider = ({
     [sceneInfra, rustContext, sceneEntitiesManager, commands.actor]
   )
   const wasmInstance = use(kclManager.wasmInstancePromise)
-  const settingsValues = settings.useSettings()
   const {
     app: { allowOrbitInSketchMode },
     modeling: {
@@ -92,7 +92,7 @@ export const ModelingMachineProvider = ({
       useNewSketchMode,
       snapToGrid,
     },
-  } = settingsValues
+  } = useSettings()
   const previousCameraOrbit = useRef<CameraOrbitType | null>(null)
   const loaderData = useLoaderData<IndexLoaderData>()
   const projects = useFolders()

--- a/src/components/ModelingPageProvider.tsx
+++ b/src/components/ModelingPageProvider.tsx
@@ -13,15 +13,6 @@ import { useApp, useSingletons } from '@src/lib/boot'
 import { type IndexLoaderData } from '@src/lib/types'
 import { modelingMenuCallbackMostActions } from '@src/menu/register'
 import { createStandardViewsCommands } from '@src/lib/commandBarConfigs/standardViewsConfig'
-import type { SaveSettingsPayload } from '@src/lib/settings/settingsTypes'
-import { reportRejection } from '@src/lib/trap'
-import { getOppositeTheme, getResolvedTheme } from '@src/lib/theme'
-import type { SnapshotFrom } from 'xstate'
-import {
-  getOnlySettingsFromContext,
-  type SettingsActorType,
-} from '@src/machines/settingsMachine'
-import { getAllCurrentSettings } from '@src/lib/settings/settingsUtils'
 
 /**
  * FileMachineProvider moved to ModelingPageProvider.
@@ -34,21 +25,21 @@ export const ModelingPageProvider = ({
 }: {
   children: React.ReactNode
 }) => {
-  const { auth, commands, settings, lastSettings } = useApp()
+  const { auth, commands } = useApp()
   const {
     engineCommandManager,
     kclManager,
     rustContext,
     sceneInfra,
     systemIOActor,
-    sceneEntitiesManager,
+    useSettings,
+    settingsActor,
   } = useSingletons()
   const wasmInstance = use(kclManager.wasmInstancePromise)
   const navigate = useNavigate()
   const location = useLocation()
   const token = auth.useToken()
-  const settingsValues = settings.useSettings()
-  const settingsActor = settings.actor
+  const settings = useSettings()
   const projectData = useRouteLoaderData(PATHS.FILE) as IndexLoaderData
   const { project, file } = projectData
 
@@ -152,7 +143,7 @@ export const ModelingPageProvider = ({
     kclManager,
     navigate,
     sceneInfra,
-    settings: settingsValues,
+    settings,
     settingsActor,
   })
   useMenuListener(cb)
@@ -193,8 +184,7 @@ export const ModelingPageProvider = ({
       kclManager,
       settings: {
         defaultUnit:
-          settingsValues.modeling.defaultUnit.current ??
-          DEFAULT_DEFAULT_LENGTH_UNIT,
+          settings.modeling.defaultUnit.current ?? DEFAULT_DEFAULT_LENGTH_UNIT,
       },
       specialPropsForInsertCommand: { providedOptions },
       project,
@@ -219,102 +209,6 @@ export const ModelingPageProvider = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps, @typescript-eslint/unbound-method -- TODO: blanket-ignored fix me!
   }, [commands.send, kclCommandMemo])
-
-  // Subscribe to the settings to perform effects on the editor, stream, and other systems.
-  // TODO: pass in the settings as a dependency to these systems so that this is unnecessary,
-  // and they just have the values they need.
-  useEffect(() => {
-    const onSettingsUpdate = (snapshot: SnapshotFrom<SettingsActorType>) => {
-      const { context } = snapshot
-
-      // Update line wrapping
-      const newWrapping = context.textEditor.textWrapping.current
-      if (newWrapping !== lastSettings.value?.textEditor.textWrapping) {
-        kclManager.setEditorLineWrapping(newWrapping)
-      }
-
-      // Update engine highlighting
-      const newHighlighting = context.modeling.highlightEdges.current
-      if (newHighlighting !== lastSettings.value?.modeling.highlightEdges) {
-        engineCommandManager
-          .setHighlightEdges(newHighlighting)
-          .catch(reportRejection)
-      }
-
-      // Update cursor blinking
-      const newBlinking = context.textEditor.blinkingCursor.current
-      if (newBlinking !== lastSettings.value?.textEditor.blinkingCursor) {
-        document.documentElement.style.setProperty(
-          `--cursor-color`,
-          newBlinking ? 'auto' : 'transparent'
-        )
-        kclManager.setCursorBlinking(newBlinking)
-      }
-
-      // Update theme
-      const newTheme = context.app.theme.current
-      if (newTheme !== lastSettings.value?.app.theme) {
-        const resolvedTheme = getResolvedTheme(newTheme)
-        const opposingTheme = getOppositeTheme(newTheme)
-        sceneInfra.theme = opposingTheme
-        sceneEntitiesManager.updateSegmentBaseColor(opposingTheme)
-        kclManager.setEditorTheme(resolvedTheme)
-        engineCommandManager.setTheme(newTheme).catch(reportRejection)
-      }
-
-      // Execute AST
-      try {
-        const relevantSetting = (s: SaveSettingsPayload | undefined) => {
-          const hasScaleGrid =
-            s?.modeling.showScaleGrid !== context.modeling.showScaleGrid.current
-          const hasHighlightEdges =
-            s?.modeling?.highlightEdges !==
-            context.modeling.highlightEdges.current
-          return hasScaleGrid || hasHighlightEdges
-        }
-
-        const settingsIncludeNewRelevantValues = relevantSetting(
-          lastSettings.value
-        )
-
-        // Unit changes requires a re-exec of code
-        if (settingsIncludeNewRelevantValues) {
-          kclManager.executeCode().catch(reportRejection)
-        }
-      } catch (e) {
-        console.error('Error executing AST after settings change', e)
-      }
-
-      sceneInfra.camControls._setting_allowOrbitInSketchMode =
-        context.app.allowOrbitInSketchMode.current
-
-      const newCurrentProjection = context.modeling.cameraProjection.current
-      if (
-        sceneInfra.camControls &&
-        !kclManager.modelingState?.matches('Sketch') &&
-        newCurrentProjection !== sceneInfra.camControls.engineCameraProjection
-      ) {
-        sceneInfra.camControls.engineCameraProjection = newCurrentProjection
-      }
-
-      // TODO: Migrate settings to not be an XState actor so we don't need to save a snapshot
-      // of the last settings to know if they've changed.
-      lastSettings.value = getAllCurrentSettings(
-        getOnlySettingsFromContext(context)
-      )
-    }
-
-    const subscription = settingsActor.subscribe(onSettingsUpdate)
-
-    return () => subscription.unsubscribe()
-  }, [
-    sceneEntitiesManager,
-    kclManager,
-    sceneInfra,
-    engineCommandManager,
-    lastSettings,
-    settingsActor,
-  ])
 
   return <div>{children}</div>
 }

--- a/src/components/OpenedProject.tsx
+++ b/src/components/OpenedProject.tsx
@@ -74,18 +74,19 @@ if (window.electron) {
 }
 
 export function OpenedProject() {
-  const { auth, billing, settings } = useApp()
+  const { auth, billing } = useApp()
   const {
     systemIOActor,
+    getSettings,
+    settingsActor,
     engineCommandManager,
     sceneInfra,
     kclManager,
     useLayout,
     setLayout,
     getLayout,
+    useSettings,
   } = useSingletons()
-  const settingsActor = settings.actor
-  const getSettings = settings.get
   const defaultAreaLibrary = useDefaultAreaLibrary()
   const defaultActionLibrary = useDefaultActionLibrary()
   const { state: modelingState } = useModelingContext()
@@ -154,7 +155,7 @@ export function OpenedProject() {
 
   useHotKeyListener(kclManager)
 
-  const settingsValues = settings.useSettings()
+  const settings = useSettings()
   const authToken = auth.useToken()
   const layout = useLayout()
 
@@ -211,8 +212,8 @@ export function OpenedProject() {
   // and they're on the web
   useEffect(() => {
     const onboardingStatus =
-      settingsValues.app.onboardingStatus.current ||
-      settingsValues.app.onboardingStatus.default
+      settings.app.onboardingStatus.current ||
+      settings.app.onboardingStatus.default
     const needsOnboarded =
       !isDesktop() && // Only show if we're in the browser,
       authToken && // we're logged in,
@@ -223,10 +224,10 @@ export function OpenedProject() {
       toast.success(
         () =>
           TutorialRequestToast({
-            onboardingStatus: settingsValues.app.onboardingStatus.current,
+            onboardingStatus: settings.app.onboardingStatus.current,
             navigate,
             kclManager,
-            theme: getResolvedTheme(settingsValues.app.theme.current),
+            theme: getResolvedTheme(settings.app.theme.current),
             accountUrl: withSiteBaseURL('/account'),
             systemIOActor,
             settingsActor,
@@ -240,8 +241,8 @@ export function OpenedProject() {
       )
     }
   }, [
-    settingsValues.app.onboardingStatus,
-    settingsValues.app.theme,
+    settings.app.onboardingStatus,
+    settings.app.theme,
     location,
     navigate,
     searchParams.size,
@@ -358,7 +359,7 @@ export function OpenedProject() {
             setLayout={setLayout}
             areaLibrary={defaultAreaLibrary}
             actionLibrary={defaultActionLibrary}
-            showDebugPanel={settingsValues.app.showDebugPanel.current}
+            showDebugPanel={settings.app.showDebugPanel.current}
             notifications={notifications}
             artifactGraph={kclManager.artifactGraph}
           />

--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -99,8 +99,8 @@ function ProjectMenuPopover({
   project?: IndexLoaderData['project']
   file?: IndexLoaderData['file']
 }) {
-  const { commands, settings } = useApp()
-  const { engineCommandManager, kclManager } = useSingletons()
+  const { commands } = useApp()
+  const { engineCommandManager, kclManager, settingsActor } = useSingletons()
   const platform = usePlatform()
   const location = useLocation()
   const navigate = useNavigate()
@@ -157,7 +157,7 @@ function ProjectMenuPopover({
           ),
           onClick: () =>
             sendAddFileToProjectCommandForCurrentProject(
-              settings.actor,
+              settingsActor,
               commands.actor
             ),
         },

--- a/src/components/Providers/SystemIOProviderDesktop.tsx
+++ b/src/components/Providers/SystemIOProviderDesktop.tsx
@@ -32,14 +32,15 @@ import { useNavigate } from 'react-router-dom'
 import { useLocation } from 'react-router-dom'
 
 export function SystemIOMachineLogicListenerDesktop() {
-  const { auth, billing, settings } = useApp()
-  const { engineCommandManager, kclManager, systemIOActor } = useSingletons()
+  const { auth, billing } = useApp()
+  const { engineCommandManager, kclManager, systemIOActor, useSettings } =
+    useSingletons()
   const requestedProjectName = useRequestedProjectName()
   const requestedFileName = useRequestedFileName()
   const projectDirectoryPath = useProjectDirectoryPath()
   const hasListedProjects = useHasListedProjects()
   const navigate = useNavigate()
-  const settingsValues = settings.useSettings()
+  const settings = useSettings()
   const token = auth.useToken()
   const { onFileOpen, onFileClose } = useLspContext()
   const { pathname } = useLocation()
@@ -64,8 +65,7 @@ export function SystemIOMachineLogicListenerDesktop() {
       encodedURI
     ) {
       filePathWithExtension = decodeURIComponent(encodedURI)
-      const applicationProjectDirectory =
-        settingsValues.app.projectDirectory.current
+      const applicationProjectDirectory = settings.app.projectDirectory.current
       projectDirectory = getProjectDirectoryFromKCLFilePath(
         filePathWithExtension,
         applicationProjectDirectory
@@ -174,12 +174,12 @@ export function SystemIOMachineLogicListenerDesktop() {
           type: SystemIOMachineEvents.setProjectDirectoryPath,
           data: {
             requestedProjectDirectoryPath:
-              settingsValues.app.projectDirectory.current || '',
+              settings.app.projectDirectory.current || '',
           },
         })
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-    }, [settingsValues.app.projectDirectory.current, pathname])
+    }, [settings.app.projectDirectory.current, pathname])
   }
 
   const useDefaultProjectName = () => {
@@ -188,11 +188,11 @@ export function SystemIOMachineLogicListenerDesktop() {
         type: SystemIOMachineEvents.setDefaultProjectFolderName,
         data: {
           requestedDefaultProjectFolderName:
-            settingsValues.projects.defaultProjectName.current || '',
+            settings.projects.defaultProjectName.current || '',
         },
       })
       // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-    }, [settingsValues.projects.defaultProjectName.current])
+    }, [settings.projects.defaultProjectName.current])
   }
 
   const useWatchingApplicationProjectDirectory = () => {
@@ -225,8 +225,8 @@ export function SystemIOMachineLogicListenerDesktop() {
           })
         }
       },
-      settingsValues.app.projectDirectory.current
-        ? [settingsValues.app.projectDirectory.current]
+      settings.app.projectDirectory.current
+        ? [settings.app.projectDirectory.current]
         : []
     )
   }
@@ -288,11 +288,7 @@ export function SystemIOMachineLogicListenerDesktop() {
   )
 
   // Save the conversation id for the project id if necessary.
-  useProjectIdToConversationId(
-    mlEphantManagerActor,
-    systemIOActor,
-    settingsValues
-  )
+  useProjectIdToConversationId(mlEphantManagerActor, systemIOActor, settings)
 
   useGlobalProjectNavigation()
   useGlobalFileNavigation()

--- a/src/components/Providers/SystemIOProviderWeb.tsx
+++ b/src/components/Providers/SystemIOProviderWeb.tsx
@@ -14,10 +14,10 @@ import { useCallback, useEffect } from 'react'
 import { useSearchParams } from 'react-router-dom'
 
 export function SystemIOMachineLogicListenerWeb() {
-  const { auth, billing, settings } = useApp()
-  const { engineCommandManager, systemIOActor } = useSingletons()
+  const { auth, billing } = useApp()
+  const { engineCommandManager, systemIOActor, useSettings } = useSingletons()
   const clearURLParams = useClearURLParams()
-  const settingsValues = settings.useSettings()
+  const settings = useSettings()
   const token = auth.useToken()
   const [searchParams, setSearchParams] = useSearchParams()
   const clearImportSearchParams = useCallback(() => {
@@ -66,11 +66,7 @@ export function SystemIOMachineLogicListenerWeb() {
     }
   )
 
-  useProjectIdToConversationId(
-    mlEphantManagerActor,
-    systemIOActor,
-    settingsValues
-  )
+  useProjectIdToConversationId(mlEphantManagerActor, systemIOActor, settings)
 
   return null
 }

--- a/src/components/RouteProvider.tsx
+++ b/src/components/RouteProvider.tsx
@@ -16,7 +16,7 @@ import { getAppSettingsFilePath } from '@src/lib/desktop'
 import { PATHS, getStringAfterLastSeparator } from '@src/lib/paths'
 import { markOnce } from '@src/lib/performance'
 import { loadAndValidateSettings } from '@src/lib/settings/settingsUtils'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useSingletons } from '@src/lib/boot'
 import { trap } from '@src/lib/trap'
 import type { IndexLoaderData } from '@src/lib/types'
 import { useSignals } from '@preact/signals-react/runtime'
@@ -24,9 +24,7 @@ import { useSignals } from '@preact/signals-react/runtime'
 export const RouteProviderContext = createContext({})
 
 export function RouteProvider({ children }: { children: ReactNode }) {
-  const { settings } = useApp()
-  const { kclManager } = useSingletons()
-  const settingsActor = settings.actor
+  const { kclManager, settingsActor } = useSingletons()
   useSignals()
   useAuthNavigation()
   const loadedProject = useRouteLoaderData(PATHS.FILE) as IndexLoaderData

--- a/src/components/Settings/AllSettingsFields.tsx
+++ b/src/components/Settings/AllSettingsFields.tsx
@@ -4,6 +4,7 @@ import { forwardRef, useMemo } from 'react'
 import toast from 'react-hot-toast'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { Fragment } from 'react/jsx-runtime'
+
 import { ActionButton } from '@src/components/ActionButton'
 import { SettingsFieldInput } from '@src/components/Settings/SettingsFieldInput'
 import { SettingsSection } from '@src/components/Settings/SettingsSection'
@@ -21,7 +22,7 @@ import {
   shouldHideSetting,
   shouldShowSettingInput,
 } from '@src/lib/settings/settingsUtils'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useSingletons } from '@src/lib/boot'
 import { reportRejection } from '@src/lib/trap'
 import { toSync } from '@src/lib/utils'
 import {
@@ -41,11 +42,11 @@ export const AllSettingsFields = forwardRef(
     { searchParamTab, isFileSettings }: AllSettingsFieldsProps,
     scrollRef: ForwardedRef<HTMLDivElement>
   ) => {
-    const { settings } = useApp()
-    const { appActor, kclManager, systemIOActor } = useSingletons()
+    const { appActor, kclManager, settingsActor, useSettings, systemIOActor } =
+      useSingletons()
     const location = useLocation()
     const navigate = useNavigate()
-    const context = settings.useSettings()
+    const context = useSettings()
 
     const projectPath = useMemo(() => {
       const filteredPathname = location.pathname
@@ -70,7 +71,7 @@ export const AllSettingsFields = forwardRef(
         navigate,
         kclManager,
         systemIOActor,
-        settingsActor: settings.actor,
+        settingsActor,
       }
       // We need to navigate out of settings before accepting onboarding
       // in the web
@@ -128,7 +129,7 @@ export const AllSettingsFields = forwardRef(
                         }
                         parentLevel={setting.getParentLevel(searchParamTab)}
                         onFallback={() =>
-                          settings.send({
+                          settingsActor.send({
                             type: `set.${category}.${settingName}`,
                             data: {
                               level: searchParamTab,
@@ -206,7 +207,7 @@ export const AllSettingsFields = forwardRef(
               <ActionButton
                 Element="button"
                 onClick={() => {
-                  settings.send({
+                  settingsActor.send({
                     type: 'Reset settings',
                     level: searchParamTab,
                   })

--- a/src/components/Settings/SettingsFieldInput.tsx
+++ b/src/components/Settings/SettingsFieldInput.tsx
@@ -9,7 +9,7 @@ import type {
   WildcardSetEvent,
 } from '@src/lib/settings/settingsTypes'
 import { getSettingInputType } from '@src/lib/settings/settingsUtils'
-import { useApp } from '@src/lib/boot'
+import { useSingletons } from '@src/lib/boot'
 
 interface SettingsFieldInputProps {
   // We don't need the fancy types here,
@@ -26,9 +26,9 @@ export function SettingsFieldInput({
   settingsLevel,
   setting,
 }: SettingsFieldInputProps) {
-  const { settings } = useApp()
-  const context = settings.useSettings()
-  const send = settings.send
+  const { settingsActor, useSettings } = useSingletons()
+  const context = useSettings()
+  const send = settingsActor.send
   const options = useMemo(() => {
     return setting.commandConfig &&
       'options' in setting.commandConfig &&

--- a/src/components/Settings/SettingsSearchBar.tsx
+++ b/src/components/Settings/SettingsSearchBar.tsx
@@ -9,7 +9,7 @@ import { CustomIcon } from '@src/components/CustomIcon'
 import { isDesktop } from '@src/lib/isDesktop'
 import { interactionMap } from '@src/lib/settings/initialKeybindings'
 import type { SettingsLevel } from '@src/lib/settings/settingsTypes'
-import { useApp } from '@src/lib/boot'
+import { useSingletons } from '@src/lib/boot'
 import { hiddenOnPlatform } from '@src/lib/settings/settingsUtils'
 
 type ExtendedSettingsLevel = SettingsLevel | 'keybindings'
@@ -23,7 +23,7 @@ export type SettingsSearchItem = {
 }
 
 export function SettingsSearchBar() {
-  const { settings } = useApp()
+  const { useSettings } = useSingletons()
   const inputRef = useRef<HTMLInputElement>(null)
   useHotkeys(
     'Ctrl+.',
@@ -35,25 +35,24 @@ export function SettingsSearchBar() {
   )
   const navigate = useNavigate()
   const [query, setQuery] = useState('')
-  const settingsValues = settings.useSettings()
+  const settings = useSettings()
   const settingsAsSearchable: SettingsSearchItem[] = useMemo(
     () => [
-      ...Object.entries(settingsValues).flatMap(
-        ([category, categorySettings]) =>
-          Object.entries(categorySettings).flatMap(([settingName, setting]) => {
-            const s = setting
-            return (['project', 'user'] satisfies SettingsLevel[])
-              .filter(
-                (l) => s.hideOnLevel !== l && !hiddenOnPlatform(s, isDesktop())
-              )
-              .map((l) => ({
-                category: decamelize(category, { separator: ' ' }),
-                name: settingName,
-                description: s.description ?? '',
-                displayName: decamelize(settingName, { separator: ' ' }),
-                level: l,
-              }))
-          })
+      ...Object.entries(settings).flatMap(([category, categorySettings]) =>
+        Object.entries(categorySettings).flatMap(([settingName, setting]) => {
+          const s = setting
+          return (['project', 'user'] satisfies SettingsLevel[])
+            .filter(
+              (l) => s.hideOnLevel !== l && !hiddenOnPlatform(s, isDesktop())
+            )
+            .map((l) => ({
+              category: decamelize(category, { separator: ' ' }),
+              name: settingName,
+              description: s.description ?? '',
+              displayName: decamelize(settingName, { separator: ' ' }),
+              level: l,
+            }))
+        })
       ),
       ...Object.entries(interactionMap).flatMap(
         ([category, categoryKeybindings]) =>
@@ -66,7 +65,7 @@ export function SettingsSearchBar() {
           }))
       ),
     ],
-    [settingsValues]
+    [settings]
   )
   const [searchResults, setSearchResults] = useState(settingsAsSearchable)
 

--- a/src/components/Settings/SettingsSectionsList.tsx
+++ b/src/components/Settings/SettingsSectionsList.tsx
@@ -2,7 +2,7 @@ import decamelize from 'decamelize'
 
 import type { SettingsLevel } from '@src/lib/settings/settingsTypes'
 import { shouldHideSetting } from '@src/lib/settings/settingsUtils'
-import { useApp } from '@src/lib/boot'
+import { useSingletons } from '@src/lib/boot'
 
 interface SettingsSectionsListProps {
   searchParamTab: SettingsLevel
@@ -13,8 +13,8 @@ export function SettingsSectionsList({
   searchParamTab,
   scrollRef,
 }: SettingsSectionsListProps) {
-  const { settings } = useApp()
-  const context = settings.useSettings()
+  const { useSettings } = useSingletons()
+  const context = useSettings()
 
   const visibleCategories = Object.entries(context).filter(
     ([_, categorySettings]) =>

--- a/src/components/gizmo/AxisGizmo.tsx
+++ b/src/components/gizmo/AxisGizmo.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 import type { MutableRefObject } from 'react'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useSingletons } from '@src/lib/boot'
 
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import type { Camera, ColorRepresentation, Intersection, Object3D } from 'three'
@@ -24,10 +24,9 @@ import { reportRejection } from '@src/lib/trap'
 import { ViewControlContextMenu } from '@src/components/ViewControlMenu'
 
 export default function AxisGizmo() {
-  const { settings } = useApp()
-  const { sceneInfra } = useSingletons()
+  const { sceneInfra, useSettings } = useSingletons()
   const { state: modelingState } = useModelingContext()
-  const settingsValues = settings.useSettings()
+  const settings = useSettings()
   const wrapperRef = useRef<HTMLDivElement>(null!)
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const raycasterIntersect = useRef<Intersection | null>(null)
@@ -41,7 +40,7 @@ export default function AxisGizmo() {
   useEffect(() => {
     disableOrbitRef.current =
       modelingState.matches('Sketch') &&
-      !settingsValues.app.allowOrbitInSketchMode.current
+      !settings.app.allowOrbitInSketchMode.current
     if (wrapperRef.current) {
       wrapperRef.current.style.filter = disableOrbitRef.current
         ? 'grayscale(100%)'
@@ -51,7 +50,7 @@ export default function AxisGizmo() {
         : 'auto'
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-  }, [modelingState, settingsValues.app.allowOrbitInSketchMode.current])
+  }, [modelingState, settings.app.allowOrbitInSketchMode.current])
 
   useEffect(() => {
     if (!canvasRef.current) return

--- a/src/components/gizmo/CubeGizmo.tsx
+++ b/src/components/gizmo/CubeGizmo.tsx
@@ -1,15 +1,14 @@
 import { useEffect, useRef, useState } from 'react'
 import GizmoRenderer from '@src/components/gizmo/GizmoRenderer'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useSingletons } from '@src/lib/boot'
 
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { useResolvedTheme } from '@src/hooks/useResolvedTheme'
 
 export default function CubeGizmo() {
-  const { settings } = useApp()
-  const { sceneInfra } = useSingletons()
+  const { sceneInfra, useSettings } = useSingletons()
   const { state: modelingState } = useModelingContext()
-  const settingsValues = settings.useSettings()
+  const settings = useSettings()
 
   const resolvedTheme = useResolvedTheme()
 
@@ -54,12 +53,12 @@ export default function CubeGizmo() {
   useEffect(() => {
     const disabled =
       modelingState.matches('Sketch') &&
-      !settingsValues.app.allowOrbitInSketchMode.current
+      !settings.app.allowOrbitInSketchMode.current
 
     setDisabledOrbit(disabled)
     renderer.current?.setDisabled(disabled)
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-  }, [modelingState, settingsValues.app.allowOrbitInSketchMode.current])
+  }, [modelingState, settings.app.allowOrbitInSketchMode.current])
 
   return (
     <div

--- a/src/components/gizmo/Gizmo.tsx
+++ b/src/components/gizmo/Gizmo.tsx
@@ -3,13 +3,13 @@ import { CustomIcon } from '@src/components/CustomIcon'
 import { useViewControlMenuItems } from '@src/components/ViewControlMenu'
 import CubeGizmo from '@src/components/gizmo/CubeGizmo'
 import AxisGizmo from '@src/components/gizmo/AxisGizmo'
-import { useApp } from '@src/lib/boot'
+import { useSingletons } from '@src/lib/boot'
 
 export default function Gizmo() {
-  const { settings } = useApp()
+  const { useSettings } = useSingletons()
   const menuItems = useViewControlMenuItems()
-  const settingsValues = settings.useSettings()
-  const gizmoType = settingsValues.modeling.gizmoType.current
+  const settings = useSettings()
+  const gizmoType = settings.modeling.gizmoType.current
 
   return (
     <div className="relative">

--- a/src/components/layout/areas/KclEditorPane.tsx
+++ b/src/components/layout/areas/KclEditorPane.tsx
@@ -81,9 +81,8 @@ function copyKclCodeToClipboard(kclManager: Singletons['kclManager']) {
 }
 
 export const KclEditorMenu = () => {
-  const { commands, settings } = useApp()
-  const { kclManager } = useSingletons()
-  const settingsActor = settings.actor
+  const { commands } = useApp()
+  const { kclManager, settingsActor } = useSingletons()
   const { enable: convertToVarEnabled, handleClick: handleConvertToVarClick } =
     useConvertToVariable(kclManager)
 

--- a/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
+++ b/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
@@ -18,9 +18,10 @@ import {
 import { BillingTransition } from '@src/machines/billingMachine'
 
 export function MlEphantConversationPaneWrapper(props: AreaTypeComponentProps) {
-  const { auth, billing, settings } = useApp()
-  const { kclManager, systemIOActor } = useSingletons()
-  const settingsValues = settings.useSettings()
+  const { billing } = useApp()
+  const { kclManager, systemIOActor, useSettings } = useSingletons()
+  const { auth } = useApp()
+  const settings = useSettings()
   const user = auth.useUser()
   const token = auth.useToken()
   const {
@@ -61,7 +62,7 @@ export function MlEphantConversationPaneWrapper(props: AreaTypeComponentProps) {
           sendBillingUpdate,
           theProject: theProject.current,
           loaderFile,
-          settings: settingsValues,
+          settings,
           user,
         }}
       />

--- a/src/hooks/network/useOnPageIdle.tsx
+++ b/src/hooks/network/useOnPageIdle.tsx
@@ -1,5 +1,5 @@
 import { KclManagerEvents } from '@src/lang/KclManager'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useSingletons } from '@src/lib/boot'
 import { useEffect, useRef, useState } from 'react'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { EngineDebugger } from '@src/lib/debugger'
@@ -11,12 +11,12 @@ export const useOnPageIdle = ({
   startCallback: () => void
   idleCallback: () => void
 }) => {
-  const { settings } = useApp()
-  const { engineCommandManager, kclManager, sceneInfra } = useSingletons()
-  const settingsValues = settings.useSettings()
+  const { engineCommandManager, kclManager, sceneInfra, useSettings } =
+    useSingletons()
+  const settings = useSettings()
   const intervalId = useRef<NodeJS.Timeout | null>(null)
   const [streamIdleMode, setStreamIdleMode] = useState(
-    settingsValues.app.streamIdleMode.current
+    settings.app.streamIdleMode.current
   )
   const { state: modelingMachineState } = useModelingContext()
   const IDLE_TIME_MS = Number(streamIdleMode)

--- a/src/hooks/useResolvedTheme.ts
+++ b/src/hooks/useResolvedTheme.ts
@@ -1,4 +1,4 @@
-import { useApp } from '@src/lib/boot'
+import { useSingletons } from '@src/lib/boot'
 import { Themes, getSystemTheme } from '@src/lib/theme'
 
 /**
@@ -7,9 +7,9 @@ import { Themes, getSystemTheme } from '@src/lib/theme'
  * @returns {Themes.Light | Themes.Dark}
  */
 export function useResolvedTheme() {
-  const { settings } = useApp()
-  const settingsValues = settings.useSettings()
-  return settingsValues.app.theme.current === Themes.System
+  const { useSettings } = useSingletons()
+  const settings = useSettings()
+  return settings.app.theme.current === Themes.System
     ? getSystemTheme()
-    : settingsValues.app.theme.current
+    : settings.app.theme.current
 }

--- a/src/lang/queryAst.spec.ts
+++ b/src/lang/queryAst.spec.ts
@@ -1219,7 +1219,7 @@ profile002 = circle(sketch001, center = [2, 2], radius = 1)
   it('should return the pipe substitution symbol and a variable name in a complex multi profile selection', async () => {
     const circleProfileInVar = `startSketchOn(XY)
   |> circle(center = [0, 0], radius = 1)
-profile002 = circle(startSketchOn(XZ), center = [2, 2], radius = 1)
+profile002 = circle(sketch001, center = [2, 2], radius = 1)
 `
     const ast = assertParse(circleProfileInVar, instanceInThisFile)
     const { artifactGraph } = await enginelessExecutor(

--- a/src/lib/layout/defaultActionLibrary.ts
+++ b/src/lib/layout/defaultActionLibrary.ts
@@ -11,8 +11,8 @@ import { sendAddFileToProjectCommandForCurrentProject } from '@src/lib/commandBa
  * we should make it possible to register your own in an extension.
  */
 export const useDefaultActionLibrary = () => {
-  const { commands, settings } = useApp()
-  const { kclManager } = useSingletons()
+  const { commands } = useApp()
+  const { kclManager, settingsActor } = useSingletons()
 
   return Object.freeze({
     export: {
@@ -36,7 +36,7 @@ export const useDefaultActionLibrary = () => {
       shortcut: 'Mod + Alt + L',
       execute: () =>
         sendAddFileToProjectCommandForCurrentProject(
-          settings.actor,
+          settingsActor,
           commands.actor
         ),
     },

--- a/src/lib/layout/defaultAreaLibrary.tsx
+++ b/src/lib/layout/defaultAreaLibrary.tsx
@@ -38,9 +38,7 @@ function ModelingArea() {
  * we should make it possible to register your own in an extension.
  */
 export const useDefaultAreaLibrary = () => {
-  const { settings } = useApp()
-  const { getLayout, kclManager, setLayout } = useSingletons()
-  const getSettings = settings.get
+  const { getLayout, getSettings, kclManager, setLayout } = useSingletons()
   const onCodeNotificationClick: MouseEventHandler = useCallback(
     (e) => {
       e.preventDefault()

--- a/src/machines/machineConstants.ts
+++ b/src/machines/machineConstants.ts
@@ -1,3 +1,4 @@
 export const ACTOR_IDS = {
+  SETTINGS: 'settings',
   SYSTEM_IO: 'systemIO',
 } as const

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -68,9 +68,9 @@ type ReadWriteProjectState = {
 // This route only opens in the desktop context for now,
 // as defined in Router.tsx, so we can use the desktop APIs and types.
 const Home = () => {
-  const { auth, billing, commands, settings } = useApp()
-  const { kclManager, systemIOActor } = useSingletons()
-  const settingsActor = settings.actor
+  const { auth, billing, commands } = useApp()
+  const { kclManager, useSettings, systemIOActor, settingsActor } =
+    useSingletons()
   useQueryParamEffects(kclManager)
   const navigate = useNavigate()
   const readWriteProjectDir = useCanReadWriteProjectDirectory()
@@ -95,8 +95,8 @@ const Home = () => {
   }, [])
 
   const location = useLocation()
-  const settingsValues = settings.useSettings()
-  const onboardingStatus = settingsValues.app.onboardingStatus.current
+  const settings = useSettings()
+  const onboardingStatus = settings.app.onboardingStatus.current
 
   // Menu listeners
   const cb = (data: WebContentSendPayload) => {
@@ -107,7 +107,7 @@ const Home = () => {
           groupId: 'projects',
           name: 'Create project',
           argDefaultValues: {
-            name: settingsValues.projects.defaultProjectName.current,
+            name: settings.projects.defaultProjectName.current,
           },
         },
       })
@@ -221,7 +221,7 @@ const Home = () => {
           setQuery={setQuery}
           sort={sort}
           setSearchParams={setSearchParams}
-          settings={settingsValues}
+          settings={settings}
           readWriteProjectDir={readWriteProjectDir}
           className="col-start-2 -col-end-1"
         />

--- a/src/routes/Onboarding/utils.tsx
+++ b/src/routes/Onboarding/utils.tsx
@@ -67,7 +67,7 @@ export const OnboardingCard = ({
 )
 
 export function useNextClick(newStatus: OnboardingStatus) {
-  const { settings } = useApp()
+  const { settingsActor } = useSingletons()
   const filePath = useAbsoluteFilePath()
   const navigate = useNavigate()
 
@@ -77,18 +77,19 @@ export function useNextClick(newStatus: OnboardingStatus) {
         `Failed to navigate to invalid onboarding status ${newStatus}`
       )
     }
-    settings.send({
+    settingsActor.send({
       type: 'set.app.onboardingStatus',
       data: { level: 'user', value: newStatus },
     })
     const targetRoute = joinRouterPaths(filePath, PATHS.ONBOARDING, newStatus)
     void navigate(targetRoute)
-  }, [filePath, newStatus, navigate, settings])
+  }, [filePath, newStatus, navigate, settingsActor])
 }
 
 export function useDismiss() {
-  const { settings } = useApp()
+  const { settingsActor } = useSingletons()
   const filePath = useAbsoluteFilePath()
+  const send = settingsActor.send
   const navigate = useNavigate()
 
   const settingsCallback = useCallback(
@@ -97,11 +98,11 @@ export function useDismiss() {
         | Extract<OnboardingStatus, 'completed' | 'dismissed'>
         | undefined = 'dismissed'
     ) => {
-      settings.send({
+      send({
         type: 'set.app.onboardingStatus',
         data: { level: 'user', value: dismissalType },
       })
-      waitFor(settings.actor, (state) => state.matches('idle'))
+      waitFor(settingsActor, (state) => state.matches('idle'))
         .then(() => {
           void navigate(filePath)
           toast.success(
@@ -113,7 +114,7 @@ export function useDismiss() {
         })
         .catch(reportRejection)
     },
-    [settings, filePath, navigate]
+    [send, filePath, navigate, settingsActor]
   )
 
   return settingsCallback
@@ -384,7 +385,7 @@ function TutorialToastCard(props: TutorialToastCardProps) {
 export function TutorialRequestToast(
   props: OnboardingUtilDeps & { theme: Themes; accountUrl: string }
 ) {
-  const { settings } = useApp()
+  const { settingsActor } = useSingletons()
   function onAccept() {
     acceptOnboarding(props)
       .then(() => {
@@ -448,7 +449,7 @@ export function TutorialRequestToast(
           }}
           data-negative-button="dismiss"
           name="dismiss"
-          onClick={() => onDismissOnboardingInvite(settings.actor)}
+          onClick={() => onDismissOnboardingInvite(settingsActor)}
         >
           Not right now
         </ActionButton>

--- a/src/routes/SignIn.tsx
+++ b/src/routes/SignIn.tsx
@@ -19,7 +19,7 @@ import { returnSelfOrGetHostNameFromURL, toSync } from '@src/lib/utils'
 import { withAPIBaseURL, withSiteBaseURL } from '@src/lib/withBaseURL'
 import { AdvancedSignInOptions } from '@src/routes/AdvancedSignInOptions'
 import { APP_VERSION, generateSignInUrl } from '@src/routes/utils'
-import { useApp } from '@src/lib/boot'
+import { useApp, useSingletons } from '@src/lib/boot'
 
 const subtleBorder =
   'border border-solid border-chalkboard-30 dark:border-chalkboard-80'
@@ -28,7 +28,8 @@ const cardArea = `${subtleBorder} rounded-lg px-6 py-3 text-chalkboard-70 dark:t
 let didReadFromDiskCacheForEnvironment = false
 
 const SignIn = () => {
-  const { auth, settings } = useApp()
+  const { auth } = useApp()
+  const { useSettings } = useSingletons()
   // Only create the native file menus on desktop
   if (window.electron) {
     window.electron.createFallbackMenu().catch(reportRejection)
@@ -93,7 +94,7 @@ const SignIn = () => {
 
   const {
     app: { theme },
-  } = settings.useSettings()
+  } = useSettings()
   const signInUrl = generateSignInUrl()
   const kclSampleUrl = withSiteBaseURL('/docs/kcl-samples/car-wheel-assembly')
 

--- a/src/unitTestUtils.ts
+++ b/src/unitTestUtils.ts
@@ -67,11 +67,7 @@ export async function buildTheWorldAndConnectToEngine() {
     input: { commands: [], wasmInstancePromise: instancePromise },
   }).start()
   const settingsActor = createActor(settingsMachine, {
-    input: {
-      commandBarActor,
-      ...createSettings(),
-      wasmInstancePromise: instancePromise,
-    },
+    input: { commandBarActor, ...createSettings() },
   })
   const rustContext = new RustContext(
     engineCommandManager,
@@ -168,11 +164,7 @@ export async function buildTheWorldAndNoEngineConnection(mockWasm = false) {
     input: { commands: [], wasmInstancePromise: instancePromise },
   }).start()
   const settingsActor = createActor(settingsMachine, {
-    input: {
-      commandBarActor,
-      ...createSettings(),
-      wasmInstancePromise: instancePromise,
-    },
+    input: { commandBarActor, ...createSettings() },
   })
   const rustContext = new RustContext(
     engineCommandManager,


### PR DESCRIPTION
Reverts KittyCAD/modeling-app#9989

---

This may have introduced failures in a snapshot test, blocking the engine ([Slack thread](https://kittycadworkspace.slack.com/archives/C051T469VQ8/p1771463791910929)):

https://test-analysis-bot.corp.zoo.dev/projects/KittyCAD/modeling-app/tests/163?branch=revert-9989-franknoirot/adhoc/migrate-settings-actor