### PR TITLE
Add a benchmark for mouse dragging in sketch block

### DIFF
--- a/e2e/playwright/benchmark/sketch-solve-drag.spec.ts
+++ b/e2e/playwright/benchmark/sketch-solve-drag.spec.ts
@@ -1,0 +1,437 @@
+import fsp from 'node:fs/promises'
+
+import type { Page } from '@playwright/test'
+import { settingsToToml } from '@e2e/playwright/test-utils'
+import { TEST_SETTINGS, TEST_SETTINGS_KEY } from '@e2e/playwright/storageStates'
+import { expect, test } from '@e2e/playwright/zoo-test'
+import {
+  SKETCH_SOLVE_DRAG_BENCHMARK_MARKS,
+  SKETCH_SOLVE_DRAG_BENCHMARK_PREFIX,
+} from '@src/machines/sketchSolve/sketchSolveBenchmark'
+
+type BrowserMark = {
+  name: string
+  startTime: number
+  detail: unknown
+}
+
+type BenchmarkSample = {
+  iteration: number
+  direction: 'down' | 'up'
+  dragTicks: number
+  rustMs: number
+  sceneMs: number
+  applyMs: number
+  totalMs: number
+}
+
+const DEFAULT_LINE_COUNT = parseIntegerEnv('BENCHMARK_LINE_COUNT', 100)
+const DEFAULT_WARMUPS = parseIntegerEnv('BENCHMARK_WARMUPS', 5)
+const DEFAULT_ITERATIONS = parseIntegerEnv('BENCHMARK_ITERATIONS', 25)
+const DEFAULT_DRAG_DISTANCE_PX = parseIntegerEnv(
+  'BENCHMARK_DRAG_DISTANCE_PX',
+  50
+)
+const DEFAULT_DRAG_STEPS = parseIntegerEnv('BENCHMARK_DRAG_STEPS', 5)
+const DEFAULT_TARGET_LINE_INDEX = parseIntegerEnv(
+  'BENCHMARK_TARGET_LINE_INDEX',
+  Math.min(24, Math.max(0, Math.floor(DEFAULT_LINE_COUNT / 4)))
+)
+const MAX_TOTAL_MEDIAN_MS = parseOptionalNumberEnv('BENCHMARK_MAX_TOTAL_MS')
+
+const userSettingsToml = settingsToToml({
+  settings: {
+    ...TEST_SETTINGS,
+    modeling: {
+      ...TEST_SETTINGS.modeling,
+      use_sketch_solve_mode: true,
+    },
+  },
+})
+
+function parseIntegerEnv(name: string, fallback: number): number {
+  const value = Number.parseInt(process.env[name] ?? '', 10)
+  return Number.isFinite(value) ? value : fallback
+}
+
+function parseOptionalNumberEnv(name: string): number | undefined {
+  const value = Number.parseFloat(process.env[name] ?? '')
+  return Number.isFinite(value) ? value : undefined
+}
+
+function isNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+function round(value: number): number {
+  return Math.round(value * 1000) / 1000
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) {
+    return 0
+  }
+  const sorted = [...values].sort((a, b) => a - b)
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil((p / 100) * sorted.length) - 1)
+  )
+  return round(sorted[index])
+}
+
+function summarizePhase(
+  samples: BenchmarkSample[],
+  key: keyof BenchmarkSample
+) {
+  const values = samples.map((sample) => sample[key]).filter(isNumber)
+  return {
+    minMs: round(Math.min(...values)),
+    medianMs: percentile(values, 50),
+    p95Ms: percentile(values, 95),
+    maxMs: round(Math.max(...values)),
+  }
+}
+
+function buildBenchmarkSketch(lineCount: number): string {
+  const columnCount = Math.ceil(Math.sqrt(lineCount))
+  const rowCount = Math.ceil(lineCount / columnCount)
+  const xSpacing = 6
+  const ySpacing = 6
+  const lineDx = 3.5
+  const lineDy = 1.75
+  const xOffset = ((columnCount - 1) * xSpacing) / 2
+  const yOffset = ((rowCount - 1) * ySpacing) / 2
+
+  const lines = Array.from({ length: lineCount }, (_, index) => {
+    const row = Math.floor(index / columnCount)
+    const column = index % columnCount
+    const startX = round(column * xSpacing - xOffset)
+    const startY = round(row * ySpacing - yOffset)
+    const endX = round(startX + lineDx)
+    const endY = round(startY + lineDy)
+
+    return `  line(start = [var ${startX}mm, var ${startY}mm], end = [var ${endX}mm, var ${endY}mm])`
+  })
+
+  return `@settings(experimentalFeatures = allow)
+
+sketch(on = XZ) {
+${lines.join('\n')}
+}
+`
+}
+
+async function clearBenchmarkMarks(page: Page) {
+  await page.evaluate(() => {
+    performance.clearMarks()
+    performance.clearMeasures()
+  })
+}
+
+async function readBenchmarkMarks(page: Page): Promise<BrowserMark[]> {
+  return page.evaluate((prefix: string) => {
+    return performance
+      .getEntriesByType('mark')
+      .filter((entry) => entry.name.startsWith(prefix))
+      .map((entry) => ({
+        name: entry.name,
+        startTime: entry.startTime,
+        detail: entry.detail ?? null,
+      }))
+  }, SKETCH_SOLVE_DRAG_BENCHMARK_PREFIX)
+}
+
+function getUniqueMarkTime(marks: BrowserMark[], name: string): number {
+  const matches = marks.filter((mark) => mark.name === name)
+  if (matches.length !== 1) {
+    throw new Error(
+      `Expected exactly one mark named "${name}", found ${matches.length}.`
+    )
+  }
+  return matches[0].startTime
+}
+
+function extractBenchmarkSample(
+  marks: BrowserMark[],
+  iteration: number,
+  direction: 'down' | 'up'
+): BenchmarkSample {
+  const editStarts = getMarkTimes(
+    marks,
+    SKETCH_SOLVE_DRAG_BENCHMARK_MARKS.editSegmentsStart
+  )
+  const editEnds = getMarkTimes(
+    marks,
+    SKETCH_SOLVE_DRAG_BENCHMARK_MARKS.editSegmentsEnd
+  )
+  const sceneStarts = getMarkTimes(
+    marks,
+    SKETCH_SOLVE_DRAG_BENCHMARK_MARKS.updateSceneGraphStart
+  )
+  const sceneEnds = getMarkTimes(
+    marks,
+    SKETCH_SOLVE_DRAG_BENCHMARK_MARKS.updateSceneGraphEnd
+  )
+  const outcomeStarts = getMarkTimes(
+    marks,
+    SKETCH_SOLVE_DRAG_BENCHMARK_MARKS.updateSketchOutcomeStart
+  )
+  const outcomeEnds = getMarkTimes(
+    marks,
+    SKETCH_SOLVE_DRAG_BENCHMARK_MARKS.updateSketchOutcomeEnd
+  )
+  const frameEnds = getMarkTimes(
+    marks,
+    SKETCH_SOLVE_DRAG_BENCHMARK_MARKS.animationFrameEnd
+  )
+
+  return {
+    iteration,
+    direction,
+    dragTicks: editStarts.length,
+    rustMs: sumPairDurations(
+      editStarts,
+      editEnds,
+      SKETCH_SOLVE_DRAG_BENCHMARK_MARKS.editSegmentsStart
+    ),
+    sceneMs: sumPairDurations(
+      sceneStarts,
+      sceneEnds,
+      SKETCH_SOLVE_DRAG_BENCHMARK_MARKS.updateSceneGraphStart
+    ),
+    applyMs: sumPairDurations(
+      outcomeStarts,
+      outcomeEnds,
+      SKETCH_SOLVE_DRAG_BENCHMARK_MARKS.updateSketchOutcomeStart
+    ),
+    totalMs: round(frameEnds.at(-1)! - editStarts[0]),
+  }
+}
+
+function getMarkTimes(marks: BrowserMark[], name: string): number[] {
+  return marks
+    .filter((mark) => mark.name === name)
+    .map((mark) => mark.startTime)
+    .sort((a, b) => a - b)
+}
+
+function sumPairDurations(
+  starts: number[],
+  ends: number[],
+  label: string
+): number {
+  if (
+    starts.length === 0 ||
+    ends.length === 0 ||
+    starts.length !== ends.length
+  ) {
+    throw new Error(
+      `Expected matched benchmark mark pairs for "${label}", found ${starts.length} starts and ${ends.length} ends.`
+    )
+  }
+
+  return round(
+    starts.reduce((sum, start, index) => sum + (ends[index] - start), 0)
+  )
+}
+
+async function getPointHandleCenter(page: Page, handleIndex: number) {
+  const handle = page
+    .locator('[data-handle="sketch-point-handle"]')
+    .nth(handleIndex)
+  const box = await handle.boundingBox()
+
+  if (!box) {
+    throw new Error(`Failed to resolve point handle ${handleIndex}.`)
+  }
+
+  return {
+    x: box.x + box.width / 2,
+    y: box.y + box.height / 2,
+  }
+}
+
+async function runMeasuredDrag({
+  page,
+  targetHandleIndex,
+  deltaY,
+  steps,
+}: {
+  page: Page
+  targetHandleIndex: number
+  deltaY: number
+  steps: number
+}) {
+  const point = await getPointHandleCenter(page, targetHandleIndex)
+
+  await clearBenchmarkMarks(page)
+  await page.mouse.move(point.x, point.y)
+  await page.mouse.down()
+  await page.mouse.move(point.x, point.y + deltaY, { steps })
+  await page.mouse.up()
+
+  await expect
+    .poll(async () => {
+      const marks = await readBenchmarkMarks(page)
+      return getMarkTimes(
+        marks,
+        SKETCH_SOLVE_DRAG_BENCHMARK_MARKS.animationFrameEnd
+      ).length
+    })
+    .toBeGreaterThan(0)
+
+  return readBenchmarkMarks(page)
+}
+
+test.describe('Sketch solve drag benchmark', { tag: '@benchmark' }, () => {
+  test('benchmarks drag latency for a dense straight-line sketch', async ({
+    page,
+    context,
+    homePage,
+    scene,
+    cmdBar,
+    toolbar,
+    tronApp,
+  }, testInfo) => {
+    const lineCount = DEFAULT_LINE_COUNT
+    const warmups = DEFAULT_WARMUPS
+    const iterations = DEFAULT_ITERATIONS
+    const dragDistancePx = DEFAULT_DRAG_DISTANCE_PX
+    const dragSteps = DEFAULT_DRAG_STEPS
+    const targetLineIndex = Math.min(DEFAULT_TARGET_LINE_INDEX, lineCount - 1)
+    const targetHandleIndex = targetLineIndex * 2
+    const minimumHandleCount = targetHandleIndex + 1
+    const benchmarkSketch = buildBenchmarkSketch(lineCount)
+
+    await test.step('Set up benchmark sketch and enable benchmark marks', async () => {
+      if (tronApp) {
+        await tronApp.cleanProjectDir({
+          modeling: {
+            use_sketch_solve_mode: true,
+          },
+        })
+      }
+
+      await context.addInitScript(
+        async ({ code, settingsKey, settingsToml }) => {
+          localStorage.setItem('persistCode', code)
+          localStorage.setItem(settingsKey, settingsToml)
+          ;(
+            window as typeof window & {
+              __zooBenchmark?: { enabled?: boolean }
+            }
+          ).__zooBenchmark = { enabled: true }
+        },
+        {
+          code: benchmarkSketch,
+          settingsKey: TEST_SETTINGS_KEY,
+          settingsToml: userSettingsToml,
+        }
+      )
+
+      await page.setBodyDimensions({ width: 1400, height: 900 })
+      await homePage.goToModelingScene()
+      await scene.settled(cmdBar)
+      await expect
+        .poll(() =>
+          page.evaluate(() => {
+            return Boolean(
+              (
+                window as typeof window & {
+                  __zooBenchmark?: { enabled?: boolean }
+                }
+              ).__zooBenchmark?.enabled
+            )
+          })
+        )
+        .toBe(true)
+      await toolbar.openFeatureTreePane()
+      await expect(page.getByText('Building feature tree')).not.toBeVisible({
+        timeout: 10000,
+      })
+
+      const solveSketchOperation = await toolbar.getFeatureTreeOperation(
+        'Solve Sketch',
+        0
+      )
+      await solveSketchOperation.dblclick()
+      await page.waitForTimeout(600)
+      await expect(toolbar.exitSketchBtn).toBeEnabled()
+      await expect
+        .poll(() => page.locator('[data-handle="sketch-point-handle"]').count())
+        .toBeGreaterThanOrEqual(minimumHandleCount)
+    })
+
+    await test.step('Collect warmups', async () => {
+      for (let iteration = 0; iteration < warmups; iteration += 1) {
+        const direction: 'down' | 'up' = iteration % 2 === 0 ? 'down' : 'up'
+        const deltaY = direction === 'down' ? dragDistancePx : -dragDistancePx
+        await runMeasuredDrag({
+          page,
+          targetHandleIndex,
+          deltaY,
+          steps: dragSteps,
+        })
+      }
+    })
+
+    const samples: BenchmarkSample[] = []
+
+    await test.step('Measure drag latency', async () => {
+      for (let iteration = 0; iteration < iterations; iteration += 1) {
+        const direction: 'down' | 'up' = iteration % 2 === 0 ? 'down' : 'up'
+        const deltaY = direction === 'down' ? dragDistancePx : -dragDistancePx
+        const marks = await runMeasuredDrag({
+          page,
+          targetHandleIndex,
+          deltaY,
+          steps: dragSteps,
+        })
+        samples.push(extractBenchmarkSample(marks, iteration, direction))
+        await page.waitForTimeout(50)
+      }
+    })
+
+    const report = {
+      generatedAt: new Date().toISOString(),
+      platform: process.platform,
+      arch: process.arch,
+      config: {
+        lineCount,
+        warmups,
+        iterations,
+        dragDistancePx,
+        dragSteps,
+        targetLineIndex,
+        targetHandleIndex,
+      },
+      summary: {
+        rust: summarizePhase(samples, 'rustMs'),
+        scene: summarizePhase(samples, 'sceneMs'),
+        apply: summarizePhase(samples, 'applyMs'),
+        total: summarizePhase(samples, 'totalMs'),
+      },
+      samples,
+    }
+
+    const reportPath = testInfo.outputPath('sketch-solve-drag-benchmark.json')
+    await fsp.writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`)
+    await testInfo.attach('sketch-solve-drag-benchmark', {
+      path: reportPath,
+      contentType: 'application/json',
+    })
+
+    console.log(
+      `Sketch solve drag benchmark summary: ${JSON.stringify(report.summary)}`
+    )
+
+    if (
+      MAX_TOTAL_MEDIAN_MS !== undefined &&
+      report.summary.total.medianMs > MAX_TOTAL_MEDIAN_MS
+    ) {
+      throw new Error(
+        `Median total drag latency ${report.summary.total.medianMs}ms exceeded threshold ${MAX_TOTAL_MEDIAN_MS}ms.`
+      )
+    }
+  })
+})

--- a/e2e/playwright/benchmark/sketch-solve-drag.spec.ts
+++ b/e2e/playwright/benchmark/sketch-solve-drag.spec.ts
@@ -136,7 +136,11 @@ async function readBenchmarkMarks(page: Page): Promise<BrowserMark[]> {
       .map((entry) => ({
         name: entry.name,
         startTime: entry.startTime,
-        detail: entry.detail ?? null,
+        detail:
+          'detail' in entry
+            ? ((entry as PerformanceEntry & { detail?: unknown }).detail ??
+              null)
+            : null,
       }))
   }, SKETCH_SOLVE_DRAG_BENCHMARK_PREFIX)
 }

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "test:e2e:kcl": "(cd rust && just test && just lint)",
     "test:e2e:web": "cross-env TARGET=web NODE_ENV=development playwright test --config=playwright.config.ts --grep=@web --project=\"Google Chrome\"",
     "test:e2e:desktop": "cross-env TARGET=desktop playwright test --config=playwright.electron.config.ts --grep=@desktop",
+    "benchmark:sketch-solve-drag": "cross-env TARGET=desktop E2E_WORKERS=1 npm run tronb:vite:dev && cross-env TARGET=desktop E2E_WORKERS=1 playwright test --config=playwright.electron.config.ts e2e/playwright/benchmark/sketch-solve-drag.spec.ts",
     "test:e2e:desktop:local": "cross-env TARGET=desktop npm run tronb:vite:dev && playwright test --config=playwright.electron.config.ts --grep=@desktop --grep-invert=\"$(curl --silent https://https://test-analysis-bot.corp.zoo.dev/projects/KittyCAD/modeling-app/tests/disabled/regex)\"",
     "test:e2e:desktop:local-engine": "cross-env TARGET=desktop npm run tronb:vite:dev && playwright test --config=playwright.electron.config.ts --grep=@desktop --grep-invert=\"@skipLocalEngine\" --grep-invert=\"$(curl --silent https://https://test-analysis-bot.corp.zoo.dev/projects/KittyCAD/modeling-app/tests/disabled/regex)\""
   },

--- a/src/machines/sketchSolve/segmentsUtils.ts
+++ b/src/machines/sketchSolve/segmentsUtils.ts
@@ -36,7 +36,9 @@ export function deriveSegmentFreedom(
   }
 
   const getObjById = (id?: number) =>
-    typeof id === 'number' ? (objects.find((o) => o?.id === id) ?? null) : null
+    typeof id === 'number'
+      ? (objects[id] ?? objects.find((o) => o?.id === id) ?? null)
+      : null
 
   const segmentData = segment.kind.segment
 

--- a/src/machines/sketchSolve/sketchSolveBenchmark.ts
+++ b/src/machines/sketchSolve/sketchSolveBenchmark.ts
@@ -1,0 +1,39 @@
+import { mark, type PerformanceMarkDetail } from '@src/lib/performance'
+
+type BenchmarkConfig = {
+  enabled?: boolean
+}
+
+type BenchmarkGlobal = typeof globalThis & {
+  __zooBenchmark?: BenchmarkConfig
+}
+
+export const SKETCH_SOLVE_DRAG_BENCHMARK_PREFIX = 'benchmark/sketch-solve-drag'
+
+export const SKETCH_SOLVE_DRAG_BENCHMARK_MARKS = {
+  editSegmentsStart: `${SKETCH_SOLVE_DRAG_BENCHMARK_PREFIX}/editSegments/start`,
+  editSegmentsEnd: `${SKETCH_SOLVE_DRAG_BENCHMARK_PREFIX}/editSegments/end`,
+  updateSketchOutcomeStart: `${SKETCH_SOLVE_DRAG_BENCHMARK_PREFIX}/updateSketchOutcome/start`,
+  updateSketchOutcomeEnd: `${SKETCH_SOLVE_DRAG_BENCHMARK_PREFIX}/updateSketchOutcome/end`,
+  updateSceneGraphStart: `${SKETCH_SOLVE_DRAG_BENCHMARK_PREFIX}/updateSceneGraph/start`,
+  updateSceneGraphEnd: `${SKETCH_SOLVE_DRAG_BENCHMARK_PREFIX}/updateSceneGraph/end`,
+  animationFrameEnd: `${SKETCH_SOLVE_DRAG_BENCHMARK_PREFIX}/animationFrame/end`,
+} as const
+
+type SketchSolveDragBenchmarkMarkName =
+  (typeof SKETCH_SOLVE_DRAG_BENCHMARK_MARKS)[keyof typeof SKETCH_SOLVE_DRAG_BENCHMARK_MARKS]
+
+function isBenchmarkEnabled(): boolean {
+  return Boolean((globalThis as BenchmarkGlobal).__zooBenchmark?.enabled)
+}
+
+export function markSketchSolveDragBenchmark(
+  name: SketchSolveDragBenchmarkMarkName,
+  detail?: PerformanceMarkDetail
+): void {
+  if (!isBenchmarkEnabled()) {
+    return
+  }
+
+  mark(name, { detail })
+}

--- a/src/machines/sketchSolve/sketchSolveBenchmark.ts
+++ b/src/machines/sketchSolve/sketchSolveBenchmark.ts
@@ -35,5 +35,5 @@ export function markSketchSolveDragBenchmark(
     return
   }
 
-  mark(name, { detail })
+  mark(name, detail ? ({ detail } as any) : undefined)
 }

--- a/src/machines/sketchSolve/sketchSolveImpl.ts
+++ b/src/machines/sketchSolve/sketchSolveImpl.ts
@@ -436,6 +436,24 @@ export function updateSegmentGroup({
   }
 }
 
+function indexSketchSolveChildGroups(
+  sketchSolveGroup: Group | undefined
+): Map<string, Group> {
+  const groupsByName = new Map<string, Group>()
+  if (!sketchSolveGroup) {
+    return groupsByName
+  }
+
+  for (const child of sketchSolveGroup.children) {
+    if (!(child instanceof Group) || child.name === '') {
+      continue
+    }
+    groupsByName.set(child.name, child)
+  }
+
+  return groupsByName
+}
+
 /**
  * Helper function to initialize a segment group with the given input.
  * Determines the correct segment init method based on the input type.
@@ -518,6 +536,9 @@ export function updateSceneGraphFromDelta({
 
     const sketchSolveGroup =
       context.sceneInfra.scene.getObjectByName(SKETCH_SOLVE_GROUP)
+    const sketchChildGroups = indexSketchSolveChildGroups(
+      sketchSolveGroup instanceof Group ? sketchSolveGroup : undefined
+    )
 
     const hoveredSegmentIds = getHoveredSegmentIds(context.hoveredId, objects)
     const hoveredObjectId = isObjectSelectionId(context.hoveredId)
@@ -567,9 +588,7 @@ export function updateSceneGraphFromDelta({
 
       // Render constraints
       if (isConstraint(obj)) {
-        const foundObject = context.sceneInfra.scene.getObjectByName(
-          String(obj.id)
-        )
+        const foundObject = sketchChildGroups.get(String(obj.id))
         let constraintGroup: Group | null =
           foundObject instanceof Group ? foundObject : null
         if (!constraintGroup) {
@@ -598,7 +617,7 @@ export function updateSceneGraphFromDelta({
         }
         return
       }
-      let group = context.sceneInfra.scene.getObjectByName(String(obj.id))
+      let group = sketchChildGroups.get(String(obj.id))
       const ctor = buildSegmentCtorFromObject(obj, objects)
       const state = getSegmentRenderState(
         obj.id,
@@ -628,6 +647,7 @@ export function updateSceneGraphFromDelta({
           })
           newGroup.layers.set(SKETCH_LAYER)
           sketchSolveGroup.add(newGroup)
+          sketchChildGroups.set(newGroup.name, newGroup)
         }
         group = newGroup
       }
@@ -798,6 +818,9 @@ export function refreshSelectionStyling({ context }: SolveActionArgs) {
 
   const sketchSolveGroup =
     context.sceneInfra.scene.getObjectByName(SKETCH_SOLVE_GROUP)
+  const sketchChildGroups = indexSketchSolveChildGroups(
+    sketchSolveGroup instanceof Group ? sketchSolveGroup : undefined
+  )
   if (sketchSolveGroup instanceof Group) {
     updateOriginSprite(
       sketchSolveGroup,
@@ -812,9 +835,7 @@ export function refreshSelectionStyling({ context }: SolveActionArgs) {
       return
     }
     if (obj.kind.type === 'Constraint') {
-      const foundObject = context.sceneInfra.scene.getObjectByName(
-        String(obj.id)
-      )
+      const foundObject = sketchChildGroups.get(String(obj.id))
       let constraintGroup: Group | null =
         foundObject instanceof Group ? foundObject : null
       if (constraintGroup) {
@@ -830,7 +851,7 @@ export function refreshSelectionStyling({ context }: SolveActionArgs) {
         )
       }
     } else {
-      const group = context.sceneInfra.scene.getObjectByName(String(obj.id))
+      const group = sketchChildGroups.get(String(obj.id))
       if (!(group instanceof Group)) {
         return
       }
@@ -920,6 +941,7 @@ export function refreshSketchSolveScale(context: SketchSolveContext): void {
     ])
   )
   const draftEntityIds = context.draftEntities?.segmentIds
+  const sketchChildGroups = indexSketchSolveChildGroups(sketchSolveGroup)
 
   updateOriginSprite(
     sketchSolveGroup,
@@ -933,7 +955,7 @@ export function refreshSketchSolveScale(context: SketchSolveContext): void {
       return
     }
 
-    const group = sketchSolveGroup.getObjectByName(String(obj.id))
+    const group = sketchChildGroups.get(String(obj.id))
     if (!(group instanceof Group)) {
       return
     }

--- a/src/machines/sketchSolve/sketchSolveImpl.ts
+++ b/src/machines/sketchSolve/sketchSolveImpl.ts
@@ -55,6 +55,10 @@ import {
 } from '@src/machines/sketchSolve/constraints/invisibleConstraintSpriteUtils'
 import { updateOriginSprite } from '@src/machines/sketchSolve/originSprite'
 import { getCurrentSketchObjectsById } from '@src/machines/sketchSolve/sceneGraphUtils'
+import {
+  SKETCH_SOLVE_DRAG_BENCHMARK_MARKS,
+  markSketchSolveDragBenchmark,
+} from '@src/machines/sketchSolve/sketchSolveBenchmark'
 import { deriveSegmentFreedom } from '@src/machines/sketchSolve/segmentsUtils'
 import {
   getSketchSolveExecOutcomeIssues,
@@ -499,147 +503,153 @@ export function updateSceneGraphFromDelta({
   selectedIds,
   duringAreaSelectIds,
 }: IUpdateSketchSceneGraph): void {
-  const objects = sceneGraphDelta.new_graph.objects
-  const hasSolveErrors =
-    getSketchSolveExecOutcomeIssues(sceneGraphDelta).length > 0
-  const currentSketchObjects = getCurrentSketchObjectsById(
-    objects,
-    context.sketchId
+  markSketchSolveDragBenchmark(
+    SKETCH_SOLVE_DRAG_BENCHMARK_MARKS.updateSceneGraphStart
   )
-  const factor = getSketchSolveScaleFactor(context)
+  try {
+    const objects = sceneGraphDelta.new_graph.objects
+    const hasSolveErrors =
+      getSketchSolveExecOutcomeIssues(sceneGraphDelta).length > 0
+    const currentSketchObjects = getCurrentSketchObjectsById(
+      objects,
+      context.sketchId
+    )
+    const factor = getSketchSolveScaleFactor(context)
 
-  const sketchSolveGroup =
-    context.sceneInfra.scene.getObjectByName(SKETCH_SOLVE_GROUP)
+    const sketchSolveGroup =
+      context.sceneInfra.scene.getObjectByName(SKETCH_SOLVE_GROUP)
 
-  const hoveredSegmentIds = getHoveredSegmentIds(context.hoveredId, objects)
-  const hoveredObjectId = isObjectSelectionId(context.hoveredId)
-    ? context.hoveredId
-    : null
-  const draftEntityIds = context.draftEntities?.segmentIds
+    const hoveredSegmentIds = getHoveredSegmentIds(context.hoveredId, objects)
+    const hoveredObjectId = isObjectSelectionId(context.hoveredId)
+      ? context.hoveredId
+      : null
+    const draftEntityIds = context.draftEntities?.segmentIds
 
-  // If invalidates_ids is true, we need to delete everything and start fresh
-  // because the old IDs can't be trusted
-  if (sceneGraphDelta.invalidates_ids && sketchSolveGroup instanceof Group) {
-    resetSketchSolvePointHandleCount()
-    disposeGroupChildren(sketchSolveGroup)
-  } else {
-    // This invalidation logic is kinda based on some heuristics and is not exhaustive,
-    // so there are bugs, it's here to let some direct editing of the code from
-    // hackSetProgram in `src/editor/plugins/lsp/kcl/index.ts`.
-    // The proper way to do this is to get an invalidation signal from the rust side.
-    const invalidateScene = sketchSolveGroup?.children.some((child) => {
-      const childId = Number(child.name)
-      // check if number
-      if (Number.isNaN(childId)) {
-        return
-      }
-      // check id is not greater than new_graph.objects length
-      return childId >= sceneGraphDelta.new_graph.objects.length
-    })
-    if (invalidateScene && sketchSolveGroup instanceof Group) {
+    // If invalidates_ids is true, we need to delete everything and start fresh
+    // because the old IDs can't be trusted
+    if (sceneGraphDelta.invalidates_ids && sketchSolveGroup instanceof Group) {
       resetSketchSolvePointHandleCount()
       disposeGroupChildren(sketchSolveGroup)
+    } else {
+      // This invalidation logic is kinda based on some heuristics and is not exhaustive,
+      // so there are bugs, it's here to let some direct editing of the code from
+      // hackSetProgram in `src/editor/plugins/lsp/kcl/index.ts`.
+      // The proper way to do this is to get an invalidation signal from the rust side.
+      const invalidateScene = sketchSolveGroup?.children.some((child) => {
+        const childId = Number(child.name)
+        // check if number
+        if (Number.isNaN(childId)) {
+          return
+        }
+        // check id is not greater than new_graph.objects length
+        return childId >= sceneGraphDelta.new_graph.objects.length
+      })
+      if (invalidateScene && sketchSolveGroup instanceof Group) {
+        resetSketchSolvePointHandleCount()
+        disposeGroupChildren(sketchSolveGroup)
+      }
     }
-  }
 
-  if (sketchSolveGroup instanceof Group) {
-    updateOriginSprite(
-      sketchSolveGroup,
-      factor,
-      context.sceneInfra.theme,
-      getOriginSpriteState(context)
-    )
-  }
-
-  currentSketchObjects.forEach((obj) => {
-    // sketch is not a drawable object
-    if (obj.kind.type === 'Sketch') {
-      return
-    }
-
-    // Combine selectedIds and duringAreaSelectIds for highlighting
-    const allSelectedIds = Array.from(
-      new Set([...getObjectSelectionIds(selectedIds), ...duringAreaSelectIds])
-    )
-
-    // Render constraints
-    if (isConstraint(obj)) {
-      const foundObject = context.sceneInfra.scene.getObjectByName(
-        String(obj.id)
+    if (sketchSolveGroup instanceof Group) {
+      updateOriginSprite(
+        sketchSolveGroup,
+        factor,
+        context.sceneInfra.theme,
+        getOriginSpriteState(context)
       )
-      let constraintGroup: Group | null =
-        foundObject instanceof Group ? foundObject : null
-      if (!constraintGroup) {
-        constraintGroup = segmentUtilsMap.Constraint.init(obj)
-        if (constraintGroup) {
-          if (sketchSolveGroup) {
-            constraintGroup.traverse((child) => child.layers.set(SKETCH_LAYER))
-            constraintGroup.layers.set(SKETCH_LAYER)
-            sketchSolveGroup.add(constraintGroup)
+    }
+
+    currentSketchObjects.forEach((obj) => {
+      // Combine selectedIds and duringAreaSelectIds for highlighting
+      const allSelectedIds = Array.from(
+        new Set([...getObjectSelectionIds(selectedIds), ...duringAreaSelectIds])
+      )
+
+      // Render constraints
+      if (isConstraint(obj)) {
+        const foundObject = context.sceneInfra.scene.getObjectByName(
+          String(obj.id)
+        )
+        let constraintGroup: Group | null =
+          foundObject instanceof Group ? foundObject : null
+        if (!constraintGroup) {
+          constraintGroup = segmentUtilsMap.Constraint.init(obj)
+          if (constraintGroup) {
+            if (sketchSolveGroup) {
+              constraintGroup.traverse((child) =>
+                child.layers.set(SKETCH_LAYER)
+              )
+              constraintGroup.layers.set(SKETCH_LAYER)
+              sketchSolveGroup.add(constraintGroup)
+            }
           }
         }
-      }
-      if (constraintGroup) {
-        segmentUtilsMap.Constraint.update(
-          constraintGroup,
-          obj,
-          objects,
-          factor,
-          context.sceneInfra,
-          allSelectedIds,
-          hoveredObjectId,
-          getInvisibleConstraintDisplayState(context)
-        )
-      }
-      return
-    }
-    let group = context.sceneInfra.scene.getObjectByName(String(obj.id))
-    const ctor = buildSegmentCtorFromObject(obj, objects)
-    const state = getSegmentRenderState(
-      obj.id,
-      selectedIds,
-      duringAreaSelectIds,
-      context.hoveredId,
-      hoveredSegmentIds,
-      draftEntityIds,
-      objects
-    )
-    if (!(group instanceof Group)) {
-      if (!ctor) {
+        if (constraintGroup) {
+          segmentUtilsMap.Constraint.update(
+            constraintGroup,
+            obj,
+            objects,
+            factor,
+            context.sceneInfra,
+            allSelectedIds,
+            hoveredObjectId,
+            getInvisibleConstraintDisplayState(context)
+          )
+        }
         return
       }
-      const newGroup = initSegmentGroup({
+      let group = context.sceneInfra.scene.getObjectByName(String(obj.id))
+      const ctor = buildSegmentCtorFromObject(obj, objects)
+      const state = getSegmentRenderState(
+        obj.id,
+        selectedIds,
+        duringAreaSelectIds,
+        context.hoveredId,
+        hoveredSegmentIds,
+        draftEntityIds,
+        objects
+      )
+      if (!(group instanceof Group)) {
+        if (!ctor) {
+          return
+        }
+        const newGroup = initSegmentGroup({
+          input: ctor,
+          id: obj.id,
+          objects,
+        })
+        if (newGroup instanceof Error) {
+          console.error('Failed to init segment group for object', obj.id)
+          return
+        }
+        if (sketchSolveGroup) {
+          newGroup.traverse((child) => {
+            child.layers.set(SKETCH_LAYER)
+          })
+          newGroup.layers.set(SKETCH_LAYER)
+          sketchSolveGroup.add(newGroup)
+        }
+        group = newGroup
+      }
+      if (!(group instanceof Group) || !ctor) {
+        return
+      }
+
+      updateSegmentGroup({
+        group,
         input: ctor,
-        id: obj.id,
+        state,
+        scale: factor,
+        theme: context.sceneInfra.theme,
+        hasSolveErrors,
         objects,
       })
-      if (newGroup instanceof Error) {
-        console.error('Failed to init segment group for object', obj.id)
-        return
-      }
-      if (sketchSolveGroup) {
-        newGroup.traverse((child) => {
-          child.layers.set(SKETCH_LAYER)
-        })
-        newGroup.layers.set(SKETCH_LAYER)
-        sketchSolveGroup.add(newGroup)
-      }
-      group = newGroup
-    }
-    if (!(group instanceof Group) || !ctor) {
-      return
-    }
-
-    updateSegmentGroup({
-      group,
-      input: ctor,
-      state,
-      scale: factor,
-      theme: context.sceneInfra.theme,
-      hasSolveErrors,
-      objects,
     })
-  })
+  } finally {
+    markSketchSolveDragBenchmark(
+      SKETCH_SOLVE_DRAG_BENCHMARK_MARKS.updateSceneGraphEnd
+    )
+  }
 }
 
 function getLinkedPoint({
@@ -1063,98 +1073,123 @@ const debouncedEditorUpdate = deferredCallback(
 
 export function updateSketchOutcome({ event, context }: SolveAssignArgs) {
   assertEvent(event, 'update sketch outcome')
+  markSketchSolveDragBenchmark(
+    SKETCH_SOLVE_DRAG_BENCHMARK_MARKS.updateSketchOutcomeStart
+  )
+  try {
+    if (!event.data.sourceDelta) {
+      console.error(
+        'updateSketchOutcome: ERROR - No sourceDelta provided',
+        event.data
+      )
+      // eslint-disable-next-line suggest-no-throw/suggest-no-throw
+      throw new Error(
+        'updateSketchOutcome: event.data must contain sourceDelta'
+      )
+    }
 
-  if (!event.data.sourceDelta) {
-    console.error(
-      'updateSketchOutcome: ERROR - No sourceDelta provided',
-      event.data
+    const sketchSolveDiagnostics = compilationIssuesToDiagnostics(
+      getSketchSolveExecOutcomeIssues(event.data.sceneGraphDelta),
+      event.data.sourceDelta.text
     )
-    // eslint-disable-next-line suggest-no-throw/suggest-no-throw
-    throw new Error('updateSketchOutcome: event.data must contain sourceDelta')
-  }
+    context.kclManager.setSketchSolveDiagnostics(sketchSolveDiagnostics)
+    toastSketchSolveExecOutcomeErrors(
+      event.data.sceneGraphDelta,
+      'Sketch solver failed to find a solution'
+    )
 
-  const sketchSolveDiagnostics = compilationIssuesToDiagnostics(
-    getSketchSolveExecOutcomeIssues(event.data.sceneGraphDelta),
-    event.data.sourceDelta.text
-  )
-  context.kclManager.setSketchSolveDiagnostics(sketchSolveDiagnostics)
-  toastSketchSolveExecOutcomeErrors(
-    event.data.sceneGraphDelta,
-    'Sketch solver failed to find a solution'
-  )
-
-  // If the incoming KCL differs from the current editor doc, apply the scene
-  // immediately for responsiveness, but keep that scene-only dispatch out of
-  // history. Checkpoint-backed undo is the only restore mechanism for
-  // committed sketch edits.
-  const additionalSpec = {
-    sketchCheckpointId: event.data.checkpointId,
-    effects: [
-      updateSketchSceneGraphEffect.of({
-        sceneGraphDelta: event.data.sceneGraphDelta,
-        context,
-        selectedIds: context.selectedIds,
-        duringAreaSelectIds: context.duringAreaSelectIds,
-      }),
-    ],
-  }
-
-  const shouldWriteToDisk = event.data.writeToDisk !== false
-  const shouldAddToHistory = event.data.addToHistory ?? shouldWriteToDisk
-  const shouldDispatchSceneImmediately =
-    context.kclManager.code !== event.data.sourceDelta.text
-
-  if (shouldDispatchSceneImmediately) {
+    // Update scene immediately - no delay, no flicker
+    // This is wired through a CodeMirror StateEffect so that
+    // an extension (in @src/editor/plugins/sketch.ts) can apply its
+    // effects while undoing as well.
     context.kclManager.dispatch({
-      annotations: Transaction.addToHistory.of(false),
-      effects: additionalSpec.effects,
+      effects: [
+        updateSketchSceneGraphEffect.of({
+          sceneGraphDelta: event.data.sceneGraphDelta,
+          context,
+          selectedIds: context.selectedIds,
+          duringAreaSelectIds: context.duringAreaSelectIds,
+        }),
+      ],
     })
-  }
 
-  // Strip scene effects from the follow-up editor update when we already
-  // dispatched them above. This avoids double-applying the same scene delta
-  // and creating extra scene-only history entries.
-  const editorAdditionalSpec = shouldDispatchSceneImmediately
-    ? {
-        ...additionalSpec,
-        effects: [] as StateEffect<unknown>[],
-      }
-    : additionalSpec
+    // If the incoming KCL differs from the current editor doc, apply the scene
+    // immediately for responsiveness, but keep that scene-only dispatch out of
+    // history. Checkpoint-backed undo is the only restore mechanism for
+    // committed sketch edits.
+    const additionalSpec = {
+      sketchCheckpointId: event.data.checkpointId,
+      effects: [
+        updateSketchSceneGraphEffect.of({
+          sceneGraphDelta: event.data.sceneGraphDelta,
+          context,
+          selectedIds: context.selectedIds,
+          duringAreaSelectIds: context.duringAreaSelectIds,
+        }),
+      ],
+    }
 
-  // Update editor - debounce only if explicitly requested (e.g., for single-click that might be double-click)
-  // This allows frequent updates (dragging handles) to be immediate, while others can be debounce
-  // a good example of this is When a user double clicks with the line tool, we want to end the chaining and so
-  // - First click still adds the new segment and coincident constraint
-  // - Followed closely by the second click making it a double click, in which case we want to delete the recently added segments, but don't want flicker in the editor
-  if (event.data.debounceEditorUpdate) {
-    // Debounce editor update - this can be cancelled if a double-click is detected
-    // by calling the debounced function again with new text before the delay expires
-    // If a new update comes in within 200ms, the previous one is cancelled
-    debouncedEditorUpdate({
-      text: event.data.sourceDelta.text,
-      kclManager: context.kclManager,
-      shouldWriteToDisk,
-      shouldAddToHistory,
-      spec: editorAdditionalSpec,
-    })
-  } else {
-    // Update editor immediately - no debounce for frequent updates like onMove
-    context.kclManager.updateCodeEditor(
-      event.data.sourceDelta.text,
-      {
-        shouldExecute: false,
+    const shouldWriteToDisk = event.data.writeToDisk !== false
+    const shouldAddToHistory = event.data.addToHistory ?? shouldWriteToDisk
+    const shouldDispatchSceneImmediately =
+      context.kclManager.code !== event.data.sourceDelta.text
+
+    if (shouldDispatchSceneImmediately) {
+      context.kclManager.dispatch({
+        annotations: Transaction.addToHistory.of(false),
+        effects: additionalSpec.effects,
+      })
+    }
+
+    // Strip scene effects from the follow-up editor update when we already
+    // dispatched them above. This avoids double-applying the same scene delta
+    // and creating extra scene-only history entries.
+    const editorAdditionalSpec = shouldDispatchSceneImmediately
+      ? {
+          ...additionalSpec,
+          effects: [] as StateEffect<unknown>[],
+        }
+      : additionalSpec
+
+    // Update editor - debounce only if explicitly requested (e.g., for single-click that might be double-click)
+    // This allows frequent updates (dragging handles) to be immediate, while others can be debounce
+    // a good example of this is When a user double clicks with the line tool, we want to end the chaining and so
+    // - First click still adds the new segment and coincident constraint
+    // - Followed closely by the second click making it a double click, in which case we want to delete the recently added segments, but don't want flicker in the editor
+    if (event.data.debounceEditorUpdate) {
+      // Debounce editor update - this can be cancelled if a double-click is detected
+      // by calling the debounced function again with new text before the delay expires
+      // If a new update comes in within 200ms, the previous one is cancelled
+      debouncedEditorUpdate({
+        text: event.data.sourceDelta.text,
+        kclManager: context.kclManager,
         shouldWriteToDisk,
         shouldAddToHistory,
-      },
-      editorAdditionalSpec
-    )
-  }
+        spec: editorAdditionalSpec,
+      })
+    } else {
+      // Update editor immediately - no debounce for frequent updates like onMove
+      context.kclManager.updateCodeEditor(
+        event.data.sourceDelta.text,
+        {
+          shouldExecute: false,
+          shouldWriteToDisk,
+          shouldAddToHistory,
+        },
+        editorAdditionalSpec
+      )
+    }
 
-  return {
-    sketchExecOutcome: {
-      sourceDelta: event.data.sourceDelta,
-      sceneGraphDelta: event.data.sceneGraphDelta,
-    },
+    return {
+      sketchExecOutcome: {
+        sourceDelta: event.data.sourceDelta,
+        sceneGraphDelta: event.data.sceneGraphDelta,
+      },
+    }
+  } finally {
+    markSketchSolveDragBenchmark(
+      SKETCH_SOLVE_DRAG_BENCHMARK_MARKS.updateSketchOutcomeEnd
+    )
   }
 }
 

--- a/src/machines/sketchSolve/tools/moveTool/moveTool.ts
+++ b/src/machines/sketchSolve/tools/moveTool/moveTool.ts
@@ -57,6 +57,10 @@ import {
 import { updateSnappingPreviewSprite } from '@src/machines/sketchSolve/snappingPreviewSprite'
 import type { ConstraintSegment } from '@src/machines/sketchSolve/types'
 import {
+  SKETCH_SOLVE_DRAG_BENCHMARK_MARKS,
+  markSketchSolveDragBenchmark,
+} from '@src/machines/sketchSolve/sketchSolveBenchmark'
+import {
   type SelectionBoxVisualState,
   findContainedSegments,
   findIntersectingSegments,
@@ -834,6 +838,9 @@ export function createOnDragCallback({
       const settings = await getJsAppSettings()
       // Get sketchId from context data (needed for editSegments)
       const sketchId = getContextData().sketchId
+      markSketchSolveDragBenchmark(
+        SKETCH_SOLVE_DRAG_BENCHMARK_MARKS.editSegmentsStart
+      )
       const result = await editSegments(
         0,
         sketchId,
@@ -844,6 +851,9 @@ export function createOnDragCallback({
         toastSketchSolveError(err)
         return null
       })
+      markSketchSolveDragBenchmark(
+        SKETCH_SOLVE_DRAG_BENCHMARK_MARKS.editSegmentsEnd
+      )
 
       // After successful drag, update the lastSuccessfulDragFromPoint
       // This ensures the next drag calculates from the correct starting point
@@ -853,6 +863,9 @@ export function createOnDragCallback({
       if (result) {
         onNewSketchOutcome({ ...result, writeToDisk: false })
         await new Promise((resolve) => requestAnimationFrame(resolve))
+        markSketchSolveDragBenchmark(
+          SKETCH_SOLVE_DRAG_BENCHMARK_MARKS.animationFrameEnd
+        )
       }
     } finally {
       setIsSolveInProgress(false)


### PR DESCRIPTION
You can use `npm run benchmark:sketch-solve-drag` to run this benchmark. It makes a bunch of straight line segments in a sketch block, then benches dragging the mouse.

commit 0 adds this benchmark:
```json
{
  "rust": {
    "minMs": 76.1,
    "medianMs": 94.9,
    "p95Ms": 108.7,
    "maxMs": 114.1
  },
  "scene": {
    "minMs": 38.1,
    "medianMs": 49.2,
    "p95Ms": 71.2,
    "maxMs": 71.7
  },
  "apply": {
    "minMs": 54.1,
    "medianMs": 87.8,
    "p95Ms": 110.1,
    "maxMs": 110.4
  },
  "total": {
    "minMs": 237.8,
    "medianMs": 301.7,
    "p95Ms": 331.6,
    "maxMs": 333
  }
}
```

commit 1 improves it:

```
{
  "rust": {
    "minMs": 73.7,
    "medianMs": 87.3,
    "p95Ms": 96.5,
    "maxMs": 98.8
  },
  "scene": {
    "minMs": 2,
    "medianMs": 3.5,
    "p95Ms": 9.4,
    "maxMs": 14
  },
  "apply": {
    "minMs": 17.2,
    "medianMs": 26.9,
    "p95Ms": 36.3,
    "maxMs": 37.5
  },
  "total": {
    "minMs": 162.6,
    "medianMs": 226,
    "p95Ms": 256.6,
    "maxMs": 276.7
  }
}
```