### PR TITLE
Fix hotkeys for toolbar items that are first in dropdown

### DIFF
--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -26,6 +26,7 @@ import {
   modelingMachineStateToToolbarModeName,
   useToolbarConfig,
 } from '@src/lib/toolbar'
+import { collectToolbarHotkeyActions } from '@src/lib/toolbarHotkeys'
 import { EngineConnectionStateType } from '@src/network/utils'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { useSignals } from '@preact/signals-react/runtime'
@@ -239,6 +240,24 @@ const Toolbar_ = memo(
         number /* index in currentModeItems */,
         number /* index in maybeIconConfig */
       >()
+    )
+
+    const hotkeyActions = useMemo(
+      () => collectToolbarHotkeyActions(currentModeItems),
+      [currentModeItems]
+    )
+    const hotkeyActionMap = useMemo(
+      () => new Map(hotkeyActions.map((action) => [action.hotkey, action])),
+      [hotkeyActions]
+    )
+
+    useHotkeys(
+      hotkeyActions.map((action) => action.hotkey),
+      (_, hotkeysEvent) => {
+        hotkeyActionMap.get(hotkeysEvent.hotkey)?.onTrigger()
+      },
+      { enabled: hotkeyActions.length > 0 },
+      [hotkeyActionMap]
     )
 
     return (
@@ -481,8 +500,7 @@ interface ToolbarItemContentsProps extends React.PropsWithChildren {
 }
 /**
  * The single button and dropdown button share content, so we extract it here
- * It contains a tooltip with the title, description, and links
- * and a hotkey listener
+ * It contains a tooltip with the title, description, and links.
  */
 const ToolbarItemTooltip = memo(function ToolbarItemContents({
   itemConfig,
@@ -491,24 +509,6 @@ const ToolbarItemTooltip = memo(function ToolbarItemContents({
   contentClassName = '',
   children,
 }: ToolbarItemContentsProps) {
-  /**
-   * GOTCHA: `useHotkeys` can only register one hotkey listener per component.
-   * TODO: make a global hotkey registration system. make them editable.
-   */
-  useHotkeys(
-    itemConfig.hotkey || '',
-    () => {
-      itemConfig.onClick(itemConfig.callbackProps)
-    },
-    {
-      enabled:
-        ['available', 'experimental'].includes(itemConfig.status) &&
-        !!itemConfig.hotkey &&
-        !itemConfig.disabled &&
-        !itemConfig.disableHotkey,
-    }
-  )
-
   const onDesktop = isDesktop()
   const wrapperStyle = useMemo(
     () =>

--- a/src/components/ActionButtonDropdown.tsx
+++ b/src/components/ActionButtonDropdown.tsx
@@ -4,7 +4,6 @@ import type { ActionButtonProps } from '@src/components/ActionButton'
 import { CustomIcon } from '@src/components/CustomIcon'
 import Tooltip from '@src/components/Tooltip'
 import { filterEscHotkey } from '@src/lib/hotkeyWrapper'
-import { useHotkeys } from 'react-hotkeys-hook'
 
 type ActionButtonSplitProps = ActionButtonProps & { Element: 'button' } & {
   name?: string
@@ -92,19 +91,6 @@ function ActionButtonDropdownListItem({
   item: ActionButtonSplitProps['splitMenuItems'][number]
   onClick: () => void
 }) {
-  /**
-   * GOTCHA: `useHotkeys` can only register one hotkey listener per component.
-   * and since the first item in the dropdown has a top-level button too,
-   * it already has a hotkey listener, so we should skip it.
-   * TODO: make a global hotkey registration system. make them editable.
-   */
-  useHotkeys(item.hotkey || '', item.onClick, {
-    enabled:
-      ['available', 'experimental'].includes(item.status || '') &&
-      !!item.hotkey &&
-      !item.disabled,
-  })
-
   return (
     <li className="contents">
       <button

--- a/src/lib/toolbarHotkeys.spec.ts
+++ b/src/lib/toolbarHotkeys.spec.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type {
+  ToolbarItemCallbackProps,
+  ToolbarItemResolved,
+  ToolbarItemResolvedDropdown,
+} from '@src/lib/toolbar'
+import { collectToolbarHotkeyActions } from '@src/lib/toolbarHotkeys'
+
+function makeResolvedItem(
+  overrides: Partial<ToolbarItemResolved> = {}
+): ToolbarItemResolved {
+  return {
+    id: overrides.id ?? 'item',
+    onClick: overrides.onClick ?? vi.fn(),
+    status: overrides.status ?? 'available',
+    title: overrides.title ?? 'Item',
+    description: overrides.description ?? 'Description',
+    links: overrides.links ?? [],
+    callbackProps:
+      overrides.callbackProps ??
+      ({
+        modelingState: {} as any,
+        modelingSend: vi.fn(),
+        sketchPathId: false,
+        editorHasFocus: false,
+        isActive: false,
+      } satisfies ToolbarItemCallbackProps),
+    ...overrides,
+  }
+}
+
+describe('collectToolbarHotkeyActions', () => {
+  it('registers hotkeys for all dropdown items, including the first item', () => {
+    const firstItemSpy = vi.fn()
+    const secondItemSpy = vi.fn()
+    const dropdown: ToolbarItemResolvedDropdown = {
+      id: 'rectangles',
+      array: [
+        makeResolvedItem({
+          id: 'corner-rectangle',
+          title: 'Corner Rectangle',
+          hotkey: 'R',
+          onClick: firstItemSpy,
+        }),
+        makeResolvedItem({
+          id: 'center-rectangle',
+          title: 'Center Rectangle',
+          hotkey: 'Shift+R',
+          onClick: secondItemSpy,
+        }),
+      ],
+    }
+
+    const hotkeyActions = collectToolbarHotkeyActions([dropdown])
+    const actionMap = new Map(
+      hotkeyActions.map((action) => [action.hotkey, action])
+    )
+
+    expect(hotkeyActions).toHaveLength(2)
+
+    actionMap.get('R')?.onTrigger()
+    actionMap.get('Shift+R')?.onTrigger()
+
+    expect(firstItemSpy).toHaveBeenCalledTimes(1)
+    expect(secondItemSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps hotkeys for dropdown items that are not surfaced as the top-level button', () => {
+    const topLevelSpy = vi.fn()
+    const hiddenItemSpy = vi.fn()
+    const dropdown: ToolbarItemResolvedDropdown = {
+      id: 'arcs',
+      array: [
+        makeResolvedItem({
+          id: 'center-arc',
+          title: 'Center Arc',
+          hotkey: 'A',
+          isActive: true,
+          onClick: topLevelSpy,
+        }),
+        makeResolvedItem({
+          id: 'three-point-arc',
+          title: '3-Point Arc',
+          hotkey: 'Alt+A',
+          onClick: hiddenItemSpy,
+        }),
+      ],
+    }
+
+    const hotkeyActions = collectToolbarHotkeyActions([dropdown])
+    const actionMap = new Map(
+      hotkeyActions.map((action) => [action.hotkey, action])
+    )
+
+    actionMap.get('Alt+A')?.onTrigger()
+
+    expect(hiddenItemSpy).toHaveBeenCalledTimes(1)
+    expect(topLevelSpy).not.toHaveBeenCalled()
+  })
+
+  it('deduplicates conflicting hotkeys in render order', () => {
+    const firstSpy = vi.fn()
+    const secondSpy = vi.fn()
+
+    const hotkeyActions = collectToolbarHotkeyActions([
+      makeResolvedItem({
+        id: 'line',
+        title: 'Line',
+        hotkey: 'L',
+        onClick: firstSpy,
+      }),
+      makeResolvedItem({
+        id: 'loft',
+        title: 'Loft',
+        hotkey: 'L',
+        onClick: secondSpy,
+      }),
+    ])
+
+    expect(hotkeyActions).toHaveLength(1)
+
+    hotkeyActions[0].onTrigger()
+
+    expect(firstSpy).toHaveBeenCalledTimes(1)
+    expect(secondSpy).not.toHaveBeenCalled()
+  })
+
+  it('skips disabled and hotkey-disabled items', () => {
+    const hotkeyActions = collectToolbarHotkeyActions([
+      makeResolvedItem({
+        id: 'disabled-item',
+        hotkey: 'D',
+        disabled: true,
+      }),
+      makeResolvedItem({
+        id: 'disable-hotkey-item',
+        hotkey: 'H',
+        disableHotkey: true,
+      }),
+      makeResolvedItem({
+        id: 'enabled-item',
+        hotkey: 'E',
+      }),
+    ])
+
+    expect(hotkeyActions.map((action) => action.hotkey)).toEqual(['E'])
+  })
+})

--- a/src/lib/toolbarHotkeys.ts
+++ b/src/lib/toolbarHotkeys.ts
@@ -1,0 +1,62 @@
+import {
+  isToolbarItemResolvedDropdown,
+  type ToolbarItemResolved,
+  type ToolbarItemResolvedDropdown,
+} from '@src/lib/toolbar'
+import { isArray } from '@src/lib/utils'
+
+export type ResolvedToolbarEntry =
+  | ToolbarItemResolved
+  | ToolbarItemResolvedDropdown
+  | 'break'
+
+export type ToolbarHotkeyAction = {
+  hotkey: string
+  itemId: string
+  onTrigger: () => void
+}
+
+export function collectToolbarHotkeyActions(
+  items: ResolvedToolbarEntry[]
+): ToolbarHotkeyAction[] {
+  const seenHotkeys = new Set<string>()
+  const hotkeyActions: ToolbarHotkeyAction[] = []
+
+  for (const item of items) {
+    if (item === 'break') continue
+
+    if (isToolbarItemResolvedDropdown(item)) {
+      for (const dropdownItem of item.array) {
+        registerHotkeys(dropdownItem)
+      }
+      continue
+    }
+
+    registerHotkeys(item)
+  }
+
+  return hotkeyActions
+
+  function registerHotkeys(item: ToolbarItemResolved) {
+    if (
+      !['available', 'experimental'].includes(item.status) ||
+      item.disabled ||
+      item.disableHotkey ||
+      !item.hotkey
+    ) {
+      return
+    }
+
+    for (const hotkey of isArray(item.hotkey) ? item.hotkey : [item.hotkey]) {
+      // Keep the first rendered action for any conflicting hotkey.
+      if (seenHotkeys.has(hotkey)) continue
+
+      seenHotkeys.add(hotkey)
+      hotkeyActions.push({
+        hotkey,
+        itemId: item.id,
+        onTrigger: () => item.onClick(item.callbackProps),
+      })
+    }
+  }
+}


### PR DESCRIPTION
Codex-assisted. I suspected that Arc and Rectangle hotkeys weren't working because of a duplicate hotkey listener, one for the button and one for the dropdown menu entry. This fixes that by removing a duplicate hotkey registration in the dropdown items, centralizing toolbar hotkey registration. Adds some integration tests. Test by hitting <kbd>A</kbd> in sketch mode and having it actually work.