### PR TITLE
Update sketch and tag docs to new API

### DIFF
--- a/docs/kcl-sketch-solve/modules.md
+++ b/docs/kcl-sketch-solve/modules.md
@@ -76,17 +76,23 @@ There are two common patterns for re‑using geometry:
 ### Parametric function example
 
 ```kcl
-fn cube(center) {
-  sketch001 = startSketchOn(XY)
-    |> startProfile(at = [center[0] - 10, center[1] - 10])
-    |> line(endAbsolute = [center[0] + 10, center[1] - 10])
-    |> line(endAbsolute = [center[0] + 10, center[1] + 10])
-    |> line(endAbsolute = [center[0] - 10, center[1] + 10])
-    |> close()
-  return extrude(sketch001, length = 10)
+fn cube(height) {
+sketch001 = sketch(on = XY) {
+  line1 = line(start = [var 0mm, var 0mm], end = [var 0mm, var 3mm])
+  coincident([line1.start, ORIGIN])
+  line2 = line(start = [var 0mm, var 3mm], end = [var 3mm, var 3mm])
+  coincident([line1.end, line2.start])
+  line3 = line(start = [var 3mm, var 3mm], end = [var 3mm, var 0mm])
+  coincident([line2.end, line3.start])
+  line4 = line(start = [var 3mm, var 0mm], end = [var 0mm, var 0mm])
+  coincident([line3.end, line4.start])
+  coincident([line4.end, line1.start])
+}
+region001 = region(point = [2mm, 2mm], sketch = sketch001)
+  return extrude(region001, length = height)
 }
 
-myCube = cube(center = [0, 0])
+myCube = cube(height = 2)
 
 ```
 

--- a/docs/kcl-sketch-solve/types.md
+++ b/docs/kcl-sketch-solve/types.md
@@ -48,19 +48,29 @@ Tags are used to give a name (tag) to a specific path.
 
 ### Tag declarations - `TagDecl`
 
-The syntax for declaring a tag is `$myTag` you would use it in the following
-way:
+
+The syntax for declaring a tag is `$myTag`. Tags are used for bodies (such as extrude cap faces). For sketches, reference segment names directly.
+
+**Example: Referencing sketch segments and tagging cap faces**
 
 ```kcl
-startSketchOn(XZ)
-  |> startProfile(at = [0, 0])
-  |> angledLine(angle = 0, length = 191.26, tag = $rectangleSegmentA001)
-  |> angledLine(angle = segAng(rectangleSegmentA001) - 90, length = 196.99, tag = $rectangleSegmentB001)
-  |> angledLine(angle = segAng(rectangleSegmentA001), length = -segLen(rectangleSegmentA001), tag = $rectangleSegmentC001)
-  |> line(endAbsolute = [profileStartX(%), profileStartY(%)])
-  |> close()
-
+sketch001 = sketch(on = XZ) {
+  line1 = line(start = [var -2.17mm, var -0.91mm], end = [var 3.01mm, var -1.57mm])
+  line2 = line(start = [var 3.01mm, var -1.57mm], end = [var 3.13mm, var 3.12mm])
+  coincident([line1.end, line2.start])
+  line3 = line(start = [var 3.13mm, var 3.12mm], end = [var -2.26mm, var 2.4mm])
+  coincident([line2.end, line3.start])
+  line4 = line(start = [var -2.26mm, var 2.4mm], end = [var -2.17mm, var -0.91mm])
+  coincident([line3.end, line4.start])
+  coincident([line4.end, line1.start])
+}
+region001 = region(point = [0.4203mm, -1.2375mm], sketch = sketch001)
+extrude001 = extrude(region001, length = 5, tagEnd = $capEnd001)
+fillet001 = fillet(extrude001, tags = getCommonEdge(faces = [region001.tags.line4, capEnd001]), radius = 1)
 ```
+
+
+In this example, you reference sketch segments by their names (e.g., `line4`). Tags (using `$`) are only needed for cap faces or other body features.
 
 When a function requires declaring a new tag (using the `$` syntax), the argument has type [`TagDecl`](/docs/kcl-std/types/std-types-TagDecl).
 
