### PR TITLE
Add undo checkpoint after drag-end

### DIFF
--- a/rust/kcl-wasm-lib/src/api.rs
+++ b/rust/kcl-wasm-lib/src/api.rs
@@ -184,10 +184,19 @@ impl Context {
 
         let frontend = Arc::clone(&self.frontend);
         let mut guard = frontend.write().await;
-        let result = guard
+        let (source_delta, scene_graph_delta) = guard
             .execute_mock(&ctx, version, sketch)
             .await
             .map_err(|e: KclErrorWithOutputs| JsValue::from_serde(&e).unwrap())?;
+        let checkpoint_id = guard
+            .create_sketch_checkpoint(scene_graph_delta.exec_outcome.clone())
+            .await
+            .map_err(|e: Error| js_value_from_serde(&e))?;
+        let result = kcl_lib::front::SketchMutationOutcome {
+            source_delta,
+            scene_graph_delta,
+            checkpoint_id: Some(checkpoint_id),
+        };
 
         Ok(JsValue::from_serde(&result)
             .map_err(|e| format!("Could not serialize execute mock result. {TRUE_BUG} Details: {e}"))?)

--- a/src/lib/rustContext.ts
+++ b/src/lib/rustContext.ts
@@ -332,22 +332,27 @@ export default class RustContext {
   async sketchExecuteMock(
     version: ApiVersion,
     sketch: ApiObjectId
-  ): Promise<{
-    kclSource: SourceDelta
-    sceneGraphDelta: SceneGraphDelta
-  }> {
+  ): Promise<SketchMutationResult> {
     const instance = await this._checkContextInstance()
 
     try {
-      const result: [SourceDelta, SceneGraphDelta] =
-        await instance.sketch_execute_mock(
-          JSON.stringify(version),
-          JSON.stringify(sketch),
-          JSON.stringify(jsAppSettings(this.settingsActor))
-        )
+      const result: {
+        sourceDelta: SourceDelta
+        sceneGraphDelta: SceneGraphDelta
+        checkpointId?: number | null
+      } = await instance.sketch_execute_mock(
+        JSON.stringify(version),
+        JSON.stringify(sketch),
+        JSON.stringify(jsAppSettings(this.settingsActor))
+      )
+      const checkpointId = normalizeSketchCheckpointId(result.checkpointId)
+      if (checkpointId instanceof Error) {
+        return Promise.reject(checkpointId)
+      }
       return {
-        kclSource: result[0],
-        sceneGraphDelta: result[1],
+        kclSource: result.sourceDelta,
+        sceneGraphDelta: result.sceneGraphDelta,
+        checkpointId,
       }
     } catch (e: any) {
       const err = errFromErrWithOutputs(e)


### PR DESCRIPTION
Fixes #10973.

Before, dragging a point wouldn't create an undo checkpoint. Undo would go right past it.