### PR TITLE
docs: Add more docs on KCL types and on fixed()

### DIFF
--- a/docs/kcl-std/consts/std-sketch2-fixed.md
+++ b/docs/kcl-std/consts/std-sketch2-fixed.md
@@ -11,6 +11,8 @@ Constrain a point to be fixed to a position.
 sketch2::fixed
 ```
 
+`fixed()` is an alias for `coincident()`. By convention, `fixed()` is used when one of the points is a known location, not solved with constraints and not another point in the sketch.
+
 See [coincident()](/docs/kcl-std/functions/std-sketch2-coincident) for more info.
 
 

--- a/docs/kcl-std/functions/std-gdt-datum.md
+++ b/docs/kcl-std/functions/std-gdt-datum.md
@@ -37,7 +37,7 @@ gdt::datum(
 
 ### Returns
 
-[`GdtAnnotation`](/docs/kcl-std/types/std-types-GdtAnnotation) - A GD&T annotation.
+[`GdtAnnotation`](/docs/kcl-std/types/std-types-GdtAnnotation) - A GD&T annotation created by one of the [`gdt` functions](/docs/kcl-std/modules/std-gdt).
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-helix.md
+++ b/docs/kcl-std/functions/std-helix.md
@@ -35,7 +35,7 @@ helix(
 
 ### Returns
 
-[`Helix`](/docs/kcl-std/types/std-types-Helix) - A helix; created by the `helix` function.
+[`Helix`](/docs/kcl-std/types/std-types-Helix) - A helix.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-sketch2-arc.md
+++ b/docs/kcl-std/functions/std-sketch2-arc.md
@@ -31,7 +31,7 @@ sketch2::arc(
 
 ### Returns
 
-[`Segment`](/docs/kcl-std/types/std-types-Segment) - A segment of a path in a sketch. It may be a line, arc, or other segment type.
+[`Segment`](/docs/kcl-std/types/std-types-Segment) - A segment in a sketch created in a sketch block. It may be a line, arc, point, or other segment type.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-sketch2-circle.md
+++ b/docs/kcl-std/functions/std-sketch2-circle.md
@@ -29,7 +29,7 @@ sketch2::circle(
 
 ### Returns
 
-[`Segment`](/docs/kcl-std/types/std-types-Segment) - A segment of a path in a sketch. It may be a line, arc, or other segment type.
+[`Segment`](/docs/kcl-std/types/std-types-Segment) - A segment in a sketch created in a sketch block. It may be a line, arc, point, or other segment type.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-sketch2-line.md
+++ b/docs/kcl-std/functions/std-sketch2-line.md
@@ -29,7 +29,7 @@ sketch2::line(
 
 ### Returns
 
-[`Segment`](/docs/kcl-std/types/std-types-Segment) - A segment of a path in a sketch. It may be a line, arc, or other segment type.
+[`Segment`](/docs/kcl-std/types/std-types-Segment) - A segment in a sketch created in a sketch block. It may be a line, arc, point, or other segment type.
 
 
 ### Examples

--- a/docs/kcl-std/functions/std-sketch2-point.md
+++ b/docs/kcl-std/functions/std-sketch2-point.md
@@ -23,7 +23,7 @@ sketch2::point(at: Point2d): Segment
 
 ### Returns
 
-[`Segment`](/docs/kcl-std/types/std-types-Segment) - A segment of a path in a sketch. It may be a line, arc, or other segment type.
+[`Segment`](/docs/kcl-std/types/std-types-Segment) - A segment in a sketch created in a sketch block. It may be a line, arc, point, or other segment type.
 
 
 ### Examples

--- a/docs/kcl-std/types/std-types-Axis2d.md
+++ b/docs/kcl-std/types/std-types-Axis2d.md
@@ -7,7 +7,20 @@ layout: manual
 
 An abstract and infinite line in 2d space.
 
+The `X`, `Y`, and `Z` axes are defined in the standard library. You can define custom axes by using an object with origin and direction properties.
 
+The 2D version of the X axis could be defined like:
+
+```js
+xAxis2d = {
+  origin = [0, 0],
+  direction = [1, 0],
+}
+```
+
+The number components of the origin and direction must be usable as lengths.
+
+A 3D axis can be used in contexts that require a 2D axis. The Z component is ignored.
 
 
 

--- a/docs/kcl-std/types/std-types-Axis3d.md
+++ b/docs/kcl-std/types/std-types-Axis3d.md
@@ -7,7 +7,20 @@ layout: manual
 
 An abstract and infinite line in 3d space.
 
+The `X`, `Y`, and `Z` axes are defined in the standard library. You can define custom axes by using an object with origin and direction properties.
 
+The 3D X axis is defined similar to the following:
+
+```js
+xAxis = {
+  origin = [0, 0, 0],
+  direction = [1, 0, 0],
+}
+```
+
+The number components of the origin and direction must be usable as lengths.
+
+A 3D axis can be used in contexts that require a 2D axis. The Z component is ignored.
 
 
 

--- a/docs/kcl-std/types/std-types-GdtAnnotation.md
+++ b/docs/kcl-std/types/std-types-GdtAnnotation.md
@@ -1,13 +1,13 @@
 ---
 title: "GdtAnnotation"
 subtitle: "Type in std::types"
-excerpt: "A GD&T annotation."
+excerpt: "A GD&T annotation created by one of the [`gdt` functions](/docs/kcl-std/modules/std-gdt)."
 layout: manual
 ---
 
 **WARNING:** This type is experimental and may change or be removed.
 
-A GD&T annotation.
+A GD&T annotation created by one of the [`gdt` functions](/docs/kcl-std/modules/std-gdt).
 
 
 

--- a/docs/kcl-std/types/std-types-Helix.md
+++ b/docs/kcl-std/types/std-types-Helix.md
@@ -1,13 +1,13 @@
 ---
 title: "Helix"
 subtitle: "Type in std::types"
-excerpt: "A helix; created by the `helix` function."
+excerpt: "A helix."
 layout: manual
 ---
 
-A helix; created by the `helix` function.
+A helix.
 
-
+A helix can be created by the [`helix` function](/docs/kcl-std/functions/std-helix).
 
 
 

--- a/docs/kcl-std/types/std-types-Segment.md
+++ b/docs/kcl-std/types/std-types-Segment.md
@@ -1,15 +1,15 @@
 ---
 title: "Segment"
 subtitle: "Type in std::types"
-excerpt: "A segment of a path in a sketch. It may be a line, arc, or other segment type."
+excerpt: "A segment in a sketch created in a sketch block. It may be a line, arc, point, or other segment type."
 layout: manual
 ---
 
 **WARNING:** This type is experimental and may change or be removed.
 
-A segment of a path in a sketch. It may be a line, arc, or other segment type.
+A segment in a sketch created in a sketch block. It may be a line, arc, point, or other segment type.
 
-
+See the [sketch2 module](/docs/kcl-std/modules/std-sketch2) for functions that create segments and the [region function](/docs/kcl-std/functions/std-sketch2-region) for examples using segments to create a region that can be extruded.
 
 
 

--- a/rust/kcl-lib/std/sketch2.kcl
+++ b/rust/kcl-lib/std/sketch2.kcl
@@ -405,6 +405,8 @@ export fn tangent(
 
 /// Constrain a point to be fixed to a position.
 ///
+/// `fixed()` is an alias for `coincident()`. By convention, `fixed()` is used when one of the points is a known location, not solved with constraints and not another point in the sketch.
+///
 /// See [coincident()](/docs/kcl-std/functions/std-sketch2-coincident) for more info.
 export fixed = coincident
 

--- a/rust/kcl-lib/std/types.kcl
+++ b/rust/kcl-lib/std/types.kcl
@@ -221,7 +221,9 @@ export type fn
 @(impl = std_rust)
 export type Plane
 
-/// A segment of a path in a sketch. It may be a line, arc, or other segment type.
+/// A segment in a sketch created in a sketch block. It may be a line, arc, point, or other segment type.
+///
+/// See the [sketch2 module](/docs/kcl-std/modules/std-sketch2) for functions that create segments and the [region function](/docs/kcl-std/functions/std-sketch2-region) for examples using segments to create a region that can be extruded.
 @(impl = std_rust_constrainable, experimental = true)
 export type Segment
 
@@ -319,7 +321,9 @@ export type Solid
 @(impl = std_rust)
 export type Face
 
-/// A helix; created by the `helix` function.
+/// A helix.
+///
+/// A helix can be created by the [`helix` function](/docs/kcl-std/functions/std-helix).
 @(impl = std_rust)
 export type Helix
 
@@ -344,14 +348,44 @@ export type Point2d = [number(Length); 2]
 export type Point3d = [number(Length); 3]
 
 /// An abstract and infinite line in 2d space.
+///
+/// The `X`, `Y`, and `Z` axes are defined in the standard library. You can define custom axes by using an object with origin and direction properties.
+///
+/// The 2D version of the X axis could be defined like:
+///
+/// ```kcl,inline
+/// xAxis2d = {
+///   origin = [0, 0],
+///   direction = [1, 0],
+/// }
+/// ```
+///
+/// The number components of the origin and direction must be usable as lengths.
+/// 
+/// A 3D axis can be used in contexts that require a 2D axis. The Z component is ignored.
 @(impl = std_rust)
 export type Axis2d
 
 /// An abstract and infinite line in 3d space.
+///
+/// The `X`, `Y`, and `Z` axes are defined in the standard library. You can define custom axes by using an object with origin and direction properties.
+///
+/// The 3D X axis is defined similar to the following:
+///
+/// ```kcl,inline
+/// xAxis = {
+///   origin = [0, 0, 0],
+///   direction = [1, 0, 0],
+/// }
+/// ```
+///
+/// The number components of the origin and direction must be usable as lengths.
+/// 
+/// A 3D axis can be used in contexts that require a 2D axis. The Z component is ignored.
 @(impl = std_rust)
 export type Axis3d
 
-/// A GD&T annotation.
+/// A GD&T annotation created by one of the [`gdt` functions](/docs/kcl-std/modules/std-gdt).
 @(impl = std_rust, experimental = true)
 export type GdtAnnotation
 


### PR DESCRIPTION
Part of https://github.com/KittyCAD/modeling-app/issues/7673.

The axis types weren't documented.

I also added:

- some more cross linking
- explanation of `fixed()`