@@ -72,12 +82,10 @@ Where necessary to disambiguate from tag declarations, we call these tag identif
 In the example above we use the tag identifier `rectangleSegmentA001` to get the angle of the segment
 using `segAng(rectangleSegmentA001)`.
 
-Tags can identify either an edge or face of a solid, or a line or other edge of a sketch. Functions
-which take a tag identifier as an argument will use either [`TaggedEdge`](/docs/kcl-std/types/std-types-TaggedEdge) (for the edge of a
-solid or sketch) or [`TaggedFace`](/docs/kcl-std/types/std-types-TaggedFace).
 
-If a line in a sketch is tagged and then the sketch is extruded, the tag is a `TaggedEdge` before
-extrusion and a `TaggedFace` after extrusion.
+Tags can identify an edge or face of a solid. Functions that take a tag identifier as an argument will use either [`TaggedEdge`](/docs/kcl-std/types/std-types-TaggedEdge) (for the edge of a solid) or [`TaggedFace`](/docs/kcl-std/types/std-types-TaggedFace).
+
+For sketches, always use the segment name (e.g., `line1`, `line2`).
 
 #### `START` and `END`
 
@@ -87,65 +95,7 @@ for identifying the starting and ending faces of an extruded solid.
 
 ### Tag Scope
 
-Tags are scoped globally if in the root context meaning in this example you can 
-use the tag `rectangleSegmentA001` in any function or expression in the file.
-
-However if the code was written like this:
-
-```kcl
-fn rect(origin) {
-  return startSketchOn(XZ)
-    |> startProfile(at = origin)
-    |> angledLine(angle = 0, length = 191.26, tag = $rectangleSegmentA001)
-    |> angledLine(angle = segAng(rectangleSegmentA001) - 90, length = 196.99, tag = $rectangleSegmentB001)
-    |> angledLine(angle = segAng(rectangleSegmentA001), length = -segLen(rectangleSegmentA001), tag = $rectangleSegmentC001)
-    |> line(endAbsolute = [profileStartX(%), profileStartY(%)])
-    |> close()
-}
-
-rect(origin = [0, 0])
-rect(origin = [20, 0])
-
-```
-
-Those tags would only be available in the `rect` function and not globally.
-
-However you likely want to use those tags somewhere outside the `rect` function.
-
-Tags are accessible through the sketch group they are declared in.
-For example the following code works.
-
-<!-- transpile failed -->
-```kcl
-fn rect(origin) {
-  return startSketchOn(XZ)
-    |> startProfile(at = origin)
-    |> angledLine(angle = 0, length = 191.26, tag = $rectangleSegmentA001)
-    |> angledLine(
-         angle = segAng(rectangleSegmentA001) - 90,
-         length = 196.99,
-         tag = $rectangleSegmentB001,
-       )
-    |> angledLine(
-         angle = segAng(rectangleSegmentA001),
-         length = -segLen(rectangleSegmentA001),
-         tag = $rectangleSegmentC001,
-       )
-    |> line(endAbsolute = [profileStartX(%), profileStartY(%)])
-    |> close()
-}
-
-rect(origin = [0, 0])
-myRect = rect(origin = [20, 0])
-
-myRect
-  |> extrude(length = 10)
-  |> fillet(radius = 0.5, tags = [myRect.tags.rectangleSegmentA001])
-```
-
-See how we use the tag `rectangleSegmentA001` in the `fillet` function outside
-the `rect` function. This is because the `rect` function is returning the
-sketch group that contains the tags.
+Tags are scoped globally if declared in the root context. For bodies, you can use the tag anywhere in the file. For sketches, always use the segment name directly.
 
 ---
 


### PR DESCRIPTION
Replace old pipeline-style sketch examples with the new sketch/region/extrude API in modules.md (update cube example to use sketch, region, and a height parameter). Revise tags/types.md to clarify tag declarations and scope: sketches should reference segment names directly, tags using `$` are intended for bodies/cap faces, and a concise example shows tagging a cap face and using getCommonEdge. Remove outdated pipeline examples and long scope discussion.