### PR TITLE
Fix corner rectangle behavior when first corner is snapped coincident

### DIFF
--- a/src/machines/sketchSolve/tools/rectTool.ts
+++ b/src/machines/sketchSolve/tools/rectTool.ts
@@ -295,8 +295,8 @@ export const machine = setup({
                     sketchId: context.sketchId,
                     draft: context.draft,
                     mode: context.rectOriginMode,
-                    origin: start,
-                    point:
+                    startPoint: start,
+                    currentPoint:
                       context.rectOriginMode === 'center'
                         ? [max[0], max[1]]
                         : end,

--- a/src/machines/sketchSolve/tools/rectTool.ts
+++ b/src/machines/sketchSolve/tools/rectTool.ts
@@ -294,7 +294,12 @@ export const machine = setup({
                     kclManager: context.kclManager,
                     sketchId: context.sketchId,
                     draft: context.draft,
-                    rect: { min, max },
+                    mode: context.rectOriginMode,
+                    origin: start,
+                    point:
+                      context.rectOriginMode === 'center'
+                        ? [max[0], max[1]]
+                        : end,
                   })
                 }
               }

--- a/src/machines/sketchSolve/tools/rectUtils.spec.ts
+++ b/src/machines/sketchSolve/tools/rectUtils.spec.ts
@@ -405,10 +405,9 @@ describe('rectUtils.updateDraftRectangleAligned', () => {
           centerPointId: 15,
         },
       },
-      rect: {
-        min: [0, 0],
-        max: [4, 6],
-      },
+      mode: 'center',
+      origin: [2, 3],
+      point: [4, 6],
     })
 
     const edits = editSegmentsMock.mock.calls[0]?.[2]
@@ -453,5 +452,91 @@ describe('rectUtils.updateDraftRectangleAligned', () => {
         },
       },
     })
+  })
+
+  it('keeps the first corner pinned when dragging into the negative quadrant', async () => {
+    const rustContext = createMockRustContext()
+    const kclManager = createMockKclManager()
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const editSegmentsMock = vi.mocked(rustContext.editSegments)
+
+    editSegmentsMock.mockResolvedValue({
+      kclSource: { text: 'updated' } as SourceDelta,
+      sceneGraphDelta: createSceneGraphDelta([]),
+    })
+
+    await updateDraftRectangleAligned({
+      rustContext,
+      kclManager,
+      sketchId: 9,
+      draft: {
+        lineIds: [1, 2, 3, 4],
+        segmentIds: [],
+        constraintIds: [],
+        originPointId: 1,
+      },
+      mode: 'corner',
+      origin: [0, 0],
+      point: [-4, -6],
+    })
+
+    expect(editSegmentsMock.mock.calls[0]?.[2]).toEqual([
+      {
+        id: 1,
+        ctor: {
+          type: 'Line',
+          start: {
+            x: { type: 'Var', value: 0, units: 'Mm' },
+            y: { type: 'Var', value: 0, units: 'Mm' },
+          },
+          end: {
+            x: { type: 'Var', value: -4, units: 'Mm' },
+            y: { type: 'Var', value: 0, units: 'Mm' },
+          },
+        },
+      },
+      {
+        id: 2,
+        ctor: {
+          type: 'Line',
+          start: {
+            x: { type: 'Var', value: -4, units: 'Mm' },
+            y: { type: 'Var', value: 0, units: 'Mm' },
+          },
+          end: {
+            x: { type: 'Var', value: -4, units: 'Mm' },
+            y: { type: 'Var', value: -6, units: 'Mm' },
+          },
+        },
+      },
+      {
+        id: 3,
+        ctor: {
+          type: 'Line',
+          start: {
+            x: { type: 'Var', value: -4, units: 'Mm' },
+            y: { type: 'Var', value: -6, units: 'Mm' },
+          },
+          end: {
+            x: { type: 'Var', value: 0, units: 'Mm' },
+            y: { type: 'Var', value: -6, units: 'Mm' },
+          },
+        },
+      },
+      {
+        id: 4,
+        ctor: {
+          type: 'Line',
+          start: {
+            x: { type: 'Var', value: 0, units: 'Mm' },
+            y: { type: 'Var', value: -6, units: 'Mm' },
+          },
+          end: {
+            x: { type: 'Var', value: 0, units: 'Mm' },
+            y: { type: 'Var', value: 0, units: 'Mm' },
+          },
+        },
+      },
+    ])
   })
 })

