### PR TITLE
Fix "not implemented: SketchVar" console error

### DIFF
--- a/rust/kcl-lib/src/parsing/ast/types/path.rs
+++ b/rust/kcl-lib/src/parsing/ast/types/path.rs
@@ -373,7 +373,6 @@ impl NodePath {
                 }
             }
             Expr::SketchVar(node) => {
-                // TODO: sketch-api: implement initial.
                 if node.contains_range(&range) {
                     path.push(Step::SketchVar);
                     return Some(path);

--- a/src/lang/queryAstNodePathUtils.ts
+++ b/src/lang/queryAstNodePathUtils.ts
@@ -43,7 +43,8 @@ function moreNodePathFromSourceRange(
     (_node.type === 'Name' ||
       _node.type === 'Literal' ||
       _node.type === 'Identifier' ||
-      _node.type === 'TagDeclarator') &&
+      _node.type === 'TagDeclarator' ||
+      _node.type === 'SketchVar') &&
     isInRange
   ) {
     return path


### PR DESCRIPTION
When you put your cursor on `var 123`, it was trying to compute the PathToNode of a sketch var and falling through.