### PR TITLE
Overload "Vertical" and "Horizontal" for Point[] selections to mean "*Distance = 0"

### DIFF
--- a/src/machines/sketchSolve/sketchSolveDiagram.ts
+++ b/src/machines/sketchSolve/sketchSolveDiagram.ts
@@ -147,7 +147,7 @@ async function addHorizontalConstraint(
   let result
   for (const id of context.selectedIds) {
     // TODO this is not how Horizontal should operate long term, as it should be an equipable tool
-    await context.rustContext.addConstraint(
+    result = await context.rustContext.addConstraint(
       0,
       context.sketchId,
       {


### PR DESCRIPTION
When users of CAD programs select multiple points and click the Horizontal constraint, they really mean "apply a vertical distance constraint of 0 between these points", and visa versa with Vertical. This PR closes #10465 by making it possible to click these buttons with points selected and see a result.

Note: only works for 2 points at a time right now. Need to implement >2 support for VerticalDistance and HorizontalDistance constraints as a separate effort.