### PR TITLE
Avoid false positive "degenerate" geometry while constructing rectangles

### DIFF
--- a/src/machines/sketchSolve/sketchSolveImpl.spec.ts
+++ b/src/machines/sketchSolve/sketchSolveImpl.spec.ts
@@ -148,4 +148,54 @@ describe('updateSketchOutcome', () => {
       vi.useRealTimers()
     }
   })
+
+  test('strips draft preview issues when suppression is requested', () => {
+    const setSketchSolveDiagnostics = vi.fn()
+    const dispatch = vi.fn()
+    const updateCodeEditor = vi.fn()
+    const syncSketchSolveOutcome = vi.fn()
+    const sceneGraphDelta = createSceneGraphDelta([])
+    sceneGraphDelta.exec_outcome.issues = [
+      {
+        message: 'Overlapping geometry',
+        severity: 'Warning',
+        sourceRanges: [],
+      } as any,
+    ]
+
+    const result = updateSketchOutcome({
+      context: {
+        kclManager: {
+          code: 'old code',
+          dispatch,
+          setSketchSolveDiagnostics,
+          updateCodeEditor,
+          syncSketchSolveOutcome,
+        },
+        selectedIds: [],
+        duringAreaSelectIds: [],
+      },
+      event: {
+        type: 'update sketch outcome',
+        data: {
+          sourceDelta: { text: 'new code' },
+          sceneGraphDelta,
+          suppressExecOutcomeIssues: true,
+        },
+      },
+    } as any)
+
+    expect(setSketchSolveDiagnostics).toHaveBeenCalledWith([])
+    expect(syncSketchSolveOutcome).toHaveBeenCalledWith(
+      'new code',
+      expect.objectContaining({
+        exec_outcome: expect.objectContaining({
+          issues: [],
+        }),
+      })
+    )
+    expect(
+      result.sketchExecOutcome?.sceneGraphDelta.exec_outcome.issues
+    ).toEqual([])
+  })
 })

--- a/src/machines/sketchSolve/sketchSolveImpl.spec.ts
+++ b/src/machines/sketchSolve/sketchSolveImpl.spec.ts
@@ -1,4 +1,5 @@
 import { expect, describe, test, vi } from 'vitest'
+import toast from 'react-hot-toast'
 import {
   sendToActorIfActive,
   updateSketchOutcome,
@@ -149,53 +150,58 @@ describe('updateSketchOutcome', () => {
     }
   })
 
-  test('strips draft preview issues when suppression is requested', () => {
-    const setSketchSolveDiagnostics = vi.fn()
-    const dispatch = vi.fn()
-    const updateCodeEditor = vi.fn()
-    const syncSketchSolveOutcome = vi.fn()
-    const sceneGraphDelta = createSceneGraphDelta([])
-    sceneGraphDelta.exec_outcome.issues = [
-      {
-        message: 'Overlapping geometry',
-        severity: 'Warning',
-        sourceRanges: [],
-      } as any,
-    ]
+  test('suppresses preview toasts while preserving exec outcome issues', () => {
+    const toastErrorSpy = vi.spyOn(toast, 'error').mockImplementation(() => '')
+    try {
+      const setSketchSolveDiagnostics = vi.fn()
+      const dispatch = vi.fn()
+      const updateCodeEditor = vi.fn()
+      const syncSketchSolveOutcome = vi.fn()
+      const sceneGraphDelta = createSceneGraphDelta([])
+      sceneGraphDelta.exec_outcome.issues = [
+        {
+          message: 'Overlapping geometry',
+          severity: 'Warning',
+          sourceRange: [0, 0, 0],
+        } as any,
+      ]
 
-    const result = updateSketchOutcome({
-      context: {
-        kclManager: {
-          code: 'old code',
-          dispatch,
-          setSketchSolveDiagnostics,
-          updateCodeEditor,
-          syncSketchSolveOutcome,
+      const result = updateSketchOutcome({
+        context: {
+          kclManager: {
+            code: 'old code',
+            dispatch,
+            setSketchSolveDiagnostics,
+            updateCodeEditor,
+            syncSketchSolveOutcome,
+          },
+          selectedIds: [],
+          duringAreaSelectIds: [],
         },
-        selectedIds: [],
-        duringAreaSelectIds: [],
-      },
-      event: {
-        type: 'update sketch outcome',
-        data: {
-          sourceDelta: { text: 'new code' },
-          sceneGraphDelta,
-          suppressExecOutcomeIssues: true,
+        event: {
+          type: 'update sketch outcome',
+          data: {
+            sourceDelta: { text: 'new code' },
+            sceneGraphDelta,
+            suppressExecOutcomeIssues: true,
+          },
         },
-      },
-    } as any)
+      } as any)
 
-    expect(setSketchSolveDiagnostics).toHaveBeenCalledWith([])
-    expect(syncSketchSolveOutcome).toHaveBeenCalledWith(
-      'new code',
-      expect.objectContaining({
-        exec_outcome: expect.objectContaining({
-          issues: [],
-        }),
-      })
-    )
-    expect(
-      result.sketchExecOutcome?.sceneGraphDelta.exec_outcome.issues
-    ).toEqual([])
+      expect(toastErrorSpy).not.toHaveBeenCalled()
+      expect(
+        result.sketchExecOutcome?.sceneGraphDelta.exec_outcome.issues
+      ).toEqual(sceneGraphDelta.exec_outcome.issues)
+      expect(setSketchSolveDiagnostics).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            message: 'Overlapping geometry',
+            severity: 'warning',
+          }),
+        ])
+      )
+    } finally {
+      toastErrorSpy.mockRestore()
+    }
   })
 })

