### PR TITLE
Revert timeout for deferred execution to 1s from 300ms

### DIFF
--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -740,7 +740,7 @@ export class KclManager extends EventTarget {
         console.error('Error when updating Rust state after user edit:', error)
       }
     },
-    300
+    1_000
   )
 
   private createEditorExtensions() {


### PR DESCRIPTION
We have an architectural disconnect between the editor that writes to disk and our file system watching system. This disconnect is exacerbated by any mismatch between our debounce timeout for execution and our timeout for writing to disk, so I'm realigning them to improve the behavior, although we have seen that this alone does not completely fix the "jumping" behavior we have seen in the editor.