### PR TITLE
KCL: Enable the artifact-graph crate feature by default

### DIFF
--- a/rust/kcl-lib/Cargo.toml
+++ b/rust/kcl-lib/Cargo.toml
@@ -26,7 +26,7 @@ path = "src/main.rs"
 bench = false
 
 [features]
-default = ["cli", "engine"]
+default = ["cli", "engine", "artifact-graph"]
 artifact-graph = []
 benchmark-execution = []
 cli = ["dep:clap", "kittycad/clap"]


### PR DESCRIPTION
This means that if you run `cargo nextest run` it'll include the artifact graph by default. We basically always want it on for tests etc. This avoids cargo rebuilding stuff when you run one of the justfile commands that uses --feature artifact-graph

Consumers who don't want this feature, like the CLI, can opt out of it.