### PR TITLE
Update Center Rectangle tool to have center point, construction lines

### DIFF
--- a/src/machines/sketchSolve/tools/rectTool.spec.ts
+++ b/src/machines/sketchSolve/tools/rectTool.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createActor, waitFor, fromPromise } from 'xstate'
 import { machine } from '@src/machines/sketchSolve/tools/rectTool'
 import type { RectDraftIds } from '@src/machines/sketchSolve/tools/rectUtils'
@@ -12,6 +12,19 @@ import {
   createMockRustContext,
   createMockKclManager,
 } from '@src/machines/sketchSolve/tools/sketchToolTestUtils'
+import {
+  clearToolSnappingState,
+  getBestSnappingCandidate,
+  sendHoveredSnappingCandidate,
+  updateToolSnappingPreview,
+} from '@src/machines/sketchSolve/tools/toolSnappingUtils'
+
+vi.mock('@src/machines/sketchSolve/tools/toolSnappingUtils', () => ({
+  clearToolSnappingState: vi.fn(),
+  getBestSnappingCandidate: vi.fn(() => null),
+  sendHoveredSnappingCandidate: vi.fn(),
+  updateToolSnappingPreview: vi.fn(),
+}))
 
 function createTestMachine(mockActors?: {
   modAndSolveFirstClick?: (input: unknown) => Promise<
@@ -40,6 +53,7 @@ function createTestMachine(mockActors?: {
               lineIds: [1, 2, 3, 4],
               segmentIds: [1, 2, 3, 4],
               constraintIds: [10],
+              originPointId: 1,
             },
           }))
       ),