--- a/src/machines/sketchSolve/tools/rectUtils.spec.ts
+++ b/src/machines/sketchSolve/tools/rectUtils.spec.ts
@@ -406,8 +406,8 @@ describe('rectUtils.updateDraftRectangleAligned', () => {
         },
       },
       mode: 'center',
-      origin: [2, 3],
-      point: [4, 6],
+      startPoint: [2, 3],
+      currentPoint: [4, 6],
     })
 
     const edits = editSegmentsMock.mock.calls[0]?.[2]
@@ -476,8 +476,8 @@ describe('rectUtils.updateDraftRectangleAligned', () => {
         originPointId: 1,
       },
       mode: 'corner',
-      origin: [0, 0],
-      point: [-4, -6],
+      startPoint: [0, 0],
+      currentPoint: [-4, -6],
     })
 
     expect(editSegmentsMock.mock.calls[0]?.[2]).toEqual([

--- a/src/machines/sketchSolve/tools/rectUtils.ts
+++ b/src/machines/sketchSolve/tools/rectUtils.ts
@@ -452,16 +452,16 @@ export async function updateDraftRectangleAligned({
   sketchId,
   draft,
   mode,
-  origin,
-  point,
+  startPoint,
+  currentPoint,
 }: {
   rustContext: RustContext
   kclManager: KclManager
   sketchId: number
   draft: RectDraftIds
   mode: Extract<RectOriginMode, 'corner' | 'center'>
-  origin: Coords2d
-  point: Coords2d
+  startPoint: Coords2d
+  currentPoint: Coords2d
 }): Promise<{
   kclSource: SourceDelta
   sceneGraphDelta: SceneGraphDelta
@@ -479,8 +479,8 @@ export async function updateDraftRectangleAligned({
     units,
     corners: getAlignedRectangleCorners({
       mode,
-      origin,
-      point,
+      origin: startPoint,
+      point: currentPoint,
     }),
   })
 }

--- a/src/machines/sketchSolve/tools/rectUtils.ts
+++ b/src/machines/sketchSolve/tools/rectUtils.ts
@@ -451,16 +451,17 @@ export async function updateDraftRectangleAligned({
   kclManager,
   sketchId,
   draft,
-  rect,
+  mode,
+  origin,
+  point,
 }: {
   rustContext: RustContext
   kclManager: KclManager
   sketchId: number
   draft: RectDraftIds
-  rect: {
-    min: Coords2d
-    max: Coords2d
-  }
+  mode: Extract<RectOriginMode, 'corner' | 'center'>
+  origin: Coords2d
+  point: Coords2d
 }): Promise<{
   kclSource: SourceDelta
   sceneGraphDelta: SceneGraphDelta
@@ -476,8 +477,45 @@ export async function updateDraftRectangleAligned({
     settings,
     draft,
     units,
-    corners: getAxisAlignedRectangleCorners(rect),
+    corners: getAlignedRectangleCorners({
+      mode,
+      origin,
+      point,
+    }),
   })
+}
+
+function getAlignedRectangleCorners({
+  mode,
+  origin,
+  point,
+}: {
+  mode: Extract<RectOriginMode, 'corner' | 'center'>
+  origin: Coords2d
+  point: Coords2d
+}): {
+  start1: Coords2d
+  start2: Coords2d
+  start3: Coords2d
+  start4: Coords2d
+} {
+  if (mode === 'center') {
+    const halfWidth = Math.abs(point[0] - origin[0])
+    const halfHeight = Math.abs(point[1] - origin[1])
+    return getAxisAlignedRectangleCorners({
+      min: [origin[0] - halfWidth, origin[1] - halfHeight],
+      max: [origin[0] + halfWidth, origin[1] + halfHeight],
+    })
+  }
+
+  // Keep the first clicked corner pinned to start1 so snap constraints stay on
+  // the user-selected corner even when the drag crosses into another quadrant.
+  return {
+    start1: origin,
+    start2: [point[0], origin[1]],
+    start3: point,
+    start4: [origin[0], point[1]],
+  }
 }
 
 function getAxisAlignedRectangleCorners(rect: {


### PR DESCRIPTION
Fixes an untracked (I believe) issue logged by @cgoates [here in Slack](https://kittycadworkspace.slack.com/archives/C06L2RHP9SL/p1776461352621619).

## Demo

https://github.com/user-attachments/assets/a3a309b0-f3f4-4dba-8828-923a21ac2380

