### PR TITLE
Warn on ENOENT error in KclManager, don't fail big

### DIFF
--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -2288,11 +2288,16 @@ export class KclManager extends File {
             })
             .catch((err: Error) => {
               // TODO: add tracing per GH issue #254 (https://github.com/KittyCAD/modeling-app/issues/254)
-              console.error('error saving file', err)
+              console.warn('error saving file', err)
               toast.error('Error saving file, please check file permissions')
               reject(err)
             })
         }, 1000)
+      }).catch((err: Error) => {
+        if (err.cause === 'ENOENT') {
+          return
+        }
+        return err
       })
     }
   }


### PR DESCRIPTION
Alternative to #10478, suggested by @andrewvarga in his review over there. What if we just treated ENOENT as a warn-able offense in `KclManager`, so that the errors emitted while renaming your current project or deleting it externally won't trip up our E2E tests so badly.