### PR TITLE
Update all occurences of double/missing caps in loft/sweep results

### DIFF
--- a/rust/kcl-lib/tests/kcl_samples/cold-plate/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/cold-plate/artifact_graph_flowchart.snap.md
@@ -228,7 +228,7 @@ flowchart LR
     %% face_code_ref=Missing NodePath
   130["Cap Start"]
     %% face_code_ref=Missing NodePath
-  131["Cap Start"]
+  131["Cap End"]
     %% face_code_ref=Missing NodePath
   132["SweepEdge Opposite"]
   133["SweepEdge Adjacent"]

--- a/rust/kcl-lib/tests/kcl_samples/cold-plate/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/cold-plate/program_memory.snap
@@ -1720,7 +1720,7 @@ description: Variables in memory after executing cold-plate.kcl
         "units": "in"
       },
       "startCapId": "[uuid]",
-      "endCapId": null,
+      "endCapId": "[uuid]",
       "units": "in",
       "sectional": false
     }

--- a/rust/kcl-lib/tests/kcl_samples/end-effector-gripper-fingers/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/end-effector-gripper-fingers/program_memory.snap
@@ -8213,7 +8213,7 @@ description: Variables in memory after executing end-effector-gripper-fingers.kc
         "originalId": "[uuid]",
         "units": "mm"
       },
-      "startCapId": null,
+      "startCapId": "[uuid]",
       "endCapId": "[uuid]",
       "units": "mm",
       "sectional": false
@@ -11410,7 +11410,7 @@ description: Variables in memory after executing end-effector-gripper-fingers.kc
         "originalId": "[uuid]",
         "units": "mm"
       },
-      "startCapId": null,
+      "startCapId": "[uuid]",
       "endCapId": "[uuid]",
       "units": "mm",
       "sectional": false

--- a/rust/kcl-lib/tests/kcl_samples/inner-thread/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/inner-thread/artifact_graph_flowchart.snap.md
@@ -67,7 +67,7 @@ flowchart LR
     %% face_code_ref=Missing NodePath
   34["Cap Start"]
     %% face_code_ref=Missing NodePath
-  35["Cap Start"]
+  35["Cap End"]
     %% face_code_ref=Missing NodePath
   36["SweepEdge Opposite"]
   37["SweepEdge Adjacent"]

--- a/rust/kcl-lib/tests/kcl_samples/inner-thread/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/inner-thread/program_memory.snap
@@ -394,7 +394,7 @@ description: Variables in memory after executing inner-thread.kcl
         "units": "mm"
       },
       "startCapId": "[uuid]",
-      "endCapId": null,
+      "endCapId": "[uuid]",
       "units": "mm",
       "sectional": false
     }

--- a/rust/kcl-lib/tests/kcl_samples/mug/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/mug/artifact_graph_flowchart.snap.md
@@ -138,7 +138,7 @@ flowchart LR
     %% face_code_ref=Missing NodePath
   55[Wall]
     %% face_code_ref=Missing NodePath
-  56["Cap End"]
+  56["Cap Start"]
     %% face_code_ref=Missing NodePath
   57["Cap End"]
     %% face_code_ref=Missing NodePath

--- a/rust/kcl-lib/tests/kcl_samples/mug/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/mug/program_memory.snap
@@ -191,7 +191,7 @@ description: Variables in memory after executing mug.kcl
         "originalId": "[uuid]",
         "units": "mm"
       },
-      "startCapId": null,
+      "startCapId": "[uuid]",
       "endCapId": "[uuid]",
       "units": "mm",
       "sectional": false

--- a/rust/kcl-lib/tests/kcl_samples/prosthetic-hip/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/prosthetic-hip/program_memory.snap
@@ -657,7 +657,7 @@ description: Variables in memory after executing prosthetic-hip.kcl
         "originalId": "[uuid]",
         "units": "mm"
       },
-      "startCapId": null,
+      "startCapId": "[uuid]",
       "endCapId": "[uuid]",
       "units": "mm",
       "sectional": false

--- a/rust/kcl-lib/tests/kcl_samples/split-washer-spring-version/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/split-washer-spring-version/artifact_graph_flowchart.snap.md
@@ -31,7 +31,7 @@ flowchart LR
     %% face_code_ref=Missing NodePath
   15["Cap Start"]
     %% face_code_ref=Missing NodePath
-  16["Cap Start"]
+  16["Cap End"]
     %% face_code_ref=Missing NodePath
   17["SweepEdge Opposite"]
   18["SweepEdge Adjacent"]

--- a/rust/kcl-lib/tests/kcl_samples/split-washer-spring-version/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/split-washer-spring-version/program_memory.snap
@@ -177,7 +177,7 @@ description: Variables in memory after executing split-washer-spring-version.kcl
         "units": "mm"
       },
       "startCapId": "[uuid]",
