### PR TITLE
Don't allow `useFileSystemWatcher` to watch root or empty paths

### DIFF
--- a/src/hooks/useFileSystemWatcher.tsx
+++ b/src/hooks/useFileSystemWatcher.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-
+import fsZds from '@src/lib/fs-zds'
 import { isDesktop } from '@src/lib/isDesktop'
 import { reportRejection } from '@src/lib/trap'
 import { uuidv4 } from '@src/lib/utils'
@@ -15,8 +15,15 @@ type Path = string
 
 export const useFileSystemWatcher = (
   callback: (eventType: string, path: Path) => Promise<void>,
-  paths: Path[]
+  providedPaths: Path[]
 ): void => {
+  const paths = providedPaths.filter((p) => {
+    const isValid = p !== '' && p !== fsZds.sep
+    if (!isValid) {
+      console.trace(`Invalid path passed into useFileSystemWatcher: ${p}`)
+    }
+    return isValid
+  })
   // Used to track this instance of useFileSystemWatcher.
   // Assign to ref so it doesn't change between renders.
   const key = useRef(uuidv4())


### PR DESCRIPTION
This sidesteps the issue reported in Slack when users of the new sketch solve (or "sketch 2") experience in the Staging app exit a sketch, they start to experience pretty aggressive freezing which has been traced back to an empty path being passed into one of our file system watchers. There are a few so we don't know yet for certain which one is receiving an empty string, but this should ignore that and add a trace to the console so that we can pin down the source without breaking the app for folks.