### PR TITLE
(feature): DOF generation even if errors in KCL parse/execution

### DIFF
--- a/rust/kcl-lib/src/errors.rs
+++ b/rust/kcl-lib/src/errors.rs
@@ -301,6 +301,11 @@ impl KclErrorWithOutputs {
         }
     }
 
+    #[cfg(feature = "artifact-graph")]
+    pub fn sketch_constraint_report(&self) -> crate::SketchConstraintReport {
+        crate::execution::sketch_constraint_report_from_scene_objects(&self.scene_objects)
+    }
+
     pub fn into_miette_report_with_outputs(self, code: &str) -> anyhow::Result<ReportWithOutputs> {
         let mut source_ranges = self.error.source_ranges();
 

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -350,6 +350,105 @@ pub struct SketchConstraintReport {
     pub errors: Vec<SketchConstraintStatus>,
 }
 
+#[cfg(feature = "artifact-graph")]
+pub(crate) fn sketch_constraint_report_from_scene_objects(scene_objects: &[Object]) -> SketchConstraintReport {
+    use crate::front::ObjectKind;
+    use crate::front::Segment;
+
+    // Closure to look up a point's freedom by ObjectId.
+    let lookup = |id: ObjectId| -> Option<crate::front::Freedom> {
+        let obj = scene_objects.get(id.0)?;
+        if let ObjectKind::Segment {
+            segment: Segment::Point(p),
+        } = &obj.kind
+        {
+            Some(p.freedom())
+        } else {
+            None
+        }
+    };
+
+    let mut fully_constrained = Vec::new();
+    let mut under_constrained = Vec::new();
+    let mut over_constrained = Vec::new();
+    let mut errors = Vec::new();
+
+    for obj in scene_objects {
+        let ObjectKind::Sketch(sketch) = &obj.kind else {
+            continue;
+        };
+
+        let mut free_count: usize = 0;
+        let mut conflict_count: usize = 0;
+        let mut error_count: usize = 0;
+        let mut total_count: usize = 0;
+
+        for &seg_id in &sketch.segments {
+            let Some(seg_obj) = scene_objects.get(seg_id.0) else {
+                continue;
+            };
+            let ObjectKind::Segment { segment } = &seg_obj.kind else {
+                continue;
+            };
+            // Skip owned points — their freedom is already captured by
+            // the parent geometry (Line/Arc/Circle) that looks them up.
+            if let Segment::Point(p) = segment
+                && p.owner.is_some()
+            {
+                continue;
+            }
+            let freedom = segment
+                .freedom(lookup)
+                .map(SegmentFreedom::from)
+                .unwrap_or(SegmentFreedom::Error);
+            total_count += 1;
+            match freedom {
+                SegmentFreedom::Free => free_count += 1,
+                SegmentFreedom::Conflict => conflict_count += 1,
+                SegmentFreedom::Error => error_count += 1,
+                SegmentFreedom::Fixed => {}
+            }
+        }
+
+        // Note: a sketch with no countable segments (total_count == 0)
+        // is reported as FullyConstrained. This is vacuously true — there
+        // are no free or conflicting segments, so it satisfies the
+        // definition. Callers can check total_count == 0 to distinguish
+        // this from a genuinely constrained sketch.
+        let status = if error_count > 0 {
+            ConstraintKind::Error
+        } else if conflict_count > 0 {
+            ConstraintKind::OverConstrained
+        } else if free_count > 0 {
+            ConstraintKind::UnderConstrained
+        } else {
+            ConstraintKind::FullyConstrained
+        };
+
+        let entry = SketchConstraintStatus {
+            name: obj.label.clone(),
+            status,
+            free_count,
+            conflict_count,
+            total_count,
+        };
+
+        match status {
+            ConstraintKind::FullyConstrained => fully_constrained.push(entry),
+            ConstraintKind::UnderConstrained => under_constrained.push(entry),
+            ConstraintKind::OverConstrained => over_constrained.push(entry),
+            ConstraintKind::Error => errors.push(entry),
+        }
+    }
+
+    SketchConstraintReport {
+        fully_constrained,
+        under_constrained,
+        over_constrained,
+        errors,
+    }
+}
+
 impl ExecOutcome {
     pub fn scene_object_by_id(&self, id: ObjectId) -> Option<&Object> {
         #[cfg(feature = "artifact-graph")]
@@ -382,101 +481,7 @@ impl ExecOutcome {
     /// Line/Arc/Circle) are skipped to avoid double-counting.
     #[cfg(feature = "artifact-graph")]
     pub fn sketch_constraint_report(&self) -> SketchConstraintReport {
-        use crate::front::ObjectKind;
-        use crate::front::Segment;
-
-        // Closure to look up a point's freedom by ObjectId.
-        let lookup = |id: ObjectId| -> Option<crate::front::Freedom> {
-            let obj = self.scene_objects.get(id.0)?;
-            if let ObjectKind::Segment {
-                segment: Segment::Point(p),
-            } = &obj.kind
-            {
-                Some(p.freedom())
-            } else {
-                None
-            }
-        };
-
-        let mut fully_constrained = Vec::new();
-        let mut under_constrained = Vec::new();
-        let mut over_constrained = Vec::new();
-        let mut errors = Vec::new();
-
-        for obj in &self.scene_objects {
-            let ObjectKind::Sketch(sketch) = &obj.kind else {
-                continue;
-            };
-
-            let mut free_count: usize = 0;
-            let mut conflict_count: usize = 0;
-            let mut error_count: usize = 0;
-            let mut total_count: usize = 0;
-
-            for &seg_id in &sketch.segments {
-                let Some(seg_obj) = self.scene_objects.get(seg_id.0) else {
-                    continue;
-                };
-                let ObjectKind::Segment { segment } = &seg_obj.kind else {
-                    continue;
-                };
-                // Skip owned points — their freedom is already captured by
-                // the parent geometry (Line/Arc/Circle) that looks them up.
-                if let Segment::Point(p) = segment
-                    && p.owner.is_some()
-                {
-                    continue;
-                }
-                let freedom = segment
-                    .freedom(lookup)
-                    .map(SegmentFreedom::from)
-                    .unwrap_or(SegmentFreedom::Error);
-                total_count += 1;
-                match freedom {
-                    SegmentFreedom::Free => free_count += 1,
-                    SegmentFreedom::Conflict => conflict_count += 1,
-                    SegmentFreedom::Error => error_count += 1,
-                    SegmentFreedom::Fixed => {}
-                }
-            }
-
-            // Note: a sketch with no countable segments (total_count == 0)
-            // is reported as FullyConstrained. This is vacuously true — there
-            // are no free or conflicting segments, so it satisfies the
-            // definition. Callers can check total_count == 0 to distinguish
-            // this from a genuinely constrained sketch.
-            let status = if error_count > 0 {
-                ConstraintKind::Error
-            } else if conflict_count > 0 {
-                ConstraintKind::OverConstrained
-            } else if free_count > 0 {
-                ConstraintKind::UnderConstrained
-            } else {
-                ConstraintKind::FullyConstrained
-            };
-
-            let entry = SketchConstraintStatus {
-                name: obj.label.clone(),
-                status,
-                free_count,
-                conflict_count,
-                total_count,
-            };
-
-            match status {
-                ConstraintKind::FullyConstrained => fully_constrained.push(entry),
-                ConstraintKind::UnderConstrained => under_constrained.push(entry),
-                ConstraintKind::OverConstrained => over_constrained.push(entry),
-                ConstraintKind::Error => errors.push(entry),
-            }
-        }
-
-        SketchConstraintReport {
-            fully_constrained,
-            under_constrained,
-            over_constrained,
-            errors,
-        }
+        sketch_constraint_report_from_scene_objects(&self.scene_objects)
     }
 }
 

--- a/rust/kcl-python-bindings/kcl.pyi
+++ b/rust/kcl-python-bindings/kcl.pyi
@@ -209,6 +209,15 @@ class InputFormat3d:
     
     ...
 
+class KclErrorInfo:
+    r"""
+    Full KCL error details associated with an incomplete report.
+    """
+    @property
+    def phase(self) -> builtins.str: ...
+    @property
+    def text(self) -> builtins.str: ...
+
 class ObjExportOptions:
     r"""
     Options for exporting OBJ.
@@ -336,6 +345,10 @@ class SketchConstraintReport:
     def over_constrained(self) -> builtins.list[SketchConstraintStatus]: ...
     @property
     def errors(self) -> builtins.list[SketchConstraintStatus]: ...
+    @property
+    def is_complete(self) -> builtins.bool: ...
+    @property
+    def kcl_error(self) -> typing.Optional[KclErrorInfo]: ...
 
 class SketchConstraintStatus:
     r"""

--- a/rust/kcl-python-bindings/src/bridge/sketch_constraints.rs
+++ b/rust/kcl-python-bindings/src/bridge/sketch_constraints.rs
@@ -53,6 +53,17 @@ impl From<kcl_lib::SketchConstraintStatus> for SketchConstraintStatus {
     }
 }
 
+/// Full KCL error details associated with an incomplete report.
+#[pyo3_stub_gen::derive::gen_stub_pyclass]
+#[pyclass]
+#[derive(Debug, Clone)]
+pub struct KclErrorInfo {
+    #[pyo3(get)]
+    pub phase: String,
+    #[pyo3(get)]
+    pub text: String,
+}
+
 /// Grouped report of all sketches by constraint status.
 #[pyo3_stub_gen::derive::gen_stub_pyclass]
 #[pyclass]
@@ -66,6 +77,10 @@ pub struct SketchConstraintReport {
     pub over_constrained: Vec<SketchConstraintStatus>,
     #[pyo3(get)]
     pub errors: Vec<SketchConstraintStatus>,
+    #[pyo3(get)]
+    pub is_complete: bool,
+    #[pyo3(get)]
+    pub kcl_error: Option<KclErrorInfo>,
 }
 
 #[pymethods]
@@ -83,6 +98,8 @@ impl From<kcl_lib::SketchConstraintReport> for SketchConstraintReport {
             under_constrained: r.under_constrained.into_iter().map(Into::into).collect(),
             over_constrained: r.over_constrained.into_iter().map(Into::into).collect(),
             errors: r.errors.into_iter().map(Into::into).collect(),
+            is_complete: true,
+            kcl_error: None,
         }
     }
 }

