### PR TITLE
Support DNS-based API preview envs

### DIFF
--- a/src/components/environment/Environment.tsx
+++ b/src/components/environment/Environment.tsx
@@ -63,9 +63,25 @@ export function EnvironmentDescription() {
       </div>
       <ul>
         <li className="flex flex-col px-2 py-2 gap-1 last:mb-0 ">
-          <p className="text-chalkboard-100 dark:text-chalkboard-10">Account</p>{' '}
-          <p className="text-chalkboard-60 dark:text-chalkboard-40">
-            {env().VITE_ZOO_API_BASE_URL}
+          <p className="text-chalkboard-100 dark:text-chalkboard-10">API</p>{' '}
+          <p className="text-chalkboard-60 dark:text-chalkboard-40 flex flex-row justify-between items-center">
+            <span className="flex-1 min-w-0 truncate">
+              {env().VITE_ZOO_API_BASE_URL}
+            </span>
+            <ActionButton
+              Element="button"
+              onClick={() => {
+                commands.send({
+                  type: 'Find and select command',
+                  data: {
+                    groupId: 'application',
+                    name: 'override-api',
+                  },
+                })
+              }}
+              iconEnd={{ icon: 'sketch', bgClassName: '!bg-transparent' }}
+              className="ml-3 p-0.5 pr-2 flex-shrink-0"
+            />
           </p>
         </li>
         <li className="flex flex-col px-2 py-2 gap-1 last:mb-0 ">

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -2,6 +2,8 @@ import env from '@src/env'
 import {
   generateDomainsFromBaseDomain,
   processEnv,
+  updateEnvironment,
+  updateEnvironmentApiSubdomain,
   viteEnv,
   windowElectronProcessEnv,
 } from '@src/env'
@@ -130,6 +132,31 @@ describe('@src/env', () => {
       }
       const actual = generateDomainsFromBaseDomain('dev.zoo.dev')
       expect(actual).toStrictEqual(expected)
+    })
+  })
+
+  describe('runtime API overrides', () => {
+    it('should override the API URL while keeping the selected base domain', () => {
+      const windowWithElectron = window as typeof window & {
+        electron?: unknown
+      }
+      const originalElectron = windowWithElectron.electron
+      windowWithElectron.electron = {} as typeof window.electron
+
+      updateEnvironment('dev.zoo.dev')
+      updateEnvironmentApiSubdomain('dev.zoo.dev', 'api-pr-3072')
+
+      const actual = env()
+
+      expect(actual.VITE_ZOO_BASE_DOMAIN).toBe('dev.zoo.dev')
+      expect(actual.VITE_ZOO_API_BASE_URL).toBe(
+        'https://api-pr-3072.dev.zoo.dev'
+      )
+      expect(actual.VITE_ZOO_SITE_BASE_URL).toBe('https://dev.zoo.dev')
+      expect(actual.VITE_ZOO_SITE_APP_URL).toBe('https://app.dev.zoo.dev')
+
+      updateEnvironment(null)
+      windowWithElectron.electron = originalElectron
     })
   })
 })

