### PR TITLE
Codex: Fix sceneInfra to actually clear mouseDown listeners

### DIFF
--- a/src/clientSideScene/sceneInfra.spec.ts
+++ b/src/clientSideScene/sceneInfra.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { SceneInfra } from '@src/clientSideScene/sceneInfra'
+
+function makeSceneInfraForCallbacksTest() {
+  return new SceneInfra(
+    {
+      streamDimensions: { width: 1, height: 1 },
+      sendSceneCommand: vi.fn(),
+      subscribeTo: vi.fn(),
+      subscribeToUnreliable: vi.fn(),
+    } as any,
+    Promise.resolve({} as any),
+    () => ({}) as any
+  )
+}
+
+describe('SceneInfra callback resets', () => {
+  it('clears solver-only mouse down selection callback when listeners reset', () => {
+    const sceneInfra = makeSceneInfraForCallbacksTest()
+    const solverMouseDownSelection = vi.fn(() => false)
+
+    sceneInfra.setCallbacks({
+      onMouseDownSelection: solverMouseDownSelection,
+    })
+    expect(sceneInfra.onMouseDownSelection).toBe(solverMouseDownSelection)
+
+    sceneInfra.resetMouseListeners()
+
+    expect(sceneInfra.onMouseDownSelection).toBeUndefined()
+  })
+})

--- a/src/clientSideScene/sceneInfra.ts
+++ b/src/clientSideScene/sceneInfra.ts
@@ -141,8 +141,9 @@ export class SceneInfra {
     this.onDragCallback = callbacks.onDrag || this.onDragCallback
     this.onMoveCallback = callbacks.onMove || this.onMoveCallback
     this.onClickCallback = callbacks.onClick || this.onClickCallback
-    this.onMouseDownSelection =
-      callbacks.onMouseDownSelection || this.onMouseDownSelection
+    if ('onMouseDownSelection' in callbacks) {
+      this.onMouseDownSelection = callbacks.onMouseDownSelection
+    }
     this.onMouseEnter = callbacks.onMouseEnter || this.onMouseEnter
     this.onMouseLeave = callbacks.onMouseLeave || this.onMouseLeave
     this.onAreaSelectStartCallback =


### PR DESCRIPTION
Fixes #11054. Codex-debugged and written.

## Demo
https://github.com/user-attachments/assets/21bc8b76-40b5-40f8-a525-40e6b4cf9e3e


## Prompt
Could you read through https://github.com/KittyCAD/modeling-app/issues/11054 and investigate what might be causing it in our code base? I believe the dragging behavior for legacy sketches should be in [sceneInfra.ts](src/clientSideScene/sceneInfra.ts) or [sceneEntities.ts](src/clientSideScene/sceneEntities.ts), and maybe something about the shared state in either [KclManager.ts](src/lang/KclManager.ts) or [modelingMachine.ts](src/machines/modelingMachine.ts) is stale or broken when exiting a solver-based sketch and entering a legacy sketch, but I'm not sure what since the failure while dragging is silent.

## Final response
The likely root cause is a stale solver-only mousedown callback surviving the mode transition.

In solver mode, the move tool installs onMouseDownSelection in moveTool.ts (line 1367). Legacy sketch mode is supposed to clear that via resetMouseListeners(), but sceneInfra.ts (line 144) was preserving the old callback because it used callbacks.onMouseDownSelection || this.onMouseDownSelection. Passing undefined therefore did nothing.

That leaves legacy onMouseDown taking the sketch-solve branch in sceneInfra.ts (line 799) instead of the legacy raycast-selection branch. The result matches the issue very closely:

clicks can still appear to work, because the fallback path becomes area-select/click handling
drag never starts on the legacy segment path
there is no visible error, because nothing throws; the wrong branch just runs
I patched that in sceneInfra.ts (line 144) so onMouseDownSelection is explicitly clearable, and added a regression test in sceneInfra.spec.ts (line 1).