### PR TITLE
Fix missed migration in #10315

### DIFF
--- a/src/hooks/useQueryParamEffects.ts
+++ b/src/hooks/useQueryParamEffects.ts
@@ -119,7 +119,7 @@ export function useQueryParamEffects(kclManager: KclManager) {
       commandData.argDefaultValues?.projectName
     ) {
       const projectName = commandData.argDefaultValues.projectName
-      const systemIO = app.singletons.systemIOActor
+      const systemIO = app.systemIOActor
       const foldersIncludeProject = (folders: { name: string }[] | undefined) =>
         (folders ?? []).some((f) => f.name === projectName)
 


### PR DESCRIPTION
This change didn't cause a merge conflict so it didn't seem like an issue, but after CI ran on #10315 we merged a PR that took `systemIOActor` out of `app.singletons` in #10260, so this had errors in it.