### PR TITLE
Convert sketch test back to desktop from web

### DIFF
--- a/e2e/playwright/sketch-tests.spec.ts
+++ b/e2e/playwright/sketch-tests.spec.ts
@@ -316,34 +316,22 @@ profile001 = startProfile(sketch001, at = [0.0, 0.0])`
   )
   test(
     'Can edit a sketch that has been extruded in the same pipe',
-    { tag: '@web' },
-    async ({
-      page,
-      editor,
-      toolbar,
-      scene,
-      cmdBar,
-      folderSetupFn,
-      fs,
-      homePage,
-    }) => {
-      await folderSetupFn(async (dir) => {
-        const projectDir = await fs.join(dir, 'demo-project')
-        await fs.mkdir(projectDir, { recursive: true })
-        await fs.writeFile(
-          await fs.join(projectDir, 'main.kcl'),
-          new TextEncoder().encode(
-            `@settings(defaultLengthUnit=in)
+    { tag: '@desktop' },
+    async ({ page, homePage, editor, toolbar, scene, cmdBar }) => {
+      await page.addInitScript(async () => {
+        localStorage.setItem(
+          'persistCode',
+          `@settings(defaultLengthUnit=in)
 sketch001 = startSketchOn(XZ)
   |> startProfile(at = [0, 0])
   |> line(end = [5, 0])
   |> tangentialArc(end = [5, 5])
   |> close()
   |> extrude(length = 5)`
-          )
         )
       })
 
+      await homePage.goToModelingScene()
       await scene.settled(cmdBar)
       await toolbar.waitForFeatureTreeToBeBuilt()
 


### PR DESCRIPTION
This reverts part of this change: https://github.com/KittyCAD/modeling-app/commit/89c3bc351c90ff697bca82d9822f10a3a55c2358#diff-ad8c61d3b841cc34d1dc4fd63603027643c7d08585e2cf783d9cc05a8b1a91d9L320-R348

Since this test is merely a regression test for a particular KCL feature that is going away in the coming months, it can stay as a `@desktop` test, which was more reliable: https://test-analysis-bot.corp.zoo.dev/projects/KittyCAD/modeling-app/tests/310?weeks=6&branch=revert-webfs-test