### PR TITLE
Always run the e2e test against Vercel

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -473,9 +473,9 @@ jobs:
         continue-on-error: true
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 1200 # average build times are 17-18 minutes
+          max_timeout: 120 # average build times are 17-18 minutes
           check_interval: 30
-          vercel_protection_bypass_header: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          vercel_protection_bypass_header: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}x
 
       - name: Check Vercel
         continue-on-error: true


### PR DESCRIPTION
This will ensure it reports logs to the Test Analysis Bot for debugging and make it easier to retry the job.