### PR TITLE
Bump to latest kittycad.rs & remove debug upload

### DIFF
--- a/e2e/playwright/editor-tests.spec.ts
+++ b/e2e/playwright/editor-tests.spec.ts
@@ -1476,10 +1476,10 @@ profile001 = startProfile(sketch001, at = [0, 0])
 
     await page.keyboard.press(`${modifier}+Shift+.`)
 
-    const toast1 = page.getByText('Starting core dump...')
+    const toast1 = page.getByText('Submitting support ticket...')
     await expect(toast1).toBeVisible()
 
-    const toast2 = page.getByText('Core dump completed')
+    const toast2 = page.getByText('Support ticket created successfully')
     await expect(toast2).toBeVisible()
   })
 })

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2423,9 +2423,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "890ab946c7ea266317c75861e8c138e428acc6ecc1b78cb738e64e1b40c817ca"
+checksum = "d14071a649404c083dd875d1e8013955163656686b5b2f65e5154c8387de50dd"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -24,7 +24,7 @@ dashmap = { version = "6.1.0" }
 http = "1"
 indexmap = "2.13.0"
 ezpz = "0.2.18"
-kittycad = { version = "0.4.7", default-features = false, features = [
+kittycad = { version = "0.4.8", default-features = false, features = [
   "js",
   "requests",
 ] }

--- a/rust/kcl-lib/src/coredump/local.rs
+++ b/rust/kcl-lib/src/coredump/local.rs
@@ -22,16 +22,6 @@ impl Default for CoreDumper {
 
 #[async_trait::async_trait(?Send)]
 impl CoreDump for CoreDumper {
-    fn token(&self) -> Result<String> {
-        Ok(std::env::var("ZOO_API_TOKEN")
-            .or_else(|_| std::env::var("KITTYCAD_API_TOKEN"))
-            .unwrap_or_default())
-    }
-
-    fn base_api_url(&self) -> Result<String> {
-        Ok("https://api.zoo.dev".to_string())
-    }
-
     fn version(&self) -> Result<String> {
         Ok(env!("CARGO_PKG_VERSION").to_string())
     }
@@ -60,10 +50,5 @@ impl CoreDump for CoreDumper {
 
     async fn get_client_state(&self) -> Result<JValue> {
         Ok(JValue::default())
-    }
-
-    async fn screenshot(&self) -> Result<String> {
-        // Take a screenshot of the engine.
-        todo!()
     }
 }

--- a/rust/kcl-lib/src/coredump/mod.rs
+++ b/rust/kcl-lib/src/coredump/mod.rs
@@ -6,11 +6,7 @@ pub mod local;
 #[cfg(target_arch = "wasm32")]
 pub mod wasm;
 
-use std::path::Path;
-
 use anyhow::Result;
-use base64::Engine;
-use kittycad::Client;
 use serde::Deserialize;
 use serde::Serialize;
 /// "Value" would be OK. This is imported as "JValue" throughout the rest of this crate.
@@ -19,11 +15,6 @@ use uuid::Uuid;
 
 #[async_trait::async_trait(?Send)]
 pub trait CoreDump: Clone {
-    /// Return the authentication token.
-    fn token(&self) -> Result<String>;
-
-    fn base_api_url(&self) -> Result<String>;
-
     fn version(&self) -> Result<String>;
 
     fn kcl_code(&self) -> Result<String>;
@@ -36,48 +27,14 @@ pub trait CoreDump: Clone {
 
     async fn get_client_state(&self) -> Result<JValue>;
 
-    /// Return a screenshot of the app.
-    async fn screenshot(&self) -> Result<String>;
-
-    /// Get a screenshot of the app and upload it to public cloud storage.
-    async fn upload_screenshot(&self, coredump_id: &Uuid, zoo_client: &Client) -> Result<String> {
-        let screenshot = self.screenshot().await?;
-        let cleaned = screenshot.trim_start_matches("data:image/png;base64,");
-
-        // Base64 decode the screenshot.
-        let data = base64::engine::general_purpose::STANDARD.decode(cleaned)?;
-        // Upload the screenshot.
-        let links = zoo_client
-            .meta()
-            .create_debug_uploads(vec![kittycad::types::multipart::Attachment {
-                name: "".to_string(),
-                filepath: Some(format!(r#"modeling-app/coredump-{coredump_id}-screenshot.png"#).into()),
-                content_type: Some("image/png".to_string()),
-                data,
-            }])
-            .await
-            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
-
-        if links.is_empty() {
-            anyhow::bail!("Failed to upload screenshot");
-        }
-
-        Ok(links[0].clone())
-    }
-
     /// Dump the app info.
     async fn dump(&self) -> Result<CoreDumpInfo> {
-        // Create the zoo client.
-        let mut zoo_client = kittycad::Client::new(self.token()?);
-        zoo_client.set_base_url(&self.base_api_url()?);
-
         let coredump_id = uuid::Uuid::new_v4();
         let client_state = self.get_client_state().await?;
         let webrtc_stats = self.get_webrtc_stats().await?;
         let os = self.os()?;
-        let screenshot_url = self.upload_screenshot(&coredump_id, &zoo_client).await?;
 
-        let mut core_dump_info = CoreDumpInfo {
+        let core_dump_info = CoreDumpInfo {
             id: coredump_id,
             version: self.version()?,
             git_rev: git_rev::try_revision_string!().map_or_else(|| "unknown".to_string(), |s| s.to_string()),
@@ -86,33 +43,10 @@ pub trait CoreDump: Clone {
             kcl_code: self.kcl_code()?,
             os,
             webrtc_stats,
-            github_issue_url: None,
             client_state,
         };
 
         // pretty-printed JSON byte vector of the coredump.
-        let data = serde_json::to_vec_pretty(&core_dump_info)?;
-
-        // Upload the coredump.
-        let links = zoo_client
-            .meta()
-            .create_debug_uploads(vec![kittycad::types::multipart::Attachment {
-                name: "".to_string(),
-                filepath: Some(format!(r#"modeling-app/coredump-{coredump_id}.json"#).into()),
-                content_type: Some("application/json".to_string()),
-                data,
-            }])
-            .await
-            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
-
-        if links.is_empty() {
-            anyhow::bail!("Failed to upload coredump");
-        }
-
-        let coredump_url = &links[0];
-
-        core_dump_info.set_github_issue_url(&screenshot_url, coredump_url, &coredump_id)?;
-
         Ok(core_dump_info)
     }
 }
@@ -138,70 +72,10 @@ pub struct CoreDumpInfo {
     pub os: OsInfo,
     /// The webrtc stats.
     pub webrtc_stats: WebrtcStats,
-    /// A GitHub issue url to report the core dump.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub github_issue_url: Option<String>,
     /// The kcl code the user is using.
     pub kcl_code: String,
     /// The client state (singletons and xstate).
     pub client_state: JValue,
-}
-
-impl CoreDumpInfo {
-    /// Set the github issue url.
-    pub fn set_github_issue_url(&mut self, screenshot_url: &str, coredump_url: &str, coredump_id: &Uuid) -> Result<()> {
-        let coredump_filename = Path::new(coredump_url).file_name().unwrap().to_str().unwrap();
-        let desktop_or_browser_label = if self.desktop { "desktop-app" } else { "browser" };
-        let labels = ["coredump", "bug", desktop_or_browser_label];
-        let mut body = format!(
-            r#"[Add a title above and insert a description of the issue here]
-
-![Screenshot]({screenshot_url})
-
-> _Note: If you are capturing from a browser there is limited support for screenshots, only captures the modeling scene.
-  If you are on MacOS native screenshots may be disabled by default. To enable native screenshots add Zoo Design Studio to System Settings -> Screen & SystemAudio Recording for native screenshots._
-
-<details>
-<summary><b>Core Dump</b></summary>
-
-[{coredump_filename}]({coredump_url})
-
-Reference ID: {coredump_id}
-</details>
-"#
-        );
-
-        // Add the kcl code if it exists.
-        if !self.kcl_code.trim().is_empty() {
-            body.push_str(&format!(
-                r#"
-<details>
-<summary><b>KCL Code</b></summary>
-
-```kcl
-{}
-```
-</details>
-"#,
-                self.kcl_code
-            ));
-        }
-
-        let urlencoded: String = form_urlencoded::byte_serialize(body.as_bytes()).collect();
-
-        // Note that `github_issue_url` is not included in the coredump file.
-        // It has already been encoded and uploaded at this point.
-        // The `github_issue_url` is used in openWindow in wasm.ts.
-        self.github_issue_url = Some(format!(
-            r#"https://github.com/{}/{}/issues/new?body={}&labels={}"#,
-            "KittyCAD",
-            "modeling-app",
-            urlencoded,
-            labels.join(",")
-        ));
-
-        Ok(())
-    }
 }
 
 /// The os info structure.

--- a/rust/kcl-lib/src/coredump/wasm.rs
+++ b/rust/kcl-lib/src/coredump/wasm.rs
@@ -12,15 +12,6 @@ extern "C" {
     #[derive(Debug, Clone)]
     pub type CoreDumpManager;
 
-    #[wasm_bindgen(method, js_name = authToken, catch)]
-    fn auth_token(this: &CoreDumpManager) -> Result<String, js_sys::Error>;
-
-    #[wasm_bindgen(method, js_name = baseApiUrl, catch)]
-    fn baseApiUrl(this: &CoreDumpManager) -> Result<String, js_sys::Error>;
-
-    #[wasm_bindgen(method, js_name = pool, catch)]
-    fn pool(this: &CoreDumpManager) -> Result<String, js_sys::Error>;
-
     #[wasm_bindgen(method, js_name = version, catch)]
     fn version(this: &CoreDumpManager) -> Result<String, js_sys::Error>;
 
@@ -38,9 +29,6 @@ extern "C" {
 
     #[wasm_bindgen(method, js_name = getClientState, catch)]
     fn get_client_state(this: &CoreDumpManager) -> Result<js_sys::Promise, js_sys::Error>;
-
-    #[wasm_bindgen(method, js_name = screenshot, catch)]
-    fn screenshot(this: &CoreDumpManager) -> Result<js_sys::Promise, js_sys::Error>;
 }
 
 #[derive(Debug, Clone)]
@@ -59,18 +47,6 @@ unsafe impl Sync for CoreDumper {}
 
 #[async_trait::async_trait(?Send)]
 impl CoreDump for CoreDumper {
-    fn token(&self) -> Result<String> {
-        self.manager
-            .auth_token()
-            .map_err(|e| anyhow::anyhow!("Failed to get response from token: {:?}", e))
-    }
-
-    fn base_api_url(&self) -> Result<String> {
-        self.manager
-            .baseApiUrl()
-            .map_err(|e| anyhow::anyhow!("Failed to get response from base api url: {:?}", e))
-    }
-
     fn version(&self) -> Result<String> {
         self.manager
             .version()
@@ -142,23 +118,5 @@ impl CoreDump for CoreDumper {
             serde_json::from_str(&s).map_err(|e| anyhow::anyhow!("Failed to parse client state: {:?}", e))?;
 
         Ok(client_state)
-    }
-
-    async fn screenshot(&self) -> Result<String> {
-        let promise = self
-            .manager
-            .screenshot()
-            .map_err(|e| anyhow::anyhow!("Failed to get promise from get screenshot: {:?}", e))?;
-
-        let value = JsFuture::from(promise)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to get response from screenshot: {:?}", e))?;
-
-        // Parse the value as a string.
-        let s = value
-            .as_string()
-            .ok_or_else(|| anyhow::anyhow!("Failed to get string from response from screenshot: `{:?}`", value))?;
-
-        Ok(s)
     }
 }

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -15,7 +15,10 @@ import ModelingPageProvider from '@src/components/ModelingPageProvider'
 import { NetworkContext } from '@src/hooks/useNetworkContext'
 import { useNetworkStatus } from '@src/hooks/useNetworkStatus'
 import { coreDump } from '@src/lang/wasm'
-import { CoreDumpManager } from '@src/lib/coredump'
+import {
+  CoreDumpManager,
+  submitCoreDumpSupportTicket,
+} from '@src/lib/coredump'
 import useHotkeyWrapper from '@src/lib/hotkeyWrapper'
 import { isDesktop } from '@src/lib/isDesktop'
 import makeUrlPathRelative from '@src/lib/makeUrlPathRelative'
@@ -168,21 +171,30 @@ function CoreDump() {
   const { auth } = useApp()
   const { kclManager } = useSingletons()
   const token = auth.useToken()
+  const user = auth.useUser()
   const coreDumpManager = useMemo(
-    () => new CoreDumpManager(kclManager, token),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-    []
+    () => new CoreDumpManager(kclManager),
+    [kclManager]
   )
   useHotkeyWrapper(
     ['mod + shift + period'],
     () => {
       toast
         .promise(
-          coreDump(coreDumpManager, kclManager.wasmInstancePromise, true),
+          coreDump(coreDumpManager, kclManager.wasmInstancePromise).then(
+            async (dump) => {
+              await submitCoreDumpSupportTicket({
+                dump,
+                token,
+                user,
+              })
+              return dump
+            }
+          ),
           {
-            loading: 'Starting core dump...',
-            success: 'Core dump completed successfully',
-            error: 'Error while exporting core dump',
+            loading: 'Submitting support ticket...',
+            success: 'Support ticket created successfully',
+            error: 'Error while creating support ticket',
           },
           {
             success: {

--- a/src/lang/wasm.ts
+++ b/src/lang/wasm.ts
@@ -36,7 +36,6 @@ import {
 import type { Coords2d } from '@src/lang/util'
 import { isTopLevelModule } from '@src/lang/util'
 import type { CoreDumpManager } from '@src/lib/coredump'
-import openWindow from '@src/lib/openWindow'
 import { Reason, err } from '@src/lib/trap'
 import type { DeepPartial } from '@src/lib/types'
 import { isArray } from '@src/lib/utils'
@@ -715,27 +714,12 @@ export function getTangentialArcToInfo({
 
 export async function coreDump(
   coreDumpManager: CoreDumpManager,
-  wasmInstancePromise: Promise<ModuleType>,
-  openGithubIssue: boolean = false
+  wasmInstancePromise: Promise<ModuleType>
 ): Promise<CoreDumpInfo> {
   try {
     console.warn('CoreDump: Initializing core dump')
     const wasmInstance = await wasmInstancePromise
     const dump: CoreDumpInfo = await wasmInstance.coredump(coreDumpManager)
-    /* NOTE: this console output of the coredump should include the field
-       `github_issue_url` which is not in the uploaded coredump file.
-       `github_issue_url` is added after the file is uploaded
-       and is only needed for the openWindow operation which creates
-       a new GitHub issue for the user.
-     */
-    if (openGithubIssue && dump.github_issue_url) {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      openWindow(dump.github_issue_url)
-    } else {
-      console.error(
-        'github_issue_url undefined. Unable to create GitHub issue for coredump.'
-      )
-    }
     console.log('CoreDump: final coredump', dump)
     console.log('CoreDump: final coredump JSON', JSON.stringify(dump))
     return dump

--- a/src/lib/coredump.test.ts
+++ b/src/lib/coredump.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockState = vi.hoisted(() => ({
+  putPublicSupportForm: vi.fn(),
+  createKCClient: vi.fn(() => ({ mocked: true })),
+  kcCall: vi.fn(async (fn: () => Promise<unknown>) => await fn()),
+}))
+
+vi.mock('@kittycad/lib', () => ({
+  users: {
+    put_public_support_form: mockState.putPublicSupportForm,
+  },
+}))
+
+vi.mock('@src/lib/kcClient', () => ({
+  createKCClient: mockState.createKCClient,
+  kcCall: mockState.kcCall,
+}))
+
+vi.mock('@src/routes/utils', () => ({
+  APP_VERSION: 'test-version',
+}))
+
+import {
+  getCoreDumpSupportContact,
+  getCoreDumpSupportMessage,
+  submitCoreDumpSupportTicket,
+} from '@src/lib/coredump'
+
+describe('coredump support ticket helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('derives support contact names from the user profile', () => {
+    expect(
+      getCoreDumpSupportContact({
+        email: 'test@example.com',
+        name: 'Test User',
+      } as never)
+    ).toEqual({
+      firstName: 'Test',
+      lastName: 'User',
+    })
+
+    expect(
+      getCoreDumpSupportContact({
+        email: 'fallback@example.com',
+      } as never)
+    ).toEqual({
+      firstName: 'fallback',
+      lastName: 'User',
+    })
+  })
+
+  it('builds a support-ready message directly from the coredump', () => {
+    const message = getCoreDumpSupportMessage({
+      id: 'abc123',
+      version: '1.2.3',
+      git_rev: 'deadbeef',
+      timestamp: '2026-03-30T00:00:00Z',
+      desktop: true,
+      kcl_code: '',
+      os: {
+        platform: 'macOS',
+        arch: 'arm64',
+        version: '15.4',
+      },
+      webrtc_stats: {},
+      client_state: {},
+    } as never)
+
+    expect(message).toContain('Automatic support report from Zoo Design Studio.')
+    expect(message).toContain('Reference ID: abc123')
+    expect(message).toContain('Desktop: yes')
+    expect(message).toContain('OS: macOS arm64 15.4')
+    expect(message).toContain(
+      'This support report includes the collected diagnostic context for this reference ID.'
+    )
+  })
+
+  it('submits a technical support form with the coredump message', async () => {
+    mockState.putPublicSupportForm.mockResolvedValue(undefined)
+
+    await submitCoreDumpSupportTicket({
+      dump: {
+        id: 'abc123',
+        version: '1.2.3',
+        git_rev: 'deadbeef',
+        timestamp: '2026-03-30T00:00:00Z',
+        desktop: true,
+        kcl_code: '',
+        os: {},
+        webrtc_stats: {},
+        client_state: {},
+      } as never,
+      token: 'token-123',
+      user: {
+        company: 'Zoo',
+        email: 'test@example.com',
+        first_name: 'Test',
+        last_name: 'User',
+        phone: '555-0100',
+      } as never,
+    })
+
+    expect(mockState.createKCClient).toHaveBeenCalledWith('token-123')
+    expect(mockState.putPublicSupportForm).toHaveBeenCalledWith({
+      client: { mocked: true },
+      body: {
+        company: 'Zoo',
+        email: 'test@example.com',
+        first_name: 'Test',
+        inquiry_type: 'technical_support',
+        last_name: 'User',
+        message: `Automatic support report from Zoo Design Studio.
+
+Reference ID: abc123
+Version: 1.2.3
+Git Revision: deadbeef
+Desktop: yes
+
+This support report includes the collected diagnostic context for this reference ID.`,
+        phone: '555-0100',
+      },
+    })
+  })
+})

--- a/src/lib/coredump.ts
+++ b/src/lib/coredump.ts
@@ -1,12 +1,14 @@
+import { users } from '@kittycad/lib'
+import type { UserResponse } from '@kittycad/lib'
 import { UAParser } from 'ua-parser-js'
 
+import type { CoreDumpInfo } from '@rust/kcl-lib/bindings/CoreDumpInfo'
 import type { OsInfo } from '@rust/kcl-lib/bindings/OsInfo'
 import type { WebrtcStats } from '@rust/kcl-lib/bindings/WebrtcStats'
 import type { KclManager } from '@src/lang/KclManager'
 import type { CommandLog } from '@src/lang/std/commandLog'
 import { isDesktop } from '@src/lib/isDesktop'
-import screenshot from '@src/lib/screenshot'
-import { withAPIBaseURL } from '@src/lib/withBaseURL'
+import { createKCClient, kcCall } from '@src/lib/kcClient'
 import { APP_VERSION } from '@src/routes/utils'
 import type { ILog } from '@src/lib/debugger'
 import { EngineDebugger } from '@src/lib/debugger'
@@ -31,25 +33,9 @@ import { EngineDebugger } from '@src/lib/debugger'
 // TODO: Throw more
 export class CoreDumpManager {
   kclManager: KclManager
-  token: string | undefined
-  baseUrl: string = withAPIBaseURL('')
 
-  constructor(kclManager: KclManager, token: string | undefined) {
+  constructor(kclManager: KclManager) {
     this.kclManager = kclManager
-    this.token = token
-  }
-
-  // Get the token
-  authToken(): string {
-    if (!this.token) {
-      throw new Error('Token not set')
-    }
-    return this.token
-  }
-
-  // Get the base URL
-  baseApiUrl(): string {
-    return this.baseUrl
   }
 
   // Get the version of the app from the package.json
@@ -414,14 +400,87 @@ export class CoreDumpManager {
       return Promise.reject(JSON.stringify(error))
     }
   }
+}
 
-  // Return a data URL (png format) of the screenshot of the current page.
-  screenshot(): Promise<string> {
-    return (
-      screenshot()
-        .then((screenshotStr: string) => screenshotStr)
-        // maybe rust should handle an error, but an empty string at least doesn't cause the core dump to fail entirely
-        .catch((_error: any) => ``)
+export const getCoreDumpSupportContact = (user?: UserResponse) => {
+  const trimmedFirstName = user?.first_name?.trim()
+  const trimmedLastName = user?.last_name?.trim()
+  const trimmedName = user?.name?.trim()
+  const nameParts = trimmedName ? trimmedName.split(/\s+/).filter(Boolean) : []
+  const emailFallback = user?.email?.split('@')[0]?.trim()
+
+  return {
+    firstName:
+      trimmedFirstName || nameParts[0] || emailFallback || 'Zoo Design Studio',
+    lastName:
+      trimmedLastName || nameParts.slice(1).join(' ') || 'User',
+  }
+}
+
+export const getCoreDumpSupportMessage = (dump: CoreDumpInfo) => {
+  const sections = [
+    'Automatic support report from Zoo Design Studio.',
+    '',
+    `Reference ID: ${dump.id}`,
+    `Version: ${dump.version}`,
+    `Git Revision: ${dump.git_rev}`,
+    `Desktop: ${dump.desktop ? 'yes' : 'no'}`,
+  ]
+
+  if (dump.os.platform || dump.os.arch || dump.os.version) {
+    sections.push(
+      `OS: ${[dump.os.platform, dump.os.arch, dump.os.version].filter(Boolean).join(' ')}`
     )
+  }
+
+  sections.push(
+    '',
+    'This support report includes the collected diagnostic context for this reference ID.'
+  )
+
+  if (dump.kcl_code.trim()) {
+    sections.push('', 'KCL Code:', '```kcl', dump.kcl_code, '```')
+  }
+
+  return sections.join('\n')
+}
+
+export const submitCoreDumpSupportTicket = async ({
+  dump,
+  token,
+  user,
+}: {
+  dump: CoreDumpInfo
+  token?: string
+  user?: UserResponse
+}) => {
+  if (!token) {
+    throw new Error('Token not set')
+  }
+
+  const email = user?.email?.trim()
+  if (!email) {
+    throw new Error('User email not available')
+  }
+
+  const { firstName, lastName } = getCoreDumpSupportContact(user)
+  const client = createKCClient(token)
+  const result = await kcCall(() =>
+    users.put_public_support_form({
+      client,
+      body: {
+        company: user?.company || undefined,
+        email,
+        first_name: firstName,
+        inquiry_type: 'technical_support',
+        last_name: lastName,
+        message: getCoreDumpSupportMessage(dump),
+        phone: user?.phone || undefined,
+      },
+    })
+  )
+
+  if (result instanceof Error) {
+    throw result
   }
 }


### PR DESCRIPTION
kittycad.rs contained some breaking changes due to an API being removed. I realize now this API was wired into a keyboard shortcut, so it's still possible to use it.

Instead, I'm just rewiring this to create a support ticket directly. I tried to preserve what makes sense via the support API, and it should be a bit lower friction as it won't require a github account.

We could also just drop this functionality entirely, I removed the old debug upload API because I only saw confused bots and security probes trying to use this endpoint and failing.