### PR TITLE
Fix capitalization in settings labels

### DIFF
--- a/src/components/CommandBar/CommandBarHeaderFooter.tsx
+++ b/src/components/CommandBar/CommandBarHeaderFooter.tsx
@@ -115,7 +115,12 @@ function CommandBarHeaderFooter({
                 selectedCommand.icon && (
                   <CustomIcon name={selectedCommand.icon} className="w-5 h-5" />
                 )}
-              <span data-testid="command-name">
+              <span
+                data-testid="command-name"
+                className={
+                  selectedCommand.groupId === 'settings' ? 'capitalize' : ''
+                }
+              >
                 {selectedCommand.displayName || selectedCommand.name}
               </span>
               {selectedCommand.status === 'experimental' ? (

--- a/src/components/CommandComboBox.tsx
+++ b/src/components/CommandComboBox.tsx
@@ -99,7 +99,12 @@ function CommandComboBox({
                 <CustomIcon name={option.icon} className="w-5 h-5" />
               )}
               <div className="flex-grow flex flex-col">
-                <p className="my-0 leading-tight">
+                <p
+                  className={
+                    'my-0 leading-tight' +
+                    (option.groupId === 'settings' ? ' capitalize' : '')
+                  }
+                >
                   {option.displayName || option.name}{' '}
                 </p>
                 {option.description && (

--- a/src/components/Settings/AllSettingsFields.tsx
+++ b/src/components/Settings/AllSettingsFields.tsx
@@ -1,4 +1,3 @@
-import decamelize from 'decamelize'
 import type { ForwardedRef } from 'react'
 import { forwardRef, useMemo } from 'react'
 import toast from 'react-hot-toast'
@@ -18,6 +17,7 @@ import type {
   SettingsLevel,
 } from '@src/lib/settings/settingsTypes'
 import {
+  formatSettingsLabel,
   shouldHideSetting,
   shouldShowSettingInput,
 } from '@src/lib/settings/settingsUtils'
@@ -90,7 +90,7 @@ export const AllSettingsFields = forwardRef(
                   id={`category-${category}`}
                   className="text-xl mt-6 first-of-type:mt-0 capitalize font-bold"
                 >
-                  {decamelize(category, { separator: ' ' })}
+                  {formatSettingsLabel(category)}
                 </h2>
                 {Object.entries(categorySettings)
                   .filter((item: [string, Setting<unknown>]) =>
@@ -102,9 +102,7 @@ export const AllSettingsFields = forwardRef(
                       setting[setting.getParentLevel(searchParamTab)]
                     return (
                       <SettingsSection
-                        title={decamelize(settingName, {
-                          separator: ' ',
-                        })}
+                        title={formatSettingsLabel(settingName)}
                         id={settingName}
                         className={
                           location.hash === `#${settingName}`

--- a/src/components/Settings/SettingsSearchBar.tsx
+++ b/src/components/Settings/SettingsSearchBar.tsx
@@ -1,5 +1,4 @@
 import { Combobox } from '@headlessui/react'
-import decamelize from 'decamelize'
 import Fuse from 'fuse.js'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
@@ -10,7 +9,10 @@ import { isDesktop } from '@src/lib/isDesktop'
 import { interactionMap } from '@src/lib/settings/initialKeybindings'
 import type { SettingsLevel } from '@src/lib/settings/settingsTypes'
 import { useApp } from '@src/lib/boot'
-import { hiddenOnPlatform } from '@src/lib/settings/settingsUtils'
+import {
+  hiddenOnPlatform,
+  formatSettingsLabel,
+} from '@src/lib/settings/settingsUtils'
 
 type ExtendedSettingsLevel = SettingsLevel | 'keybindings'
 
@@ -47,10 +49,10 @@ export function SettingsSearchBar() {
                 (l) => s.hideOnLevel !== l && !hiddenOnPlatform(s, isDesktop())
               )
               .map((l) => ({
-                category: decamelize(category, { separator: ' ' }),
+                category: formatSettingsLabel(category),
                 name: settingName,
                 description: s.description ?? '',
-                displayName: decamelize(settingName, { separator: ' ' }),
+                displayName: formatSettingsLabel(settingName),
                 level: l,
               }))
           })
@@ -113,9 +115,7 @@ export function SettingsSearchBar() {
               className="flex flex-col items-start gap-2 px-4 py-2 ui-active:bg-primary/10 dark:ui-active:bg-chalkboard-90"
             >
               <p className="flex-grow text-base capitalize m-0 leading-none">
-                {option.level} ·{' '}
-                {decamelize(option.category, { separator: ' ' })} ·{' '}
-                {option.displayName}
+                {option.level} · {option.category} · {option.displayName}
               </p>
               {option.description && (
                 <p className="text-xs leading-tight text-chalkboard-70 dark:text-chalkboard-50">

--- a/src/components/Settings/SettingsSectionsList.tsx
+++ b/src/components/Settings/SettingsSectionsList.tsx
@@ -1,7 +1,8 @@
-import decamelize from 'decamelize'
-
 import type { SettingsLevel } from '@src/lib/settings/settingsTypes'
-import { shouldHideSetting } from '@src/lib/settings/settingsUtils'
+import {
+  formatSettingsLabel,
+  shouldHideSetting,
+} from '@src/lib/settings/settingsUtils'
 import { useApp } from '@src/lib/boot'
 
 interface SettingsSectionsListProps {
@@ -39,7 +40,7 @@ export function SettingsSectionsList({
           }
           className="capitalize text-left border-none px-1"
         >
-          {decamelize(category, { separator: ' ' })}
+          {formatSettingsLabel(category)}
         </button>
       ))}
       <button

--- a/src/lib/commandBarConfigs/settingsCommandConfig.ts
+++ b/src/lib/commandBarConfigs/settingsCommandConfig.ts
@@ -1,4 +1,3 @@
-import decamelize from 'decamelize'
 import type { ActorRefFrom, AnyStateMachine } from 'xstate'
 
 import type {
@@ -17,7 +16,10 @@ import type {
 } from '@src/lib/settings/settingsTypes'
 import type { PathValue } from '@src/lib/types'
 import type { settingsMachine } from '@src/machines/settingsMachine'
-import { hiddenOnPlatform } from '@src/lib/settings/settingsUtils'
+import {
+  hiddenOnPlatform,
+  formatSettingsLabel,
+} from '@src/lib/settings/settingsUtils'
 
 // An array of the paths to all of the settings that have commandConfigs
 export const settingsWithCommandConfigs = (s: SettingsType) =>
@@ -113,9 +115,10 @@ export function createSettingsCommand({ type, actor }: CreateSettingsArgs) {
 
   const command: Command = {
     name: type,
-    displayName: `Settings · ${decamelize(type.replaceAll('.', ' · '), {
-      separator: ' ',
-    })}`,
+    displayName: `Settings · ${type
+      .split('.')
+      .map((segment) => formatSettingsLabel(segment))
+      .join(' · ')}`,
     description: setting.description,
     groupId: 'settings',
     icon: 'settings',

--- a/src/lib/settings/settingsUtils.spec.ts
+++ b/src/lib/settings/settingsUtils.spec.ts
@@ -10,6 +10,7 @@ import { loadAndInitialiseWasmInstance } from '@src/lang/wasmUtilsNode'
 import { createSettings, type Setting } from '@src/lib/settings/initialSettings'
 import {
   configurationToSettingsPayload,
+  formatSettingsLabel,
   getChangedSettingsAtLevel,
   getAllCurrentSettings,
   hiddenOnPlatform,
@@ -213,5 +214,14 @@ describe('project settings serialization regression', () => {
     expect(settings.app.showDebugPanel.user).toBe(true)
     expect(settings.app.showDebugPanel.project).toBe(false)
     expect(settings.app.showDebugPanel.current).toBe(false)
+  })
+})
+
+describe('formatSettingsLabel', () => {
+  it('capitalizes known initialisms', () => {
+    expect(formatSettingsLabel('machineApi')).toBe('machine API')
+    expect(formatSettingsLabel('siteUrl')).toBe('site URL')
+    expect(formatSettingsLabel('projectId')).toBe('project ID')
+    expect(formatSettingsLabel('showUi')).toBe('show UI')
   })
 })

--- a/src/lib/settings/settingsUtils.ts
+++ b/src/lib/settings/settingsUtils.ts
@@ -1,6 +1,7 @@
 import type { Configuration } from '@rust/kcl-lib/bindings/Configuration'
 import type { NamedView } from '@rust/kcl-lib/bindings/NamedView'
 import type { ProjectConfiguration } from '@rust/kcl-lib/bindings/ProjectConfiguration'
+import decamelize from 'decamelize'
 import { NIL as uuidNIL, v4 } from 'uuid'
 
 import {
@@ -33,6 +34,22 @@ import { err } from '@src/lib/trap'
 import type { DeepPartial } from '@src/lib/types'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { SettingsActorType } from '@src/machines/settingsMachine'
+
+const INITIALISM_MAPPING: Record<string, string> = {
+  api: 'API',
+  id: 'ID',
+  ui: 'UI',
+  url: 'URL',
+}
+
+export function formatSettingsLabel(key: string): string {
+  return decamelize(key, { separator: ' ' })
+    .split(' ')
+    .map((word) =>
+      word in INITIALISM_MAPPING ? INITIALISM_MAPPING[word] : word
+    )
+    .join(' ')
+}
 
 type OmitNull<T> = T extends null ? undefined : T
 const toUndefinedIfNull = (a: any): OmitNull<any> =>


### PR DESCRIPTION
Before:

<img width="606" height="137" alt="Screenshot 2026-03-24 at 11 26 05 AM" src="https://github.com/user-attachments/assets/4da68576-7103-4ff4-91f4-b32b02351f58" /><br>

<img width="450" height="182" alt="Screenshot 2026-03-24 at 11 25 56 AM" src="https://github.com/user-attachments/assets/938fea5e-2894-4497-92c2-5452e0c28aea" /><br>

After:

<img width="612" height="145" alt="Screenshot 2026-03-24 at 11 25 10 AM" src="https://github.com/user-attachments/assets/0b4ce145-d041-4a43-80fd-f074677c274f" /><br>

<img width="446" height="180" alt="Screenshot 2026-03-24 at 11 25 01 AM" src="https://github.com/user-attachments/assets/f41c7eba-8e50-4611-9789-556742831597" />

