### PR TITLE
Change all constraints to return KCL none

### DIFF
--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -2882,7 +2882,7 @@ impl Node<BinaryExpression> {
                 (KclValue::SketchVar { value: left_value, .. }, KclValue::SketchVar { value: right_value, .. })
                     if left_value.id == right_value.id =>
                 {
-                    return Ok(KclValue::Bool { value: true, meta });
+                    return Ok(KclValue::none());
                 }
                 // Different sketch variables.
                 (KclValue::SketchVar { value: var0 }, KclValue::SketchVar { value: var1, .. }) => {
@@ -2896,7 +2896,7 @@ impl Node<BinaryExpression> {
                         return Err(internal_err(message, self));
                     };
                     sketch_block_state.solver_constraints.push(constraint);
-                    return Ok(KclValue::Bool { value: true, meta });
+                    return Ok(KclValue::none());
                 }
                 // One sketch variable, one number.
                 (KclValue::SketchVar { value: var, .. }, input_number @ KclValue::Number { .. })
@@ -2922,7 +2922,7 @@ impl Node<BinaryExpression> {
                         return Err(internal_err(message, self));
                     };
                     sketch_block_state.solver_constraints.push(constraint);
-                    return Ok(KclValue::Bool { value: true, meta });
+                    return Ok(KclValue::none());
                 }
                 // One sketch constraint, one number.
                 (KclValue::SketchConstraint { value: constraint }, input_number @ KclValue::Number { .. })
@@ -3508,7 +3508,7 @@ impl Node<BinaryExpression> {
                             }
                         }
                     }
-                    return Ok(KclValue::Bool { value: true, meta });
+                    return Ok(KclValue::none());
                 }
                 _ => {
                     return Err(KclError::new_semantic(KclErrorDetails::new(


### PR DESCRIPTION
Resolves #10762.

This allows us to change the return values to something more interesting after stabilization, without a breaking change.