### PR TITLE
Increase write to disk timeout to 10s

### DIFF
--- a/src/lang/KclManager.spec.ts
+++ b/src/lang/KclManager.spec.ts
@@ -302,7 +302,8 @@ describe('KclManager diagnostics', () => {
       shouldResetCamera: false,
     })
 
-    await vi.advanceTimersByTimeAsync(999)
+    // Write debounce timer is currently 10s
+    await vi.advanceTimersByTimeAsync(9_999)
     expect(writeSpy).not.toHaveBeenCalled()
 
     await vi.advanceTimersByTimeAsync(1)

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -33,6 +33,7 @@ import {
 import type { ArtifactIndex } from '@src/lib/artifactIndex'
 import { buildArtifactIndex } from '@src/lib/artifactIndex'
 import {
+  AUTOSAVE_TIMEOUT,
   DEFAULT_DEFAULT_LENGTH_UNIT,
   EXECUTE_AST_INTERRUPT_ERROR_MESSAGE,
 } from '@src/lib/constants'
@@ -3007,7 +3008,7 @@ export class KclManager extends File {
             requestedDocumentVersion,
             options,
           }).then(resolve, reject)
-        }, 1000)
+        }, AUTOSAVE_TIMEOUT)
       }).catch((err: unknown) => {
         if (
           typeof err === 'object' &&

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -358,6 +358,9 @@ export const PENDING_COMMAND_TIMEOUT = 60_000
 /** Timeout in MS to save layout */
 export const LAYOUT_SAVE_THROTTLE = 500
 
+/** How often we write to disk when autosave is on (it's always on right now, TODO: add a ZDS-only setting) */
+export const AUTOSAVE_TIMEOUT = 10_000
+
 // Zookeeper input
 export const DEFAULT_ML_COPILOT_MODE: MlCopilotMode = 'fast'
 


### PR DESCRIPTION
iCloud storage systems ping back pretty frequently, even after fixes within #10918 to ignore "late hit" edits. We have a hypothesis that increasing this timeout loop will also help, but as @maxmgrsk and I discussed, the better fix is to let users set their file system strategy, and default to not hot-reloading from disk, as that is truly the source of our troubles.