### PR TITLE
KCL: Don't write JUnit output except in CI

### DIFF
--- a/rust/.config/nextest.toml
+++ b/rust/.config/nextest.toml
@@ -50,9 +50,6 @@ test-group = "after-engine"
 filter = "test(docs::gen_std_tests)"
 test-group = "after-engine"
 
-[profile.default.junit]
-path = "../../../../test-results/junit.xml"
-
 [[profile.default.overrides]]
 filter = 'test(kcl_samples)'
 junit.store-success-output = true


### PR DESCRIPTION
Nextest is configured to write JUnit.xml whenever it's run, outside the rust/ dir. This means agents running nextest will hit permission errors because it's outside their sandbox.

So let's only write the JUnit file in CI, because that's when it's used anyway.