### PR TITLE
Fix wasm build warning about unneeded expect

### DIFF
--- a/rust/kcl-lib/src/errors.rs
+++ b/rust/kcl-lib/src/errors.rs
@@ -46,7 +46,6 @@ impl From<KclErrorWithOutputs> for ExecError {
 }
 
 /// How did the KCL execution fail, with extra state.
-#[cfg_attr(target_arch = "wasm32", expect(dead_code))]
 #[derive(Debug, thiserror::Error)]
 #[error("{error}")]
 pub struct ExecErrorWithState {


### PR DESCRIPTION
This was probably introduced in #10399 or one of the other retry PRs.