### PR TITLE
Bring back desktop checks in authMachine

### DIFF
--- a/src/machines/authMachine.ts
+++ b/src/machines/authMachine.ts
@@ -325,9 +325,6 @@ async function getAndSyncStoredToken(input: {
     return token
   }
 
-  // If you are web and you made it this far, you do not get a token
-  if (!isDesktop()) return ''
-
   if (!fileToken) return ''
   // default desktop login workflow to always read from disk, file will ensure login persists after app updates
   return fileToken


### PR DESCRIPTION
Fixes #10417 by reverting two changes made to `authMachine` in #10225

This makes sure we don't read from the file or write from the file on web, but the rest of the env stuff is untouched (versus the full revert of the changes done to authMachine at first)