### PR TITLE
Let getOperationVariableName retrieve sketch variable names

### DIFF
--- a/src/lib/operations.spec.ts
+++ b/src/lib/operations.spec.ts
@@ -296,6 +296,71 @@ describe('operations.test.ts', () => {
       const variableName = getOperationVariableName(op, program, instance)
       expect(variableName).toBeUndefined()
     })
+    it('finds variable names for operations inside a sketch block', async () => {
+      const instance = await loadAndInitialiseWasmInstance(WASM_PATH)
+      const code = `sketch001 = sketch(on = YZ) {
+  line1 = line(start = [var -13.64mm, var 7.86mm], end = [var 0mm, var 18.94mm])
+  horizontalDistance([line1.end, ORIGIN]) == 0mm
+  line2 = line(start = [var -12.18mm, var -3.65mm], end = [var -13.64mm, var 7.86mm])
+  coincident([line2.end, line1.start])
+  point2 = point(at = [var 7.65mm, var 18.08mm])
+  point1 = point(at = [var 9.37mm, var 7.94mm])
+  verticalDistance([point1, point2]) == 0mm
+  circle1 = circle(start = [var 10.57mm, var 2.96mm], center = [var 10.49mm, var 0mm])
+  arc1 = arc(start = [var 1.04mm, var -8.29mm], end = [var -3.62mm, var -5.28mm], center = [var -3.42mm, var -10.09mm])
+  coincident([arc1.end, line2.start])
+}
+`
+      const program = assertParse(code, instance)
+
+      const cases = [
+        {
+          name: 'line',
+          target:
+            'line(start = [var -13.64mm, var 7.86mm], end = [var 0mm, var 18.94mm])',
+          expected: 'line1',
+        },
+        {
+          name: 'line',
+          target:
+            'line(start = [var -12.18mm, var -3.65mm], end = [var -13.64mm, var 7.86mm])',
+          expected: 'line2',
+        },
+        {
+          name: 'point',
+          target: 'point(at = [var 7.65mm, var 18.08mm])',
+          expected: 'point2',
+        },
+        {
+          name: 'point',
+          target: 'point(at = [var 9.37mm, var 7.94mm])',
+          expected: 'point1',
+        },
+        {
+          name: 'arc',
+          target:
+            'arc(start = [var 1.04mm, var -8.29mm], end = [var -3.62mm, var -5.28mm], center = [var -3.42mm, var -10.09mm])',
+          expected: 'arc1',
+        },
+        {
+          name: 'circle',
+          target:
+            'circle(start = [var 10.57mm, var 2.96mm], center = [var 10.49mm, var 0mm])',
+          expected: 'circle1',
+        },
+      ] as const
+
+      for (const testCase of cases) {
+        const op = stdlib(testCase.name)
+        if (op.type !== 'StdLibCall') {
+          throw new Error('Expected operation to be a StdLibCall')
+        }
+        op.nodePath = await buildNodePath(code, testCase.target, instance)
+
+        const variableName = getOperationVariableName(op, program, instance)
+        expect(variableName).toBe(testCase.expected)
+      }
+    })
   })
 
   /**

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -2388,14 +2388,6 @@ export function getOperationVariableName(
     return undefined
   }
 
-  // Handle inner sketch block variables
-  if (
-    op.type === 'StdLibCall' &&
-    op.nodePath.steps.some((s) => s.type === 'SketchBlockBody')
-  ) {
-    return undefined
-  }
-
   if (
     op.type !== 'StdLibCall' &&
     op.type !== 'SketchSolve' &&


### PR DESCRIPTION
Reported by @adamchalmers

<img width="1281" height="1031" alt="image" src="https://github.com/user-attachments/assets/2a6bbc61-74fb-4989-bd9d-cb604dc69ff9" />
