### PR TITLE
Fix Flip and Split codemods on compositeSolid selection

### DIFF
--- a/src/lang/modifyAst/boolean.spec.ts
+++ b/src/lang/modifyAst/boolean.spec.ts
@@ -6,6 +6,7 @@ import { addSplit, addSubtract } from '@src/lang/modifyAst/boolean'
 import {
   enginelessExecutor,
   getAstAndArtifactGraph,
+  createSelectionFromArtifacts,
 } from '@src/lib/testHelpers'
 import type RustContext from '@src/lib/rustContext'
 import type { ConnectionManager } from '@src/network/connectionManager'
@@ -367,6 +368,82 @@ extrude002 = extrude(profile002, length = .1)`
         merge: true,
         keepTools: true,
       })
+      expect(newCode).toContain(code + '\n' + expectedNewLine)
+    })
+
+    it('should work with a compositeSolid for tools in a more complex part', async () => {
+      const code = `sketch001 = sketch(on = YZ) {
+  line1 = line(start = [var 7.1mm, var -1.58mm], end = [var 10.16mm, var -1.58mm])
+  line2 = line(start = [var 10.16mm, var -1.58mm], end = [var 10.16mm, var 1.33mm])
+  line3 = line(start = [var 10.16mm, var 1.33mm], end = [var 7.1mm, var 1.33mm])
+  line4 = line(start = [var 7.1mm, var 1.33mm], end = [var 7.1mm, var -1.58mm])
+  coincident([line1.end, line2.start])
+  coincident([line2.end, line3.start])
+  coincident([line3.end, line4.start])
+  coincident([line4.end, line1.start])
+  parallel([line2, line4])
+  parallel([line3, line1])
+  perpendicular([line1, line2])
+  horizontal(line3)
+}
+region001 = region(point = [8.63mm, -1.5775mm], sketch = sketch001)
+extrude001 = extrude(region001, length = 20, bodyType = SURFACE)
+
+sketch002 = sketch(on = XZ) {
+  line1 = line(start = [var 11.27mm, var 4.91mm], end = [var 9.6mm, var -6.31mm])
+}
+extrude002 = extrude(sketch002.line1, length = 10, bodyType = SURFACE)
+
+sketch003 = sketch(on = YZ) {
+  line1 = line(start = [var 16.37mm, var 5.98mm], end = [var 16.6mm, var -5.82mm])
+}
+extrude003 = extrude(sketch003.line1, length = -10, bodyType = SURFACE)
+hidden001 = hide(sketch003)
+hidden002 = hide(sketch002)
+hidden003 = hide(sketch001)
+blend001 = blend([
+  getBoundedEdge(extrude002, edge = extrude002.sketch.tags.line1),
+  getBoundedEdge(extrude003, edge = extrude003.sketch.tags.line1)
+])
+surface001 = flipSurface(blend001)
+surface002 = joinSurfaces([extrude002, extrude003, surface001])`
+      const expectedNewLine = `split001 = split(extrude001, tools = surface002)`
+
+      const { ast, artifactGraph } = await getAstAndArtifactGraph(
+        code,
+        instanceInThisFile,
+        kclManagerInThisFile
+      )
+      const firstSweep = [...artifactGraph.values()].find(
+        (artifact) => artifact.type === 'sweep'
+      )
+      const lastCompositeSolid = [...artifactGraph.values()]
+        .filter((artifact) => artifact.type === 'compositeSolid')
+        .at(-1)
+      if (!firstSweep) {
+        throw new Error('sweep artifact not found in graph')
+      }
+      if (!lastCompositeSolid) {
+        throw new Error('compositeSolid artifact not found in graph')
+      }
+
+      const targets = createSelectionFromArtifacts([firstSweep], artifactGraph)
+      const tools = createSelectionFromArtifacts(
+        [lastCompositeSolid],
+        artifactGraph
+      )
+
+      const result = addSplit({
+        ast,
+        artifactGraph,
+        targets,
+        tools,
+        wasmInstance: instanceInThisFile,
+      })
+      if (err(result)) throw result
+
+      await enginelessExecutor(ast, rustContextInThisFile)
+      const newCode = recast(result.modifiedAst, instanceInThisFile)
       expect(newCode).toContain(code + '\n' + expectedNewLine)
     })
   })

--- a/src/lang/modifyAst/surfaces.spec.ts
+++ b/src/lang/modifyAst/surfaces.spec.ts
@@ -3,6 +3,7 @@ import { err } from '@src/lib/trap'
 import type { Selections } from '@src/machines/modelingSharedTypes'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import {
+  createSelectionFromArtifacts,
   createSelectionFromPathArtifact,
   enginelessExecutor,
   getAstAndArtifactGraph,
@@ -66,6 +67,81 @@ extrude001 = extrude(profile001, length = 1, bodyType = SURFACE)`
         otherSelections: [],
       }
 