@@ -56,6 +70,11 @@ function createTestMachine(mockActors?: {
 }
 
 describe('rectTool - XState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getBestSnappingCandidate).mockReturnValue(null)
+  })
+
   describe('when initialized', () => {
     it('should have default context values', () => {
       const { machine, sceneInfra, rustContext, kclManager } =
@@ -112,6 +131,84 @@ describe('rectTool - XState', () => {
   })
 
   describe('adding points', () => {
+    it('should use snapped coordinates for the first click', async () => {
+      vi.mocked(getBestSnappingCandidate).mockReturnValue({
+        position: [10, 20],
+        target: { type: 'origin' },
+        distance: 0,
+      })
+
+      const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
+        createTestMachine()
+      const actor = createActor(machine, {
+        input: {
+          sceneInfra,
+          rustContext,
+          kclManager,
+          sketchId: 0,
+        },
+      }).start()
+
+      const callbacks = setCallbacksMock.mock.calls.at(-1)?.[0]
+      callbacks?.onClick?.({
+        mouseEvent: { which: 1 },
+        intersectionPoint: { twoD: { x: 1, y: 2 } },
+      })
+
+      await waitFor(actor, (state) => state.matches('awaiting second point'))
+      expect(actor.getSnapshot().context.origin).toEqual([10, 20])
+
+      actor.stop()
+    })
+
+    it('should pass the first click snap target into rectangle creation', async () => {
+      const modAndSolveFirstClick = vi.fn(async () => ({
+        kclSource: { text: 'test' } as SourceDelta,
+        sceneGraphDelta: createSceneGraphDelta([], []),
+        draft: {
+          lineIds: [1, 2, 3, 4] as [number, number, number, number],
+          segmentIds: [1, 2, 3, 4],
+          constraintIds: [10],
+          originPointId: 1,
+        },
+      }))
+      vi.mocked(getBestSnappingCandidate).mockReturnValue({
+        position: [10, 20],
+        target: { type: 'origin' },
+        distance: 0,
+      })
+
+      const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
+        createTestMachine({
+          modAndSolveFirstClick,
+        })
+      const actor = createActor(machine, {
+        input: {
+          sceneInfra,
+          rustContext,
+          kclManager,
+          sketchId: 0,
+        },
+      }).start()
+
+      const callbacks = setCallbacksMock.mock.calls.at(-1)?.[0]
+      callbacks?.onClick?.({
+        mouseEvent: { which: 1 },
+        intersectionPoint: { twoD: { x: 1, y: 2 } },
+      })
+
+      await waitFor(actor, (state) => state.matches('awaiting second point'))
+      expect(modAndSolveFirstClick).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({
+            snapTarget: { type: 'origin' },
+          }),
+        })
+      )
+
+      actor.stop()
+    })
+
     it('should transition to awaiting second point after first click', async () => {
       const { machine, sceneInfra, rustContext, kclManager } =
         createTestMachine()
@@ -150,6 +247,40 @@ describe('rectTool - XState', () => {
       actor.send({ type: 'set second point', data: [3, 4] })
       await waitFor(actor, (state) => state.matches('awaiting third point'))
       expect(actor.getSnapshot().context.secondPoint).toEqual([3, 4])
+
+      actor.stop()
+    })
+
+    it('should use snapped coordinates for the angled second click', async () => {
+      vi.mocked(getBestSnappingCandidate).mockReturnValue({
+        position: [30, 40],
+        target: { type: 'origin' },
+        distance: 0,
+      })
+
+      const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
+        createTestMachine()
+      const actor = createActor(machine, {
+        input: {
+          sceneInfra,
+          rustContext,
+          kclManager,
+          sketchId: 0,
+          toolVariant: 'angled',
+        },
+      }).start()
+
+      actor.send({ type: 'add point', data: [1, 2] })
+      await waitFor(actor, (state) => state.matches('awaiting second point'))
+
+      const callbacks = setCallbacksMock.mock.calls.at(-1)?.[0]
+      callbacks?.onClick?.({
+        mouseEvent: { which: 1 },
+        intersectionPoint: { twoD: { x: 3, y: 4 } },
+      })
+
+      await waitFor(actor, (state) => state.matches('awaiting third point'))
+      expect(actor.getSnapshot().context.secondPoint).toEqual([30, 40])
 
       actor.stop()
     })
@@ -291,6 +422,68 @@ describe('rectTool - XState', () => {
       expect(context.origin).toEqual([0, 0])
       expect(context.secondPoint).toBeUndefined()
       expect(context.draft).toBeUndefined()
+      actor.stop()
+    })
+  })
+
+  describe('snapping preview', () => {
+    it('updates snapping preview on pointer move in the first-point state', () => {
+      const snappingCandidate = {
+        position: [5, 6] as [number, number],
+        target: { type: 'origin' as const },
+        distance: 0,
+      }
+      vi.mocked(getBestSnappingCandidate).mockReturnValue(snappingCandidate)
+
+      const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
+        createTestMachine()
+      const actor = createActor(machine, {
+        input: {
+          sceneInfra,
+          rustContext,
+          kclManager,
+          sketchId: 0,
+        },
+      }).start()
+
+      const callbacks = setCallbacksMock.mock.calls.at(-1)?.[0]
+      callbacks?.onMove?.({
+        mouseEvent: { shiftKey: false },
+        intersectionPoint: { twoD: { x: 1, y: 2 } },
+      })
+
+      expect(sendHoveredSnappingCandidate).toHaveBeenCalledWith(
+        expect.anything(),
+        snappingCandidate
+      )
+      expect(updateToolSnappingPreview).toHaveBeenCalledWith({
+        sceneInfra,
+        target: snappingCandidate,
+      })
+
+      actor.stop()
+    })
+
+    it('clears snapping preview when pointer leaves the sketch plane', () => {
+      const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
+        createTestMachine()
+      const actor = createActor(machine, {
+        input: {
+          sceneInfra,
+          rustContext,
+          kclManager,
+          sketchId: 0,
+        },
+      }).start()
+
+      const callbacks = setCallbacksMock.mock.calls.at(-1)?.[0]
+      callbacks?.onMove?.(undefined)
+
+      expect(clearToolSnappingState).toHaveBeenCalledWith({
+        self: expect.anything(),
+        sceneInfra,
+      })
+
       actor.stop()
     })
   })

--- a/src/machines/sketchSolve/tools/rectTool.ts
+++ b/src/machines/sketchSolve/tools/rectTool.ts
@@ -1,4 +1,5 @@
 import type {
+  ApiObject,
   SceneGraphDelta,
   SourceDelta,
 } from '@rust/kcl-lib/bindings/FrontendApi'
@@ -19,12 +20,20 @@ import { assertEvent, assign, createMachine, fromPromise, setup } from 'xstate'
 
 import type { Coords2d } from '@src/lang/util'
 import { pointsAreEqual } from '@src/lib/utils2d'
+import { isPointSegment } from '@src/machines/sketchSolve/constraints/constraintUtils'
+import type { SnapTarget } from '@src/machines/sketchSolve/snapping'
 import type { RectDraftIds } from '@src/machines/sketchSolve/tools/rectUtils'
 import {
   createDraftRectangle,
   updateDraftRectangleAligned,
   updateDraftRectangleAngled,
 } from '@src/machines/sketchSolve/tools/rectUtils'
+import {
+  clearToolSnappingState,
+  getBestSnappingCandidate,
+  sendHoveredSnappingCandidate,
+  updateToolSnappingPreview,
+} from '@src/machines/sketchSolve/tools/toolSnappingUtils'
 
 export const RECTANGLE_TOOL_ID = 'Rectangle tool'
 export const ADDING_FIRST_POINT = `xstate.done.actor.0.${RECTANGLE_TOOL_ID}.adding first point`
@@ -53,6 +62,7 @@ type RectToolContext = {
   firstPointId?: number
   draft?: RectDraftIds
   origin: Coords2d
+  originSnapTarget?: SnapTarget
   secondPoint?: Coords2d
   rectOriginMode: RectOriginMode
 }
@@ -63,6 +73,19 @@ type RectToolAssignArgs<TActor extends ProvidedActor = any> = AssignArgs<
   RectToolEvent,
   TActor
 >
+
+function getRectSnappingExcludedPointIds(
+  currentSketchObjects: Array<ApiObject | undefined | null>,
+  draft?: RectDraftIds
+): number[] {
+  if (!draft) {
+    return []
+  }
+
+  return draft.segmentIds.filter((id) =>
+    isPointSegment(currentSketchObjects[id])
+  )
+}
 
 export const machine = setup({
   types: {
@@ -77,15 +100,47 @@ export const machine = setup({
   actions: {
     'add first point listener': ({ self, context }) => {
       context.sceneInfra.setCallbacks({
-        onMove: () => {},
+        onMove: (args) => {
+          const twoD = args?.intersectionPoint?.twoD
+          if (!twoD) {
+            clearToolSnappingState({
+              self,
+              sceneInfra: context.sceneInfra,
+            })
+            return
+          }
+
+          const snappingCandidate = getBestSnappingCandidate({
+            self,
+            sceneInfra: context.sceneInfra,
+            sketchId: context.sketchId,
+            mousePosition: [twoD.x, twoD.y],
+            mouseEvent: args.mouseEvent,
+          })
+          sendHoveredSnappingCandidate(self, snappingCandidate)
+          updateToolSnappingPreview({
+            sceneInfra: context.sceneInfra,
+            target: snappingCandidate,
+          })
+        },
         onClick: (args) => {
           if (!args) return
           if (args.mouseEvent.which !== 1) return
           const twoD = args.intersectionPoint?.twoD
           if (!twoD) return
+          const mousePosition: Coords2d = [twoD.x, twoD.y]
+          const snappingCandidate = getBestSnappingCandidate({
+            self,
+            sceneInfra: context.sceneInfra,
+            sketchId: context.sketchId,
+            mousePosition,
+            mouseEvent: args.mouseEvent,
+          })
+          const [x, y] = snappingCandidate?.position ?? mousePosition
           self.send({
             type: 'add point',
-            data: [twoD.x, twoD.y],
+            data: [x, y],
+            snapTarget: snappingCandidate?.target,
           })
         },
       })
@@ -96,7 +151,33 @@ export const machine = setup({
         onMove: async (args) => {
           if (!args || !context.draft) return
           const twoD = args.intersectionPoint?.twoD
-          if (twoD && !isEditInProgress) {
+          if (!twoD) {
+            clearToolSnappingState({
+              self,
+              sceneInfra: context.sceneInfra,
+            })
+            return
+          }
+
+          const snappingCandidate = getBestSnappingCandidate({
+            self,
+            sceneInfra: context.sceneInfra,
+            sketchId: context.sketchId,
+            mousePosition: [twoD.x, twoD.y],
+            mouseEvent: args.mouseEvent,
+            getExcludedPointIds: (currentSketchObjects) =>
+              getRectSnappingExcludedPointIds(
+                currentSketchObjects,
+                context.draft
+              ),
+          })
+          sendHoveredSnappingCandidate(self, snappingCandidate)
+          updateToolSnappingPreview({
+            sceneInfra: context.sceneInfra,
+            target: snappingCandidate,
+          })
+
+          if (!isEditInProgress) {
             try {
               isEditInProgress = true
 
@@ -166,13 +247,27 @@ export const machine = setup({
         onClick: (args) => {
           if (!args) return
           if (args.mouseEvent.which !== 1) return
+          const twoD = args.intersectionPoint?.twoD
+          if (!twoD) return
+          const mousePosition: Coords2d = [twoD.x, twoD.y]
+          const snappingCandidate = getBestSnappingCandidate({
+            self,
+            sceneInfra: context.sceneInfra,
+            sketchId: context.sketchId,
+            mousePosition,
+            mouseEvent: args.mouseEvent,
+            getExcludedPointIds: (currentSketchObjects) =>
+              getRectSnappingExcludedPointIds(
+                currentSketchObjects,
+                context.draft
+              ),
+          })
+          const [x, y] = snappingCandidate?.position ?? mousePosition
 
           if (context.rectOriginMode === 'angled') {
-            const twoD = args.intersectionPoint?.twoD
-            if (!twoD) return
             self.send({
               type: 'set second point',
-              data: [twoD.x, twoD.y],
+              data: [x, y],
             })
           } else {
             self.send({
@@ -188,7 +283,33 @@ export const machine = setup({
         onMove: async (args) => {
           if (!args || !context.draft || !context.secondPoint) return
           const twoD = args.intersectionPoint?.twoD
-          if (twoD && !isEditInProgress) {
+          if (!twoD) {
+            clearToolSnappingState({
+              self,
+              sceneInfra: context.sceneInfra,
+            })
+            return
+          }
+
+          const snappingCandidate = getBestSnappingCandidate({
+            self,
+            sceneInfra: context.sceneInfra,
+            sketchId: context.sketchId,
+            mousePosition: [twoD.x, twoD.y],
+            mouseEvent: args.mouseEvent,
+            getExcludedPointIds: (currentSketchObjects) =>
+              getRectSnappingExcludedPointIds(
+                currentSketchObjects,
+                context.draft
+              ),
+          })
+          sendHoveredSnappingCandidate(self, snappingCandidate)
+          updateToolSnappingPreview({
+            sceneInfra: context.sceneInfra,
+            target: snappingCandidate,
+          })
+
+          if (!isEditInProgress) {
             try {
               isEditInProgress = true
               const result = await updateDraftRectangleAngled({
@@ -224,9 +345,23 @@ export const machine = setup({
           if (args.mouseEvent.which !== 1) return
           const twoD = args.intersectionPoint?.twoD
           if (!twoD) return
+          const mousePosition: Coords2d = [twoD.x, twoD.y]
+          const snappingCandidate = getBestSnappingCandidate({
+            self,
+            sceneInfra: context.sceneInfra,
+            sketchId: context.sketchId,
+            mousePosition,
+            mouseEvent: args.mouseEvent,
+            getExcludedPointIds: (currentSketchObjects) =>
+              getRectSnappingExcludedPointIds(
+                currentSketchObjects,
+                context.draft
+              ),
+          })
+          const [x, y] = snappingCandidate?.position ?? mousePosition
           if (
             context.secondPoint &&
-            pointsAreEqual(context.secondPoint, [twoD.x, twoD.y])
+            pointsAreEqual(context.secondPoint, [x, y])
           ) {
             return
           }
@@ -262,7 +397,11 @@ export const machine = setup({
       }
       self._parent?.send(sendData)
     },
-    'remove point listener': ({ context }) => {
+    'remove point listener': ({ context, self }) => {
+      clearToolSnappingState({
+        self,
+        sceneInfra: context.sceneInfra,
+      })
       context.sceneInfra.setCallbacks({
         onClick: () => {},
         onMove: () => {},
@@ -298,10 +437,17 @@ export const machine = setup({
           kclManager: KclManager
           sketchId: number
           origin: [number, number]
+          snapTarget?: SnapTarget
           rectOriginMode: RectOriginMode
         }
       }) => {
-        const { rustContext, kclManager, sketchId, rectOriginMode } = input
+        const {
+          rustContext,
+          kclManager,
+          sketchId,
+          rectOriginMode,
+          snapTarget,
+        } = input
 
         try {
           const result = await createDraftRectangle({
@@ -309,6 +455,8 @@ export const machine = setup({
             kclManager,
             sketchId,
             mode: rectOriginMode,
+            origin: input.origin,
+            snapTarget,
           })
 
           return result
@@ -331,6 +479,7 @@ export const machine = setup({
     kclManager: input.kclManager,
     sketchId: input.sketchId,
     origin: [0, 0],
+    originSnapTarget: undefined,
     rectOriginMode: (input.toolVariant ?? 'corner') as RectOriginMode,
   }),
   id: RECTANGLE_TOOL_ID,
@@ -356,6 +505,7 @@ export const machine = setup({
           actions: assign(({ event }) => {
             return {
               origin: event.data,
+              originSnapTarget: event.snapTarget,
             }
           }),
           target: 'adding first point',
@@ -370,6 +520,7 @@ export const machine = setup({
           return {
             pointData: event.data,
             origin: context.origin,
+            snapTarget: context.originSnapTarget,
             rectOriginMode: context.rectOriginMode,
             rustContext: context.rustContext,
             kclManager: context.kclManager,
@@ -409,6 +560,7 @@ export const machine = setup({
             },
             assign({
               origin: [0, 0],
+              originSnapTarget: undefined,
               secondPoint: undefined,
               draft: undefined,
             }),
@@ -449,6 +601,7 @@ export const machine = setup({
             },
             assign({
               origin: [0, 0],
+              originSnapTarget: undefined,
               secondPoint: undefined,
               draft: undefined,
             }),
@@ -473,6 +626,7 @@ export const machine = setup({
         target: 'awaiting first point',
         actions: assign({
           origin: [0, 0],
+          originSnapTarget: undefined,
           secondPoint: undefined,
           draft: undefined,
         }),

--- a/src/machines/sketchSolve/tools/rectUtils.spec.ts
+++ b/src/machines/sketchSolve/tools/rectUtils.spec.ts
@@ -1,6 +1,72 @@
-import { describe, expect, it } from 'vitest'
+import type {
+  ApiConstraint,
+  ApiObject,
+  SceneGraphDelta,
+  SourceDelta,
+} from '@rust/kcl-lib/bindings/FrontendApi'
+import { describe, expect, it, vi } from 'vitest'
 
-import { getAngledRectangleCorners } from '@src/machines/sketchSolve/tools/rectUtils'
+import {
+  createDraftRectangle,
+  getAngledRectangleCorners,
+  updateDraftRectangleAligned,
+} from '@src/machines/sketchSolve/tools/rectUtils'
+import {
+  createLineApiObject,
+  createMockKclManager,
+  createMockRustContext,
+  createPointApiObject,
+  createSceneGraphDelta,
+} from '@src/machines/sketchSolve/tools/sketchToolTestUtils'
+
+function createConstraintApiObject(
+  id: number,
+  constraint: ApiConstraint
+): ApiObject {
+  return {
+    id,
+    kind: {
+      type: 'Constraint',
+      constraint,
+    },
+    label: '',
+    comments: '',
+    artifact_id: '0',
+    source: { type: 'Simple', range: [0, 0, 0] },
+  } as ApiObject
+}
+
+function createLineSceneGraphDelta(
+  lineId: number,
+  startPointId: number,
+  endPointId: number
+): SceneGraphDelta {
+  return createSceneGraphDelta(
+    [
+      createPointApiObject({ id: startPointId }),
+      createPointApiObject({ id: endPointId }),
+      createLineApiObject({ id: lineId, start: startPointId, end: endPointId }),
+    ],
+    [startPointId, endPointId, lineId]
+  )
+}
+
+function createPointSceneGraphDelta(pointId: number): SceneGraphDelta {
+  return createSceneGraphDelta(
+    [createPointApiObject({ id: pointId })],
+    [pointId]
+  )
+}
+
+function createConstraintSceneGraphDelta(
+  constraintId: number,
+  constraint: ApiConstraint
+): SceneGraphDelta {
+  return createSceneGraphDelta(
+    [createConstraintApiObject(constraintId, constraint)],
+    [constraintId]
+  )
+}
 
 describe('rectUtils.getAngledRectangleCorners', () => {
   it('builds a rectangle from a horizontal first side and perpendicular third point', () => {
@@ -28,5 +94,297 @@ describe('rectUtils.getAngledRectangleCorners', () => {
     expect(corners.start3).toEqual([4, 2])
     expect(corners.start4[0]).toBeCloseTo(2)
     expect(corners.start4[1]).toBeCloseTo(0)
+  })
+})
+
+describe('rectUtils.createDraftRectangle', () => {
+  it('adds center rectangle construction geometry and constraints in center mode', async () => {
+    const rustContext = createMockRustContext()
+    const kclManager = createMockKclManager()
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const addSegmentMock = vi.mocked(rustContext.addSegment)
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const addConstraintMock = vi.mocked(rustContext.addConstraint)
+
+    addSegmentMock
+      .mockResolvedValueOnce({
+        kclSource: { text: 'center-point' } as SourceDelta,
+        sceneGraphDelta: createPointSceneGraphDelta(100),
+      })
+      .mockResolvedValueOnce({
+        kclSource: { text: 'line-1' } as SourceDelta,
+        sceneGraphDelta: createLineSceneGraphDelta(1, 11, 12),
+      })
+      .mockResolvedValueOnce({
+        kclSource: { text: 'line-2' } as SourceDelta,
+        sceneGraphDelta: createLineSceneGraphDelta(2, 13, 14),
+      })
+      .mockResolvedValueOnce({
+        kclSource: { text: 'line-3' } as SourceDelta,
+        sceneGraphDelta: createLineSceneGraphDelta(3, 15, 16),
+      })
+      .mockResolvedValueOnce({
+        kclSource: { text: 'line-4' } as SourceDelta,
+        sceneGraphDelta: createLineSceneGraphDelta(4, 17, 18),
+      })
+      .mockResolvedValueOnce({
+        kclSource: { text: 'diag-1' } as SourceDelta,
+        sceneGraphDelta: createLineSceneGraphDelta(5, 19, 20),
+      })
+      .mockResolvedValueOnce({
+        kclSource: { text: 'diag-2' } as SourceDelta,
+        sceneGraphDelta: createLineSceneGraphDelta(6, 21, 22),
+      })
+
+    const constraintTypes: ApiConstraint[] = [
+      { type: 'Coincident', segments: [12, 13] },
+      { type: 'Coincident', segments: [14, 15] },
+      { type: 'Coincident', segments: [16, 17] },
+      { type: 'Coincident', segments: [18, 11] },
+      { type: 'Parallel', lines: [2, 4] },
+      { type: 'Parallel', lines: [3, 1] },
+      { type: 'Perpendicular', lines: [1, 2] },
+      { type: 'Horizontal', line: 3 },
+      { type: 'Coincident', segments: [19, 11] },
+      { type: 'Coincident', segments: [20, 14] },
+      { type: 'Coincident', segments: [21, 12] },
+      { type: 'Coincident', segments: [22, 17] },
+      { type: 'Coincident', segments: [100, 5] },
+      { type: 'Coincident', segments: [100, 6] },
+      { type: 'LinesEqualLength', lines: [5, 6] },
+    ]
+
+    let constraintIndex = 0
+    addConstraintMock.mockImplementation(
+      async (_version, _sketchId, constraint) => {
+        const index = constraintIndex
+        constraintIndex += 1
+        return {
+          kclSource: { text: `constraint-${index}` } as SourceDelta,
+          sceneGraphDelta: createConstraintSceneGraphDelta(
+            200 + index,
+            constraintTypes[index] ?? constraint
+          ),
+        }
+      }
+    )
+
+    const result = await createDraftRectangle({
+      rustContext,
+      kclManager,
+      sketchId: 7,
+      mode: 'center',
+      origin: [12, 8],
+    })
+
+    expect(addSegmentMock).toHaveBeenCalledTimes(7)
+    expect(addConstraintMock).toHaveBeenCalledTimes(15)
+
+    expect(addSegmentMock.mock.calls[0]?.[2]).toEqual({
+      type: 'Point',
+      position: {
+        x: { type: 'Var', value: 12, units: 'Mm' },
+        y: { type: 'Var', value: 8, units: 'Mm' },
+      },
+    })
+
+    expect(addSegmentMock.mock.calls[1]?.[2]).toEqual({
+      type: 'Line',
+      start: {
+        x: { type: 'Var', value: 7, units: 'Mm' },
+        y: { type: 'Var', value: 3, units: 'Mm' },
+      },
+      end: {
+        x: { type: 'Var', value: 17, units: 'Mm' },
+        y: { type: 'Var', value: 3, units: 'Mm' },
+      },
+    })
+
+    expect(addSegmentMock.mock.calls[5]?.[2]).toEqual({
+      type: 'Line',
+      start: {
+        x: { type: 'Var', value: 7, units: 'Mm' },
+        y: { type: 'Var', value: 3, units: 'Mm' },
+      },
+      end: {
+        x: { type: 'Var', value: 17, units: 'Mm' },
+        y: { type: 'Var', value: 13, units: 'Mm' },
+      },
+      construction: true,
+    })
+
+    expect(addSegmentMock.mock.calls[6]?.[2]).toEqual({
+      type: 'Line',
+      start: {
+        x: { type: 'Var', value: 17, units: 'Mm' },
+        y: { type: 'Var', value: 3, units: 'Mm' },
+      },
+      end: {
+        x: { type: 'Var', value: 7, units: 'Mm' },
+        y: { type: 'Var', value: 13, units: 'Mm' },
+      },
+      construction: true,
+    })
+
+    expect(result.draft.centerGeometry).toEqual({
+      diagonalLineIds: [5, 6],
+      diagonalPointIds: [19, 20, 21, 22],
+      centerPointId: 100,
+    })
+    expect(result.draft.originPointId).toBe(100)
+    expect(result.draft.segmentIds).toHaveLength(19)
+    expect(result.draft.constraintIds).toHaveLength(15)
+  })
+
+  it('adds a snap constraint for the rectangle origin point when the first click snaps', async () => {
+    const rustContext = createMockRustContext()
+    const kclManager = createMockKclManager()
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const addSegmentMock = vi.mocked(rustContext.addSegment)
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const addConstraintMock = vi.mocked(rustContext.addConstraint)
+
+    addSegmentMock
+      .mockResolvedValueOnce({
+        kclSource: { text: 'line-1' } as SourceDelta,
+        sceneGraphDelta: createLineSceneGraphDelta(1, 11, 12),
+      })
+      .mockResolvedValueOnce({
+        kclSource: { text: 'line-2' } as SourceDelta,
+        sceneGraphDelta: createLineSceneGraphDelta(2, 13, 14),
+      })
+      .mockResolvedValueOnce({
+        kclSource: { text: 'line-3' } as SourceDelta,
+        sceneGraphDelta: createLineSceneGraphDelta(3, 15, 16),
+      })
+      .mockResolvedValueOnce({
+        kclSource: { text: 'line-4' } as SourceDelta,
+        sceneGraphDelta: createLineSceneGraphDelta(4, 17, 18),
+      })
+
+    const constraintTypes: ApiConstraint[] = [
+      { type: 'Coincident', segments: [12, 13] },
+      { type: 'Coincident', segments: [14, 15] },
+      { type: 'Coincident', segments: [16, 17] },
+      { type: 'Coincident', segments: [18, 11] },
+      { type: 'Parallel', lines: [2, 4] },
+      { type: 'Parallel', lines: [3, 1] },
+      { type: 'Perpendicular', lines: [1, 2] },
+      { type: 'Horizontal', line: 3 },
+      {
+        type: 'Coincident',
+        segments: [11, 'ORIGIN'] as unknown as [number, number],
+      },
+    ]
+
+    let constraintIndex = 0
+    addConstraintMock.mockImplementation(
+      async (_version, _sketchId, constraint) => {
+        const index = constraintIndex
+        constraintIndex += 1
+        return {
+          kclSource: { text: `constraint-${index}` } as SourceDelta,
+          sceneGraphDelta: createConstraintSceneGraphDelta(
+            300 + index,
+            constraintTypes[index] ?? constraint
+          ),
+        }
+      }
+    )
+
+    const result = await createDraftRectangle({
+      rustContext,
+      kclManager,
+      sketchId: 4,
+      mode: 'corner',
+      origin: [1, 2],
+      snapTarget: { type: 'origin' },
+    })
+
+    expect(addConstraintMock).toHaveBeenCalledTimes(9)
+    expect(addConstraintMock.mock.calls[8]?.[2]).toEqual({
+      type: 'Coincident',
+      segments: [11, 'ORIGIN'],
+    })
+    expect(result.draft.originPointId).toBe(11)
+    expect(result.draft.constraintIds.at(-1)).toBe(308)
+  })
+})
+
+describe('rectUtils.updateDraftRectangleAligned', () => {
+  it('updates center rectangle diagonals and center point alongside the outer lines', async () => {
+    const rustContext = createMockRustContext()
+    const kclManager = createMockKclManager()
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const editSegmentsMock = vi.mocked(rustContext.editSegments)
+
+    editSegmentsMock.mockResolvedValue({
+      kclSource: { text: 'updated' } as SourceDelta,
+      sceneGraphDelta: createSceneGraphDelta([]),
+    })
+
+    await updateDraftRectangleAligned({
+      rustContext,
+      kclManager,
+      sketchId: 9,
+      draft: {
+        lineIds: [1, 2, 3, 4],
+        segmentIds: [],
+        constraintIds: [],
+        originPointId: 1,
+        centerGeometry: {
+          diagonalLineIds: [5, 6],
+          diagonalPointIds: [11, 12, 13, 14],
+          centerPointId: 15,
+        },
+      },
+      rect: {
+        min: [0, 0],
+        max: [4, 6],
+      },
+    })
+
+    const edits = editSegmentsMock.mock.calls[0]?.[2]
+    expect(edits).toHaveLength(7)
+    expect(edits?.[4]).toEqual({
+      id: 5,
+      ctor: {
+        type: 'Line',
+        start: {
+          x: { type: 'Var', value: 0, units: 'Mm' },
+          y: { type: 'Var', value: 0, units: 'Mm' },
+        },
+        end: {
+          x: { type: 'Var', value: 4, units: 'Mm' },
+          y: { type: 'Var', value: 6, units: 'Mm' },
+        },
+        construction: true,
+      },
+    })
+    expect(edits?.[5]).toEqual({
+      id: 6,
+      ctor: {
+        type: 'Line',
+        start: {
+          x: { type: 'Var', value: 4, units: 'Mm' },
+          y: { type: 'Var', value: 0, units: 'Mm' },
+        },
+        end: {
+          x: { type: 'Var', value: 0, units: 'Mm' },
+          y: { type: 'Var', value: 6, units: 'Mm' },
+        },
+        construction: true,
+      },
+    })
+    expect(edits?.[6]).toEqual({
+      id: 15,
+      ctor: {
+        type: 'Point',
+        position: {
+          x: { type: 'Var', value: 2, units: 'Mm' },
+          y: { type: 'Var', value: 3, units: 'Mm' },
+        },
+      },
+    })
   })
 })

--- a/src/machines/sketchSolve/tools/rectUtils.ts
+++ b/src/machines/sketchSolve/tools/rectUtils.ts
@@ -11,7 +11,14 @@ import { roundOff } from '@src/lib/utils'
 import type { Coords2d } from '@src/lang/util'
 import type { RectOriginMode } from '@src/machines/sketchSolve/tools/rectTool'
 import { addVec, dot2d, scaleVec, subVec } from '@src/lib/utils2d'
-import { isLineSegment } from '@src/machines/sketchSolve/constraints/constraintUtils'
+import {
+  isLineSegment,
+  isPointSegment,
+} from '@src/machines/sketchSolve/constraints/constraintUtils'
+import {
+  type SnapTarget,
+  getConstraintForSnapTarget,
+} from '@src/machines/sketchSolve/snapping'
 
 type AppSettings = Awaited<ReturnType<typeof jsAppSettings>>
 type NumericSuffix = ReturnType<typeof baseUnitToNumericSuffix>
@@ -20,7 +27,15 @@ export type RectDraftIds = {
   lineIds: [number, number, number, number]
   segmentIds: number[] // all segments, including points, lines
   constraintIds: number[]
+  originPointId: number
+  centerGeometry?: {
+    diagonalLineIds: [number, number]
+    diagonalPointIds: [number, number, number, number]
+    centerPointId: number
+  }
 }
+
+const INITIAL_CENTER_RECT_HALF_SIZE = 5
 
 function getLineFromDelta(
   sceneGraphDelta: SceneGraphDelta
@@ -69,16 +84,37 @@ function getConstraintFromDelta(
   return constraintId
 }
 
+function getPointFromDelta(
+  sceneGraphDelta: SceneGraphDelta
+): { pointId: number } | Error {
+  const pointId = [...sceneGraphDelta.new_objects].reverse().find((objId) => {
+    const obj = sceneGraphDelta.new_graph.objects[objId]
+    return isPointSegment(obj)
+  })
+
+  if (pointId === undefined) {
+    return new Error(
+      'Expected a Point segment to be created, but none was found'
+    )
+  }
+
+  return { pointId }
+}
+
 export async function createDraftRectangle({
   rustContext,
   kclManager,
   sketchId,
   mode,
+  origin = [0, 0],
+  snapTarget,
 }: {
   rustContext: RustContext
   kclManager: KclManager
   sketchId: number
   mode: RectOriginMode
+  origin?: Coords2d
+  snapTarget?: SnapTarget
 }): Promise<{
   kclSource: SourceDelta
   sceneGraphDelta: SceneGraphDelta
@@ -88,30 +124,53 @@ export async function createDraftRectangle({
     kclManager.fileSettings.defaultLengthUnit
   )
   const settings = jsAppSettings(rustContext.settingsActor)
+  const centerDraftCorners =
+    mode === 'center'
+      ? getCenteredDraftRectangleCorners(origin, INITIAL_CENTER_RECT_HALF_SIZE)
+      : null
+
+  const centerPoint =
+    mode === 'center'
+      ? await makeDraftPoint({
+          units,
+          rustContext,
+          sketchId,
+          settings,
+          position: origin,
+        })
+      : null
 
   const line1 = await makeDraftLine({
     units,
     rustContext,
     sketchId,
     settings,
+    start: centerDraftCorners?.start1,
+    end: centerDraftCorners?.start2,
   })
   const line2 = await makeDraftLine({
     units,
     rustContext,
     sketchId,
     settings,
+    start: centerDraftCorners?.start2,
+    end: centerDraftCorners?.start3,
   })
   const line3 = await makeDraftLine({
     units,
     rustContext,
     sketchId,
     settings,
+    start: centerDraftCorners?.start3,
+    end: centerDraftCorners?.start4,
   })
   const line4 = await makeDraftLine({
     units,
     rustContext,
     sketchId,
     settings,
+    start: centerDraftCorners?.start4,
+    end: centerDraftCorners?.start1,
   })
 
   /**
@@ -137,6 +196,8 @@ export async function createDraftRectangle({
   const end4 = line4.endPointId
 
   const constraintIds: number[] = []
+  let centerGeometry: RectDraftIds['centerGeometry']
+  const originPointId = centerPoint?.pointId ?? start1
 
   // Connect corners (close loop): line1 -> line2 -> line3 -> line4 -> line1
   const c1 = await addCoincidentConstraint({
@@ -224,6 +285,123 @@ export async function createDraftRectangle({
     lastOperation = topHorizontal
   }
 
+  if (mode === 'center' && centerPoint) {
+    const diagonal1 = await makeDraftLine({
+      units,
+      rustContext,
+      sketchId,
+      settings,
+      construction: true,
+      start: centerDraftCorners?.start1,
+      end: centerDraftCorners?.start3,
+    })
+    const diagonal2 = await makeDraftLine({
+      units,
+      rustContext,
+      sketchId,
+      settings,
+      construction: true,
+      start: centerDraftCorners?.start2,
+      end: centerDraftCorners?.start4,
+    })
+
+    const diagonalStartCoincident = await addCoincidentConstraint({
+      a: diagonal1.startPointId,
+      b: start1,
+      rustContext,
+      sketchId,
+      settings,
+    })
+    const diagonalEndCoincident = await addCoincidentConstraint({
+      a: diagonal1.endPointId,
+      b: end2,
+      rustContext,
+      sketchId,
+      settings,
+    })
+    const opposingDiagonalStartCoincident = await addCoincidentConstraint({
+      a: diagonal2.startPointId,
+      b: end1,
+      rustContext,
+      sketchId,
+      settings,
+    })
+    const opposingDiagonalEndCoincident = await addCoincidentConstraint({
+      a: diagonal2.endPointId,
+      b: start4,
+      rustContext,
+      sketchId,
+      settings,
+    })
+    const centerOnDiagonal1 = await addCoincidentConstraint({
+      a: centerPoint.pointId,
+      b: diagonal1.lineId,
+      rustContext,
+      sketchId,
+      settings,
+    })
+    const centerOnDiagonal2 = await addCoincidentConstraint({
+      a: centerPoint.pointId,
+      b: diagonal2.lineId,
+      rustContext,
+      sketchId,
+      settings,
+    })
+    const equalDiagonals = await addTwoLineConstraint({
+      type: 'LinesEqualLength',
+      lines: [diagonal1.lineId, diagonal2.lineId],
+      rustContext,
+      sketchId,
+      settings,
+    })
+
+    constraintIds.push(
+      diagonalStartCoincident.constraintId,
+      diagonalEndCoincident.constraintId,
+      opposingDiagonalStartCoincident.constraintId,
+      opposingDiagonalEndCoincident.constraintId,
+      centerOnDiagonal1.constraintId,
+      centerOnDiagonal2.constraintId,
+      equalDiagonals.constraintId
+    )
+
+    centerGeometry = {
+      diagonalLineIds: [diagonal1.lineId, diagonal2.lineId],
+      diagonalPointIds: [
+        diagonal1.startPointId,
+        diagonal1.endPointId,
+        diagonal2.startPointId,
+        diagonal2.endPointId,
+      ],
+      centerPointId: centerPoint.pointId,
+    }
+
+    lastOperation = equalDiagonals
+  }
+
+  const snapConstraint = getConstraintForSnapTarget(
+    originPointId,
+    snapTarget,
+    units
+  )
+  if (snapConstraint !== null) {
+    const snapResult = await rustContext.addConstraint(
+      0,
+      sketchId,
+      snapConstraint,
+      settings
+    )
+    const snapConstraintId = getConstraintFromDelta(snapResult.sceneGraphDelta)
+    if (snapConstraintId instanceof Error) {
+      return Promise.reject(snapConstraintId)
+    }
+    constraintIds.push(snapConstraintId)
+    lastOperation = {
+      ...snapResult,
+      constraintId: snapConstraintId,
+    }
+  }
+
   const segmentIds = [
     line1.lineId,
     line2.lineId,
@@ -239,6 +417,25 @@ export async function createDraftRectangle({
     end4,
   ]
 
+  if (centerGeometry) {
+    const [diagonal1Id, diagonal2Id] = centerGeometry.diagonalLineIds
+    const [
+      diagonal1StartPointId,
+      diagonal1EndPointId,
+      diagonal2StartPointId,
+      diagonal2EndPointId,
+    ] = centerGeometry.diagonalPointIds
+    segmentIds.push(
+      diagonal1Id,
+      diagonal2Id,
+      centerGeometry.centerPointId,
+      diagonal1StartPointId,
+      diagonal1EndPointId,
+      diagonal2StartPointId,
+      diagonal2EndPointId
+    )
+  }
+
   return {
     // Return the latest delta so the caller has all new ids
     kclSource: lastOperation.kclSource,
@@ -247,6 +444,8 @@ export async function createDraftRectangle({
       lineIds: [line1.lineId, line2.lineId, line3.lineId, line4.lineId],
       segmentIds,
       constraintIds,
+      originPointId,
+      centerGeometry,
     },
   }
 }
@@ -300,6 +499,21 @@ function getAxisAlignedRectangleCorners(rect: {
   const start3: Coords2d = [rect.max[0], rect.max[1]]
   const start4: Coords2d = [rect.min[0], rect.max[1]]
   return { start1, start2, start3, start4 }
+}
+
+function getCenteredDraftRectangleCorners(
+  center: Coords2d,
+  halfSize: number
+): {
+  start1: Coords2d
+  start2: Coords2d
+  start3: Coords2d
+  start4: Coords2d
+} {
+  return getAxisAlignedRectangleCorners({
+    min: [center[0] - halfSize, center[1] - halfSize],
+    max: [center[0] + halfSize, center[1] + halfSize],
+  })
 }
 
 // Updates draft rectangle for angled (rotated) rectangle
@@ -403,8 +617,12 @@ async function updateDraftRectangleFromCorners({
 }> {
   const [line1Id, line2Id, line3Id, line4Id] = draft.lineIds
   const { start1, start2, start3, start4 } = corners
+  const center: Coords2d = [
+    (start1[0] + start3[0]) / 2,
+    (start1[1] + start3[1]) / 2,
+  ]
 
-  const edits = [
+  const edits: Array<{ id: number; ctor: SegmentCtor }> = [
     {
       id: line1Id,
       ctor: makeLineSegmentCtor(start1, start2, units),
@@ -423,6 +641,28 @@ async function updateDraftRectangleFromCorners({
     },
   ]
 
+  if (draft.centerGeometry) {
+    const [diagonal1Id, diagonal2Id] = draft.centerGeometry.diagonalLineIds
+    edits.push(
+      {
+        id: diagonal1Id,
+        ctor: makeLineSegmentCtor(start1, start3, units, {
+          construction: true,
+        }),
+      },
+      {
+        id: diagonal2Id,
+        ctor: makeLineSegmentCtor(start2, start4, units, {
+          construction: true,
+        }),
+      },
+      {
+        id: draft.centerGeometry.centerPointId,
+        ctor: makePointSegmentCtor(center, units),
+      }
+    )
+  }
+
   return rustContext.editSegments(0, sketchId, edits, settings)
 }
 
@@ -437,7 +677,10 @@ function makeVarExpr(value: number, units: NumericSuffix) {
 function makeLineSegmentCtor(
   start: Coords2d,
   end: Coords2d,
-  units: NumericSuffix
+  units: NumericSuffix,
+  options?: {
+    construction?: boolean
+  }
 ): SegmentCtor {
   return {
     type: 'Line',
@@ -449,6 +692,20 @@ function makeLineSegmentCtor(
       x: makeVarExpr(end[0], units),
       y: makeVarExpr(end[1], units),
     },
+    ...(options?.construction ? { construction: true } : {}),
+  }
+}
+
+function makePointSegmentCtor(
+  position: Coords2d,
+  units: NumericSuffix
+): SegmentCtor {
+  return {
+    type: 'Point',
+    position: {
+      x: makeVarExpr(position[0], units),
+      y: makeVarExpr(position[1], units),
+    },
   }
 }
 
@@ -457,11 +714,17 @@ async function makeDraftLine({
   rustContext,
   sketchId,
   settings,
+  start,
+  end,
+  construction = false,
 }: {
   units: NumericSuffix
   rustContext: RustContext
   sketchId: number
   settings: AppSettings
+  start?: Coords2d
+  end?: Coords2d
+  construction?: boolean
 }): Promise<{
   lineId: number
   startPointId: number
@@ -469,13 +732,12 @@ async function makeDraftLine({
   kclSource: SourceDelta
   sceneGraphDelta: SceneGraphDelta
 }> {
-  const ctor: SegmentCtor = {
-    type: 'Line',
-    // These are dummy values as they will be overridden by updateDraftRectangle immediately
-    // If needed they can be sent as a param
-    start: { x: makeVarExpr(0, units), y: makeVarExpr(0, units) },
-    end: { x: makeVarExpr(10, units), y: makeVarExpr(0, units) },
-  }
+  const ctor = makeLineSegmentCtor(
+    start ?? [0, 0],
+    end ?? [10, 0],
+    units,
+    construction ? { construction: true } : undefined
+  )
   const result = await rustContext.addSegment(
     0,
     sketchId,
@@ -487,6 +749,38 @@ async function makeDraftLine({
   if (line instanceof Error) return Promise.reject(line)
   return {
     ...line,
+    ...result,
+  }
+}
+
+async function makeDraftPoint({
+  units,
+  rustContext,
+  sketchId,
+  settings,
+  position,
+}: {
+  units: NumericSuffix
+  rustContext: RustContext
+  sketchId: number
+  settings: AppSettings
+  position: Coords2d
+}): Promise<{
+  pointId: number
+  kclSource: SourceDelta
+  sceneGraphDelta: SceneGraphDelta
+}> {
+  const result = await rustContext.addSegment(
+    0,
+    sketchId,
+    makePointSegmentCtor(position, units),
+    'rectangle-center-point',
+    settings
+  )
+  const point = getPointFromDelta(result.sceneGraphDelta)
+  if (point instanceof Error) return Promise.reject(point)
+  return {
+    ...point,
     ...result,
   }
 }
@@ -554,7 +848,7 @@ async function addTwoLineConstraint({
   sketchId,
   settings,
 }: {
-  type: 'Parallel' | 'Perpendicular'
+  type: 'Parallel' | 'Perpendicular' | 'LinesEqualLength'
   lines: [number, number]
   rustContext: RustContext
   sketchId: number


### PR DESCRIPTION
Addresses a concern raised by @alteous and @jamwaffles regarding our Center Rectangle sketch tool, which until now has been a light wrapper around the corner rectangle tool. Now it matches other CAD tool implementations, with equal diagonal construction lines between opposing corners, and a point coincident to both lines.

This also adds proper snapping behavior to the rectangle tool family, which had been being swallowed by the tool's state machine.

## Demo

https://github.com/user-attachments/assets/7ec4ba51-c7df-4e69-a22c-9c800d9ccd18

Codex-assisted, sorry @jamwaffles

Initial prompt:
>Our centerRectTool in sketchSolveImpl.ts uses the same underlying rectangle geometry as the cornerRectTool, but it should really also include two additional construction lines, each coincident with opposing corner points of the rectangle, an equal length constraint on those lines, and a point coincident with both lines, placed in the rectangle's center as its first point during the creation flow. 
>
>Please refactor sketchSolveImpl.ts and rectTool.ts as needed to support this alternative rectangle representation. If it's easiest to create a new centerRectTool.ts based on rectTool.ts and rename the latter to cornerRectTool.ts afterward, go for it. If it's simpler to extend rectTool to take additional config somehow, go for it.