### PR TITLE
Initialize all the theme touch points, not just editor

### DIFF
--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -132,7 +132,7 @@ import { getStringAfterLastSeparator } from '@src/lib/paths'
 import type { SettingsActorType } from '@src/machines/settingsMachine'
 import type { CommandBarActorType } from '@src/machines/commandBarMachine'
 import { isCodeTheSame } from '@src/lib/codeEditor'
-import { getResolvedTheme } from '@src/lib/theme'
+import { getOppositeTheme, getResolvedTheme, type Themes } from '@src/lib/theme'
 
 interface ExecuteArgs {
   ast?: Node<Program>
@@ -279,15 +279,15 @@ export class ZDSProject {
         () => this.projectIORefSignal.value.path
       )
     }
-    // Initialize the editor theme
+
+    // Initialize the theme
     // Subsequent changes are listened for within app.onSettingsUpdate()
     // TODO: Disassemble onSettingsUpdate, subscribe to changes from subsystems
-    newEditor.setEditorTheme(
-      getResolvedTheme(
-        getSettingsFromActorContext(newEditor.systemDeps.settings).app.theme
-          .current
+    newEditor
+      .updateTheme(
+        getSettingsFromActorContext(this.app.settings.actor).app.theme.current
       )
-    )
+      .catch(reportRejection)
 
     this.set(signal(path), newEditor)
     return newEditor
@@ -1611,6 +1611,16 @@ export class KclManager extends EventTarget {
           Transaction.addToHistory.of(false),
         ],
       })
+    }
+  }
+  async updateTheme(newTheme: Themes) {
+    const resolvedTheme = getResolvedTheme(newTheme)
+    const opposingTheme = getOppositeTheme(newTheme)
+    this.sceneInfra.theme = opposingTheme
+    this.sceneEntitiesManager.updateSegmentBaseColor(opposingTheme)
+    this.setEditorTheme(resolvedTheme)
+    if (this.engineCommandManager.connection) {
+      return this.engineCommandManager.setTheme(newTheme).catch(reportRejection)
     }
   }
   setEditorTheme(theme: 'light' | 'dark') {

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -49,7 +49,6 @@ import {
   jsAppSettings,
 } from '@src/lib/settings/settingsUtils'
 import { MachineManager } from '@src/lib/MachineManager'
-import { getOppositeTheme, getResolvedTheme } from '@src/lib/theme'
 import { reportRejection } from '@src/lib/trap'
 import type { Project } from '@src/lib/project'
 import type { User } from '@kittycad/lib/dist/types/src'
@@ -419,21 +418,16 @@ export class App implements AppSubsystems {
     // Update theme
     const newTheme = context.app.theme.current
     const newBackfaceColor = context.modeling.backfaceColor.current
-    const resolvedTheme = getResolvedTheme(newTheme)
-    const opposingTheme = getOppositeTheme(newTheme)
-    this.singletons.kclManager.sceneInfra.theme = opposingTheme
-    this.singletons.kclManager.sceneEntitiesManager.updateSegmentBaseColor(
-      opposingTheme
-    )
-    this.singletons.kclManager.setEditorTheme(resolvedTheme)
-    if (this.singletons.kclManager.engineCommandManager.connection) {
-      Promise.all([
-        this.singletons.kclManager.engineCommandManager.setTheme(newTheme),
-        this.singletons.kclManager.engineCommandManager.setBackfaceColor(
-          newBackfaceColor
-        ),
-      ]).catch(reportRejection)
-    }
+    Promise.all([
+      this.singletons.kclManager.updateTheme(newTheme),
+      ...(this.singletons.kclManager.engineCommandManager.connection?.connected
+        ? [
+            this.singletons.kclManager.engineCommandManager.setBackfaceColor(
+              newBackfaceColor
+            ),
+          ]
+        : []),
+    ]).catch(reportRejection)
 
     // Execute AST
     try {


### PR DESCRIPTION
Another follow-up to the settings migration. In a previous follow-up, I had realized that the editor theme had actually been relying on the settings actor state flow to initialize, not just listen for subsequent changes. It turns out other subsystems, such as the sketch scene, rely on that initialization also. So this PR wraps all the theme updating code into a method, and calls it at initialization as well as in the subscription.