### PR TITLE
Automatically rerun the flaky KCL integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,11 +50,11 @@ trace.zip
 /public/kcl-samples/step/main.kcl
 /public/kcl-samples/internal
 /rust/kcl-lib/tests/kcl_samples/internal
-/test-results/
-/playwright-report/
-/blob-report/
-/playwright/.cache/
 /src/lang/std/artifactMapCache
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/
 
 ## generated files
 src/**/*.typegen.ts

--- a/rust/kcl-python-bindings/pyproject.toml
+++ b/rust/kcl-python-bindings/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-asyncio"]
+test = ["pytest", "pytest-asyncio", "flaky"]
 
 [tool.maturin]
 features = ["pyo3/extension-module"]

--- a/rust/kcl-python-bindings/tests/tests.py
+++ b/rust/kcl-python-bindings/tests/tests.py
@@ -3,6 +3,7 @@ import os
 
 import kcl
 from kcl import Point3d
+from flaky import flaky
 import pytest
 
 # Get the path to this script's parent directory.
@@ -164,6 +165,7 @@ async def test_kcl_execute_code_and_export():
         assert len(contents) > 0
 
 
+@flaky
 @pytest.mark.asyncio
 async def test_kcl_execute_dir_assembly():
     # Read from a file.
@@ -244,6 +246,7 @@ async def test_import_and_snapshots_single():
     assert len(image_bytes) > 0
 
 
+@flaky
 @pytest.mark.asyncio
 async def test_kcl_execute_and_snapshot_dir():
     # Read from a file.


### PR DESCRIPTION
This uses a [pytest plugin](https://github.com/box/flaky) to rerun the flakiest tests identified here: https://test-analysis-bot.corp.zoo.dev/projects/KittyCAD/modeling-app/suite/59

We'll know this strategy is working if the "Block Rate" on those tests drops to zero.