### PR TITLE
Add `transpile --no-fail-fast` for research

### DIFF
--- a/rust/kcl-lib/src/bin/transpile.rs
+++ b/rust/kcl-lib/src/bin/transpile.rs
@@ -9,14 +9,44 @@ use kcl_lib::{
     pre_execute_transpile, transpile_all_old_sketches_to_new,
 };
 
+fn print_usage() {
+    eprintln!("Usage: transpile [--no-fail-fast] <filename.kcl>");
+}
+
 #[tokio::main]
 async fn main() -> Result<ExitCode, std::io::Error> {
     let mut args = env::args();
+    // Discard program name.
     args.next();
-    let Some(filename) = args.next() else {
-        eprintln!("Usage: transpile <filename.kcl>");
+
+    // Parse arguments.
+    let mut fail_fast = true;
+    let mut filename = None;
+    for arg in args {
+        match arg.as_ref() {
+            "--help" | "-h" => {
+                print_usage();
+                return Ok(ExitCode::SUCCESS);
+            }
+            "--no-fail-fast" => {
+                fail_fast = false;
+            }
+            _ => {
+                if filename.is_some() {
+                    eprintln!("Error: multiple filenames provided");
+                    print_usage();
+                    return Ok(ExitCode::FAILURE);
+                }
+                filename = Some(arg);
+            }
+        }
+    }
+    let Some(filename) = filename else {
+        print_usage();
         return Ok(ExitCode::FAILURE);
     };
+
+    // Normalize the path.
     let mut path = PathBuf::from(&filename);
     if let Some(ext) = path.extension() {
         if !ext.eq_ignore_ascii_case("kcl") {
@@ -57,7 +87,7 @@ async fn main() -> Result<ExitCode, std::io::Error> {
             .await
             .map_err(|e| e.error)?;
         // Transpile.
-        transpile_all_old_sketches_to_new(&exec_outcome, &mut program)
+        transpile_all_old_sketches_to_new(&exec_outcome, &mut program, fail_fast)
     }
     .await;
 

--- a/rust/kcl-lib/src/execution/sketch_transpiler.rs
+++ b/rust/kcl-lib/src/execution/sketch_transpiler.rs
@@ -36,13 +36,17 @@ pub fn pre_execute_transpile(program: &mut Program) -> Result<(), KclError> {
     intermediate_var::transpile(&mut program.ast)
 }
 
-pub fn transpile_all_old_sketches_to_new(exec_outcome: &ExecOutcome, program: &mut Program) -> Result<(), KclError> {
+pub fn transpile_all_old_sketches_to_new(
+    exec_outcome: &ExecOutcome,
+    program: &mut Program,
+    fail_fast: bool,
+) -> Result<(), KclError> {
     // Convert sketches in variables.
     let mut sketch_blocks = HashMap::with_capacity(exec_outcome.variables.len());
     for variable in &exec_outcome.variables {
         if let KclValue::Sketch { .. } = &variable.1 {
             // This variable contains a sketch that needs to be transpiled
-            let sketch_block = transpile_old_sketch_to_new_ast(exec_outcome, program, variable.0)?;
+            let sketch_block = transpile_old_sketch_to_new_ast(exec_outcome, program, variable.0, fail_fast)?;
             sketch_blocks.insert(variable.0.clone(), sketch_block);
         }
     }
@@ -84,7 +88,7 @@ pub fn transpile_old_sketch_to_new(
     variable_name: &str,
 ) -> Result<String, KclError> {
     // Build the sketch block AST
-    let sketch_block = transpile_old_sketch_to_new_ast(exec_outcome, program, variable_name)?;
+    let sketch_block = transpile_old_sketch_to_new_ast(exec_outcome, program, variable_name, true)?;
 
     // Create a program with just the sketch block
     let program = ast::Program {
@@ -110,15 +114,25 @@ pub fn transpile_old_sketch_to_new_ast(
     exec_outcome: &ExecOutcome,
     program: &Program,
     variable_name: &str,
+    fail_fast: bool,
 ) -> Result<ast::SketchBlock, KclError> {
     // Get the sketch from execution outcome
     let sketch = get_sketch_from_exec_outcome(exec_outcome, variable_name)?;
 
     // Get the plane name
-    let plane_name = get_plane_name(&sketch)?;
+    let plane_name = match get_plane_name(&sketch) {
+        Ok(p) => p,
+        Err(err) => {
+            if fail_fast {
+                return Err(err);
+            } else {
+                "XY".to_owned()
+            }
+        }
+    };
 
     // Build the sketch block AST
-    build_sketch_block_ast(&sketch, &plane_name, program, variable_name)
+    build_sketch_block_ast(&sketch, &plane_name, program, variable_name, fail_fast)
 }
 
 /// Transpile an old-style sketch to new sketch block syntax by re-executing the program.
@@ -171,17 +185,25 @@ fn build_sketch_block_ast(
     plane_name: &str,
     program: &Program,
     variable_name: &str,
+    fail_fast: bool,
 ) -> Result<ast::SketchBlock, KclError> {
     // Check that all segments are supported types (currently only ToPoint is supported)
     for (i, path_segment) in sketch.paths.iter().enumerate() {
         if !matches!(path_segment, Path::ToPoint { .. }) {
-            return Err(KclError::new_internal(KclErrorDetails::new(
-                format!(
-                    "Transpilation not supported: segment {} is not a line segment (ToPoint). Only line segments are currently supported.",
+            if fail_fast {
+                return Err(KclError::new_internal(KclErrorDetails::new(
+                    format!(
+                        "Transpilation not supported: segment {} is not a line segment (ToPoint). Only line segments are currently supported.",
+                        i + 1
+                    ),
+                    vec![],
+                )));
+            } else {
+                std::eprintln!(
+                    "Transpilation not supported: segment {} is not a line segment (ToPoint). Only line segments are currently supported. path_segment={path_segment:?}",
                     i + 1
-                ),
-                vec![],
-            )));
+                );
+            }
         }
     }
 


### PR DESCRIPTION
I made this to help count number of occurrences of line segments that we don't yet support.

Related #9278.