### PR TITLE
Add a transpile binary for dev only

### DIFF
--- a/rust/kcl-lib/src/bin/transpile.rs
+++ b/rust/kcl-lib/src/bin/transpile.rs
@@ -1,0 +1,80 @@
+//! A binary to transpile KCL files with old sketch syntax (startProfile in pipe
+//! expressions) to the new sketch block syntax. This is only a temporary dev
+//! tool before we integrate it into the app.
+use std::{env, fs::File, io::Read, path::PathBuf, process::ExitCode};
+
+use kcl_lib::{ExecutorContext, ExecutorSettings, Program, TypedPath, transpile_all_old_sketches_to_new};
+
+#[tokio::main]
+async fn main() -> Result<ExitCode, std::io::Error> {
+    let mut args = env::args();
+    args.next();
+    let Some(filename) = args.next() else {
+        eprintln!("Usage: transpile <filename.kcl>");
+        return Ok(ExitCode::FAILURE);
+    };
+    let mut path = PathBuf::from(&filename);
+    if let Some(ext) = path.extension() {
+        if !ext.eq_ignore_ascii_case("kcl") {
+            eprintln!("Error: file must have .kcl extension");
+            return Ok(ExitCode::FAILURE);
+        }
+    } else {
+        // Given a directory. Use main.kcl in that directory.
+        path = path.join("main.kcl");
+    }
+
+    // Read the file.
+    let mut f = File::open(&path)?;
+    let mut text = String::new();
+    f.read_to_string(&mut text)?;
+
+    // Parse.
+    let (program, errs) = Program::parse(&text).unwrap();
+    if !errs.is_empty() {
+        for e in errs {
+            eprintln!("{e:#?}");
+        }
+        return Ok(ExitCode::FAILURE);
+    }
+    let mut program = program.unwrap();
+
+    let project_directory_string = path.parent().map(|p| p.to_string_lossy());
+    let project_directory = project_directory_string.map(|p| TypedPath::from(p.as_ref()));
+
+    let ctx = ExecutorContext::new_with_client(
+        ExecutorSettings {
+            project_directory,
+            ..Default::default()
+        },
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let result = async {
+        // Execute.
+        let exec_outcome = ctx.run_with_caching(program.clone()).await.map_err(|e| e.error)?;
+        // Transpile.
+        transpile_all_old_sketches_to_new(&exec_outcome, &mut program)
+    }
+    .await;
+    // Always close the context.
+    ctx.close().await;
+
+    match result {
+        Ok(_) => {}
+        Err(err) => {
+            eprintln!("Execution error: {err:#?}");
+            return Ok(ExitCode::FAILURE);
+        }
+    }
+
+    // Format the new source.
+    let new_source = program.recast();
+    // Output it. In the future, we should support imported files and write them
+    // all to an output directory.
+    println!("{}", new_source);
+
+    Ok(ExitCode::SUCCESS)
+}

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -30,7 +30,10 @@ pub use memory::EnvironmentRef;
 pub(crate) use modeling::ModelingCmdMeta;
 use serde::{Deserialize, Serialize};
 pub(crate) use sketch_solve::normalize_to_solver_distance_unit;
-pub use sketch_transpiler::{transpile_old_sketch_to_new, transpile_old_sketch_to_new_with_execution};
+pub use sketch_transpiler::{
+    transpile_all_old_sketches_to_new, transpile_old_sketch_to_new, transpile_old_sketch_to_new_ast,
+    transpile_old_sketch_to_new_with_execution,
+};
 pub(crate) use state::ModuleArtifactState;
 pub use state::{ExecState, MetaSettings};
 use uuid::Uuid;

--- a/rust/kcl-lib/src/execution/sketch_transpiler.rs
+++ b/rust/kcl-lib/src/execution/sketch_transpiler.rs
@@ -1,5 +1,7 @@
 //! Transpiler for converting old sketch syntax to new sketch block syntax.
 
+use std::collections::HashMap;
+
 use crate::{
     Program,
     errors::{KclError, KclErrorDetails},
@@ -25,6 +27,25 @@ enum SegmentConstraint {
     EqualLength { other_segment_index: usize },
 }
 
+pub fn transpile_all_old_sketches_to_new(exec_outcome: &ExecOutcome, program: &mut Program) -> Result<(), KclError> {
+    let mut sketch_blocks = HashMap::with_capacity(exec_outcome.variables.len());
+    for variable in &exec_outcome.variables {
+        if let KclValue::Sketch { .. } = &variable.1 {
+            // This variable contains a sketch that needs to be transpiled
+            let sketch_block = transpile_old_sketch_to_new_ast(exec_outcome, program, variable.0)?;
+            sketch_blocks.insert(variable.0.clone(), sketch_block);
+        }
+    }
+    for item in &mut program.ast.body {
+        if let ast::BodyItem::VariableDeclaration(var_decl) = item
+            && let Some(sketch_block) = sketch_blocks.get(&var_decl.declaration.id.name)
+        {
+            var_decl.declaration.init = ast::Expr::SketchBlock(Box::new(ast::Node::no_src(sketch_block.clone())));
+        }
+    }
+    Ok(())
+}
+
 /// Transpile an old-style sketch to new sketch block syntax.
 ///
 /// This function takes a variable name that should contain a Sketch value in
@@ -43,6 +64,34 @@ pub fn transpile_old_sketch_to_new(
     program: &Program,
     variable_name: &str,
 ) -> Result<String, KclError> {
+    // Build the sketch block AST
+    let sketch_block = transpile_old_sketch_to_new_ast(exec_outcome, program, variable_name)?;
+
+    // Create a program with just the sketch block
+    let program = ast::Program {
+        body: vec![ast::BodyItem::ExpressionStatement(ast::Node::no_src(
+            ast::ExpressionStatement {
+                expression: ast::Expr::SketchBlock(Box::new(ast::Node::no_src(sketch_block))),
+                digest: None,
+            },
+        ))],
+        shebang: None,
+        non_code_meta: Default::default(),
+        inner_attrs: Default::default(),
+        digest: None,
+    };
+
+    let program_node = ast::Node::no_src(program);
+
+    // Convert AST to string
+    Ok(program_node.recast_top(&Default::default(), 0))
+}
+
+pub fn transpile_old_sketch_to_new_ast(
+    exec_outcome: &ExecOutcome,
+    program: &Program,
+    variable_name: &str,
+) -> Result<ast::SketchBlock, KclError> {
     // Get the sketch from execution outcome
     let sketch = get_sketch_from_exec_outcome(exec_outcome, variable_name)?;
 
@@ -50,11 +99,7 @@ pub fn transpile_old_sketch_to_new(
     let plane_name = get_plane_name(&sketch)?;
 
     // Build the sketch block AST
-    let sketch_block = build_sketch_block_ast(&sketch, &plane_name, program, variable_name)?;
-
-    // Convert AST to string
-    let output = sketch_block.recast_top(&Default::default(), 0);
-    Ok(output)
+    build_sketch_block_ast(&sketch, &plane_name, program, variable_name)
 }
 
 /// Transpile an old-style sketch to new sketch block syntax by re-executing the program.
@@ -107,7 +152,7 @@ fn build_sketch_block_ast(
     plane_name: &str,
     program: &Program,
     variable_name: &str,
-) -> Result<ast::Node<ast::Program>, KclError> {
+) -> Result<ast::SketchBlock, KclError> {
     // Check that all segments are supported types (currently only ToPoint is supported)
     for (i, path_segment) in sketch.paths.iter().enumerate() {
         if !matches!(path_segment, Path::ToPoint { .. }) {
@@ -248,7 +293,7 @@ fn build_sketch_block_ast(
     };
 
     // Create the sketch block
-    let sketch_block = ast::SketchBlock {
+    Ok(ast::SketchBlock {
         arguments: vec![ast::LabeledArg {
             label: Some(ast::Identifier::new(SKETCH_BLOCK_PARAM_ON)),
             arg: plane_expr,
@@ -257,23 +302,7 @@ fn build_sketch_block_ast(
         is_being_edited: false,
         non_code_meta: Default::default(),
         digest: None,
-    };
-
-    // Create a program with just the sketch block
-    let program = ast::Program {
-        body: vec![ast::BodyItem::ExpressionStatement(ast::Node::no_src(
-            ast::ExpressionStatement {
-                expression: ast::Expr::SketchBlock(Box::new(ast::Node::no_src(sketch_block))),
-                digest: None,
-            },
-        ))],
-        shebang: None,
-        non_code_meta: Default::default(),
-        inner_attrs: Default::default(),
-        digest: None,
-    };
-
-    Ok(ast::Node::no_src(program))
+    })
 }
 
 /// Convert f64 + UnitLength to Number (rounding to 2 decimal places)

--- a/rust/kcl-lib/src/lib.rs
+++ b/rust/kcl-lib/src/lib.rs
@@ -95,7 +95,8 @@ pub use errors::{
 };
 pub use execution::{
     ExecOutcome, ExecState, ExecutorContext, ExecutorSettings, MetaSettings, MockConfig, Point2d, bust_cache,
-    clear_mem_cache, transpile_old_sketch_to_new, transpile_old_sketch_to_new_with_execution, typed_path::TypedPath,
+    clear_mem_cache, transpile_all_old_sketches_to_new, transpile_old_sketch_to_new, transpile_old_sketch_to_new_ast,
+    transpile_old_sketch_to_new_with_execution, typed_path::TypedPath,
 };
 pub use kcl_error::SourceRange;
 pub use lsp::{


### PR DESCRIPTION
Related #9278.

This might be helpful for development.

```shell
cd rust
cargo run --bin transpile -- ../local/angle-gauge.kcl
```

It prints the error or compiled output.