### PR TITLE
Add ability to double-click sketch solve entities to enter sketch editing

### DIFF
--- a/src/components/ConnectionStream.tsx
+++ b/src/components/ConnectionStream.tsx
@@ -1,5 +1,5 @@
 import type { MouseEventHandler } from 'react'
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { use, useCallback, useMemo, useRef, useState } from 'react'
 import { ClientSideScene } from '@src/clientSideScene/ClientSideSceneComp'
 import { useApp, useSingletons } from '@src/lib/boot'
 import { ViewControlContextMenu } from '@src/components/ViewControlMenu'
@@ -10,7 +10,10 @@ import { useAppState } from '@src/AppState'
 import { useNetworkContext } from '@src/hooks/useNetworkContext'
 import { NetworkHealthState } from '@src/hooks/useNetworkStatus'
 import { useModelingContext } from '@src/hooks/useModelingContext'
-import { sendSelectEventToEngine } from '@src/lib/selections'
+import {
+  getEngineRegionSelectionFromEntity,
+  sendSelectEventToEngine,
+} from '@src/lib/selections'
 import {
   getArtifactOfTypes,
   getSketchBlockForArtifact,
@@ -35,7 +38,8 @@ export const ConnectionStream = (props: {
   authToken: string | undefined
   sketchSolveStreamDimming?: number
 }) => {
-  const { settings, project } = useApp()
+  const { settings, project, wasmPromise } = useApp()
+  const wasmInstance = use(wasmPromise)
   const { kclManager } = useSingletons()
   const engineCommandManager = kclManager.engineCommandManager
   const sceneInfra = kclManager.sceneInfra
@@ -109,7 +113,7 @@ export const ConnectionStream = (props: {
         sendSelectEventToEngine(e, videoRef.current, {
           engineCommandManager,
         })
-          .then((result) => {
+          .then(async (result) => {
             if (!result) {
               return
             }
@@ -130,6 +134,32 @@ export const ConnectionStream = (props: {
               })
               return
             }
+
+            // If the selection is an undeclared region, get the corresponding sketch
+            if (!artifact) {
+              try {
+                const regionSelection =
+                  await getEngineRegionSelectionFromEntity(
+                    entity_id,
+                    kclManager.artifactGraph,
+                    kclManager.ast,
+                    engineCommandManager,
+                    wasmInstance
+                  )
+
+                if (regionSelection && regionSelection.sketchId) {
+                  sceneInfra.modelingSend({
+                    type: 'Edit sketch solve',
+                    data: { artifactId: regionSelection.sketchId },
+                  })
+                }
+
+                return
+              } catch (e) {
+                return e
+              }
+            }
+
             const path = getArtifactOfTypes(
               {
                 key: entity_id,

--- a/src/components/ConnectionStream.tsx
+++ b/src/components/ConnectionStream.tsx
@@ -11,7 +11,10 @@ import { useNetworkContext } from '@src/hooks/useNetworkContext'
 import { NetworkHealthState } from '@src/hooks/useNetworkStatus'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { sendSelectEventToEngine } from '@src/lib/selections'
-import { getArtifactOfTypes } from '@src/lang/std/artifactGraph'
+import {
+  getArtifactOfTypes,
+  getSketchBlockForArtifact,
+} from '@src/lang/std/artifactGraph'
 import { useOnPageExit } from '@src/hooks/network/useOnPageExit'
 import { useOnPageResize } from '@src/hooks/network/useOnPageResize'
 import { useOnPageIdle } from '@src/hooks/network/useOnPageIdle'
@@ -113,6 +116,18 @@ export const ConnectionStream = (props: {
             const { entity_id } = result
             if (!entity_id) {
               // No entity selected. This is benign
+              return
+            }
+            const artifact = kclManager.artifactGraph.get(entity_id)
+            const sketchBlockArtifact = getSketchBlockForArtifact(
+              artifact,
+              kclManager.artifactGraph
+            )
+            if (sketchBlockArtifact) {
+              sceneInfra.modelingSend({
+                type: 'Edit sketch solve',
+                data: { artifactId: sketchBlockArtifact.id },
+              })
               return
             }
             const path = getArtifactOfTypes(

--- a/src/lang/std/artifactGraph.test.ts
+++ b/src/lang/std/artifactGraph.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   coerceSelectionsToBody,
+  getSketchBlockForArtifact,
   getSweepArtifactFromSelection,
   type Artifact,
 } from '@src/lang/std/artifactGraph'
@@ -150,6 +151,57 @@ describe('getSweepArtifactFromSelection', () => {
 })
 
 describe('coerceSelectionsToBody', () => {
+  it('should resolve a sketchBlock from a segment artifact', () => {
+    const artifactGraph: ArtifactGraph = new Map()
+
+    const pathToNode = [['body', '']]
+    const codeRef = {
+      range: [0, 100, 0] as [number, number, number],
+      pathToNode,
+      nodePath: { steps: [] },
+    }
+
+    const sketchBlock: Artifact = {
+      type: 'sketchBlock',
+      id: 'sketch-block-1',
+      codeRef,
+      pathIds: ['path-1'],
+      constraintIds: [],
+      segmentIds: ['segment-1'],
+      edgeIds: [],
+      planeId: 'plane-1',
+      sketchId: 7,
+    }
+
+    const path: Artifact = {
+      type: 'path',
+      subType: 'sketch',
+      id: 'path-1',
+      codeRef,
+      planeId: 'plane-1',
+      segIds: ['segment-1'],
+      trajectorySweepId: null,
+      consumed: false,
+    }
+
+    const segment: Artifact = {
+      type: 'segment',
+      id: 'segment-1',
+      pathId: 'path-1',
+      edgeIds: [],
+      commonSurfaceIds: [],
+      codeRef,
+    }
+
+    artifactGraph.set(sketchBlock.id, sketchBlock)
+    artifactGraph.set(path.id, path)
+    artifactGraph.set(segment.id, segment)
+
+    expect(getSketchBlockForArtifact(segment, artifactGraph)?.id).toBe(
+      'sketch-block-1'
+    )
+  })
+
   it('should pass through path artifact unchanged', () => {
     const artifactGraph: ArtifactGraph = new Map()
 

--- a/src/lang/std/artifactGraph.test.ts
+++ b/src/lang/std/artifactGraph.test.ts
@@ -5,7 +5,7 @@ import {
   getSweepArtifactFromSelection,
   type Artifact,
 } from '@src/lang/std/artifactGraph'
-import type { ArtifactGraph } from '@src/lang/wasm'
+import type { ArtifactGraph, PathToNode } from '@src/lang/wasm'
 import type { Selections, Selection } from '@src/machines/modelingSharedTypes'
 
 describe('getSweepArtifactFromSelection', () => {
@@ -154,21 +154,17 @@ describe('coerceSelectionsToBody', () => {
   it('should resolve a sketchBlock from a segment artifact', () => {
     const artifactGraph: ArtifactGraph = new Map()
 
-    const pathToNode = [['body', '']]
+    const pathToNode: PathToNode = [['body', '']]
     const codeRef = {
       range: [0, 100, 0] as [number, number, number],
       pathToNode,
       nodePath: { steps: [] },
     }
 
-    const sketchBlock: Artifact = {
+    const sketchBlock: Extract<Artifact, { type: 'sketchBlock' }> = {
       type: 'sketchBlock',
       id: 'sketch-block-1',
       codeRef,
-      pathIds: ['path-1'],
-      constraintIds: [],
-      segmentIds: ['segment-1'],
-      edgeIds: [],
       planeId: 'plane-1',
       sketchId: 7,
     }

--- a/src/lang/std/artifactGraph.ts
+++ b/src/lang/std/artifactGraph.ts
@@ -815,6 +815,36 @@ export function getSketchBlockForPathArtifact(
   )
 }
 
+export function getSketchBlockForArtifact(
+  artifact: Artifact | undefined,
+  artifactGraph: ArtifactGraph
+): Extract<Artifact, { type: 'sketchBlock' }> | undefined {
+  if (!artifact) {
+    return undefined
+  }
+
+  if (artifact.type === 'sketchBlock') {
+    return artifact
+  }
+
+  if (artifact.type === 'path') {
+    return getSketchBlockForPathArtifact(artifact, artifactGraph)
+  }
+
+  if (artifact.type === 'segment' || artifact.type === 'solid2d') {
+    const path = getArtifactOfTypes(
+      { key: artifact.pathId, types: ['path'] },
+      artifactGraph
+    )
+    if (err(path)) {
+      return undefined
+    }
+    return getSketchBlockForPathArtifact(path, artifactGraph)
+  }
+
+  return undefined
+}
+
 /**
  * Coerce selections that may contain faces or edges to their parent body (sweep/compositeSolid).
  * This is useful for commands that only work with bodies, but users may have faces or edges selected.

--- a/src/lib/selections.ts
+++ b/src/lib/selections.ts
@@ -127,7 +127,7 @@ async function getRegionQueryPointForRegion(
   return queryPointResponse.data.query_point
 }
 
-async function getEngineRegionSelectionFromEntity(
+export async function getEngineRegionSelectionFromEntity(
   regionEntityId: string,
   artifactGraph: ArtifactGraph,
   ast: Node<Program>,

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -235,6 +235,10 @@ export type ModelingMachineEvent =
       data: ArtifactId
     }
   | {
+      type: 'Edit sketch solve'
+      data: { artifactId: ArtifactId }
+    }
+  | {
       type: 'Set selection'
       data: SetSelections
     }
@@ -5398,6 +5402,14 @@ export const modelingMachine = setup({
   states: {
     idle: {
       on: {
+        'Edit sketch solve': {
+          target: 'animating to existing sketch solve',
+          actions: [
+            ({ context }) => {
+              context.kclManager.sceneInfra.animate()
+            },
+          ],
+        },
         'Enter sketch': [
           {
             target: 'animating to existing sketch solve',
@@ -7756,6 +7768,16 @@ export const modelingMachine = setup({
       invoke: {
         src: 'animate-to-existing-sketch-solve',
         input: ({ event, context }) => {
+          if (event.type === 'Edit sketch solve') {
+            return {
+              artifactId: event.data.artifactId,
+              kclManager: context.kclManager,
+              rustContext: context.rustContext,
+              engineCommandManager: context.engineCommandManager,
+              defaultUnit: context.store.defaultUnit,
+              projectRef: context.projectRef,
+            }
+          }
           if (event.type === 'Enter sketch') {
             // Get artifact ID from selection
             const artifact =


### PR DESCRIPTION
Closes #10867. Codex-assisted.

## Demo

Worth noting that this does not fix the "animating to wrong side of a sketch" bug, which you can see at the end of this video. That is tracked in #10847.


https://github.com/user-attachments/assets/494fca4e-2bb8-49cd-9627-3cb0b590431f

