### PR TITLE
KCL: Fix main

### DIFF
--- a/rust/kcl-lib/src/std/loft.rs
+++ b/rust/kcl-lib/src/std/loft.rs
@@ -283,6 +283,7 @@ mod tests {
             sketch: None,
             tag: None,
             meta: vec![],
+            node_path: None,
         };
         KclValue::Segment {
             value: Box::new(AbstractSegment {


### PR DESCRIPTION
My Loft migration PR passed CI and then lingered in GitHub. Then Jon merged his NodePath PR, which added a new field to structs. Jon merged his PR.
I merged my Loft PR (which wasn't updated to latest main). Now main is broken because my Loft struct instantiation is missing a field.