### PR TITLE
Bugfix: don't re-encode files when adding them to project

### DIFF
--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -19,8 +19,9 @@ import { fsArchiveFile, fsMoveFile } from '@src/editor/plugins/fs'
 import { kclErrorsByFilename } from '@src/lang/errors'
 import { relevantFileExtensions } from '@src/lang/wasmUtils'
 import { FILE_EXT } from '@src/lib/constants'
-import { getNextFileName, sortFilesAndDirectories } from '@src/lib/desktopFS'
+import { sortFilesAndDirectories } from '@src/lib/desktopFS'
 import fsZds from '@src/lib/fs-zds'
+import { importLocalFilesToProject } from '@src/lib/importLocalFilesToProject'
 import {
   desktopSafePathJoin,
   desktopSafePathSplit,
@@ -325,7 +326,6 @@ export const ProjectExplorer = ({
   const handleExternalFileDrop = useCallback(
     async (dataTransfer: DataTransfer, target: FileExplorerEntry | null) => {
       if (readOnly || !window.electron) return
-      const electron = window.electron
 
       const supportedFiles: { file: File; relativePath: string }[] = []
       const unsupportedFiles: string[] = []
@@ -398,35 +398,21 @@ export const ProjectExplorer = ({
       // Copy supported files to the target directory
       if (supportedFiles.length > 0) {
         const targetPath = getDropTargetPath(target, project.path)
-        const createdDirs = new Set<string>()
 
-        for (const { file, relativePath } of supportedFiles) {
-          try {
-            const destinationDirPath = relativePath
-              ? joinOSPaths(targetPath, relativePath)
-              : targetPath
-
-            // Create parent directories if needed
-            if (relativePath && !createdDirs.has(destinationDirPath)) {
-              await electron.mkdir(destinationDirPath, { recursive: true })
-              createdDirs.add(destinationDirPath)
-            }
-
-            const { path: destinationPath } = await getNextFileName({
-              entryName: file.name,
-              baseDir: destinationDirPath,
-              wasmInstance,
-            })
-
-            const arrayBuffer = await file.arrayBuffer()
-            await electron.writeFile(
-              destinationPath,
-              new Uint8Array(arrayBuffer)
-            )
-          } catch (e) {
-            console.error('Failed to copy file:', file.name, e)
-            toast.error(`Failed to import ${file.name}.`)
-          }
+        try {
+          await importLocalFilesToProject({
+            files: supportedFiles.map(({ file, relativePath }) => ({
+              name: file.name,
+              relativePath,
+              readData: async () => new Uint8Array(await file.arrayBuffer()),
+            })),
+            projectPath: targetPath,
+            wasmInstance,
+          })
+        } catch (e) {
+          console.error('Failed to import dropped files:', e)
+          toast.error('Failed to import dropped files.')
+          return
         }
 
         // Open the target folder so the user can see the imported files

--- a/src/lib/commandBarConfigs/applicationCommandConfig.test.ts
+++ b/src/lib/commandBarConfigs/applicationCommandConfig.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createApplicationCommands } from '@src/lib/commandBarConfigs/applicationCommandConfig'
@@ -10,18 +11,13 @@ vi.mock('@src/lang/wasmUtils', () => ({
 }))
 
 vi.mock('@src/lib/fs-zds', () => {
-  const join = (...parts: string[]) => {
-    const joined = parts.filter(Boolean).join('/').replace(/\/+/g, '/')
-    return parts[0]?.startsWith('/') && !joined.startsWith('/')
-      ? `/${joined}`
-      : joined
-  }
+  const join = (...parts: string[]) => path.posix.join(...parts.filter(Boolean))
 
   return {
     default: {
       join,
       sep: '/',
-      basename: (targetPath: string) => targetPath.split('/').pop() || '',
+      basename: (targetPath: string) => path.posix.basename(targetPath),
       mkdir: vi.fn(() => Promise.resolve(undefined)),
       readFile: vi.fn(),
       writeFile: vi.fn(() => Promise.resolve(undefined)),

--- a/src/lib/commandBarConfigs/applicationCommandConfig.test.ts
+++ b/src/lib/commandBarConfigs/applicationCommandConfig.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createApplicationCommands } from '@src/lib/commandBarConfigs/applicationCommandConfig'
+import fsZds from '@src/lib/fs-zds'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
+
+vi.mock('@src/lang/wasmUtils', () => ({
+  relevantFileExtensions: vi.fn(() => ['glb', 'kcl']),
+}))
+
+vi.mock('@src/lib/fs-zds', () => {
+  const join = (...parts: string[]) => {
+    const joined = parts.filter(Boolean).join('/').replace(/\/+/g, '/')
+    return parts[0]?.startsWith('/') && !joined.startsWith('/')
+      ? `/${joined}`
+      : joined
+  }
+
+  return {
+    default: {
+      join,
+      sep: '/',
+      basename: (targetPath: string) => targetPath.split('/').pop() || '',
+      mkdir: vi.fn(() => Promise.resolve(undefined)),
+      readFile: vi.fn(),
+      writeFile: vi.fn(() => Promise.resolve(undefined)),
+    },
+  }
+})
+
+vi.mock('react-hot-toast', () => ({
+  default: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+vi.mock('@src/lib/desktopFS', async () => {
+  const actual = await vi.importActual<object>('@src/lib/desktopFS')
+  return {
+    ...actual,
+    getNextFileName: vi.fn(
+      async ({
+        entryName,
+        baseDir,
+      }: {
+        entryName: string
+        baseDir: string
+      }) => ({
+        name: entryName,
+        path: `${baseDir}/${entryName}`.replace(/\/+/g, '/'),
+      })
+    ),
+  }
+})
+
+describe('add-kcl-file-to-project', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('preserves raw bytes for local files imported into an existing project', async () => {
+    const sourceBytes = Uint8Array.from([0x00, 0x80, 0xff, 0xc3, 0x28])
+    vi.mocked(fsZds.readFile).mockResolvedValue(sourceBytes)
+
+    const send = vi.fn()
+    const app = {
+      project: { name: 'widget-project' },
+      layout: {
+        reset: vi.fn(),
+      },
+      systemIOActor: {
+        getSnapshot: () => ({
+          context: {
+            folders: [{ name: 'widget-project' }],
+            projectDirectoryPath: '/projects',
+          },
+        }),
+        send,
+      },
+    }
+
+    const command = createApplicationCommands({
+      app: app as unknown as Parameters<
+        typeof createApplicationCommands
+      >[0]['app'],
+      wasmInstance: {} as ModuleType,
+    }).find((candidate) => candidate.name === 'add-kcl-file-to-project')
+
+    expect(command).toBeDefined()
+
+    command?.onSubmit({
+      source: 'local',
+      method: 'existingProject',
+      projectName: 'widget-project',
+      files: '/tmp/input.glb',
+    })
+
+    await vi.waitFor(() => {
+      expect(fsZds.writeFile).toHaveBeenCalledWith(
+        '/projects/widget-project/input.glb',
+        sourceBytes
+      )
+    })
+
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(send).toHaveBeenCalledWith({
+      type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+    })
+    expect(send).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: SystemIOMachineEvents.importFileFromURL,
+      })
+    )
+  })
+})

--- a/src/lib/commandBarConfigs/applicationCommandConfig.ts
+++ b/src/lib/commandBarConfigs/applicationCommandConfig.ts
@@ -15,6 +15,7 @@ import {
   joinOSPaths,
   webSafePathSplit,
 } from '@src/lib/paths'
+import { importLocalFilesToProject } from '@src/lib/importLocalFilesToProject'
 import { reportRejection } from '@src/lib/trap'
 import { isArray, returnSelfOrGetHostNameFromURL } from '@src/lib/utils'
 import { getAllSubDirectoriesAtProjectRoot } from '@src/machines/systemIO/snapshotContext'
@@ -185,25 +186,31 @@ export function createApplicationCommands({
 
           const fileNameWithExtension =
             getStringAfterLastSeparator(selectedFilePath)
-          const fr = new FileReader()
-          fr.addEventListener('load', () => {
-            app.systemIOActor.send({
-              type: SystemIOMachineEvents.importFileFromURL,
-              data: {
-                requestedProjectName: uniqueNameIfNeeded,
-                requestedFileNameWithExtension: fileNameWithExtension,
-                requestedCode:
-                  typeof fr.result === 'string'
-                    ? fr.result
-                    : '// Tried importing a binary',
+          const projectDirectoryPath =
+            app.systemIOActor.getSnapshot().context.projectDirectoryPath
+
+          void importLocalFilesToProject({
+            files: [
+              {
+                name: fileNameWithExtension,
+                readData: () => fsZds.readFile(selectedFilePath),
               },
-            })
+            ],
+            projectPath: fsZds.join(projectDirectoryPath, uniqueNameIfNeeded),
+            wasmInstance,
           })
-          fsZds
-            .readFile(selectedFilePath)
-            .then((content) => {
-              const blob = new Blob([new Uint8Array(content)])
-              fr.readAsText(blob)
+            .then(() => {
+              if (isProjectNew || app.project?.name !== uniqueNameIfNeeded) {
+                app.systemIOActor.send({
+                  type: SystemIOMachineEvents.navigateToProject,
+                  data: {
+                    requestedProjectName: uniqueNameIfNeeded,
+                  },
+                })
+              }
+              app.systemIOActor.send({
+                type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
+              })
             })
             .catch(() => toast.error(error))
         } else {

--- a/src/lib/importLocalFilesToProject.ts
+++ b/src/lib/importLocalFilesToProject.ts
@@ -1,0 +1,48 @@
+import { getNextFileName } from '@src/lib/desktopFS'
+import fsZds from '@src/lib/fs-zds'
+import { joinOSPaths } from '@src/lib/paths'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+
+export type LocalProjectImportSource = {
+  name: string
+  relativePath?: string
+  readData: () => Promise<Uint8Array>
+}
+
+export async function importLocalFilesToProject({
+  files,
+  projectPath,
+  wasmInstance,
+}: {
+  files: LocalProjectImportSource[]
+  projectPath: string
+  wasmInstance: ModuleType
+}) {
+  await fsZds.mkdir(projectPath, { recursive: true })
+
+  const createdDirs = new Set<string>()
+  const importedPaths: string[] = []
+
+  for (const file of files) {
+    const relativePath = file.relativePath || ''
+    const destinationDirPath = relativePath
+      ? joinOSPaths(projectPath, relativePath)
+      : projectPath
+
+    if (relativePath && !createdDirs.has(destinationDirPath)) {
+      await fsZds.mkdir(destinationDirPath, { recursive: true })
+      createdDirs.add(destinationDirPath)
+    }
+
+    const { path: destinationPath } = await getNextFileName({
+      entryName: file.name,
+      baseDir: destinationDirPath,
+      wasmInstance,
+    })
+
+    await fsZds.writeFile(destinationPath, await file.readData())
+    importedPaths.push(destinationPath)
+  }
+
+  return importedPaths
+}

--- a/src/lib/share.test.ts
+++ b/src/lib/share.test.ts
@@ -202,7 +202,8 @@ describe('copyCurrentFileShareLink', () => {
       body: { access_mode: 'anyone_with_link' },
     })
 
-    const createProjectCalls = mockState.createProject.mock.calls as unknown as Array<
+    const createProjectCalls = mockState.createProject.mock
+      .calls as unknown as Array<
       [
         {
           client: unknown
@@ -221,11 +222,9 @@ describe('copyCurrentFileShareLink', () => {
       baseUrl: 'https://api.dev.zoo.dev',
     })
 
-    expect(createArgs.files.map((file: { name: string }) => file.name)).toEqual([
-      'body',
-      'project.toml',
-      'main.kcl',
-    ])
+    expect(createArgs.files.map((file: { name: string }) => file.name)).toEqual(
+      ['body', 'project.toml', 'main.kcl']
+    )
 
     const bodyFile = createArgs.files.find(
       (file: { name: string }) => file.name === 'body'
@@ -256,7 +255,9 @@ describe('copyCurrentFileShareLink', () => {
     if (!mainFile) {
       throw new Error('Expected main.kcl file to be uploaded')
     }
-    await expect(mainFile.data.text()).resolves.toBe('part001 = startSketchOn(XY)')
+    await expect(mainFile.data.text()).resolves.toBe(
+      'part001 = startSketchOn(XY)'
+    )
     expect(mockState.writeText).toHaveBeenCalledWith(
       'https://zoo.dev/project/share-key'
     )
@@ -315,7 +316,8 @@ describe('copyCurrentFileShareLink', () => {
       'https://zoo.dev/project/existing-share-key'
     )
 
-    const updateProjectCalls = mockState.updateProject.mock.calls as unknown as Array<
+    const updateProjectCalls = mockState.updateProject.mock
+      .calls as unknown as Array<
       [
         {
           files: Array<{ name: string; data: Blob }>


### PR DESCRIPTION
Fixes https://github.com/KittyCAD/modeling-app/issues/11107

3 commits, I suggest you review each separately for readability:

1. Adds a failing test for "Add file"
2. Refactors the drag-and-drop file-copying code into a shared helper
3. Changes the "add file" path to use that helper, making the test pass