### PR TITLE
test: Fix cache tests to fail when there's a non-fatal error

### DIFF
--- a/rust/kcl-error/src/lib.rs
+++ b/rust/kcl-error/src/lib.rs
@@ -67,6 +67,10 @@ impl CompilationError {
             &src[suggestion.source_range.end()..]
         ))
     }
+
+    pub fn is_err(&self) -> bool {
+        self.severity.is_err()
+    }
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, ts_rs::TS)]

--- a/rust/kcl-lib/e2e/executor/cache.rs
+++ b/rust/kcl-lib/e2e/executor/cache.rs
@@ -57,7 +57,11 @@ async fn cache_test(
         }
 
         let outcome = match ctx.run_with_caching(program).await {
-            Ok(outcome) => outcome,
+            Ok(outcome) => {
+                let errors = outcome.actual_errors().collect::<Vec<_>>();
+                assert!(errors.is_empty(), "Execution resulted in error: {errors:#?}");
+                outcome
+            }
             Err(error) => {
                 let report = error.into_miette_report_with_outputs(variation.code).unwrap();
                 let report = miette::Report::new(report);

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -277,6 +277,7 @@ pub struct ExecOutcome {
     #[serde(skip)]
     pub var_solutions: Vec<(SourceRange, Number)>,
     /// Non-fatal errors and warnings.
+    /// TODO: Rename this since it's confusing that it contains warnings.
     pub errors: Vec<CompilationError>,
     /// File Names in module Id array index order
     pub filenames: IndexMap<ModuleId, ModulePath>,
@@ -301,6 +302,11 @@ impl ExecOutcome {
             let _ = id;
             None
         }
+    }
+
+    /// Returns non-fatal errors. Warnings are not included.
+    pub fn actual_errors(&self) -> impl Iterator<Item = &CompilationError> {
+        self.errors.iter().filter(|error| error.is_err())
     }
 }
 


### PR DESCRIPTION
I just noticed that we might miss an error since this code was written before non-fatal errors existed.