### PR TITLE
KCL python refactor: deduplicate repeated code

### DIFF
--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -90,14 +90,14 @@ enum KclInput {
     Code(String),
 }
 
-struct LoadedAndParsedKcl {
+struct KclProgram {
     code: String,
     program: kcl_lib::Program,
     path: Option<PathBuf>,
     filename: String,
 }
 
-async fn load_and_parse(input: KclInput) -> PyResult<LoadedAndParsedKcl> {
+async fn load_and_parse(input: KclInput) -> PyResult<KclProgram> {
     let (code, path, filename) = match input {
         KclInput::Path(input_path) => {
             let (code, path) = get_code_and_file_path(&input_path).await.map_err(to_py_exception)?;
@@ -109,7 +109,7 @@ async fn load_and_parse(input: KclInput) -> PyResult<LoadedAndParsedKcl> {
 
     let program = kcl_lib::Program::parse_no_errs(&code).map_err(|err| into_miette_for_parse(&filename, &code, err))?;
 
-    Ok(LoadedAndParsedKcl {
+    Ok(KclProgram {
         code,
         program,
         path,
@@ -142,7 +142,7 @@ struct ExecutedKcl {
 }
 
 async fn run_kcl(input: KclInput, mock: bool) -> PyResult<ExecutedKcl> {
-    let LoadedAndParsedKcl {
+    let KclProgram {
         code,
         program,
         path,


### PR DESCRIPTION
I noticed that the KCL python bindings have a lot of duplicated code, so I asked Codex to do some refactors to deduplicate, each in their own commit.

1. Breaks the "spawn async task, map Tokio errors to Python exceptions" logic into its own helper function
2. Make a KclInput type that wraps both "KCL source code literal string" and "filepath to KCL source code"
3. Make pairs of functions like "execute this KCL file by source string" and "execute this KCL file by filepath" so they call into one shared function with the implementation.