### PR TITLE
Fix Boolean P&C with sketch solve modeling

### DIFF
--- a/e2e/playwright/boolean-sketch-v1.spec.ts
+++ b/e2e/playwright/boolean-sketch-v1.spec.ts
@@ -5,26 +5,26 @@ import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 import { expect, test } from '@e2e/playwright/zoo-test'
 
 test.describe(
-  'Point and click for boolean workflows',
+  'Point and click for boolean workflows - sketch v1',
   { tag: '@desktop' },
   () => {
     // Boolean operations to test
     const booleanOperations = [
       {
         name: 'union',
-        code: 'union([extrude001, extrude002])',
+        code: 'union([extrude001, extrude006])',
       },
       {
         name: 'subtract',
-        code: 'subtract(extrude001, tools = extrude002)',
+        code: 'subtract(extrude001, tools = extrude006)',
       },
       {
         name: 'intersect',
-        code: 'intersect([extrude001, extrude002])',
+        code: 'intersect([extrude001, extrude006])',
       },
       {
         name: 'split',
-        code: 'split([extrude001, extrude002])',
+        code: 'split([extrude001, extrude006])',
       },
     ] as const
     for (let i = 0; i < booleanOperations.length; i++) {
@@ -46,7 +46,7 @@ test.describe(
           path.resolve(
             __dirname,
             '../../',
-            './rust/kcl-lib/e2e/executor/inputs/boolean-setup-with-sketch-solve-on-faces.kcl'
+            './rust/kcl-lib/e2e/executor/inputs/boolean-setup-with-sketch-on-faces.kcl'
           ),
           'utf-8'
         )
@@ -110,7 +110,7 @@ test.describe(
             await cmdBar.expectState({
               stage: 'review',
               headerArguments: {
-                Solids: '2 regions',
+                Solids: '2 paths',
               },
               commandName,
             })
@@ -118,8 +118,8 @@ test.describe(
             await cmdBar.expectState({
               stage: 'review',
               headerArguments: {
-                Solids: '1 region',
-                Tools: '1 region',
+                Solids: '1 path',
+                Tools: '1 path',
               },
               commandName,
             })
@@ -127,7 +127,7 @@ test.describe(
             await cmdBar.expectState({
               stage: 'review',
               headerArguments: {
-                Targets: '2 regions',
+                Targets: '2 paths',
               },
               commandName,
             })
@@ -136,6 +136,7 @@ test.describe(
           await cmdBar.submit()
           await scene.settled(cmdBar)
           await editor.openPane()
+          await editor.scrollToText(operation.code)
           await editor.expectEditor.toContain(operation.code)
         })
 

--- a/rust/kcl-lib/e2e/executor/inputs/boolean-setup-with-sketch-solve-on-faces.kcl
+++ b/rust/kcl-lib/e2e/executor/inputs/boolean-setup-with-sketch-solve-on-faces.kcl
@@ -1,0 +1,79 @@
+profile001 = sketch(on = XZ) {
+  circle1 = circle(start = [var 195.45mm, var 113.92mm], center = [var 154.36mm, var 113.92mm])
+}
+region001 = region(segments = [profile001.circle1])
+extrude001 = extrude(region001, length = 200)
+profile002 = sketch(on = XY) {
+  line1 = line(start = [var 72.24mm, var -52.05mm], end = [var 253.5mm, var -52.05mm])
+  line2 = line(start = [var 253.5mm, var -52.05mm], end = [var 253.5mm, var -73.59mm])
+  coincident([line1.end, line2.start])
+  line3 = line(start = [var 253.5mm, var -73.59mm], end = [var 72.24mm, var -73.59mm])
+  coincident([line2.end, line3.start])
+  line4 = line(start = [var 72.24mm, var -73.59mm], end = [var 72.24mm, var -52.05mm])
+  coincident([line3.end, line4.start])
+}
+region002 = region(segments = [profile002.line1, profile002.line2])
+extrude002 = extrude(region002, length = 150)
+chamfer002 = chamfer(
+  extrude002,
+  length = 15,
+  tags = [region002.tags.line4],
+  tag = $seg02,
+)
+
+face003 = faceOf(chamfer002, face = region002.tags.line4)
+profile003 = sketch(on = face003) {
+  line1 = line(start = [var 207.36mm, var 126.19mm], end = [var 240.93mm, var 126.19mm])
+  line2 = line(start = [var 240.93mm, var 126.19mm], end = [var 240.93mm, var 27.08mm])
+  coincident([line1.end, line2.start])
+  line3 = line(start = [var 240.93mm, var 27.08mm], end = [var 207.36mm, var 27.08mm])
+  coincident([line2.end, line3.start])
+  line4 = line(start = [var 207.36mm, var 27.08mm], end = [var 207.36mm, var 126.19mm])
+  coincident([line3.end, line4.start])
+}
+region003 = region(segments = [profile003.line1, profile003.line2])
+extrude003 = extrude(region003, length = -20)
+face004 = faceOf(extrude003, face = region003.tags.line4)
+profile004 = sketch(on = face004) {
+  line1 = line(start = [var -235.38mm, var 66.16mm], end = [var -211.17mm, var 66.16mm])
+  line2 = line(start = [var -211.17mm, var 66.16mm], end = [var -211.17mm, var 62.44mm])
+  coincident([line1.end, line2.start])
+  line3 = line(start = [var -211.17mm, var 62.44mm], end = [var -235.38mm, var 62.44mm])
+  coincident([line2.end, line3.start])
+  line4 = line(start = [var -235.38mm, var 62.44mm], end = [var -235.38mm, var 66.16mm])
+  coincident([line3.end, line4.start])
+}
+region004 = region(segments = [profile004.line1, profile004.line2])
+extrude004 = extrude(region004, length = 30)
+
+profile005 = sketch(on = faceOf(chamfer002, face = seg02)) {
+  line1 = line(start = [var -129.93mm, var -59.19mm], end = [var -81.14mm, var -59.19mm])
+  line2 = line(start = [var -81.14mm, var -59.19mm], end = [var -79.81mm, var -48.16mm])
+  coincident([line1.end, line2.start])
+  line3 = line(start = [var -79.81mm, var -48.16mm], end = [var -140.37mm, var -48.16mm])
+  coincident([line2.end, line3.start])
+  line4 = line(start = [var -140.37mm, var -48.16mm], end = [var -129.93mm, var -59.19mm])
+  coincident([line3.end, line4.start])
+  horizontal(line1)
+  horizontal(line3)
+}
+region005 = region(segments = [profile005.line1, profile005.line2])
+extrude005 = extrude(region005, length = -10)
+face006 = faceOf(extrude005, face = region005.tags.line4)
+profile006 = sketch(on = face006) {
+  line1 = line(start = [var -95.86mm, var 38.73mm], end = [var -92.38mm, var 38.73mm])
+  line2 = line(start = [var -92.38mm, var 38.73mm], end = [var -92.38mm, var 35.37mm])
+  coincident([line1.end, line2.start])
+  line3 = line(start = [var -92.38mm, var 35.37mm], end = [var -95.86mm, var 35.37mm])
+  coincident([line2.end, line3.start])
+  line4 = line(start = [var -95.86mm, var 35.37mm], end = [var -95.86mm, var 38.73mm])
+  coincident([line3.end, line4.start])
+}
+region006 = region(segments = [profile006.line1, profile006.line2])
+extrude006 = extrude(region006, length = 13)
+hidden001 = hide(profile001)
+hidden002 = hide(profile002)
+hidden003 = hide(profile003)
+hidden004 = hide(profile004)
+hidden005 = hide(profile005)
+hidden006 = hide(profile006)

--- a/src/components/CommandBar/CommandBarSelectionMixedInput.tsx
+++ b/src/components/CommandBar/CommandBarSelectionMixedInput.tsx
@@ -48,7 +48,7 @@ export default function CommandBarSelectionMixedInput({
   }, [selection, kclManager.ast])
 
   // Coerce selections to bodies if this argument requires bodies
-  useEffect(() => {
+  function coerceSelectionsAndSendIt() {
     // Only run once per component mount
     if (hasCoercedSelections) return
 
@@ -81,6 +81,10 @@ export default function CommandBarSelectionMixedInput({
         selection: coercedSelections,
       },
     })
+  }
+
+  useEffect(() => {
+    coerceSelectionsAndSendIt()
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Only run on mount
   }, [])
 
@@ -204,6 +208,10 @@ export default function CommandBarSelectionMixedInput({
     if (!canSubmitSelection) {
       setHasSubmitted(true)
       return
+    }
+
+    if (!hasCoercedSelections) {
+      coerceSelectionsAndSendIt()
     }
 
     /**

--- a/src/components/CommandBar/CommandBarSelectionMixedInput.tsx
+++ b/src/components/CommandBar/CommandBarSelectionMixedInput.tsx
@@ -48,7 +48,7 @@ export default function CommandBarSelectionMixedInput({
   }, [selection, kclManager.ast])
 
   // Coerce selections to bodies if this argument requires bodies
-  function coerceSelectionsAndSendIt() {
+  useEffect(() => {
     // Only run once per component mount
     if (hasCoercedSelections) return
 
@@ -81,10 +81,6 @@ export default function CommandBarSelectionMixedInput({
         selection: coercedSelections,
       },
     })
-  }
-
-  useEffect(() => {
-    coerceSelectionsAndSendIt()
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Only run on mount
   }, [])
 
@@ -208,10 +204,6 @@ export default function CommandBarSelectionMixedInput({
     if (!canSubmitSelection) {
       setHasSubmitted(true)
       return
-    }
-
-    if (!hasCoercedSelections) {
-      coerceSelectionsAndSendIt()
     }
 
     /**

--- a/src/lang/modifyAst/boolean.ts
+++ b/src/lang/modifyAst/boolean.ts
@@ -42,6 +42,7 @@ export function addUnion({
     mNodeToEdit,
     {
       lastChildLookup: true,
+      artifactTypeFilter: ['compositeSolid', 'sweep'],
     }
   )
   if (err(vars)) {
@@ -97,6 +98,7 @@ export function addIntersect({
     mNodeToEdit,
     {
       lastChildLookup: true,
+      artifactTypeFilter: ['compositeSolid', 'sweep'],
     }
   )
   if (err(vars)) {

--- a/src/lang/std/artifactGraph.ts
+++ b/src/lang/std/artifactGraph.ts
@@ -30,6 +30,7 @@ import type {
 } from '@src/lang/wasm'
 import type { Selection, Selections } from '@src/machines/modelingSharedTypes'
 import { err } from '@src/lib/trap'
+import { isNonNullable } from '@src/lib/utils'
 
 export type { Artifact, ArtifactId, SegmentArtifact } from '@src/lang/wasm'
 
@@ -373,6 +374,17 @@ export function getSweepArtifactFromSelection(
   } else if (
     selection.artifact?.type === 'cap' ||
     selection.artifact?.type === 'wall'
+  ) {
+    const _artifact = getArtifactOfTypes(
+      { key: selection.artifact.sweepId, types: ['sweep'] },
+      artifactGraph
+    )
+    if (err(_artifact)) return _artifact
+    sweepArtifact = _artifact
+  } else if (
+    selection.artifact?.type === 'path' &&
+    selection.artifact.subType === 'region' &&
+    isNonNullable(selection.artifact.sweepId)
   ) {
     const _artifact = getArtifactOfTypes(
       { key: selection.artifact.sweepId, types: ['sweep'] },
@@ -872,10 +884,13 @@ export function coerceSelectionsToBody(
     }
 
     // If it's already a body type, use it directly
+    const isSketchPath =
+      selection.artifact.type === 'path' &&
+      selection.artifact.subType === 'sketch'
     if (
       selection.artifact.type === 'sweep' ||
       selection.artifact.type === 'compositeSolid' ||
-      selection.artifact.type === 'path'
+      isSketchPath
     ) {
       if (!seenBodyIds.has(selection.artifact.id)) {
         seenBodyIds.add(selection.artifact.id)
@@ -899,7 +914,7 @@ export function coerceSelectionsToBody(
         { key: maybeSweep.pathId, types: ['path'] },
         artifactGraph
       )
-      if (!err(maybePath)) {
+      if (!err(maybePath) && isSketchPath) {
         // Successfully got the path from the sweep
         if (!seenBodyIds.has(maybePath.id)) {
           seenBodyIds.add(maybePath.id)

--- a/src/lang/std/artifactGraph.ts
+++ b/src/lang/std/artifactGraph.ts
@@ -30,7 +30,6 @@ import type {
 } from '@src/lang/wasm'
 import type { Selection, Selections } from '@src/machines/modelingSharedTypes'
 import { err } from '@src/lib/trap'
-import { isNonNullable } from '@src/lib/utils'
 
 export type { Artifact, ArtifactId, SegmentArtifact } from '@src/lang/wasm'
 
@@ -374,17 +373,6 @@ export function getSweepArtifactFromSelection(
   } else if (
     selection.artifact?.type === 'cap' ||
     selection.artifact?.type === 'wall'
-  ) {
-    const _artifact = getArtifactOfTypes(
-      { key: selection.artifact.sweepId, types: ['sweep'] },
-      artifactGraph
-    )
-    if (err(_artifact)) return _artifact
-    sweepArtifact = _artifact
-  } else if (
-    selection.artifact?.type === 'path' &&
-    selection.artifact.subType === 'region' &&
-    isNonNullable(selection.artifact.sweepId)
   ) {
     const _artifact = getArtifactOfTypes(
       { key: selection.artifact.sweepId, types: ['sweep'] },
@@ -884,13 +872,10 @@ export function coerceSelectionsToBody(
     }
 
     // If it's already a body type, use it directly
-    const isSketchPath =
-      selection.artifact.type === 'path' &&
-      selection.artifact.subType === 'sketch'
     if (
       selection.artifact.type === 'sweep' ||
       selection.artifact.type === 'compositeSolid' ||
-      isSketchPath
+      selection.artifact.type === 'path'
     ) {
       if (!seenBodyIds.has(selection.artifact.id)) {
         seenBodyIds.add(selection.artifact.id)
@@ -914,7 +899,7 @@ export function coerceSelectionsToBody(
         { key: maybeSweep.pathId, types: ['path'] },
         artifactGraph
       )
-      if (!err(maybePath) && isSketchPath) {
+      if (!err(maybePath)) {
         // Successfully got the path from the sweep
         if (!seenBodyIds.has(maybePath.id)) {
           seenBodyIds.add(maybePath.id)

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -1253,7 +1253,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       },
       tools: {
         ...objectsTypesAndFilters,
-        inputType: 'selection',
+        inputType: 'selectionMixed',
         clearSelectionFirst: true,
         multiple: true,
         required: true,


### PR DESCRIPTION
Closes #11010. But not addressing the confusing "region" selection type just yet.

I ported the boolean playwright tests to use sketch solve modeling, got 4 failures, fixed inconsistencies in the codemods, got down to 1 failure representing the issue #11010, fixed it also through a more consistent config for the Tools arg vs. Solids.