### PR TITLE
Revert "macOS updater: Don't app.quit() on windows-all-closed"

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -324,9 +324,7 @@ const isBoundsVisible = (bounds: Electron.Rectangle): boolean => {
 // for applications and their menu bar to stay active until the user quits
 // explicitly with Cmd + Q, but it is a really weird behavior with our app.
 app.on('window-all-closed', () => {
-  if (os.platform() !== 'darwin') {
-    app.quit()
-  }
+  app.quit()
 })
 
 // This method will be called when Electron has finished


### PR DESCRIPTION
Reverts KittyCAD/modeling-app#10428, reopens https://github.com/KittyCAD/modeling-app/issues/10009