### PR TITLE
Apply hide on extrude/revolve/sweep/loft p&c

### DIFF
--- a/e2e/playwright/point-click.spec.ts
+++ b/e2e/playwright/point-click.spec.ts
@@ -877,6 +877,7 @@ plane001 = offsetPlane(XY, offset = 5)
 sketch002 = sketch(on = plane001) {
   circle1 = circle(start = [var 2mm, var 2mm], center = [var 0mm, var 0mm])
 }
+hidden001 = hide(sketch002)
 region002 = region(point = [0mm, 0mm], sketch = sketch002)`
     // TODO: replace point with segments = [sketch002.circle1] when the issue is fixed
     await context.addInitScript((initialCode) => {
@@ -2250,6 +2251,7 @@ face001 = faceOf(extrude001, face = region001.tags.line1)
 sketch002 = sketch(on = face001) {
   circle1 = circle(start = [var -2.65mm, var 10mm], center = [var -11.34mm, var 10mm])
 }
+hidden001 = hide(sketch002)
 region002 = region(point = [-20.0275mm, 10mm], sketch = sketch002)`
     // TODO: replace region line above with topological selection, see https://kittycadworkspace.slack.com/archives/C09CJ6XPY1Y/p1775311720628419?thread_ts=1775157918.840339&cid=C09CJ6XPY1Y
     const newCodeToFind = `revolve001 = revolve(region002, angle = 360deg, axis = getCommonEdge(faces = [region001.tags.line1, capEnd001]))`

