### PR TITLE
Only attach logs for passing tests when running TAB locally

### DIFF
--- a/e2e/playwright/lib/api-reporter.ts
+++ b/e2e/playwright/lib/api-reporter.ts
@@ -73,6 +73,11 @@ class APIReporter implements Reporter {
       logsAsString = stringContent
     }
 
+    // Only attach logs for passing tests when running TAB locally
+    if (result.status === 'passed' && process.env.TAB_API_KEY !== 'localhost') {
+      logsAsString = ''
+    }
+
     const payload = {
       // Required information
       project: `${process.env.GITHUB_SERVER_URL}/KittyCAD/modeling-app`,


### PR DESCRIPTION
This amends https://github.com/KittyCAD/modeling-app/pull/10218 to reduce large payloads sent to TAB, which are causing intermittent crashes.