### PR TITLE
Use the default Playwright retries for web

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -111,18 +111,12 @@ jobs:
       - name: Install browsers
         run: npm run playwright install --with-deps
 
-      - name: npm run test:snapshots
-        uses: nick-fields/retry@v4.0.0
-        with:
-          shell: bash
-          command: npm run test:snapshots
-          timeout_minutes: 15
-          max_attempts: 5
+      - run: npm run test:snapshots
         env:
           VITE_ZOO_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
           TAB_API_URL: ${{ vars.TAB_API_URL }}
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
-          CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+          CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           CI_PR_NUMBER: ${{ github.event.pull_request.number }}
           CI_SUITE: e2e:snapshots
           TARGET: web
@@ -134,7 +128,7 @@ jobs:
           VITE_ZOO_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
           TAB_API_URL: ${{ vars.TAB_API_URL }}
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
-          CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+          CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           CI_PR_NUMBER: ${{ github.event.pull_request.number }}
           CI_SUITE: e2e:snapshots
           TARGET: web
@@ -254,18 +248,12 @@ jobs:
           GH_ACTIONS_AXIOM_TOKEN: ${{ secrets.GH_ACTIONS_AXIOM_TOKEN }}
           OS_NAME: ${{ env.OS_NAME }}
 
-      - name: npm run test:e2e:web
-        uses: nick-fields/retry@v4.0.0
-        with:
-          shell: bash
-          command: npm run test:e2e:web
-          timeout_minutes: 15
-          max_attempts: 5
+      - run: npm run test:e2e:web
         env:
           VITE_ZOO_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
           TAB_API_URL: ${{ vars.TAB_API_URL }}
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
-          CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+          CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           CI_PR_NUMBER: ${{ github.event.pull_request.number }}
           CI_SUITE: e2e:web
           TARGET: web
@@ -286,7 +274,7 @@ jobs:
         env:
           TAB_API_URL: ${{ vars.TAB_API_URL }}
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
-          CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+          CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           CI_PR_NUMBER: ${{ github.event.pull_request.number }}
           CI_SUITE: e2e:web
           CI_STEP: teardown
@@ -493,7 +481,7 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: npm run test:e2e:web
-        run: npm run test:e2e:web -- --grep=demo --retries=3
+        run: npm run test:e2e:web -- --grep=demo
         env:
           VERCEL_BASE_URL: ${{ steps.wait-for-vercel-preview.outputs.url || steps.wait-for-vercel-staging.outputs.url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
@@ -501,7 +489,7 @@ jobs:
           TAB_API_URL: ${{ vars.TAB_API_URL }}
           TAB_API_KEY: ${{ secrets.TAB_API_KEY }}
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          CI_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          CI_PR_NUMBER: ${{ github.event.pull_request.number }}
           CI_SUITE: e2e:web
           TARGET: web
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,7 @@ const platform = os.platform() // 'linux' (Ubuntu), 'darwin' (macOS), 'win32' (W
 
 let workers: number | string
 
+/* Use all available CPU cores based on platform. */
 if (process.env.E2E_WORKERS) {
   workers = process.env.E2E_WORKERS.includes('%')
     ? process.env.E2E_WORKERS
@@ -33,13 +34,9 @@ export default defineConfig({
   testDir: './e2e/playwright',
   testIgnore: '*.test.ts', // ignore unit tests
   snapshotPathTemplate: '{testDir}/{testFileName}-snapshots/{arg}{ext}',
-  /* Run tests in files in parallel */
   fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: Boolean(process.env.CI),
-  /* Do not retry using Playwright's built-in retry mechanism */
-  retries: 3,
-  /* Use all available CPU cores */
+  forbidOnly: Boolean(process.env.CI), // fail the build if test.only is used
+  retries: 5,
   workers: workers,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: Boolean(process.env.CI),
   /* Do not retry using Playwright's built-in retry mechanism */
-  retries: 0,
+  retries: 3,
   /* Use all available CPU cores */
   workers: workers,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */


### PR DESCRIPTION
This seems to have been working for the Vercel job so we can apply it to the rest of the web tests to simplify our CI setup. It should also be a bit faster to retry inline.