### PR TITLE
Use "Team" instead of "Org" in the onboarding tutorial

### DIFF
--- a/src/routes/Onboarding/DesktopOnboardingRoutes.tsx
+++ b/src/routes/Onboarding/DesktopOnboardingRoutes.tsx
@@ -178,7 +178,7 @@ function TextToCad() {
         </p>
         <p className="my-4">
           Our free plan includes a limited number of Zookeeper generations each
-          month. Upgrade to a paid plan for additional usage. Pro and Org plans
+          month. Upgrade to a paid plan for additional usage. Pro and Team plans
           come with unlimited Zookeeper generations.
         </p>
         <p className="my-4">


### PR DESCRIPTION
This was requested by @merritlandsteiner here: https://kittycadworkspace.slack.com/archives/C04KFV6NKL0/p1773428950511559