### PR TITLE
Fix Dvorak (and prob other keyboard) handling

### DIFF
--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -34,7 +34,10 @@ import {
   modelingMachineStateToToolbarModeName,
   useToolbarConfig,
 } from '@src/lib/toolbar'
-import { collectToolbarHotkeyActions } from '@src/lib/toolbarHotkeys'
+import {
+  collectToolbarHotkeyActions,
+  isToolbarHotkeyCompatibleWithEventKey,
+} from '@src/lib/toolbarHotkeys'
 import { EngineConnectionStateType } from '@src/network/utils'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { useSignals } from '@preact/signals-react/runtime'
@@ -334,7 +337,16 @@ const Toolbar_ = memo(
 
     useHotkeys(
       hotkeyActions.map((action) => action.hotkey),
-      (_, hotkeysEvent) => {
+      (keyboardEvent, hotkeysEvent) => {
+        if (
+          !isToolbarHotkeyCompatibleWithEventKey(
+            keyboardEvent.key,
+            hotkeysEvent.hotkey
+          )
+        ) {
+          return
+        }
+
         hotkeyActionMap.get(hotkeysEvent.hotkey)?.onTrigger()
       },
       { enabled: hotkeyActions.length > 0 },

--- a/src/lib/toolbarHotkeys.spec.ts
+++ b/src/lib/toolbarHotkeys.spec.ts
@@ -5,7 +5,10 @@ import type {
   ToolbarItemResolved,
   ToolbarItemResolvedDropdown,
 } from '@src/lib/toolbar'
-import { collectToolbarHotkeyActions } from '@src/lib/toolbarHotkeys'
+import {
+  collectToolbarHotkeyActions,
+  isToolbarHotkeyCompatibleWithEventKey,
+} from '@src/lib/toolbarHotkeys'
 
 function makeResolvedItem(
   overrides: Partial<ToolbarItemResolved> = {}
@@ -146,5 +149,16 @@ describe('collectToolbarHotkeyActions', () => {
     ])
 
     expect(hotkeyActions.map((action) => action.hotkey)).toEqual(['E'])
+  })
+
+  it('matches letter hotkeys against the semantic event key', () => {
+    expect(isToolbarHotkeyCompatibleWithEventKey('v', 'V')).toBe(true)
+    expect(isToolbarHotkeyCompatibleWithEventKey('V', 'Shift+V')).toBe(true)
+    expect(isToolbarHotkeyCompatibleWithEventKey('k', 'V')).toBe(false)
+  })
+
+  it('does not add extra filtering for non-letter hotkeys', () => {
+    expect(isToolbarHotkeyCompatibleWithEventKey('.', '.')).toBe(true)
+    expect(isToolbarHotkeyCompatibleWithEventKey('Escape', 'Esc')).toBe(true)
   })
 })

--- a/src/lib/toolbarHotkeys.ts
+++ b/src/lib/toolbarHotkeys.ts
@@ -16,6 +16,30 @@ export type ToolbarHotkeyAction = {
   onTrigger: () => void
 }
 
+const TOOLBAR_HOTKEY_MODIFIERS = new Set([
+  'alt',
+  'ctrl',
+  'meta',
+  'mod',
+  'shift',
+])
+
+export function isToolbarHotkeyCompatibleWithEventKey(
+  eventKey: string,
+  hotkey: string
+): boolean {
+  const mainKey = hotkey
+    .split('+')
+    .map((part) => part.trim().toLowerCase())
+    .find((part) => !TOOLBAR_HOTKEY_MODIFIERS.has(part))
+
+  if (!mainKey || !/^[a-z]$/.test(mainKey)) {
+    return true
+  }
+
+  return eventKey.toLowerCase() === mainKey
+}
+
 export function collectToolbarHotkeyActions(
   items: ResolvedToolbarEntry[]
 ): ToolbarHotkeyAction[] {


### PR DESCRIPTION
On dvorak `v` maps to qwerty `.`, and with our current `a-z` filter it just gets ignored. There is possibly more nuance to this that I'm missing, but minimally I'd expect this specific shortcut to not break on dvorak!