### PR TITLE
Change Zookeeper default to thoughtful and restore UI

### DIFF
--- a/e2e/playwright/zookeeper.spec.ts
+++ b/e2e/playwright/zookeeper.spec.ts
@@ -18,6 +18,7 @@ test.describe('Zookeeper tests', { tag: ['@desktop', '@web'] }, () => {
     await test.step(`Submit basic prompt`, async () => {
       await toolbar.closePane(DefaultLayoutPaneID.Code)
       await toolbar.openPane(DefaultLayoutPaneID.TTC)
+      await copilot.setMode('fast')
       await copilot.conversationInput.fill(
         'make a 10x10x10cm cube centered on the origin, name the last variable "cube"'
       )

--- a/src/components/MlEphantConversation.tsx
+++ b/src/components/MlEphantConversation.tsx
@@ -20,11 +20,7 @@ import { isNonNullable } from '@src/lib/utils'
 
 const noop = () => {}
 
-/** The current focus is to optimize one reasoning mode before providing
- * multiple options to users. On staging the project setting is available
- * to select between modes.
- */
-export const SHOW_ZOOKEEPER_REASONING_MODE_DROPDOWN = false
+export const SHOW_ZOOKEEPER_REASONING_MODE_DROPDOWN = true
 
 export interface QueuedMessage {
   id: string

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -360,7 +360,7 @@ export const PENDING_COMMAND_TIMEOUT = 60_000
 export const LAYOUT_SAVE_THROTTLE = 500
 
 // Zookeeper input
-export const DEFAULT_ML_COPILOT_MODE: MlCopilotMode = 'fast'
+export const DEFAULT_ML_COPILOT_MODE: MlCopilotMode = 'thoughtful'
 
 // Default backface color
 export const DEFAULT_BACKFACE_COLOR = '#00D5FF'

--- a/src/lib/settings/initialSettings.tsx
+++ b/src/lib/settings/initialSettings.tsx
@@ -30,7 +30,6 @@ import { reportRejection } from '@src/lib/trap'
 import { isEnumMember } from '@src/lib/types'
 import { capitaliseFC, isArray, toSync } from '@src/lib/utils'
 import { hexToRgba } from '@src/lib/utils'
-import { IS_STAGING_OR_DEBUG } from '@src/routes/utils'
 
 /**
  * A setting that can be set at the user or project level
@@ -193,9 +192,7 @@ export function createSettings() {
       zookeeperMode: new Setting<MlCopilotMode>({
         defaultValue: DEFAULT_ML_COPILOT_MODE,
         validate: (v) => v === 'fast' || v === 'thoughtful',
-        hideOnPlatform: IS_STAGING_OR_DEBUG ? undefined : 'both',
-        description:
-          'In Staging only, configure which reasoning mode Zookeeper uses.',
+        description: 'The default reasoning mode for Zookeeper.',
         commandConfig: {
           inputType: 'options',
           defaultValueFromContext: (context) =>


### PR DESCRIPTION
This amends https://github.com/KittyCAD/modeling-app/pull/11251 to reflect improvements that have been made to the Thoughtful mode in Zookeeper.

See: https://kittycadworkspace.slack.com/archives/C04KFV6NKL0/p1777016879326019?thread_ts=1777016705.778409&cid=C04KFV6NKL0