### PR TITLE
Remove the infinite loop from the onboarding test

### DIFF
--- a/e2e/playwright/projects.spec.ts
+++ b/e2e/playwright/projects.spec.ts
@@ -1711,7 +1711,7 @@ test(
   {
     tag: ['@desktop'],
   },
-  async ({ page, toolbar, scene, cmdBar }, testInfo) => {
+  async ({ page, toolbar }) => {
     const nextButton = page.getByTestId('onboarding-next')
     await page.setBodyDimensions({ width: 1200, height: 500 })
 
@@ -1727,11 +1727,19 @@ test(
       await toolbar.userSidebarButton.click()
       await page.getByTestId('user-settings').click()
       await page.getByRole('button', { name: 'Replay Onboarding' }).click()
+      await expect(nextButton).toBeVisible()
 
-      while ((await nextButton.innerText()) !== 'Finish') {
+      let advances = 0
+      while ((await nextButton.innerText()).trim() !== 'Finish') {
+        if (++advances > 20) {
+          throw new Error('Onboarding did not finish')
+        }
+        const urlBefore = page.url()
         await nextButton.click()
+        await expect.poll(() => page.url()).not.toBe(urlBefore)
       }
       await nextButton.click()
+      await expect(page).not.toHaveURL(/\/onboarding\//)
 
       await page.getByTestId('project-sidebar-toggle').click()
     })


### PR DESCRIPTION
We want this test to actually fail if it gets stuck clicking through onboarding instead of just time out in an infinite loop.

https://test-analysis-bot.corp.zoo.dev/projects/KittyCAD/modeling-app/tests/179?branch=fix-onboarding-loop