### PR TITLE
Fix idle recovery behavior while in sketch solve

### DIFF
--- a/src/components/ConnectionStream.tsx
+++ b/src/components/ConnectionStream.tsx
@@ -381,7 +381,7 @@ export const ConnectionStream = (props: {
       },
       engineCommandManager,
     }),
-    [modelingSend, engineCommandManager]
+    [modelingMachineState, modelingSend, engineCommandManager]
   )
   useOnOfflineToExitSketchMode(onOfflineToExitSketchModeParams)
 


### PR DESCRIPTION
Sending "cancel" would break the app while attempting to recover from idle if you left the app in sketch solve mode. This sends the more appropriate recovery event for sketch solve, so sketch solve continues to be useful after coming out of idle.