-      "endCapId": null,
+      "endCapId": "[uuid]",
       "units": "mm",
       "sectional": false
     }

--- a/rust/kcl-lib/tests/kcl_samples/teapot/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/teapot/program_memory.snap
@@ -540,7 +540,7 @@ description: Variables in memory after executing teapot.kcl
         "units": "mm"
       },
       "startCapId": "[uuid]",
-      "endCapId": null,
+      "endCapId": "[uuid]",
       "units": "mm",
       "sectional": false
     }
@@ -879,7 +879,7 @@ description: Variables in memory after executing teapot.kcl
         "originalId": "[uuid]",
         "units": "mm"
       },
-      "startCapId": null,
+      "startCapId": "[uuid]",
       "endCapId": "[uuid]",
       "units": "mm",
       "sectional": false

--- a/rust/kcl-lib/tests/kcl_samples/usb-c/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/usb-c/artifact_graph_flowchart.snap.md
@@ -181,7 +181,7 @@ flowchart LR
     %% [ProgramBodyItem { index: 33 }, VariableDeclarationDeclaration, VariableDeclarationInit, PipeBodyItem { index: 2 }]
   103[Wall]
     %% face_code_ref=Missing NodePath
-  104["Cap End"]
+  104["Cap Start"]
     %% face_code_ref=Missing NodePath
   105["Cap End"]
     %% face_code_ref=Missing NodePath

--- a/rust/kcl-lib/tests/kcl_samples/usb-c/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/usb-c/program_memory.snap
@@ -98,7 +98,7 @@ description: Variables in memory after executing usb-c.kcl
         "originalId": "[uuid]",
         "units": "mm"
       },
-      "startCapId": null,
+      "startCapId": "[uuid]",
       "endCapId": "[uuid]",
       "units": "mm",
       "sectional": false

--- a/rust/kcl-lib/tests/kcl_samples/utility-sink/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/utility-sink/artifact_graph_flowchart.snap.md
@@ -542,7 +542,7 @@ flowchart LR
     %% face_code_ref=Missing NodePath
   310["Cap Start"]
     %% face_code_ref=Missing NodePath
-  311["Cap Start"]
+  311["Cap End"]
     %% face_code_ref=Missing NodePath
   312["SweepEdge Opposite"]
   313["SweepEdge Adjacent"]

--- a/rust/kcl-lib/tests/kcl_samples/utility-sink/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/utility-sink/program_memory.snap
@@ -891,7 +891,7 @@ description: Variables in memory after executing utility-sink.kcl
             "units": "mm"
           },
           "startCapId": "[uuid]",
-          "endCapId": null,
+          "endCapId": "[uuid]",
           "units": "mm",
           "sectional": false
         }
@@ -992,7 +992,7 @@ description: Variables in memory after executing utility-sink.kcl
             "units": "mm"
           },
           "startCapId": "[uuid]",
-          "endCapId": null,
+          "endCapId": "[uuid]",
           "units": "mm",
           "sectional": false
         }

--- a/rust/kcl-lib/tests/subtract_regression03/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/subtract_regression03/artifact_graph_flowchart.snap.md
@@ -59,9 +59,9 @@ flowchart LR
     %% [ProgramBodyItem { index: 5 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   15[Wall]
     %% face_code_ref=Missing NodePath
-  16["Cap End"]
+  16["Cap Start"]
     %% face_code_ref=Missing NodePath
-  17["Cap Start"]
+  17["Cap End"]
     %% face_code_ref=Missing NodePath
   18["SweepEdge Opposite"]
   19["SweepEdge Adjacent"]

--- a/rust/kcl-lib/tests/subtract_regression07/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/subtract_regression07/artifact_graph_flowchart.snap.md
@@ -83,7 +83,7 @@ flowchart LR
     %% [ProgramBodyItem { index: 9 }, VariableDeclarationDeclaration, VariableDeclarationInit]
   47[Wall]
     %% face_code_ref=Missing NodePath
-  48["Cap End"]
+  48["Cap Start"]
     %% face_code_ref=Missing NodePath
   49["Cap End"]
     %% face_code_ref=Missing NodePath

--- a/rust/kcl-lib/tests/subtract_regression07/program_memory.snap
+++ b/rust/kcl-lib/tests/subtract_regression07/program_memory.snap
@@ -345,7 +345,7 @@ description: Variables in memory after executing subtract_regression07.kcl
         "originalId": "[uuid]",
         "units": "in"
       },
-      "startCapId": null,
+      "startCapId": "[uuid]",
       "endCapId": "[uuid]",
       "units": "in",
       "sectional": false


### PR DESCRIPTION
Will be green after engine merges.  Closes #10951