### PR TITLE
Use the same styling for all "Dismiss" buttons

### DIFF
--- a/src/routes/Onboarding/utils.tsx
+++ b/src/routes/Onboarding/utils.tsx
@@ -507,10 +507,10 @@ export function TutorialRequestToast(
           onClick={() => onDismissOnboardingInvite(settings.actor)}
           iconStart={{
             icon: 'close',
-            bgClassName: 'bg-destroy-80 dark:bg-destroy-20',
-            iconClassName: 'text-destroy-10 dark:text-destroy-80',
+            className: 'text-chalkboard-10',
+            bgClassName: 'bg-destroy-80 group-hover:bg-destroy-80',
           }}
-          className="border-chalkboard-40 bg-chalkboard-20 text-default hover:border-chalkboard-50 dark:border-chalkboard-70 dark:bg-chalkboard-80 dark:hover:border-chalkboard-60"
+          className="hover:border-destroy-40 hover:bg-destroy-10/50 dark:hover:bg-destroy-80/50"
           data-testid="onboarding-not-right-now"
         >
           Dismiss


### PR DESCRIPTION
The "Dismiss" button in the onboarding modal did not match the rest of the app (gray with a red hover).

Before:

<img width="340" height="233" alt="Screenshot 2026-04-02 at 1 53 21 PM" src="https://github.com/user-attachments/assets/dab4fd3b-9186-4bd3-b2eb-99bef1317cbe" />


After:

<img width="356" height="275" alt="Screenshot 2026-04-02 at 1 53 40 PM" src="https://github.com/user-attachments/assets/fc5a85e0-cfa6-42a6-acae-14e23b55fb14" />
