### PR TITLE
Fix circle tool flicker in sketch solve

### DIFF
--- a/src/machines/sketchSolve/arcPositions.test.ts
+++ b/src/machines/sketchSolve/arcPositions.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { createArcPositions } from '@src/machines/sketchSolve/arcPositions'
+
+describe('createArcPositions', () => {
+  it('does not collapse full circles when startAngle + 2π rounds above 2π', () => {
+    const startAngle = 2.752564435001932
+    const positions = createArcPositions({
+      center: [0, 0],
+      radius: 5,
+      startAngle,
+      endAngle: startAngle + Math.PI * 2,
+      ccw: true,
+    })
+
+    const uniquePoints = new Set<string>()
+    for (let i = 0; i < positions.length; i += 3) {
+      uniquePoints.add(
+        `${positions[i].toFixed(6)},${positions[i + 1].toFixed(6)}`
+      )
+    }
+
+    expect(positions).toHaveLength(303)
+    expect(uniquePoints.size).toBeGreaterThan(95)
+
+    const firstX = positions[0]
+    const firstY = positions[1]
+    const lastX = positions[positions.length - 3]
+    const lastY = positions[positions.length - 2]
+    expect(Math.hypot(firstX - lastX, firstY - lastY)).toBeLessThan(1e-9)
+  })
+})

--- a/src/machines/sketchSolve/arcPositions.ts
+++ b/src/machines/sketchSolve/arcPositions.ts
@@ -1,5 +1,43 @@
 import { EllipseCurve } from 'three'
 
+const TAU = Math.PI * 2
+const FULL_CIRCLE_TOLERANCE = 1e-12
+
+function isFullCircleSweep(startAngle: number, endAngle: number): boolean {
+  return (
+    Math.abs(Math.abs(endAngle - startAngle) - TAU) <= FULL_CIRCLE_TOLERANCE
+  )
+}
+
+function createFullCirclePositions({
+  center,
+  radius,
+  startAngle,
+  ccw,
+  numberOfPoints,
+}: {
+  center: [number, number]
+  radius: number
+  startAngle: number
+  ccw: boolean
+  numberOfPoints: number
+}): number[] {
+  const direction = ccw ? 1 : -1
+  const positions: number[] = []
+
+  for (let i = 0; i <= numberOfPoints; i++) {
+    const t = i / numberOfPoints
+    const angle = startAngle + direction * t * TAU
+    positions.push(
+      center[0] + radius * Math.cos(angle),
+      center[1] + radius * Math.sin(angle),
+      0
+    )
+  }
+
+  return positions
+}
+
 /**
  * Similar to src/clientSideScene/segments.ts / createArcGeometry, but:
  * - uses LineGeometry which supports screen space line thickness
@@ -37,6 +75,18 @@ export function createArcPositions({
   // const numberOfPoints = Math.ceil(100 * (angleDiff / (Math.PI * 2)))
 
   const numberOfPoints = 100
+
+  // Three's EllipseCurve can collapse nominal startAngle + 2π sweeps into a
+  // near-zero arc when floating point rounding pushes the delta slightly above 2π.
+  if (isFullCircleSweep(startAngle, endAngle)) {
+    return createFullCirclePositions({
+      center,
+      radius,
+      startAngle,
+      ccw,
+      numberOfPoints,
+    })
+  }
 
   const points = arcStart.getPoints(numberOfPoints)
   const positions: number[] = []


### PR DESCRIPTION
Had Codex investigate and patch this based on a hunch that proved correct. Our ellipse-based ThreeJS circle entities could sometimes round to a value over TAU and render as a tiny arc instead of a circle, which would often feel like glitchiness or flickering while moving circles. This fixes that.

## Demo

https://github.com/user-attachments/assets/e920a677-3998-43b9-ab5a-15e094812bd3