+      const result = addFlipSurface({
+        ast,
+        artifactGraph,
+        surface,
+        wasmInstance: instanceInThisFile,
+      })
+      if (err(result)) throw result
+
+      const newCode = recast(result.modifiedAst, instanceInThisFile)
+      expect(newCode).toContain(code + '\n' + expectedNewLine)
+      await enginelessExecutor(result.modifiedAst, rustContextInThisFile)
+    })
+
+    it('should resolve selected joinSurfaces result instead of a child blend surface', async () => {
+      const code = `sketch001 = sketch(on = XY) {
+  line1 = line(start = [var 5.2mm, var 0mm], end = [var 7.61mm, var 0mm])
+  line2 = line(start = [var 7.61mm, var 0mm], end = [var 7.61mm, var 2.28mm])
+  line3 = line(start = [var 7.61mm, var 2.28mm], end = [var 5.2mm, var 2.28mm])
+  line4 = line(start = [var 5.2mm, var 2.28mm], end = [var 5.2mm, var 0mm])
+  coincident([line1.end, line2.start])
+  coincident([line2.end, line3.start])
+  coincident([line3.end, line4.start])
+  coincident([line4.end, line1.start])
+  parallel([line2, line4])
+  parallel([line3, line1])
+  perpendicular([line1, line2])
+  horizontal(line3)
+  horizontal([line1.start, ORIGIN])
+}
+hidden001 = hide(sketch001)
+region001 = region(point = [6.405mm, 0.0025mm], sketch = sketch001)
+extrude001 = extrude(region001, length = 5, bodyType = SURFACE)
+sketch002 = sketch(on = YZ) {
+  line1 = line(start = [var 0.24mm, var 7.22mm], end = [var 2.22mm, var 7.22mm])
+  line2 = line(start = [var 2.22mm, var 7.22mm], end = [var 2.22mm, var 9mm])
+  line3 = line(start = [var 2.22mm, var 9mm], end = [var 0.24mm, var 9mm])
+  line4 = line(start = [var 0.24mm, var 9mm], end = [var 0.24mm, var 7.22mm])
+  coincident([line1.end, line2.start])
+  coincident([line2.end, line3.start])
+  coincident([line3.end, line4.start])
+  coincident([line4.end, line1.start])
+  parallel([line2, line4])
+  parallel([line3, line1])
+  perpendicular([line1, line2])
+  horizontal(line3)
+}
+hidden002 = hide(sketch002)
+region002 = region(point = [1.23mm, 7.2225mm], sketch = sketch002)
+extrude002 = extrude(region002, length = -5, bodyType = SURFACE)
+blend001 = blend([
+  getBoundedEdge(extrude002, edge = region002.tags.line1),
+  getBoundedEdge(extrude001, edge = getOppositeEdge(region001.tags.line2))
+])
+blend002 = blend([
+  getBoundedEdge(extrude002, edge = region002.tags.line2),
+  getBoundedEdge(extrude001, edge = getOppositeEdge(region001.tags.line1))
+])
+surface001 = joinSurfaces([blend001, blend002])`
+      const expectedNewLine = `surface002 = flipSurface(surface001)`
+      const { ast, artifactGraph } = await getAstAndArtifactGraph(
+        code,
+        instanceInThisFile,
+        kclManagerInThisFile
+      )
+      const selectedSurface = [...artifactGraph.values()].find(
+        (artifact) => artifact.type === 'compositeSolid'
+      )
+      if (!selectedSurface) {
+        throw new Error('compositeSolid artifact not found in graph')
+      }
+
+      const surface = createSelectionFromArtifacts(
+        [selectedSurface],
+        artifactGraph
+      )
       const result = addFlipSurface({
         ast,
         artifactGraph,

--- a/src/lang/modifyAst/surfaces.ts
+++ b/src/lang/modifyAst/surfaces.ts
@@ -50,6 +50,8 @@ export function addFlipSurface({
     mNodeToEdit,
     {
       lastChildLookup: true,
+      skipNewSweepCutoff: true,
+      artifactTypeFilter: ['compositeSolid', 'sweep'],
     }
   )
   if (err(vars)) {

--- a/src/lang/modifyAst/surfaces.ts
+++ b/src/lang/modifyAst/surfaces.ts
@@ -50,8 +50,6 @@ export function addFlipSurface({
     mNodeToEdit,
     {
       lastChildLookup: true,
-      skipNewSweepCutoff: true,
-      artifactTypeFilter: ['compositeSolid', 'sweep'],
     }
   )
   if (err(vars)) {

--- a/src/lang/queryAst.ts
+++ b/src/lang/queryAst.ts
@@ -1747,7 +1747,7 @@ export function findAllChildrenAndOrderByPlaceInCode(
       if (path && path.type === 'path') {
         const compositeSolidId = path.compositeSolidId
         if (compositeSolidId) {
-          result.push(compositeSolidId)
+          pushToSomething(compositeSolidId, undefined)
         }
       }
     } else if (current?.type === 'wall' || current?.type === 'cap') {
@@ -1762,8 +1762,8 @@ export function findAllChildrenAndOrderByPlaceInCode(
     } else if (current?.type === 'plane') {
       pushToSomething(currentId, current.pathIds)
     } else if (current?.type === 'compositeSolid') {
-      pushToSomething(currentId, current.solidIds)
-      pushToSomething(currentId, current.toolIds)
+      // No need to go up-graph here for composite solids, it's the end of the line
+      result.push(currentId)
     }
   }
 
@@ -1778,16 +1778,10 @@ export function findAllChildrenAndOrderByPlaceInCode(
     return aCodeRef.range[0] - bCodeRef.range[0]
   })
 
-  // Cut off traversal results at the first NEW sweep, so long as:
-  // it's not the first sweep,
-  // and it's not a blend.
+  // Cut off traversal results at the first NEW sweep (so long as it's not the first sweep)
   let firstSweep = true
   const cutoffIndex = orderedByCodeRefDest.findIndex((artifact) => {
-    if (
-      artifact.type === 'sweep' &&
-      artifact.subType !== 'blend' &&
-      firstSweep
-    ) {
+    if (artifact.type === 'sweep' && firstSweep) {
       firstSweep = false
       return false
     }

--- a/src/lang/queryAst.ts
+++ b/src/lang/queryAst.ts
@@ -1153,7 +1153,6 @@ export function getVariableNameFromNodePath(
 type GetVariableExprsOptions = {
   lastChildLookup?: boolean
   artifactTypeFilter?: Array<Artifact['type']>
-  skipNewSweepCutoff?: boolean
 }
 
 // Go from a selection to a list of KCL expressions that
@@ -1167,11 +1166,7 @@ export function getVariableExprsFromSelection(
   nodeToEdit?: PathToNode,
   options: GetVariableExprsOptions = {}
 ): Error | { exprs: Expr[]; pathIfPipe?: PathToNode } {
-  const {
-    lastChildLookup = false,
-    artifactTypeFilter,
-    skipNewSweepCutoff = false,
-  } = options
+  const { lastChildLookup = false, artifactTypeFilter } = options
   let pathIfPipe: PathToNode | undefined
   let exprs: Expr[] = []
   const pushedNames = {} as Record<string, boolean>
@@ -1210,8 +1205,7 @@ export function getVariableExprsFromSelection(
     if (lastChildLookup && s.artifact) {
       const children = findAllChildrenAndOrderByPlaceInCode(
         s.artifact,
-        artifactGraph,
-        { skipNewSweepCutoff }
+        artifactGraph
       )
       const lastChildVariable = getLastVariable(
         children,
@@ -1705,12 +1699,8 @@ export const getPathNormalisedForTruncatedAst = (
  */
 export function findAllChildrenAndOrderByPlaceInCode(
   artifact: Artifact,
-  artifactGraph: ArtifactGraph,
-  options: {
-    skipNewSweepCutoff?: boolean
-  } = {}
+  artifactGraph: ArtifactGraph
 ): Artifact[] {
-  const { skipNewSweepCutoff = false } = options
   const result: string[] = []
   const stack: string[] = [artifact.id]
 
@@ -1788,20 +1778,24 @@ export function findAllChildrenAndOrderByPlaceInCode(
     return aCodeRef.range[0] - bCodeRef.range[0]
   })
 
-  if (!skipNewSweepCutoff) {
-    // Cut off traversal results at the first NEW sweep (so long as it's not the first sweep)
-    let firstSweep = true
-    const cutoffIndex = orderedByCodeRefDest.findIndex((artifact) => {
-      if (artifact.type === 'sweep' && firstSweep) {
-        firstSweep = false
-        return false
-      }
-      const isNew = artifact.type === 'sweep' && artifact.method === 'new'
-      return isNew && !firstSweep
-    })
-    if (cutoffIndex !== -1) {
-      orderedByCodeRefDest = orderedByCodeRefDest.slice(0, cutoffIndex)
+  // Cut off traversal results at the first NEW sweep, so long as:
+  // it's not the first sweep,
+  // and it's not a blend.
+  let firstSweep = true
+  const cutoffIndex = orderedByCodeRefDest.findIndex((artifact) => {
+    if (
+      artifact.type === 'sweep' &&
+      artifact.subType !== 'blend' &&
+      firstSweep
+    ) {
+      firstSweep = false
+      return false
     }
+    const isNew = artifact.type === 'sweep' && artifact.method === 'new'
+    return isNew && !firstSweep
+  })
+  if (cutoffIndex !== -1) {
+    orderedByCodeRefDest = orderedByCodeRefDest.slice(0, cutoffIndex)
   }
 
   return orderedByCodeRefDest.reverse()

--- a/src/lang/queryAst.ts
+++ b/src/lang/queryAst.ts
@@ -1153,6 +1153,7 @@ export function getVariableNameFromNodePath(
 type GetVariableExprsOptions = {
   lastChildLookup?: boolean
   artifactTypeFilter?: Array<Artifact['type']>
+  skipNewSweepCutoff?: boolean
 }
 
 // Go from a selection to a list of KCL expressions that
@@ -1166,7 +1167,11 @@ export function getVariableExprsFromSelection(
   nodeToEdit?: PathToNode,
   options: GetVariableExprsOptions = {}
 ): Error | { exprs: Expr[]; pathIfPipe?: PathToNode } {
-  const { lastChildLookup = false, artifactTypeFilter } = options
+  const {
+    lastChildLookup = false,
+    artifactTypeFilter,
+    skipNewSweepCutoff = false,
+  } = options
   let pathIfPipe: PathToNode | undefined
   let exprs: Expr[] = []
   const pushedNames = {} as Record<string, boolean>
@@ -1205,7 +1210,8 @@ export function getVariableExprsFromSelection(
     if (lastChildLookup && s.artifact) {
       const children = findAllChildrenAndOrderByPlaceInCode(
         s.artifact,
-        artifactGraph
+        artifactGraph,
+        { skipNewSweepCutoff }
       )
       const lastChildVariable = getLastVariable(
         children,
@@ -1699,8 +1705,12 @@ export const getPathNormalisedForTruncatedAst = (
  */
 export function findAllChildrenAndOrderByPlaceInCode(
   artifact: Artifact,
-  artifactGraph: ArtifactGraph
+  artifactGraph: ArtifactGraph,
+  options: {
+    skipNewSweepCutoff?: boolean
+  } = {}
 ): Artifact[] {
+  const { skipNewSweepCutoff = false } = options
   const result: string[] = []
   const stack: string[] = [artifact.id]
 
@@ -1778,18 +1788,20 @@ export function findAllChildrenAndOrderByPlaceInCode(
     return aCodeRef.range[0] - bCodeRef.range[0]
   })
 
-  // Cut off traversal results at the first NEW sweep (so long as it's not the first sweep)
-  let firstSweep = true
-  const cutoffIndex = orderedByCodeRefDest.findIndex((artifact) => {
-    if (artifact.type === 'sweep' && firstSweep) {
-      firstSweep = false
-      return false
+  if (!skipNewSweepCutoff) {
+    // Cut off traversal results at the first NEW sweep (so long as it's not the first sweep)
+    let firstSweep = true
+    const cutoffIndex = orderedByCodeRefDest.findIndex((artifact) => {
+      if (artifact.type === 'sweep' && firstSweep) {
+        firstSweep = false
+        return false
+      }
+      const isNew = artifact.type === 'sweep' && artifact.method === 'new'
+      return isNew && !firstSweep
+    })
+    if (cutoffIndex !== -1) {
+      orderedByCodeRefDest = orderedByCodeRefDest.slice(0, cutoffIndex)
     }
-    const isNew = artifact.type === 'sweep' && artifact.method === 'new'
-    return isNew && !firstSweep
-  })
-  if (cutoffIndex !== -1) {
-    orderedByCodeRefDest = orderedByCodeRefDest.slice(0, cutoffIndex)
   }
 
   return orderedByCodeRefDest.reverse()


### PR DESCRIPTION
Fixes #11180 by making sure the traversal for children stops at compositeSolid, which should be the end of the line.

Adds two tests: one for #11180 (Flip example) and as well as one for an issue with Split reported at https://kittycadworkspace.slack.com/archives/C06L2RHP9SL/p1776711623994679