--- a/src/env.ts
+++ b/src/env.ts
@@ -26,6 +26,13 @@ export type EnvironmentVariables = {
 /** Store the environment in memory to be accessed during runtime */
 let ENVIRONMENT: EnvironmentConfigurationRuntime | null = null
 
+function generateApiUrlFromSubdomain(
+  apiSubdomain: string,
+  baseDomain: string | undefined
+) {
+  return `https://${apiSubdomain}.${baseDomain ?? ''}`
+}
+
 /** Update the runtime environment */
 export const updateEnvironment = (environment: string | null) => {
   if (environment === '') {
@@ -57,6 +64,16 @@ export const updateEnvironmentKittycadWebSocketUrl = (
   }
 }
 
+export const updateEnvironmentApiSubdomain = (
+  environmentName: string,
+  apiSubdomain: string
+) => {
+  if (!ENVIRONMENT) return
+  if (ENVIRONMENT.domain === environmentName) {
+    ENVIRONMENT.apiSubdomain = apiSubdomain
+  }
+}
+
 export const updateEnvironmentMlephantWebSocketUrl = (
   environmentName: string,
   mlephantWebSocketUrl: string
@@ -72,6 +89,7 @@ const getEnvironmentFromThisFile = (baseDomain: string | undefined) => {
   return (
     ENVIRONMENT || {
       domain: baseDomain ?? '',
+      apiSubdomain: undefined,
       kittycadWebSocketUrl: undefined,
       mlephantWebSocketUrl: undefined,
     }
@@ -170,6 +188,13 @@ export default (): EnvironmentVariables => {
     env.VITE_MLEPHANT_WEBSOCKET_URL !== 'undefined'
   ) {
     MLEPHANT_WEBSOCKET_URL = env.VITE_MLEPHANT_WEBSOCKET_URL
+  }
+
+  if (environment.apiSubdomain) {
+    API_URL = generateApiUrlFromSubdomain(
+      environment.apiSubdomain,
+      environment.domain || BASE_DOMAIN
+    )
   }
 
   // Allow the in-app settings to override local WebSocket URLs

--- a/src/lib/commandBarConfigs/applicationCommandConfig.ts
+++ b/src/lib/commandBarConfigs/applicationCommandConfig.ts
@@ -3,6 +3,7 @@ import fsZds from '@src/lib/fs-zds'
 import { relevantFileExtensions } from '@src/lang/wasmUtils'
 import type { Command, CommandArgumentOption } from '@src/lib/commandTypes'
 import {
+  writeEnvironmentConfigurationApiSubdomain,
   writeEnvironmentConfigurationKittycadWebSocketUrl,
   writeEnvironmentConfigurationMlephantWebSocketUrl,
   writeEnvironmentFile,
@@ -29,6 +30,38 @@ import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { SettingsActorType } from '@src/machines/settingsMachine'
 import type { CommandBarActorType } from '@src/machines/commandBarMachine'
 import type { App } from '@src/lib/app'
+
+function getApiSubdomainOverrideFromCurrentEnvironment() {
+  const apiBaseUrl = env().VITE_ZOO_API_BASE_URL
+  const baseDomain = env().VITE_ZOO_BASE_DOMAIN
+  if (!apiBaseUrl || !baseDomain) return ''
+
+  try {
+    const hostname = new URL(apiBaseUrl).hostname
+    const suffix = `.${baseDomain}`
+    if (!hostname.endsWith(suffix)) {
+      return ''
+    }
+    return hostname.slice(0, -suffix.length)
+  } catch {
+    return ''
+  }
+}
+
+function normalizeApiSubdomainOverride(
+  requestedValue: string,
+  baseDomain: string | undefined
+) {
+  const trimmedValue = requestedValue.trim()
+  if (!trimmedValue || !baseDomain) return trimmedValue
+
+  const hostname = returnSelfOrGetHostNameFromURL(trimmedValue)
+  const suffix = `.${baseDomain}`
+  if (hostname.endsWith(suffix)) {
+    return hostname.slice(0, -suffix.length)
+  }
+  return hostname
+}
 
 function onSubmitKCLSampleCreation({
   sample,
@@ -511,6 +544,59 @@ export function createApplicationCommands({
     },
   }
 
+  const overrideApiCommand: Command = {
+    name: 'override-api',
+    displayName: 'Override API',
+    description: 'Route API requests to a custom API subdomain',
+    icon: 'gear',
+    groupId: 'application',
+    needsReview: true,
+    reviewValidation: async (context) => {
+      const requestedSubdomain = context.argumentsToSubmit.subdomain as
+        | string
+        | undefined
+      const baseDomain = env().VITE_ZOO_BASE_DOMAIN
+      if (!requestedSubdomain || !baseDomain) {
+        return
+      }
+
+      const normalizedSubdomain = normalizeApiSubdomainOverride(
+        requestedSubdomain,
+        baseDomain
+      )
+
+      try {
+        new URL(`https://${normalizedSubdomain}.${baseDomain}`)
+      } catch {
+        return new Error('Invalid API subdomain override')
+      }
+    },
+    onSubmit: (data) => {
+      const environmentName = env().VITE_ZOO_BASE_DOMAIN
+      if (environmentName)
+        writeEnvironmentConfigurationApiSubdomain(
+          environmentName,
+          normalizeApiSubdomainOverride(data?.subdomain ?? '', environmentName)
+        )
+          .then(() => {
+            window.location.reload()
+          })
+          .catch(reportRejection)
+    },
+    args: {
+      subdomain: {
+        inputType: 'string',
+        required: false,
+        displayName: 'Subdomain',
+        description: `
+          Default cluster: **api**
+          Pull Requests: **api-pr-NUMBER**
+        `.trim(),
+        defaultValue: () => getApiSubdomainOverrideFromCurrentEnvironment(),
+      },
+    },
+  }
+
   const overrideZookeeperCommand: Command = {
     name: 'override-zookeeper',
     displayName: 'Override Zookeeper',
@@ -609,6 +695,7 @@ export function createApplicationCommands({
     setLayoutCommand,
     createASampleDesktopOnly,
     switchEnvironmentsCommand,
+    overrideApiCommand,
     overrideEngineCommand,
     overrideZookeeperCommand,
   ]

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -317,6 +317,7 @@ export const OAUTH2_DEVICE_CLIENT_ID = '2af127fb-e14e-400a-9c57-a9ed08d1a5b7'
 export type EnvironmentConfiguration = {
   domain: string // same name as the file development for development.json
   token: string // authentication token from signing in. Can be empty string
+  apiSubdomain?: string // optional override for API subdomain
   kittycadWebSocketUrl?: string // optional override for Engine WebSocket URL
   mlephantWebSocketUrl?: string // optional override for Zookeeper WebSocket URL
 }
@@ -327,6 +328,7 @@ export type EnvironmentConfiguration = {
  */
 export type EnvironmentConfigurationRuntime = {
   domain: string // same name as the file development for development.json
+  apiSubdomain?: string // optional override for API subdomain
   kittycadWebSocketUrl?: string // optional override for Engine WebSocket URL
   mlephantWebSocketUrl?: string // optional override for Zookeeper WebSocket URL
 }

--- a/src/lib/desktop.spec.ts
+++ b/src/lib/desktop.spec.ts
@@ -8,6 +8,7 @@ import {
   getEnvironmentConfigurationPath,
   getEnvironmentFilePath,
   listProjects,
+  readEnvironmentConfigurationApiSubdomain,
   readEnvironmentConfigurationFile,
   readEnvironmentConfigurationToken,
   readEnvironmentFile,
@@ -356,6 +357,31 @@ describe('desktop utilities', () => {
       // mock clean up
       mockElectron.packageJson.name = ''
       expect(actual).toBe(expected)
+    })
+  })
+
+  describe('readEnvironmentConfigurationApiSubdomain', () => {
+    it('should return the empty string when no API override is set', async () => {
+      const expected = ''
+      const actual =
+        await readEnvironmentConfigurationApiSubdomain('dev.zoo.dev')
+      expect(actual).toBe(expected)
+    })
+
+    it('should return the stored API subdomain override', async () => {
+      mockElectron.exists.mockImplementation(() => true)
+      mockElectron.readFile.mockImplementation(() => {
+        return JSON.stringify({
+          token: '',
+          domain: 'dev.zoo.dev',
+          apiSubdomain: 'api-pr-3072',
+        })
+      })
+      mockElectron.packageJson.name = 'zoo-modeling-app'
+      const actual =
+        await readEnvironmentConfigurationApiSubdomain('dev.zoo.dev')
+      mockElectron.packageJson.name = ''
+      expect(actual).toBe('api-pr-3072')
     })
   })
 })

--- a/src/lib/desktop.ts
+++ b/src/lib/desktop.ts
@@ -844,6 +844,24 @@ export const writeEnvironmentConfigurationKittycadWebSocketUrl = async (
   return result
 }
 
+export const writeEnvironmentConfigurationApiSubdomain = async (
+  environmentName: string,
+  apiSubdomain: string
+) => {
+  apiSubdomain = apiSubdomain.trim()
+  const path = await getEnvironmentConfigurationPath(environmentName)
+  const environmentConfiguration =
+    await getEnvironmentConfigurationObject(environmentName)
+  environmentConfiguration.apiSubdomain = apiSubdomain
+  const requestedConfiguration = JSON.stringify(environmentConfiguration)
+  const result = await fsZds.writeFile(
+    path,
+    new TextEncoder().encode(requestedConfiguration)
+  )
+  console.log(`wrote ${environmentName}.json to disk`)
+  return result
+}
+
 export const getEnvironmentConfigurationObject = async (
   environmentName: string
 ) => {
@@ -875,6 +893,15 @@ export const readEnvironmentConfigurationKittycadWebSocketUrl = async (
     await readEnvironmentConfigurationFile(environmentName)
   if (!environmentConfiguration?.kittycadWebSocketUrl) return ''
   return environmentConfiguration.kittycadWebSocketUrl.trim()
+}
+
+export const readEnvironmentConfigurationApiSubdomain = async (
+  environmentName: string
+) => {
+  const environmentConfiguration =
+    await readEnvironmentConfigurationFile(environmentName)
+  if (!environmentConfiguration?.apiSubdomain) return ''
+  return environmentConfiguration.apiSubdomain.trim()
 }
 
 export const writeEnvironmentConfigurationMlephantWebSocketUrl = async (

--- a/src/machines/authMachine.ts
+++ b/src/machines/authMachine.ts
@@ -2,6 +2,7 @@ import type { UserResponse } from '@kittycad/lib'
 import { users, oauth2 } from '@kittycad/lib'
 import env, {
   updateEnvironment,
+  updateEnvironmentApiSubdomain,
   updateEnvironmentKittycadWebSocketUrl,
   updateEnvironmentMlephantWebSocketUrl,
   generateDomainsFromBaseDomain,
@@ -16,6 +17,7 @@ import {
   VERCEL_PLAYWRIGHT_TOKEN_QUERY_PARAM,
 } from '@src/lib/constants'
 import {
+  readEnvironmentConfigurationApiSubdomain,
   readEnvironmentConfigurationKittycadWebSocketUrl,
   readEnvironmentConfigurationMlephantWebSocketUrl,
 } from '@src/lib/desktop'
@@ -34,6 +36,7 @@ import { withAPIBaseURL } from '@src/lib/withBaseURL'
 export interface UserContext {
   user?: UserResponse
   token: string
+  error?: string
 }
 
 export type Events =
@@ -96,6 +99,7 @@ export const authMachine = setup({
           {
             target: 'loggedIn',
             actions: assign(({ context, event }) => ({
+              error: undefined,
               user: event.output.user,
               token: event.output.token || context.token,
             })),
@@ -104,9 +108,14 @@ export const authMachine = setup({
         onError: [
           {
             target: 'loggedOut',
-            actions: assign({
-              user: () => undefined,
-            }),
+            actions: assign(({ event }) => ({
+              error:
+                event.error instanceof Error &&
+                event.error.message !== 'No token found'
+                  ? event.error.message
+                  : undefined,
+              user: undefined,
+            })),
           },
         ],
       },
@@ -177,6 +186,13 @@ async function getUser(input: { token?: string }) {
     (await readEnvironmentFile()) || env().VITE_ZOO_BASE_DOMAIN || ''
   updateEnvironment(environment)
 
+  // Update the API subdomain override
+  const cachedApiSubdomain =
+    await readEnvironmentConfigurationApiSubdomain(environment)
+  if (cachedApiSubdomain) {
+    updateEnvironmentApiSubdomain(environment, cachedApiSubdomain)
+  }
+
   // Update the Engine WebSocket URL override
   const cachedKittycadWebSocketUrl =
     await readEnvironmentConfigurationKittycadWebSocketUrl(environment)
@@ -219,7 +235,16 @@ async function getUser(input: { token?: string }) {
   if (!token) return Promise.reject(new Error('No token found'))
 
   const me = await kcCall(() => users.get_user_self({ client }))
-  if (me instanceof Error) return Promise.reject(me)
+  if (me instanceof Error) {
+    if (cachedApiSubdomain) {
+      return Promise.reject(
+        new Error(
+          `Failed to use API override https://${cachedApiSubdomain}.${environment}: ${me.message}`
+        )
+      )
+    }
+    return Promise.reject(me)
+  }
 
   // Necessary here because we use Kurt's API key in CI
   if (localStorage.getItem('FORCE_NO_IMAGE')) {

--- a/src/routes/SignIn.tsx
+++ b/src/routes/SignIn.tsx
@@ -7,10 +7,19 @@ import type { IElectronAPI } from '@root/interface'
 import { ActionButton } from '@src/components/ActionButton'
 import { CustomIcon } from '@src/components/CustomIcon'
 import { Logo } from '@src/components/Logo'
-import { updateEnvironment } from '@src/env'
+import {
+  generateDomainsFromBaseDomain,
+  updateEnvironment,
+  updateEnvironmentApiSubdomain,
+} from '@src/env'
 import env from '@src/env'
 import { APP_NAME } from '@src/lib/constants'
-import { readEnvironmentFile, writeEnvironmentFile } from '@src/lib/desktop'
+import {
+  readEnvironmentConfigurationApiSubdomain,
+  readEnvironmentFile,
+  writeEnvironmentConfigurationApiSubdomain,
+  writeEnvironmentFile,
+} from '@src/lib/desktop'
 import { isDesktop } from '@src/lib/isDesktop'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
 import { Themes, getSystemTheme } from '@src/lib/theme'
@@ -29,6 +38,7 @@ let didReadFromDiskCacheForEnvironment = false
 
 const SignIn = () => {
   const { auth, settings } = useApp()
+  const authState = auth.useAuthState()
   // Only create the native file menus on desktop
   if (window.electron) {
     window.electron.createFallbackMenu().catch(reportRejection)
@@ -46,6 +56,7 @@ const SignIn = () => {
   const [selectedEnvironment, setSelectedEnvironment] = useState(
     lastSelectedEnvironmentName
   )
+  const [apiSubdomainOverride, setApiSubdomainOverride] = useState('')
 
   // See if the user added a real URL if they did, auto take the hostname!
   const setSelectedEnvironmentFormatter = (requestedEnvironment: string) => {
@@ -88,11 +99,40 @@ const SignIn = () => {
     }
   }, [])
 
+  useEffect(() => {
+    if (!window.electron || !selectedEnvironment) {
+      setApiSubdomainOverride('')
+      return
+    }
+
+    readEnvironmentConfigurationApiSubdomain(selectedEnvironment)
+      .then(setApiSubdomainOverride)
+      .catch(reportRejection)
+  }, [selectedEnvironment])
+
   const {
     app: { theme },
   } = settings.useSettings()
   const signInUrl = generateSignInUrl()
   const kclSampleUrl = withSiteBaseURL('/docs/kcl-samples/car-wheel-assembly')
+  const defaultApiUrl =
+    generateDomainsFromBaseDomain(selectedEnvironment).API_URL
+  const activeApiUrl =
+    apiSubdomainOverride && selectedEnvironment
+      ? `https://${apiSubdomainOverride}.${selectedEnvironment}`
+      : defaultApiUrl
+
+  const clearApiOverride = useCallback(() => {
+    const environmentName = selectedEnvironment.trim()
+    if (!window.electron || !environmentName) return
+
+    writeEnvironmentConfigurationApiSubdomain(environmentName, '')
+      .then(() => {
+        updateEnvironmentApiSubdomain(environmentName, '')
+        window.location.reload()
+      })
+      .catch(reportRejection)
+  }, [selectedEnvironment])
 
   const getThemeText = useCallback(
     (shouldContrast = true) =>
@@ -178,6 +218,35 @@ const SignIn = () => {
             </p>
             {window.electron ? (
               <div className="flex flex-col gap-2">
+                {apiSubdomainOverride && (
+                  <div className="mt-4 max-w-xl rounded-lg border border-solid border-destroy-60/40 bg-destroy-10/70 px-4 py-3 text-sm text-chalkboard-90 dark:bg-destroy-90/20 dark:text-chalkboard-10">
+                    <p className="font-medium text-destroy-80 dark:text-destroy-20">
+                      API override active
+                    </p>
+                    <p className="mt-1 break-all">
+                      Using <code>{activeApiUrl}</code> instead of{' '}
+                      <code>{defaultApiUrl}</code>.
+                    </p>
+                    {authState.context.error && (
+                      <p className="mt-2 text-destroy-80 dark:text-destroy-20">
+                        {authState.context.error}
+                      </p>
+                    )}
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <ActionButton
+                        Element="button"
+                        onClick={clearApiOverride}
+                        iconStart={{
+                          icon: 'close',
+                          bgClassName: '!bg-transparent',
+                        }}
+                        className="!bg-destroy-70 !text-chalkboard-10 !border-transparent"
+                      >
+                        Clear API override
+                      </ActionButton>
+                    </div>
+                  </div>
+                )}
                 {!userCode ? (
                   <>
                     <button


### PR DESCRIPTION
The nginx header approach I tried first didn't work very reliably. DNS has its own quirks but is ultimately pretty stable and reliable.

Supersedes #7631 

## What does this change?

This adds a way to customize the `api` portion of our domains. So, instead of `api.dev.zoo.dev` you can set `api-pr-3742.dev.zoo.dev`. The interface currently restricts you to exactly that pattern, but I'm fine with whatever.

This worked in my basic testing and has made some query perf tweaks much faster to test in dev which helps better reproduce performance in prod, but there are still some things I want to improve before this is ready.