### PR TITLE
Force variable declaration for circles

### DIFF
--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -99,6 +99,7 @@ const ARC_START_PARAM: &str = "start";
 const ARC_END_PARAM: &str = "end";
 const ARC_CENTER_PARAM: &str = "center";
 const CIRCLE_FN: &str = "circle";
+const CIRCLE_VARIABLE: &str = "circle";
 const CIRCLE_START_PARAM: &str = "start";
 const CIRCLE_CENTER_PARAM: &str = "center";
 
@@ -1665,7 +1666,10 @@ impl FrontendState {
         let (sketch_block_range, _) = self.mutate_ast(
             &mut new_ast,
             sketch_id,
-            AstMutateCommand::AddSketchBlockExprStmt { expr: circle_ast },
+            AstMutateCommand::AddSketchBlockVarDecl {
+                prefix: CIRCLE_VARIABLE.to_owned(),
+                expr: circle_ast,
+            },
         )?;
         // Convert to string source to create real source ranges.
         let new_source = source_from_ast(&new_ast);
@@ -2353,7 +2357,7 @@ impl FrontendState {
                             ),
                         });
                     };
-                    get_or_insert_ast_reference(new_ast, &owner_object.source, "circle", Some(property))
+                    get_or_insert_ast_reference(new_ast, &owner_object.source, CIRCLE_VARIABLE, Some(property))
                 }
                 _ => Err(Error {
                     msg: format!(
@@ -2407,7 +2411,7 @@ impl FrontendState {
             }
             Segment::Circle(_) => {
                 // Reference the segment directly (for point-circle coincident)
-                get_or_insert_ast_reference(new_ast, &seg0_object.source, "circle", None)?
+                get_or_insert_ast_reference(new_ast, &seg0_object.source, CIRCLE_VARIABLE, None)?
             }
         };
 
@@ -2435,7 +2439,7 @@ impl FrontendState {
             }
             Segment::Circle(_) => {
                 // Reference the segment directly (for point-circle coincident)
-                get_or_insert_ast_reference(new_ast, &seg1_object.source, "circle", None)?
+                get_or_insert_ast_reference(new_ast, &seg1_object.source, CIRCLE_VARIABLE, None)?
             }
         };
 
@@ -2622,7 +2626,7 @@ impl FrontendState {
         let seg0_ast = match seg0_segment {
             Segment::Line(_) => get_or_insert_ast_reference(new_ast, &seg0_object.source, "line", None)?,
             Segment::Arc(_) => get_or_insert_ast_reference(new_ast, &seg0_object.source, "arc", None)?,
-            Segment::Circle(_) => get_or_insert_ast_reference(new_ast, &seg0_object.source, "circle", None)?,
+            Segment::Circle(_) => get_or_insert_ast_reference(new_ast, &seg0_object.source, CIRCLE_VARIABLE, None)?,
             _ => {
                 return Err(Error {
                     msg: format!("Tangent supports only line/arc/circle segments, got: {seg0_segment:?}"),
@@ -2641,7 +2645,7 @@ impl FrontendState {
         let seg1_ast = match seg1_segment {
             Segment::Line(_) => get_or_insert_ast_reference(new_ast, &seg1_object.source, "line", None)?,
             Segment::Arc(_) => get_or_insert_ast_reference(new_ast, &seg1_object.source, "arc", None)?,
-            Segment::Circle(_) => get_or_insert_ast_reference(new_ast, &seg1_object.source, "circle", None)?,
+            Segment::Circle(_) => get_or_insert_ast_reference(new_ast, &seg1_object.source, CIRCLE_VARIABLE, None)?,
             _ => {
                 return Err(Error {
                     msg: format!("Tangent supports only line/arc/circle segments, got: {seg1_segment:?}"),
@@ -2746,7 +2750,7 @@ impl FrontendState {
         };
         let ref_type = match arc_segment {
             Segment::Arc(_) => "arc",
-            Segment::Circle(_) => "circle",
+            Segment::Circle(_) => CIRCLE_VARIABLE,
             _ => {
                 return Err(Error {
                     msg: format!(
@@ -3843,6 +3847,11 @@ enum AstMutateCommand {
     AddSketchBlockExprStmt {
         expr: ast::Expr,
     },
+    /// Add a variable declaration to the sketch block (e.g. `line1 = line(...)`).
+    AddSketchBlockVarDecl {
+        prefix: String,
+        expr: ast::Expr,
+    },
     AddVariableDeclaration {
         prefix: String,
     },
@@ -3969,6 +3978,26 @@ fn process(ctx: &AstMutateContext, node: NodeMut) -> TraversalReturn<Result<AstM
                         comment_start: Default::default(),
                     }));
                 return TraversalReturn::new_break(Ok(AstMutateCommandReturn::None));
+            }
+        }
+        AstMutateCommand::AddSketchBlockVarDecl { prefix, expr } => {
+            if let NodeMut::SketchBlock(sketch_block) = node {
+                let empty_defined_names = HashSet::new();
+                let defined_names = ctx.defined_names_stack.last().unwrap_or(&empty_defined_names);
+                let Ok(name) = next_free_name(prefix, defined_names) else {
+                    return TraversalReturn::new_break(Ok(AstMutateCommandReturn::None));
+                };
+                sketch_block
+                    .body
+                    .items
+                    .push(ast::BodyItem::VariableDeclaration(Box::new(ast::Node::no_src(
+                        ast::VariableDeclaration::new(
+                            ast::VariableDeclarator::new(&name, expr.clone()),
+                            ast::ItemVisibility::Default,
+                            ast::VariableKind::Const,
+                        ),
+                    ))));
+                return TraversalReturn::new_break(Ok(AstMutateCommandReturn::Name(name)));
             }
         }
         AstMutateCommand::AddVariableDeclaration { prefix } => {
@@ -4250,7 +4279,13 @@ impl<'a> crate::walk::Visitor<'a> for &FindSketchBlockSourceRange {
                 // End shouldn't match since we added something.
                 && node_range.end() >= self.target_before_mutation.end()
             {
-                self.found.set(sketch_block.body.items.last().map(SourceRange::from));
+                self.found.set(sketch_block.body.items.last().map(|item| match item {
+                    // For declarations like `circle1 = circle(...)`, use
+                    // the init expression range so lookup in source_range_to_object
+                    // matches the segment source range.
+                    ast::BodyItem::VariableDeclaration(node) => SourceRange::from(&node.declaration.init),
+                    _ => SourceRange::from(item),
+                }));
                 return Ok(false);
             } else {
                 // We found a different sketch block. No need to descend into
@@ -5159,7 +5194,7 @@ sketch001 = sketch(on = XY) {
             "@settings(experimentalFeatures = allow)
 
 sketch001 = sketch(on = XY) {
-  circle(start = [var 5mm, var 0mm], center = [var 0mm, var 0mm])
+  circle1 = circle(start = [var 5mm, var 0mm], center = [var 0mm, var 0mm])
 }
 "
         );
@@ -5206,7 +5241,7 @@ sketch001 = sketch(on = XY) {
             "@settings(experimentalFeatures = allow)
 
 sketch001 = sketch(on = XY) {
-  circle(start = [var 10mm, var 0mm], center = [var 3mm, var 4mm])
+  circle1 = circle(start = [var 10mm, var 0mm], center = [var 3mm, var 4mm])
 }
 "
         );


### PR DESCRIPTION
Fixes #10707

AI-assisted attempt at making sure we declare a `circle###` variable when drawing a circle so that I don't have to mutate the AST in Typescript. 