--- a/src/machines/sketchSolve/sketchSolveImpl.ts
+++ b/src/machines/sketchSolve/sketchSolveImpl.ts
@@ -162,6 +162,12 @@ export type UpdateSketchOutcomeEvent = {
     sourceDelta: SourceDelta
     sceneGraphDelta: SceneGraphDelta
     /**
+     * If true, transient solver issues are stripped from the stored outcome so
+     * draft previews can pass through intentionally degenerate states without
+     * surfacing diagnostics, toast spam, or error styling.
+     */
+    suppressExecOutcomeIssues?: boolean
+    /**
      * If true, debounce editor updates to allow cancellation (e.g., for double-click handling)
      */
     debounceEditorUpdate?: boolean
@@ -1077,13 +1083,23 @@ export function updateSketchOutcome({ event, context }: SolveAssignArgs) {
     throw new Error('updateSketchOutcome: event.data must contain sourceDelta')
   }
 
+  const sceneGraphDelta = event.data.suppressExecOutcomeIssues
+    ? {
+        ...event.data.sceneGraphDelta,
+        exec_outcome: {
+          ...event.data.sceneGraphDelta.exec_outcome,
+          issues: [],
+        },
+      }
+    : event.data.sceneGraphDelta
+
   const sketchSolveDiagnostics = compilationIssuesToDiagnostics(
-    getSketchSolveExecOutcomeIssues(event.data.sceneGraphDelta),
+    getSketchSolveExecOutcomeIssues(sceneGraphDelta),
     event.data.sourceDelta.text
   )
   context.kclManager.setSketchSolveDiagnostics(sketchSolveDiagnostics)
   toastSketchSolveExecOutcomeErrors(
-    event.data.sceneGraphDelta,
+    sceneGraphDelta,
     'Sketch solver failed to find a solution'
   )
 
@@ -1095,7 +1111,7 @@ export function updateSketchOutcome({ event, context }: SolveAssignArgs) {
     sketchCheckpointId: event.data.checkpointId,
     effects: [
       updateSketchSceneGraphEffect.of({
-        sceneGraphDelta: event.data.sceneGraphDelta,
+        sceneGraphDelta,
         context,
         selectedIds: context.selectedIds,
         duringAreaSelectIds: context.duringAreaSelectIds,
@@ -1137,7 +1153,7 @@ export function updateSketchOutcome({ event, context }: SolveAssignArgs) {
     debouncedEditorUpdate({
       text: event.data.sourceDelta.text,
       kclManager: context.kclManager,
-      sceneGraphDelta: event.data.sceneGraphDelta,
+      sceneGraphDelta,
       shouldWriteToDisk,
       shouldAddToHistory,
       spec: editorAdditionalSpec,
@@ -1155,14 +1171,14 @@ export function updateSketchOutcome({ event, context }: SolveAssignArgs) {
     )
     context.kclManager.syncSketchSolveOutcome(
       event.data.sourceDelta.text,
-      event.data.sceneGraphDelta
+      sceneGraphDelta
     )
   }
 
   return {
     sketchExecOutcome: {
       sourceDelta: event.data.sourceDelta,
-      sceneGraphDelta: event.data.sceneGraphDelta,
+      sceneGraphDelta,
     },
   }
 }

--- a/src/machines/sketchSolve/sketchSolveImpl.ts
+++ b/src/machines/sketchSolve/sketchSolveImpl.ts
@@ -162,9 +162,9 @@ export type UpdateSketchOutcomeEvent = {
     sourceDelta: SourceDelta
     sceneGraphDelta: SceneGraphDelta
     /**
-     * If true, transient solver issues are stripped from the stored outcome so
-     * draft previews can pass through intentionally degenerate states without
-     * surfacing diagnostics, toast spam, or error styling.
+     * If true, transient preview states still update exec-outcome issues so the
+     * sketch can render warning/error styling, but repeated toast errors are
+     * suppressed until the interaction commits.
      */
     suppressExecOutcomeIssues?: boolean
     /**
@@ -1083,25 +1083,19 @@ export function updateSketchOutcome({ event, context }: SolveAssignArgs) {
     throw new Error('updateSketchOutcome: event.data must contain sourceDelta')
   }
 
-  const sceneGraphDelta = event.data.suppressExecOutcomeIssues
-    ? {
-        ...event.data.sceneGraphDelta,
-        exec_outcome: {
-          ...event.data.sceneGraphDelta.exec_outcome,
-          issues: [],
-        },
-      }
-    : event.data.sceneGraphDelta
+  const sceneGraphDelta = event.data.sceneGraphDelta
 
   const sketchSolveDiagnostics = compilationIssuesToDiagnostics(
     getSketchSolveExecOutcomeIssues(sceneGraphDelta),
     event.data.sourceDelta.text
   )
   context.kclManager.setSketchSolveDiagnostics(sketchSolveDiagnostics)
-  toastSketchSolveExecOutcomeErrors(
-    sceneGraphDelta,
-    'Sketch solver failed to find a solution'
-  )
+  if (!event.data.suppressExecOutcomeIssues) {
+    toastSketchSolveExecOutcomeErrors(
+      sceneGraphDelta,
+      'Sketch solver failed to find a solution'
+    )
+  }
 
   // If the incoming KCL differs from the current editor doc, apply the scene
   // immediately for responsiveness, but keep that scene-only dispatch out of

--- a/src/machines/sketchSolve/tools/draftGeometryPolicy.ts
+++ b/src/machines/sketchSolve/tools/draftGeometryPolicy.ts
@@ -1,0 +1,23 @@
+import type { Coords2d } from '@src/lang/util'
+import { distance2d } from '@src/lib/utils2d'
+
+/**
+ * Multi-click sketch tools often create several connected segments after the
+ * first click so the preview can be edited in place. Until the next anchor has
+ * moved a small but meaningful distance, keep that seeded preview and ignore
+ * confirmation clicks inside this radius instead of collapsing the draft into
+ * overlapping points or zero-length segments.
+ *
+ * Reuse this policy for rectangle, polygon, and similar tools that would
+ * otherwise emit degenerate geometry while the user is still establishing the
+ * next edge.
+ */
+export const MIN_DRAFT_GEOMETRY_DELTA_MM = 0.1
+
+export function hasCrossedDraftGeometryThreshold(
+  anchor: Coords2d,
+  candidate: Coords2d,
+  minDelta = MIN_DRAFT_GEOMETRY_DELTA_MM
+): boolean {
+  return distance2d(anchor, candidate) >= minDelta
+}

--- a/src/machines/sketchSolve/tools/moveTool/moveTool.spec.ts
+++ b/src/machines/sketchSolve/tools/moveTool/moveTool.spec.ts
@@ -1537,6 +1537,7 @@ describe('createOnDragCallback', () => {
     expect(onNewSketchOutcome).toHaveBeenCalledWith({
       ...result,
       writeToDisk: false,
+      suppressExecOutcomeIssues: true,
     })
   })
 

--- a/src/machines/sketchSolve/tools/moveTool/moveTool.ts
+++ b/src/machines/sketchSolve/tools/moveTool/moveTool.ts
@@ -721,6 +721,7 @@ export function createOnDragCallback({
     kclSource: SourceDelta
     sceneGraphDelta: SceneGraphDelta
     writeToDisk?: boolean
+    suppressExecOutcomeIssues?: boolean
   }) => void
   getDefaultLengthUnit: () => UnitLength | undefined
   getJsAppSettings: () => Promise<DeepPartial<Configuration>>
@@ -851,7 +852,11 @@ export function createOnDragCallback({
 
       // Notify about new sketch outcome if edit was successful
       if (result) {
-        onNewSketchOutcome({ ...result, writeToDisk: false })
+        onNewSketchOutcome({
+          ...result,
+          writeToDisk: false,
+          suppressExecOutcomeIssues: true,
+        })
         await new Promise((resolve) => requestAnimationFrame(resolve))
       }
     } finally {
@@ -1354,6 +1359,7 @@ export function setUpOnDragAndSelectionClickCallbacks({
             sourceDelta: outcome.kclSource,
             sceneGraphDelta: outcome.sceneGraphDelta,
             writeToDisk: false,
+            suppressExecOutcomeIssues: outcome.suppressExecOutcomeIssues,
           },
         })
       },

--- a/src/machines/sketchSolve/tools/rectTool.spec.ts
+++ b/src/machines/sketchSolve/tools/rectTool.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createActor, waitFor, fromPromise } from 'xstate'
 import { machine } from '@src/machines/sketchSolve/tools/rectTool'
+import { MIN_DRAFT_GEOMETRY_DELTA_MM } from '@src/machines/sketchSolve/tools/draftGeometryPolicy'
 import type { RectDraftIds } from '@src/machines/sketchSolve/tools/rectUtils'
 import type {
   SceneGraphDelta,
@@ -310,6 +311,106 @@ describe('rectTool - XState', () => {
       actor.stop()
     })
 
+    it('should ignore an aligned finalize click until the rectangle crosses the preview threshold', async () => {
+      const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
+        createTestMachine()
+      const actor = createActor(machine, {
+        input: {
+          sceneInfra,
+          rustContext,
+          kclManager,
+          sketchId: 0,
+        },
+      }).start()
+
+      actor.send({ type: 'add point', data: [1, 2] })
+      await waitFor(actor, (state) => state.matches('awaiting second point'))
+
+      const callbacks = setCallbacksMock.mock.calls.at(-1)?.[0]
+      callbacks?.onClick?.({
+        mouseEvent: { which: 1 },
+        intersectionPoint: {
+          twoD: {
+            x: 1 + MIN_DRAFT_GEOMETRY_DELTA_MM / 2,
+            y: 2,
+          },
+        },
+      })
+
+      expect(actor.getSnapshot().matches('awaiting second point')).toBe(true)
+      actor.stop()
+    })
+
+    it('should ignore a center-rectangle finalize click when snapping keeps one dimension at zero', async () => {
+      vi.mocked(getBestSnappingCandidate).mockReturnValue({
+        position: [1 + MIN_DRAFT_GEOMETRY_DELTA_MM * 3, 2],
+        target: { type: 'origin' },
+        distance: 0,
+      })
+
+      const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
+        createTestMachine()
+      const actor = createActor(machine, {
+        input: {
+          sceneInfra,
+          rustContext,
+          kclManager,
+          sketchId: 0,
+          toolVariant: 'center',
+        },
+      }).start()
+
+      actor.send({ type: 'add point', data: [1, 2] })
+      await waitFor(actor, (state) => state.matches('awaiting second point'))
+
+      const callbacks = setCallbacksMock.mock.calls.at(-1)?.[0]
+      callbacks?.onClick?.({
+        mouseEvent: { which: 1 },
+        intersectionPoint: {
+          twoD: {
+            x: 99,
+            y: 99,
+          },
+        },
+      })
+
+      expect(actor.getSnapshot().matches('awaiting second point')).toBe(true)
+      actor.stop()
+    })
+
+    it('should ignore an angled second click until the first side crosses the preview threshold', async () => {
+      const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
+        createTestMachine()
+      const actor = createActor(machine, {
+        input: {
+          sceneInfra,
+          rustContext,
+          kclManager,
+          sketchId: 0,
+          toolVariant: 'angled',
+        },
+      }).start()
+
+      actor.send({ type: 'add point', data: [1, 2] })
+      await waitFor(actor, (state) => state.matches('awaiting second point'))
+
+      const callbacks = setCallbacksMock.mock.calls.at(-1)?.[0]
+      callbacks?.onClick?.({
+        mouseEvent: { which: 1 },
+        intersectionPoint: {
+          twoD: {
+            x: 1 + MIN_DRAFT_GEOMETRY_DELTA_MM / 2,
+            y: 2,
+          },
+        },
+      })
+
+      const snapshot = actor.getSnapshot()
+      expect(snapshot.matches('awaiting second point')).toBe(true)
+      expect(snapshot.context.secondPoint).toBeUndefined()
+      actor.stop()
+    })
+
     it('should remain in awaiting third point in angled mode when third click equals second point', async () => {
       const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
         createTestMachine()
@@ -341,6 +442,43 @@ describe('rectTool - XState', () => {
       expect(snapshot.matches('awaiting third point')).toBe(true)
       expect(snapshot.context.secondPoint).toEqual([3, 4])
 
+      actor.stop()
+    })
+
+    it('should ignore an angled third click until the rectangle has non-zero width', async () => {
+      const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
+        createTestMachine()
+      const actor = createActor(machine, {
+        input: {
+          sceneInfra,
+          rustContext,
+          kclManager,
+          sketchId: 0,
+          toolVariant: 'angled',
+        },
+      }).start()
+
+      actor.send({ type: 'add point', data: [1, 2] })
+      await waitFor(actor, (state) => state.matches('awaiting second point'))
+
+      actor.send({
+        type: 'set second point',
+        data: [1 + MIN_DRAFT_GEOMETRY_DELTA_MM * 2, 2],
+      })
+      await waitFor(actor, (state) => state.matches('awaiting third point'))
+
+      const callbacks = setCallbacksMock.mock.calls.at(-1)?.[0]
+      callbacks?.onClick?.({
+        mouseEvent: { which: 1 },
+        intersectionPoint: {
+          twoD: {
+            x: 1 + MIN_DRAFT_GEOMETRY_DELTA_MM * 2,
+            y: 2 + MIN_DRAFT_GEOMETRY_DELTA_MM / 2,
+          },
+        },
+      })
+
+      expect(actor.getSnapshot().matches('awaiting third point')).toBe(true)
       actor.stop()
     })
   })
@@ -484,6 +622,37 @@ describe('rectTool - XState', () => {
         sceneInfra,
       })
 
+      actor.stop()
+    })
+
+    it('skips aligned draft edits until the preview threshold is crossed', async () => {
+      const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
+        createTestMachine()
+      const actor = createActor(machine, {
+        input: {
+          sceneInfra,
+          rustContext,
+          kclManager,
+          sketchId: 0,
+        },
+      }).start()
+      const editSegmentsSpy = vi.spyOn(rustContext, 'editSegments')
+
+      actor.send({ type: 'add point', data: [1, 2] })
+      await waitFor(actor, (state) => state.matches('awaiting second point'))
+
+      const callbacks = setCallbacksMock.mock.calls.at(-1)?.[0]
+      callbacks?.onMove?.({
+        mouseEvent: { shiftKey: false },
+        intersectionPoint: {
+          twoD: {
+            x: 1 + MIN_DRAFT_GEOMETRY_DELTA_MM / 2,
+            y: 2,
+          },
+        },
+      })
+
+      expect(editSegmentsSpy).not.toHaveBeenCalled()
       actor.stop()
     })
   })

--- a/src/machines/sketchSolve/tools/rectTool.ts
+++ b/src/machines/sketchSolve/tools/rectTool.ts
@@ -19,12 +19,17 @@ import type { AssignArgs, ProvidedActor } from 'xstate'
 import { assertEvent, assign, createMachine, fromPromise, setup } from 'xstate'
 
 import type { Coords2d } from '@src/lang/util'
-import { pointsAreEqual } from '@src/lib/utils2d'
 import { isPointSegment } from '@src/machines/sketchSolve/constraints/constraintUtils'
 import type { SnapTarget } from '@src/machines/sketchSolve/snapping'
+import {
+  MIN_DRAFT_GEOMETRY_DELTA_MM,
+  hasCrossedDraftGeometryThreshold,
+} from '@src/machines/sketchSolve/tools/draftGeometryPolicy'
 import type { RectDraftIds } from '@src/machines/sketchSolve/tools/rectUtils'
 import {
   createDraftRectangle,
+  getAngledRectangleWidth,
+  getSeededAngledRectangleThirdPoint,
   updateDraftRectangleAligned,
   updateDraftRectangleAngled,
 } from '@src/machines/sketchSolve/tools/rectUtils'
@@ -84,6 +89,53 @@ function getRectSnappingExcludedPointIds(
 
   return draft.segmentIds.filter((id) =>
     isPointSegment(currentSketchObjects[id])
+  )
+}
+
+// Rectangle previews are seeded on the first click, then only replaced with
+// user-driven geometry once the next anchor is far enough away to keep the
+// solver out of a degenerate overlapping state. This matches the shared
+// multi-click draft policy in draftGeometryPolicy.ts for future polygon-like tools.
+function canPreviewAlignedRectangle(
+  origin: Coords2d,
+  point: Coords2d
+): boolean {
+  return hasCrossedDraftGeometryThreshold(origin, point)
+}
+
+function canCommitAlignedRectangle(
+  mode: RectOriginMode,
+  origin: Coords2d,
+  point: Coords2d
+): boolean {
+  const width = Math.abs(point[0] - origin[0]) * (mode === 'center' ? 2 : 1)
+  const height = Math.abs(point[1] - origin[1]) * (mode === 'center' ? 2 : 1)
+  return (
+    width >= MIN_DRAFT_GEOMETRY_DELTA_MM &&
+    height >= MIN_DRAFT_GEOMETRY_DELTA_MM
+  )
+}
+
+function canPreviewAngledRectangleSecondPoint(
+  origin: Coords2d,
+  point: Coords2d
+): boolean {
+  return hasCrossedDraftGeometryThreshold(origin, point)
+}
+
+function canPreviewAngledRectangleThirdPoint(
+  origin: Coords2d,
+  secondPoint: Coords2d,
+  thirdPoint: Coords2d
+): boolean {
+  return (
+    Math.abs(
+      getAngledRectangleWidth({
+        p1: origin,
+        p2: secondPoint,
+        p3: thirdPoint,
+      })
+    ) >= MIN_DRAFT_GEOMETRY_DELTA_MM
   )
 }
 
@@ -176,54 +228,79 @@ export const machine = setup({
             sceneInfra: context.sceneInfra,
             target: snappingCandidate,
           })
+          const candidatePoint = snappingCandidate?.position ?? [twoD.x, twoD.y]
 
           if (!isEditInProgress) {
             try {
-              isEditInProgress = true
-
               let result: {
                 kclSource: SourceDelta
                 sceneGraphDelta: SceneGraphDelta
-              }
+              } | null = null
+              let suppressExecOutcomeIssues = false
 
               if (context.rectOriginMode === 'angled') {
-                result = await updateDraftRectangleAngled({
-                  rustContext: context.rustContext,
-                  kclManager: context.kclManager,
-                  sketchId: context.sketchId,
-                  draft: context.draft,
-                  p1: context.origin,
-                  p2: [twoD.x, twoD.y],
-                  p3: [twoD.x, twoD.y], // no third click yet
-                })
+                if (
+                  canPreviewAngledRectangleSecondPoint(
+                    context.origin,
+                    candidatePoint
+                  )
+                ) {
+                  isEditInProgress = true
+                  result = await updateDraftRectangleAngled({
+                    rustContext: context.rustContext,
+                    kclManager: context.kclManager,
+                    sketchId: context.sketchId,
+                    draft: context.draft,
+                    p1: context.origin,
+                    p2: candidatePoint,
+                    // Keep a tiny non-zero width until the third click exists so
+                    // the preview remains non-degenerate during the second-point drag.
+                    p3: getSeededAngledRectangleThirdPoint(
+                      context.origin,
+                      candidatePoint
+                    ),
+                  })
+                }
               } else {
                 const start = context.origin
-                const end: Coords2d = [twoD.x, twoD.y]
+                const end = candidatePoint
 
-                const min: Coords2d = [
-                  Math.min(start[0], end[0]),
-                  Math.min(start[1], end[1]),
-                ]
-                const max: Coords2d = [
-                  Math.max(start[0], end[0]),
-                  Math.max(start[1], end[1]),
-                ]
+                if (canPreviewAlignedRectangle(start, end)) {
+                  suppressExecOutcomeIssues = !canCommitAlignedRectangle(
+                    context.rectOriginMode,
+                    start,
+                    end
+                  )
+                  isEditInProgress = true
+                  const min: Coords2d = [
+                    Math.min(start[0], end[0]),
+                    Math.min(start[1], end[1]),
+                  ]
+                  const max: Coords2d = [
+                    Math.max(start[0], end[0]),
+                    Math.max(start[1], end[1]),
+                  ]
 
-                if (context.rectOriginMode === 'center') {
-                  const size = [max[0] - min[0], max[1] - min[1]]
-                  min[0] = start[0] - size[0]
-                  min[1] = start[1] - size[1]
-                  max[0] = min[0] + size[0] * 2
-                  max[1] = min[1] + size[1] * 2
+                  if (context.rectOriginMode === 'center') {
+                    const size = [max[0] - min[0], max[1] - min[1]]
+                    min[0] = start[0] - size[0]
+                    min[1] = start[1] - size[1]
+                    max[0] = min[0] + size[0] * 2
+                    max[1] = min[1] + size[1] * 2
+                  }
+
+                  result = await updateDraftRectangleAligned({
+                    rustContext: context.rustContext,
+                    kclManager: context.kclManager,
+                    sketchId: context.sketchId,
+                    draft: context.draft,
+                    rect: { min, max },
+                  })
                 }
+              }
 
-                result = await updateDraftRectangleAligned({
-                  rustContext: context.rustContext,
-                  kclManager: context.kclManager,
-                  sketchId: context.sketchId,
-                  draft: context.draft,
-                  rect: { min, max },
-                })
+              if (!result) {
+                return
               }
 
               const sendData: SketchSolveMachineEvent = {
@@ -231,6 +308,7 @@ export const machine = setup({
                 data: {
                   sourceDelta: result.kclSource,
                   sceneGraphDelta: result.sceneGraphDelta,
+                  suppressExecOutcomeIssues,
                   writeToDisk: false,
                 },
               }
@@ -263,13 +341,28 @@ export const machine = setup({
               ),
           })
           const [x, y] = snappingCandidate?.position ?? mousePosition
+          const nextPoint: Coords2d = [x, y]
 
           if (context.rectOriginMode === 'angled') {
+            if (
+              !canPreviewAngledRectangleSecondPoint(context.origin, nextPoint)
+            ) {
+              return
+            }
             self.send({
               type: 'set second point',
-              data: [x, y],
+              data: nextPoint,
             })
           } else {
+            if (
+              !canCommitAlignedRectangle(
+                context.rectOriginMode,
+                context.origin,
+                nextPoint
+              )
+            ) {
+              return
+            }
             self.send({
               type: 'finalize',
             })
@@ -308,9 +401,20 @@ export const machine = setup({
             sceneInfra: context.sceneInfra,
             target: snappingCandidate,
           })
+          const candidatePoint = snappingCandidate?.position ?? [twoD.x, twoD.y]
 
           if (!isEditInProgress) {
             try {
+              if (
+                !canPreviewAngledRectangleThirdPoint(
+                  context.origin,
+                  context.secondPoint,
+                  candidatePoint
+                )
+              ) {
+                return
+              }
+
               isEditInProgress = true
               const result = await updateDraftRectangleAngled({
                 rustContext: context.rustContext,
@@ -319,7 +423,7 @@ export const machine = setup({
                 draft: context.draft,
                 p1: context.origin,
                 p2: context.secondPoint,
-                p3: [twoD.x, twoD.y],
+                p3: candidatePoint,
               })
 
               const sendData: SketchSolveMachineEvent = {
@@ -359,9 +463,14 @@ export const machine = setup({
               ),
           })
           const [x, y] = snappingCandidate?.position ?? mousePosition
+          const nextPoint: Coords2d = [x, y]
           if (
             context.secondPoint &&
-            pointsAreEqual(context.secondPoint, [x, y])
+            !canPreviewAngledRectangleThirdPoint(
+              context.origin,
+              context.secondPoint,
+              nextPoint
+            )
           ) {
             return
           }
@@ -571,7 +680,10 @@ export const machine = setup({
           guard: ({ context, event }) => {
             if (context.rectOriginMode !== 'angled') return false
             if (event.type !== 'set second point') return false
-            return !pointsAreEqual(context.origin, event.data)
+            return canPreviewAngledRectangleSecondPoint(
+              context.origin,
+              event.data
+            )
           },
           actions: assign(({ event }) => {
             if (event.type !== 'set second point') return {}

--- a/src/machines/sketchSolve/tools/rectUtils.spec.ts
+++ b/src/machines/sketchSolve/tools/rectUtils.spec.ts
@@ -11,6 +11,7 @@ import {
   getAngledRectangleCorners,
   updateDraftRectangleAligned,
 } from '@src/machines/sketchSolve/tools/rectUtils'
+import { MIN_DRAFT_GEOMETRY_DELTA_MM } from '@src/machines/sketchSolve/tools/draftGeometryPolicy'
 import {
   createLineApiObject,
   createMockKclManager,
@@ -308,6 +309,72 @@ describe('rectUtils.createDraftRectangle', () => {
     })
     expect(result.draft.originPointId).toBe(11)
     expect(result.draft.constraintIds.at(-1)).toBe(308)
+  })
+
+  it('seeds corner rectangles at the clicked origin with a non-degenerate draft size', async () => {
+    const rustContext = createMockRustContext()
+    const kclManager = createMockKclManager()
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const addSegmentMock = vi.mocked(rustContext.addSegment)
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const addConstraintMock = vi.mocked(rustContext.addConstraint)
+
+    addSegmentMock
+      .mockResolvedValueOnce({
+        kclSource: { text: 'line-1' } as SourceDelta,
+        sceneGraphDelta: createLineSceneGraphDelta(1, 11, 12),
+      })
+      .mockResolvedValueOnce({
+        kclSource: { text: 'line-2' } as SourceDelta,
+        sceneGraphDelta: createLineSceneGraphDelta(2, 13, 14),
+      })
+      .mockResolvedValueOnce({
+        kclSource: { text: 'line-3' } as SourceDelta,
+        sceneGraphDelta: createLineSceneGraphDelta(3, 15, 16),
+      })
+      .mockResolvedValueOnce({
+        kclSource: { text: 'line-4' } as SourceDelta,
+        sceneGraphDelta: createLineSceneGraphDelta(4, 17, 18),
+      })
+
+    let constraintIndex = 0
+    addConstraintMock.mockImplementation(
+      async (_version, _sketchId, constraint) => {
+        const index = constraintIndex
+        constraintIndex += 1
+        return {
+          kclSource: { text: `constraint-${index}` } as SourceDelta,
+          sceneGraphDelta: createConstraintSceneGraphDelta(
+            400 + index,
+            constraint
+          ),
+        }
+      }
+    )
+
+    await createDraftRectangle({
+      rustContext,
+      kclManager,
+      sketchId: 12,
+      mode: 'corner',
+      origin: [12, 8],
+    })
+
+    expect(addSegmentMock.mock.calls[0]?.[2]).toEqual({
+      type: 'Line',
+      start: {
+        x: { type: 'Var', value: 12, units: 'Mm' },
+        y: { type: 'Var', value: 8, units: 'Mm' },
+      },
+      end: {
+        x: {
+          type: 'Var',
+          value: 12 + MIN_DRAFT_GEOMETRY_DELTA_MM,
+          units: 'Mm',
+        },
+        y: { type: 'Var', value: 8, units: 'Mm' },
+      },
+    })
   })
 })
 

--- a/src/machines/sketchSolve/tools/rectUtils.ts
+++ b/src/machines/sketchSolve/tools/rectUtils.ts
@@ -19,6 +19,7 @@ import {
   type SnapTarget,
   getConstraintForSnapTarget,
 } from '@src/machines/sketchSolve/snapping'
+import { MIN_DRAFT_GEOMETRY_DELTA_MM } from '@src/machines/sketchSolve/tools/draftGeometryPolicy'
 
 type AppSettings = Awaited<ReturnType<typeof jsAppSettings>>
 type NumericSuffix = ReturnType<typeof baseUnitToNumericSuffix>
@@ -36,6 +37,7 @@ export type RectDraftIds = {
 }
 
 const INITIAL_CENTER_RECT_HALF_SIZE = 5
+const INITIAL_CORNER_RECT_SIZE = MIN_DRAFT_GEOMETRY_DELTA_MM
 
 function getLineFromDelta(
   sceneGraphDelta: SceneGraphDelta
@@ -124,10 +126,7 @@ export async function createDraftRectangle({
     kclManager.fileSettings.defaultLengthUnit
   )
   const settings = jsAppSettings(rustContext.settingsActor)
-  const centerDraftCorners =
-    mode === 'center'
-      ? getCenteredDraftRectangleCorners(origin, INITIAL_CENTER_RECT_HALF_SIZE)
-      : null
+  const draftCorners = getInitialDraftRectangleCorners(origin, mode)
 
   const centerPoint =
     mode === 'center'
@@ -145,32 +144,32 @@ export async function createDraftRectangle({
     rustContext,
     sketchId,
     settings,
-    start: centerDraftCorners?.start1,
-    end: centerDraftCorners?.start2,
+    start: draftCorners.start1,
+    end: draftCorners.start2,
   })
   const line2 = await makeDraftLine({
     units,
     rustContext,
     sketchId,
     settings,
-    start: centerDraftCorners?.start2,
-    end: centerDraftCorners?.start3,
+    start: draftCorners.start2,
+    end: draftCorners.start3,
   })
   const line3 = await makeDraftLine({
     units,
     rustContext,
     sketchId,
     settings,
-    start: centerDraftCorners?.start3,
-    end: centerDraftCorners?.start4,
+    start: draftCorners.start3,
+    end: draftCorners.start4,
   })
   const line4 = await makeDraftLine({
     units,
     rustContext,
     sketchId,
     settings,
-    start: centerDraftCorners?.start4,
-    end: centerDraftCorners?.start1,
+    start: draftCorners.start4,
+    end: draftCorners.start1,
   })
 
   /**
@@ -292,8 +291,8 @@ export async function createDraftRectangle({
       sketchId,
       settings,
       construction: true,
-      start: centerDraftCorners?.start1,
-      end: centerDraftCorners?.start3,
+      start: draftCorners.start1,
+      end: draftCorners.start3,
     })
     const diagonal2 = await makeDraftLine({
       units,
@@ -301,8 +300,8 @@ export async function createDraftRectangle({
       sketchId,
       settings,
       construction: true,
-      start: centerDraftCorners?.start2,
-      end: centerDraftCorners?.start4,
+      start: draftCorners.start2,
+      end: draftCorners.start4,
     })
 
     const diagonalStartCoincident = await addCoincidentConstraint({
@@ -516,6 +515,31 @@ function getCenteredDraftRectangleCorners(
   })
 }
 
+function getInitialDraftRectangleCorners(
+  origin: Coords2d,
+  mode: RectOriginMode
+): {
+  start1: Coords2d
+  start2: Coords2d
+  start3: Coords2d
+  start4: Coords2d
+} {
+  if (mode === 'center') {
+    return getCenteredDraftRectangleCorners(
+      origin,
+      INITIAL_CENTER_RECT_HALF_SIZE
+    )
+  }
+
+  return getAxisAlignedRectangleCorners({
+    min: origin,
+    max: [
+      origin[0] + INITIAL_CORNER_RECT_SIZE,
+      origin[1] + INITIAL_CORNER_RECT_SIZE,
+    ],
+  })
+}
+
 // Updates draft rectangle for angled (rotated) rectangle
 export async function updateDraftRectangleAngled({
   rustContext,
@@ -575,6 +599,12 @@ export function getAngledRectangleCorners({
 } {
   const side = subVec(p2, p1)
   const sideLength = Math.hypot(side[0], side[1])
+  if (sideLength === 0) {
+    return getAxisAlignedRectangleCorners({
+      min: p1,
+      max: [p1[0] + INITIAL_CORNER_RECT_SIZE, p1[1] + INITIAL_CORNER_RECT_SIZE],
+    })
+  }
 
   // Unit normal to the first side: rotate 90deg
   const normal: Coords2d = [-side[1] / sideLength, side[0] / sideLength]
@@ -590,6 +620,40 @@ export function getAngledRectangleCorners({
   const start4: Coords2d = addVec(p1, offset)
 
   return { start1, start2, start3, start4 }
+}
+
+export function getAngledRectangleWidth({
+  p1,
+  p2,
+  p3,
+}: {
+  p1: Coords2d
+  p2: Coords2d
+  p3: Coords2d
+}): number {
+  const side = subVec(p2, p1)
+  const sideLength = Math.hypot(side[0], side[1])
+  if (sideLength === 0) {
+    return 0
+  }
+
+  const normal: Coords2d = [-side[1] / sideLength, side[0] / sideLength]
+  return dot2d(subVec(p3, p1), normal)
+}
+
+export function getSeededAngledRectangleThirdPoint(
+  p1: Coords2d,
+  p2: Coords2d,
+  width = MIN_DRAFT_GEOMETRY_DELTA_MM
+): Coords2d {
+  const side = subVec(p2, p1)
+  const sideLength = Math.hypot(side[0], side[1])
+  if (sideLength === 0) {
+    return [p2[0], p2[1] + width]
+  }
+
+  const normal: Coords2d = [-side[1] / sideLength, side[0] / sideLength]
+  return addVec(p2, scaleVec(normal, width))
 }
 
 async function updateDraftRectangleFromCorners({


### PR DESCRIPTION
Codex written after a bit of back-and-forth. Fixes #11015, trying to set up something we can follow with the polygon tool. Adjusts the rectangle tool so it no longer drives the solver into degenerate overlapping drafts while the user is still within a tiny post-click movement radius.

Adds a new shared policy helper `draftGeometryPolicy.ts`. The policy is documented there: multi-click tools should seed a safe preview after the first click, skip live edits and confirmation clicks until the next anchor crosses a small threshold, and keep angled previews non-zero-width until the third point exists.

For rectangles specifically:
1. Corner/center rectangles now ignore near-zero second-point moves/clicks until the threshold is crossed.
2. Angled rectangles now use a tiny seeded width while choosing the second point, then require a real perpendicular width before third-point updates/finalization.
3. Non-center rectangle drafts are seeded at the clicked origin instead of relying on the old generic fallback placement.
4. Non-angled rectangles (meaning either center or corner types) also distinguishes between:
    - Preview-valid: the pointer has moved far enough from the first point to justify updating the draft.
    - Commit-valid: the rectangle has nonzero width and height above the minimum threshold.

## Demo

https://github.com/user-attachments/assets/0e755a80-6a33-4ea1-a648-d801c48ee417


