### PR TITLE
Change panic behavior to the default of unwind

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -68,7 +68,6 @@ redundant_clone = "warn"
 result_large_err = "allow"
 
 [profile.release]
-panic = "abort"
 debug = true
 
 [profile.bench]


### PR DESCRIPTION
Related: #10121.

The primary motivation of this is so that Python code using the bindings can catch any panics in the Rust code, rather than the panic aborting the process.

- [x] Test to verify it actually raises `PanicException`. I did this locally, but I don't think it's worth committing since it requires triggering a panic. Also, I learned that for async Rust, we handle it and raise `Exception` instead. But it's not guaranteed, so it's good to catch `PanicException` also. https://github.com/KittyCAD/modeling-app/blob/092129abd9b36292fa5c9bbc0d8d730bc989f8be/rust/kcl-python-bindings/src/lib.rs#L47

Note: wasm32-unknown-unknown doesn't currently implement unwinding, so that target is unaffected by this change. https://doc.rust-lang.org/rustc/platform-support/wasm32-unknown-unknown.html#unwinding

It was originally set in #207.