### PR TITLE
fix coincidents with circle

### DIFF
--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -2066,6 +2066,28 @@ myBlend = blend([extrude001.sketch.tags.line7, extrude002.sketch.tags.line3])
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn issue_10741_point_circle_coincident_executes() {
+        let code = r#"@settings(experimentalFeatures = allow)
+sketch001 = sketch(on = YZ) {
+  circle1 = circle(start = [var -2.67mm, var 1.8mm], center = [var -1.53mm, var 0.78mm])
+  line1 = line(start = [var -1.05mm, var 2.22mm], end = [var -3.58mm, var -0.78mm])
+  coincident([line1.start, circle1])
+}
+"#;
+
+        let result = parse_execute(code).await.unwrap();
+        assert!(
+            result
+                .exec_state
+                .errors()
+                .iter()
+                .all(|error| error.severity != Severity::Error),
+            "unexpected execution errors: {:#?}",
+            result.exec_state.errors()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_execute_with_pipe_substitutions_unary() {
         let ast = r#"myVar = 3
 part001 = startSketchOn(XY)

--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -6331,6 +6331,86 @@ sketch(on = XY) {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_coincident_of_line_point_and_circle_segment() {
+        let initial_source = "\
+@settings(experimentalFeatures = allow)
+
+sketch(on = XY) {
+  circle1 = circle(start = [var 5mm, var 0mm], center = [var 0mm, var 0mm])
+  line1 = line(start = [var 9mm, var 1mm], end = [var 10mm, var 2mm])
+}
+";
+        let program = Program::parse(initial_source).unwrap().0.unwrap();
+        let mut frontend = FrontendState::new();
+
+        let mock_ctx = ExecutorContext::new_mock(None).await;
+        let version = Version(0);
+
+        let outcome = mock_ctx.run_mock(&program, &MockConfig::default()).await.unwrap();
+        frontend.program = program;
+        frontend.update_state_after_exec(outcome, true);
+        let sketch_object = find_first_sketch_object(&frontend.scene_graph).expect("Expected sketch object");
+        let sketch_id = sketch_object.id;
+        let sketch = expect_sketch(sketch_object);
+
+        let circle_id = sketch
+            .segments
+            .iter()
+            .copied()
+            .find(|seg_id| {
+                matches!(
+                    &frontend.scene_graph.objects[seg_id.0].kind,
+                    ObjectKind::Segment {
+                        segment: Segment::Circle(_)
+                    }
+                )
+            })
+            .expect("Expected a circle segment in sketch");
+        let line_id = sketch
+            .segments
+            .iter()
+            .copied()
+            .find(|seg_id| {
+                matches!(
+                    &frontend.scene_graph.objects[seg_id.0].kind,
+                    ObjectKind::Segment {
+                        segment: Segment::Line(_)
+                    }
+                )
+            })
+            .expect("Expected a line segment in sketch");
+
+        let line_start_point_id = match &frontend.scene_graph.objects[line_id.0].kind {
+            ObjectKind::Segment {
+                segment: Segment::Line(line),
+            } => line.start,
+            _ => panic!("Expected line segment object"),
+        };
+
+        let constraint = Constraint::Coincident(Coincident {
+            segments: vec![line_start_point_id, circle_id],
+        });
+        let (src_delta, _scene_delta) = frontend
+            .add_constraint(&mock_ctx, version, sketch_id, constraint)
+            .await
+            .unwrap();
+        assert_eq!(
+            src_delta.text.as_str(),
+            "\
+@settings(experimentalFeatures = allow)
+
+sketch(on = XY) {
+  circle1 = circle(start = [var 5mm, var 0mm], center = [var 0mm, var 0mm])
+  line1 = line(start = [var 9mm, var 1mm], end = [var 10mm, var 2mm])
+  coincident([line1.start, circle1])
+}
+"
+        );
+
+        mock_ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_invalid_coincident_arc_and_line_preserves_state() {
         // Test that attempting an invalid coincident constraint (arc and line)
         // doesn't corrupt the state, allowing subsequent operations to work.

--- a/rust/kcl-lib/src/std/constraints.rs
+++ b/rust/kcl-lib/src/std/constraints.rs
@@ -1145,6 +1145,99 @@ pub async fn coincident(exec_state: &mut ExecState, args: Args) -> Result<KclVal
                         ))),
                     }
                 }
+                // Point-Circle or Circle-Point case: constrain point-to-center distance
+                // to equal the circle radius.
+                (
+                    UnsolvedSegmentKind::Point {
+                        position: point_pos, ..
+                    },
+                    UnsolvedSegmentKind::Circle {
+                        start: circle_start,
+                        center: circle_center,
+                        ..
+                    },
+                )
+                | (
+                    UnsolvedSegmentKind::Circle {
+                        start: circle_start,
+                        center: circle_center,
+                        ..
+                    },
+                    UnsolvedSegmentKind::Point {
+                        position: point_pos, ..
+                    },
+                ) => {
+                    let point_x = &point_pos[0];
+                    let point_y = &point_pos[1];
+                    match (point_x, point_y) {
+                        (UnsolvedExpr::Unknown(point_x), UnsolvedExpr::Unknown(point_y)) => {
+                            // Extract circle center and start coordinates.
+                            let (center_x, center_y) = (&circle_center[0], &circle_center[1]);
+                            let (start_x, start_y) = (&circle_start[0], &circle_start[1]);
+
+                            match (center_x, center_y, start_x, start_y) {
+                                (
+                                    UnsolvedExpr::Unknown(cx),
+                                    UnsolvedExpr::Unknown(cy),
+                                    UnsolvedExpr::Unknown(sx),
+                                    UnsolvedExpr::Unknown(sy),
+                                ) => {
+                                    let point_radius_line = DatumLineSegment::new(
+                                        DatumPoint::new_xy(
+                                            cx.to_constraint_id(range)?,
+                                            cy.to_constraint_id(range)?,
+                                        ),
+                                        DatumPoint::new_xy(
+                                            point_x.to_constraint_id(range)?,
+                                            point_y.to_constraint_id(range)?,
+                                        ),
+                                    );
+                                    let circle_radius_line = DatumLineSegment::new(
+                                        DatumPoint::new_xy(
+                                            cx.to_constraint_id(range)?,
+                                            cy.to_constraint_id(range)?,
+                                        ),
+                                        DatumPoint::new_xy(
+                                            sx.to_constraint_id(range)?,
+                                            sy.to_constraint_id(range)?,
+                                        ),
+                                    );
+                                    let constraint =
+                                        SolverConstraint::LinesEqualLength(point_radius_line, circle_radius_line);
+
+                                    #[cfg(feature = "artifact-graph")]
+                                    let constraint_id = exec_state.next_object_id();
+
+                                    let Some(sketch_state) = exec_state.sketch_block_mut() else {
+                                        return Err(KclError::new_semantic(KclErrorDetails::new(
+                                            "coincident() can only be used inside a sketch block".to_owned(),
+                                            vec![args.source_range],
+                                        )));
+                                    };
+                                    sketch_state.solver_constraints.push(constraint);
+                                    #[cfg(feature = "artifact-graph")]
+                                    {
+                                        let constraint = crate::front::Constraint::Coincident(Coincident {
+                                            segments: vec![unsolved0.object_id, unsolved1.object_id],
+                                        });
+                                        sketch_state.sketch_constraints.push(constraint_id);
+                                        track_constraint(constraint_id, constraint, exec_state, &args);
+                                    }
+                                    Ok(KclValue::none())
+                                }
+                                _ => Err(KclError::new_semantic(KclErrorDetails::new(
+                                    "Circle start and center points must be sketch variables for point-circle coincident constraint".to_owned(),
+                                    vec![args.source_range],
+                                ))),
+                            }
+                        }
+                        _ => Err(KclError::new_semantic(KclErrorDetails::new(
+                            "Point coordinates must be sketch variables for point-circle coincident constraint"
+                                .to_owned(),
+                            vec![args.source_range],
+                        ))),
+                    }
+                }
                 // Line-Line case: create parallel constraint and perpendicular distance of zero
                 (
                     UnsolvedSegmentKind::Line {


### PR DESCRIPTION
Resolves #10741

The following works
```
sketch001 = sketch(on = YZ) {
  circle1 = circle(start = [var -2.67mm, var 1.8mm], center = [var -1.53mm, var 0.78mm])
  line1 = line(start = [var -1.05mm, var 2.22mm], end = [var -3.58mm, var -0.78mm])
  coincident([line1.start, circle1])
}
```

No change to point and click was needed because it was already submitting it to the code-mod api, it was just erroring before.