### PR TITLE
KCL: Bump number of CPUs for python tests

### DIFF
--- a/.github/workflows/kcl-python-bindings.yml
+++ b/.github/workflows/kcl-python-bindings.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   linux-x86_64:
     name: kcl-python-bindings (linux-x86_64)
-    runs-on: namespace-profile-ubuntu-2-cores
+    runs-on: namespace-profile-ubuntu-8-cores
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -111,7 +111,7 @@ jobs:
           path: rust/kcl-python-bindings/dist
   test:
     name: kcl-python-bindings (test)
-    runs-on: namespace-profile-ubuntu-2-cores
+    runs-on: namespace-profile-ubuntu-8-cores
     steps:
       - uses: actions/checkout@v6
       - name: Track setup
@@ -154,7 +154,7 @@ jobs:
           CI_SUITE: integration:kcl
   sdist:
     name: kcl-python-bindings (sdist)
-    runs-on: namespace-profile-ubuntu-2-cores
+    runs-on: namespace-profile-ubuntu-8-cores
     steps:
       - uses: actions/checkout@v6
       - name: Install the latest version of uv
@@ -178,7 +178,7 @@ jobs:
           path: rust/kcl-python-bindings/dist
   release:
     name: Release
-    runs-on: namespace-profile-ubuntu-2-cores
+    runs-on: namespace-profile-ubuntu-8-cores
     permissions:
       contents: write
     if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
I think the Python tests are OOMing, I'm going to try a bigger machine. 

Fixes this error (hopefully), which I can't repro locally, so I think it's a CI issue.

