### PR TITLE
Release KCL 129

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-bumper"
-version = "0.1.128"
+version = "0.1.129"
 dependencies = [
  "anyhow",
  "clap",
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-derive-docs"
-version = "0.2.128"
+version = "0.2.129"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2208,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-directory-test-macro"
-version = "0.1.128"
+version = "0.1.129"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-error"
-version = "0.2.128"
+version = "0.2.129"
 dependencies = [
  "miette",
  "serde",
@@ -2242,7 +2242,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-language-server"
-version = "0.2.128"
+version = "0.2.129"
 dependencies = [
  "anyhow",
  "clap",
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-language-server-release"
-version = "0.1.128"
+version = "0.1.129"
 dependencies = [
  "anyhow",
  "clap",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-lib"
-version = "0.2.128"
+version = "0.2.129"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2366,7 +2366,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-python-bindings"
-version = "0.3.128"
+version = "0.3.129"
 dependencies = [
  "anyhow",
  "kcl-lib",
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-test-server"
-version = "0.2.128"
+version = "0.2.129"
 dependencies = [
  "anyhow",
  "hyper 0.14.32",
@@ -2395,7 +2395,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-to-core"
-version = "0.1.128"
+version = "0.1.129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-wasm-lib"
-version = "0.1.128"
+version = "0.1.129"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",

--- a/rust/kcl-bumper/Cargo.toml
+++ b/rust/kcl-bumper/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "kcl-bumper"
-version = "0.1.128"
+version = "0.1.129"
 edition = "2021"
 repository = "https://github.com/KittyCAD/modeling-api"
 rust-version = "1.76"

--- a/rust/kcl-derive-docs/Cargo.toml
+++ b/rust/kcl-derive-docs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-derive-docs"
 description = "A tool for generating documentation from Rust derive macros"
-version = "0.2.128"
+version = "0.2.129"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-directory-test-macro/Cargo.toml
+++ b/rust/kcl-directory-test-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-directory-test-macro"
 description = "A tool for generating tests from a directory of kcl files"
-version = "0.1.128"
+version = "0.1.129"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-error/Cargo.toml
+++ b/rust/kcl-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-error"
-version = "0.2.128"
+version = "0.2.129"
 edition = "2024"
 description = "KCL error definitions"
 license = "MIT"

--- a/rust/kcl-language-server-release/Cargo.toml
+++ b/rust/kcl-language-server-release/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-language-server-release"
-version = "0.1.128"
+version = "0.1.129"
 edition = "2021"
 authors = ["KittyCAD Inc <kcl@kittycad.io>"]
 publish = false

--- a/rust/kcl-language-server/Cargo.toml
+++ b/rust/kcl-language-server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kcl-language-server"
 description = "A language server for KCL."
 authors = ["KittyCAD Inc <kcl@kittycad.io>"]
-version = "0.2.128"
+version = "0.2.129"
 edition = "2021"
 license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust/kcl-lib/Cargo.toml
+++ b/rust/kcl-lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-lib"
 description = "KittyCAD Language implementation and tools"
-version = "0.2.128"
+version = "0.2.129"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"
@@ -64,8 +64,8 @@ http = { workspace = true }
 image = { version = "0.25.9", default-features = false, features = ["png"] }
 indexmap = { workspace = true, features = ["serde", "rayon"] }
 itertools = "0.14.0"
-kcl-derive-docs = { version = "0.2", path = "../kcl-derive-docs" }
-kcl-error = { version = "0.2", path = "../kcl-error" }
+kcl-derive-docs = { version = "0.2.129", path = "../kcl-derive-docs" }
+kcl-error = { version = "0.2.129", path = "../kcl-error" }
 kcl-ezpz = { workspace = true }
 kittycad = { workspace = true }
 kittycad-modeling-cmds = { workspace = true }

--- a/rust/kcl-python-bindings/Cargo.toml
+++ b/rust/kcl-python-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-python-bindings"
-version = "0.3.128"
+version = "0.3.129"
 edition = "2021"
 repository = "https://github.com/kittycad/modeling-app"
 exclude = ["tests/*", "files/*", "venv/*"]

--- a/rust/kcl-test-server/Cargo.toml
+++ b/rust/kcl-test-server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-test-server"
 description = "A test server for KCL"
-version = "0.2.128"
+version = "0.2.129"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"
@@ -12,7 +12,7 @@ bench = false
 [dependencies]
 anyhow = "1.0.101"
 hyper = { version = "0.14.29", features = ["http1", "server", "tcp"] }
-kcl-lib = { version = "0.2", path = "../kcl-lib" }
+kcl-lib = { version = "0.2.129", path = "../kcl-lib" }
 pico-args = "0.5.0"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/kcl-to-core/Cargo.toml
+++ b/rust/kcl-to-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-to-core"
 description = "Utility methods to convert kcl to engine core executable tests"
-version = "0.1.128"
+version = "0.1.129"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"

--- a/rust/kcl-wasm-lib/Cargo.toml
+++ b/rust/kcl-wasm-lib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kcl-wasm-lib"
 description = "KittyCAD Language wasm bindings"
 license = "MIT"
-version = "0.1.128"
+version = "0.1.129"
 edition = "2021"
 repository = "https://github.com/KittyCAD/modeling-app"
 publish = false


### PR DESCRIPTION
Thanks to #10145, the crate dependency versions for helper crates should be more accurate.