### PR TITLE
bug: when emptying codemirror your selection still stay

### DIFF
--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -537,8 +537,8 @@ export class File extends EventTarget {
     read: (path: string) => fsZds.readFile(path, 'utf8'),
     write: (path: string, content: string) =>
       fsZds.writeFile(path, File.encoder.encode(content)),
-    watch: window.electron?.watchFileOn || (() => { }),
-    unwatch: window.electron?.watchFileOff || (() => { }),
+    watch: window.electron?.watchFileOn || (() => {}),
+    unwatch: window.electron?.watchFileOff || (() => {}),
   }
   static encoder = new TextEncoder()
 }
@@ -572,7 +572,7 @@ export class KclManager extends File {
     return this._wasmInstance
   }
   readonly systemDeps: SystemDeps
-  private _modelingSend: (eventInfo: ModelingMachineEvent) => void = () => { }
+  private _modelingSend: (eventInfo: ModelingMachineEvent) => void = () => {}
   private _modelingState: StateFrom<typeof modelingMachine> | null = null
 
   // CORE STATE
@@ -726,10 +726,10 @@ export class KclManager extends File {
     If this value isn't `null`, don't watch for file system writes it was probably us!
    */
   public writingPromise = signal<Promise<unknown> | null>(null)
-  sceneInfraBaseUnitMultiplierSetter: (unit: BaseUnit) => void = () => { }
+  sceneInfraBaseUnitMultiplierSetter: (unit: BaseUnit) => void = () => {}
   /** Values merged in from former EditorManager and CodeManager classes */
   private _convertToVariableEnabled: boolean = false
-  private _convertToVariableCallback: () => void = () => { }
+  private _convertToVariableCallback: () => void = () => {}
 
   // CONFIGURATION
 
@@ -2246,7 +2246,7 @@ export class KclManager extends File {
       annotations: [
         Transaction.addToHistory.of(
           resolvedOptions.shouldAddToHistory &&
-          !resolvedOptions.shouldClearHistory
+            !resolvedOptions.shouldClearHistory
         ),
       ],
       effects: [


### PR DESCRIPTION
# issue

When you make a selection the delete the entire codemirror body your selection will stay

# implementation

I made a codemirror extension in kclmanager to check if the doc updated and the new doc is empty clear all your selections.

# reproduction

1. go to an empty file
2. start sketch mode
3. make a sketch
4. select something
5. CRTL+A delete the code
6. Your selection will stay.