### PR TITLE
Add cloud storage ids for projects

### DIFF
--- a/docs/kcl-lang/settings/project.md
+++ b/docs/kcl-lang/settings/project.md
@@ -27,6 +27,11 @@ base_unit = "in"
 
 ## Available Settings
 
+### cloud
+
+
+
+
 ### settings
 
 

--- a/docs/kcl-sketch-solve/settings/project.md
+++ b/docs/kcl-sketch-solve/settings/project.md
@@ -9,15 +9,17 @@ Project specific settings for the app. These live in `project.toml` in the base 
 ## Project Configuration Structure
 
 ```toml
-[settings.app]
-# Set the appearance of the application
-name = "My Awesome Project"
+[cloud."zoo.dev"]
+project_id = "6ddf6fb1-4b7c-4945-bb5b-b3265577b34e"
 
-[settings.app.appearance]
-# Use dark mode theme
-theme = "dark" 
-# Set the app color to blue (240.0 = blue, 0.0 = red, 120.0 = green)
-color = 240.0
+[cloud."dev.zoo.dev"]
+project_id = "f1573aa5-2e77-4a2d-a092-116fad864bf0"
+
+[settings.meta]
+id = "b7af85a2-9e10-49f6-94fe-a0c8b3c0ea5f"
+
+[settings.app]
+show_debug_panel = true
 
 [settings.modeling]
 # Use inches as the default measurement unit
@@ -26,6 +28,18 @@ base_unit = "in"
 ```
 
 ## Available Settings
+
+### cloud
+
+Environment-scoped cloud metadata keyed by environment name. Use quoted table
+names for dotted environments, for example `[cloud."zoo.dev"]`.
+
+#### <environment>.project_id
+
+
+
+
+**Default:** None
 
 ### settings
 
@@ -212,15 +226,17 @@ Whether to wrap text in the editor or overflow with scroll.
 ## Complete Example
 
 ```toml
-[settings.app]
-# Set the appearance of the application
-name = "My Awesome Project"
+[cloud."zoo.dev"]
+project_id = "6ddf6fb1-4b7c-4945-bb5b-b3265577b34e"
 
-[settings.app.appearance]
-# Use dark mode theme
-theme = "dark" 
-# Set the app color to blue (240.0 = blue, 0.0 = red, 120.0 = green)
-color = 240.0
+[cloud."dev.zoo.dev"]
+project_id = "f1573aa5-2e77-4a2d-a092-116fad864bf0"
+
+[settings.meta]
+id = "b7af85a2-9e10-49f6-94fe-a0c8b3c0ea5f"
+
+[settings.app]
+show_debug_panel = true
 
 [settings.modeling]
 # Use inches as the default measurement unit

--- a/rust/kcl-lib/src/settings/types/project.rs
+++ b/rust/kcl-lib/src/settings/types/project.rs
@@ -27,6 +27,11 @@ pub struct ProjectConfiguration {
     #[serde(default)]
     #[validate(nested)]
     pub settings: PerProjectSettings,
+
+    /// Settings for cloud-backed project metadata.
+    #[serde(default, skip_serializing_if = "is_default")]
+    #[validate(nested)]
+    pub cloud: ProjectCloudSettings,
 }
 
 impl ProjectConfiguration {
@@ -77,6 +82,27 @@ pub struct PerProjectSettings {
 pub struct ProjectMetaSettings {
     #[serde(default, skip_serializing_if = "is_default")]
     pub id: uuid::Uuid,
+}
+
+/// Cloud-backed project metadata.
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema, ts_rs::TS, PartialEq, Validate)]
+#[ts(export)]
+#[serde(rename_all = "snake_case")]
+pub struct ProjectCloudSettings {
+    /// Environment-scoped cloud metadata keyed by environment name.
+    /// TOML with dotted environment names should use quoted table names, for
+    /// example `[cloud."zoo.dev"]`.
+    #[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
+    pub environments: IndexMap<String, ProjectCloudEnvironmentSettings>,
+}
+
+/// Cloud-backed metadata for a single environment.
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema, ts_rs::TS, PartialEq, Validate)]
+#[ts(export)]
+#[serde(rename_all = "snake_case")]
+pub struct ProjectCloudEnvironmentSettings {
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub project_id: uuid::Uuid,
 }
 
 /// Project specific application settings.
@@ -189,6 +215,8 @@ mod tests {
     use super::NamedView;
     use super::PerProjectSettings;
     use super::ProjectAppSettings;
+    use super::ProjectCloudEnvironmentSettings;
+    use super::ProjectCloudSettings;
     use super::ProjectCommandBarSettings;
     use super::ProjectConfiguration;
     use super::ProjectMetaSettings;
@@ -334,6 +362,7 @@ mod tests {
                     include_settings: Some(false),
                 },
             },
+            cloud: ProjectCloudSettings::default(),
         };
         let serialized = toml::to_string(&conf).unwrap();
         let old_project_file = r#"[settings.meta]
@@ -377,5 +406,47 @@ include_settings = false
 "#;
 
         assert_eq!(serialized, old_project_file)
+    }
+
+    #[test]
+    fn test_project_settings_cloud_metadata_round_trip() {
+        let local_project_id = uuid::uuid!("e8f5178c-5227-4567-bb5a-f52b3caef5ea");
+        let zoo_cloud_project_id = uuid::uuid!("04c988e3-ec37-48a4-b491-45c3668934f1");
+        let dev_cloud_project_id = uuid::uuid!("e9632dae-19ca-49ea-bcc1-ee8e34ff9de3");
+
+        let conf = ProjectConfiguration {
+            settings: PerProjectSettings {
+                meta: ProjectMetaSettings { id: local_project_id },
+                ..Default::default()
+            },
+            cloud: ProjectCloudSettings {
+                environments: IndexMap::from([
+                    (
+                        "zoo.dev".to_owned(),
+                        ProjectCloudEnvironmentSettings {
+                            project_id: zoo_cloud_project_id,
+                        },
+                    ),
+                    (
+                        "dev.zoo.dev".to_owned(),
+                        ProjectCloudEnvironmentSettings {
+                            project_id: dev_cloud_project_id,
+                        },
+                    ),
+                ]),
+            },
+        };
+
+        let serialized = toml::to_string(&conf).unwrap();
+        assert!(serialized.contains(&format!(
+            "[cloud.\"zoo.dev\"]\nproject_id = \"{zoo_cloud_project_id}\"\n"
+        )));
+        assert!(serialized.contains(&format!(
+            "[cloud.\"dev.zoo.dev\"]\nproject_id = \"{dev_cloud_project_id}\"\n"
+        )));
+        assert!(serialized.contains(&format!("[settings.meta]\nid = \"{local_project_id}\"\n")));
+
+        let parsed = ProjectConfiguration::parse_and_validate(&serialized).unwrap();
+        assert_eq!(parsed, conf);
     }
 }


### PR DESCRIPTION
If we upload the KCL, we want to keep track of that so we can easily update the project again in the future.

## What is getting added?
To account for our internal usage of multiple environments, we track cloud project id per environment:
```
[cloud."zoo.dev"]
project_id = "<uuid>"

