### PR TITLE
Allow the prompt to be empty as long as there is an attachment

### DIFF
--- a/src/components/MlEphantConversation.tsx
+++ b/src/components/MlEphantConversation.tsx
@@ -202,7 +202,7 @@ export const MlEphantConversationInput = (
   const onClick = () => {
     if (props.disabled) return
 
-    if (!value) return
+    if (!value && attachments.length === 0) return
     if (!refDiv.current) return
 
     props.onProcess(value, mode, attachments)


### PR DESCRIPTION
Depends on <https://github.com/KittyCAD/text-to-cad/pull/2832>