### PR TITLE
Allow md files

### DIFF
--- a/rust/kcl-lib/src/lib.rs
+++ b/rust/kcl-lib/src/lib.rs
@@ -251,6 +251,7 @@ lazy_static::lazy_static! {
     pub static ref RELEVANT_FILE_EXTENSIONS: Vec<String> = {
         let mut relevant_extensions = IMPORT_FILE_EXTENSIONS.clone();
         relevant_extensions.push("kcl".to_string());
+        relevant_extensions.push("md".to_string());
         relevant_extensions
     };
 }

--- a/src/lang/wasm.spec.ts
+++ b/src/lang/wasm.spec.ts
@@ -250,6 +250,16 @@ describe('relevantFileExtensions', () => {
       )
       expect(actual).toBe(expected)
     })
+
+    it('contains md', () => {
+      const expected = true
+      const actual = relevantFileExtensions(instanceInThisFile).some(
+        (extension) => {
+          return extension === 'md'
+        }
+      )
+      expect(actual).toBe(expected)
+    })
   })
 })
 


### PR DESCRIPTION
This allows markdown (`.md`) files to appear in the project pane. This allows a user to potentially include an AGENTS.md which Zookeeper can load for additional user specific instructions