```
      error: could not compile `kcl-lib` (lib)

      Caused by:
        process didn't exit successfully:
      `/home/runner/.rustup/toolchains/1.94.1-x86_64-unknown-linux-gnu/bin/rustc
      --crate-name kcl_lib --edition=2024
      kcl-lib/src/lib.rs --error-format=json
      --json=diagnostic-rendered-ansi,artifacts,future-incompat
      --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C
      embed-bitcode=no -C debuginfo=2 '--allow=clippy::result_large_err'
      '--warn=clippy::redundant_clone' '--warn=clippy::lossy_float_literal'
      '--warn=clippy::iter_over_hash_type' '--warn=clippy::dbg_macro'
      '--warn=clippy::assertions_on_result_states' --cfg 'feature="cli"'
      --cfg 'feature="default"' --cfg 'feature="disable-println"'
      --cfg 'feature="engine"' --cfg 'feature="pyo3"' --check-cfg
      'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("artifact-graph",
      "benchmark-execution", "cli", "default", "dhat-heap",
      "disable-println", "engine", "lsp-test-util", "pyo3", "tabled"))' -C
      metadata=ac0369df09d50ead -C extra-filename=-8c5ebdd335c9b895 --out-dir
      /home/runner/work/modeling-app/modeling-app/rust/target/release/deps -L
      dependency=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps
      --extern
      ahash=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libahash-f32becba46522b76.rmeta
      --extern
      anyhow=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libanyhow-d483694ce1757421.rmeta
      --extern
      async_recursion=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libasync_recursion-2a60e9b2cf8ba225.so
      --extern
      async_trait=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libasync_trait-60400a4422f4f9f4.so
      --extern
      base64=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libbase64-a8b31e2c4dd3169e.rmeta
      --extern
      chrono=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libchrono-8aa15c9f1d511493.rmeta
      --extern
      clap=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libclap-bd7e5376326b5787.rmeta
      --extern
      convert_case=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libconvert_case-64b65ba8cd7b9c6c.rmeta
      --extern
      csscolorparser=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libcsscolorparser-bd8769f9473a12eb.rmeta
      --extern
      dashmap=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libdashmap-311d6c36866cef0e.rmeta
      --extern
      ezpz=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libezpz-4b870d01038a1308.rmeta
      --extern
      fnv=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libfnv-7935ffecdf8332b2.rmeta
      --extern
      form_urlencoded=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libform_urlencoded-ef753c2effaa9cf6.rmeta
      --extern
      futures=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libfutures-dca83b484914d92b.rmeta
      --extern
      git_rev=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libgit_rev-c72b85fe533bd065.so
      --extern
      gltf_json=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libgltf_json-48341ad088fa677c.rmeta
      --extern
      http=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libhttp-88618afdd50b7108.rmeta
      --extern
      ignore=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libignore-6cb17888ea0a2fa6.rmeta
      --extern
      image=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libimage-d29c91dd321d2285.rmeta
      --extern
      image_compare=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libimage_compare-b142526b29a47298.rmeta
      --extern
      indexmap=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libindexmap-8dc0ed2092fcc1c2.rmeta
      --extern
      itertools=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libitertools-c5851dcbb900d9b6.rmeta
      --extern
      kcl_derive_docs=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libkcl_derive_docs-fe95eb0e2112509f.so
      --extern
      kcl_error=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libkcl_error-bd2e3052e3481d17.rmeta
      --extern
      kittycad=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libkittycad-a5f8e7670cd03861.rmeta
      --extern
      kittycad_modeling_cmds=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libkittycad_modeling_cmds-c23d45de14e97317.rmeta
      --extern
      lazy_static=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/liblazy_static-9af45f376061a8d8.rmeta
      --extern
      libm=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/liblibm-aa14503a99edaef3.rmeta
      --extern
      measurements=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libmeasurements-e13650ae0a730c28.rmeta
      --extern
      miette=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libmiette-eafa438ffd00a80d.rmeta
      --extern
      mime_guess=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libmime_guess-385c40d49bcb7415.rmeta
      --extern
      nalgebra_glm=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libnalgebra_glm-6c15a7eedefcb5e4.rmeta
      --extern
      parse_display=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libparse_display-d6a291a3328839fc.rmeta
      --extern
      pyo3=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libpyo3-004de1bee687303a.rmeta
      --extern
      pyo3_stub_gen=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libpyo3_stub_gen-74607169e761447f.rmeta
      --extern
      rayon=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/librayon-4d857e501d98ee7a.rmeta
      --extern
      regex=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libregex-1ff3bb93fb34b5ae.rmeta
      --extern
      reqwest=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libreqwest-5f54c0494f325a10.rmeta
      --extern
      rgba_simple=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/librgba_simple-cbf18f236db76c02.rmeta
      --extern
      rmp_serde=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/librmp_serde-c70d827a33594155.rmeta
      --extern
      ropey=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libropey-a7039ed96e33d9a2.rmeta
      --extern
      schemars=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libschemars-e98046e419e9b951.rmeta
      --extern
      serde=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libserde-2d309e71e483f362.rmeta
      --extern
      serde_json=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libserde_json-8e21fa609589f1b7.rmeta
      --extern
      sha2=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libsha2-841c60309753f283.rmeta
      --extern
      tempfile=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libtempfile-3424a93a0242fdea.rmeta
      --extern
      thiserror=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libthiserror-9f2b7f8ea215a8e1.rmeta
      --extern
      tokio=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libtokio-e57d3969e68504fb.rmeta
      --extern
      tokio_tungstenite=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libtokio_tungstenite-c5ab3c6f80f30de7.rmeta
      --extern
      toml=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libtoml-6eda58f69847e6bc.rmeta
      --extern
      tower_lsp=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libtower_lsp-264b47b08d49994c.rmeta
      --extern
      ts_rs=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libts_rs-c1a4fcadc58beea9.rmeta
      --extern
      tynm=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libtynm-3fdb63da8f2b4c19.rmeta
      --extern
      typed_path=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libtyped_path-fff642cda629f52d.rmeta
      --extern
      url=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/liburl-8f5691bd9e1a0fb6.rmeta
      --extern
      uuid=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libuuid-7499e3135ddfba5f.rmeta
      --extern
      validator=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libvalidator-2967dc3d72c9f192.rmeta
      --extern
      walkdir=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libwalkdir-5bda6964374758fa.rmeta
      --extern
      web_time=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libweb_time-5d69940bdab9103c.rmeta
      --extern
      winnow=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libwinnow-3de9b5b4ae34403c.rmeta
      --extern
      zip=/home/runner/work/modeling-app/modeling-app/rust/target/release/deps/libzip-336737ad003c8390.rmeta
      -L
      native=/home/runner/work/modeling-app/modeling-app/rust/target/release/build/ring-8d530e1672e5e78c/out`
      (signal: 9, SIGKILL: kill)
      warning: build failed, waiting for other jobs to finish...
      💥 maturin failed
        Caused by: Failed to build a native library through cargo
        Caused by: Cargo build finished with "exit status:
      101": `env -u CARGO PYO3_BUILD_EXTENSION_MODULE="1"
      PYO3_ENVIRONMENT_SIGNATURE="cpython-3.14-64bit"
      PYO3_PYTHON="/home/runner/.cache/uv/builds-v0/.tmp1G6saM/bin/python"
      PYTHON_SYS_EXECUTABLE="/home/runner/.cache/uv/builds-v0/.tmp1G6saM/bin/python"
      "cargo" "rustc" "--profile" "release" "--features"
      "pyo3/extension-module" "--message-format"
      "json-render-diagnostics" "--manifest-path"
      "/home/runner/work/modeling-app/modeling-app/rust/kcl-python-bindings/Cargo.toml"
      "--lib" "--crate-type" "cdylib"`
      Error: command ['maturin', 'pep517', 'build-wheel', '-i',
      '/home/runner/.cache/uv/builds-v0/.tmp1G6saM/bin/python',
      '--compatibility', 'off'] returned non-zero exit status 1

      hint: This usually indicates a problem with the package or the build
      environment.
error: Recipe `test` failed on line 2 with exit code 1
```