### PR TITLE
Use latest nodejs in kcl-wasm-lib publishing

### DIFF
--- a/.github/workflows/kcl-wasm-lib-build-publish.yml
+++ b/.github/workflows/kcl-wasm-lib-build-publish.yml
@@ -18,7 +18,8 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version-file: '.nvmrc'
+          # node 24 fixed OIDC npm publishing, but might as well use latest anyway
+          node-version: 'latest'
           registry-url: 'https://registry.npmjs.org/'
           cache: 'npm'
 


### PR DESCRIPTION
Web development was a mistake https://github.com/npm/cli/issues/8976

Because `modeling-app` uses `node 22` we hit this exact bug. `@kittycad/lib` doesn't have this issue because it uses `node 24`, as noted in the issue.