--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -40,6 +40,7 @@ use uuid::Uuid;
 use crate::bridge::bounding_box::BoundingBoxResponse;
 use crate::bridge::physical_properties::PhysicalPropertiesRequest;
 use crate::bridge::physical_properties::PhysicalPropertiesResponse;
+use crate::bridge::sketch_constraints::KclErrorInfo;
 use crate::bridge::sketch_constraints::SketchConstraintReport;
 
 mod bridge;
@@ -62,19 +63,41 @@ where
 }
 
 fn into_miette(error: kcl_lib::KclErrorWithOutputs, code: &str) -> PyErr {
+    pyo3::exceptions::PyException::new_err(render_miette(error, code))
+}
+
+fn render_miette(error: kcl_lib::KclErrorWithOutputs, code: &str) -> String {
     let report = error.into_miette_report_with_outputs(code).unwrap();
     let report = miette::Report::new(report);
-    pyo3::exceptions::PyException::new_err(format!("{report:?}"))
+    format!("{report:?}")
 }
 
 fn into_miette_for_parse(filename: &str, input: &str, error: kcl_lib::KclError) -> PyErr {
+    pyo3::exceptions::PyException::new_err(render_miette_for_parse(filename, input, error))
+}
+
+fn render_miette_for_parse(filename: &str, input: &str, error: kcl_lib::KclError) -> String {
     let report = kcl_lib::Report {
         kcl_source: input.to_string(),
         error,
         filename: filename.to_string(),
     };
     let report = miette::Report::new(report);
-    pyo3::exceptions::PyException::new_err(format!("{report:?}"))
+    format!("{report:?}")
+}
+
+fn incomplete_sketch_constraint_report(phase: &str, text: String) -> SketchConstraintReport {
+    SketchConstraintReport {
+        fully_constrained: Vec::new(),
+        under_constrained: Vec::new(),
+        over_constrained: Vec::new(),
+        errors: Vec::new(),
+        is_complete: false,
+        kcl_error: Some(KclErrorInfo {
+            phase: phase.to_string(),
+            text,
+        }),
+    }
 }
 
 /// Get the path to the current file from the path given, and read the code.
