### PR TITLE
Make Rust serialize and ignore unrecognized settings, serialize `false` for boolean settings

### DIFF
--- a/docs/kcl-lang/settings/user.md
+++ b/docs/kcl-lang/settings/user.md
@@ -121,10 +121,10 @@ The default color to use for surface backfaces.
 
 ##### base_unit
 
-The default unit to use in modeling dimensions.
+The default unit to use in modeling dimensions. If not given, defaults to millimeters.
 
 
-**Default:** `mm`
+**Default:** None
 
 ##### camera_orbit
 

--- a/e2e/playwright/test-utils.ts
+++ b/e2e/playwright/test-utils.ts
@@ -990,7 +990,9 @@ export async function setup(
           },
           project: {
             ...TEST_SETTINGS.project,
-            directory: TEST_SETTINGS.project?.directory,
+            ...(TEST_SETTINGS.project?.directory !== undefined
+              ? { directory: TEST_SETTINGS.project.directory }
+              : {}),
           },
         },
       }),
@@ -1211,10 +1213,11 @@ export async function pollEditorLinesSelectedLength(page: Page, lines: number) {
     .toBe(lines)
 }
 
-// TODO: fix type to allow for meta.id in configuration
-export function settingsToToml(
-  settings: DeepPartial<Configuration | { settings: { meta: { id: string } } }>
-) {
+type SettingsTomlConfiguration = {
+  settings?: Record<string, unknown>
+}
+
+export function settingsToToml(settings: SettingsTomlConfiguration) {
   // eslint-disable-next-line no-restricted-syntax
   return TOML.stringify(settings as any)
 }

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -798,14 +798,15 @@ impl From<crate::settings::types::Configuration> for ExecutorSettings {
 
 impl From<crate::settings::types::Settings> for ExecutorSettings {
     fn from(settings: crate::settings::types::Settings) -> Self {
+        let modeling_settings = settings.modeling.unwrap_or_default();
         Self {
-            highlight_edges: settings.modeling.highlight_edges.into(),
-            enable_ssao: settings.modeling.enable_ssao.into(),
-            show_grid: settings.modeling.show_scale_grid,
+            highlight_edges: modeling_settings.highlight_edges.unwrap_or_default().into(),
+            enable_ssao: modeling_settings.enable_ssao.unwrap_or_default().into(),
+            show_grid: modeling_settings.show_scale_grid.unwrap_or_default(),
             replay: None,
             project_directory: None,
             current_file: None,
-            fixed_size_grid: settings.modeling.fixed_size_grid,
+            fixed_size_grid: modeling_settings.fixed_size_grid.unwrap_or_default().0,
         }
     }
 }
@@ -819,9 +820,9 @@ impl From<crate::settings::types::project::ProjectConfiguration> for ExecutorSet
 impl From<crate::settings::types::ModelingSettings> for ExecutorSettings {
     fn from(modeling: crate::settings::types::ModelingSettings) -> Self {
         Self {
-            highlight_edges: modeling.highlight_edges.into(),
-            enable_ssao: modeling.enable_ssao.into(),
-            show_grid: modeling.show_scale_grid,
+            highlight_edges: modeling.highlight_edges.unwrap_or_default().into(),
+            enable_ssao: modeling.enable_ssao.unwrap_or_default().into(),
+            show_grid: modeling.show_scale_grid.unwrap_or_default(),
             replay: None,
             project_directory: None,
             current_file: None,

--- a/rust/kcl-lib/src/settings/mod.rs
+++ b/rust/kcl-lib/src/settings/mod.rs
@@ -39,9 +39,9 @@ base_unit = "mm"
             UnitLength::Millimeters
         );
 
-        // Serializing defaults should omit modeling/base_unit entirely.
+        // Serializing the settings file back should not change it.
         let serialized = toml::to_string(&parsed).unwrap();
-        assert_eq!(serialized, "");
+        assert_eq!(serialized, with_mm);
 
         // An empty [settings.modeling] section should still default to mm.
         let empty_modeling_section = r#"[settings.modeling]
@@ -49,6 +49,7 @@ base_unit = "mm"
         let parsed2 = toml::from_str::<Configuration>(empty_modeling_section).unwrap();
         assert_eq!(
             parsed2
+                .clone()
                 .settings
                 .modeling
                 .unwrap_or_default()
@@ -57,6 +58,9 @@ base_unit = "mm"
                 .0,
             UnitLength::Millimeters
         );
+        // Serializing the settings file back should not change it.
+        let serialized = toml::to_string(&parsed2).unwrap();
+        assert_eq!(serialized, empty_modeling_section);
     }
 
     #[test]

--- a/rust/kcl-lib/src/settings/mod.rs
+++ b/rust/kcl-lib/src/settings/mod.rs
@@ -16,7 +16,7 @@ mod tests {
     fn default_unit_length_is_millimeters() {
         // Ensure our settings default to millimeters as the base unit.
         let modeling = ModelingSettings::default();
-        assert_eq!(modeling.base_unit, UnitLength::Millimeters);
+        assert_eq!(modeling.base_unit.unwrap_or_default().0, UnitLength::Millimeters);
     }
 
     #[test]
@@ -27,7 +27,17 @@ base_unit = "mm"
 "#;
 
         let parsed = toml::from_str::<Configuration>(with_mm).unwrap();
-        assert_eq!(parsed.settings.modeling.base_unit, UnitLength::Millimeters);
+        assert_eq!(
+            parsed
+                .settings
+                .modeling
+                .clone()
+                .unwrap_or_default()
+                .base_unit
+                .unwrap_or_default()
+                .0,
+            UnitLength::Millimeters
+        );
 
         // Serializing defaults should omit modeling/base_unit entirely.
         let serialized = toml::to_string(&parsed).unwrap();
@@ -37,13 +47,31 @@ base_unit = "mm"
         let empty_modeling_section = r#"[settings.modeling]
 "#;
         let parsed2 = toml::from_str::<Configuration>(empty_modeling_section).unwrap();
-        assert_eq!(parsed2.settings.modeling.base_unit, UnitLength::Millimeters);
+        assert_eq!(
+            parsed2
+                .settings
+                .modeling
+                .unwrap_or_default()
+                .base_unit
+                .unwrap_or_default()
+                .0,
+            UnitLength::Millimeters
+        );
     }
 
     #[test]
     fn configuration_default_has_mm() {
         let cfg = Configuration::default();
-        assert_eq!(cfg.settings.modeling.base_unit, UnitLength::Millimeters);
+        assert_eq!(
+            cfg.settings
+                .modeling
+                .clone()
+                .unwrap_or_default()
+                .base_unit
+                .unwrap_or_default()
+                .0,
+            UnitLength::Millimeters
+        );
 
         // Default config serializes to empty TOML because everything is defaulted/omitted.
         let serialized = toml::to_string(&cfg).unwrap();

--- a/rust/kcl-lib/src/settings/types/mod.rs
+++ b/rust/kcl-lib/src/settings/types/mod.rs
@@ -45,23 +45,23 @@ impl Configuration {
 #[serde(rename_all = "snake_case")]
 pub struct Settings {
     /// The settings for the Design Studio.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[validate(nested)]
     pub app: Option<AppSettings>,
     /// Settings that affect the behavior while modeling.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[validate(nested)]
     pub modeling: Option<ModelingSettings>,
     /// Settings that affect the behavior of the KCL text editor.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[validate(nested)]
     pub text_editor: Option<TextEditorSettings>,
     /// Settings that affect the behavior of project management.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[validate(nested)]
     pub project: Option<ProjectSettings>,
     /// Settings that affect the behavior of the command bar.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[validate(nested)]
     pub command_bar: Option<CommandBarSettings>,
 }
@@ -72,26 +72,26 @@ pub struct Settings {
 #[serde(rename_all = "snake_case")]
 pub struct AppSettings {
     /// The settings for the appearance of the app.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[validate(nested)]
     pub appearance: Option<AppearanceSettings>,
     /// The onboarding status of the app.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub onboarding_status: Option<OnboardingStatus>,
     /// When the user is idle, teardown the stream after some time.
     #[serde(
         default,
         deserialize_with = "deserialize_stream_idle_mode",
         alias = "streamIdleMode",
-        skip_serializing_if = "is_default"
+        skip_serializing_if = "Option::is_none"
     )]
     stream_idle_mode: Option<u32>,
     /// Allow orbiting in sketch mode.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allow_orbit_in_sketch_mode: Option<bool>,
     /// Whether to show the debug panel, which lets you see various states
     /// of the app to aid in development.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub show_debug_panel: Option<bool>,
     /// Whether to enable Machine API discovery and printing controls on desktop.
     #[serde(default, skip_serializing_if = "is_default")]
@@ -148,7 +148,7 @@ impl From<FloatOrInt> for f64 {
 #[serde(rename_all = "snake_case")]
 pub struct AppearanceSettings {
     /// The overall theme of the app.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub theme: Option<AppTheme>,
 }
 
@@ -238,54 +238,54 @@ impl From<BackfaceDefault> for String {
 pub struct ModelingSettings {
     /// The default unit to use in modeling dimensions.
     /// If not given, defaults to millimeters.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_unit: Option<LengthDefaultMm>,
     /// The projection mode the camera should use while modeling.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub camera_projection: Option<CameraProjectionType>,
     /// The methodology the camera should use to orbit around the model.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub camera_orbit: Option<CameraOrbitType>,
     /// The controls for how to navigate the 3D view.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mouse_controls: Option<MouseControlType>,
     /// Which type of orientation gizmo to use.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gizmo_type: Option<GizmoType>,
     /// Toggle touch controls for 3D view navigation
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enable_touch_controls: Option<DefaultTrue>,
     /// Default to the experimental solver-based sketch mode for all new sketches.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub use_sketch_solve_mode: Option<bool>,
     /// Highlight edges of 3D objects?
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub highlight_edges: Option<DefaultTrue>,
     /// Whether or not Screen Space Ambient Occlusion (SSAO) is enabled.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enable_ssao: Option<DefaultTrue>,
     /// The default color to use for surface backfaces.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backface_color: Option<BackfaceDefault>,
     /// Whether or not to show a scale grid in the 3D modeling view
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub show_scale_grid: Option<bool>,
     /// When enabled, the grid will use a fixed size based on your selected units rather than automatically scaling with zoom level.
     /// If true, the grid cells will be fixed-size, where the width is your default length unit.
     /// If false, the grid will get larger as you zoom out, and smaller as you zoom in.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fixed_size_grid: Option<DefaultTrue>,
     /// When enabled, tools like line, rectangle, etc. will snap to the grid.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub snap_to_grid: Option<bool>,
     /// The space between major grid lines, specified in the current unit.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub major_grid_spacing: Option<f64>,
     /// The number of minor grid lines per major grid line.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub minor_grids_per_major: Option<f64>,
     /// The number of snaps between minor grid lines. 1 means snapping to each minor grid line.
-    #[serde(default, skip_serializing_if = "is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub snaps_per_minor: Option<f64>,
 }
 
@@ -390,11 +390,11 @@ pub enum GizmoType {
 #[ts(export)]
 pub struct TextEditorSettings {
     /// Whether to wrap text in the editor or overflow with scroll.
-    #[serde(default, skip_serializing_if = "is_default")]
-    pub text_wrapping: DefaultTrue,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text_wrapping: Option<DefaultTrue>,
     /// Whether to make the cursor blink in the editor.
-    #[serde(default, skip_serializing_if = "is_default")]
-    pub blinking_cursor: DefaultTrue,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blinking_cursor: Option<DefaultTrue>,
 }
 
 /// Same as TextEditorSettings but applies to a per-project basis.
@@ -416,11 +416,11 @@ pub struct ProjectTextEditorSettings {
 #[ts(export)]
 pub struct ProjectSettings {
     /// The directory to save and load projects from.
-    #[serde(default, skip_serializing_if = "is_default")]
-    pub directory: std::path::PathBuf,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub directory: Option<std::path::PathBuf>,
     /// The default project name to use when creating a new project.
-    #[serde(default, skip_serializing_if = "is_default")]
-    pub default_project_name: ProjectNameTemplate,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_project_name: Option<ProjectNameTemplate>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, ts_rs::TS, PartialEq, Eq)]
@@ -452,8 +452,8 @@ impl From<String> for ProjectNameTemplate {
 #[ts(export)]
 pub struct CommandBarSettings {
     /// Whether to include settings in the command bar.
-    #[serde(default, skip_serializing_if = "is_default")]
-    pub include_settings: DefaultTrue,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub include_settings: Option<DefaultTrue>,
 }
 
 /// Same as CommandBarSettings but applies to a per-project basis.
@@ -595,25 +595,24 @@ mod tests {
     #[test]
     fn test_settings_parse_basic() {
         let settings_file = r#"[settings.app]
-default_project_name = "untitled"
-directory = ""
 onboarding_status = "dismissed"
 
 [settings.app.appearance]
 theme = "dark"
 
 [settings.modeling]
-enable_ssao = false
 base_unit = "in"
-mouse_controls = "zoo"
 camera_projection = "perspective"
-
-[settings.project]
-default_project_name = "untitled"
-directory = ""
+mouse_controls = "zoo"
+enable_ssao = false
 
 [settings.text_editor]
-text_wrapping = true"#;
+text_wrapping = true
+
+[settings.project]
+directory = ""
+default_project_name = "untitled"
+"#;
 
         let expected = Configuration {
             settings: Settings {
@@ -633,11 +632,11 @@ text_wrapping = true"#;
                     ..Default::default()
                 }),
                 project: Some(ProjectSettings {
-                    default_project_name: ProjectNameTemplate("untitled".to_string()),
-                    directory: "".into(),
+                    default_project_name: Some(ProjectNameTemplate("untitled".to_string())),
+                    directory: Some("".into()),
                 }),
                 text_editor: Some(TextEditorSettings {
-                    text_wrapping: true.into(),
+                    text_wrapping: Some(true.into()),
                     ..Default::default()
                 }),
                 command_bar: None,
@@ -646,11 +645,11 @@ text_wrapping = true"#;
         let parsed = toml::from_str::<Configuration>(settings_file).unwrap();
         assert_eq!(parsed, expected);
 
-        let expected_unwrap = CommandBarSettings {
-            include_settings: true.into(),
-        };
+        let expected_unwrap = CommandBarSettings { include_settings: None };
         let actual_unwrap = expected.clone().settings.command_bar.unwrap_or_default();
         assert_eq!(actual_unwrap, expected_unwrap);
+        let actual_unwrap = actual_unwrap.include_settings.unwrap_or_default();
+        assert_eq!(actual_unwrap.0, true);
 
         // Write the file back out.
         let serialized = toml::to_string(&parsed).unwrap();

--- a/rust/kcl-lib/src/settings/types/mod.rs
+++ b/rust/kcl-lib/src/settings/types/mod.rs
@@ -47,23 +47,23 @@ pub struct Settings {
     /// The settings for the Design Studio.
     #[serde(default, skip_serializing_if = "is_default")]
     #[validate(nested)]
-    pub app: AppSettings,
+    pub app: Option<AppSettings>,
     /// Settings that affect the behavior while modeling.
     #[serde(default, skip_serializing_if = "is_default")]
     #[validate(nested)]
-    pub modeling: ModelingSettings,
+    pub modeling: Option<ModelingSettings>,
     /// Settings that affect the behavior of the KCL text editor.
     #[serde(default, skip_serializing_if = "is_default")]
     #[validate(nested)]
-    pub text_editor: TextEditorSettings,
+    pub text_editor: Option<TextEditorSettings>,
     /// Settings that affect the behavior of project management.
     #[serde(default, skip_serializing_if = "is_default")]
     #[validate(nested)]
-    pub project: ProjectSettings,
+    pub project: Option<ProjectSettings>,
     /// Settings that affect the behavior of the command bar.
     #[serde(default, skip_serializing_if = "is_default")]
     #[validate(nested)]
-    pub command_bar: CommandBarSettings,
+    pub command_bar: Option<CommandBarSettings>,
 }
 
 /// Application wide settings.
@@ -74,10 +74,10 @@ pub struct AppSettings {
     /// The settings for the appearance of the app.
     #[serde(default, skip_serializing_if = "is_default")]
     #[validate(nested)]
-    pub appearance: AppearanceSettings,
+    pub appearance: Option<AppearanceSettings>,
     /// The onboarding status of the app.
     #[serde(default, skip_serializing_if = "is_default")]
-    pub onboarding_status: OnboardingStatus,
+    pub onboarding_status: Option<OnboardingStatus>,
     /// When the user is idle, teardown the stream after some time.
     #[serde(
         default,
@@ -88,23 +88,14 @@ pub struct AppSettings {
     stream_idle_mode: Option<u32>,
     /// Allow orbiting in sketch mode.
     #[serde(default, skip_serializing_if = "is_default")]
-    pub allow_orbit_in_sketch_mode: bool,
+    pub allow_orbit_in_sketch_mode: Option<bool>,
     /// Whether to show the debug panel, which lets you see various states
     /// of the app to aid in development.
     #[serde(default, skip_serializing_if = "is_default")]
-    pub show_debug_panel: bool,
+    pub show_debug_panel: Option<bool>,
     /// Whether to enable Machine API discovery and printing controls on desktop.
     #[serde(default, skip_serializing_if = "is_default")]
-    pub machine_api: bool,
-}
-
-/// Default to true.
-fn make_it_so() -> bool {
-    true
-}
-
-fn is_true(b: &bool) -> bool {
-    *b
+    pub machine_api: Option<bool>,
 }
 
 fn deserialize_stream_idle_mode<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
@@ -158,7 +149,7 @@ impl From<FloatOrInt> for f64 {
 pub struct AppearanceSettings {
     /// The overall theme of the app.
     #[serde(default, skip_serializing_if = "is_default")]
-    pub theme: AppTheme,
+    pub theme: Option<AppTheme>,
 }
 
 /// The overall appearance of the app.
@@ -202,64 +193,99 @@ impl From<AppTheme> for kittycad::types::Color {
     }
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, ts_rs::TS, PartialEq)]
+#[serde(transparent)]
+pub struct LengthDefaultMm(pub UnitLength);
+
+impl Default for LengthDefaultMm {
+    fn default() -> Self {
+        Self(default_length_unit_millimeters())
+    }
+}
+
+impl From<LengthDefaultMm> for UnitLength {
+    fn from(val: LengthDefaultMm) -> Self {
+        val.0
+    }
+}
+
+impl From<UnitLength> for LengthDefaultMm {
+    fn from(unit: UnitLength) -> Self {
+        Self(unit)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, ts_rs::TS, PartialEq)]
+#[serde(transparent)]
+pub struct BackfaceDefault(pub String);
+
+impl Default for BackfaceDefault {
+    fn default() -> Self {
+        Self(default_backface_color())
+    }
+}
+
+impl From<BackfaceDefault> for String {
+    fn from(val: BackfaceDefault) -> Self {
+        val.0
+    }
+}
+
 /// Settings that affect the behavior while modeling.
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, ts_rs::TS, PartialEq, Validate)]
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, ts_rs::TS, PartialEq, Validate, Default)]
 #[serde(rename_all = "snake_case")]
 #[ts(export)]
 pub struct ModelingSettings {
     /// The default unit to use in modeling dimensions.
-    #[serde(default = "default_length_unit_millimeters", skip_serializing_if = "is_default")]
-    pub base_unit: UnitLength,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub base_unit: Option<LengthDefaultMm>,
     /// The projection mode the camera should use while modeling.
     #[serde(default, skip_serializing_if = "is_default")]
-    pub camera_projection: CameraProjectionType,
+    pub camera_projection: Option<CameraProjectionType>,
     /// The methodology the camera should use to orbit around the model.
     #[serde(default, skip_serializing_if = "is_default")]
-    pub camera_orbit: CameraOrbitType,
+    pub camera_orbit: Option<CameraOrbitType>,
     /// The controls for how to navigate the 3D view.
     #[serde(default, skip_serializing_if = "is_default")]
-    pub mouse_controls: MouseControlType,
+    pub mouse_controls: Option<MouseControlType>,
     /// Which type of orientation gizmo to use.
     #[serde(default, skip_serializing_if = "is_default")]
-    pub gizmo_type: GizmoType,
+    pub gizmo_type: Option<GizmoType>,
     /// Toggle touch controls for 3D view navigation
     #[serde(default, skip_serializing_if = "is_default")]
-    pub enable_touch_controls: DefaultTrue,
+    pub enable_touch_controls: Option<DefaultTrue>,
     /// Default to the experimental solver-based sketch mode for all new sketches.
     #[serde(default, skip_serializing_if = "is_default")]
-    pub use_sketch_solve_mode: bool,
+    pub use_sketch_solve_mode: Option<bool>,
     /// Highlight edges of 3D objects?
     #[serde(default, skip_serializing_if = "is_default")]
-    pub highlight_edges: DefaultTrue,
+    pub highlight_edges: Option<DefaultTrue>,
     /// Whether or not Screen Space Ambient Occlusion (SSAO) is enabled.
     #[serde(default, skip_serializing_if = "is_default")]
-    pub enable_ssao: DefaultTrue,
+    pub enable_ssao: Option<DefaultTrue>,
     /// The default color to use for surface backfaces.
-    #[serde(
-        default = "default_backface_color",
-        skip_serializing_if = "is_default_backface_color"
-    )]
-    pub backface_color: String,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub backface_color: Option<BackfaceDefault>,
     /// Whether or not to show a scale grid in the 3D modeling view
     #[serde(default, skip_serializing_if = "is_default")]
-    pub show_scale_grid: bool,
+    pub show_scale_grid: Option<bool>,
     /// When enabled, the grid will use a fixed size based on your selected units rather than automatically scaling with zoom level.
     /// If true, the grid cells will be fixed-size, where the width is your default length unit.
     /// If false, the grid will get larger as you zoom out, and smaller as you zoom in.
-    #[serde(default = "make_it_so", skip_serializing_if = "is_true")]
-    pub fixed_size_grid: bool,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub fixed_size_grid: Option<DefaultTrue>,
     /// When enabled, tools like line, rectangle, etc. will snap to the grid.
     #[serde(default, skip_serializing_if = "is_default")]
-    pub snap_to_grid: bool,
+    pub snap_to_grid: Option<bool>,
     /// The space between major grid lines, specified in the current unit.
     #[serde(default, skip_serializing_if = "is_default")]
-    pub major_grid_spacing: f64,
+    pub major_grid_spacing: Option<f64>,
     /// The number of minor grid lines per major grid line.
     #[serde(default, skip_serializing_if = "is_default")]
-    pub minor_grids_per_major: f64,
+    pub minor_grids_per_major: Option<f64>,
     /// The number of snaps between minor grid lines. 1 means snapping to each minor grid line.
     #[serde(default, skip_serializing_if = "is_default")]
-    pub snaps_per_minor: f64,
+    pub snaps_per_minor: Option<f64>,
 }
 
 fn default_length_unit_millimeters() -> UnitLength {
@@ -269,33 +295,6 @@ fn default_length_unit_millimeters() -> UnitLength {
 // Also defined at src/lib/constants.ts#L333-L335
 fn default_backface_color() -> String {
     "#00D5FF".to_string()
-}
-
-fn is_default_backface_color(color: &String) -> bool {
-    *color == default_backface_color()
-}
-
-impl Default for ModelingSettings {
-    fn default() -> Self {
-        Self {
-            base_unit: UnitLength::Millimeters,
-            camera_projection: Default::default(),
-            camera_orbit: Default::default(),
-            mouse_controls: Default::default(),
-            gizmo_type: Default::default(),
-            enable_touch_controls: Default::default(),
-            use_sketch_solve_mode: Default::default(),
-            highlight_edges: Default::default(),
-            enable_ssao: Default::default(),
-            backface_color: default_backface_color(),
-            show_scale_grid: Default::default(),
-            fixed_size_grid: true,
-            snap_to_grid: Default::default(),
-            major_grid_spacing: Default::default(),
-            minor_grids_per_major: Default::default(),
-            snaps_per_minor: Default::default(),
-        }
-    }
 }
 
 #[derive(Debug, Copy, Clone, Deserialize, Serialize, JsonSchema, ts_rs::TS, PartialEq, Eq)]
@@ -562,7 +561,17 @@ mod tests {
 
         let parsed = toml::from_str::<Configuration>(empty_settings_file).unwrap();
         assert_eq!(parsed, Configuration::default());
-        assert_eq!(parsed.settings.modeling.backface_color, default_backface_color());
+        assert_eq!(
+            parsed
+                .clone()
+                .settings
+                .modeling
+                .unwrap_or_default()
+                .backface_color
+                .unwrap_or_default()
+                .0,
+            default_backface_color()
+        );
 
         // Write the file back out.
         let serialized = toml::to_string(&parsed).unwrap();
@@ -570,7 +579,16 @@ mod tests {
 
         let parsed = Configuration::parse_and_validate(empty_settings_file).unwrap();
         assert_eq!(parsed, Configuration::default());
-        assert_eq!(parsed.settings.modeling.backface_color, default_backface_color());
+        assert_eq!(
+            parsed
+                .settings
+                .modeling
+                .unwrap_or_default()
+                .backface_color
+                .unwrap_or_default()
+                .0,
+            default_backface_color()
+        );
     }
 
     #[test]
@@ -580,8 +598,8 @@ default_project_name = "untitled"
 directory = ""
 onboarding_status = "dismissed"
 
-  [settings.app.appearance]
-  theme = "dark"
+[settings.app.appearance]
+theme = "dark"
 
 [settings.modeling]
 enable_ssao = false
@@ -598,30 +616,32 @@ text_wrapping = true"#;
 
         let expected = Configuration {
             settings: Settings {
-                app: AppSettings {
-                    onboarding_status: OnboardingStatus::Dismissed,
-                    appearance: AppearanceSettings { theme: AppTheme::Dark },
+                app: Some(AppSettings {
+                    onboarding_status: Some(OnboardingStatus::Dismissed),
+                    appearance: Some(AppearanceSettings {
+                        theme: Some(AppTheme::Dark),
+                    }),
                     ..Default::default()
-                },
-                modeling: ModelingSettings {
-                    enable_ssao: false.into(),
-                    base_unit: UnitLength::Inches,
-                    mouse_controls: MouseControlType::Zoo,
-                    camera_projection: CameraProjectionType::Perspective,
-                    fixed_size_grid: true,
+                }),
+                modeling: Some(ModelingSettings {
+                    enable_ssao: Some(false.into()),
+                    base_unit: Some(From::from(UnitLength::Inches)),
+                    mouse_controls: Some(MouseControlType::Zoo),
+                    camera_projection: Some(CameraProjectionType::Perspective),
+                    fixed_size_grid: Some(true.into()),
                     ..Default::default()
-                },
-                project: ProjectSettings {
+                }),
+                project: Some(ProjectSettings {
                     default_project_name: ProjectNameTemplate("untitled".to_string()),
                     directory: "".into(),
-                },
-                text_editor: TextEditorSettings {
+                }),
+                text_editor: Some(TextEditorSettings {
                     text_wrapping: true.into(),
                     ..Default::default()
-                },
-                command_bar: CommandBarSettings {
+                }),
+                command_bar: Some(CommandBarSettings {
                     include_settings: true.into(),
-                },
+                }),
             },
         };
         let parsed = toml::from_str::<Configuration>(settings_file).unwrap();
@@ -655,7 +675,17 @@ backface_color = "#112233"
 "##;
 
         let parsed = toml::from_str::<Configuration>(settings_file).unwrap();
-        assert_eq!(parsed.settings.modeling.backface_color, "#112233");
+        assert_eq!(
+            parsed
+                .clone()
+                .settings
+                .modeling
+                .unwrap_or_default()
+                .backface_color
+                .unwrap_or_default()
+                .0,
+            "#112233"
+        );
 
         let serialized = toml::to_string(&parsed).unwrap();
         let reparsed = toml::from_str::<Configuration>(&serialized).unwrap();

--- a/rust/kcl-lib/src/settings/types/mod.rs
+++ b/rust/kcl-lib/src/settings/types/mod.rs
@@ -237,6 +237,7 @@ impl From<BackfaceDefault> for String {
 #[ts(export)]
 pub struct ModelingSettings {
     /// The default unit to use in modeling dimensions.
+    /// If not given, defaults to millimeters.
     #[serde(default, skip_serializing_if = "is_default")]
     pub base_unit: Option<LengthDefaultMm>,
     /// The projection mode the camera should use while modeling.

--- a/rust/kcl-lib/src/settings/types/mod.rs
+++ b/rust/kcl-lib/src/settings/types/mod.rs
@@ -629,7 +629,7 @@ text_wrapping = true"#;
                     base_unit: Some(From::from(UnitLength::Inches)),
                     mouse_controls: Some(MouseControlType::Zoo),
                     camera_projection: Some(CameraProjectionType::Perspective),
-                    fixed_size_grid: Some(true.into()),
+                    fixed_size_grid: None,
                     ..Default::default()
                 }),
                 project: Some(ProjectSettings {
@@ -640,30 +640,21 @@ text_wrapping = true"#;
                     text_wrapping: true.into(),
                     ..Default::default()
                 }),
-                command_bar: Some(CommandBarSettings {
-                    include_settings: true.into(),
-                }),
+                command_bar: None,
             },
         };
         let parsed = toml::from_str::<Configuration>(settings_file).unwrap();
         assert_eq!(parsed, expected);
 
+        let expected_unwrap = CommandBarSettings {
+            include_settings: true.into(),
+        };
+        let actual_unwrap = expected.clone().settings.command_bar.unwrap_or_default();
+        assert_eq!(actual_unwrap, expected_unwrap);
+
         // Write the file back out.
         let serialized = toml::to_string(&parsed).unwrap();
-        assert_eq!(
-            serialized,
-            r#"[settings.app]
-onboarding_status = "dismissed"
-
-[settings.app.appearance]
-theme = "dark"
-
-[settings.modeling]
-base_unit = "in"
-camera_projection = "perspective"
-enable_ssao = false
-"#
-        );
+        assert_eq!(serialized, settings_file);
 
         let parsed = Configuration::parse_and_validate(settings_file).unwrap();
         assert_eq!(parsed, expected);

--- a/rust/kcl-lib/src/settings/types/mod.rs
+++ b/rust/kcl-lib/src/settings/types/mod.rs
@@ -64,6 +64,9 @@ pub struct Settings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[validate(nested)]
     pub command_bar: Option<CommandBarSettings>,
+    /// Other fields that weren't recognized by our schema.
+    #[serde(flatten)]
+    pub other: std::collections::HashMap<String, serde_json::Value>,
 }
 
 /// Application wide settings.
@@ -96,6 +99,9 @@ pub struct AppSettings {
     /// Whether to enable Machine API discovery and printing controls on desktop.
     #[serde(default, skip_serializing_if = "is_default")]
     pub machine_api: Option<bool>,
+    /// Other fields that weren't recognized by our schema.
+    #[serde(flatten)]
+    pub other: std::collections::HashMap<String, serde_json::Value>,
 }
 
 fn deserialize_stream_idle_mode<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
@@ -150,6 +156,9 @@ pub struct AppearanceSettings {
     /// The overall theme of the app.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub theme: Option<AppTheme>,
+    /// Other fields that weren't recognized by our schema.
+    #[serde(flatten)]
+    pub other: std::collections::HashMap<String, serde_json::Value>,
 }
 
 /// The overall appearance of the app.
@@ -287,6 +296,9 @@ pub struct ModelingSettings {
     /// The number of snaps between minor grid lines. 1 means snapping to each minor grid line.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub snaps_per_minor: Option<f64>,
+    /// Other fields that weren't recognized by our schema.
+    #[serde(flatten)]
+    pub other: std::collections::HashMap<String, serde_json::Value>,
 }
 
 fn default_length_unit_millimeters() -> UnitLength {
@@ -395,6 +407,9 @@ pub struct TextEditorSettings {
     /// Whether to make the cursor blink in the editor.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub blinking_cursor: Option<DefaultTrue>,
+    /// Other fields that weren't recognized by our schema.
+    #[serde(flatten)]
+    pub other: std::collections::HashMap<String, serde_json::Value>,
 }
 
 /// Same as TextEditorSettings but applies to a per-project basis.
@@ -408,6 +423,9 @@ pub struct ProjectTextEditorSettings {
     /// Whether to make the cursor blink in the editor.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub blinking_cursor: Option<bool>,
+    /// Other fields that weren't recognized by our schema.
+    #[serde(flatten)]
+    pub other: std::collections::HashMap<String, serde_json::Value>,
 }
 
 /// Settings that affect the behavior of project management.
@@ -421,6 +439,9 @@ pub struct ProjectSettings {
     /// The default project name to use when creating a new project.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_project_name: Option<ProjectNameTemplate>,
+    /// Other fields that weren't recognized by our schema.
+    #[serde(flatten)]
+    pub other: std::collections::HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, ts_rs::TS, PartialEq, Eq)]
@@ -454,6 +475,9 @@ pub struct CommandBarSettings {
     /// Whether to include settings in the command bar.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub include_settings: Option<DefaultTrue>,
+    /// Other fields that weren't recognized by our schema.
+    #[serde(flatten)]
+    pub other: std::collections::HashMap<String, serde_json::Value>,
 }
 
 /// Same as CommandBarSettings but applies to a per-project basis.
@@ -464,6 +488,9 @@ pub struct ProjectCommandBarSettings {
     /// Whether to include settings in the command bar.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub include_settings: Option<bool>,
+    /// Other fields that weren't recognized by our schema.
+    #[serde(flatten)]
+    pub other: std::collections::HashMap<String, serde_json::Value>,
 }
 
 /// The types of onboarding status.
@@ -596,6 +623,7 @@ mod tests {
     fn test_settings_parse_basic() {
         let settings_file = r#"[settings.app]
 onboarding_status = "dismissed"
+foo = "bar"
 
 [settings.app.appearance]
 theme = "dark"
@@ -620,7 +648,9 @@ default_project_name = "untitled"
                     onboarding_status: Some(OnboardingStatus::Dismissed),
                     appearance: Some(AppearanceSettings {
                         theme: Some(AppTheme::Dark),
+                        other: Default::default(),
                     }),
+                    other: std::collections::HashMap::from([("foo".to_owned(), "bar".into())]),
                     ..Default::default()
                 }),
                 modeling: Some(ModelingSettings {
@@ -634,18 +664,23 @@ default_project_name = "untitled"
                 project: Some(ProjectSettings {
                     default_project_name: Some(ProjectNameTemplate("untitled".to_string())),
                     directory: Some("".into()),
+                    other: Default::default(),
                 }),
                 text_editor: Some(TextEditorSettings {
                     text_wrapping: Some(true.into()),
                     ..Default::default()
                 }),
                 command_bar: None,
+                other: Default::default(),
             },
         };
         let parsed = toml::from_str::<Configuration>(settings_file).unwrap();
         assert_eq!(parsed, expected);
 
-        let expected_unwrap = CommandBarSettings { include_settings: None };
+        let expected_unwrap = CommandBarSettings {
+            include_settings: None,
+            other: Default::default(),
+        };
         let actual_unwrap = expected.clone().settings.command_bar.unwrap_or_default();
         assert_eq!(actual_unwrap, expected_unwrap);
         let actual_unwrap = actual_unwrap.include_settings.unwrap_or_default();

--- a/rust/kcl-lib/src/settings/types/project.rs
+++ b/rust/kcl-lib/src/settings/types/project.rs
@@ -357,9 +357,11 @@ mod tests {
                 text_editor: ProjectTextEditorSettings {
                     text_wrapping: Some(false),
                     blinking_cursor: Some(false),
+                    other: Default::default(),
                 },
                 command_bar: ProjectCommandBarSettings {
                     include_settings: Some(false),
+                    other: Default::default(),
                 },
             },
             cloud: ProjectCloudSettings::default(),

--- a/src/lib/settings/settingsUtils.spec.ts
+++ b/src/lib/settings/settingsUtils.spec.ts
@@ -16,6 +16,7 @@ import {
   hiddenOnPlatform,
   mergeProjectConfiguration,
   projectConfigurationToSettingsPayload,
+  replaceProjectSettingsPreservingMetadata,
   settingsPayloadToProjectConfiguration,
   setSettingsAtLevel,
 } from '@src/lib/settings/settingsUtils'
@@ -265,6 +266,63 @@ describe('project settings serialization regression', () => {
 
     expect(parsedProjectConfiguration.cloud?.['dev.zoo.dev']?.project_id).toBe(
       'e9632dae-19ca-49ea-bcc1-ee8e34ff9de3'
+    )
+  })
+
+  it('drops cleared project settings while preserving project metadata', async () => {
+    const WASM_PATH = join(process.cwd(), 'public/kcl_wasm_lib_bg.wasm')
+    const wasmInstance = await loadAndInitialiseWasmInstance(WASM_PATH)
+
+    const existingProjectConfiguration: DeepPartial<ProjectConfiguration> = {
+      settings: {
+        meta: {
+          id: 'e8f5178c-5227-4567-bb5a-f52b3caef5ea',
+        },
+        modeling: {
+          base_unit: 'cm',
+        },
+        app: {
+          named_views: {
+            '0656fb1a-9640-473e-b334-591dc70c0138': {
+              name: 'uuid1',
+              eye_offset: 1,
+              fov_y: 1,
+              ortho_scale_enabled: false,
+              ortho_scale_factor: 1,
+              pivot_position: [0, 0, 0],
+              pivot_rotation: [0, 0, 0, 1],
+              world_coord_system: 'right_handed_up_z',
+              is_ortho: false,
+              version: 1,
+            },
+          },
+        },
+      },
+      cloud: {
+        'dev.zoo.dev': {
+          project_id: 'e9632dae-19ca-49ea-bcc1-ee8e34ff9de3',
+        },
+      },
+    }
+
+    const rewrittenProjectConfiguration =
+      replaceProjectSettingsPreservingMetadata(
+        existingProjectConfiguration,
+        settingsPayloadToProjectConfiguration({})
+      )
+    const serializedToml = serializeProjectConfiguration(
+      rewrittenProjectConfiguration,
+      wasmInstance
+    )
+    if (serializedToml instanceof Error) throw serializedToml
+
+    expect(serializedToml).not.toContain('base_unit = "cm"')
+    expect(serializedToml).not.toContain('named_views')
+    expect(serializedToml).toContain(
+      'id = "e8f5178c-5227-4567-bb5a-f52b3caef5ea"'
+    )
+    expect(serializedToml).toContain(
+      '[cloud."dev.zoo.dev"]\nproject_id = "e9632dae-19ca-49ea-bcc1-ee8e34ff9de3"'
     )
   })
 })

--- a/src/lib/settings/settingsUtils.ts
+++ b/src/lib/settings/settingsUtils.ts
@@ -127,6 +127,16 @@ type OmitNull<T> = T extends null ? undefined : T
 const toUndefinedIfNull = (a: any): OmitNull<any> =>
   a === null ? undefined : a
 
+function compactRecord<T extends Record<string, unknown>>(
+  value: T
+): Partial<T> | undefined {
+  const compacted = Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined)
+  ) as Partial<T>
+
+  return Object.keys(compacted).length > 0 ? compacted : undefined
+}
+
 /**
  * Convert from a rust settings struct into the JS settings struct.
  * We do this because the JS settings type has all the fancy shit
@@ -137,50 +147,95 @@ export function configurationToSettingsPayload(
 ): DeepPartial<SaveSettingsPayload> {
   return {
     app: {
-      theme: appThemeToTheme(configuration?.settings?.app?.appearance?.theme),
-      onboardingStatus: configuration?.settings?.app?.onboarding_status,
+      theme: configuration?.settings?.app?.appearance?.theme
+        ? appThemeToTheme(configuration?.settings?.app?.appearance?.theme)
+        : undefined,
+      onboardingStatus: toUndefinedIfNull(
+        configuration?.settings?.app?.onboarding_status
+      ),
       streamIdleMode: toUndefinedIfNull(
         configuration?.settings?.app?.stream_idle_mode
       ),
-      allowOrbitInSketchMode:
-        configuration?.settings?.app?.allow_orbit_in_sketch_mode,
-      projectDirectory: configuration?.settings?.project?.directory,
-      showDebugPanel: configuration?.settings?.app?.show_debug_panel,
-      machineApi: configuration?.settings?.app?.machine_api,
+      allowOrbitInSketchMode: toUndefinedIfNull(
+        configuration?.settings?.app?.allow_orbit_in_sketch_mode
+      ),
+      projectDirectory: toUndefinedIfNull(
+        configuration?.settings?.project?.directory
+      ),
+      showDebugPanel: toUndefinedIfNull(
+        configuration?.settings?.app?.show_debug_panel
+      ),
+      machineApi: toUndefinedIfNull(configuration?.settings?.app?.machine_api),
     },
     modeling: {
-      defaultUnit: configuration?.settings?.modeling?.base_unit,
-      cameraProjection: configuration?.settings?.modeling?.camera_projection,
-      cameraOrbit: configuration?.settings?.modeling?.camera_orbit,
-      mouseControls: mouseControlsToCameraSystem(
-        configuration?.settings?.modeling?.mouse_controls
+      defaultUnit: toUndefinedIfNull(
+        configuration?.settings?.modeling?.base_unit
       ),
-      gizmoType: configuration?.settings?.modeling?.gizmo_type,
-      enableTouchControls:
-        configuration?.settings?.modeling?.enable_touch_controls,
-      useSketchSolveMode:
-        configuration?.settings?.modeling?.use_sketch_solve_mode,
-      highlightEdges: configuration?.settings?.modeling?.highlight_edges,
-      enableSSAO: configuration?.settings?.modeling?.enable_ssao,
-      backfaceColor: configuration?.settings?.modeling?.backface_color,
-      showScaleGrid: configuration?.settings?.modeling?.show_scale_grid,
-      fixedSizeGrid: configuration?.settings?.modeling?.fixed_size_grid,
-      snapToGrid: configuration?.settings?.modeling?.snap_to_grid,
-      majorGridSpacing: configuration?.settings?.modeling?.major_grid_spacing,
-      minorGridsPerMajor:
-        configuration?.settings?.modeling?.minor_grids_per_major,
-      snapsPerMinor: configuration?.settings?.modeling?.snaps_per_minor,
+      cameraProjection: toUndefinedIfNull(
+        configuration?.settings?.modeling?.camera_projection
+      ),
+      cameraOrbit: toUndefinedIfNull(
+        configuration?.settings?.modeling?.camera_orbit
+      ),
+      mouseControls: configuration?.settings?.modeling?.mouse_controls
+        ? mouseControlsToCameraSystem(
+            configuration?.settings?.modeling?.mouse_controls
+          )
+        : undefined,
+      gizmoType: toUndefinedIfNull(
+        configuration?.settings?.modeling?.gizmo_type
+      ),
+      enableTouchControls: toUndefinedIfNull(
+        configuration?.settings?.modeling?.enable_touch_controls
+      ),
+      useSketchSolveMode: toUndefinedIfNull(
+        configuration?.settings?.modeling?.use_sketch_solve_mode
+      ),
+      highlightEdges: toUndefinedIfNull(
+        configuration?.settings?.modeling?.highlight_edges
+      ),
+      enableSSAO: toUndefinedIfNull(
+        configuration?.settings?.modeling?.enable_ssao
+      ),
+      backfaceColor: toUndefinedIfNull(
+        configuration?.settings?.modeling?.backface_color
+      ),
+      showScaleGrid: toUndefinedIfNull(
+        configuration?.settings?.modeling?.show_scale_grid
+      ),
+      fixedSizeGrid: toUndefinedIfNull(
+        configuration?.settings?.modeling?.fixed_size_grid
+      ),
+      snapToGrid: toUndefinedIfNull(
+        configuration?.settings?.modeling?.snap_to_grid
+      ),
+      majorGridSpacing: toUndefinedIfNull(
+        configuration?.settings?.modeling?.major_grid_spacing
+      ),
+      minorGridsPerMajor: toUndefinedIfNull(
+        configuration?.settings?.modeling?.minor_grids_per_major
+      ),
+      snapsPerMinor: toUndefinedIfNull(
+        configuration?.settings?.modeling?.snaps_per_minor
+      ),
     },
     textEditor: {
-      textWrapping: configuration?.settings?.text_editor?.text_wrapping,
-      blinkingCursor: configuration?.settings?.text_editor?.blinking_cursor,
+      textWrapping: toUndefinedIfNull(
+        configuration?.settings?.text_editor?.text_wrapping
+      ),
+      blinkingCursor: toUndefinedIfNull(
+        configuration?.settings?.text_editor?.blinking_cursor
+      ),
     },
     projects: {
-      defaultProjectName:
-        configuration?.settings?.project?.default_project_name,
+      defaultProjectName: toUndefinedIfNull(
+        configuration?.settings?.project?.default_project_name
+      ),
     },
     commandBar: {
-      includeSettings: configuration?.settings?.command_bar?.include_settings,
+      includeSettings: toUndefinedIfNull(
+        configuration?.settings?.command_bar?.include_settings
+      ),
     },
   }
 }
@@ -188,50 +243,84 @@ export function configurationToSettingsPayload(
 export function settingsPayloadToConfiguration(
   configuration: DeepPartial<SaveSettingsPayload>
 ): DeepPartial<Configuration> {
+  const appearance = compactRecord({
+    theme: toUndefinedIfNull(configuration?.app?.theme),
+  })
+
+  const app = compactRecord({
+    appearance,
+    onboarding_status: toUndefinedIfNull(configuration?.app?.onboardingStatus),
+    stream_idle_mode: toUndefinedIfNull(configuration?.app?.streamIdleMode),
+    allow_orbit_in_sketch_mode: toUndefinedIfNull(
+      configuration?.app?.allowOrbitInSketchMode
+    ),
+    show_debug_panel: toUndefinedIfNull(configuration?.app?.showDebugPanel),
+    machine_api: toUndefinedIfNull(configuration?.app?.machineApi),
+  })
+
+  const modeling = compactRecord({
+    base_unit: toUndefinedIfNull(configuration?.modeling?.defaultUnit),
+    camera_projection: toUndefinedIfNull(
+      configuration?.modeling?.cameraProjection
+    ),
+    camera_orbit: toUndefinedIfNull(configuration?.modeling?.cameraOrbit),
+    mouse_controls:
+      configuration?.modeling?.mouseControls !== null &&
+      configuration?.modeling?.mouseControls !== undefined
+        ? cameraSystemToMouseControl(configuration?.modeling?.mouseControls)
+        : undefined,
+    gizmo_type: toUndefinedIfNull(configuration?.modeling?.gizmoType),
+    enable_touch_controls: toUndefinedIfNull(
+      configuration?.modeling?.enableTouchControls
+    ),
+    use_sketch_solve_mode: toUndefinedIfNull(
+      configuration?.modeling?.useSketchSolveMode
+    ),
+    highlight_edges: toUndefinedIfNull(configuration?.modeling?.highlightEdges),
+    enable_ssao: toUndefinedIfNull(configuration?.modeling?.enableSSAO),
+    backface_color: toUndefinedIfNull(configuration?.modeling?.backfaceColor),
+    show_scale_grid: toUndefinedIfNull(configuration?.modeling?.showScaleGrid),
+    fixed_size_grid: toUndefinedIfNull(configuration?.modeling?.fixedSizeGrid),
+    snap_to_grid: toUndefinedIfNull(configuration?.modeling?.snapToGrid),
+    major_grid_spacing: toUndefinedIfNull(
+      configuration?.modeling?.majorGridSpacing
+    ),
+    minor_grids_per_major: toUndefinedIfNull(
+      configuration?.modeling?.minorGridsPerMajor
+    ),
+    snaps_per_minor: toUndefinedIfNull(configuration?.modeling?.snapsPerMinor),
+  })
+
+  const textEditor = compactRecord({
+    text_wrapping: toUndefinedIfNull(configuration?.textEditor?.textWrapping),
+    blinking_cursor: toUndefinedIfNull(
+      configuration?.textEditor?.blinkingCursor
+    ),
+  })
+
+  const project = compactRecord({
+    directory: toUndefinedIfNull(configuration?.app?.projectDirectory),
+    default_project_name: toUndefinedIfNull(
+      configuration?.projects?.defaultProjectName
+    ),
+  })
+
+  const commandBar = compactRecord({
+    include_settings: toUndefinedIfNull(
+      configuration?.commandBar?.includeSettings
+    ),
+  })
+
+  const settings = compactRecord({
+    app,
+    modeling,
+    text_editor: textEditor,
+    project,
+    command_bar: commandBar,
+  })
+
   return {
-    settings: {
-      app: {
-        appearance: {
-          theme: configuration?.app?.theme,
-        },
-        onboarding_status: configuration?.app?.onboardingStatus,
-        stream_idle_mode: configuration?.app?.streamIdleMode,
-        allow_orbit_in_sketch_mode: configuration?.app?.allowOrbitInSketchMode,
-        show_debug_panel: configuration?.app?.showDebugPanel,
-        machine_api: configuration?.app?.machineApi,
-      },
-      modeling: {
-        base_unit: configuration?.modeling?.defaultUnit,
-        camera_projection: configuration?.modeling?.cameraProjection,
-        camera_orbit: configuration?.modeling?.cameraOrbit,
-        mouse_controls: configuration?.modeling?.mouseControls
-          ? cameraSystemToMouseControl(configuration?.modeling?.mouseControls)
-          : undefined,
-        gizmo_type: configuration?.modeling?.gizmoType,
-        enable_touch_controls: configuration?.modeling?.enableTouchControls,
-        use_sketch_solve_mode: configuration?.modeling?.useSketchSolveMode,
-        highlight_edges: configuration?.modeling?.highlightEdges,
-        enable_ssao: configuration?.modeling?.enableSSAO,
-        backface_color: configuration?.modeling?.backfaceColor,
-        show_scale_grid: configuration?.modeling?.showScaleGrid,
-        fixed_size_grid: configuration?.modeling?.fixedSizeGrid,
-        snap_to_grid: configuration?.modeling?.snapToGrid,
-        major_grid_spacing: configuration?.modeling?.majorGridSpacing,
-        minor_grids_per_major: configuration?.modeling?.minorGridsPerMajor,
-        snaps_per_minor: configuration?.modeling?.snapsPerMinor,
-      },
-      text_editor: {
-        text_wrapping: configuration?.textEditor?.textWrapping,
-        blinking_cursor: configuration?.textEditor?.blinkingCursor,
-      },
-      project: {
-        directory: configuration?.app?.projectDirectory,
-        default_project_name: configuration?.projects?.defaultProjectName,
-      },
-      command_bar: {
-        include_settings: configuration?.commandBar?.includeSettings,
-      },
-    },
+    ...(settings ? { settings } : {}),
   }
 }
 
@@ -330,38 +419,52 @@ export function projectConfigurationToSettingsPayload(
 export function settingsPayloadToProjectConfiguration(
   configuration: DeepPartial<SaveSettingsPayload>
 ): DeepPartial<ProjectConfiguration> {
+  const namedViews = deepPartialNamedViewsToNamedViews(
+    configuration?.app?.namedViews
+  )
+
+  const meta = compactRecord({
+    id: configuration?.meta?.id,
+  })
+
+  const app = compactRecord({
+    onboarding_status: configuration?.app?.onboardingStatus,
+    allow_orbit_in_sketch_mode: configuration?.app?.allowOrbitInSketchMode,
+    show_debug_panel: configuration?.app?.showDebugPanel,
+    zookeeper_mode: configuration?.app?.zookeeperMode,
+    named_views: Object.keys(namedViews).length > 0 ? namedViews : undefined,
+  })
+
+  const modeling = compactRecord({
+    base_unit: configuration?.modeling?.defaultUnit,
+    highlight_edges: configuration?.modeling?.highlightEdges,
+    enable_ssao: configuration?.modeling?.enableSSAO,
+    fixed_size_grid: configuration?.modeling?.fixedSizeGrid,
+    snap_to_grid: configuration?.modeling?.snapToGrid,
+    major_grid_spacing: configuration?.modeling?.majorGridSpacing,
+    minor_grids_per_major: configuration?.modeling?.minorGridsPerMajor,
+    snaps_per_minor: configuration?.modeling?.snapsPerMinor,
+  })
+
+  const textEditor = compactRecord({
+    text_wrapping: configuration?.textEditor?.textWrapping,
+    blinking_cursor: configuration?.textEditor?.blinkingCursor,
+  })
+
+  const commandBar = compactRecord({
+    include_settings: configuration?.commandBar?.includeSettings,
+  })
+
+  const settings = compactRecord({
+    meta,
+    app,
+    modeling,
+    text_editor: textEditor,
+    command_bar: commandBar,
+  })
+
   return {
-    settings: {
-      meta: {
-        id: configuration?.meta?.id,
-      },
-      app: {
-        onboarding_status: configuration?.app?.onboardingStatus,
-        allow_orbit_in_sketch_mode: configuration?.app?.allowOrbitInSketchMode,
-        show_debug_panel: configuration?.app?.showDebugPanel,
-        zookeeper_mode: configuration?.app?.zookeeperMode,
-        named_views: deepPartialNamedViewsToNamedViews(
-          configuration?.app?.namedViews
-        ),
-      },
-      modeling: {
-        base_unit: configuration?.modeling?.defaultUnit,
-        highlight_edges: configuration?.modeling?.highlightEdges,
-        enable_ssao: configuration?.modeling?.enableSSAO,
-        fixed_size_grid: configuration?.modeling?.fixedSizeGrid,
-        snap_to_grid: configuration?.modeling?.snapToGrid,
-        major_grid_spacing: configuration?.modeling?.majorGridSpacing,
-        minor_grids_per_major: configuration?.modeling?.minorGridsPerMajor,
-        snaps_per_minor: configuration?.modeling?.snapsPerMinor,
-      },
-      text_editor: {
-        text_wrapping: configuration?.textEditor?.textWrapping,
-        blinking_cursor: configuration?.textEditor?.blinkingCursor,
-      },
-      command_bar: {
-        include_settings: configuration?.commandBar?.includeSettings,
-      },
-    },
+    ...(settings ? { settings } : {}),
   }
 }
 

--- a/src/lib/settings/settingsUtils.ts
+++ b/src/lib/settings/settingsUtils.ts
@@ -502,6 +502,29 @@ export function mergeProjectConfiguration(
   }
 }
 
+export function replaceProjectSettingsPreservingMetadata(
+  existingConfiguration: DeepPartial<ProjectConfiguration>,
+  updatedConfiguration: DeepPartial<ProjectConfiguration>
+): DeepPartial<ProjectConfiguration> {
+  const meta = compactRecord({
+    ...existingConfiguration.settings?.meta,
+    ...updatedConfiguration.settings?.meta,
+  })
+
+  const settings = compactRecord({
+    meta,
+    app: updatedConfiguration.settings?.app,
+    modeling: updatedConfiguration.settings?.modeling,
+    text_editor: updatedConfiguration.settings?.text_editor,
+    command_bar: updatedConfiguration.settings?.command_bar,
+  })
+
+  return {
+    ...existingConfiguration,
+    settings,
+  }
+}
+
 function setProjectConfigurationId(
   projectConfiguration: DeepPartial<ProjectConfiguration>,
   id: string
@@ -678,7 +701,7 @@ export async function saveSettings(
   )
   if (err(existingProjectSettings)) return
 
-  const mergedProjectSettings = mergeProjectConfiguration(
+  const mergedProjectSettings = replaceProjectSettingsPreservingMetadata(
     existingProjectSettings,
     settingsPayloadToProjectConfiguration(jsProjectSettings)
   )

--- a/src/lib/settings/settingsUtils.ts
+++ b/src/lib/settings/settingsUtils.ts
@@ -773,7 +773,7 @@ export function setSettingsAtLevel(
       // TODO: How do you get a valid type for allSettings[categoryKey][settingKey]?
       // it seems to always collapses to `never`, which is not correct
       // @ts-ignore
-      if (!allSettings[categoryKey][settingKey]) return // ignore unrecognized settings
+      if (!(settingKey in allSettings[categoryKey])) return // ignore unrecognized settings
       // @ts-ignore
       allSettings[categoryKey][settingKey][level] = settingValue as unknown
     })

--- a/src/machines/settingsMachine.ts
+++ b/src/machines/settingsMachine.ts
@@ -29,11 +29,8 @@ import type {
 } from '@src/lib/settings/settingsTypes'
 import {
   clearSettingsAtLevel,
-  configurationToSettingsPayload,
   loadAndValidateSettings,
-  projectConfigurationToSettingsPayload,
   saveSettings,
-  setSettingsAtLevel,
 } from '@src/lib/settings/settingsUtils'
 import {
   Themes,
@@ -257,14 +254,12 @@ export const settingsMachine = setup({
 
       console.log('Resetting settings at level', event.level)
 
-      // Create a new, blank payload
-      const newPayload =
-        event.level === 'user'
-          ? configurationToSettingsPayload({})
-          : projectConfigurationToSettingsPayload({})
-
-      // Reset the settings at that level
-      const newSettings = setSettingsAtLevel(context, event.level, newPayload)
+      // Clear the selected level entirely so settings fall back to the
+      // parent level/default rather than retaining stale values in memory.
+      const newSettings = clearSettingsAtLevel(
+        getOnlySettingsFromContext(context),
+        event.level
+      )
 
       return newSettings
     }),


### PR DESCRIPTION
Authored primarily by @adamchalmers as he was on a huddle with me. This PR enables the serialization of boolean settings that are set to `false`, and allows settings that are not defined in the Rust settings schema to be serialized but ignored. The first point solves buggy behavior with our app around toggling boolean settings, and the latter **allows ZDS to define settings that are not available to the CLI**. This is huge because we can have far more settings without the friction of needing CLI to care about them!. Closes #10397.