### PR TITLE
KCL: Build Python without unnecessary features

### DIFF
--- a/rust/kcl-python-bindings/Cargo.toml
+++ b/rust/kcl-python-bindings/Cargo.toml
@@ -13,7 +13,7 @@ bench = false
 
 [dependencies]
 anyhow = { workspace = true }
-kcl-lib = { path = "../kcl-lib", features = [
+kcl-lib = { path = "../kcl-lib", default-features = false, features = [
   "pyo3",
   "engine",
   "disable-println",


### PR DESCRIPTION
Our python test build is OOMing the CI runner. Experimenting to see if I can reduce the memory needed. If this doesn't work, I'll use a larger runner.