### PR TITLE
Fix move path pen command to reference the segment source range

### DIFF
--- a/rust/kcl-lib/src/std/sketch2.rs
+++ b/rust/kcl-lib/src/std/sketch2.rs
@@ -32,7 +32,7 @@ pub(crate) async fn create_segments_in_engine(
     segment_tags: &IndexMap<ObjectId, TagNode>,
     ctx: &ExecutorContext,
     exec_state: &mut ExecState,
-    range: SourceRange,
+    sketch_block_range: SourceRange,
 ) -> Result<Option<Sketch>, KclError> {
     let mut outer_sketch: Option<Sketch> = None;
     for segment in segments.iter() {
@@ -51,6 +51,13 @@ pub(crate) async fn create_segments_in_engine(
             SegmentKind::Line { start, .. } => start.clone(),
             SegmentKind::Arc { start, .. } => start.clone(),
         };
+
+        // Get the source range of the segment from its metadata, falling back to the sketch block's.
+        let default_meta = Metadata {
+            source_range: sketch_block_range,
+        };
+        let meta = segment.meta.first().unwrap_or(&default_meta);
+        let range = meta.source_range;
 
         if let Some(sketch) = &mut outer_sketch {
             // TODO: Check if we're within tolerance of the last point. If so,
@@ -94,16 +101,11 @@ pub(crate) async fn create_segments_in_engine(
                 !exec_state.sketch_mode(),
                 exec_state,
                 ctx,
-                range,
+                sketch_block_range,
             )
             .await?;
             outer_sketch = Some(sketch);
         };
-
-        // Get the source range of the segment from its metadata, falling back to the sketch block's
-        let default_meta = Metadata { source_range: range };
-        let meta = segment.meta.first().unwrap_or(&default_meta);
-        let range = meta.source_range;
 
         let Some(sketch) = &outer_sketch else {
             return Err(KclError::new_internal(KclErrorDetails::new(


### PR DESCRIPTION
Follow-up to #10499.