### PR TITLE
Initialize theme while opening editor

### DIFF
--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -131,6 +131,7 @@ import type { FileEntry, Project } from '@src/lib/project'
 import { getStringAfterLastSeparator } from '@src/lib/paths'
 import type { SettingsActorType } from '@src/machines/settingsMachine'
 import type { CommandBarActorType } from '@src/machines/commandBarMachine'
+import { getResolvedTheme } from '@src/lib/theme'
 
 interface ExecuteArgs {
   ast?: Node<Program>
@@ -268,6 +269,16 @@ export class ZDSProject {
         commandBar: this.app.commands.actor,
         settings: this.app.settings.actor,
       })
+
+    // Initialize the editor theme
+    // Subsequent changes are listened for within app.onSettingsUpdate()
+    // TODO: Disassemble onSettingsUpdate, subscribe to changes from subsystems
+    newEditor.setEditorTheme(
+      getResolvedTheme(
+        getSettingsFromActorContext(newEditor.systemDeps.settings).app.theme
+          .current
+      )
+    )
 
     this.set(signal(path), newEditor)
     return newEditor


### PR DESCRIPTION
Fixes a minor regression that seems to have occurred recently where the editor theme would not be applied initially, only after changing the theme setting.