### PR TITLE
"Clear" sketch solve scene graph when entering a new sketch

### DIFF
--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -17,7 +17,10 @@ import type {
   ModelingMachineInput,
   Selections,
 } from '@src/machines/modelingSharedTypes'
-import { modelingMachineInitialInternalContext } from '@src/machines/modelingSharedContext'
+import {
+  dummyInitSketchGraphDelta,
+  modelingMachineInitialInternalContext,
+} from '@src/machines/modelingSharedContext'
 
 import type { Node } from '@rust/kcl-lib/bindings/Node'
 import type {
@@ -798,6 +801,7 @@ export const modelingMachine = setup({
       sketchEnginePathId: '',
       sketchPlaneId: '',
       showNonVisualConstraints: false,
+      initialSceneGraphDelta: dummyInitSketchGraphDelta,
     }),
     'reset camera position': ({ context: { engineCommandManager } }) => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/src/machines/modelingSharedContext.ts
+++ b/src/machines/modelingSharedContext.ts
@@ -9,7 +9,7 @@ import type {
 import type { CommandBarActorType } from '@src/machines/commandBarMachine'
 import type { MachineManager } from '@src/lib/MachineManager'
 
-const dummyInitSketchGraphDelta = Object.freeze({
+export const dummyInitSketchGraphDelta = Object.freeze({
   new_graph: {
     project: 0,
     file: 0,


### PR DESCRIPTION
Fixes #10678 by ensuring that `initialSceneGraphDelta` is set to the initial "dummy" value whenever we enter a new sketch. When entering a sketch we are editing, this state is used to hydrate the initial scene graph and show the sketch scene after we transition in. We didn't clear it after leaving sketch mode, nor overwrite it when entering new sketches, so stale state could make it in.