### PR TITLE
KCL Python: Enable transparent snapshots

### DIFF
--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -125,6 +125,8 @@ async fn new_context_state(
     if let Some(current_file) = current_file {
         settings.with_current_file(kcl_lib::TypedPath(current_file));
     }
+    // Must turn on SSAO, without it, transparent images will look opaque.
+    settings.enable_ssao = true;
     let ctx = if mock {
         ExecutorContext::new_mock(Some(settings)).await
     } else {


### PR DESCRIPTION
Transparency requires SSAO to be on. We've been turning it on in ZDS with no opt-out setting, we should do the same in ZK and Python.