### PR TITLE
Prefill the demo project name on web when opening share links

### DIFF
--- a/e2e/playwright/share-link.spec.ts
+++ b/e2e/playwright/share-link.spec.ts
@@ -51,4 +51,24 @@ test.describe('Share link tests', () => {
       await expect(getToastError(page)).toBeVisible()
     }
   )
+
+  test(
+    'should prefill demo project name on web',
+    { tag: ['@web'] },
+    async ({ page }) => {
+      const code = 'Zm9vYmFyID0gMQ==' // KCL: foobar = 1
+      const next = new URL(page.url())
+      next.searchParams.set('create-file', 'true')
+      next.searchParams.set('name', 'test')
+      next.searchParams.set('code', code)
+      await page.goto(next.toString())
+
+      const projectTab = page
+        .getByTestId('cmd-bar-input-tab')
+        .filter({ has: page.getByTestId('arg-name-projectname') })
+      await expect(projectTab.getByTestId('header-arg-value')).toHaveText(
+        'demo-project'
+      )
+    }
+  )
 })

--- a/src/hooks/useQueryParamEffects.ts
+++ b/src/hooks/useQueryParamEffects.ts
@@ -58,7 +58,14 @@ export function useQueryParamEffects(kclManager: KclManager) {
    */
   useEffect(() => {
     if (shouldInvokeCreateFile && authState.matches('loggedIn')) {
-      const argDefaultValues = buildCreateFileCommandArgs(searchParams)
+      const webProjectName = !isDesktop()
+        ? (app.settings.actor.getSnapshot().context.currentProject?.name ??
+          DEFAULT_WEB_PROJECT_NAME)
+        : undefined
+      const argDefaultValues = buildCreateFileCommandArgs(
+        searchParams,
+        webProjectName
+      )
       commands.send({
         type: 'Find and select command',
         data: {
@@ -169,7 +176,10 @@ export function useQueryParamEffects(kclManager: KclManager) {
   }, [shouldInvokeGenericCmd, setSearchParams, authState])
 }
 
-function buildCreateFileCommandArgs(searchParams: URLSearchParams) {
+function buildCreateFileCommandArgs(
+  searchParams: URLSearchParams,
+  webProjectName?: string
+) {
   const params: Omit<FileLinkParams, 'isRestrictedToOrg'> = {
     code: base64ToString(decodeURIComponent(searchParams.get('code') ?? '')),
     name: searchParams.get('name') ?? DEFAULT_FILE_NAME,
@@ -179,6 +189,9 @@ function buildCreateFileCommandArgs(searchParams: URLSearchParams) {
     name: PROJECT_ENTRYPOINT,
     code: params.code || '',
     method: isDesktop() ? undefined : 'existingProject',
+  }
+  if (!isDesktop()) {
+    argDefaultValues.projectName = webProjectName ?? DEFAULT_WEB_PROJECT_NAME
   }
 
   return argDefaultValues


### PR DESCRIPTION
To test this, visit `/?create-file=true&code=Zm9vYmFyID0gMQ==` on the Vercel preview, which I believe emulates clicking on a share link. I will test again once this is live on staging.

---

Closes https://github.com/KittyCAD/modeling-app/issues/10302