### PR TITLE
Skip the Vercel e2e job when workflow is invoked externally

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -445,7 +445,7 @@ jobs:
   vercel:
     name: e2e:web (vercel)
     runs-on: namespace-profile-ubuntu-8-cores
-    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'main')
+    if: github.repository == 'kittycad/modeling-app' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'main'))
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Relates to https://github.com/KittyCAD/modeling-app/issues/10376