### PR TITLE
KCL: Send body ID when querying edge by point

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -110,7 +110,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -121,7 +121,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1018,7 +1018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2124,7 +2124,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2460,9 +2460,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c37b518b1a587a055b6fe0417878ead3690c3f1f5ff1ff2d824180590f0010e"
+checksum = "14f46c7329027aaf9e2ecf5236ab6e9bef1581af17938b66c9aa5a2ba4d0ef6b"
 dependencies = [
  "anyhow",
  "bon",
@@ -2944,7 +2944,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4024,7 +4024,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4678,7 +4678,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4687,7 +4687,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5665,7 +5665,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,7 +28,7 @@ kittycad = { version = "0.4.7", default-features = false, features = [
   "js",
   "requests",
 ] }
-kittycad-modeling-cmds = { version = "0.2.177", features = [
+kittycad-modeling-cmds = { version = "0.2.178", features = [
   "ts-rs",
   "websocket",
 ] }

--- a/rust/kcl-lib/src/std/ids.rs
+++ b/rust/kcl-lib/src/std/ids.rs
@@ -117,7 +117,7 @@ pub async fn edge_id(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
             "Must use either `index` or `closestTo`".to_string(),
             vec![args.source_range],
         ))),
-        (None, Some(closest_to)) => inner_edge_id_by_point(closest_to, exec_state, args).await,
+        (None, Some(closest_to)) => inner_edge_id_by_point(body, closest_to, exec_state, args).await,
         (Some(edge_index), None) => inner_edge_id(body, edge_index, exec_state, args).await,
         (Some(_), Some(_)) => Err(KclError::new_semantic(KclErrorDetails::new(
             "Cannot use both `index` and `closestTo`".to_string(),
@@ -173,6 +173,7 @@ async fn inner_edge_id(
 
 /// Finds ID of edge closest to this point.
 async fn inner_edge_id_by_point(
+    body: Solid,
     closest_point: Point3d<f64>,
     exec_state: &mut ExecState,
     args: Args,
@@ -185,7 +186,12 @@ async fn inner_edge_id_by_point(
         let edge_uuid_response = exec_state
             .send_modeling_cmd(
                 ModelingCmdMeta::from_args(exec_state, &args),
-                ModelingCmd::from(mcmd::ClosestEdge::builder().closest_to(closest_point).build()),
+                ModelingCmd::from(
+                    mcmd::ClosestEdge::builder()
+                        .object_id(body.id)
+                        .closest_to(closest_point)
+                        .build(),
+                ),
             )
             .await?;
 


### PR DESCRIPTION
On the engine side, if this body ID is given, then the Closest Edge endpoint should only consider that particular body. It should ignore edges from other bodies, even if they're closer to the query point. 