### PR TITLE
Hide the ability to change the Zookeeper mode in production

### DIFF
--- a/e2e/playwright/zookeeper.spec.ts
+++ b/e2e/playwright/zookeeper.spec.ts
@@ -18,7 +18,6 @@ test.describe('Zookeeper tests', { tag: ['@desktop', '@web'] }, () => {
     await test.step(`Submit basic prompt`, async () => {
       await toolbar.closePane(DefaultLayoutPaneID.Code)
       await toolbar.openPane(DefaultLayoutPaneID.TTC)
-      await copilot.setMode('fast')
       await copilot.conversationInput.fill(
         'make a 10x10x10cm cube centered on the origin, name the last variable "cube"'
       )

--- a/src/components/MlEphantConversation.tsx
+++ b/src/components/MlEphantConversation.tsx
@@ -20,6 +20,12 @@ import { isNonNullable } from '@src/lib/utils'
 
 const noop = () => {}
 
+/** The current focus is to optimize one reasoning mode before providing
+ * multiple options to users. On staging the project setting is available
+ * to select between modes.
+ */
+export const SHOW_ZOOKEEPER_REASONING_MODE_DROPDOWN = false
+
 export interface QueuedMessage {
   id: string
   text: string
@@ -146,12 +152,14 @@ export const MlEphantExtraInputs = (props: MlEphantExtraInputsProps) => {
         {props.context && (
           <MlCopilotSelectionsContext selections={props.context} />
         )}
-        <MlCopilotModes onClick={props.onSetMode} current={props.mode}>
-          {ML_COPILOT_MODE_META[props.mode].icon({
-            className: 'w-5 h-5',
-          })}
-          {ML_COPILOT_MODE_META[props.mode].pretty}
-        </MlCopilotModes>
+        {SHOW_ZOOKEEPER_REASONING_MODE_DROPDOWN && (
+          <MlCopilotModes onClick={props.onSetMode} current={props.mode}>
+            {ML_COPILOT_MODE_META[props.mode].icon({
+              className: 'w-5 h-5',
+            })}
+            {ML_COPILOT_MODE_META[props.mode].pretty}
+          </MlCopilotModes>
+        )}
         <button
           type="button"
           data-testid="ml-ephant-attachments-button"
@@ -464,7 +472,6 @@ export const MlEphantConversationInput = (
             ))}
           </div>
         )}
-        {}
         <div className="flex items-end">
           <MlEphantExtraInputs
             context={selectionsContext}

--- a/src/lib/settings/initialSettings.tsx
+++ b/src/lib/settings/initialSettings.tsx
@@ -30,6 +30,7 @@ import { reportRejection } from '@src/lib/trap'
 import { isEnumMember } from '@src/lib/types'
 import { capitaliseFC, isArray, toSync } from '@src/lib/utils'
 import { hexToRgba } from '@src/lib/utils'
+import { IS_STAGING_OR_DEBUG } from '@src/routes/utils'
 
 /**
  * A setting that can be set at the user or project level
@@ -192,7 +193,24 @@ export function createSettings() {
       zookeeperMode: new Setting<MlCopilotMode>({
         defaultValue: DEFAULT_ML_COPILOT_MODE,
         validate: (v) => v === 'fast' || v === 'thoughtful',
-        hideOnPlatform: 'both', // this setting is managed by the Zookeeper pane
+        hideOnPlatform: IS_STAGING_OR_DEBUG ? undefined : 'both',
+        description:
+          'In Staging only, configure which reasoning mode Zookeeper uses.',
+        commandConfig: {
+          inputType: 'options',
+          defaultValueFromContext: (context) =>
+            context.app.zookeeperMode.current,
+          options: (cmdContext, settingsContext) =>
+            (['fast', 'thoughtful'] as const).map((v) => ({
+              name: capitaliseFC(v),
+              value: v,
+              isCurrent:
+                settingsContext.app.zookeeperMode.shouldShowCurrentLabel(
+                  cmdContext.argumentsToSubmit.level as SettingsLevel,
+                  v
+                ),
+            })),
+        },
       }),
       /**
        * Stream resource saving behavior toggle


### PR DESCRIPTION
This is a request from @JordanNoone here: https://kittycadworkspace.slack.com/archives/C07A80B83FS/p1776985859897659