### PR TITLE
Fix: remove ability to lock orbit when canceling a sketch

### DIFF
--- a/src/machines/modelingMachine.spec.ts
+++ b/src/machines/modelingMachine.spec.ts
@@ -1549,7 +1549,6 @@ sketch001 = sketch(on = YZ) {
             } as any,
             sketchSolveId: 1,
           })),
-          sketchSolveMachine: fromPromise(async () => undefined),
         },
       })
 
@@ -1565,6 +1564,17 @@ sketch001 = sketch(on = YZ) {
         return (
           JSON.stringify(actor.getSnapshot().value) ===
           JSON.stringify({
+            sketchSolveMode: 'active',
+          })
+        )
+      })
+
+      actor.send({ type: 'Exit sketch' })
+
+      await waitForCondition(() => {
+        return (
+          JSON.stringify(actor.getSnapshot().value) ===
+          JSON.stringify({
             idle: 'hidePlanes',
           })
         )
@@ -1572,7 +1582,6 @@ sketch001 = sketch(on = YZ) {
 
       expect(sendSceneCommandSpy).toHaveBeenCalled()
       expect(kclManager.sceneInfra.camControls.enableRotate).toBe(true)
-      expect(kclManager.sceneInfra.camControls.enableMouseDragPan).toBe(true)
       expect(kclManager.sceneInfra.camControls.enablePan).toBe(true)
       expect(kclManager.sceneInfra.camControls.syncDirection).toBe(
         'engineToClient'

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -1287,7 +1287,6 @@ export const modelingMachine = setup({
       const camControls = context.kclManager.sceneInfra.camControls
       camControls.enablePan = true
       camControls.enableRotate = true
-      camControls.enableMouseDragPan = true
       camControls.syncDirection = 'engineToClient'
     },
     'clientToEngine cam sync direction': ({ context }) => {
@@ -1985,7 +1984,6 @@ export const modelingMachine = setup({
           kclManager.sceneEntitiesManager.removeSketchGrid()
           camControls.enablePan = true
           camControls.enableRotate = true
-          camControls.enableMouseDragPan = true
           camControls.syncDirection = 'engineToClient'
           kclManager.sceneEntitiesManager.resetOverlays()
           kclManager.sceneInfra.stop()


### PR DESCRIPTION
Fixes part of the video reported in #10755, where @max-mrgrsk adds a parser error and then cancels while entering a sketch, and the camera is subsequently permanently locked from orbiting. The issue was that camera controls resetting would never be reached if `teardownSketch` failed, so this Codex-written PR makes that code path independent, and adds an integration test to the `modelingMachine` to prevent regression.

## Demo

https://github.com/user-attachments/assets/e702a198-a603-4beb-9ba8-7eaa42c60c4e


