### PR TITLE
KCL: Nicer error messages

### DIFF
--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -630,7 +630,7 @@ impl SketchApi for FrontendState {
                                     let SegmentCtor::Line(line_ctor) = existing else {
                                         return Err(KclErrorWithOutputs::no_outputs(KclError::refactor(format!(
                                             "Internal: Expected line ctor for owner, but found {}",
-                                            owner_object.kind.human_friendly_kind_with_article()
+                                            existing.human_friendly_kind_with_article()
                                         ))));
                                     };
                                     // Line owner is already in final_edits -> apply this point edit
@@ -652,7 +652,7 @@ impl SketchApi for FrontendState {
                                     // This should never run..
                                     return Err(KclErrorWithOutputs::no_outputs(KclError::refactor(format!(
                                         "Internal: Line does not have line ctor, but found {}",
-                                        owner_object.kind.human_friendly_kind_with_article()
+                                        line.ctor.human_friendly_kind_with_article()
                                     ))));
                                 }
                                 continue;
@@ -664,7 +664,7 @@ impl SketchApi for FrontendState {
                                     let SegmentCtor::Arc(arc_ctor) = existing else {
                                         return Err(KclErrorWithOutputs::no_outputs(KclError::refactor(format!(
                                             "Internal: Expected arc ctor for owner, but found {}",
-                                            owner_object.kind.human_friendly_kind_with_article()
+                                            existing.human_friendly_kind_with_article()
                                         ))));
                                     };
                                     if arc.start == segment_id {
@@ -687,7 +687,7 @@ impl SketchApi for FrontendState {
                                 } else {
                                     return Err(KclErrorWithOutputs::no_outputs(KclError::refactor(format!(
                                         "Internal: Arc does not have arc ctor, but found {}",
-                                        owner_object.kind.human_friendly_kind_with_article()
+                                        arc.ctor.human_friendly_kind_with_article()
                                     ))));
                                 }
                                 continue;
@@ -697,7 +697,7 @@ impl SketchApi for FrontendState {
                                     let SegmentCtor::Circle(circle_ctor) = existing else {
                                         return Err(KclErrorWithOutputs::no_outputs(KclError::refactor(format!(
                                             "Internal: Expected circle ctor for owner, but found {}",
-                                            owner_object.kind.human_friendly_kind_with_article()
+                                            existing.human_friendly_kind_with_article()
                                         ))));
                                     };
                                     if circle.start == segment_id {
@@ -716,7 +716,7 @@ impl SketchApi for FrontendState {
                                 } else {
                                     return Err(KclErrorWithOutputs::no_outputs(KclError::refactor(format!(
                                         "Internal: Circle does not have circle ctor, but found {}",
-                                        owner_object.kind.human_friendly_kind_with_article()
+                                        circle.ctor.human_friendly_kind_with_article()
                                     ))));
                                 }
                                 continue;
@@ -2094,7 +2094,7 @@ impl FrontendState {
                 let SegmentCtor::Line(line_ctor) = &line.ctor else {
                     return Err(KclError::refactor(format!(
                         "Internal: Owner of point does not have line ctor, but found {}",
-                        owner_object.kind.human_friendly_kind_with_article()
+                        line.ctor.human_friendly_kind_with_article()
                     )));
                 };
                 let mut line_ctor = line_ctor.clone();
@@ -2116,7 +2116,7 @@ impl FrontendState {
                 let SegmentCtor::Arc(arc_ctor) = &arc.ctor else {
                     return Err(KclError::refactor(format!(
                         "Internal: Owner of point does not have arc ctor, but found {}",
-                        owner_object.kind.human_friendly_kind_with_article()
+                        arc.ctor.human_friendly_kind_with_article()
                     )));
                 };
                 let mut arc_ctor = arc_ctor.clone();
@@ -2140,7 +2140,7 @@ impl FrontendState {
                 let SegmentCtor::Circle(circle_ctor) = &circle.ctor else {
                     return Err(KclError::refactor(format!(
                         "Internal: Owner of point does not have circle ctor, but found {}",
-                        owner_object.kind.human_friendly_kind_with_article()
+                        circle.ctor.human_friendly_kind_with_article()
                     )));
                 };
                 let mut circle_ctor = circle_ctor.clone();

--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -1580,7 +1580,10 @@ impl FrontendState {
                 .get(segment_id.0)
                 .ok_or_else(|| make_err(format!("Segment not found: {segment_id:?}")))?;
             let ObjectKind::Segment { segment } = &segment_object.kind else {
-                return Err(make_err(format!("Object is not a segment: {segment_object:?}")));
+                return Err(make_err(format!(
+                    "Object is not a segment, it is {}",
+                    segment_object.kind.human_friendly_kind_with_article()
+                )));
             };
             let Segment::Point(_) = segment else {
                 return Err(make_err(format!(
@@ -1717,7 +1720,10 @@ impl FrontendState {
                 .scene_object_by_id(segment_id)
                 .ok_or_else(|| make_err(format!("Segment not found: {segment_id:?}")))?;
             let ObjectKind::Segment { segment } = &segment_object.kind else {
-                return Err(make_err(format!("Object is not a segment: {segment_object:?}")));
+                return Err(make_err(format!(
+                    "Object is not a segment, it is {}",
+                    segment_object.kind.human_friendly_kind_with_article()
+                )));
             };
             let Segment::Line(line) = segment else {
                 return Err(make_err(format!(
@@ -1861,7 +1867,10 @@ impl FrontendState {
                 .get(segment_id.0)
                 .ok_or_else(|| make_err(format!("Segment not found: {segment_id:?}")))?;
             let ObjectKind::Segment { segment } = &segment_object.kind else {
-                return Err(make_err(format!("Object is not a segment: {segment_object:?}")));
+                return Err(make_err(format!(
+                    "Object is not a segment, it is {}",
+                    segment_object.kind.human_friendly_kind_with_article()
+                )));
             };
             let Segment::Arc(arc) = segment else {
                 return Err(make_err(format!(
@@ -2002,7 +2011,10 @@ impl FrontendState {
                 .get(segment_id.0)
                 .ok_or_else(|| make_err(format!("Segment not found: {segment_id:?}")))?;
             let ObjectKind::Segment { segment } = &segment_object.kind else {
-                return Err(make_err(format!("Object is not a segment: {segment_object:?}")));
+                return Err(make_err(format!(
+                    "Object is not a segment, it is {}",
+                    segment_object.kind.human_friendly_kind_with_article()
+                )));
             };
             let Segment::Circle(circle) = segment else {
                 return Err(make_err(format!(
@@ -2338,7 +2350,8 @@ impl FrontendState {
             })?;
         let ObjectKind::Segment { .. } = &segment_object.kind else {
             return Err(KclError::refactor(format!(
-                "Object is not a segment: {segment_object:?}"
+                "Object is not a segment, it is {}",
+                segment_object.kind.human_friendly_kind_with_article()
             )));
         };
 
@@ -2673,7 +2686,8 @@ impl FrontendState {
                     .ok_or_else(|| KclError::refactor(format!("Object not found: {segment_id:?}")))?;
                 let ObjectKind::Segment { segment } = &segment_object.kind else {
                     return Err(KclError::refactor(format!(
-                        "Object is not a segment: {segment_object:?}"
+                        "Object is not a segment, it is {}",
+                        segment_object.kind.human_friendly_kind_with_article()
                     )));
                 };
 

--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -469,7 +469,8 @@ impl SketchApi for FrontendState {
         })?;
         let ObjectKind::Sketch(_) = &sketch_object.kind else {
             return Err(KclErrorWithOutputs::no_outputs(KclError::refactor(format!(
-                "Object is not a sketch: {sketch_object:?}"
+                "Object is not a sketch, it is {}",
+                sketch_object.kind.human_friendly_kind_with_article()
             ))));
         };
         let sketch_block_ref = expect_single_node_ref(sketch_object).map_err(KclErrorWithOutputs::no_outputs)?;
@@ -546,7 +547,8 @@ impl SketchApi for FrontendState {
         })?;
         let ObjectKind::Sketch(_) = &sketch_object.kind else {
             return Err(KclErrorWithOutputs::no_outputs(KclError::refactor(format!(
-                "Object is not a sketch: {sketch_object:?}"
+                "Object is not a sketch, it is {}",
+                sketch_object.kind.human_friendly_kind_with_article(),
             ))));
         };
 
@@ -627,7 +629,8 @@ impl SketchApi for FrontendState {
                                 if let Some(existing) = final_edits.get_mut(&owner_id) {
                                     let SegmentCtor::Line(line_ctor) = existing else {
                                         return Err(KclErrorWithOutputs::no_outputs(KclError::refactor(format!(
-                                            "Internal: Expected line ctor for owner: {owner_object:?}"
+                                            "Internal: Expected line ctor for owner, but found {}",
+                                            owner_object.kind.human_friendly_kind_with_article()
                                         ))));
                                     };
                                     // Line owner is already in final_edits -> apply this point edit
@@ -648,7 +651,8 @@ impl SketchApi for FrontendState {
                                 } else {
                                     // This should never run..
                                     return Err(KclErrorWithOutputs::no_outputs(KclError::refactor(format!(
-                                        "Internal: Line does not have line ctor: {owner_object:?}"
+                                        "Internal: Line does not have line ctor, but found {}",
+                                        owner_object.kind.human_friendly_kind_with_article()
                                     ))));
                                 }
                                 continue;
@@ -659,7 +663,8 @@ impl SketchApi for FrontendState {
                                 if let Some(existing) = final_edits.get_mut(&owner_id) {
                                     let SegmentCtor::Arc(arc_ctor) = existing else {
                                         return Err(KclErrorWithOutputs::no_outputs(KclError::refactor(format!(
-                                            "Internal: Expected arc ctor for owner: {owner_object:?}"
+                                            "Internal: Expected arc ctor for owner, but found {}",
+                                            owner_object.kind.human_friendly_kind_with_article()
                                         ))));
                                     };
                                     if arc.start == segment_id {
@@ -681,7 +686,8 @@ impl SketchApi for FrontendState {
                                     final_edits.insert(owner_id, SegmentCtor::Arc(arc_ctor));
                                 } else {
                                     return Err(KclErrorWithOutputs::no_outputs(KclError::refactor(format!(
-                                        "Internal: Arc does not have arc ctor: {owner_object:?}"
+                                        "Internal: Arc does not have arc ctor, but found {}",
+                                        owner_object.kind.human_friendly_kind_with_article()
                                     ))));
                                 }
                                 continue;
@@ -690,7 +696,8 @@ impl SketchApi for FrontendState {
                                 if let Some(existing) = final_edits.get_mut(&owner_id) {
                                     let SegmentCtor::Circle(circle_ctor) = existing else {
                                         return Err(KclErrorWithOutputs::no_outputs(KclError::refactor(format!(
-                                            "Internal: Expected circle ctor for owner: {owner_object:?}"
+                                            "Internal: Expected circle ctor for owner, but found {}",
+                                            owner_object.kind.human_friendly_kind_with_article()
                                         ))));
                                     };
                                     if circle.start == segment_id {
@@ -708,7 +715,8 @@ impl SketchApi for FrontendState {
                                     final_edits.insert(owner_id, SegmentCtor::Circle(circle_ctor));
                                 } else {
                                     return Err(KclErrorWithOutputs::no_outputs(KclError::refactor(format!(
-                                        "Internal: Circle does not have circle ctor: {owner_object:?}"
+                                        "Internal: Circle does not have circle ctor, but found {}",
+                                        owner_object.kind.human_friendly_kind_with_article()
                                     ))));
                                 }
                                 continue;
@@ -1501,7 +1509,8 @@ impl FrontendState {
         })?;
         let ObjectKind::Sketch(_) = &sketch_object.kind else {
             return Err(KclErrorWithOutputs::no_outputs(KclError::refactor(format!(
-                "Object is not a sketch: {sketch_object:?}"
+                "Object is not a sketch, it is {}",
+                sketch_object.kind.human_friendly_kind_with_article(),
             ))));
         };
         // Add the point to the AST of the sketch block.
@@ -1635,7 +1644,8 @@ impl FrontendState {
         })?;
         let ObjectKind::Sketch(_) = &sketch_object.kind else {
             return Err(KclErrorWithOutputs::no_outputs(KclError::refactor(format!(
-                "Object is not a sketch: {sketch_object:?}"
+                "Object is not a sketch, it is {}",
+                sketch_object.kind.human_friendly_kind_with_article(),
             ))));
         };
         // Add the line to the AST of the sketch block.
@@ -1774,7 +1784,8 @@ impl FrontendState {
         })?;
         let ObjectKind::Sketch(_) = &sketch_object.kind else {
             return Err(KclErrorWithOutputs::no_outputs(KclError::refactor(format!(
-                "Object is not a sketch: {sketch_object:?}"
+                "Object is not a sketch, it is {}",
+                sketch_object.kind.human_friendly_kind_with_article(),
             ))));
         };
         // Add the arc to the AST of the sketch block.
@@ -1908,7 +1919,8 @@ impl FrontendState {
         })?;
         let ObjectKind::Sketch(_) = &sketch_object.kind else {
             return Err(KclErrorWithOutputs::no_outputs(KclError::refactor(format!(
-                "Object is not a sketch: {sketch_object:?}"
+                "Object is not a sketch, it is {}",
+                sketch_object.kind.human_friendly_kind_with_article(),
             ))));
         };
         // Add the circle to the AST of the sketch block.
@@ -2046,7 +2058,8 @@ impl FrontendState {
             })?;
             let ObjectKind::Segment { segment } = &owner_object.kind else {
                 return Err(KclError::refactor(format!(
-                    "Internal: Owner of point is not a segment: {owner_object:?}"
+                    "Internal: Owner of point is not a segment, but found {}",
+                    owner_object.kind.human_friendly_kind_with_article()
                 )));
             };
 
@@ -2054,7 +2067,8 @@ impl FrontendState {
             if let Segment::Line(line) = segment {
                 let SegmentCtor::Line(line_ctor) = &line.ctor else {
                     return Err(KclError::refactor(format!(
-                        "Internal: Owner of point does not have line ctor: {owner_object:?}"
+                        "Internal: Owner of point does not have line ctor, but found {}",
+                        owner_object.kind.human_friendly_kind_with_article()
                     )));
                 };
                 let mut line_ctor = line_ctor.clone();
@@ -2075,7 +2089,8 @@ impl FrontendState {
             if let Segment::Arc(arc) = segment {
                 let SegmentCtor::Arc(arc_ctor) = &arc.ctor else {
                     return Err(KclError::refactor(format!(
-                        "Internal: Owner of point does not have arc ctor: {owner_object:?}"
+                        "Internal: Owner of point does not have arc ctor, but found {}",
+                        owner_object.kind.human_friendly_kind_with_article()
                     )));
                 };
                 let mut arc_ctor = arc_ctor.clone();
@@ -2098,7 +2113,8 @@ impl FrontendState {
             if let Segment::Circle(circle) = segment {
                 let SegmentCtor::Circle(circle_ctor) = &circle.ctor else {
                     return Err(KclError::refactor(format!(
-                        "Internal: Owner of point does not have circle ctor: {owner_object:?}"
+                        "Internal: Owner of point does not have circle ctor, but found {}",
+                        owner_object.kind.human_friendly_kind_with_article()
                     )));
                 };
                 let mut circle_ctor = circle_ctor.clone();
@@ -2157,7 +2173,10 @@ impl FrontendState {
             .get(line_id.0)
             .ok_or_else(|| KclError::refactor(format!("Line not found in scene graph: line={line:?}")))?;
         let ObjectKind::Segment { .. } = &line_object.kind else {
-            return Err(KclError::refactor(format!("Object is not a segment: {line_object:?}")));
+            let kind = line_object.kind.human_friendly_kind_with_article();
+            return Err(KclError::refactor(format!(
+                "This constraint only works on Segments, but you selected {kind}"
+            )));
         };
 
         // Modify the line AST.
@@ -2379,11 +2398,15 @@ impl FrontendState {
                     .get(line_id.0)
                     .ok_or_else(|| KclError::refactor(format!("Line not found: {line_id:?}")))?;
                 let ObjectKind::Segment { segment: line_segment } = &line_object.kind else {
-                    return Err(KclError::refactor(format!("Object is not a segment: {line_object:?}")));
+                    let kind = line_object.kind.human_friendly_kind_with_article();
+                    return Err(KclError::refactor(format!(
+                        "This constraint only works on Segments, but you selected {kind}"
+                    )));
                 };
                 let Segment::Line(_) = line_segment else {
+                    let kind = line_segment.human_friendly_kind_with_article();
                     return Err(KclError::refactor(format!(
-                        "Only lines can be made equal length: {line_object:?}"
+                        "Only lines can be made equal length, but you selected {kind}"
                     )));
                 };
 
@@ -2566,7 +2589,8 @@ impl FrontendState {
             })?;
             let ObjectKind::Segment { segment: owner_segment } = &owner_object.kind else {
                 return Err(KclError::refactor(format!(
-                    "Owner of point is not a segment: {owner_object:?}"
+                    "Owner of point is not a segment, but found {}",
+                    owner_object.kind.human_friendly_kind_with_article()
                 )));
             };
 
@@ -3156,11 +3180,15 @@ impl FrontendState {
             .get(line_id.0)
             .ok_or_else(|| KclError::refactor(format!("Line not found: {line_id:?}")))?;
         let ObjectKind::Segment { segment: line_segment } = &line_object.kind else {
-            return Err(KclError::refactor(format!("Object is not a segment: {line_object:?}")));
+            let kind = line_object.kind.human_friendly_kind_with_article();
+            return Err(KclError::refactor(format!(
+                "This constraint only works on Segments, but you selected {kind}"
+            )));
         };
         let Segment::Line(_) = line_segment else {
             return Err(KclError::refactor(format!(
-                "Only lines can be made horizontal: {line_object:?}"
+                "Only lines can be made horizontal, but you selected {}",
+                line_segment.human_friendly_kind_with_article(),
             )));
         };
         let line_ast = get_or_insert_ast_reference(new_ast, &line_object.source.clone(), "line", None)?;
@@ -3203,11 +3231,15 @@ impl FrontendState {
                     .get(line_id.0)
                     .ok_or_else(|| KclError::refactor(format!("Line not found: {line_id:?}")))?;
                 let ObjectKind::Segment { segment: line_segment } = &line_object.kind else {
-                    return Err(KclError::refactor(format!("Object is not a segment: {line_object:?}")));
+                    let kind = line_object.kind.human_friendly_kind_with_article();
+                    return Err(KclError::refactor(format!(
+                        "This constraint only works on Segments, but you selected {kind}"
+                    )));
                 };
                 let Segment::Line(_) = line_segment else {
+                    let kind = line_segment.human_friendly_kind_with_article();
                     return Err(KclError::refactor(format!(
-                        "Only lines can be made equal length: {line_object:?}"
+                        "Only lines can be made equal length, but you selected {kind}"
                     )));
                 };
 
@@ -3271,12 +3303,16 @@ impl FrontendState {
             .get(line0_id.0)
             .ok_or_else(|| KclError::refactor(format!("Line not found: {line0_id:?}")))?;
         let ObjectKind::Segment { segment: line0_segment } = &line0_object.kind else {
-            return Err(KclError::refactor(format!("Object is not a segment: {line0_object:?}")));
+            let kind = line0_object.kind.human_friendly_kind_with_article();
+            return Err(KclError::refactor(format!(
+                "This constraint only works on Segments, but you selected {kind}"
+            )));
         };
         let Segment::Line(_) = line0_segment else {
             return Err(KclError::refactor(format!(
-                "Only lines can be made {}: {line0_object:?}",
-                angle_kind.to_function_name()
+                "Only lines can be made {}, but you selected {}",
+                angle_kind.to_function_name(),
+                line0_segment.human_friendly_kind_with_article(),
             )));
         };
         let line0_ast = get_or_insert_ast_reference(new_ast, &line0_object.source.clone(), "line", None)?;
@@ -3287,12 +3323,16 @@ impl FrontendState {
             .get(line1_id.0)
             .ok_or_else(|| KclError::refactor(format!("Line not found: {line1_id:?}")))?;
         let ObjectKind::Segment { segment: line1_segment } = &line1_object.kind else {
-            return Err(KclError::refactor(format!("Object is not a segment: {line1_object:?}")));
+            let kind = line1_object.kind.human_friendly_kind_with_article();
+            return Err(KclError::refactor(format!(
+                "This constraint only works on Segments, but you selected {kind}"
+            )));
         };
         let Segment::Line(_) = line1_segment else {
             return Err(KclError::refactor(format!(
-                "Only lines can be made {}: {line1_object:?}",
-                angle_kind.to_function_name()
+                "Only lines can be made {}, but you selected {}",
+                angle_kind.to_function_name(),
+                line1_segment.human_friendly_kind_with_article(),
             )));
         };
         let line1_ast = get_or_insert_ast_reference(new_ast, &line1_object.source.clone(), "line", None)?;
@@ -3337,11 +3377,15 @@ impl FrontendState {
             .get(line_id.0)
             .ok_or_else(|| KclError::refactor(format!("Line not found: {line_id:?}")))?;
         let ObjectKind::Segment { segment: line_segment } = &line_object.kind else {
-            return Err(KclError::refactor(format!("Object is not a segment: {line_object:?}")));
+            let kind = line_object.kind.human_friendly_kind_with_article();
+            return Err(KclError::refactor(format!(
+                "This constraint only works on Segments, but you selected {kind}"
+            )));
         };
         let Segment::Line(_) = line_segment else {
             return Err(KclError::refactor(format!(
-                "Only lines can be made vertical: {line_object:?}"
+                "Only lines can be made vertical, but you selected {}",
+                line_segment.human_friendly_kind_with_article()
             )));
         };
         let line_ast = get_or_insert_ast_reference(new_ast, &line_object.source.clone(), "line", None)?;

--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -819,7 +819,8 @@ impl SketchApi for FrontendState {
             })?;
             let ObjectKind::Constraint { constraint } = &constraint_object.kind else {
                 return Err(KclErrorWithOutputs::no_outputs(KclError::refactor(format!(
-                    "Object is not a constraint: {constraint_object:?}"
+                    "Object is not a constraint, it is {}",
+                    constraint_object.kind.human_friendly_kind_with_article()
                 ))));
             };
 
@@ -967,7 +968,8 @@ impl SketchApi for FrontendState {
         // First, add the segment (line) to get its start point ID
         let SegmentCtor::Line(line_ctor) = segment else {
             return Err(KclErrorWithOutputs::no_outputs(KclError::refactor(format!(
-                "chain_segment currently only supports Line segments, got: {segment:?}"
+                "chain_segment currently only supports Line segments, got {}",
+                segment.human_friendly_kind_with_article(),
             ))));
         };
 
@@ -1581,7 +1583,10 @@ impl FrontendState {
                 return Err(make_err(format!("Object is not a segment: {segment_object:?}")));
             };
             let Segment::Point(_) = segment else {
-                return Err(make_err(format!("Segment is not a point: {segment:?}")));
+                return Err(make_err(format!(
+                    "Segment is not a point, it is {}",
+                    segment.human_friendly_kind_with_article()
+                )));
             };
             vec![segment_id]
         };
@@ -1715,7 +1720,10 @@ impl FrontendState {
                 return Err(make_err(format!("Object is not a segment: {segment_object:?}")));
             };
             let Segment::Line(line) = segment else {
-                return Err(make_err(format!("Segment is not a line: {segment:?}")));
+                return Err(make_err(format!(
+                    "Segment is not a line, it is {}",
+                    segment.human_friendly_kind_with_article()
+                )));
             };
             vec![line.start, line.end, segment_id]
         };
@@ -1856,7 +1864,10 @@ impl FrontendState {
                 return Err(make_err(format!("Object is not a segment: {segment_object:?}")));
             };
             let Segment::Arc(arc) = segment else {
-                return Err(make_err(format!("Segment is not an arc: {segment:?}")));
+                return Err(make_err(format!(
+                    "Segment is not an arc, it is {}",
+                    segment.human_friendly_kind_with_article()
+                )));
             };
             vec![arc.start, arc.end, arc.center, segment_id]
         };
@@ -1994,7 +2005,10 @@ impl FrontendState {
                 return Err(make_err(format!("Object is not a segment: {segment_object:?}")));
             };
             let Segment::Circle(circle) = segment else {
-                return Err(make_err(format!("Segment is not a circle: {segment:?}")));
+                return Err(make_err(format!(
+                    "Segment is not a circle, it is {}",
+                    segment.human_friendly_kind_with_article()
+                )));
             };
             vec![circle.start, circle.center, segment_id]
         };
@@ -2366,7 +2380,8 @@ impl FrontendState {
         })?;
         let ObjectKind::Constraint { .. } = &constraint_object.kind else {
             return Err(KclError::refactor(format!(
-                "Object is not a constraint: {constraint_object:?}"
+                "Object is not a constraint, it is {}",
+                constraint_object.kind.human_friendly_kind_with_article()
             )));
         };
 
@@ -3501,7 +3516,8 @@ impl FrontendState {
                 .ok_or_else(|| KclError::refactor(format!("Constraint not found: {constraint_id:?}")))?;
             let ObjectKind::Constraint { constraint } = &constraint_object.kind else {
                 return Err(KclError::refactor(format!(
-                    "Object is not a constraint: {constraint_object:?}"
+                    "Object is not a constraint, it is {}",
+                    constraint_object.kind.human_friendly_kind_with_article()
                 )));
             };
             let depends_on_segment = match constraint {

--- a/rust/kcl-lib/src/frontend/api.rs
+++ b/rust/kcl-lib/src/frontend/api.rs
@@ -202,6 +202,23 @@ pub enum ObjectKind {
     },
 }
 
+impl ObjectKind {
+    /// What kind of object is this (point, line, arc, etc)
+    /// Suitable for use in user-facing messages.
+    pub fn human_friendly_kind_with_article(&self) -> &'static str {
+        match self {
+            Self::Nil => "a Nil",
+            Self::Plane(..) => "a Plane",
+            Self::Face(..) => "a Face",
+            Self::Wall(..) => "a Wall",
+            Self::Cap(..) => "a Cap",
+            Self::Sketch(..) => "a Sketch",
+            Self::Segment { .. } => "a Segment",
+            Self::Constraint { .. } => "a Constraint",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, ts_rs::TS)]
 #[ts(export, export_to = "FrontendApi.ts", rename = "ApiPlane")]
 #[serde(rename_all = "camelCase")]

--- a/rust/kcl-lib/src/frontend/sketch.rs
+++ b/rust/kcl-lib/src/frontend/sketch.rs
@@ -213,6 +213,19 @@ pub enum Segment {
     Circle(Circle),
 }
 
+impl Segment {
+    /// What kind of geometry is this (point, line, arc, etc)
+    /// Suitable for use in user-facing messages.
+    pub fn human_friendly_kind_with_article(&self) -> &'static str {
+        match self {
+            Segment::Point(_) => "a Point",
+            Segment::Line(_) => "a Line",
+            Segment::Arc(_) => "an Arc",
+            Segment::Circle(_) => "a Circle",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, ts_rs::TS)]
 #[ts(export, export_to = "FrontendApi.ts")]
 pub struct ExistingSegmentCtor {

--- a/rust/kcl-lib/src/frontend/sketch.rs
+++ b/rust/kcl-lib/src/frontend/sketch.rs
@@ -218,10 +218,10 @@ impl Segment {
     /// Suitable for use in user-facing messages.
     pub fn human_friendly_kind_with_article(&self) -> &'static str {
         match self {
-            Segment::Point(_) => "a Point",
-            Segment::Line(_) => "a Line",
-            Segment::Arc(_) => "an Arc",
-            Segment::Circle(_) => "a Circle",
+            Self::Point(_) => "a Point",
+            Self::Line(_) => "a Line",
+            Self::Arc(_) => "an Arc",
+            Self::Circle(_) => "a Circle",
         }
     }
 }
@@ -241,6 +241,19 @@ pub enum SegmentCtor {
     Line(LineCtor),
     Arc(ArcCtor),
     Circle(CircleCtor),
+}
+
+impl SegmentCtor {
+    /// What kind of geometry is this (point, line, arc, etc)
+    /// Suitable for use in user-facing messages.
+    pub fn human_friendly_kind_with_article(&self) -> &'static str {
+        match self {
+            Self::Point(_) => "a Point constructor",
+            Self::Line(_) => "a Line constructor",
+            Self::Arc(_) => "an Arc constructor",
+            Self::Circle(_) => "a Circle constructor",
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, ts_rs::TS)]


### PR DESCRIPTION
Fixes https://github.com/KittyCAD/modeling-app/issues/10855. As Jon pointed out, there were many places that the KCL was including Rust debug strings instead of printing nice, human-friendly error messages. I've gone through and found a bunch of these, replacing the debug strings with better messages.

Here's one such example. Before:

<img width="3580" height="2166" alt="bad_msg" src="https://github.com/user-attachments/assets/2311fc06-1604-4f74-825e-6e2a0fda9270" />

After:

<img width="1790" height="1083" alt="Screenshot 2026-04-09 at 9 33 53 PM" src="https://github.com/user-attachments/assets/1217f159-86a0-4840-a8cf-33d74cbc3841" />
