### PR TITLE
Fix formatting of inline KCL code block in module docs

### DIFF
--- a/docs/kcl-std/modules/std-sketch.md
+++ b/docs/kcl-std/modules/std-sketch.md
@@ -7,7 +7,8 @@ layout: manual
 
 Sketching is the foundational activity for most KCL programs. A sketch is a two-dimensional drawing made from paths or shapes. A sketch is always drawn on a surface (either an abstract plane of a face of a solid). A sketch can be made into a solid by extruding it (or revolving, etc.). 
 
-This module contains functions for creating and manipulating sketches, and making them into solids. 
+This module contains functions for creating and manipulating sketches, and making them into solids.
+
 
 
 ## Functions and constants

--- a/docs/kcl-std/modules/std-solver.md
+++ b/docs/kcl-std/modules/std-solver.md
@@ -5,7 +5,7 @@ excerpt: "Functions for sketch-solve using constraints. This module's items are 
 layout: manual
 ---
 
-Functions for sketch-solve using constraints. This module's items are for use within sketch blocks.
+Functions for sketch-solve using constraints. This module's items are for use within sketch blocks. 
 
 ```kcl,inline
 triangle = sketch(on = XY) {
@@ -23,13 +23,24 @@ triangleRegion = region(point = [0.5mm, 0.5mm], sketch = triangle)
 extrude(triangleRegion, length = 5)
 ```
 
-In the above example, the `sketch(on = XY) { ... }` is called the sketch block. Inside the curly braces, all the functions and constants in this module are in scope and available. 
+In the above example, the `sketch(on = XY) { ... }` is called the sketch
+block. Inside the curly braces, all the functions and constants in this
+module are in scope and available.
 
-Values introduced with `var` are only initial guesses for the solver. They are starting positions or starting sizes, not locked values, and the solver is free to change them in the final solved sketch. 
+Values introduced with `var` are only initial guesses for the solver.
+They are starting positions or starting sizes, not locked values, and the
+solver is free to change them in the final solved sketch.
 
-For that reason, initial guesses should always be literals. Do not use identifiers, constant references, or computed expressions as initial guesses. For example, use `var 0mm` or `var 10mm`, not `var width`, `var baseRadius`, or `var (plateWidth / 2)`. 
+For that reason, initial guesses should always be literals. Do not use
+identifiers, constant references, or computed expressions as initial
+guesses. For example, use `var 0mm` or `var 10mm`, not `var width`,
+`var baseRadius`, or `var (plateWidth / 2)`.
 
-If a value must stay fixed, put that value in the constraint itself. Constants and expressions belong in `distance`, `radius`, `diameter`, `horizontalDistance`, `verticalDistance`, and similar constraint functions, because those are what actually constrain the solved result. 
+If a value must stay fixed, put that value in the constraint itself.
+Constants and expressions belong in `distance`, `radius`, `diameter`,
+`horizontalDistance`, `verticalDistance`, and similar constraint
+functions, because those are what actually constrain the solved result.
+
 
 
 ## Functions and constants

--- a/docs/kcl-std/modules/std-solver.md
+++ b/docs/kcl-std/modules/std-solver.md
@@ -5,11 +5,23 @@ excerpt: "Functions for sketch-solve using constraints. This module's items are 
 layout: manual
 ---
 
-Functions for sketch-solve using constraints. This module's items are for use within sketch blocks. 
+Functions for sketch-solve using constraints. This module's items are for use within sketch blocks.
 
-```kcl,inline triangle = sketch(on = XY) { line1 = line(start = [var -0.05mm, var -0.01mm], end = [var 3.88mm, var 0.81mm]) line2 = line(start = [var 3.88mm, var 0.81mm], end = [var 0.92mm, var 4.67mm]) coincident([line1.end, line2.start]) line3 = line(start = [var 0.92mm, var 4.67mm], end = [var -0.03mm, var -0.04mm]) coincident([line2.end, line3.start]) coincident([line1.start, line3.end]) horizontal(line1) equalLength([line2, line3]) } 
+```kcl,inline
+triangle = sketch(on = XY) {
+  line1 = line(start = [var -0.05mm, var -0.01mm], end = [var 3.88mm, var 0.81mm])
+  line2 = line(start = [var 3.88mm, var 0.81mm], end = [var 0.92mm, var 4.67mm])
+  coincident([line1.end, line2.start])
+  line3 = line(start = [var 0.92mm, var 4.67mm], end = [var -0.03mm, var -0.04mm])
+  coincident([line2.end, line3.start])
+  coincident([line1.start, line3.end])
+  horizontal(line1)
+  equalLength([line2, line3])
+}
 
