### PR TITLE
Fix to update frontend state on all engine executions

### DIFF
--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -1148,7 +1148,9 @@ impl FrontendState {
             Err(mut err) => {
                 // Don't return an error just because execution failed. Instead,
                 // update state as much as possible.
-                let outcome = self.exec_outcome_from_exec_error(err.clone())?;
+                let outcome = self.exec_outcome_from_exec_error(err.clone()).map_err(|err| Error {
+                    msg: err.error.message().to_owned(),
+                })?;
                 self.update_state_after_exec(outcome, true);
                 err.scene_graph = Some(self.scene_graph.clone());
                 Ok(SetProgramOutcome::ExecFailure { error: Box::new(err) })
@@ -1156,14 +1158,47 @@ impl FrontendState {
         }
     }
 
-    fn exec_outcome_from_exec_error(&self, err: KclErrorWithOutputs) -> api::Result<ExecOutcome> {
+    /// Decorate engine execution such that our state is updated and the scene
+    /// graph is added to the return.
+    pub async fn engine_execute(
+        &mut self,
+        ctx: &ExecutorContext,
+        program: Program,
+    ) -> Result<SceneGraphDelta, KclErrorWithOutputs> {
+        self.program = program.clone();
+
+        // Engine execution now runs freedom analysis automatically. Clear the
+        // freedom cache since IDs might have changed after direct editing, and
+        // we're about to run freedom analysis which will repopulate it.
+        self.point_freedom_cache.clear();
+        match ctx.run_with_caching(program).await {
+            Ok(outcome) => {
+                let outcome = self.update_state_after_exec(outcome, true);
+                Ok(SceneGraphDelta {
+                    new_graph: self.scene_graph.clone(),
+                    exec_outcome: outcome,
+                    // We don't know what the new objects are.
+                    new_objects: Default::default(),
+                    // We don't know if IDs were invalidated.
+                    invalidates_ids: Default::default(),
+                })
+            }
+            Err(mut err) => {
+                // Update state as much as possible, even when there's an error.
+                let outcome = self.exec_outcome_from_exec_error(err.clone())?;
+                self.update_state_after_exec(outcome, true);
+                err.scene_graph = Some(self.scene_graph.clone());
+                Err(err)
+            }
+        }
+    }
+
+    fn exec_outcome_from_exec_error(&self, err: KclErrorWithOutputs) -> Result<ExecOutcome, KclErrorWithOutputs> {
         if matches!(err.error, KclError::EngineHangup { .. }) {
             // It's not ideal to special-case this, but this error is very
             // common during development, and it causes confusing downstream
             // errors that have nothing to do with the actual problem.
-            return Err(Error {
-                msg: err.error.message().to_owned(),
-            });
+            return Err(err);
         }
 
         let KclErrorWithOutputs {

--- a/rust/kcl-wasm-lib/src/api.rs
+++ b/rust/kcl-wasm-lib/src/api.rs
@@ -9,7 +9,9 @@ use kcl_lib::front::FileId;
 use kcl_lib::front::LifecycleApi;
 use kcl_lib::front::ObjectId;
 use kcl_lib::front::ProjectId;
+use kcl_lib::front::SceneGraphDelta;
 use kcl_lib::front::SketchApi;
+use kcl_lib::front::SourceDelta;
 use kcl_lib::front::Version;
 use wasm_bindgen::prelude::*;
 
@@ -18,8 +20,8 @@ use crate::TRUE_BUG;
 
 #[derive(serde::Serialize)]
 struct TrimOutcome {
-    source_delta: kcl_lib::front::SourceDelta,
-    scene_graph_delta: kcl_lib::front::SceneGraphDelta,
+    source_delta: SourceDelta,
+    scene_graph_delta: SceneGraphDelta,
     operations_performed: bool,
 }
 

--- a/rust/kcl-wasm-lib/src/context.rs
+++ b/rust/kcl-wasm-lib/src/context.rs
@@ -11,6 +11,7 @@ use kcl_lib::MockConfig;
 use kcl_lib::Program;
 use kcl_lib::ProjectManager;
 use kcl_lib::front::FrontendState;
+use kcl_lib::front::SceneGraphDelta;
 use kcl_lib::wasm_engine::FileManager;
 use wasm_bindgen::prelude::*;
 
@@ -114,7 +115,7 @@ impl Context {
         program_ast_json: &str,
         path: Option<String>,
         settings: &str,
-    ) -> Result<ExecOutcome, KclErrorWithOutputs> {
+    ) -> Result<SceneGraphDelta, KclErrorWithOutputs> {
         let program: Program = serde_json::from_str(program_ast_json).map_err(|e| {
             let err = KclError::internal(format!("Could not deserialize KCL AST. {TRUE_BUG} Details: {e}"));
             KclErrorWithOutputs::no_outputs(err)
@@ -124,7 +125,10 @@ impl Context {
                 "Could not create KCL executor context. {TRUE_BUG} Details: {e}"
             )))
         })?;
-        ctx.run_with_caching(program).await
+
+        let frontend = Arc::clone(&self.frontend);
+        let mut guard = frontend.write().await;
+        guard.engine_execute(&ctx, program).await
     }
 
     /// Reset the scene and bust the cache.

--- a/src/lib/rustContext.ts
+++ b/src/lib/rustContext.ts
@@ -139,14 +139,14 @@ export default class RustContext {
     const instance = await this._checkContextInstance()
 
     try {
-      const result = await instance.execute(
+      const result: SceneGraphDelta = await instance.execute(
         JSON.stringify(node),
         path,
         JSON.stringify(settings)
       )
-      // Set the default planes, safe to call after execute.
-      const outcome = execStateFromRust(result)
+      const outcome = execStateFromRust(result.exec_outcome)
 
+      // Set the default planes, safe to call after execute.
       this.setDefaultPlanes(outcome.defaultPlanes)
 
       // Return the result.


### PR DESCRIPTION
Resolves #10739.

Execute now returns a `SceneGraphDelta`. TS doesn't use it yet.