### PR TITLE
Tell Zookeeper to reference experimental sketch solve docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@csstools/postcss-oklab-function": "^4.0.12",
         "@headlessui/react": "^1.7.19",
         "@headlessui/tailwindcss": "^0.2.2",
-        "@kittycad/lib": "^3.1.43",
+        "@kittycad/lib": "^3.1.44",
         "@kittycad/react-shared": "^1.2.0",
         "@lezer/highlight": "^1.2.1",
         "@lezer/lr": "^1.4.8",
@@ -4800,9 +4800,9 @@
       "link": true
     },
     "node_modules/@kittycad/lib": {
-      "version": "3.1.43",
-      "resolved": "https://registry.npmjs.org/@kittycad/lib/-/lib-3.1.43.tgz",
-      "integrity": "sha512-Yg1FHAhtaPn8XC6UhtHXtvOWKbNGALOqVTiTxw0vkE6WH4A0e85SpJoziMh58U8T6HJWWAWOA41U4eAife+Rsw==",
+      "version": "3.1.44",
+      "resolved": "https://registry.npmjs.org/@kittycad/lib/-/lib-3.1.44.tgz",
+      "integrity": "sha512-M8T7G62XJM0egE3vdGI5LuUKDnGLN0uWPV+ky1fWTr8EE1jxxrwzZRkfWHY89vUaLLWsfA7P4c/IHnrq34qPNQ==",
       "license": "MIT",
       "dependencies": {
         "bson": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@csstools/postcss-oklab-function": "^4.0.12",
     "@headlessui/react": "^1.7.19",
     "@headlessui/tailwindcss": "^0.2.2",
-    "@kittycad/lib": "^3.1.43",
+    "@kittycad/lib": "^3.1.44",
     "@kittycad/react-shared": "^1.2.0",
     "@lezer/highlight": "^1.2.1",
     "@lezer/lr": "^1.4.8",

--- a/src/components/layout/areas/MlEphantConversationPane.tsx
+++ b/src/components/layout/areas/MlEphantConversationPane.tsx
@@ -95,6 +95,7 @@ export const MlEphantConversationPane = (props: {
       selections: props.contextModeling.selectionRanges,
       artifactGraph: props.kclManager.artifactGraph,
       mode,
+      sketch_solve: props.settings.modeling.useSketchSolveMode?.current,
       additionalFiles: attachments,
     })
 

--- a/src/lib/settings/initialSettings.tsx
+++ b/src/lib/settings/initialSettings.tsx
@@ -266,6 +266,7 @@ export function createSettings() {
       zookeeperMode: new Setting<MlCopilotMode>({
         defaultValue: DEFAULT_ML_COPILOT_MODE,
         validate: (v) => v === 'fast' || v === 'thoughtful',
+        hideOnPlatform: 'both', // this setting is managed by the Zookeeper pane
       }),
       /**
        * Stream resource saving behavior toggle

--- a/src/machines/mlEphantManagerMachine.ts
+++ b/src/machines/mlEphantManagerMachine.ts
@@ -97,6 +97,7 @@ export type MlEphantManagerEvents =
       artifactGraph: ArtifactGraph
       mode: MlCopilotMode
       additionalFiles?: File[]
+      sketch_solve?: boolean // allow Zookeeper to reference experimental docs
     }
   | {
       type: MlEphantManagerTransitions.ResponseReceive
@@ -640,6 +641,7 @@ export const mlEphantManagerMachine = setup({
         source_ranges: requestData.body.source_ranges,
         current_files: filesAsByteArrays,
         mode: event.mode,
+        sketch_solve: event.sketch_solve ?? false,
         ...(additionalFiles ? { additional_files: additionalFiles } : {}),
       }
 


### PR DESCRIPTION
Uses https://github.com/KittyCAD/api/pull/3551 cc @r-barton 

Contributes to https://github.com/KittyCAD/modeling-app/issues/9723

Pairs with https://github.com/KittyCAD/text-to-cad/pull/2959

---

`sketch_solve` in this payload is now synchronized with the **Use Sketch Solve Mode** user setting:

  
<img width="644" height="135" alt="Screenshot 2026-03-12 at 1 33 55 PM" src="https://github.com/user-attachments/assets/f482e60a-2989-4b43-95e9-a508d57dca79" />
