### PR TITLE
KCL docs: clarify global = true exists

### DIFF
--- a/docs/kcl-std/functions/std-transform-rotate.md
+++ b/docs/kcl-std/functions/std-transform-rotate.md
@@ -24,6 +24,9 @@ and then rotate it to the correct orientation.
 
 For sketches, you can use this to rotate a sketch and then loft it with another sketch.
 
+By default, this does a local rotation, around the sketch/body's center.
+To rotate around the global scene coordinates, use `global = true`.
+
 ### Using Roll, Pitch, and Yaw
 
 When rotating a part in 3D space, "roll," "pitch," and "yaw" refer to the

--- a/docs/kcl-std/functions/std-transform-translate.md
+++ b/docs/kcl-std/functions/std-transform-translate.md
@@ -21,6 +21,9 @@ translate(
 This is really useful for assembling parts together. You can create a part
 and then move it to the correct location.
 
+By default, this does a local translation, around the sketch/body's coordinate system.
+To translate around the global scene coordinate system, use `global = true`.
+
 Translate is really useful for sketches if you want to move a sketch
 and then rotate it using the `rotate` function to create a loft.
 

--- a/rust/kcl-lib/std/transform.kcl
+++ b/rust/kcl-lib/std/transform.kcl
@@ -98,6 +98,9 @@ export fn mirror2d(
 /// This is really useful for assembling parts together. You can create a part
 /// and then move it to the correct location.
 ///
+/// By default, this does a local translation, around the sketch/body's coordinate system.
+/// To translate around the global scene coordinate system, use `global = true`.
+///
 /// Translate is really useful for sketches if you want to move a sketch
 /// and then rotate it using the `rotate` function to create a loft.
 ///
@@ -281,6 +284,9 @@ export fn translate(
 /// and then rotate it to the correct orientation.
 ///
 /// For sketches, you can use this to rotate a sketch and then loft it with another sketch.
+///
+/// By default, this does a local rotation, around the sketch/body's center.
+/// To rotate around the global scene coordinates, use `global = true`.
 ///
 /// ### Using Roll, Pitch, and Yaw
 ///


### PR DESCRIPTION
Zookeeper is forgetting that global=true is an option for transforms. This may help remind it.