[cloud."dev.zoo.dev"]
project_id = "<uuid>"
```

Most folks will only ever interact with one environment, but for us, that's a pretty common use case. Because of this, we want to make sure that our way of working is not impacted, insofar as we can upload/download from any environment.

## Why not reuse `meta.id`?

`meta.id` is a locally generated id and it serves as a good artifact of that local or shared lineage. None of our APIs currently accept customer generated ids, and we do that so the API remains the source of truth. Because these are IDs in our database it should be in charge of issuing valid values.

For now, we accept that this could lead to some drift between environments.

## Not in scope for this PR

- automatic reconciliation between environments
- automatic merge behavior when the same local meta.id appears in multiple places
- sample upload to projects


## Expected workflow from ZDS/CLI
```mermaid
flowchart TD
      subgraph ZDS[ZDS]
          A[User clicks Share / Upload]
          B[Read local project.toml]
          C[Determine active API environment]
          D{cloud.env.project_id present?}
          E[Choose Create request]
          F[Choose Update request]
          G[Write cloud.env.project_id to project.toml]
          H[Leave other cloud.other-env bindings unchanged]
      end

      subgraph API[API]
          I[Receive create request]
          J[Upload current project files]
          K[Create DB record in active environment]
          L[Return success + remote project_id]

          M[Receive update request]
          N[Upload current project files]
          O[Update DB record for existing remote project_id]
          P[Return success]
      end

      A --> B
      B --> C
      C --> D

      D -- No --> E
      E --> I
      I --> J
      J --> K
      K --> L
      L --> G
      G --> H

      D -- Yes --> F
      F --> M
      M --> N
      N --> O
      O --> P
      P --> H
  ```


Relates to https://github.com/KittyCAD/roadmap/issues/296
Prereq for https://github.com/KittyCAD/modeling-app/pull/10903