### PR TITLE
Fix so that logging works in the migration script

### DIFF
--- a/scripts/migrate-samples-to-sketch-solve.sh
+++ b/scripts/migrate-samples-to-sketch-solve.sh
@@ -8,7 +8,7 @@ popd()  { builtin popd  "$@" > /dev/null; }
 
 # Build once before touching the file system.
 pushd rust/
-cargo build --release --bin transpile
+cargo build --release --bin transpile -p kcl-lib
 popd
 
 succeeded=0


### PR DESCRIPTION
`ZOO_LOG=1` only works when the `disable-println` cargo feature isn't used. The default (without `-p`) is to use the workspace, which looks at all crates to determine the set of cargo features to use.