@@ -207,23 +230,42 @@ async fn execute_impl(input: KclInput, mock: bool) -> PyResult<()> {
 }
 
 async fn sketch_constraint_report_impl(input: KclInput) -> PyResult<SketchConstraintReport> {
-    let KclProgram {
-        code,
-        program,
-        path,
-        filename: _,
-    } = load_and_parse(input).await?;
+    let (code, path, filename) = match input {
+        KclInput::Path(input_path) => {
+            let (code, path) = get_code_and_file_path(&input_path).await.map_err(to_py_exception)?;
+            let filename = path.display().to_string();
+            (code, Some(path), filename)
+        }
+        KclInput::Code(code) => (code, None, String::new()),
+    };
+
+    let program = match kcl_lib::Program::parse_no_errs(&code) {
+        Ok(program) => program,
+        Err(err) => {
+            let error_text = render_miette_for_parse(&filename, &code, err);
+            return Ok(incomplete_sketch_constraint_report("parse", error_text));
+        }
+    };
 
     let (ctx, mut state) = new_context_state(path, false).await.map_err(to_py_exception)?;
-    let (env_ref, _) = ctx
-        .run(&program, &mut state)
-        .await
-        .map_err(|err| into_miette(err, &code))?;
-
-    let outcome = state.into_exec_outcome(env_ref, &ctx).await;
-    let report = outcome.sketch_constraint_report();
+    let result = match ctx.run(&program, &mut state).await {
+        Ok((env_ref, _)) => {
+            let outcome = state.into_exec_outcome(env_ref, &ctx).await;
+            Ok(outcome.sketch_constraint_report().into())
+        }
+        Err(err) => {
+            let error_text = render_miette(err.clone(), &code);
+            let mut report: SketchConstraintReport = err.sketch_constraint_report().into();
+            report.is_complete = false;
+            report.kcl_error = Some(KclErrorInfo {
+                phase: "execution".to_string(),
+                text: error_text,
+            });
+            Ok(report)
+        }
+    };
     ctx.close().await;
-    Ok(report.into())
+    result
 }
 
 async fn execute_and_snapshot_views_impl(
@@ -974,6 +1016,7 @@ fn kcl(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<kcmc::format::InputFormat3d>()?;
     m.add_class::<FindingFamily>()?;
     m.add_class::<bridge::sketch_constraints::ConstraintKind>()?;
+    m.add_class::<bridge::sketch_constraints::KclErrorInfo>()?;
     m.add_class::<bridge::sketch_constraints::SketchConstraintStatus>()?;
     m.add_class::<bridge::sketch_constraints::SketchConstraintReport>()?;
 

--- a/rust/kcl-python-bindings/tests/tests.py
+++ b/rust/kcl-python-bindings/tests/tests.py
@@ -576,6 +576,31 @@ s2 = sketch(on = XZ) {
 }
 """
 
+execution_error_after_sketch_code = """
+@settings(experimentalFeatures = allow)
+
+s1 = sketch(on = YZ) {
+  line1 = line(start = [var 2mm, var 8mm], end = [var 5mm, var 7mm])
+  line1.start.at[0] == 2
+  line1.start.at[1] == 8
+  line1.end.at[0] == 5
+  line1.end.at[1] == 7
+}
+
+extrude(missing_sketch, length = 5mm)
+"""
+
+parse_error_sketch_code = """
+@settings(experimentalFeatures = allow)
+
+s1 = sketch(on = YZ) {
+  line1 = line(start = [var 2mm, var 8mm], end = [var 5mm, var 7mm])
+  line1.start.at[0] == 2
+  line1.start.at[1] == 8
+  line1.end.at[0] == 5
+  line1.end.at[1] == 7
+"""
+
 
 @requires_engine
 @pytest.mark.asyncio
@@ -585,6 +610,8 @@ async def test_sketch_constraint_status_fully_constrained():
     assert len(report.under_constrained) == 0
     assert len(report.over_constrained) == 0
     assert len(report.errors) == 0
+    assert report.is_complete is True
+    assert report.kcl_error is None
     assert report.fully_constrained[0].status == kcl.ConstraintKind.FullyConstrained
     assert report.total_sketches() == 1
 
@@ -609,3 +636,35 @@ async def test_sketch_constraint_status_mixed():
     assert len(report.fully_constrained) == 1
     assert len(report.under_constrained) == 1
     assert len(report.errors) == 0
+    assert report.is_complete is True
+    assert report.kcl_error is None
+
+
+@pytest.mark.asyncio
+async def test_sketch_constraint_status_parse_error_returns_report():
+    report = await kcl.get_sketch_constraint_status_code(parse_error_sketch_code)
+    assert report.total_sketches() == 0
+    assert len(report.fully_constrained) == 0
+    assert len(report.under_constrained) == 0
+    assert len(report.over_constrained) == 0
+    assert len(report.errors) == 0
+    assert report.is_complete is False
+    assert report.kcl_error is not None
+    assert report.kcl_error.phase == "parse"
+    assert "KCL Syntax error" in report.kcl_error.text
+    assert "Unexpected token" in report.kcl_error.text
+
+
+@requires_engine
+@pytest.mark.asyncio
+async def test_sketch_constraint_status_execution_error_returns_partial_report():
+    report = await kcl.get_sketch_constraint_status_code(execution_error_after_sketch_code)
+    assert report.total_sketches() == 1
+    assert len(report.fully_constrained) == 1
+    assert len(report.under_constrained) == 0
+    assert len(report.over_constrained) == 0
+    assert len(report.errors) == 0
+    assert report.is_complete is False
+    assert report.kcl_error is not None
+    assert report.kcl_error.phase == "execution"
+    assert "missing_sketch" in report.kcl_error.text


### PR DESCRIPTION

Changes the *return type* in the Python bindings function `get_sketch_constraint_status` / `get_sketch_constraint_status_code` 

Before on error in KCL (parse or execution) these function returned a Python exception 

Now on error in KCL (parse or execution) the DOF report is generated for sketches before the error location. 

* The report includes `is_complete: bool` and `kcl_error: KclErrorInfo | None` 
* New Python exception to capture KCL error and info `KclErrorInfo { phase, text }`. Phase is either `parse` or `execution`. `text` is the error message as a String. 

On the Rust side: 

* Refactor the existing function that create report so that it can be called for both Success and Error cases 
* Added bridge functions 

Closes: #11172
