### PR TITLE
Remove references to codespell

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,0 @@
-[codespell]
-ignore-words-list: crate,everytime,inout,co-ordinate,ot,nwo,atleast,ue,afterall,ser,fromM,FromM
-skip: **/target,node_modules,build,dist,./out,**/Cargo.lock,./docs/**/*.md,./e2e/playwright/lib/console-error-whitelist.ts,.package-lock.json,**/package-lock.json,./openapi/*.json,./packages/codemirror-lang-kcl/test/all.test.ts,./public/kcl-samples,./rust/kcl-lib/tests/kcl_samples,tsconfig.tsbuildinfo,./src/lib/machine-api.d.ts,./test-results,./playwright-report,./kcl-book/book
-

--- a/.github/workflows/kcl-python-bindings.yml
+++ b/.github/workflows/kcl-python-bindings.yml
@@ -159,7 +159,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v7
-      - name: Install codespell
+      - name: Create venv
         run: |
           uv venv .venv
           echo "VIRTUAL_ENV=.venv" >> $GITHUB_ENV

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -127,5 +127,5 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Run codespell
+      - name: Run typos
         uses: crate-ci/typos@v1.44.0


### PR DESCRIPTION
We switched to typos in #6716. It's confusing to have the old config file.