### PR TITLE
Don't run `executeCode` or `executeAst` before we're connected to engine

### DIFF
--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -987,6 +987,9 @@ export class KclManager extends EventTarget {
   // this function, too many other things that don't want it exist. For that,
   // use updateModelingState().
   async executeAst(args: ExecuteArgs = {}): Promise<void> {
+    if (!this.systemDeps.engineCommandManager.started) {
+      console.warn('`executeCode` called before engine connection started')
+    }
     if (this.isExecuting) {
       this.executeIsStale = args
 
@@ -1167,6 +1170,9 @@ export class KclManager extends EventTarget {
     })
   }
   async executeCode(newCode = this.codeSignal.value): Promise<void> {
+    if (!this.systemDeps.engineCommandManager.started) {
+      console.warn('`executeCode` called before engine connection started')
+    }
     const ast = await this.safeParse(newCode, await this.wasmInstancePromise)
 
     if (!ast) {


### PR DESCRIPTION
…it causes stuttering in CI I think.

This is an adjustment to changes made in #10100. In that PR, I inverted the control flow for these settings effects from _actions fired on events_ to _subscriptions to state changes_. I've run into other problems with that inversion, and this one I think is that are more aggressively competing runs of `executeCode` can clobber each other.

This adds a check to see if the connection is started before running through those methods.