### PR TITLE
Set the default backface color to a non-error looking one

### DIFF
--- a/rust/kcl-lib/src/settings/types/mod.rs
+++ b/rust/kcl-lib/src/settings/types/mod.rs
@@ -262,7 +262,7 @@ fn default_length_unit_millimeters() -> UnitLength {
 
 // Also defined at src/lib/constants.ts#L333-L335
 fn default_backface_color() -> String {
-    "#F20D0D".to_string()
+    "#00D5FF".to_string()
 }
 
 fn is_default_backface_color(color: &String) -> bool {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -328,7 +328,7 @@ export const LAYOUT_SAVE_THROTTLE = 500
 export const DEFAULT_ML_COPILOT_MODE: MlCopilotMode = 'fast'
 
 // Default backface color
-export const DEFAULT_BACKFACE_COLOR = '#F20D0D'
+export const DEFAULT_BACKFACE_COLOR = '#00D5FF'
 
 /**
  * KCL constants defined in rust/kcl-lib/std/prelude.kcl


### PR DESCRIPTION
We've received some feedback from users, I believe @r-barton has voiced it recently, that the red backface color we have been setting as the default feels like an "error" color. We were inspired by Rhino's display because it contrasts much more than the gray we were showing initially, but then I just saw @max-mrgrsk's configured color and I think it plays nicely with our brand blue and ML-Ephant green while still contrasting with the front face color.