--- a/e2e/playwright/sketch-solve-edit.spec.ts
+++ b/e2e/playwright/sketch-solve-edit.spec.ts
@@ -1795,6 +1795,7 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
 
     await test.step('Expect extrusion', async () => {
       await scene.settled(cmdBar)
+      await editor.expectEditor.toContain('hidden001 = hide(sketch001)')
       await editor.expectEditor.toContain(
         'region(point = [0.025mm, -1.9875mm], sketch = sketch001)'
       )
@@ -1896,6 +1897,7 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
 
     await test.step('Expect extrusion uses inches for region point', async () => {
       await scene.settled(cmdBar)
+      await editor.expectEditor.toContain('hidden001 = hide(sketch001)')
       await editor.expectEditor.toContain(
         'region(point = [0.0009843in, -0.078248in], sketch = sketch001)'
       )
@@ -1919,6 +1921,7 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
     tronApp,
   }) => {
     const code = `${square}
+hidden001 = hide(sketch001)
 region001 = region(point = [0.025mm, -1.9875mm], sketch = sketch001)
 extrude001 = extrude(region001, length = 5)`
     const [clickCenter] = scene.makeMouseHelpers(0.5, 0.5, {
@@ -1981,6 +1984,7 @@ extrude001 = extrude(region001, length = 5)`
     tronApp,
   }) => {
     const code = `${square}
+hidden001 = hide(sketch001)
 region001 = region(point = [0.025mm, -1.9875mm], sketch = sketch001)
 extrude001 = extrude(region001, length = 5)`
     const [clickAboveCenter] = scene.makeMouseHelpers(0.5, 0.35, {

--- a/src/lang/modifyAst.ts
+++ b/src/lang/modifyAst.ts
@@ -1084,9 +1084,10 @@ export function insertRegionVariablesAndOffsetPathToNode({
     settings.defaultLengthUnit
   )
 
+  const hiddenSketches = collectHiddenSketchNames(modifiedAst)
   let insertIndex = modifiedAst.body.length
   const regionExprs: Expr[] = []
-  for (const [index, regionSelection] of engineRegions.entries()) {
+  for (const regionSelection of engineRegions) {
     const sketchArtifact = artifactGraph.get(regionSelection.sketchId)
     if (!sketchArtifact || sketchArtifact.type !== 'sketchBlock') {
       return new Error("Couldn't retrieve sketch block artifact")
@@ -1098,6 +1099,35 @@ export function insertRegionVariablesAndOffsetPathToNode({
     )
     if (!sketchVarName) {
       return new Error("Couldn't retrieve sketch block variable")
+    }
+
+    if (!hiddenSketches.has(sketchVarName)) {
+      const hideExpr = createCallExpressionStdLibKw(
+        'hide',
+        createLocalName(sketchVarName),
+        []
+      )
+      const hideVariableName = findUniqueName(
+        modifiedAst,
+        KCL_DEFAULT_CONSTANT_PREFIXES.HIDDEN
+      )
+      insertVariableAndOffsetPathToNode(
+        {
+          valueAst: hideExpr,
+          valueText: '',
+          valueCalculated: '',
+          variableName: hideVariableName,
+          variableDeclarationAst: createVariableDeclaration(
+            hideVariableName,
+            hideExpr
+          ),
+          variableIdentifierAst: createLocalName(hideVariableName),
+          insertIndex,
+        },
+        modifiedAst
+      )
+      hiddenSketches.add(sketchVarName)
+      insertIndex++
     }
 
     const { x, y } = regionSelection.point
@@ -1130,15 +1160,61 @@ export function insertRegionVariablesAndOffsetPathToNode({
           regionExpr
         ),
         variableIdentifierAst,
-        insertIndex: insertIndex + index,
+        insertIndex,
       },
       modifiedAst
     )
+    insertIndex++
 
     regionExprs.push(variableIdentifierAst)
   }
 
   return regionExprs
+}
+
+function collectHiddenSketchNames(modifiedAst: Node<Program>): Set<string> {
+  const hiddenSketches = new Set<string>()
+
+  for (const bodyItem of modifiedAst.body) {
+    const maybeCall =
+      bodyItem.type === 'VariableDeclaration'
+        ? bodyItem.declaration.init
+        : bodyItem.type === 'ExpressionStatement'
+          ? bodyItem.expression
+          : undefined
+
+    if (
+      maybeCall?.type !== 'CallExpressionKw' ||
+      maybeCall.callee.name.name !== 'hide'
+    ) {
+      continue
+    }
+
+    const sketchNames = getSketchNamesFromHideArg(maybeCall.unlabeled)
+    sketchNames.forEach((name) => hiddenSketches.add(name))
+  }
+
+  return hiddenSketches
+}
+
+function getSketchNamesFromHideArg(
+  hideArg: CallExpressionKw['unlabeled']
+): string[] {
+  if (!hideArg) {
+    return []
+  }
+
+  if (hideArg.type === 'Name') {
+    return [hideArg.name.name]
+  }
+
+  if (hideArg.type === 'ArrayExpression') {
+    return hideArg.elements
+      .filter((element) => element.type === 'Name')
+      .map((element) => element.name.name)
+  }
+
+  return []
 }
 
 // Create an array expression for variables,

--- a/src/lang/modifyAst.ts
+++ b/src/lang/modifyAst.ts
@@ -1084,10 +1084,9 @@ export function insertRegionVariablesAndOffsetPathToNode({
     settings.defaultLengthUnit
   )
 
-  const hiddenSketches = collectHiddenSketchNames(modifiedAst)
   let insertIndex = modifiedAst.body.length
   const regionExprs: Expr[] = []
-  for (const regionSelection of engineRegions) {
+  for (const [index, regionSelection] of engineRegions.entries()) {
     const sketchArtifact = artifactGraph.get(regionSelection.sketchId)
     if (!sketchArtifact || sketchArtifact.type !== 'sketchBlock') {
       return new Error("Couldn't retrieve sketch block artifact")
@@ -1099,35 +1098,6 @@ export function insertRegionVariablesAndOffsetPathToNode({
     )
     if (!sketchVarName) {
       return new Error("Couldn't retrieve sketch block variable")
-    }
-
-    if (!hiddenSketches.has(sketchVarName)) {
-      const hideExpr = createCallExpressionStdLibKw(
-        'hide',
-        createLocalName(sketchVarName),
-        []
-      )
-      const hideVariableName = findUniqueName(
-        modifiedAst,
-        KCL_DEFAULT_CONSTANT_PREFIXES.HIDDEN
-      )
-      insertVariableAndOffsetPathToNode(
-        {
-          valueAst: hideExpr,
-          valueText: '',
-          valueCalculated: '',
-          variableName: hideVariableName,
-          variableDeclarationAst: createVariableDeclaration(
-            hideVariableName,
-            hideExpr
-          ),
-          variableIdentifierAst: createLocalName(hideVariableName),
-          insertIndex,
-        },
-        modifiedAst
-      )
-      hiddenSketches.add(sketchVarName)
-      insertIndex++
     }
 
     const { x, y } = regionSelection.point
@@ -1160,61 +1130,15 @@ export function insertRegionVariablesAndOffsetPathToNode({
           regionExpr
         ),
         variableIdentifierAst,
-        insertIndex,
+        insertIndex: insertIndex + index,
       },
       modifiedAst
     )
-    insertIndex++
 
     regionExprs.push(variableIdentifierAst)
   }
 
   return regionExprs
-}
-
-function collectHiddenSketchNames(modifiedAst: Node<Program>): Set<string> {
-  const hiddenSketches = new Set<string>()
-
-  for (const bodyItem of modifiedAst.body) {
-    const maybeCall =
-      bodyItem.type === 'VariableDeclaration'
-        ? bodyItem.declaration.init
-        : bodyItem.type === 'ExpressionStatement'
-          ? bodyItem.expression
-          : undefined
-
-    if (
-      maybeCall?.type !== 'CallExpressionKw' ||
-      maybeCall.callee.name.name !== 'hide'
-    ) {
-      continue
-    }
-
-    const sketchNames = getSketchNamesFromHideArg(maybeCall.unlabeled)
-    sketchNames.forEach((name) => hiddenSketches.add(name))
-  }
-
-  return hiddenSketches
-}
-
-function getSketchNamesFromHideArg(
-  hideArg: CallExpressionKw['unlabeled']
-): string[] {
-  if (!hideArg) {
-    return []
-  }
-
-  if (hideArg.type === 'Name') {
-    return [hideArg.name.name]
-  }
-
-  if (hideArg.type === 'ArrayExpression') {
-    return hideArg.elements
-      .filter((element) => element.type === 'Name')
-      .map((element) => element.name.name)
-  }
-
-  return []
 }
 
 // Create an array expression for variables,

--- a/src/lang/modifyAst/sweeps.spec.ts
+++ b/src/lang/modifyAst/sweeps.spec.ts
@@ -282,7 +282,8 @@ extrude002 = extrude(seg01, length = 3)`)
 
       const newCode = recast(result.modifiedAst, instanceInThisFile)
       expect(newCode).toContain(
-        `region001 = region(point = [1mm, 1mm], sketch = s)
+        `hidden001 = hide(s)
+region001 = region(point = [1mm, 1mm], sketch = s)
 extrude001 = extrude(region001, length = 1)`
       )
       await runNewAstAndCheckForSweep(result.modifiedAst, rustContextInThisFile)
@@ -959,7 +960,8 @@ profile001 = startProfile(sketch001, at = [0, 0])
 
       const newCode = recast(result.modifiedAst, instanceInThisFile)
       expect(newCode).toContain(
-        `region001 = region(point = [1mm, 1mm], sketch = s)
+        `hidden001 = hide(s)
+region001 = region(point = [1mm, 1mm], sketch = s)
 sweep001 = sweep(region001, path = profile001)`
       )
       await runNewAstAndCheckForSweep(result.modifiedAst, rustContextInThisFile)
@@ -1011,7 +1013,8 @@ sketch002 = sketch(on = XZ) {
 
       const newCode = recast(result.modifiedAst, instanceInThisFile)
       expect(newCode).toContain(
-        `region001 = region(point = [1mm, 1mm], sketch = s)
+        `hidden001 = hide(s)
+region001 = region(point = [1mm, 1mm], sketch = s)
 sweep001 = sweep(region001, path = sketch002.line1)`
       )
       await runNewAstAndCheckForSweep(result.modifiedAst, rustContextInThisFile)
@@ -1381,6 +1384,8 @@ t = sketch(on = plane001) {
 
       const newCode = recast(result.modifiedAst, instanceInThisFile)
       expect(newCode).toContain(`loft001 = loft([`)
+      expect(newCode).toContain(`hidden001 = hide(s)`)
+      expect(newCode).toContain(`hidden002 = hide(t)`)
       expect(newCode).toContain(`region(point = [1mm, 1mm], sketch = s)`)
       expect(newCode).toContain(`region(point = [1mm, 1mm], sketch = t)`)
       if (err(newCode)) throw newCode
@@ -1669,7 +1674,8 @@ profile001 = circle(sketch001, center = [3, 0], radius = 1)`
 
       const newCode = recast(result.modifiedAst, instanceInThisFile)
       expect(newCode).toContain(
-        `region001 = region(point = [1mm, 1mm], sketch = s)
+        `hidden001 = hide(s)
+region001 = region(point = [1mm, 1mm], sketch = s)
 revolve001 = revolve(region001, angle = 10, axis = X)`
       )
       await runNewAstAndCheckForSweep(result.modifiedAst, rustContextInThisFile)
@@ -2039,7 +2045,8 @@ revolve001 = revolve(sketch002, angle = 360, axis = seg01)`)
       const newCode = recast(result.modifiedAst, instanceInThisFile)
 
       expect(newCode).toContain(
-        `region001 = region(point = [-2.48mm, -1.8875mm], sketch = sketch001)
+        `hidden001 = hide(sketch001)
+region001 = region(point = [-2.48mm, -1.8875mm], sketch = sketch001)
 revolve001 = revolve(region001, angle = 36deg, axis = sketch001.line5)`
       )
     })

--- a/src/lang/modifyAst/sweeps.ts
+++ b/src/lang/modifyAst/sweeps.ts
@@ -22,14 +22,18 @@ import {
 } from '@src/lang/modifyAst/tagManagement'
 import {
   getVariableExprsFromSelection,
+  getVariableNameFromNodePath,
+  isCallExprWithName,
   valueOrVariable,
 } from '@src/lang/queryAst'
+import { addHide } from '@src/lang/modifyAst/transforms'
 import {
   getArtifactOfTypes,
   getSweepEdgeCodeRef,
 } from '@src/lang/std/artifactGraph'
 import type {
   ArtifactGraph,
+  CallExpressionKw,
   Expr,
   LabeledArg,
   PathToNode,
@@ -44,7 +48,10 @@ import {
   KCL_PRELUDE_BODY_TYPE_SURFACE,
 } from '@src/lib/constants'
 import { err } from '@src/lib/trap'
-import type { Selections } from '@src/machines/modelingSharedTypes'
+import type {
+  EngineRegionSelection,
+  Selections,
+} from '@src/machines/modelingSharedTypes'
 import {
   getFacesExprsFromSelection,
   isFaceArtifact,
@@ -145,6 +152,15 @@ export function addExtrude({
 
   const engineRegions = sketches.otherSelections.filter(isEngineRegionSelection)
   if (engineRegions.length > 0) {
+    const hideResult = addHideCallsForRegionSketches({
+      engineRegions,
+      modifiedAst,
+      artifactGraph,
+      wasmInstance,
+    })
+    if (err(hideResult)) return hideResult
+    modifiedAst = hideResult
+
     const regionExprs = insertRegionVariablesAndOffsetPathToNode({
       engineRegions,
       modifiedAst,
@@ -327,7 +343,7 @@ export function addSweep({
     }
   | Error {
   // 1. Clone the ast and nodeToEdit so we can freely edit them
-  const modifiedAst = structuredClone(ast)
+  let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // 2. Prepare unlabeled and labeled arguments
@@ -345,6 +361,15 @@ export function addSweep({
 
   const engineRegions = sketches.otherSelections.filter(isEngineRegionSelection)
   if (engineRegions.length > 0) {
+    const hideResult = addHideCallsForRegionSketches({
+      engineRegions,
+      modifiedAst,
+      artifactGraph,
+      wasmInstance,
+    })
+    if (err(hideResult)) return hideResult
+    modifiedAst = hideResult
+
     const regionExprs = insertRegionVariablesAndOffsetPathToNode({
       engineRegions,
       modifiedAst,
@@ -451,7 +476,7 @@ export function addLoft({
     }
   | Error {
   // 1. Clone the ast and nodeToEdit so we can freely edit them
-  const modifiedAst = structuredClone(ast)
+  let modifiedAst = structuredClone(ast)
   const mNodeToEdit = structuredClone(nodeToEdit)
 
   // 2. Prepare unlabeled and labeled arguments
@@ -469,6 +494,15 @@ export function addLoft({
 
   const engineRegions = sketches.otherSelections.filter(isEngineRegionSelection)
   if (engineRegions.length > 0) {
+    const hideResult = addHideCallsForRegionSketches({
+      engineRegions,
+      modifiedAst,
+      artifactGraph,
+      wasmInstance,
+    })
+    if (err(hideResult)) return hideResult
+    modifiedAst = hideResult
+
     const regionExprs = insertRegionVariablesAndOffsetPathToNode({
       engineRegions,
       modifiedAst,
@@ -599,6 +633,15 @@ export function addRevolve({
   }
   const engineRegions = sketches.otherSelections.filter(isEngineRegionSelection)
   if (engineRegions.length > 0) {
+    const hideResult = addHideCallsForRegionSketches({
+      engineRegions,
+      modifiedAst,
+      artifactGraph,
+      wasmInstance,
+    })
+    if (err(hideResult)) return hideResult
+    modifiedAst = hideResult
+
     const regionExprs = insertRegionVariablesAndOffsetPathToNode({
       engineRegions,
       modifiedAst,
@@ -694,6 +737,113 @@ export function addRevolve({
 }
 
 // Utilities
+
+function addHideCallsForRegionSketches({
+  engineRegions,
+  modifiedAst,
+  artifactGraph,
+  wasmInstance,
+}: {
+  engineRegions: EngineRegionSelection[]
+  modifiedAst: Node<Program>
+  artifactGraph: ArtifactGraph
+  wasmInstance: ModuleType
+}): Error | Node<Program> {
+  let updatedAst = modifiedAst
+  const hiddenSketches = collectHiddenSketchNames(updatedAst)
+  const hiddenSketchIds = new Set<string>()
+
+  for (const regionSelection of engineRegions) {
+    if (hiddenSketchIds.has(regionSelection.sketchId)) {
+      continue
+    }
+
+    const sketchArtifact = artifactGraph.get(regionSelection.sketchId)
+    if (!sketchArtifact || sketchArtifact.type !== 'sketchBlock') {
+      return new Error("Couldn't retrieve sketch block artifact")
+    }
+
+    const sketchVarNameForHide = getVariableNameFromNodePath(
+      sketchArtifact.codeRef.pathToNode,
+      updatedAst,
+      wasmInstance
+    )
+    if (!sketchVarNameForHide) {
+      return new Error("Couldn't retrieve sketch block variable")
+    }
+
+    if (hiddenSketches.has(sketchVarNameForHide)) {
+      hiddenSketchIds.add(regionSelection.sketchId)
+      continue
+    }
+
+    const hideResult = addHide({
+      ast: updatedAst,
+      artifactGraph,
+      objects: {
+        graphSelections: [
+          {
+            artifact: sketchArtifact,
+            codeRef: sketchArtifact.codeRef,
+          },
+        ],
+        otherSelections: [],
+      },
+      wasmInstance,
+    })
+    if (err(hideResult)) {
+      return hideResult
+    }
+
+    updatedAst = hideResult.modifiedAst
+    hiddenSketchIds.add(regionSelection.sketchId)
+    hiddenSketches.add(sketchVarNameForHide)
+  }
+
+  return updatedAst
+}
+
+function collectHiddenSketchNames(modifiedAst: Node<Program>): Set<string> {
+  const hiddenSketches = new Set<string>()
+
+  for (const bodyItem of modifiedAst.body) {
+    const maybeCall =
+      bodyItem.type === 'VariableDeclaration'
+        ? bodyItem.declaration.init
+        : bodyItem.type === 'ExpressionStatement'
+          ? bodyItem.expression
+          : undefined
+
+    if (!maybeCall || !isCallExprWithName(maybeCall, 'hide')) {
+      continue
+    }
+
+    const sketchNames = getSketchNamesFromHideArg(maybeCall.unlabeled)
+    sketchNames.forEach((name) => hiddenSketches.add(name))
+  }
+
+  return hiddenSketches
+}
+
+function getSketchNamesFromHideArg(
+  hideArg: CallExpressionKw['unlabeled']
+): string[] {
+  if (!hideArg) {
+    return []
+  }
+
+  if (hideArg.type === 'Name') {
+    return [hideArg.name.name]
+  }
+
+  if (hideArg.type === 'ArrayExpression') {
+    return hideArg.elements
+      .filter((element) => element.type === 'Name')
+      .map((element) => element.name.name)
+  }
+
+  return []
+}
 
 export function getAxisExpression(
   axis: string | undefined,


### PR DESCRIPTION
Closes #11141. 

From https://github.com/KittyCAD/modeling-app/pull/10744:

> If people are happy with this we may consider applying the hide(sketch###) directly on extrusion.

This helps with selectability and is consistent with how traditional CAD works.

One of the many threads about this for context https://kittycadworkspace.slack.com/archives/C09CJ6XPY1Y/p1776443485428279?thread_ts=1776443094.842799&cid=C09CJ6XPY1Y


https://github.com/user-attachments/assets/5884e818-b2eb-4ca0-8393-bf69d8406cb4

