### PR TITLE
Add project share backed by projects API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@csstools/postcss-oklab-function": "^4.0.12",
         "@headlessui/react": "^1.7.19",
         "@headlessui/tailwindcss": "^0.2.2",
-        "@kittycad/lib": "^3.2.27",
+        "@kittycad/lib": "^3.2.29",
         "@kittycad/react-shared": "^1.2.1",
         "@lezer/highlight": "^1.2.1",
         "@lezer/lr": "^1.4.8",
@@ -4800,9 +4800,9 @@
       "link": true
     },
     "node_modules/@kittycad/lib": {
-      "version": "3.2.27",
-      "resolved": "https://registry.npmjs.org/@kittycad/lib/-/lib-3.2.27.tgz",
-      "integrity": "sha512-/xBz+a3MOs3ECEZHh5TPm89lRKC4fVlR+/LWK70848maIx29WW+1pv2xBkcUw2GcxICTxqxtu8GADfz75xAzbA==",
+      "version": "3.2.29",
+      "resolved": "https://registry.npmjs.org/@kittycad/lib/-/lib-3.2.29.tgz",
+      "integrity": "sha512-Ji18rNyZaMT1nagYqFLyamuhSvBF6laitUSUeJpZFg1F8/Sc70KkgZrWljqGtCEKuh7jivIbAI6gwmOfKTRIgw==",
       "license": "MIT",
       "dependencies": {
         "bson": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@csstools/postcss-oklab-function": "^4.0.12",
     "@headlessui/react": "^1.7.19",
     "@headlessui/tailwindcss": "^0.2.2",
-    "@kittycad/lib": "^3.2.27",
+    "@kittycad/lib": "^3.2.29",
     "@kittycad/react-shared": "^1.2.1",
     "@lezer/highlight": "^1.2.1",
     "@lezer/lr": "^1.4.8",

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -1,9 +1,10 @@
-import { Popover } from '@headlessui/react'
 import { CustomIcon } from '@src/components/CustomIcon'
+import { ShareDialog } from '@src/components/ShareDialog'
 import Tooltip from '@src/components/Tooltip'
 import usePlatform from '@src/hooks/usePlatform'
-import { hotkeyDisplay } from '@src/lib/hotkeys'
 import { useApp, useSingletons } from '@src/lib/boot'
+import { hotkeyDisplay } from '@src/lib/hotkeys'
+import { copyCurrentFileShareLink } from '@src/lib/share'
 import { memo, useCallback, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 
@@ -11,53 +12,44 @@ const shareHotkey = 'mod+alt+s'
 
 /** Share Zoo link button shown in the upper-right of the modeling view */
 export const ShareButton = memo(function ShareButton() {
-  const { billing, commands } = useApp()
+  const app = useApp()
+  const { auth, billing } = app
   const { kclManager } = useSingletons()
   const platform = usePlatform()
+  const token = auth.useToken()
 
-  const [showOptions, setShowOptions] = useState(false)
-  const [isRestrictedToOrg, setIsRestrictedToOrg] = useState(false)
-  const [password, setPassword] = useState('')
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
 
   const billingContext = billing.useContext()
+  const currentProjectName = app.projectSignal.value?.name || ''
 
   const allowOrgRestrict = !!billingContext.isOrg
   const allowPassword = !!billingContext.hasSubscription
-  const hasOptions = allowOrgRestrict || allowPassword
 
-  // Prevents Organization and Pro tier users from one-click sharing,
-  // and give them a chance to set a password and restrict to org.
-  const onShareClickFreeOrUnknownRestricted = useCallback(() => {
-    if (hasOptions) {
-      setShowOptions(true)
-      return
-    }
+  const onShareClick = useCallback(() => {
+    setIsDialogOpen(true)
+  }, [])
 
-    commands.send({
-      type: 'Find and select command',
-      data: {
-        name: 'share-file-link',
-        groupId: 'code',
-        isRestrictedToOrg: false,
-      },
-    })
-  }, [hasOptions, commands])
-
-  const onShareClickProOrOrganization = useCallback(() => {
-    setShowOptions(false)
-
-    commands.send({
-      type: 'Find and select command',
-      data: {
-        name: 'share-file-link',
-        groupId: 'code',
+  const onCopyShareLink = useCallback(
+    async ({
+      isRestrictedToOrg,
+      password,
+    }: {
+      isRestrictedToOrg: boolean
+      password?: string
+    }) => {
+      return copyCurrentFileShareLink({
+        token,
+        code: kclManager.code,
+        name: currentProjectName,
         isRestrictedToOrg,
         password,
-      },
-    })
-  }, [isRestrictedToOrg, password, commands])
+      })
+    },
+    [currentProjectName, kclManager.code, token]
+  )
 
-  useHotkeys(shareHotkey, onShareClickFreeOrUnknownRestricted, {
+  useHotkeys(shareHotkey, onShareClick, {
     scopes: ['modeling'],
   })
 
@@ -70,16 +62,13 @@ export const ShareButton = memo(function ShareButton() {
     billingContext.hasSubscription === undefined
 
   return (
-    <Popover className="relative hidden sm:flex">
-      <Popover.Button
-        as="div"
-        className="relative group border-0 w-fit min-w-max p-0 rounded-l-full focus-visible:outline-appForeground"
-      >
+    <>
+      <div className="relative hidden sm:flex">
         <button
           type="button"
-          onClick={onShareClickFreeOrUnknownRestricted}
+          onClick={onShareClick}
           disabled={disabled}
-          className="flex gap-1 items-center py-0 pl-0.5 pr-1.5 bg-chalkboard-10/80 dark:bg-chalkboard-100/50 hover:bg-chalkboard-10 dark:hover:bg-chalkboard-100 border border-solid active:border-primary"
+          className="relative group flex gap-1 items-center py-0 pl-0.5 pr-1.5 rounded-l-full bg-chalkboard-10/80 border border-solid active:border-primary dark:bg-chalkboard-100/50 hover:bg-chalkboard-10 dark:hover:bg-chalkboard-100"
           data-testid="share-button"
         >
           <CustomIcon name="link" className="w-5 h-5" />
@@ -91,7 +80,7 @@ export const ShareButton = memo(function ShareButton() {
             <span className="flex-1">
               {disabled
                 ? `Share links are not currently supported for multi-file assemblies`
-                : `Share part via Zoo link`}
+                : `Share this file`}
             </span>
             {!disabled && (
               <kbd className="hotkey text-xs capitalize">
@@ -100,59 +89,15 @@ export const ShareButton = memo(function ShareButton() {
             )}
           </Tooltip>
         </button>
-      </Popover.Button>
-      {showOptions && (
-        <Popover.Panel
-          focus={true}
-          className={`z-10 absolute top-full right-0 mt-1 pb-1 w-48 bg-chalkboard-10 dark:bg-chalkboard-90
-        border border-solid border-chalkboard-20 dark:border-chalkboard-90 rounded
-        shadow-lg`}
-        >
-          <div className="flex flex-col px-2">
-            <div className="flex flex-row gap-1 items-center">
-              <CustomIcon name="lockClosed" className="w-6 h-6" />
-              <input
-                disabled={!allowPassword}
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                autoCapitalize="off"
-                autoComplete="off"
-                autoCorrect="off"
-                spellCheck="false"
-                className={`${allowPassword ? 'cursor-pointer' : 'cursor-not-allowed'} text-xs w-full py-1 bg-transparent text-chalkboard-100 placeholder:text-chalkboard-70 dark:text-chalkboard-10 dark:placeholder:text-chalkboard-50 focus:outline-none focus:ring-0`}
-                type="text"
-                placeholder="Set a password"
-              />
-            </div>
-            <div>
-              <label
-                htmlFor="org-only"
-                className="pl-1 inline-flex items-center"
-              >
-                <input
-                  disabled={!allowOrgRestrict}
-                  checked={isRestrictedToOrg}
-                  onChange={(_) => setIsRestrictedToOrg(!isRestrictedToOrg)}
-                  type="checkbox"
-                  name="org-only"
-                  className="form-checkbox"
-                />
-                <span
-                  className={`text-xs ml-2 ${allowOrgRestrict ? 'cursor-pointer' : 'cursor-not-allowed text-chalkboard-50'}`}
-                >
-                  Org. only access
-                </span>
-              </label>
-              {!allowOrgRestrict && (
-                <Tooltip>Upgrade to Organization to use this feature.</Tooltip>
-              )}
-            </div>
-            <button disabled={disabled} onClick={onShareClickProOrOrganization}>
-              Generate
-            </button>
-          </div>
-        </Popover.Panel>
-      )}
-    </Popover>
+      </div>
+      <ShareDialog
+        isOpen={isDialogOpen}
+        onClose={() => setIsDialogOpen(false)}
+        onSubmit={onCopyShareLink}
+        allowOrgRestrict={allowOrgRestrict}
+        allowPassword={allowPassword}
+        disabled={disabled}
+      />
+    </>
   )
 })

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -175,6 +175,7 @@ function SharePopoverContent({
         <Tooltip
           position="bottom-right"
           contentClassName="max-w-none flex items-center gap-4"
+          hoverOnly
         >
           <span className="flex-1">
             {billingLoading

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -21,32 +21,28 @@ export const ShareButton = memo(function ShareButton() {
   const [isDialogOpen, setIsDialogOpen] = useState(false)
 
   const billingContext = billing.useContext()
-  const currentProjectName = app.projectSignal.value?.name || ''
+  const currentProject = app.projectSignal.value?.projectIORefSignal.value
 
   const allowOrgRestrict = !!billingContext.isOrg
-  const allowPassword = !!billingContext.hasSubscription
 
   const onShareClick = useCallback(() => {
     setIsDialogOpen(true)
   }, [])
 
   const onCopyShareLink = useCallback(
-    async ({
-      isRestrictedToOrg,
-      password,
-    }: {
-      isRestrictedToOrg: boolean
-      password?: string
-    }) => {
+    async ({ isRestrictedToOrg }: { isRestrictedToOrg: boolean }) => {
+      const wasmInstance = await kclManager.wasmInstancePromise
+
       return copyCurrentFileShareLink({
         token,
-        code: kclManager.code,
-        name: currentProjectName,
+        project: currentProject,
+        currentFilePath: kclManager.path,
+        currentFileContents: kclManager.code,
+        wasmInstance,
         isRestrictedToOrg,
-        password,
       })
     },
-    [currentProjectName, kclManager.code, token]
+    [currentProject, kclManager, token]
   )
 
   useHotkeys(shareHotkey, onShareClick, {
@@ -95,7 +91,6 @@ export const ShareButton = memo(function ShareButton() {
         onClose={() => setIsDialogOpen(false)}
         onSubmit={onCopyShareLink}
         allowOrgRestrict={allowOrgRestrict}
-        allowPassword={allowPassword}
         disabled={disabled}
       />
     </>

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -1,10 +1,11 @@
+import { Popover } from '@headlessui/react'
 import { CustomIcon } from '@src/components/CustomIcon'
 import { ShareDialog } from '@src/components/ShareDialog'
 import Tooltip from '@src/components/Tooltip'
 import usePlatform from '@src/hooks/usePlatform'
 import { useApp, useSingletons } from '@src/lib/boot'
 import { hotkeyDisplay } from '@src/lib/hotkeys'
-import { copyCurrentFileShareLink } from '@src/lib/share'
+import { copyCurrentFileShareLink, publishCurrentProject } from '@src/lib/share'
 import { memo, useCallback, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 
@@ -24,6 +25,7 @@ export const ShareButton = memo(function ShareButton() {
   const currentProject = app.projectSignal.value?.projectIORefSignal.value
 
   const allowOrgRestrict = !!billingContext.isOrg
+  const billingLoading = billingContext.hasSubscription === undefined
 
   const onShareClick = useCallback(() => {
     setIsDialogOpen(true)
@@ -45,53 +47,68 @@ export const ShareButton = memo(function ShareButton() {
     [currentProject, kclManager, token]
   )
 
+  const onPublishProject = useCallback(async () => {
+    const wasmInstance = await kclManager.wasmInstancePromise
+
+    return publishCurrentProject({
+      token,
+      project: currentProject,
+      currentFilePath: kclManager.path,
+      currentFileContents: kclManager.code,
+      wasmInstance,
+    })
+  }, [currentProject, kclManager, token])
+
   useHotkeys(shareHotkey, onShareClick, {
     scopes: ['modeling'],
   })
 
   const ast = kclManager.astSignal.value
-
-  // It doesn't make sense for the user to be able to click on this
-  // until we get what their subscription allows for.
-  const disabled =
-    ast.body.some((n) => n.type === 'ImportStatement') ||
-    billingContext.hasSubscription === undefined
+  const shareDisabled = ast.body.some((n) => n.type === 'ImportStatement')
 
   return (
     <>
-      <div className="relative hidden sm:flex">
-        <button
-          type="button"
-          onClick={onShareClick}
-          disabled={disabled}
-          className="relative group flex gap-1 items-center py-0 pl-0.5 pr-1.5 rounded-l-full bg-chalkboard-10/80 border border-solid active:border-primary dark:bg-chalkboard-100/50 hover:bg-chalkboard-10 dark:hover:bg-chalkboard-100"
-          data-testid="share-button"
+      <Popover className="relative hidden sm:flex">
+        <Popover.Button
+          as="div"
+          className="relative group border-0 w-fit min-w-max p-0 rounded-l-full focus-visible:outline-appForeground"
         >
-          <CustomIcon name="link" className="w-5 h-5" />
-          <span className="flex-1">Share</span>
-          <Tooltip
-            position="bottom-right"
-            contentClassName="max-w-none flex items-center gap-4"
+          <button
+            type="button"
+            onClick={onShareClick}
+            disabled={billingLoading}
+            className="flex gap-1 items-center py-0 pl-0.5 pr-1.5 bg-chalkboard-10/80 dark:bg-chalkboard-100/50 hover:bg-chalkboard-10 dark:hover:bg-chalkboard-100 border border-solid active:border-primary"
+            data-testid="share-button"
           >
-            <span className="flex-1">
-              {disabled
-                ? `Share links are not currently supported for multi-file assemblies`
-                : `Share this file`}
-            </span>
-            {!disabled && (
-              <kbd className="hotkey text-xs capitalize">
-                {hotkeyDisplay(shareHotkey, platform)}
-              </kbd>
-            )}
-          </Tooltip>
-        </button>
-      </div>
+            <CustomIcon name="link" className="w-5 h-5" />
+            <span className="flex-1">Share</span>
+            <Tooltip
+              position="bottom-right"
+              contentClassName="max-w-none flex items-center gap-4"
+            >
+              <span className="flex-1">
+                {billingLoading
+                  ? 'Loading share options'
+                  : shareDisabled
+                    ? `Share links are not currently supported for multi-file assemblies, but you can still publish this project`
+                    : `Share or publish this project`}
+              </span>
+              {!billingLoading && (
+                <kbd className="hotkey text-xs capitalize">
+                  {hotkeyDisplay(shareHotkey, platform)}
+                </kbd>
+              )}
+            </Tooltip>
+          </button>
+        </Popover.Button>
+      </Popover>
       <ShareDialog
         isOpen={isDialogOpen}
         onClose={() => setIsDialogOpen(false)}
-        onSubmit={onCopyShareLink}
+        onCopyLink={onCopyShareLink}
+        onPublish={onPublishProject}
         allowOrgRestrict={allowOrgRestrict}
-        disabled={disabled}
+        shareDisabled={shareDisabled}
       />
     </>
   )

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -5,8 +5,21 @@ import Tooltip from '@src/components/Tooltip'
 import usePlatform from '@src/hooks/usePlatform'
 import { useApp, useSingletons } from '@src/lib/boot'
 import { hotkeyDisplay } from '@src/lib/hotkeys'
-import { copyCurrentFileShareLink, publishCurrentProject } from '@src/lib/share'
-import { memo, useCallback, useState } from 'react'
+import {
+  copyCurrentFileShareLink,
+  type CurrentProjectPublicationDetails,
+  getCurrentProjectPublicationDetails,
+  publishCurrentProject,
+} from '@src/lib/share'
+import { err } from '@src/lib/trap'
+import {
+  memo,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 
 const shareHotkey = 'mod+alt+s'
@@ -14,22 +27,65 @@ const shareHotkey = 'mod+alt+s'
 /** Share Zoo link button shown in the upper-right of the modeling view */
 export const ShareButton = memo(function ShareButton() {
   const app = useApp()
-  const { auth, billing } = app
-  const { kclManager } = useSingletons()
+  const { billing } = app
   const platform = usePlatform()
-  const token = auth.useToken()
-
-  const [isDialogOpen, setIsDialogOpen] = useState(false)
 
   const billingContext = billing.useContext()
-  const currentProject = app.projectSignal.value?.projectIORefSignal.value
-
-  const allowOrgRestrict = !!billingContext.isOrg
   const billingLoading = billingContext.hasSubscription === undefined
+  const shareButtonRef = useRef<HTMLButtonElement>(null)
 
   const onShareClick = useCallback(() => {
-    setIsDialogOpen(true)
+    shareButtonRef.current?.click()
   }, [])
+
+  useHotkeys(shareHotkey, onShareClick, {
+    scopes: ['modeling'],
+  })
+
+  return (
+    <Popover className="relative hidden sm:flex">
+      {(popover) => {
+        return (
+          <SharePopoverContent
+            billingLoading={billingLoading}
+            shareButtonRef={shareButtonRef}
+            close={() => popover.close()}
+            open={popover.open}
+            platform={platform}
+          />
+        )
+      }}
+    </Popover>
+  )
+})
+
+function SharePopoverContent({
+  billingLoading,
+  shareButtonRef,
+  close,
+  open,
+  platform,
+}: {
+  billingLoading: boolean
+  shareButtonRef: RefObject<HTMLButtonElement | null>
+  close: () => void
+  open: boolean
+  platform: ReturnType<typeof usePlatform>
+}) {
+  const app = useApp()
+  const { auth, billing } = app
+  const { kclManager } = useSingletons()
+  const token = auth.useToken()
+  const billingContext = billing.useContext()
+  const currentProject = app.projectSignal.value?.projectIORefSignal.value
+  const allowOrgRestrict = !!billingContext.isOrg
+  const ast = kclManager.astSignal.value
+  const shareDisabled = ast.body.some((n) => n.type === 'ImportStatement')
+
+  const [publicationDetails, setPublicationDetails] =
+    useState<CurrentProjectPublicationDetails | null>(null)
+  const [isLoadingPublicationDetails, setIsLoadingPublicationDetails] =
+    useState(false)
 
   const onCopyShareLink = useCallback(
     async ({ isRestrictedToOrg }: { isRestrictedToOrg: boolean }) => {
@@ -59,57 +115,92 @@ export const ShareButton = memo(function ShareButton() {
     })
   }, [currentProject, kclManager, token])
 
-  useHotkeys(shareHotkey, onShareClick, {
-    scopes: ['modeling'],
-  })
+  useEffect(() => {
+    let isCancelled = false
 
-  const ast = kclManager.astSignal.value
-  const shareDisabled = ast.body.some((n) => n.type === 'ImportStatement')
+    if (!open) {
+      setPublicationDetails(null)
+      setIsLoadingPublicationDetails(false)
+      return
+    }
+
+    if (!token || !currentProject) {
+      setPublicationDetails(null)
+      setIsLoadingPublicationDetails(false)
+      return
+    }
+
+    setIsLoadingPublicationDetails(true)
+    void (async () => {
+      const wasmInstance = await kclManager.wasmInstancePromise
+      if (isCancelled) {
+        return
+      }
+
+      const details = await getCurrentProjectPublicationDetails({
+        token,
+        project: currentProject,
+        wasmInstance,
+      })
+
+      if (isCancelled) {
+        return
+      }
+
+      if (err(details)) {
+        console.error('Failed to load project publication details', details)
+        setPublicationDetails(null)
+      } else {
+        setPublicationDetails(details)
+      }
+
+      setIsLoadingPublicationDetails(false)
+    })()
+
+    return () => {
+      isCancelled = true
+    }
+  }, [currentProject, kclManager, open, token])
 
   return (
     <>
-      <Popover className="relative hidden sm:flex">
-        <Popover.Button
-          as="div"
-          className="relative group border-0 w-fit min-w-max p-0 rounded-l-full focus-visible:outline-appForeground"
+      <Popover.Button
+        ref={shareButtonRef}
+        disabled={billingLoading}
+        className="relative inline-flex min-w-max items-center gap-1 rounded-md border border-chalkboard-30 bg-chalkboard-10/80 py-0 pl-0.5 pr-1.5 text-chalkboard-100 transition-colors hover:border-chalkboard-40 hover:bg-chalkboard-10 dark:border-chalkboard-70 dark:bg-chalkboard-100/50 dark:text-chalkboard-10 dark:hover:border-chalkboard-60 dark:hover:bg-chalkboard-100 focus-visible:outline-appForeground active:border-primary disabled:cursor-wait disabled:opacity-70"
+        data-testid="share-button"
+      >
+        <CustomIcon name="link" className="h-5 w-5" />
+        <span className="flex-1">Share</span>
+        <Tooltip
+          position="bottom-right"
+          contentClassName="max-w-none flex items-center gap-4"
         >
-          <button
-            type="button"
-            onClick={onShareClick}
-            disabled={billingLoading}
-            className="flex gap-1 items-center py-0 pl-0.5 pr-1.5 bg-chalkboard-10/80 dark:bg-chalkboard-100/50 hover:bg-chalkboard-10 dark:hover:bg-chalkboard-100 border border-solid active:border-primary"
-            data-testid="share-button"
-          >
-            <CustomIcon name="link" className="w-5 h-5" />
-            <span className="flex-1">Share</span>
-            <Tooltip
-              position="bottom-right"
-              contentClassName="max-w-none flex items-center gap-4"
-            >
-              <span className="flex-1">
-                {billingLoading
-                  ? 'Loading share options'
-                  : shareDisabled
-                    ? `Share links are not currently supported for multi-file assemblies, but you can still publish this project`
-                    : `Share or publish this project`}
-              </span>
-              {!billingLoading && (
-                <kbd className="hotkey text-xs capitalize">
-                  {hotkeyDisplay(shareHotkey, platform)}
-                </kbd>
-              )}
-            </Tooltip>
-          </button>
-        </Popover.Button>
-      </Popover>
-      <ShareDialog
-        isOpen={isDialogOpen}
-        onClose={() => setIsDialogOpen(false)}
-        onCopyLink={onCopyShareLink}
-        onPublish={onPublishProject}
-        allowOrgRestrict={allowOrgRestrict}
-        shareDisabled={shareDisabled}
-      />
+          <span className="flex-1">
+            {billingLoading
+              ? 'Loading share options'
+              : shareDisabled
+                ? `Share links are not currently supported for multi-file assemblies, but you can still publish this project`
+                : `Share or publish this project`}
+          </span>
+          {!billingLoading && (
+            <kbd className="hotkey text-xs capitalize">
+              {hotkeyDisplay(shareHotkey, platform)}
+            </kbd>
+          )}
+        </Tooltip>
+      </Popover.Button>
+      {open && (
+        <ShareDialog
+          onClose={close}
+          onCopyLink={onCopyShareLink}
+          onPublish={onPublishProject}
+          allowOrgRestrict={allowOrgRestrict}
+          shareDisabled={shareDisabled}
+          publicationDetails={publicationDetails}
+          isLoadingPublicationDetails={isLoadingPublicationDetails}
+        />
+      )}
     </>
   )
-})
+}

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -117,7 +117,7 @@ export function ShareDialog({
                 bgClassName: '!bg-transparent',
                 size: 'sm',
               }}
-              className="ml-2 shrink-0 whitespace-nowrap py-0.5 pr-2"
+              className="shrink-0 whitespace-nowrap py-0.5 px-2"
               onClick={() => {
                 void handleCopyLink()
               }}

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -1,5 +1,7 @@
-import { Dialog, Transition } from '@headlessui/react'
+import { Popover, Transition } from '@headlessui/react'
+import { ActionButton } from '@src/components/ActionButton'
 import { CustomIcon } from '@src/components/CustomIcon'
+import type { CurrentProjectPublicationDetails } from '@src/lib/share'
 import { Fragment, useEffect, useState } from 'react'
 
 export interface ShareDialogSubmitArgs {
@@ -7,21 +9,23 @@ export interface ShareDialogSubmitArgs {
 }
 
 type ShareDialogProps = {
-  isOpen: boolean
   onClose: () => void
   onCopyLink: (args: ShareDialogSubmitArgs) => Promise<boolean>
   onPublish: () => Promise<boolean>
   allowOrgRestrict: boolean
   shareDisabled?: boolean
+  publicationDetails?: CurrentProjectPublicationDetails | null
+  isLoadingPublicationDetails?: boolean
 }
 
 export function ShareDialog({
-  isOpen,
   onClose,
   onCopyLink,
   onPublish,
   allowOrgRestrict,
   shareDisabled = false,
+  publicationDetails = null,
+  isLoadingPublicationDetails = false,
 }: ShareDialogProps) {
   const [isRestrictedToOrg, setIsRestrictedToOrg] = useState(false)
   const [activeAction, setActiveAction] = useState<'copy' | 'publish' | null>(
@@ -29,17 +33,20 @@ export function ShareDialog({
   )
 
   useEffect(() => {
-    if (isOpen) {
-      return
-    }
-
     setIsRestrictedToOrg(false)
     setActiveAction(null)
-  }, [isOpen])
+  }, [])
 
   const isSubmitting = activeAction !== null
   const copyDisabled = shareDisabled || isSubmitting
   const publishDisabled = isSubmitting
+  const publishButtonLabel = getPublishButtonLabel(
+    publicationDetails?.publicationStatus
+  )
+  const publishPrompt = getPublishPrompt({
+    publicationDetails,
+    isLoadingPublicationDetails,
+  })
 
   async function handleCopyLink() {
     if (copyDisabled) {
@@ -76,180 +83,213 @@ export function ShareDialog({
   }
 
   return (
-    <Transition appear show={isOpen} as={Fragment}>
-      <Dialog
-        as="div"
-        className="relative z-40"
-        onClose={() => {
-          if (!isSubmitting) {
-            onClose()
-          }
-        }}
+    <Transition
+      appear
+      as={Fragment}
+      show={true}
+      enter="ease-out duration-100"
+      enterFrom="opacity-0 translate-y-1 scale-[0.98]"
+      enterTo="opacity-100 translate-y-0 scale-100"
+      leave="ease-in duration-75"
+      leaveFrom="opacity-100 translate-y-0 scale-100"
+      leaveTo="opacity-0 translate-y-1 scale-[0.98]"
+    >
+      <Popover.Panel
+        focus={true}
+        className="absolute right-0 top-full z-20 mt-2 flex w-[26rem] max-w-[calc(100vw-2rem)] flex-col overflow-hidden border border-chalkboard-30/80 bg-chalkboard-10/95 text-sm text-chalkboard-100 shadow-2xl backdrop-blur-sm dark:border-chalkboard-80/60 dark:bg-chalkboard-90/95 dark:text-chalkboard-10"
       >
-        <Transition.Child
-          as={Fragment}
-          enter="ease-out duration-200"
-          enterFrom="opacity-0"
-          enterTo="opacity-100"
-          leave="ease-in duration-150"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
-        >
-          <Dialog.Overlay className="fixed inset-0 bg-chalkboard-10/70 dark:bg-chalkboard-110/50" />
-        </Transition.Child>
-
-        <div className="fixed inset-0 overflow-y-auto p-4 pt-[14vh]">
-          <div className="flex min-h-full items-start justify-center">
-            <Transition.Child
-              as={Fragment}
-              enter="ease-out duration-200"
-              enterFrom="opacity-0 translate-y-3 scale-[0.98]"
-              enterTo="opacity-100 translate-y-0 scale-100"
-              leave="ease-in duration-150"
-              leaveFrom="opacity-100 translate-y-0 scale-100"
-              leaveTo="opacity-0 translate-y-2 scale-[0.98]"
+        <div className="border-b border-chalkboard-20/70 bg-chalkboard-20/70 px-4 py-4 text-chalkboard-100 dark:border-chalkboard-80/70 dark:bg-chalkboard-80/70 dark:text-chalkboard-10">
+          <div className="flex flex-row items-start justify-between gap-3">
+            <div className="min-w-0">
+              <h2 className="text-base font-medium leading-none">
+                Share project
+              </h2>
+              <p className="mt-2 text-xs leading-5 text-chalkboard-70 dark:text-chalkboard-30">
+                Copy a shareable link or publish this project for review.
+              </p>
+            </div>
+            <ActionButton
+              Element="button"
+              type="button"
+              disabled={copyDisabled}
+              iconStart={{
+                icon: 'link',
+                bgClassName: '!bg-transparent',
+                size: 'sm',
+              }}
+              className="ml-2 shrink-0 whitespace-nowrap py-0.5 pr-2"
+              onClick={() => {
+                void handleCopyLink()
+              }}
             >
-              <Dialog.Panel className="w-full max-w-2xl overflow-hidden rounded-xl border border-chalkboard-30 bg-chalkboard-10 text-chalkboard-100 shadow-2xl dark:border-chalkboard-70 dark:bg-chalkboard-100 dark:text-chalkboard-10">
-                <div className="flex items-start justify-between border-b border-chalkboard-20 px-5 py-4 dark:border-chalkboard-80">
-                  <div className="max-w-[30rem] pr-4">
-                    <Dialog.Title className="text-base font-medium">
-                      Share this project
-                    </Dialog.Title>
-                    <p className="mt-1 text-sm text-chalkboard-70 dark:text-chalkboard-40">
-                      Copy a shareable link or submit this project for public
-                      review.
-                    </p>
-                  </div>
-                  <div className="flex shrink-0 items-center gap-2 self-start">
-                    <button
-                      type="button"
-                      disabled={copyDisabled}
-                      className="inline-flex h-8 items-center gap-2 whitespace-nowrap rounded border border-chalkboard-30 px-3 text-xs font-medium text-chalkboard-100 hover:bg-chalkboard-20 disabled:cursor-not-allowed disabled:text-chalkboard-60 dark:border-chalkboard-70 dark:text-chalkboard-10 dark:hover:bg-chalkboard-80 dark:disabled:text-chalkboard-50"
-                      onClick={() => {
-                        void handleCopyLink()
-                      }}
-                    >
-                      <CustomIcon
-                        name="link"
-                        className="h-4 w-4 text-chalkboard-70 dark:text-chalkboard-40"
-                      />
-                      {activeAction === 'copy' ? 'Copying...' : 'Copy link'}
-                    </button>
-                    <button
-                      type="button"
-                      className="rounded p-1.5 text-chalkboard-70 hover:bg-chalkboard-20 hover:text-chalkboard-100 dark:text-chalkboard-40 dark:hover:bg-chalkboard-80 dark:hover:text-chalkboard-10"
-                      onClick={onClose}
-                      disabled={isSubmitting}
-                      aria-label="Close share dialog"
-                    >
-                      <CustomIcon name="close" className="h-4 w-4" />
-                    </button>
-                  </div>
-                </div>
-
-                <form
-                  className="space-y-4 px-5 py-5"
-                  onSubmit={(event) => {
-                    event.preventDefault()
-                    void handleCopyLink()
-                  }}
-                >
-                  <section className="rounded-xl border border-chalkboard-20 bg-chalkboard-10/60 p-4 dark:border-chalkboard-80 dark:bg-chalkboard-90">
-                    <p className="text-xs font-semibold uppercase tracking-[0.12em] text-chalkboard-60 dark:text-chalkboard-50">
-                      Who has access
-                    </p>
-
-                    <div className="mt-4 space-y-3">
-                      <div className="flex items-center gap-3 rounded-lg border border-chalkboard-20 px-4 py-3 dark:border-chalkboard-80">
-                        <CustomIcon
-                          name="link"
-                          className="h-5 w-5 text-chalkboard-70 dark:text-chalkboard-40"
-                        />
-                        <div className="flex-1">
-                          <p className="text-sm font-medium">
-                            Anyone with the link
-                          </p>
-                          <p className="mt-1 text-xs text-chalkboard-70 dark:text-chalkboard-40">
-                            They can open a copy of this project in Zoo.
-                          </p>
-                        </div>
-                        <span className="shrink-0 text-sm text-chalkboard-70 dark:text-chalkboard-40">
-                          can view
-                        </span>
-                      </div>
-
-                      <label
-                        className={`flex items-start gap-3 rounded-lg border px-4 py-3 ${
-                          allowOrgRestrict
-                            ? 'cursor-pointer border-chalkboard-20 dark:border-chalkboard-80'
-                            : 'cursor-not-allowed border-chalkboard-20/70 opacity-60 dark:border-chalkboard-80/70'
-                        }`}
-                      >
-                        <input
-                          type="checkbox"
-                          checked={isRestrictedToOrg}
-                          disabled={!allowOrgRestrict}
-                          onChange={() =>
-                            setIsRestrictedToOrg((current) => !current)
-                          }
-                          className="mt-1 h-4 w-4 form-checkbox"
-                        />
-                        <div className="flex-1">
-                          <p className="text-sm font-medium">
-                            Org. only access
-                          </p>
-                          <p className="mt-1 text-xs text-chalkboard-70 dark:text-chalkboard-40">
-                            Restrict this link to members of your organization.
-                          </p>
-                          {!allowOrgRestrict && (
-                            <p className="mt-2 text-xs text-chalkboard-60 dark:text-chalkboard-50">
-                              Requires an organization plan.
-                            </p>
-                          )}
-                        </div>
-                      </label>
-                    </div>
-                  </section>
-
-                  {shareDisabled && (
-                    <p className="text-sm text-chalkboard-70 dark:text-chalkboard-40">
-                      Share links are not currently supported for multi-file
-                      assemblies, but you can still publish this project for
-                      review.
-                    </p>
-                  )}
-
-                  <section className="rounded-xl border border-chalkboard-20 bg-chalkboard-10/60 p-4 dark:border-chalkboard-80 dark:bg-chalkboard-90">
-                    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                      <div>
-                        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-chalkboard-60 dark:text-chalkboard-50">
-                          Publish to Aquarium
-                        </p>
-                        <p className="mt-2 text-sm text-chalkboard-70 dark:text-chalkboard-40">
-                          Submit this project for review so it can be approved
-                          for public listing.
-                        </p>
-                      </div>
-                      <button
-                        type="button"
-                        disabled={publishDisabled}
-                        className="inline-flex h-8 items-center justify-center whitespace-nowrap rounded border border-chalkboard-30 px-3 text-xs font-medium text-chalkboard-100 hover:bg-chalkboard-20 disabled:cursor-not-allowed disabled:text-chalkboard-60 dark:border-chalkboard-70 dark:text-chalkboard-10 dark:hover:bg-chalkboard-80 dark:disabled:text-chalkboard-50"
-                        onClick={() => {
-                          void handlePublish()
-                        }}
-                      >
-                        {activeAction === 'publish'
-                          ? 'Publishing...'
-                          : 'Publish'}
-                      </button>
-                    </div>
-                  </section>
-                </form>
-              </Dialog.Panel>
-            </Transition.Child>
+              {activeAction === 'copy' ? 'Copying...' : 'Copy link'}
+            </ActionButton>
           </div>
         </div>
-      </Dialog>
+
+        <form
+          className="flex flex-col gap-4 px-4 py-4"
+          onSubmit={(event) => {
+            event.preventDefault()
+            void handleCopyLink()
+          }}
+        >
+          <section className="flex flex-col gap-3">
+            <p className="text-xs font-medium uppercase tracking-[0.14em] text-chalkboard-60 dark:text-chalkboard-40">
+              Who has access
+            </p>
+
+            <div className="rounded-xl border border-chalkboard-20/80 bg-chalkboard-10/70 px-3 py-3 dark:border-chalkboard-80/70 dark:bg-chalkboard-100/40">
+              <div className="flex flex-row items-start gap-2">
+                <CustomIcon
+                  name="link"
+                  className="mt-0.5 h-4 w-4 text-chalkboard-60 dark:text-chalkboard-40"
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-3">
+                    <p className="text-chalkboard-100 dark:text-chalkboard-10">
+                      Anyone with the link
+                    </p>
+                    <p className="shrink-0 text-chalkboard-60 dark:text-chalkboard-40">
+                      can view
+                    </p>
+                  </div>
+                  <p className="pt-1 text-xs leading-5 text-chalkboard-60 dark:text-chalkboard-40">
+                    They can open a copy of this project in Zoo.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <label
+              aria-label="Organization only access"
+              className={`rounded-xl border border-chalkboard-20/80 px-3 py-3 dark:border-chalkboard-80/70 ${
+                allowOrgRestrict
+                  ? 'cursor-pointer bg-chalkboard-10/70 dark:bg-chalkboard-100/40'
+                  : 'cursor-not-allowed opacity-60'
+              }`}
+            >
+              <div className="flex items-start gap-3">
+                <input
+                  type="checkbox"
+                  checked={isRestrictedToOrg}
+                  disabled={!allowOrgRestrict}
+                  onChange={() => setIsRestrictedToOrg((current) => !current)}
+                  className="mt-0.5 h-4 w-4 form-checkbox"
+                />
+                <div className="flex-1">
+                  <p className="text-chalkboard-100 dark:text-chalkboard-10">
+                    Org. only access
+                  </p>
+                  <p className="mt-1 text-xs leading-5 text-chalkboard-60 dark:text-chalkboard-40">
+                    Restrict this link to members of your organization.
+                  </p>
+                  {!allowOrgRestrict && (
+                    <p className="mt-1 text-xs leading-5 text-chalkboard-60 dark:text-chalkboard-40">
+                      Requires an organization plan.
+                    </p>
+                  )}
+                </div>
+              </div>
+            </label>
+            {shareDisabled && (
+              <p className="text-xs leading-5 text-chalkboard-60 dark:text-chalkboard-40">
+                Share links are not currently supported for multi-file
+                assemblies.
+              </p>
+            )}
+          </section>
+
+          <section className="border-t border-chalkboard-20/70 pt-4 dark:border-chalkboard-80/70">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between sm:gap-4">
+              <div className="min-w-0 flex-1">
+                <p className="text-xs font-medium uppercase tracking-[0.14em] text-chalkboard-60 dark:text-chalkboard-40">
+                  Publish to Aquarium
+                </p>
+                <p className="mt-2 text-xs leading-5 text-chalkboard-60 dark:text-chalkboard-40">
+                  {publishPrompt}
+                </p>
+              </div>
+              <ActionButton
+                Element="button"
+                type="button"
+                disabled={publishDisabled}
+                className="shrink-0 self-end whitespace-nowrap py-0.5 sm:self-auto"
+                onClick={() => {
+                  void handlePublish()
+                }}
+              >
+                {activeAction === 'publish'
+                  ? 'Publishing...'
+                  : publishButtonLabel}
+              </ActionButton>
+            </div>
+          </section>
+        </form>
+      </Popover.Panel>
     </Transition>
   )
+}
+
+function getPublishButtonLabel(
+  publicationStatus?: CurrentProjectPublicationDetails['publicationStatus']
+) {
+  switch (publicationStatus) {
+    case 'published':
+      return 'Update published version'
+    case 'pending_review':
+      return 'Update review submission'
+    case 'rejected':
+      return 'Resubmit for review'
+    default:
+      return 'Publish'
+  }
+}
+
+function getPublishPrompt({
+  publicationDetails,
+  isLoadingPublicationDetails,
+}: {
+  publicationDetails: CurrentProjectPublicationDetails | null
+  isLoadingPublicationDetails: boolean
+}) {
+  if (isLoadingPublicationDetails) {
+    return 'Checking whether this project has already been published.'
+  }
+
+  if (!publicationDetails) {
+    return 'Submit this project for review so it can be approved for public listing.'
+  }
+
+  switch (publicationDetails.publicationStatus) {
+    case 'published': {
+      const publishedOn = publicationDetails.publishedAt
+        ? formatDate(publicationDetails.publishedAt)
+        : null
+      return publishedOn
+        ? `This project was last published on ${publishedOn}. Publish again to update the public version.`
+        : 'This project has already been published. Publish again to update the public version.'
+    }
+    case 'pending_review':
+      return `This project was last submitted for review on ${formatDate(publicationDetails.updatedAt)}. Publish again to update the pending review version.`
+    case 'rejected':
+      return 'This project has been submitted before. Publish again to resubmit it for approval.'
+    case 'deleted':
+      return 'This project was previously published. Publish again to submit a new version for review.'
+    default:
+      return 'Submit this project for review so it can be approved for public listing.'
+  }
+}
+
+function formatDate(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.valueOf())) {
+    return value
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date)
 }

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -1,5 +1,4 @@
 import { Dialog, Transition } from '@headlessui/react'
-import { ActionButton } from '@src/components/ActionButton'
 import { CustomIcon } from '@src/components/CustomIcon'
 import { Fragment, useEffect, useState } from 'react'
 
@@ -10,20 +9,24 @@ export interface ShareDialogSubmitArgs {
 type ShareDialogProps = {
   isOpen: boolean
   onClose: () => void
-  onSubmit: (args: ShareDialogSubmitArgs) => Promise<boolean>
+  onCopyLink: (args: ShareDialogSubmitArgs) => Promise<boolean>
+  onPublish: () => Promise<boolean>
   allowOrgRestrict: boolean
-  disabled?: boolean
+  shareDisabled?: boolean
 }
 
 export function ShareDialog({
   isOpen,
   onClose,
-  onSubmit,
+  onCopyLink,
+  onPublish,
   allowOrgRestrict,
-  disabled = false,
+  shareDisabled = false,
 }: ShareDialogProps) {
   const [isRestrictedToOrg, setIsRestrictedToOrg] = useState(false)
-  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [activeAction, setActiveAction] = useState<'copy' | 'publish' | null>(
+    null
+  )
 
   useEffect(() => {
     if (isOpen) {
@@ -31,26 +34,44 @@ export function ShareDialog({
     }
 
     setIsRestrictedToOrg(false)
-    setIsSubmitting(false)
+    setActiveAction(null)
   }, [isOpen])
 
-  const copyDisabled = disabled || isSubmitting
+  const isSubmitting = activeAction !== null
+  const copyDisabled = shareDisabled || isSubmitting
+  const publishDisabled = isSubmitting
 
-  async function handleSubmit() {
+  async function handleCopyLink() {
     if (copyDisabled) {
       return
     }
 
-    setIsSubmitting(true)
+    setActiveAction('copy')
     try {
-      const copied = await onSubmit({
+      const copied = await onCopyLink({
         isRestrictedToOrg,
       })
       if (copied) {
         onClose()
       }
     } finally {
-      setIsSubmitting(false)
+      setActiveAction(null)
+    }
+  }
+
+  async function handlePublish() {
+    if (publishDisabled) {
+      return
+    }
+
+    setActiveAction('publish')
+    try {
+      const published = await onPublish()
+      if (published) {
+        onClose()
+      }
+    } finally {
+      setActiveAction(null)
     }
   }
 
@@ -89,72 +110,76 @@ export function ShareDialog({
               leaveTo="opacity-0 translate-y-2 scale-[0.98]"
             >
               <Dialog.Panel className="w-full max-w-2xl overflow-hidden rounded-xl border border-chalkboard-30 bg-chalkboard-10 text-chalkboard-100 shadow-2xl dark:border-chalkboard-70 dark:bg-chalkboard-100 dark:text-chalkboard-10">
-                <div className="flex items-center justify-between border-b border-chalkboard-20 px-5 py-4 dark:border-chalkboard-80">
-                  <div>
+                <div className="flex items-start justify-between border-b border-chalkboard-20 px-5 py-4 dark:border-chalkboard-80">
+                  <div className="max-w-[30rem] pr-4">
                     <Dialog.Title className="text-base font-medium">
-                      Share this file
+                      Share this project
                     </Dialog.Title>
                     <p className="mt-1 text-sm text-chalkboard-70 dark:text-chalkboard-40">
-                      Create a shareable link that opens a copy in Zoo.
+                      Copy a shareable link or submit this project for public
+                      review.
                     </p>
                   </div>
-                  <div className="flex items-center gap-2">
-                    <ActionButton
-                      Element="button"
-                      type="button"
-                      iconStart={{ icon: 'link' }}
-                      disabled={copyDisabled}
-                      onClick={() => {
-                        void handleSubmit()
-                      }}
-                    >
-                      {isSubmitting ? 'Copying...' : 'Copy link'}
-                    </ActionButton>
+                  <div className="flex shrink-0 items-center gap-2 self-start">
                     <button
                       type="button"
-                      className="rounded p-1 text-chalkboard-70 hover:bg-chalkboard-20 hover:text-chalkboard-100 dark:text-chalkboard-40 dark:hover:bg-chalkboard-80 dark:hover:text-chalkboard-10"
+                      disabled={copyDisabled}
+                      className="inline-flex h-8 items-center gap-2 whitespace-nowrap rounded border border-chalkboard-30 px-3 text-xs font-medium text-chalkboard-100 hover:bg-chalkboard-20 disabled:cursor-not-allowed disabled:text-chalkboard-60 dark:border-chalkboard-70 dark:text-chalkboard-10 dark:hover:bg-chalkboard-80 dark:disabled:text-chalkboard-50"
+                      onClick={() => {
+                        void handleCopyLink()
+                      }}
+                    >
+                      <CustomIcon
+                        name="link"
+                        className="h-4 w-4 text-chalkboard-70 dark:text-chalkboard-40"
+                      />
+                      {activeAction === 'copy' ? 'Copying...' : 'Copy link'}
+                    </button>
+                    <button
+                      type="button"
+                      className="rounded p-1.5 text-chalkboard-70 hover:bg-chalkboard-20 hover:text-chalkboard-100 dark:text-chalkboard-40 dark:hover:bg-chalkboard-80 dark:hover:text-chalkboard-10"
                       onClick={onClose}
                       disabled={isSubmitting}
                       aria-label="Close share dialog"
                     >
-                      <CustomIcon name="close" className="h-5 w-5" />
+                      <CustomIcon name="close" className="h-4 w-4" />
                     </button>
                   </div>
                 </div>
 
                 <form
-                  className="px-5 py-5"
+                  className="space-y-4 px-5 py-5"
                   onSubmit={(event) => {
                     event.preventDefault()
-                    void handleSubmit()
+                    void handleCopyLink()
                   }}
                 >
-                  <div className="rounded-xl border border-chalkboard-20 bg-chalkboard-10/60 p-4 dark:border-chalkboard-80 dark:bg-chalkboard-90">
+                  <section className="rounded-xl border border-chalkboard-20 bg-chalkboard-10/60 p-4 dark:border-chalkboard-80 dark:bg-chalkboard-90">
                     <p className="text-xs font-semibold uppercase tracking-[0.12em] text-chalkboard-60 dark:text-chalkboard-50">
                       Who has access
                     </p>
 
                     <div className="mt-4 space-y-3">
-                      <div className="flex items-start gap-3 rounded-lg border border-chalkboard-20 px-3 py-3 dark:border-chalkboard-80">
+                      <div className="flex items-center gap-3 rounded-lg border border-chalkboard-20 px-4 py-3 dark:border-chalkboard-80">
                         <CustomIcon
                           name="link"
-                          className="mt-0.5 h-5 w-5 text-chalkboard-70 dark:text-chalkboard-40"
+                          className="h-5 w-5 text-chalkboard-70 dark:text-chalkboard-40"
                         />
                         <div className="flex-1">
                           <p className="text-sm font-medium">
                             Anyone with the link
                           </p>
                           <p className="mt-1 text-xs text-chalkboard-70 dark:text-chalkboard-40">
-                            They can open a copy of this file in Zoo.
+                            They can open a copy of this project in Zoo.
                           </p>
                         </div>
-                        <span className="text-sm text-chalkboard-70 dark:text-chalkboard-40">
+                        <span className="shrink-0 text-sm text-chalkboard-70 dark:text-chalkboard-40">
                           can view
                         </span>
                       </div>
 
                       <label
-                        className={`flex items-start gap-3 rounded-lg border px-3 py-3 ${
+                        className={`flex items-start gap-3 rounded-lg border px-4 py-3 ${
                           allowOrgRestrict
                             ? 'cursor-pointer border-chalkboard-20 dark:border-chalkboard-80'
                             : 'cursor-not-allowed border-chalkboard-20/70 opacity-60 dark:border-chalkboard-80/70'
@@ -167,7 +192,7 @@ export function ShareDialog({
                           onChange={() =>
                             setIsRestrictedToOrg((current) => !current)
                           }
-                          className="mt-1 form-checkbox"
+                          className="mt-1 h-4 w-4 form-checkbox"
                         />
                         <div className="flex-1">
                           <p className="text-sm font-medium">
@@ -184,14 +209,41 @@ export function ShareDialog({
                         </div>
                       </label>
                     </div>
-                  </div>
+                  </section>
 
-                  {disabled && (
-                    <p className="mt-4 text-sm text-chalkboard-70 dark:text-chalkboard-40">
+                  {shareDisabled && (
+                    <p className="text-sm text-chalkboard-70 dark:text-chalkboard-40">
                       Share links are not currently supported for multi-file
-                      assemblies.
+                      assemblies, but you can still publish this project for
+                      review.
                     </p>
                   )}
+
+                  <section className="rounded-xl border border-chalkboard-20 bg-chalkboard-10/60 p-4 dark:border-chalkboard-80 dark:bg-chalkboard-90">
+                    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-chalkboard-60 dark:text-chalkboard-50">
+                          Publish to Aquarium
+                        </p>
+                        <p className="mt-2 text-sm text-chalkboard-70 dark:text-chalkboard-40">
+                          Submit this project for review so it can be approved
+                          for public listing.
+                        </p>
+                      </div>
+                      <button
+                        type="button"
+                        disabled={publishDisabled}
+                        className="inline-flex h-8 items-center justify-center whitespace-nowrap rounded border border-chalkboard-30 px-3 text-xs font-medium text-chalkboard-100 hover:bg-chalkboard-20 disabled:cursor-not-allowed disabled:text-chalkboard-60 dark:border-chalkboard-70 dark:text-chalkboard-10 dark:hover:bg-chalkboard-80 dark:disabled:text-chalkboard-50"
+                        onClick={() => {
+                          void handlePublish()
+                        }}
+                      >
+                        {activeAction === 'publish'
+                          ? 'Publishing...'
+                          : 'Publish'}
+                      </button>
+                    </div>
+                  </section>
                 </form>
               </Dialog.Panel>
             </Transition.Child>

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -96,7 +96,7 @@ export function ShareDialog({
     >
       <Popover.Panel
         focus={true}
-        className="absolute right-0 top-full z-20 mt-2 flex w-[26rem] max-w-[calc(100vw-2rem)] flex-col overflow-hidden border border-chalkboard-30/80 bg-chalkboard-10/95 text-sm text-chalkboard-100 shadow-2xl backdrop-blur-sm dark:border-chalkboard-80/60 dark:bg-chalkboard-90/95 dark:text-chalkboard-10"
+        className="absolute right-0 top-full z-20 mt-3 flex w-[26rem] max-w-[calc(100vw-2rem)] flex-col overflow-hidden border border-chalkboard-30/80 bg-chalkboard-10/95 rounded text-sm text-chalkboard-100 shadow-2xl backdrop-blur-sm dark:border-chalkboard-80/60 dark:bg-chalkboard-90/95 dark:text-chalkboard-10"
       >
         <div className="border-b border-chalkboard-20/70 bg-chalkboard-20/70 px-4 py-4 text-chalkboard-100 dark:border-chalkboard-80/70 dark:bg-chalkboard-80/70 dark:text-chalkboard-10">
           <div className="flex flex-row items-start justify-between gap-3">

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -5,7 +5,6 @@ import { Fragment, useEffect, useState } from 'react'
 
 export interface ShareDialogSubmitArgs {
   isRestrictedToOrg: boolean
-  password?: string
 }
 
 type ShareDialogProps = {
@@ -13,7 +12,6 @@ type ShareDialogProps = {
   onClose: () => void
   onSubmit: (args: ShareDialogSubmitArgs) => Promise<boolean>
   allowOrgRestrict: boolean
-  allowPassword: boolean
   disabled?: boolean
 }
 
@@ -22,11 +20,9 @@ export function ShareDialog({
   onClose,
   onSubmit,
   allowOrgRestrict,
-  allowPassword,
   disabled = false,
 }: ShareDialogProps) {
   const [isRestrictedToOrg, setIsRestrictedToOrg] = useState(false)
-  const [password, setPassword] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   useEffect(() => {
@@ -35,7 +31,6 @@ export function ShareDialog({
     }
 
     setIsRestrictedToOrg(false)
-    setPassword('')
     setIsSubmitting(false)
   }, [isOpen])
 
@@ -50,7 +45,6 @@ export function ShareDialog({
     try {
       const copied = await onSubmit({
         isRestrictedToOrg,
-        password: password.trim() || undefined,
       })
       if (copied) {
         onClose()
@@ -64,7 +58,7 @@ export function ShareDialog({
     <Transition appear show={isOpen} as={Fragment}>
       <Dialog
         as="div"
-        className="fixed inset-0 z-40 overflow-y-auto p-4 pt-[14vh]"
+        className="relative z-40"
         onClose={() => {
           if (!isSubmitting) {
             onClose()
@@ -80,170 +74,128 @@ export function ShareDialog({
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <Dialog.Overlay className="fixed inset-0 bg-chalkboard-110/45 backdrop-blur-[2px]" />
+          <Dialog.Overlay className="fixed inset-0 bg-chalkboard-10/70 dark:bg-chalkboard-110/50" />
         </Transition.Child>
 
-        <div className="flex min-h-full items-start justify-center">
-          <Transition.Child
-            as={Fragment}
-            enter="ease-out duration-200"
-            enterFrom="opacity-0 translate-y-3 scale-[0.98]"
-            enterTo="opacity-100 translate-y-0 scale-100"
-            leave="ease-in duration-150"
-            leaveFrom="opacity-100 translate-y-0 scale-100"
-            leaveTo="opacity-0 translate-y-2 scale-[0.98]"
-          >
-            <Dialog.Panel className="w-full max-w-2xl overflow-hidden rounded-xl border border-chalkboard-30 bg-chalkboard-10 text-chalkboard-100 shadow-2xl dark:border-chalkboard-70 dark:bg-chalkboard-100 dark:text-chalkboard-10">
-              <div className="flex items-center justify-between border-b border-chalkboard-20 px-5 py-4 dark:border-chalkboard-80">
-                <div>
-                  <Dialog.Title className="text-base font-medium">
-                    Share this file
-                  </Dialog.Title>
-                  <p className="mt-1 text-sm text-chalkboard-70 dark:text-chalkboard-40">
-                    Create a shareable link that opens a copy in Zoo.
-                  </p>
-                </div>
-                <div className="flex items-center gap-2">
-                  <ActionButton
-                    Element="button"
-                    type="button"
-                    iconStart={{ icon: 'link' }}
-                    disabled={copyDisabled}
-                    onClick={() => {
-                      void handleSubmit()
-                    }}
-                  >
-                    {isSubmitting ? 'Copying...' : 'Copy link'}
-                  </ActionButton>
-                  <button
-                    type="button"
-                    className="rounded p-1 text-chalkboard-70 hover:bg-chalkboard-20 hover:text-chalkboard-100 dark:text-chalkboard-40 dark:hover:bg-chalkboard-80 dark:hover:text-chalkboard-10"
-                    onClick={onClose}
-                    disabled={isSubmitting}
-                    aria-label="Close share dialog"
-                  >
-                    <CustomIcon name="close" className="h-5 w-5" />
-                  </button>
-                </div>
-              </div>
-
-              <form
-                className="px-5 py-5"
-                onSubmit={(event) => {
-                  event.preventDefault()
-                  void handleSubmit()
-                }}
-              >
-                <div className="rounded-xl border border-chalkboard-20 bg-chalkboard-10/60 p-4 dark:border-chalkboard-80 dark:bg-chalkboard-90">
-                  <p className="text-xs font-semibold uppercase tracking-[0.12em] text-chalkboard-60 dark:text-chalkboard-50">
-                    Who has access
-                  </p>
-
-                  <div className="mt-4 space-y-3">
-                    <div className="flex items-start gap-3 rounded-lg border border-chalkboard-20 px-3 py-3 dark:border-chalkboard-80">
-                      <CustomIcon
-                        name="link"
-                        className="mt-0.5 h-5 w-5 text-chalkboard-70 dark:text-chalkboard-40"
-                      />
-                      <div className="flex-1">
-                        <p className="text-sm font-medium">
-                          Anyone with the link
-                        </p>
-                        <p className="mt-1 text-xs text-chalkboard-70 dark:text-chalkboard-40">
-                          They can open a copy of this file in Zoo.
-                        </p>
-                      </div>
-                      <span className="text-sm text-chalkboard-70 dark:text-chalkboard-40">
-                        can view
-                      </span>
-                    </div>
-
-                    <label
-                      className={`flex items-start gap-3 rounded-lg border px-3 py-3 ${
-                        allowOrgRestrict
-                          ? 'cursor-pointer border-chalkboard-20 dark:border-chalkboard-80'
-                          : 'cursor-not-allowed border-chalkboard-20/70 opacity-60 dark:border-chalkboard-80/70'
-                      }`}
+        <div className="fixed inset-0 overflow-y-auto p-4 pt-[14vh]">
+          <div className="flex min-h-full items-start justify-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-200"
+              enterFrom="opacity-0 translate-y-3 scale-[0.98]"
+              enterTo="opacity-100 translate-y-0 scale-100"
+              leave="ease-in duration-150"
+              leaveFrom="opacity-100 translate-y-0 scale-100"
+              leaveTo="opacity-0 translate-y-2 scale-[0.98]"
+            >
+              <Dialog.Panel className="w-full max-w-2xl overflow-hidden rounded-xl border border-chalkboard-30 bg-chalkboard-10 text-chalkboard-100 shadow-2xl dark:border-chalkboard-70 dark:bg-chalkboard-100 dark:text-chalkboard-10">
+                <div className="flex items-center justify-between border-b border-chalkboard-20 px-5 py-4 dark:border-chalkboard-80">
+                  <div>
+                    <Dialog.Title className="text-base font-medium">
+                      Share this file
+                    </Dialog.Title>
+                    <p className="mt-1 text-sm text-chalkboard-70 dark:text-chalkboard-40">
+                      Create a shareable link that opens a copy in Zoo.
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <ActionButton
+                      Element="button"
+                      type="button"
+                      iconStart={{ icon: 'link' }}
+                      disabled={copyDisabled}
+                      onClick={() => {
+                        void handleSubmit()
+                      }}
                     >
-                      <input
-                        type="checkbox"
-                        checked={isRestrictedToOrg}
-                        disabled={!allowOrgRestrict}
-                        onChange={() =>
-                          setIsRestrictedToOrg((current) => !current)
-                        }
-                        className="mt-1 form-checkbox"
-                      />
-                      <div className="flex-1">
-                        <p className="text-sm font-medium">Org. only access</p>
-                        <p className="mt-1 text-xs text-chalkboard-70 dark:text-chalkboard-40">
-                          Restrict this link to members of your organization.
-                        </p>
-                        {!allowOrgRestrict && (
-                          <p className="mt-2 text-xs text-chalkboard-60 dark:text-chalkboard-50">
-                            Requires an organization plan.
-                          </p>
-                        )}
-                      </div>
-                    </label>
-
-                    <div
-                      className={`rounded-lg border px-3 py-3 ${
-                        allowPassword
-                          ? 'border-chalkboard-20 dark:border-chalkboard-80'
-                          : 'border-chalkboard-20/70 opacity-60 dark:border-chalkboard-80/70'
-                      }`}
+                      {isSubmitting ? 'Copying...' : 'Copy link'}
+                    </ActionButton>
+                    <button
+                      type="button"
+                      className="rounded p-1 text-chalkboard-70 hover:bg-chalkboard-20 hover:text-chalkboard-100 dark:text-chalkboard-40 dark:hover:bg-chalkboard-80 dark:hover:text-chalkboard-10"
+                      onClick={onClose}
+                      disabled={isSubmitting}
+                      aria-label="Close share dialog"
                     >
-                      <div className="flex items-start gap-3">
-                        <CustomIcon
-                          name="lockClosed"
-                          className="mt-0.5 h-5 w-5 text-chalkboard-70 dark:text-chalkboard-40"
-                        />
-                        <div className="flex-1">
-                          <label
-                            htmlFor="share-password"
-                            className="text-sm font-medium"
-                          >
-                            Password protection
-                          </label>
-                          <p className="mt-1 text-xs text-chalkboard-70 dark:text-chalkboard-40">
-                            Optional password required to open the link.
-                          </p>
-                          <input
-                            id="share-password"
-                            type="text"
-                            disabled={!allowPassword}
-                            value={password}
-                            onChange={(event) =>
-                              setPassword(event.target.value)
-                            }
-                            autoCapitalize="off"
-                            autoComplete="off"
-                            autoCorrect="off"
-                            spellCheck="false"
-                            placeholder="Set a password"
-                            className="mt-3 w-full rounded-md border border-chalkboard-30 bg-transparent px-3 py-2 text-sm outline-none ring-0 placeholder:text-chalkboard-60 focus:border-primary dark:border-chalkboard-70 dark:placeholder:text-chalkboard-50"
-                          />
-                          {!allowPassword && (
-                            <p className="mt-2 text-xs text-chalkboard-60 dark:text-chalkboard-50">
-                              Requires a paid plan.
-                            </p>
-                          )}
-                        </div>
-                      </div>
-                    </div>
+                      <CustomIcon name="close" className="h-5 w-5" />
+                    </button>
                   </div>
                 </div>
 
-                {disabled && (
-                  <p className="mt-4 text-sm text-chalkboard-70 dark:text-chalkboard-40">
-                    Share links are not currently supported for multi-file
-                    assemblies.
-                  </p>
-                )}
-              </form>
-            </Dialog.Panel>
-          </Transition.Child>
+                <form
+                  className="px-5 py-5"
+                  onSubmit={(event) => {
+                    event.preventDefault()
+                    void handleSubmit()
+                  }}
+                >
+                  <div className="rounded-xl border border-chalkboard-20 bg-chalkboard-10/60 p-4 dark:border-chalkboard-80 dark:bg-chalkboard-90">
+                    <p className="text-xs font-semibold uppercase tracking-[0.12em] text-chalkboard-60 dark:text-chalkboard-50">
+                      Who has access
+                    </p>
+
+                    <div className="mt-4 space-y-3">
+                      <div className="flex items-start gap-3 rounded-lg border border-chalkboard-20 px-3 py-3 dark:border-chalkboard-80">
+                        <CustomIcon
+                          name="link"
+                          className="mt-0.5 h-5 w-5 text-chalkboard-70 dark:text-chalkboard-40"
+                        />
+                        <div className="flex-1">
+                          <p className="text-sm font-medium">
+                            Anyone with the link
+                          </p>
+                          <p className="mt-1 text-xs text-chalkboard-70 dark:text-chalkboard-40">
+                            They can open a copy of this file in Zoo.
+                          </p>
+                        </div>
+                        <span className="text-sm text-chalkboard-70 dark:text-chalkboard-40">
+                          can view
+                        </span>
+                      </div>
+
+                      <label
+                        className={`flex items-start gap-3 rounded-lg border px-3 py-3 ${
+                          allowOrgRestrict
+                            ? 'cursor-pointer border-chalkboard-20 dark:border-chalkboard-80'
+                            : 'cursor-not-allowed border-chalkboard-20/70 opacity-60 dark:border-chalkboard-80/70'
+                        }`}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={isRestrictedToOrg}
+                          disabled={!allowOrgRestrict}
+                          onChange={() =>
+                            setIsRestrictedToOrg((current) => !current)
+                          }
+                          className="mt-1 form-checkbox"
+                        />
+                        <div className="flex-1">
+                          <p className="text-sm font-medium">
+                            Org. only access
+                          </p>
+                          <p className="mt-1 text-xs text-chalkboard-70 dark:text-chalkboard-40">
+                            Restrict this link to members of your organization.
+                          </p>
+                          {!allowOrgRestrict && (
+                            <p className="mt-2 text-xs text-chalkboard-60 dark:text-chalkboard-50">
+                              Requires an organization plan.
+                            </p>
+                          )}
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+
+                  {disabled && (
+                    <p className="mt-4 text-sm text-chalkboard-70 dark:text-chalkboard-40">
+                      Share links are not currently supported for multi-file
+                      assemblies.
+                    </p>
+                  )}
+                </form>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
         </div>
       </Dialog>
     </Transition>

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -1,0 +1,251 @@
+import { Dialog, Transition } from '@headlessui/react'
+import { ActionButton } from '@src/components/ActionButton'
+import { CustomIcon } from '@src/components/CustomIcon'
+import { Fragment, useEffect, useState } from 'react'
+
+export interface ShareDialogSubmitArgs {
+  isRestrictedToOrg: boolean
+  password?: string
+}
+
+type ShareDialogProps = {
+  isOpen: boolean
+  onClose: () => void
+  onSubmit: (args: ShareDialogSubmitArgs) => Promise<boolean>
+  allowOrgRestrict: boolean
+  allowPassword: boolean
+  disabled?: boolean
+}
+
+export function ShareDialog({
+  isOpen,
+  onClose,
+  onSubmit,
+  allowOrgRestrict,
+  allowPassword,
+  disabled = false,
+}: ShareDialogProps) {
+  const [isRestrictedToOrg, setIsRestrictedToOrg] = useState(false)
+  const [password, setPassword] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (isOpen) {
+      return
+    }
+
+    setIsRestrictedToOrg(false)
+    setPassword('')
+    setIsSubmitting(false)
+  }, [isOpen])
+
+  const copyDisabled = disabled || isSubmitting
+
+  async function handleSubmit() {
+    if (copyDisabled) {
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      const copied = await onSubmit({
+        isRestrictedToOrg,
+        password: password.trim() || undefined,
+      })
+      if (copied) {
+        onClose()
+      }
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog
+        as="div"
+        className="fixed inset-0 z-40 overflow-y-auto p-4 pt-[14vh]"
+        onClose={() => {
+          if (!isSubmitting) {
+            onClose()
+          }
+        }}
+      >
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-200"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-150"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <Dialog.Overlay className="fixed inset-0 bg-chalkboard-110/45 backdrop-blur-[2px]" />
+        </Transition.Child>
+
+        <div className="flex min-h-full items-start justify-center">
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-200"
+            enterFrom="opacity-0 translate-y-3 scale-[0.98]"
+            enterTo="opacity-100 translate-y-0 scale-100"
+            leave="ease-in duration-150"
+            leaveFrom="opacity-100 translate-y-0 scale-100"
+            leaveTo="opacity-0 translate-y-2 scale-[0.98]"
+          >
+            <Dialog.Panel className="w-full max-w-2xl overflow-hidden rounded-xl border border-chalkboard-30 bg-chalkboard-10 text-chalkboard-100 shadow-2xl dark:border-chalkboard-70 dark:bg-chalkboard-100 dark:text-chalkboard-10">
+              <div className="flex items-center justify-between border-b border-chalkboard-20 px-5 py-4 dark:border-chalkboard-80">
+                <div>
+                  <Dialog.Title className="text-base font-medium">
+                    Share this file
+                  </Dialog.Title>
+                  <p className="mt-1 text-sm text-chalkboard-70 dark:text-chalkboard-40">
+                    Create a shareable link that opens a copy in Zoo.
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <ActionButton
+                    Element="button"
+                    type="button"
+                    iconStart={{ icon: 'link' }}
+                    disabled={copyDisabled}
+                    onClick={() => {
+                      void handleSubmit()
+                    }}
+                  >
+                    {isSubmitting ? 'Copying...' : 'Copy link'}
+                  </ActionButton>
+                  <button
+                    type="button"
+                    className="rounded p-1 text-chalkboard-70 hover:bg-chalkboard-20 hover:text-chalkboard-100 dark:text-chalkboard-40 dark:hover:bg-chalkboard-80 dark:hover:text-chalkboard-10"
+                    onClick={onClose}
+                    disabled={isSubmitting}
+                    aria-label="Close share dialog"
+                  >
+                    <CustomIcon name="close" className="h-5 w-5" />
+                  </button>
+                </div>
+              </div>
+
+              <form
+                className="px-5 py-5"
+                onSubmit={(event) => {
+                  event.preventDefault()
+                  void handleSubmit()
+                }}
+              >
+                <div className="rounded-xl border border-chalkboard-20 bg-chalkboard-10/60 p-4 dark:border-chalkboard-80 dark:bg-chalkboard-90">
+                  <p className="text-xs font-semibold uppercase tracking-[0.12em] text-chalkboard-60 dark:text-chalkboard-50">
+                    Who has access
+                  </p>
+
+                  <div className="mt-4 space-y-3">
+                    <div className="flex items-start gap-3 rounded-lg border border-chalkboard-20 px-3 py-3 dark:border-chalkboard-80">
+                      <CustomIcon
+                        name="link"
+                        className="mt-0.5 h-5 w-5 text-chalkboard-70 dark:text-chalkboard-40"
+                      />
+                      <div className="flex-1">
+                        <p className="text-sm font-medium">
+                          Anyone with the link
+                        </p>
+                        <p className="mt-1 text-xs text-chalkboard-70 dark:text-chalkboard-40">
+                          They can open a copy of this file in Zoo.
+                        </p>
+                      </div>
+                      <span className="text-sm text-chalkboard-70 dark:text-chalkboard-40">
+                        can view
+                      </span>
+                    </div>
+
+                    <label
+                      className={`flex items-start gap-3 rounded-lg border px-3 py-3 ${
+                        allowOrgRestrict
+                          ? 'cursor-pointer border-chalkboard-20 dark:border-chalkboard-80'
+                          : 'cursor-not-allowed border-chalkboard-20/70 opacity-60 dark:border-chalkboard-80/70'
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={isRestrictedToOrg}
+                        disabled={!allowOrgRestrict}
+                        onChange={() =>
+                          setIsRestrictedToOrg((current) => !current)
+                        }
+                        className="mt-1 form-checkbox"
+                      />
+                      <div className="flex-1">
+                        <p className="text-sm font-medium">Org. only access</p>
+                        <p className="mt-1 text-xs text-chalkboard-70 dark:text-chalkboard-40">
+                          Restrict this link to members of your organization.
+                        </p>
+                        {!allowOrgRestrict && (
+                          <p className="mt-2 text-xs text-chalkboard-60 dark:text-chalkboard-50">
+                            Requires an organization plan.
+                          </p>
+                        )}
+                      </div>
+                    </label>
+
+                    <div
+                      className={`rounded-lg border px-3 py-3 ${
+                        allowPassword
+                          ? 'border-chalkboard-20 dark:border-chalkboard-80'
+                          : 'border-chalkboard-20/70 opacity-60 dark:border-chalkboard-80/70'
+                      }`}
+                    >
+                      <div className="flex items-start gap-3">
+                        <CustomIcon
+                          name="lockClosed"
+                          className="mt-0.5 h-5 w-5 text-chalkboard-70 dark:text-chalkboard-40"
+                        />
+                        <div className="flex-1">
+                          <label
+                            htmlFor="share-password"
+                            className="text-sm font-medium"
+                          >
+                            Password protection
+                          </label>
+                          <p className="mt-1 text-xs text-chalkboard-70 dark:text-chalkboard-40">
+                            Optional password required to open the link.
+                          </p>
+                          <input
+                            id="share-password"
+                            type="text"
+                            disabled={!allowPassword}
+                            value={password}
+                            onChange={(event) =>
+                              setPassword(event.target.value)
+                            }
+                            autoCapitalize="off"
+                            autoComplete="off"
+                            autoCorrect="off"
+                            spellCheck="false"
+                            placeholder="Set a password"
+                            className="mt-3 w-full rounded-md border border-chalkboard-30 bg-transparent px-3 py-2 text-sm outline-none ring-0 placeholder:text-chalkboard-60 focus:border-primary dark:border-chalkboard-70 dark:placeholder:text-chalkboard-50"
+                          />
+                          {!allowPassword && (
+                            <p className="mt-2 text-xs text-chalkboard-60 dark:text-chalkboard-50">
+                              Requires a paid plan.
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                {disabled && (
+                  <p className="mt-4 text-sm text-chalkboard-70 dark:text-chalkboard-40">
+                    Share links are not currently supported for multi-file
+                    assemblies.
+                  </p>
+                )}
+              </form>
+            </Dialog.Panel>
+          </Transition.Child>
+        </div>
+      </Dialog>
+    </Transition>
+  )
+}

--- a/src/lib/kclCommands.ts
+++ b/src/lib/kclCommands.ts
@@ -1,41 +1,41 @@
 import type { UnitLength } from '@kittycad/lib'
 import toast from 'react-hot-toast'
 
+import type { Node } from '@rust/kcl-lib/bindings/Node'
+import type { KclManager } from '@src/lang/KclManager'
 import { updateModelingState } from '@src/lang/modelingWorkflows'
 import {
   addModuleImport,
   insertVariableAndOffsetPathToNode,
 } from '@src/lang/modifyAst'
+import { setExperimentalFeatures } from '@src/lang/modifyAst/settings'
+import { getNodeFromPath } from '@src/lang/queryAst'
+import { getVariableDeclaration } from '@src/lang/queryAst/getVariableDeclaration'
 import {
+  type PathToNode,
+  type VariableDeclarator,
   changeDefaultUnits,
   isPathToNode,
   pathToNodeFromRustNodePath,
   recast,
-  type PathToNode,
-  type VariableDeclarator,
 } from '@src/lang/wasm'
+import { relevantFileExtensions } from '@src/lang/wasmUtils'
 import type { Command, CommandArgumentOption } from '@src/lib/commandTypes'
 import {
-  DEFAULT_EXPERIMENTAL_FEATURES,
   DEFAULT_DEFAULT_LENGTH_UNIT,
+  DEFAULT_EXPERIMENTAL_FEATURES,
   EXECUTION_TYPE_REAL,
 } from '@src/lib/constants'
 import { getPathFilenameInVariableCase } from '@src/lib/desktop'
-import { copyFileShareLink } from '@src/lib/links'
+import fsZds from '@src/lib/fs-zds'
+import type { Project } from '@src/lib/project'
 import { baseUnitsUnion, warningLevels } from '@src/lib/settings/settingsTypes'
-import type { KclManager } from '@src/lang/KclManager'
+import { copyCurrentFileShareLink } from '@src/lib/share'
 import { err, reportRejection } from '@src/lib/trap'
 import type { IndexLoaderData } from '@src/lib/types'
-import type { CommandBarContext } from '@src/machines/commandBarMachine'
-import { getNodeFromPath } from '@src/lang/queryAst'
-import type { Node } from '@rust/kcl-lib/bindings/Node'
-import { getVariableDeclaration } from '@src/lang/queryAst/getVariableDeclaration'
-import { setExperimentalFeatures } from '@src/lang/modifyAst/settings'
-import { listAllImportFilesWithinProject } from '@src/machines/systemIO/snapshotContext'
-import type { Project } from '@src/lib/project'
-import { relevantFileExtensions } from '@src/lang/wasmUtils'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
-import fsZds from '@src/lib/fs-zds'
+import type { CommandBarContext } from '@src/machines/commandBarMachine'
+import { listAllImportFilesWithinProject } from '@src/machines/systemIO/snapshotContext'
 import type { SystemIOActor } from '@src/machines/systemIO/utils'
 
 interface KclCommandConfig {
@@ -304,7 +304,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
       needsReview: false,
       icon: 'link',
       onSubmit: (input) => {
-        copyFileShareLink({
+        copyCurrentFileShareLink({
           token: commandProps.authToken,
           code: commandProps.kclManager.code,
           name: commandProps.projectData.project?.name || '',

--- a/src/lib/kclCommands.ts
+++ b/src/lib/kclCommands.ts
@@ -298,18 +298,19 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
     },
     {
       name: 'share-file-link',
-      displayName: 'Share part via Zoo link',
-      description: 'Create a link that contains a copy of the current file.',
+      displayName: 'Share file link',
+      description: 'Upload the current project and copy a shareable link.',
       groupId: 'code',
       needsReview: false,
       icon: 'link',
       onSubmit: (input) => {
         copyCurrentFileShareLink({
           token: commandProps.authToken,
-          code: commandProps.kclManager.code,
-          name: commandProps.projectData.project?.name || '',
+          project: commandProps.projectData.project,
+          currentFilePath: commandProps.kclManager.path,
+          currentFileContents: commandProps.kclManager.code,
+          wasmInstance: commandProps.wasmInstance,
           isRestrictedToOrg: input?.event.data.isRestrictedToOrg ?? false,
-          password: input?.event.data.password,
         }).catch(reportRejection)
       },
     },

--- a/src/lib/share.test.ts
+++ b/src/lib/share.test.ts
@@ -1,19 +1,131 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { Project } from '@src/lib/project'
+
+type ShareLink = {
+  access_mode: 'anyone_with_link' | 'organization_only'
+  key: string
+  url: string
+}
+
+type FetchResponse = {
+  ok: boolean
+  status: number
+  json: () => Promise<unknown>
+  text: () => Promise<string>
+}
+
 const mockState = vi.hoisted(() => ({
-  createCreateFileUrl: vi.fn(() => new URL('https://app.dev.zoo.dev/share')),
-  createShortlink: vi.fn(async () => ({
-    key: 'share-key',
-    url: 'https://zoo.dev/s/share-key',
+  projectFetch: vi.fn(
+    async (url: string, init?: RequestInit): Promise<FetchResponse> => {
+      const method = init?.method || 'GET'
+      if (method === 'POST' && url.endsWith('/user/projects')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ id: 'project-created' }),
+          text: async () => '',
+        }
+      }
+
+      if (method === 'PUT' && url.endsWith('/user/projects/project-existing')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ id: 'project-existing' }),
+          text: async () => '',
+        }
+      }
+
+      return {
+        ok: false,
+        status: 404,
+        json: async () => ({ message: 'not found' }),
+        text: async () => 'not found',
+      }
+    }
+  ),
+  createKCClient: vi.fn(() => ({
+    mocked: true,
+    token: 'token-123',
+    baseUrl: 'https://api.dev.zoo.dev',
+    fetch: mockState.projectFetch,
   })),
+  kcCall: vi.fn(async (fn: () => Promise<unknown>) => await fn()),
+  getUserProject: vi.fn(async () => ({
+    title: 'Bracket',
+    description: 'Existing description',
+  })),
+  listUserProjectShareLinks: vi.fn(
+    async (_args: { client?: unknown; id: string }): Promise<ShareLink[]> => []
+  ),
+  createUserProjectShareLink: vi.fn(
+    async (_args: {
+      client?: unknown
+      id: string
+      body: { access_mode: ShareLink['access_mode'] }
+    }): Promise<ShareLink> => ({
+      access_mode: 'anyone_with_link',
+      key: 'share-key',
+      url: 'https://zoo.dev/project/share-key',
+    })
+  ),
+  readProjectSettingsFile: vi.fn(async () => ({})),
+  writeProjectSettingsFile: vi.fn(async () => {}),
+  serializeProjectConfiguration: vi.fn(() => 'serialized-project-toml'),
   toastError: vi.fn(),
   toastSuccess: vi.fn(),
   writeText: vi.fn(async () => {}),
+  fsReadFile: vi.fn(async (path: string, options?: { encoding: 'utf-8' }) => {
+    if (options?.encoding === 'utf-8') {
+      return '[settings.meta]\nid = "local-project"'
+    }
+
+    return new TextEncoder().encode(`raw:${path}`)
+  }),
 }))
 
-vi.mock('@src/lib/links', () => ({
-  createCreateFileUrl: mockState.createCreateFileUrl,
-  createShortlink: mockState.createShortlink,
+vi.mock('@src/env', () => ({
+  default: () => ({
+    VITE_ZOO_BASE_DOMAIN: 'dev.zoo.dev',
+    VITE_ZOO_API_BASE_URL: 'https://api.dev.zoo.dev',
+  }),
+}))
+
+vi.mock('@src/lib/kcClient', () => ({
+  createKCClient: mockState.createKCClient,
+  kcCall: mockState.kcCall,
+}))
+
+vi.mock('@kittycad/lib', () => ({
+  users: {
+    get_user_project: mockState.getUserProject,
+    list_user_project_share_links: mockState.listUserProjectShareLinks,
+    create_user_project_share_link: mockState.createUserProjectShareLink,
+  },
+}))
+
+vi.mock('@src/lib/desktop', () => ({
+  readProjectSettingsFile: mockState.readProjectSettingsFile,
+  writeProjectSettingsFile: mockState.writeProjectSettingsFile,
+}))
+
+vi.mock('@src/lang/wasm', () => ({
+  serializeProjectConfiguration: mockState.serializeProjectConfiguration,
+}))
+
+vi.mock('@src/lib/fs-zds', () => ({
+  default: {
+    sep: '/',
+    join: (...parts: string[]) =>
+      parts.reduce((path, part) => `${path}/${part}`).replaceAll('//', '/'),
+    relative: (from: string, to: string) => to.replace(`${from}/`, ''),
+    extname: (path: string) => {
+      const lastDot = path.lastIndexOf('.')
+      return lastDot >= 0 ? path.slice(lastDot) : ''
+    },
+    readFile: mockState.fsReadFile,
+  },
 }))
 
 vi.mock('react-hot-toast', () => ({
@@ -24,6 +136,30 @@ vi.mock('react-hot-toast', () => ({
 }))
 
 import { copyCurrentFileShareLink } from '@src/lib/share'
+
+function makeProject(): Project {
+  return {
+    metadata: null,
+    kcl_file_count: 1,
+    directory_count: 0,
+    default_file: '/projects/bracket/main.kcl',
+    path: '/projects/bracket',
+    name: 'bracket',
+    children: [
+      {
+        path: '/projects/bracket/project.toml',
+        name: 'project.toml',
+        children: null,
+      },
+      {
+        path: '/projects/bracket/main.kcl',
+        name: 'main.kcl',
+        children: null,
+      },
+    ],
+    readWriteAccess: true,
+  }
+}
 
 describe('copyCurrentFileShareLink', () => {
   beforeEach(() => {
@@ -36,45 +172,153 @@ describe('copyCurrentFileShareLink', () => {
     })
   })
 
-  it('creates a shortlink and copies it to the clipboard', async () => {
+  it('creates a remote project, persists the env binding, and creates a share link', async () => {
     const copied = await copyCurrentFileShareLink({
       token: 'token-123',
-      code: 'part001 = startSketchOn(XY)',
-      name: 'bracket',
-      isRestrictedToOrg: true,
-      password: 'secret',
+      project: makeProject(),
+      currentFilePath: '/projects/bracket/main.kcl',
+      currentFileContents: 'part001 = startSketchOn(XY)',
+      wasmInstance: {} as never,
+      isRestrictedToOrg: false,
     })
 
     expect(copied).toBe(true)
-    expect(mockState.createCreateFileUrl).toHaveBeenCalledWith({
-      token: 'token-123',
-      code: 'part001 = startSketchOn(XY)',
-      name: 'bracket',
-      isRestrictedToOrg: true,
-      password: 'secret',
+    expect(mockState.projectFetch).toHaveBeenCalledTimes(1)
+    expect(mockState.getUserProject).not.toHaveBeenCalled()
+    expect(mockState.writeProjectSettingsFile).toHaveBeenCalledWith(
+      '/projects/bracket',
+      'serialized-project-toml'
+    )
+    expect(mockState.createUserProjectShareLink).toHaveBeenCalledWith({
+      client: {
+        mocked: true,
+        token: 'token-123',
+        baseUrl: 'https://api.dev.zoo.dev',
+        fetch: mockState.projectFetch,
+      },
+      id: 'project-created',
+      body: { access_mode: 'anyone_with_link' },
     })
-    expect(mockState.createShortlink).toHaveBeenCalledWith(
-      'token-123',
-      'https://app.dev.zoo.dev/share',
-      true,
-      'secret'
+
+    const [createUrl, createInit] =
+      mockState.projectFetch.mock.calls.at(0) ?? []
+    if (!createUrl || !createInit) {
+      throw new Error('Expected project upload to be called')
+    }
+
+    expect(createUrl).toBe('https://api.dev.zoo.dev/user/projects')
+    expect(createInit.method).toBe('POST')
+    expect(createInit.headers).toEqual({
+      Authorization: 'Bearer token-123',
+    })
+
+    const createForm = createInit.body as FormData
+    expect(Array.from(createForm.keys())).toEqual([
+      'body',
+      'project.toml',
+      'main.kcl',
+    ])
+    const createBody = createForm.get('body')
+    if (!(createBody instanceof File)) {
+      throw new Error('Expected body part to be a File')
+    }
+    await expect(createBody.text()).resolves.toBe(
+      JSON.stringify({
+        title: 'bracket',
+        description: '',
+      })
     )
+
+    const mainFile = createForm.get('main.kcl')
+    if (!(mainFile instanceof File)) {
+      throw new Error('Expected main.kcl part to be a File')
+    }
+    await expect(mainFile.text()).resolves.toBe('part001 = startSketchOn(XY)')
     expect(mockState.writeText).toHaveBeenCalledWith(
-      'https://zoo.dev/s/share-key'
+      'https://zoo.dev/project/share-key'
     )
-    expect(mockState.toastSuccess).toHaveBeenCalled()
+    expect(mockState.toastSuccess).toHaveBeenCalledWith(
+      'Link copied to clipboard.',
+      { duration: 5000 }
+    )
+  })
+
+  it('updates an existing remote project and reuses a matching share link', async () => {
+    mockState.readProjectSettingsFile.mockResolvedValue({
+      cloud: {
+        'dev.zoo.dev': {
+          project_id: 'project-existing',
+        },
+      },
+    })
+    mockState.listUserProjectShareLinks.mockResolvedValue([
+      {
+        access_mode: 'organization_only',
+        key: 'existing-share-key',
+        url: 'https://zoo.dev/project/existing-share-key',
+      },
+    ])
+
+    const copied = await copyCurrentFileShareLink({
+      token: 'token-123',
+      project: makeProject(),
+      currentFilePath: '/projects/bracket/main.kcl',
+      currentFileContents: 'part001 = startSketchOn(XY)',
+      wasmInstance: {} as never,
+      isRestrictedToOrg: true,
+    })
+
+    expect(copied).toBe(true)
+    expect(mockState.getUserProject).toHaveBeenCalledWith({
+      client: {
+        mocked: true,
+        token: 'token-123',
+        baseUrl: 'https://api.dev.zoo.dev',
+        fetch: mockState.projectFetch,
+      },
+      id: 'project-existing',
+    })
+    expect(mockState.projectFetch).toHaveBeenCalledWith(
+      'https://api.dev.zoo.dev/user/projects/project-existing',
+      expect.objectContaining({
+        method: 'PUT',
+      })
+    )
+    expect(mockState.writeProjectSettingsFile).not.toHaveBeenCalled()
+    expect(mockState.createUserProjectShareLink).not.toHaveBeenCalled()
+    expect(mockState.writeText).toHaveBeenCalledWith(
+      'https://zoo.dev/project/existing-share-key'
+    )
+
+    const updateInit = mockState.projectFetch.mock.calls.at(0)?.[1]
+    if (!updateInit) {
+      throw new Error('Expected update project upload to be called')
+    }
+    const updateForm = updateInit.body as FormData
+    const updateBody = updateForm.get('body')
+    if (!(updateBody instanceof File)) {
+      throw new Error('Expected update body part to be a File')
+    }
+    await expect(updateBody.text()).resolves.toBe(
+      JSON.stringify({
+        title: 'Bracket',
+        description: 'Existing description',
+      })
+    )
   })
 
   it('rejects when there is no auth token', async () => {
     const copied = await copyCurrentFileShareLink({
       token: '',
-      code: 'sketch001 = startSketchOn(XY)',
-      name: 'bracket',
+      project: makeProject(),
+      currentFilePath: '/projects/bracket/main.kcl',
+      currentFileContents: 'part001 = startSketchOn(XY)',
+      wasmInstance: {} as never,
       isRestrictedToOrg: false,
     })
 
     expect(copied).toBe(false)
-    expect(mockState.createShortlink).not.toHaveBeenCalled()
+    expect(mockState.projectFetch).not.toHaveBeenCalled()
     expect(mockState.writeText).not.toHaveBeenCalled()
     expect(mockState.toastError).toHaveBeenCalledWith(
       'You need to be signed in to share a file.',

--- a/src/lib/share.test.ts
+++ b/src/lib/share.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockState = vi.hoisted(() => ({
+  createCreateFileUrl: vi.fn(() => new URL('https://app.dev.zoo.dev/share')),
+  createShortlink: vi.fn(async () => ({
+    key: 'share-key',
+    url: 'https://zoo.dev/s/share-key',
+  })),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+  writeText: vi.fn(async () => {}),
+}))
+
+vi.mock('@src/lib/links', () => ({
+  createCreateFileUrl: mockState.createCreateFileUrl,
+  createShortlink: mockState.createShortlink,
+}))
+
+vi.mock('react-hot-toast', () => ({
+  default: {
+    error: mockState.toastError,
+    success: mockState.toastSuccess,
+  },
+}))
+
+import { copyCurrentFileShareLink } from '@src/lib/share'
+
+describe('copyCurrentFileShareLink', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: mockState.writeText,
+      },
+    })
+  })
+
+  it('creates a shortlink and copies it to the clipboard', async () => {
+    const copied = await copyCurrentFileShareLink({
+      token: 'token-123',
+      code: 'part001 = startSketchOn(XY)',
+      name: 'bracket',
+      isRestrictedToOrg: true,
+      password: 'secret',
+    })
+
+    expect(copied).toBe(true)
+    expect(mockState.createCreateFileUrl).toHaveBeenCalledWith({
+      token: 'token-123',
+      code: 'part001 = startSketchOn(XY)',
+      name: 'bracket',
+      isRestrictedToOrg: true,
+      password: 'secret',
+    })
+    expect(mockState.createShortlink).toHaveBeenCalledWith(
+      'token-123',
+      'https://app.dev.zoo.dev/share',
+      true,
+      'secret'
+    )
+    expect(mockState.writeText).toHaveBeenCalledWith(
+      'https://zoo.dev/s/share-key'
+    )
+    expect(mockState.toastSuccess).toHaveBeenCalled()
+  })
+
+  it('rejects when there is no auth token', async () => {
+    const copied = await copyCurrentFileShareLink({
+      token: '',
+      code: 'sketch001 = startSketchOn(XY)',
+      name: 'bracket',
+      isRestrictedToOrg: false,
+    })
+
+    expect(copied).toBe(false)
+    expect(mockState.createShortlink).not.toHaveBeenCalled()
+    expect(mockState.writeText).not.toHaveBeenCalled()
+    expect(mockState.toastError).toHaveBeenCalledWith(
+      'You need to be signed in to share a file.',
+      { duration: 5000 }
+    )
+  })
+})

--- a/src/lib/share.test.ts
+++ b/src/lib/share.test.ts
@@ -56,6 +56,10 @@ const mockState = vi.hoisted(() => ({
     title: 'Bracket',
     description: 'Existing description',
   })),
+  publishUserProject: vi.fn(async () => ({
+    id: 'project-created',
+    publication_status: 'pending_review',
+  })),
   listUserProjectShareLinks: vi.fn(
     async (_args: { client?: unknown; id: string }): Promise<ShareLink[]> => []
   ),
@@ -100,6 +104,7 @@ vi.mock('@src/lib/kcClient', () => ({
 vi.mock('@kittycad/lib', () => ({
   users: {
     get_user_project: mockState.getUserProject,
+    publish_user_project: mockState.publishUserProject,
     list_user_project_share_links: mockState.listUserProjectShareLinks,
     create_user_project_share_link: mockState.createUserProjectShareLink,
   },
@@ -135,7 +140,7 @@ vi.mock('react-hot-toast', () => ({
   },
 }))
 
-import { copyCurrentFileShareLink } from '@src/lib/share'
+import { copyCurrentFileShareLink, publishCurrentProject } from '@src/lib/share'
 
 function makeProject(): Project {
   return {
@@ -322,6 +327,44 @@ describe('copyCurrentFileShareLink', () => {
     expect(mockState.writeText).not.toHaveBeenCalled()
     expect(mockState.toastError).toHaveBeenCalledWith(
       'You need to be signed in to share a file.',
+      { duration: 5000 }
+    )
+  })
+})
+
+describe('publishCurrentProject', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockState.readProjectSettingsFile.mockResolvedValue({})
+  })
+
+  it('uploads the project and submits it for review', async () => {
+    const published = await publishCurrentProject({
+      token: 'token-123',
+      project: makeProject(),
+      currentFilePath: '/projects/bracket/main.kcl',
+      currentFileContents: 'part001 = startSketchOn(XY)',
+      wasmInstance: {} as never,
+    })
+
+    expect(published).toBe(true)
+    expect(mockState.projectFetch).toHaveBeenCalledWith(
+      'https://api.dev.zoo.dev/user/projects',
+      expect.objectContaining({
+        method: 'POST',
+      })
+    )
+    expect(mockState.publishUserProject).toHaveBeenCalledWith({
+      client: {
+        mocked: true,
+        token: 'token-123',
+        baseUrl: 'https://api.dev.zoo.dev',
+        fetch: mockState.projectFetch,
+      },
+      id: 'project-created',
+    })
+    expect(mockState.toastSuccess).toHaveBeenCalledWith(
+      'Project submitted for review.',
       { duration: 5000 }
     )
   })

--- a/src/lib/share.test.ts
+++ b/src/lib/share.test.ts
@@ -1,69 +1,58 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { ProjectResponse, ProjectShareLinkResponse } from '@kittycad/lib'
 import type { Project } from '@src/lib/project'
 
-type ShareLink = {
-  access_mode: 'anyone_with_link' | 'organization_only'
-  key: string
-  url: string
-}
+type ShareLink = Pick<ProjectShareLinkResponse, 'access_mode' | 'key' | 'url'>
 
-type FetchResponse = {
-  ok: boolean
-  status: number
-  json: () => Promise<unknown>
-  text: () => Promise<string>
+function makeRemoteProject(
+  overrides: Partial<ProjectResponse> = {}
+): ProjectResponse {
+  return {
+    category_ids: [],
+    created_at: '2026-04-01T00:00:00Z',
+    description: 'Existing description',
+    entrypoint_path: 'main.kcl',
+    files: [],
+    id: 'project-existing',
+    preview_status: 'pending',
+    project_toml_path: 'project.toml',
+    publication: {
+      has_unpublished_changes: false,
+    },
+    publication_status: 'draft',
+    title: 'Bracket',
+    updated_at: '2026-04-09T15:00:00Z',
+    ...overrides,
+  }
 }
 
 const mockState = vi.hoisted(() => ({
-  projectFetch: vi.fn(
-    async (url: string, init?: RequestInit): Promise<FetchResponse> => {
-      const method = init?.method || 'GET'
-      if (method === 'POST' && url.endsWith('/user/projects')) {
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({ id: 'project-created' }),
-          text: async () => '',
-        }
-      }
-
-      if (method === 'PUT' && url.endsWith('/user/projects/project-existing')) {
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({ id: 'project-existing' }),
-          text: async () => '',
-        }
-      }
-
-      return {
-        ok: false,
-        status: 404,
-        json: async () => ({ message: 'not found' }),
-        text: async () => 'not found',
-      }
-    }
-  ),
   createKCClient: vi.fn(() => ({
     mocked: true,
     token: 'token-123',
     baseUrl: 'https://api.dev.zoo.dev',
-    fetch: mockState.projectFetch,
   })),
   kcCall: vi.fn(async (fn: () => Promise<unknown>) => await fn()),
-  getUserProject: vi.fn(async () => ({
-    title: 'Bracket',
-    description: 'Existing description',
-  })),
-  publishUserProject: vi.fn(async () => ({
-    id: 'project-created',
-    publication_status: 'pending_review',
-  })),
-  listUserProjectShareLinks: vi.fn(
+  createProject: vi.fn(async () =>
+    makeRemoteProject({
+      id: 'project-created',
+      title: 'bracket',
+      description: '',
+    })
+  ),
+  updateProject: vi.fn(async () => makeRemoteProject()),
+  getProject: vi.fn(async () => makeRemoteProject()),
+  publishProject: vi.fn(async () =>
+    makeRemoteProject({
+      id: 'project-created',
+      publication_status: 'pending_review',
+    })
+  ),
+  listProjectShareLinks: vi.fn(
     async (_args: { client?: unknown; id: string }): Promise<ShareLink[]> => []
   ),
-  createUserProjectShareLink: vi.fn(
+  createProjectShareLink: vi.fn(
     async (_args: {
       client?: unknown
       id: string
@@ -102,11 +91,13 @@ vi.mock('@src/lib/kcClient', () => ({
 }))
 
 vi.mock('@kittycad/lib', () => ({
-  users: {
-    get_user_project: mockState.getUserProject,
-    publish_user_project: mockState.publishUserProject,
-    list_user_project_share_links: mockState.listUserProjectShareLinks,
-    create_user_project_share_link: mockState.createUserProjectShareLink,
+  projects: {
+    create_project: mockState.createProject,
+    update_project: mockState.updateProject,
+    get_project: mockState.getProject,
+    publish_project: mockState.publishProject,
+    list_project_share_links: mockState.listProjectShareLinks,
+    create_project_share_link: mockState.createProjectShareLink,
   },
 }))
 
@@ -140,7 +131,11 @@ vi.mock('react-hot-toast', () => ({
   },
 }))
 
-import { copyCurrentFileShareLink, publishCurrentProject } from '@src/lib/share'
+import {
+  copyCurrentFileShareLink,
+  getCurrentProjectPublicationDetails,
+  publishCurrentProject,
+} from '@src/lib/share'
 
 function makeProject(): Project {
   return {
@@ -169,6 +164,9 @@ function makeProject(): Project {
 describe('copyCurrentFileShareLink', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockState.readProjectSettingsFile.mockResolvedValue({})
+    mockState.getProject.mockResolvedValue(makeRemoteProject())
+    mockState.listProjectShareLinks.mockResolvedValue([])
     Object.defineProperty(globalThis.navigator, 'clipboard', {
       configurable: true,
       value: {
@@ -188,57 +186,77 @@ describe('copyCurrentFileShareLink', () => {
     })
 
     expect(copied).toBe(true)
-    expect(mockState.projectFetch).toHaveBeenCalledTimes(1)
-    expect(mockState.getUserProject).not.toHaveBeenCalled()
+    expect(mockState.createProject).toHaveBeenCalledTimes(1)
+    expect(mockState.getProject).not.toHaveBeenCalled()
     expect(mockState.writeProjectSettingsFile).toHaveBeenCalledWith(
       '/projects/bracket',
       'serialized-project-toml'
     )
-    expect(mockState.createUserProjectShareLink).toHaveBeenCalledWith({
+    expect(mockState.createProjectShareLink).toHaveBeenCalledWith({
       client: {
         mocked: true,
         token: 'token-123',
         baseUrl: 'https://api.dev.zoo.dev',
-        fetch: mockState.projectFetch,
       },
       id: 'project-created',
       body: { access_mode: 'anyone_with_link' },
     })
 
-    const [createUrl, createInit] =
-      mockState.projectFetch.mock.calls.at(0) ?? []
-    if (!createUrl || !createInit) {
+    const createProjectCalls = mockState.createProject.mock.calls as unknown as Array<
+      [
+        {
+          client: unknown
+          files: Array<{ name: string; data: Blob }>
+        },
+      ]
+    >
+    const createArgs = createProjectCalls[0]?.[0]
+    if (!createArgs) {
       throw new Error('Expected project upload to be called')
     }
 
-    expect(createUrl).toBe('https://api.dev.zoo.dev/user/projects')
-    expect(createInit.method).toBe('POST')
-    expect(createInit.headers).toEqual({
-      Authorization: 'Bearer token-123',
+    expect(createArgs.client).toEqual({
+      mocked: true,
+      token: 'token-123',
+      baseUrl: 'https://api.dev.zoo.dev',
     })
 
-    const createForm = createInit.body as FormData
-    expect(Array.from(createForm.keys())).toEqual([
+    expect(createArgs.files.map((file: { name: string }) => file.name)).toEqual([
       'body',
       'project.toml',
       'main.kcl',
     ])
-    const createBody = createForm.get('body')
-    if (!(createBody instanceof File)) {
-      throw new Error('Expected body part to be a File')
+
+    const bodyFile = createArgs.files.find(
+      (file: { name: string }) => file.name === 'body'
+    )
+    if (!bodyFile) {
+      throw new Error('Expected body file to be uploaded')
     }
-    await expect(createBody.text()).resolves.toBe(
+    await expect(bodyFile.data.text()).resolves.toBe(
       JSON.stringify({
         title: 'bracket',
         description: '',
       })
     )
 
-    const mainFile = createForm.get('main.kcl')
-    if (!(mainFile instanceof File)) {
-      throw new Error('Expected main.kcl part to be a File')
+    const projectToml = createArgs.files.find(
+      (file: { name: string }) => file.name === 'project.toml'
+    )
+    if (!projectToml) {
+      throw new Error('Expected project.toml file to be uploaded')
     }
-    await expect(mainFile.text()).resolves.toBe('part001 = startSketchOn(XY)')
+    await expect(projectToml.data.text()).resolves.toBe(
+      'raw:/projects/bracket/project.toml'
+    )
+
+    const mainFile = createArgs.files.find(
+      (file: { name: string }) => file.name === 'main.kcl'
+    )
+    if (!mainFile) {
+      throw new Error('Expected main.kcl file to be uploaded')
+    }
+    await expect(mainFile.data.text()).resolves.toBe('part001 = startSketchOn(XY)')
     expect(mockState.writeText).toHaveBeenCalledWith(
       'https://zoo.dev/project/share-key'
     )
@@ -256,7 +274,7 @@ describe('copyCurrentFileShareLink', () => {
         },
       },
     })
-    mockState.listUserProjectShareLinks.mockResolvedValue([
+    mockState.listProjectShareLinks.mockResolvedValue([
       {
         access_mode: 'organization_only',
         key: 'existing-share-key',
@@ -274,37 +292,48 @@ describe('copyCurrentFileShareLink', () => {
     })
 
     expect(copied).toBe(true)
-    expect(mockState.getUserProject).toHaveBeenCalledWith({
+    expect(mockState.updateProject).toHaveBeenCalledWith({
       client: {
         mocked: true,
         token: 'token-123',
         baseUrl: 'https://api.dev.zoo.dev',
-        fetch: mockState.projectFetch,
+      },
+      id: 'project-existing',
+      files: expect.any(Array),
+    })
+    expect(mockState.getProject).toHaveBeenCalledWith({
+      client: {
+        mocked: true,
+        token: 'token-123',
+        baseUrl: 'https://api.dev.zoo.dev',
       },
       id: 'project-existing',
     })
-    expect(mockState.projectFetch).toHaveBeenCalledWith(
-      'https://api.dev.zoo.dev/user/projects/project-existing',
-      expect.objectContaining({
-        method: 'PUT',
-      })
-    )
     expect(mockState.writeProjectSettingsFile).not.toHaveBeenCalled()
-    expect(mockState.createUserProjectShareLink).not.toHaveBeenCalled()
+    expect(mockState.createProjectShareLink).not.toHaveBeenCalled()
     expect(mockState.writeText).toHaveBeenCalledWith(
       'https://zoo.dev/project/existing-share-key'
     )
 
-    const updateInit = mockState.projectFetch.mock.calls.at(0)?.[1]
-    if (!updateInit) {
+    const updateProjectCalls = mockState.updateProject.mock.calls as unknown as Array<
+      [
+        {
+          files: Array<{ name: string; data: Blob }>
+        },
+      ]
+    >
+    const updateArgs = updateProjectCalls[0]?.[0]
+    if (!updateArgs) {
       throw new Error('Expected update project upload to be called')
     }
-    const updateForm = updateInit.body as FormData
-    const updateBody = updateForm.get('body')
-    if (!(updateBody instanceof File)) {
-      throw new Error('Expected update body part to be a File')
+    expect(updateArgs.files).toHaveLength(3)
+    const updateBody = updateArgs.files.find(
+      (file: { name: string; data: Blob }) => file.name === 'body'
+    )
+    if (!updateBody) {
+      throw new Error('Expected update body file to be uploaded')
     }
-    await expect(updateBody.text()).resolves.toBe(
+    await expect(updateBody.data.text()).resolves.toBe(
       JSON.stringify({
         title: 'Bracket',
         description: 'Existing description',
@@ -323,7 +352,7 @@ describe('copyCurrentFileShareLink', () => {
     })
 
     expect(copied).toBe(false)
-    expect(mockState.projectFetch).not.toHaveBeenCalled()
+    expect(mockState.createProject).not.toHaveBeenCalled()
     expect(mockState.writeText).not.toHaveBeenCalled()
     expect(mockState.toastError).toHaveBeenCalledWith(
       'You need to be signed in to share a file.',
@@ -336,6 +365,7 @@ describe('publishCurrentProject', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockState.readProjectSettingsFile.mockResolvedValue({})
+    mockState.getProject.mockResolvedValue(makeRemoteProject())
   })
 
   it('uploads the project and submits it for review', async () => {
@@ -348,18 +378,19 @@ describe('publishCurrentProject', () => {
     })
 
     expect(published).toBe(true)
-    expect(mockState.projectFetch).toHaveBeenCalledWith(
-      'https://api.dev.zoo.dev/user/projects',
-      expect.objectContaining({
-        method: 'POST',
-      })
-    )
-    expect(mockState.publishUserProject).toHaveBeenCalledWith({
+    expect(mockState.createProject).toHaveBeenCalledWith({
       client: {
         mocked: true,
         token: 'token-123',
         baseUrl: 'https://api.dev.zoo.dev',
-        fetch: mockState.projectFetch,
+      },
+      files: expect.any(Array),
+    })
+    expect(mockState.publishProject).toHaveBeenCalledWith({
+      client: {
+        mocked: true,
+        token: 'token-123',
+        baseUrl: 'https://api.dev.zoo.dev',
       },
       id: 'project-created',
     })
@@ -367,5 +398,58 @@ describe('publishCurrentProject', () => {
       'Project submitted for review.',
       { duration: 5000 }
     )
+  })
+})
+
+describe('getCurrentProjectPublicationDetails', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockState.readProjectSettingsFile.mockResolvedValue({})
+    mockState.getProject.mockResolvedValue(makeRemoteProject())
+  })
+
+  it('returns publication details for the current environment binding', async () => {
+    mockState.readProjectSettingsFile.mockResolvedValue({
+      cloud: {
+        'dev.zoo.dev': {
+          project_id: 'project-existing',
+        },
+      },
+    })
+    mockState.getProject.mockResolvedValue(
+      makeRemoteProject({
+        publication_status: 'published',
+        publication: {
+          has_unpublished_changes: false,
+          last_published_at: '2026-04-07T12:34:56Z',
+        },
+      })
+    )
+
+    const details = await getCurrentProjectPublicationDetails({
+      token: 'token-123',
+      project: makeProject(),
+      wasmInstance: {} as never,
+    })
+
+    expect(details).toEqual({
+      projectId: 'project-existing',
+      publicationStatus: 'published',
+      updatedAt: '2026-04-09T15:00:00Z',
+      publishedAt: '2026-04-07T12:34:56Z',
+    })
+  })
+
+  it('returns null when there is no bound cloud project for this environment', async () => {
+    mockState.readProjectSettingsFile.mockResolvedValue({})
+
+    const details = await getCurrentProjectPublicationDetails({
+      token: 'token-123',
+      project: makeProject(),
+      wasmInstance: {} as never,
+    })
+
+    expect(details).toBeNull()
+    expect(mockState.getProject).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,0 +1,49 @@
+import toast from 'react-hot-toast'
+
+import type { FileLinkParams } from '@src/lib/links'
+import { createCreateFileUrl, createShortlink } from '@src/lib/links'
+import { err } from '@src/lib/trap'
+
+export type CopyCurrentFileShareLinkArgs = FileLinkParams & {
+  token: string
+}
+
+/**
+ * Temporary adapter around the legacy shortlink flow.
+ * Swap this implementation to the project upload + share-links APIs once the
+ * updated TS client exposes those endpoints.
+ */
+export async function copyCurrentFileShareLink(
+  args: CopyCurrentFileShareLinkArgs
+): Promise<boolean> {
+  if (!args.token) {
+    toast.error('You need to be signed in to share a file.', {
+      duration: 5000,
+    })
+    return false
+  }
+
+  const shareUrl = createCreateFileUrl(args)
+  const shortlink = await createShortlink(
+    args.token,
+    shareUrl.toString(),
+    args.isRestrictedToOrg,
+    args.password
+  )
+
+  if (err(shortlink)) {
+    toast.error(shortlink.message, {
+      duration: 5000,
+    })
+    return false
+  }
+
+  await globalThis.navigator.clipboard.writeText(shortlink.url)
+  toast.success(
+    'Link copied to clipboard. Anyone who clicks this link will get a copy of this file. Share carefully!',
+    {
+      duration: 5000,
+    }
+  )
+  return true
+}

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,18 +1,45 @@
+import { type KclProjectShareLinkAccessMode, users } from '@kittycad/lib'
+import { serializeProjectConfiguration } from '@src/lang/wasm'
 import toast from 'react-hot-toast'
 
-import type { FileLinkParams } from '@src/lib/links'
-import { createCreateFileUrl, createShortlink } from '@src/lib/links'
+import env from '@src/env'
+import { PROJECT_SETTINGS_FILE_NAME } from '@src/lib/constants'
+import {
+  readProjectSettingsFile,
+  writeProjectSettingsFile,
+} from '@src/lib/desktop'
+import fsZds from '@src/lib/fs-zds'
+import { createKCClient, kcCall } from '@src/lib/kcClient'
+import type { FileEntry, Project } from '@src/lib/project'
 import { err } from '@src/lib/trap'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 
-export type CopyCurrentFileShareLinkArgs = FileLinkParams & {
+export type CopyCurrentFileShareLinkArgs = {
   token: string
+  project: Project | undefined
+  currentFilePath: string
+  currentFileContents: string
+  wasmInstance: ModuleType
+  isRestrictedToOrg: boolean
 }
 
-/**
- * Temporary adapter around the legacy shortlink flow.
- * Swap this implementation to the project upload + share-links APIs once the
- * updated TS client exposes those endpoints.
- */
+type ProjectSettingsCloud = Record<
+  string,
+  {
+    project_id?: string
+  }
+>
+
+type UploadFile = {
+  name: string
+  data: Blob
+}
+
+type ProjectUpsertBody = {
+  title: string
+  description: string
+}
+
 export async function copyCurrentFileShareLink(
   args: CopyCurrentFileShareLinkArgs
 ): Promise<boolean> {
@@ -23,27 +50,458 @@ export async function copyCurrentFileShareLink(
     return false
   }
 
-  const shareUrl = createCreateFileUrl(args)
-  const shortlink = await createShortlink(
-    args.token,
-    shareUrl.toString(),
-    args.isRestrictedToOrg,
-    args.password
-  )
+  if (!args.project) {
+    toast.error('You need an open project to share this file.', {
+      duration: 5000,
+    })
+    return false
+  }
+  const project = args.project
 
-  if (err(shortlink)) {
-    toast.error(shortlink.message, {
+  const environmentName = getCurrentEnvironmentName()
+  if (err(environmentName)) {
+    toast.error(environmentName.message, {
       duration: 5000,
     })
     return false
   }
 
-  await globalThis.navigator.clipboard.writeText(shortlink.url)
-  toast.success(
-    'Link copied to clipboard. Anyone who clicks this link will get a copy of this file. Share carefully!',
-    {
+  const uploadFiles = await buildProjectUploadFiles({
+    project,
+    currentFilePath: args.currentFilePath,
+    currentFileContents: args.currentFileContents,
+    wasmInstance: args.wasmInstance,
+  })
+  if (err(uploadFiles)) {
+    toast.error(uploadFiles.message, {
       duration: 5000,
-    }
+    })
+    return false
+  }
+
+  const client = createKCClient(args.token)
+  const existingProjectId = await getCloudProjectIdForEnvironment(
+    project.path,
+    args.wasmInstance,
+    environmentName
   )
+  if (err(existingProjectId)) {
+    toast.error(existingProjectId.message, {
+      duration: 5000,
+    })
+    return false
+  }
+
+  let projectId: string
+  if (existingProjectId) {
+    const projectBody = await getProjectUpsertBody({
+      client,
+      project,
+      projectId: existingProjectId,
+    })
+    if (err(projectBody)) {
+      toast.error(projectBody.message, {
+        duration: 5000,
+      })
+      return false
+    }
+
+    const projectResp = await kcCall(() =>
+      upsertUserProject({
+        client,
+        id: existingProjectId,
+        body: projectBody,
+        files: uploadFiles,
+      })
+    )
+    if (err(projectResp)) {
+      toast.error(projectResp.message, {
+        duration: 5000,
+      })
+      return false
+    }
+
+    projectId = existingProjectId
+  } else {
+    const projectBody = getDefaultProjectUpsertBody(project)
+    const projectResp = await kcCall(() =>
+      upsertUserProject({
+        client,
+        body: projectBody,
+        files: uploadFiles,
+      })
+    )
+    if (err(projectResp)) {
+      toast.error(projectResp.message, {
+        duration: 5000,
+      })
+      return false
+    }
+
+    projectId = projectResp.id
+    const persisted = await persistCloudProjectIdForEnvironment(
+      project.path,
+      args.wasmInstance,
+      environmentName,
+      projectId
+    )
+    if (err(persisted)) {
+      toast.error(persisted.message, {
+        duration: 5000,
+      })
+      return false
+    }
+  }
+
+  const accessMode: KclProjectShareLinkAccessMode = args.isRestrictedToOrg
+    ? 'organization_only'
+    : 'anyone_with_link'
+
+  const shareLink = await getOrCreateProjectShareLink({
+    client,
+    projectId,
+    accessMode,
+  })
+  if (err(shareLink)) {
+    toast.error(shareLink.message, {
+      duration: 5000,
+    })
+    return false
+  }
+
+  await globalThis.navigator.clipboard.writeText(shareLink.url)
+  toast.success('Link copied to clipboard.', {
+    duration: 5000,
+  })
   return true
+}
+
+async function getProjectUpsertBody({
+  client,
+  project,
+  projectId,
+}: {
+  client: ReturnType<typeof createKCClient>
+  project: Project
+  projectId: string
+}): Promise<ProjectUpsertBody | Error> {
+  const remoteProject = await kcCall(() =>
+    users.get_user_project({
+      client,
+      id: projectId,
+    })
+  )
+  if (err(remoteProject)) {
+    return remoteProject
+  }
+
+  return {
+    title: remoteProject.title || getDefaultProjectTitle(project),
+    description: remoteProject.description || '',
+  }
+}
+
+function getDefaultProjectUpsertBody(project: Project): ProjectUpsertBody {
+  return {
+    title: getDefaultProjectTitle(project),
+    description: '',
+  }
+}
+
+function getDefaultProjectTitle(project: Project) {
+  return project.name || getPathLeaf(project.path) || 'project'
+}
+
+async function upsertUserProject({
+  client,
+  id,
+  body,
+  files,
+}: {
+  client: ReturnType<typeof createKCClient>
+  id?: string
+  body: ProjectUpsertBody
+  files: UploadFile[]
+}): Promise<{ id: string } | Error> {
+  const formData = new FormData()
+  formData.append(
+    'body',
+    new Blob([JSON.stringify(body)], { type: 'application/json' }),
+    'body.json'
+  )
+
+  for (const file of files) {
+    formData.append(file.name, file.data, file.name)
+  }
+
+  const apiPath = id ? `/user/projects/${id}` : '/user/projects'
+  const baseUrl = client.baseUrl || 'https://api.zoo.dev'
+  const requestUrl = new URL(apiPath, baseUrl).toString()
+  const headers: Record<string, string> = {}
+  if (client.token) {
+    headers.Authorization = `Bearer ${client.token}`
+  }
+
+  const fetchImpl = client.fetch || globalThis.fetch
+  const response = await fetchImpl(requestUrl, {
+    method: id ? 'PUT' : 'POST',
+    headers,
+    body: formData,
+  })
+  if (!response.ok) {
+    return new Error(await getApiErrorMessage(response))
+  }
+
+  return response.json() as Promise<{ id: string }>
+}
+
+async function getOrCreateProjectShareLink({
+  client,
+  projectId,
+  accessMode,
+}: {
+  client: ReturnType<typeof createKCClient>
+  projectId: string
+  accessMode: KclProjectShareLinkAccessMode
+}) {
+  const existingResp = await kcCall(() =>
+    users.list_user_project_share_links({
+      client,
+      id: projectId,
+    })
+  )
+
+  if (!err(existingResp)) {
+    const existing = existingResp.find(
+      (link) => link.access_mode === accessMode
+    )
+    if (existing) {
+      return existing
+    }
+  }
+
+  return kcCall(() =>
+    users.create_user_project_share_link({
+      client,
+      id: projectId,
+      body: { access_mode: accessMode },
+    })
+  )
+}
+
+async function buildProjectUploadFiles({
+  project,
+  currentFilePath,
+  currentFileContents,
+  wasmInstance,
+}: Omit<
+  CopyCurrentFileShareLinkArgs,
+  'token' | 'isRestrictedToOrg' | 'project'
+> & {
+  project: Project
+}): Promise<UploadFile[] | Error> {
+  if (!project.children) {
+    return new Error('This project does not have any files to share.')
+  }
+
+  const files: UploadFile[] = await Promise.all(
+    flattenProjectFiles(project.children).map(async (fileEntry) => {
+      const relativePath = toProjectRelativePath(project.path, fileEntry.path)
+      const data =
+        fileEntry.path === currentFilePath
+          ? new Blob([currentFileContents], {
+              type: getMimeType(fileEntry.name),
+            })
+          : new Blob([cloneFileBytes(await fsZds.readFile(fileEntry.path))], {
+              type: getMimeType(fileEntry.name),
+            })
+
+      return {
+        name: relativePath,
+        data,
+      }
+    })
+  )
+
+  const hasProjectSettings = files.some(
+    (file) => file.name === PROJECT_SETTINGS_FILE_NAME
+  )
+  if (hasProjectSettings) {
+    return files
+  }
+
+  const projectToml = await getProjectTomlContents(project.path, wasmInstance)
+  if (err(projectToml)) {
+    return projectToml
+  }
+
+  return [
+    ...files,
+    {
+      name: PROJECT_SETTINGS_FILE_NAME,
+      data: new Blob([projectToml], { type: 'text/plain' }),
+    },
+  ]
+}
+
+async function getProjectTomlContents(
+  projectPath: string,
+  wasmInstance: ModuleType
+): Promise<string | Error> {
+  const projectTomlPath = fsZds.join(projectPath, PROJECT_SETTINGS_FILE_NAME)
+
+  try {
+    return await fsZds.readFile(projectTomlPath, { encoding: 'utf-8' })
+  } catch {
+    const projectSettings = await readProjectSettingsFile(
+      projectPath,
+      wasmInstance
+    )
+    const serialized = serializeProjectConfiguration(
+      projectSettings,
+      wasmInstance
+    )
+    if (err(serialized)) {
+      return serialized
+    }
+
+    return serialized
+  }
+}
+
+async function getCloudProjectIdForEnvironment(
+  projectPath: string,
+  wasmInstance: ModuleType,
+  environmentName: string
+): Promise<string | undefined | Error> {
+  try {
+    const projectSettings = await readProjectSettingsFile(
+      projectPath,
+      wasmInstance
+    )
+    const cloud = (projectSettings.cloud ?? {}) as ProjectSettingsCloud
+    return cloud[environmentName]?.project_id
+  } catch (error) {
+    return new Error(
+      `Failed to read local project settings: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+}
+
+async function persistCloudProjectIdForEnvironment(
+  projectPath: string,
+  wasmInstance: ModuleType,
+  environmentName: string,
+  projectId: string
+) {
+  try {
+    const projectSettings = await readProjectSettingsFile(
+      projectPath,
+      wasmInstance
+    )
+    const cloud = { ...(projectSettings.cloud ?? {}) } as ProjectSettingsCloud
+    cloud[environmentName] = {
+      ...(cloud[environmentName] ?? {}),
+      project_id: projectId,
+    }
+
+    const serialized = serializeProjectConfiguration(
+      {
+        ...projectSettings,
+        cloud,
+      },
+      wasmInstance
+    )
+    if (err(serialized)) {
+      return serialized
+    }
+
+    await writeProjectSettingsFile(projectPath, serialized)
+    return true
+  } catch (error) {
+    return new Error(
+      `Failed to save local cloud project binding: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+}
+
+function flattenProjectFiles(fileEntries: FileEntry[]): FileEntry[] {
+  const files: FileEntry[] = []
+
+  for (const entry of fileEntries) {
+    if (entry.children) {
+      files.push(...flattenProjectFiles(entry.children))
+      continue
+    }
+
+    files.push(entry)
+  }
+
+  return files
+}
+
+function cloneFileBytes(fileBytes: Uint8Array) {
+  return Uint8Array.from(fileBytes)
+}
+
+async function getApiErrorMessage(response: Response) {
+  try {
+    const body = await response.json()
+    if (
+      body &&
+      typeof body === 'object' &&
+      'message' in body &&
+      typeof body.message === 'string'
+    ) {
+      return body.message
+    }
+  } catch {}
+
+  try {
+    const text = await response.text()
+    if (text) {
+      return text
+    }
+  } catch {}
+
+  return `Project upload failed (${response.status})`
+}
+
+function toProjectRelativePath(projectPath: string, filePath: string) {
+  return fsZds.relative(projectPath, filePath).replaceAll(fsZds.sep, '/')
+}
+
+function getPathLeaf(path: string) {
+  return path.split(fsZds.sep).filter(Boolean).at(-1)
+}
+
+function getCurrentEnvironmentName(): string | Error {
+  const baseDomain = env().VITE_ZOO_BASE_DOMAIN
+  if (baseDomain) {
+    return baseDomain
+  }
+
+  const apiBaseUrl = env().VITE_ZOO_API_BASE_URL
+  if (apiBaseUrl) {
+    return new URL(apiBaseUrl).hostname.replace(/^api\./, '')
+  }
+
+  return new Error('Could not determine the active API environment.')
+}
+
+function getMimeType(fileName: string) {
+  const extension = fsZds.extname(fileName).toLowerCase()
+  if (extension === '.kcl' || extension === '.toml') {
+    return 'text/plain'
+  }
+  if (extension === '.png') {
+    return 'image/png'
+  }
+  if (extension === '.jpg' || extension === '.jpeg') {
+    return 'image/jpeg'
+  }
+  if (extension === '.webp') {
+    return 'image/webp'
+  }
+  return 'application/octet-stream'
 }

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -23,6 +23,15 @@ export type CopyCurrentFileShareLinkArgs = {
   isRestrictedToOrg: boolean
 }
 
+export type PublishCurrentProjectArgs = Omit<
+  CopyCurrentFileShareLinkArgs,
+  'isRestrictedToOrg'
+>
+
+type CurrentProjectUploadArgs = Omit<PublishCurrentProjectArgs, 'project'> & {
+  project: Project
+}
+
 type ProjectSettingsCloud = Record<
   string,
   {
@@ -56,101 +65,16 @@ export async function copyCurrentFileShareLink(
     })
     return false
   }
-  const project = args.project
 
-  const environmentName = getCurrentEnvironmentName()
-  if (err(environmentName)) {
-    toast.error(environmentName.message, {
-      duration: 5000,
-    })
-    return false
-  }
-
-  const uploadFiles = await buildProjectUploadFiles({
-    project,
-    currentFilePath: args.currentFilePath,
-    currentFileContents: args.currentFileContents,
-    wasmInstance: args.wasmInstance,
+  const uploadedProject = await ensureCurrentProjectUploaded({
+    ...args,
+    project: args.project,
   })
-  if (err(uploadFiles)) {
-    toast.error(uploadFiles.message, {
+  if (err(uploadedProject)) {
+    toast.error(uploadedProject.message, {
       duration: 5000,
     })
     return false
-  }
-
-  const client = createKCClient(args.token)
-  const existingProjectId = await getCloudProjectIdForEnvironment(
-    project.path,
-    args.wasmInstance,
-    environmentName
-  )
-  if (err(existingProjectId)) {
-    toast.error(existingProjectId.message, {
-      duration: 5000,
-    })
-    return false
-  }
-
-  let projectId: string
-  if (existingProjectId) {
-    const projectBody = await getProjectUpsertBody({
-      client,
-      project,
-      projectId: existingProjectId,
-    })
-    if (err(projectBody)) {
-      toast.error(projectBody.message, {
-        duration: 5000,
-      })
-      return false
-    }
-
-    const projectResp = await kcCall(() =>
-      upsertUserProject({
-        client,
-        id: existingProjectId,
-        body: projectBody,
-        files: uploadFiles,
-      })
-    )
-    if (err(projectResp)) {
-      toast.error(projectResp.message, {
-        duration: 5000,
-      })
-      return false
-    }
-
-    projectId = existingProjectId
-  } else {
-    const projectBody = getDefaultProjectUpsertBody(project)
-    const projectResp = await kcCall(() =>
-      upsertUserProject({
-        client,
-        body: projectBody,
-        files: uploadFiles,
-      })
-    )
-    if (err(projectResp)) {
-      toast.error(projectResp.message, {
-        duration: 5000,
-      })
-      return false
-    }
-
-    projectId = projectResp.id
-    const persisted = await persistCloudProjectIdForEnvironment(
-      project.path,
-      args.wasmInstance,
-      environmentName,
-      projectId
-    )
-    if (err(persisted)) {
-      toast.error(persisted.message, {
-        duration: 5000,
-      })
-      return false
-    }
   }
 
   const accessMode: KclProjectShareLinkAccessMode = args.isRestrictedToOrg
@@ -158,8 +82,8 @@ export async function copyCurrentFileShareLink(
     : 'anyone_with_link'
 
   const shareLink = await getOrCreateProjectShareLink({
-    client,
-    projectId,
+    client: uploadedProject.client,
+    projectId: uploadedProject.projectId,
     accessMode,
   })
   if (err(shareLink)) {
@@ -174,6 +98,151 @@ export async function copyCurrentFileShareLink(
     duration: 5000,
   })
   return true
+}
+
+export async function publishCurrentProject(
+  args: PublishCurrentProjectArgs
+): Promise<boolean> {
+  if (!args.token) {
+    toast.error('You need to be signed in to publish a project.', {
+      duration: 5000,
+    })
+    return false
+  }
+
+  if (!args.project) {
+    toast.error('You need an open project to publish.', {
+      duration: 5000,
+    })
+    return false
+  }
+
+  const uploadedProject = await ensureCurrentProjectUploaded({
+    ...args,
+    project: args.project,
+  })
+  if (err(uploadedProject)) {
+    toast.error(uploadedProject.message, {
+      duration: 5000,
+    })
+    return false
+  }
+
+  const publishedProject = await kcCall(() =>
+    users.publish_user_project({
+      client: uploadedProject.client,
+      id: uploadedProject.projectId,
+    })
+  )
+  if (err(publishedProject)) {
+    toast.error(publishedProject.message, {
+      duration: 5000,
+    })
+    return false
+  }
+
+  toast.success(
+    publishedProject.publication_status === 'published'
+      ? 'Project published.'
+      : 'Project submitted for review.',
+    {
+      duration: 5000,
+    }
+  )
+
+  return true
+}
+
+async function ensureCurrentProjectUploaded(
+  args: CurrentProjectUploadArgs
+): Promise<
+  | {
+      client: ReturnType<typeof createKCClient>
+      projectId: string
+    }
+  | Error
+> {
+  const project = args.project
+  const environmentName = getCurrentEnvironmentName()
+  if (err(environmentName)) {
+    return environmentName
+  }
+
+  const uploadFiles = await buildProjectUploadFiles({
+    project,
+    currentFilePath: args.currentFilePath,
+    currentFileContents: args.currentFileContents,
+    wasmInstance: args.wasmInstance,
+  })
+  if (err(uploadFiles)) {
+    return uploadFiles
+  }
+
+  const client = createKCClient(args.token)
+  const existingProjectId = await getCloudProjectIdForEnvironment(
+    project.path,
+    args.wasmInstance,
+    environmentName
+  )
+  if (err(existingProjectId)) {
+    return existingProjectId
+  }
+
+  if (existingProjectId) {
+    const projectBody = await getProjectUpsertBody({
+      client,
+      project,
+      projectId: existingProjectId,
+    })
+    if (err(projectBody)) {
+      return projectBody
+    }
+
+    const projectResp = await kcCall(() =>
+      upsertUserProject({
+        client,
+        id: existingProjectId,
+        body: projectBody,
+        files: uploadFiles,
+      })
+    )
+    if (err(projectResp)) {
+      return projectResp
+    }
+
+    return {
+      client,
+      projectId: existingProjectId,
+    }
+  }
+
+  const projectBody = getDefaultProjectUpsertBody(project)
+  const projectResp = await kcCall(() =>
+    upsertUserProject({
+      client,
+      body: projectBody,
+      files: uploadFiles,
+    })
+  )
+  if (err(projectResp)) {
+    return projectResp
+  }
+
+  const projectId = projectResp.id
+  const persisted = await persistCloudProjectIdForEnvironment(
+    project.path,
+    args.wasmInstance,
+    environmentName,
+    projectId
+  )
+  if (err(persisted)) {
+    return persisted
+  }
+
+  return {
+    client,
+    projectId,
+  }
 }
 
 async function getProjectUpsertBody({

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,4 +1,8 @@
-import { type KclProjectShareLinkAccessMode, users } from '@kittycad/lib'
+import {
+  type KclProjectPublicationStatus,
+  type KclProjectShareLinkAccessMode,
+  projects,
+} from '@kittycad/lib'
 import { serializeProjectConfiguration } from '@src/lang/wasm'
 import toast from 'react-hot-toast'
 
@@ -27,6 +31,13 @@ export type PublishCurrentProjectArgs = Omit<
   CopyCurrentFileShareLinkArgs,
   'isRestrictedToOrg'
 >
+
+export type CurrentProjectPublicationDetails = {
+  projectId: string
+  publicationStatus: KclProjectPublicationStatus
+  publishedAt?: string
+  updatedAt: string
+}
 
 type CurrentProjectUploadArgs = Omit<PublishCurrentProjectArgs, 'project'> & {
   project: Project
@@ -129,7 +140,7 @@ export async function publishCurrentProject(
   }
 
   const publishedProject = await kcCall(() =>
-    users.publish_user_project({
+    projects.publish_project({
       client: uploadedProject.client,
       id: uploadedProject.projectId,
     })
@@ -151,6 +162,54 @@ export async function publishCurrentProject(
   )
 
   return true
+}
+
+export async function getCurrentProjectPublicationDetails({
+  token,
+  project,
+  wasmInstance,
+}: {
+  token: string
+  project: Project | undefined
+  wasmInstance: ModuleType
+}): Promise<CurrentProjectPublicationDetails | null | Error> {
+  if (!token || !project) {
+    return null
+  }
+
+  const environmentName = getCurrentEnvironmentName()
+  if (err(environmentName)) {
+    return environmentName
+  }
+
+  const projectId = await getCloudProjectIdForEnvironment(
+    project.path,
+    wasmInstance,
+    environmentName
+  )
+  if (err(projectId)) {
+    return projectId
+  }
+
+  if (!projectId) {
+    return null
+  }
+
+  const client = createKCClient(token)
+  const remoteProject = await getRemoteProject({
+    client,
+    projectId,
+  })
+  if (err(remoteProject)) {
+    return remoteProject
+  }
+
+  return {
+    projectId,
+    publicationStatus: remoteProject.publication_status,
+    publishedAt: remoteProject.publication.last_published_at,
+    updatedAt: remoteProject.updated_at,
+  }
 }
 
 async function ensureCurrentProjectUploaded(
@@ -199,11 +258,10 @@ async function ensureCurrentProjectUploaded(
     }
 
     const projectResp = await kcCall(() =>
-      upsertUserProject({
+      projects.update_project({
         client,
         id: existingProjectId,
-        body: projectBody,
-        files: uploadFiles,
+        files: toKittyCadFiles(uploadFiles, projectBody),
       })
     )
     if (err(projectResp)) {
@@ -218,10 +276,9 @@ async function ensureCurrentProjectUploaded(
 
   const projectBody = getDefaultProjectUpsertBody(project)
   const projectResp = await kcCall(() =>
-    upsertUserProject({
+    projects.create_project({
       client,
-      body: projectBody,
-      files: uploadFiles,
+      files: toKittyCadFiles(uploadFiles, projectBody),
     })
   )
   if (err(projectResp)) {
@@ -254,12 +311,10 @@ async function getProjectUpsertBody({
   project: Project
   projectId: string
 }): Promise<ProjectUpsertBody | Error> {
-  const remoteProject = await kcCall(() =>
-    users.get_user_project({
-      client,
-      id: projectId,
-    })
-  )
+  const remoteProject = await getRemoteProject({
+    client,
+    projectId,
+  })
   if (err(remoteProject)) {
     return remoteProject
   }
@@ -281,47 +336,19 @@ function getDefaultProjectTitle(project: Project) {
   return project.name || getPathLeaf(project.path) || 'project'
 }
 
-async function upsertUserProject({
+function getRemoteProject({
   client,
-  id,
-  body,
-  files,
+  projectId,
 }: {
   client: ReturnType<typeof createKCClient>
-  id?: string
-  body: ProjectUpsertBody
-  files: UploadFile[]
-}): Promise<{ id: string } | Error> {
-  const formData = new FormData()
-  formData.append(
-    'body',
-    new Blob([JSON.stringify(body)], { type: 'application/json' }),
-    'body.json'
+  projectId: string
+}) {
+  return kcCall(() =>
+    projects.get_project({
+      client,
+      id: projectId,
+    })
   )
-
-  for (const file of files) {
-    formData.append(file.name, file.data, file.name)
-  }
-
-  const apiPath = id ? `/user/projects/${id}` : '/user/projects'
-  const baseUrl = client.baseUrl || 'https://api.zoo.dev'
-  const requestUrl = new URL(apiPath, baseUrl).toString()
-  const headers: Record<string, string> = {}
-  if (client.token) {
-    headers.Authorization = `Bearer ${client.token}`
-  }
-
-  const fetchImpl = client.fetch || globalThis.fetch
-  const response = await fetchImpl(requestUrl, {
-    method: id ? 'PUT' : 'POST',
-    headers,
-    body: formData,
-  })
-  if (!response.ok) {
-    return new Error(await getApiErrorMessage(response))
-  }
-
-  return response.json() as Promise<{ id: string }>
 }
 
 async function getOrCreateProjectShareLink({
@@ -334,7 +361,7 @@ async function getOrCreateProjectShareLink({
   accessMode: KclProjectShareLinkAccessMode
 }) {
   const existingResp = await kcCall(() =>
-    users.list_user_project_share_links({
+    projects.list_project_share_links({
       client,
       id: projectId,
     })
@@ -350,7 +377,7 @@ async function getOrCreateProjectShareLink({
   }
 
   return kcCall(() =>
-    users.create_user_project_share_link({
+    projects.create_project_share_link({
       client,
       id: projectId,
       body: { access_mode: accessMode },
@@ -513,35 +540,24 @@ function cloneFileBytes(fileBytes: Uint8Array) {
   return Uint8Array.from(fileBytes)
 }
 
-async function getApiErrorMessage(response: Response) {
-  try {
-    const body = await response.json()
-    if (
-      body &&
-      typeof body === 'object' &&
-      'message' in body &&
-      typeof body.message === 'string'
-    ) {
-      return body.message
-    }
-  } catch {}
-
-  try {
-    const text = await response.text()
-    if (text) {
-      return text
-    }
-  } catch {}
-
-  return `Project upload failed (${response.status})`
-}
-
 function toProjectRelativePath(projectPath: string, filePath: string) {
   return fsZds.relative(projectPath, filePath).replaceAll(fsZds.sep, '/')
 }
 
-function getPathLeaf(path: string) {
-  return path.split(fsZds.sep).filter(Boolean).at(-1)
+function toKittyCadFiles(
+  files: UploadFile[],
+  body: ProjectUpsertBody
+): Parameters<typeof projects.create_project>[0]['files'] {
+  return [
+    {
+      name: 'body',
+      data: new Blob([JSON.stringify(body)], { type: 'application/json' }),
+    },
+    ...files.map((file) => ({
+      name: file.name,
+      data: file.data,
+    })),
+  ]
 }
 
 function getCurrentEnvironmentName(): string | Error {
@@ -573,4 +589,8 @@ function getMimeType(fileName: string) {
     return 'image/webp'
   }
   return 'application/octet-stream'
+}
+
+function getPathLeaf(path: string) {
+  return path.split(fsZds.sep).filter(Boolean).at(-1)
 }


### PR DESCRIPTION
This PR reimplements the "Share" popup using our new cloud storage API.

The cloud storage API defaults to private project storage. So, to post publicly, or to generate a share link it's a two-step process. 

1. Create/Update the cloud project
2. Call the `share-links` api on the project --or-- Call the `publish` api on the project

Depends on https://github.com/KittyCAD/modeling-app/pull/10808