-triangleRegion = region(point = [0.5mm, 0.5mm], sketch = triangle) extrude(triangleRegion, length = 5) ``` 
+triangleRegion = region(point = [0.5mm, 0.5mm], sketch = triangle)
+extrude(triangleRegion, length = 5)
+```
 
 In the above example, the `sketch(on = XY) { ... }` is called the sketch block. Inside the curly braces, all the functions and constants in this module are in scope and available. 
 

--- a/docs/kcl-std/modules/std-types.md
+++ b/docs/kcl-std/modules/std-types.md
@@ -7,7 +7,10 @@ layout: manual
 
 KCL types. This module contains fundamental types like `number`, `string`, `Solid`, and `Sketch`. 
 
-Types can (optionally) be used to describe a function's arguments and returned value. They are checked when a program runs and can help avoid errors. They are also useful to help document what a function does. 
+Types can (optionally) be used to describe a function's arguments and returned value. They are checked
+when a program runs and can help avoid errors. They are also useful to help document what a function
+does.
+
 
 
 

--- a/docs/kcl-std/modules/std-units.md
+++ b/docs/kcl-std/modules/std-units.md
@@ -7,9 +7,13 @@ layout: manual
 
 Functions for converting numbers to different units. 
 
-All numbers in KCL include units, e.g., the number `42` is always '42 mm' or '42 degrees', etc. it is never just '42'. For more information, see [numeric types](/docs/kcl-lang/numeric). 
+All numbers in KCL include units, e.g., the number `42` is always '42 mm' or '42 degrees', etc.
+it is never just '42'. For more information, see [numeric types](/docs/kcl-lang/numeric).
 
-Note that you only need to explicitly convert the units of a number if you need a specific unit for your own calculations. When calling a function, KCL will convert a number to the required units automatically (where possible, and give an error or warning if it's not possible). 
+Note that you only need to explicitly convert the units of a number if you need a specific unit
+for your own calculations. When calling a function, KCL will convert a number to the required
+units automatically (where possible, and give an error or warning if it's not possible).
+
 
 
 ## Functions and constants

--- a/docs/kcl-std/modules/std.md
+++ b/docs/kcl-std/modules/std.md
@@ -7,11 +7,14 @@ layout: manual
 
 The KCL standard library 
 
-Contains frequently used constants, functions for interacting with the KittyCAD servers to create sketches and geometry, and utility functions. 
+Contains frequently used constants, functions for interacting with the KittyCAD servers to
+create sketches and geometry, and utility functions.
 
-The standard library is organised into modules (listed below), but most things are always available in KCL programs. 
+The standard library is organised into modules (listed below), but most things are always available
+in KCL programs.
 
-You might also want the [KCL language reference](/docs/kcl-lang) or the [KCL guide](https://zoo.dev/docs/kcl-book/intro.html). 
+You might also want the [KCL language reference](/docs/kcl-lang) or the [KCL guide](https://zoo.dev/docs/kcl-book/intro.html).
+
 
 ## Modules
 

--- a/rust/kcl-lib/src/docs/kcl_doc.rs
+++ b/rust/kcl-lib/src/docs/kcl_doc.rs
@@ -62,27 +62,28 @@ fn visit_module(name: &str, preferred_prefix: &str, names: WalkForNames) -> Resu
         .parse_errs_as_err()
         .unwrap();
 
-    // TODO handle examples; use with_comments
     let mut summary = String::new();
     let mut description = None;
     for n in &parsed.non_code_meta.start_nodes {
         match &n.value {
             NonCodeValue::BlockComment { value, .. } if value.starts_with('/') => {
-                let line = value[1..].trim();
-                if line.is_empty() {
+                let rest = &value[1..];
+                if rest.trim().is_empty() {
                     match &mut description {
                         None => description = Some(String::new()),
-                        Some(d) => d.push_str("\n\n"),
+                        Some(d) => d.push('\n'),
                     }
                 } else {
+                    let line = rest.trim_end();
+                    let line = line.strip_prefix(' ').unwrap_or(line);
                     match &mut description {
                         None => {
-                            summary.push_str(line);
+                            summary.push_str(line.trim());
                             summary.push(' ');
                         }
                         Some(d) => {
                             d.push_str(line);
-                            d.push(' ');
+                            d.push('\n');
                         }
                     }
                 }


### PR DESCRIPTION
Amends https://github.com/KittyCAD/modeling-app/pull/11046 to hopefully fix this error: https://github.com/KittyCAD/website/actions/runs/24386817703/job/71222541946?pr=4079