### PR TITLE
Fix to disable rotating while editing in sketch-solve mode

### DIFF
--- a/src/clientSideScene/CameraControls.ts
+++ b/src/clientSideScene/CameraControls.ts
@@ -116,6 +116,7 @@ export class CameraControls {
   rotationSpeed = 0.3
   enableRotate = true
   enablePan = true
+  enableMouseDragPan = true
   enableZoom = true
   moveSender: CameraRateLimiter = new CameraRateLimiter()
   zoomSender: CameraRateLimiter = new CameraRateLimiter()
@@ -1480,6 +1481,7 @@ export class CameraControls {
             this.interactionGuards,
             event,
             this.enablePan,
+            this.enableMouseDragPan,
             this.enableRotate,
             this.enableZoom
           )
@@ -1731,6 +1733,7 @@ export function getInteractionType(
   interactionGuards: MouseGuard,
   event: MouseEvent | WheelEvent,
   enablePan: boolean,
+  enableMouseDragPan: boolean,
   enableRotate: boolean,
   enableZoom: boolean
 ): interactionType | 'none' {
@@ -1745,7 +1748,9 @@ export function getInteractionType(
     if (enableZoom && interactionGuards.zoom.scrollCallback(event))
       return 'zoom'
   } else {
-    if (enablePan && interactionGuards.pan.callback(event)) return 'pan'
+    if (enableMouseDragPan && interactionGuards.pan.callback(event)) {
+      return 'pan'
+    }
     if (enableRotate && interactionGuards.rotate.callback(event))
       return 'rotate'
     if (enableZoom && interactionGuards.zoom.dragCallback(event)) return 'zoom'

--- a/src/clientSideScene/sceneEntities.ts
+++ b/src/clientSideScene/sceneEntities.ts
@@ -3741,6 +3741,7 @@ export class SceneEntities {
       this.sceneInfra.scene.remove(sketchSegments)
     }
     this.sceneInfra.camControls.enableRotate = true
+    this.sceneInfra.camControls.enableMouseDragPan = true
     this.activeSegments = {}
   }
 

--- a/src/lib/cameraControls.test.ts
+++ b/src/lib/cameraControls.test.ts
@@ -60,10 +60,15 @@ describe('isPinchToZoom', () => {
 
 describe('getInteractionType with Apple Trackpad guards', () => {
   const guards = cameraMouseDragGuards['Apple Trackpad']
-  const allEnabled = { enablePan: true, enableRotate: true, enableZoom: true }
+  const allEnabled = {
+    enablePan: true,
+    enableMouseDragPan: true,
+    enableRotate: true,
+    enableZoom: true,
+  }
 
   function resolve(event: WheelEvent, overrides?: Partial<typeof allEnabled>) {
-    const { enablePan, enableRotate, enableZoom } = {
+    const { enablePan, enableMouseDragPan, enableRotate, enableZoom } = {
       ...allEnabled,
       ...overrides,
     }
@@ -71,6 +76,7 @@ describe('getInteractionType with Apple Trackpad guards', () => {
       guards,
       event,
       enablePan,
+      enableMouseDragPan,
       enableRotate,
       enableZoom
     )
@@ -123,7 +129,7 @@ describe('getInteractionType preserves existing Zoo behavior', () => {
   const guards = cameraMouseDragGuards['Zoo']
 
   function resolve(event: WheelEvent) {
-    return getInteractionType(guards, event, true, true, true)
+    return getInteractionType(guards, event, true, true, true, true)
   }
 
   it('bare scroll => zoom (Zoo has no scroll-to-pan/rotate)', () => {

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -1286,9 +1286,10 @@ export const modelingMachine = setup({
     'clientToEngine cam sync direction': ({ context }) => {
       context.kclManager.sceneInfra.camControls.syncDirection = 'clientToEngine'
     },
-    'disable rotate unless allowed in sketch mode': ({ context }) => {
-      context.kclManager.sceneInfra.camControls.enableRotate =
-        context.kclManager.sceneInfra.camControls._setting_allowOrbitInSketchMode
+    'disable rotate and drag-pan for sketch mode': ({ context }) => {
+      const camControls = context.kclManager.sceneInfra.camControls
+      camControls.enableRotate = camControls._setting_allowOrbitInSketchMode
+      camControls.enableMouseDragPan = false
     },
     /** TODO: this action is hiding unawaited asynchronous code */
     'set selection filter to faces only': ({ context }) => {
@@ -6919,7 +6920,7 @@ export const modelingMachine = setup({
       id: 'sketchSolveMode',
       entry: [
         'clientToEngine cam sync direction',
-        'disable rotate unless allowed in sketch mode',
+        'disable rotate and drag-pan for sketch mode',
       ],
       initial: 'active',
       states: {


### PR DESCRIPTION
This became a problem since #10835.

We also disable drag-panning since that's used by sketch-mode.