### PR TITLE
Use polling in test to wait for async units update

### DIFF
--- a/e2e/playwright/testing-settings.spec.ts
+++ b/e2e/playwright/testing-settings.spec.ts
@@ -821,6 +821,7 @@ test.describe(
       `Change inline units setting`,
       { tag: ['@macos', '@windows'] },
       async ({ page, homePage, editor, folderSetupFn }) => {
+        const u = await getUtils(page)
         const initialInlineUnits = 'yd'
         const editedInlineUnits = { short: 'mm', long: 'Millimeters' }
         const inlineSettingsString = (s: string) =>
@@ -847,15 +848,19 @@ test.describe(
 
         await test.step(`Manually write inline settings`, async () => {
           await editor.openPane()
+          // Clear debug logs so expectCmdLog waits for executeAst from this edit, not a prior run.
+          await u.openDebugPanel()
+          await u.clearCommandLogs()
+          await u.closeDebugPanel()
           await editor.replaceCode(
             `fn cube`,
             `${inlineSettingsString(initialInlineUnits)}
 fn cube`
           )
-          // Per-file units come from executed AST; fill() triggers async executeAst.
-          await expect
-            .poll(async () => await unitsIndicator.innerText())
-            .toContain(initialInlineUnits)
+          await u.openDebugPanel()
+          await u.expectCmdLog('[data-message-type="execution-done"]', 20_000)
+          await u.closeDebugPanel()
+          await expect(unitsIndicator).toContainText(initialInlineUnits)
         })
 
         await test.step(`Change units setting via lower-right control`, async () => {


### PR DESCRIPTION
This is an attempt at making this test more reliable: https://test-analysis-bot.corp.zoo.dev/projects/KittyCAD/modeling-app/tests/384?weeks=2&branch=poll-for-units