### PR TITLE
Clean up animate-to-sketch-solve & only animate on success

### DIFF
--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -2945,7 +2945,7 @@ export const modelingMachine = setup({
         sketchSolveId: number
       }> => {
         if (!input || !input.artifactOrPlaneId) {
-          return reject(new Error('No artifact or plane ID provided'))
+          return reject(new Error('No artifact or plane ID provided.'))
         }
         const {
           artifactOrPlaneId,


### PR DESCRIPTION
Fixes #10811. Check the KCL code there to repro (sketcing on the top face).

Noticed two things while looking at #10811:
1. `letEngineAnimateAndSyncCamAfter` was being called before we knew the result of `newSketch`, which seems to be the root cause of the bug error; and
2. the actor is constructed with a mix of try and console logs, as well as a few checks that both toast and reject an error.

So I added `toastError` as an action when`onError` hits, and made sure we were simply rejecting errors as they came in what seems to be a better order.