### PR TITLE
KCL Python: zoom-to-fit is optional

### DIFF
--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -291,6 +291,7 @@ pub struct ExecOutcome {
 /// Per-segment freedom used by the constraint report. Mirrors
 /// [`crate::front::Freedom`] but adds an `Error` variant for when
 /// a point lookup fails.
+#[cfg_attr(not(feature = "artifact-graph"), expect(dead_code))]
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum SegmentFreedom {
     Free,

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -232,7 +232,6 @@ pub(super) struct ModuleState {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct SketchBlockState {
     pub sketch_vars: Vec<KclValue>,
-    #[cfg(feature = "artifact-graph")]
     pub sketch_id: Option<ObjectId>,
     #[cfg(feature = "artifact-graph")]
     pub sketch_constraints: Vec<ObjectId>,

--- a/rust/kcl-lib/src/std/constraints.rs
+++ b/rust/kcl-lib/src/std/constraints.rs
@@ -3400,6 +3400,7 @@ impl AxisConstraintKind {
 struct AxisLineVars {
     start: [SketchVarId; 2],
     end: [SketchVarId; 2],
+    #[cfg_attr(not(feature = "artifact-graph"), expect(dead_code))]
     object_id: ObjectId,
 }
 

--- a/rust/kcl-python-bindings/kcl.pyi
+++ b/rust/kcl-python-bindings/kcl.pyi
@@ -828,12 +828,12 @@ async def execute_and_measure(path:builtins.str, request:PhysicalPropertiesReque
     Execute a kcl file and measure physical properties of the resulting model.
     """
 
-async def execute_and_snapshot(path:builtins.str, image_format:ImageFormat) -> builtins.list[builtins.int]:
+async def execute_and_snapshot(path:builtins.str, image_format:ImageFormat, *, zoom:builtins.bool=True) -> builtins.list[builtins.int]:
     r"""
     Execute a kcl file and snapshot it in a specific format.
     """
 
-async def execute_and_snapshot_views(path:builtins.str, image_format:ImageFormat, snapshot_options:typing.Sequence[SnapshotOptions]) -> builtins.list[builtins.list[builtins.int]]: ...
+async def execute_and_snapshot_views(path:builtins.str, image_format:ImageFormat, snapshot_options:typing.Sequence[SnapshotOptions], *, zoom:builtins.bool=True) -> builtins.list[builtins.list[builtins.int]]: ...
 
 async def execute_code(code:builtins.str) -> None:
     r"""
@@ -855,12 +855,12 @@ async def execute_code_and_measure(code:builtins.str, request:PhysicalProperties
     Execute the kcl code and measure physical properties of the resulting model.
     """
 
-async def execute_code_and_snapshot(code:builtins.str, image_format:ImageFormat) -> builtins.list[builtins.int]:
+async def execute_code_and_snapshot(code:builtins.str, image_format:ImageFormat, *, zoom:builtins.bool=True) -> builtins.list[builtins.int]:
     r"""
     Execute the kcl code and snapshot it in a specific format.
     """
 
-async def execute_code_and_snapshot_views(code:builtins.str, image_format:ImageFormat, snapshot_options:typing.Sequence[SnapshotOptions]) -> builtins.list[builtins.list[builtins.int]]:
+async def execute_code_and_snapshot_views(code:builtins.str, image_format:ImageFormat, snapshot_options:typing.Sequence[SnapshotOptions], *, zoom:builtins.bool=True) -> builtins.list[builtins.list[builtins.int]]:
     r"""
     Execute the kcl code and snapshot it in a specific format.
     Returns one image for each camera angle you provide.
@@ -887,9 +887,9 @@ async def get_sketch_constraint_status_code(code:builtins.str) -> SketchConstrai
     Execute kcl code and return a report of sketch constraint status.
     """
 
-async def import_and_snapshot(filepaths:typing.Sequence[builtins.str], format:InputFormat3d, image_format:ImageFormat) -> builtins.list[builtins.int]: ...
+async def import_and_snapshot(filepaths:typing.Sequence[builtins.str], format:InputFormat3d, image_format:ImageFormat, *, zoom:builtins.bool=True) -> builtins.list[builtins.int]: ...
 
-async def import_and_snapshot_views(filepaths:typing.Sequence[builtins.str], format:InputFormat3d, image_format:ImageFormat, snapshot_options:typing.Sequence[SnapshotOptions]) -> builtins.list[builtins.list[builtins.int]]: ...
+async def import_and_snapshot_views(filepaths:typing.Sequence[builtins.str], format:InputFormat3d, image_format:ImageFormat, snapshot_options:typing.Sequence[SnapshotOptions], *, zoom:builtins.bool=True) -> builtins.list[builtins.list[builtins.int]]: ...
 
 def lint(code:builtins.str) -> builtins.list[Discovered]:
     r"""

--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -450,7 +450,7 @@ async fn get_sketch_constraint_status_code(code: String) -> PyResult<SketchConst
 }
 
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction]
+#[pyfunction(signature = (filepaths, format, image_format, *, zoom=true))]
 async fn import_and_snapshot(
     filepaths: Vec<String>,
     format: InputFormat3d,
@@ -478,7 +478,7 @@ fn relevant_file_extensions() -> PyResult<Vec<String>> {
 }
 
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction]
+#[pyfunction(signature = (filepaths, format, image_format, snapshot_options, *, zoom=true))]
 async fn import_and_snapshot_views(
     filepaths: Vec<String>,
     format: InputFormat3d,
@@ -540,7 +540,7 @@ async fn import(ctx: &ExecutorContext, filepaths: Vec<String>, format: InputForm
 
 /// Execute a kcl file and snapshot it in a specific format.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction]
+#[pyfunction(signature = (path, image_format, *, zoom=true))]
 async fn execute_and_snapshot(path: String, image_format: ImageFormat, zoom: bool) -> PyResult<Vec<u8>> {
     let img = execute_and_snapshot_views(path, image_format, Vec::new(), zoom)
         .await?
@@ -549,7 +549,7 @@ async fn execute_and_snapshot(path: String, image_format: ImageFormat, zoom: boo
 }
 
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction]
+#[pyfunction(signature = (path, image_format, snapshot_options, *, zoom=true))]
 async fn execute_and_snapshot_views(
     path: String,
     image_format: ImageFormat,
@@ -564,7 +564,7 @@ async fn execute_and_snapshot_views(
 
 /// Execute the kcl code and snapshot it in a specific format.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction]
+#[pyfunction(signature = (code, image_format, *, zoom=true))]
 async fn execute_code_and_snapshot(code: String, image_format: ImageFormat, zoom: bool) -> PyResult<Vec<u8>> {
     let mut snaps = execute_code_and_snapshot_views(code, image_format, Vec::new(), zoom).await?;
     Ok(snaps.pop().unwrap())
@@ -645,7 +645,7 @@ impl SnapshotOptions {
 /// Returns one image for each camera angle you provide.
 /// If you don't provide any camera angles, a default head-on camera angle will be used.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
-#[pyfunction]
+#[pyfunction(signature = (code, image_format, snapshot_options, *, zoom=true))]
 async fn execute_code_and_snapshot_views(
     code: String,
     image_format: ImageFormat,

--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -272,9 +272,10 @@ async fn execute_and_snapshot_views_impl(
     input: KclInput,
     image_format: ImageFormat,
     snapshot_options: Vec<SnapshotOptions>,
+    zoom: bool,
 ) -> PyResult<Vec<Vec<u8>>> {
     let ExecutedKcl { ctx, .. } = run_kcl(input, false).await?;
-    let result = take_snaps(&ctx, image_format, snapshot_options).await;
+    let result = take_snaps(&ctx, image_format, snapshot_options, zoom).await;
     ctx.close().await;
     result
 }
@@ -454,8 +455,9 @@ async fn import_and_snapshot(
     filepaths: Vec<String>,
     format: InputFormat3d,
     image_format: ImageFormat,
+    zoom: bool,
 ) -> PyResult<Vec<u8>> {
-    let img = import_and_snapshot_views(filepaths, format, image_format, Vec::new())
+    let img = import_and_snapshot_views(filepaths, format, image_format, Vec::new(), zoom)
         .await?
         .pop();
     Ok(img.unwrap())
@@ -482,11 +484,12 @@ async fn import_and_snapshot_views(
     format: InputFormat3d,
     image_format: ImageFormat,
     snapshot_options: Vec<SnapshotOptions>,
+    zoom: bool,
 ) -> PyResult<Vec<Vec<u8>>> {
     spawn_py(async move {
         let (ctx, _state) = new_context_state(None, false).await.map_err(to_py_exception)?;
         import(&ctx, filepaths, format).await?;
-        let result = take_snaps(&ctx, image_format, snapshot_options).await;
+        let result = take_snaps(&ctx, image_format, snapshot_options, zoom).await;
         ctx.close().await;
         result
     })
@@ -538,8 +541,10 @@ async fn import(ctx: &ExecutorContext, filepaths: Vec<String>, format: InputForm
 /// Execute a kcl file and snapshot it in a specific format.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
 #[pyfunction]
-async fn execute_and_snapshot(path: String, image_format: ImageFormat) -> PyResult<Vec<u8>> {
-    let img = execute_and_snapshot_views(path, image_format, Vec::new()).await?.pop();
+async fn execute_and_snapshot(path: String, image_format: ImageFormat, zoom: bool) -> PyResult<Vec<u8>> {
+    let img = execute_and_snapshot_views(path, image_format, Vec::new(), zoom)
+        .await?
+        .pop();
     Ok(img.unwrap())
 }
 
@@ -549,16 +554,19 @@ async fn execute_and_snapshot_views(
     path: String,
     image_format: ImageFormat,
     snapshot_options: Vec<SnapshotOptions>,
+    zoom: bool,
 ) -> PyResult<Vec<Vec<u8>>> {
-    spawn_py(async move { execute_and_snapshot_views_impl(KclInput::Path(path), image_format, snapshot_options).await })
-        .await
+    spawn_py(async move {
+        execute_and_snapshot_views_impl(KclInput::Path(path), image_format, snapshot_options, zoom).await
+    })
+    .await
 }
 
 /// Execute the kcl code and snapshot it in a specific format.
 #[pyo3_stub_gen::derive::gen_stub_pyfunction]
 #[pyfunction]
-async fn execute_code_and_snapshot(code: String, image_format: ImageFormat) -> PyResult<Vec<u8>> {
-    let mut snaps = execute_code_and_snapshot_views(code, image_format, Vec::new()).await?;
+async fn execute_code_and_snapshot(code: String, image_format: ImageFormat, zoom: bool) -> PyResult<Vec<u8>> {
+    let mut snaps = execute_code_and_snapshot_views(code, image_format, Vec::new(), zoom).await?;
     Ok(snaps.pop().unwrap())
 }
 
@@ -642,18 +650,22 @@ async fn execute_code_and_snapshot_views(
     code: String,
     image_format: ImageFormat,
     snapshot_options: Vec<SnapshotOptions>,
+    zoom: bool,
 ) -> PyResult<Vec<Vec<u8>>> {
-    spawn_py(async move { execute_and_snapshot_views_impl(KclInput::Code(code), image_format, snapshot_options).await })
-        .await
+    spawn_py(async move {
+        execute_and_snapshot_views_impl(KclInput::Code(code), image_format, snapshot_options, zoom).await
+    })
+    .await
 }
 
 async fn take_snaps(
     ctx: &ExecutorContext,
     image_format: ImageFormat,
     snapshot_options: Vec<SnapshotOptions>,
+    zoom: bool,
 ) -> PyResult<Vec<Vec<u8>>> {
     if snapshot_options.is_empty() {
-        let data_bytes = snapshot(ctx, image_format, 0.1).await?;
+        let data_bytes = snapshot(ctx, image_format, 0.1, zoom).await?;
         return Ok(vec![data_bytes]);
     }
 
@@ -671,13 +683,13 @@ async fn take_snaps(
                 .send_modeling_cmd(uuid::Uuid::new_v4(), Default::default(), &view_cmd)
                 .await?;
         }
-        let data_bytes = snapshot(ctx, image_format, pre_snap.padding).await?;
+        let data_bytes = snapshot(ctx, image_format, pre_snap.padding, zoom).await?;
         snaps.push(data_bytes);
     }
     Ok(snaps)
 }
 
-async fn snapshot(ctx: &ExecutorContext, image_format: ImageFormat, padding: f32) -> PyResult<Vec<u8>> {
+async fn snapshot(ctx: &ExecutorContext, image_format: ImageFormat, padding: f32, zoom: bool) -> PyResult<Vec<u8>> {
     // Set orthographic projection
     ctx.engine
         .send_modeling_cmd(
@@ -690,19 +702,21 @@ async fn snapshot(ctx: &ExecutorContext, image_format: ImageFormat, padding: f32
         .await?;
 
     // Zoom to fit.
-    ctx.engine
-        .send_modeling_cmd(
-            uuid::Uuid::new_v4(),
-            kcl_lib::SourceRange::default(),
-            &kittycad_modeling_cmds::ModelingCmd::ZoomToFit(
-                kittycad_modeling_cmds::ZoomToFit::builder()
-                    .padding(padding)
-                    .animated(false)
-                    .object_ids(Default::default())
-                    .build(),
-            ),
-        )
-        .await?;
+    if zoom {
+        ctx.engine
+            .send_modeling_cmd(
+                uuid::Uuid::new_v4(),
+                kcl_lib::SourceRange::default(),
+                &kittycad_modeling_cmds::ModelingCmd::ZoomToFit(
+                    kittycad_modeling_cmds::ZoomToFit::builder()
+                        .padding(padding)
+                        .animated(false)
+                        .object_ids(Default::default())
+                        .build(),
+                ),
+            )
+            .await?;
+    }
 
     // Send a snapshot request to the engine.
     let resp = ctx

--- a/rust/kcl-python-bindings/tests/tests.py
+++ b/rust/kcl-python-bindings/tests/tests.py
@@ -228,7 +228,9 @@ async def test_kcl_execute_dir_assembly():
 @pytest.mark.asyncio
 async def test_kcl_execute_and_snapshot():
     # Read from a file.
-    image_bytes = await kcl.execute_and_snapshot(lego_file, kcl.ImageFormat.Jpeg)
+    image_bytes = await kcl.execute_and_snapshot(
+        lego_file, kcl.ImageFormat.Jpeg, zoom=False
+    )
     assert image_bytes is not None
     assert len(image_bytes) > 0
 


### PR DESCRIPTION
Make zoom-to-fit optional and default to true. Disable it via `zoom=False`.