### PR TITLE
Make the pane titles consistent with their sidebar names

### DIFF
--- a/src/components/layout/areas/LoggingPanes.tsx
+++ b/src/components/layout/areas/LoggingPanes.tsx
@@ -15,7 +15,7 @@ export function LogsPane(props: AreaTypeComponentProps) {
       <LayoutPanelHeader
         id={props.layout.id}
         icon="logs"
-        title={props.layout.id}
+        title={props.layout.label}
         Menu={null}
         onClose={props.onClose}
       />

--- a/src/components/layout/areas/ProjectExplorerPane.tsx
+++ b/src/components/layout/areas/ProjectExplorerPane.tsx
@@ -159,7 +159,7 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
       <LayoutPanelHeader
         id={props.layout.id}
         icon="folder"
-        title={`${theProject?.name || ''}`}
+        title={props.layout.label}
         Menu={
           <FileExplorerHeaderActions
             onCreateFile={() => {


### PR DESCRIPTION
Every pane matches the sidebar name except for "Logs" and "Project Files".