### PR TITLE
KCL: Gear functions should tolerate units better

### DIFF
--- a/rust/kcl-lib/e2e/executor/inputs/gear_units.kcl
+++ b/rust/kcl-lib/e2e/executor/inputs/gear_units.kcl
@@ -1,0 +1,15 @@
+@settings(defaultLengthUnit = mm, kclVersion = 1.0, experimentalFeatures = allow)
+
+nTeeth = 24: number(_)
+moduleSize = 2mm
+pressureAngle = 20deg
+helixAngle = 10deg
+gearHeight = 8mm
+
+gearBlank = gear::helical(
+  nTeeth = nTeeth,
+  module = moduleSize,
+  pressureAngle = pressureAngle,
+  helixAngle = helixAngle,
+  gearHeight = gearHeight,
+)

--- a/rust/kcl-lib/e2e/executor/main.rs
+++ b/rust/kcl-lib/e2e/executor/main.rs
@@ -2111,3 +2111,11 @@ async fn kcl_test_exporting_step_file() {
         );
     }
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn kcl_test_gear_with_units() {
+    // This tests export like how we do it in cli and kcl.py.
+    let code = kcl_input!("gear_units");
+
+    let (_, _, _files) = execute_and_export_step(code, None).await.unwrap();
+}

--- a/rust/kcl-lib/std/gear.kcl
+++ b/rust/kcl-lib/std/gear.kcl
@@ -9,8 +9,10 @@ fn gearProfile(nTeeth: number(Count), module: number(Length), pressureAngle: num
   baseRadius = baseDiameter / 2
   tipDiameter = pitchDiameter + 2 * module
 
+  // `acos` requires an explicitly unitless ratio when the lengths carry concrete units.
+  helixRatio = (offsetHeight * tan(helixAngle) / (tipDiameter / 2)): number(_)
   // Calculate the amount to rotate each planar sketch of the gear given the gear helix angle and total gear height
-  helixCalc = acos(offsetHeight * tan(helixAngle) / (tipDiameter / 2))
+  helixCalc = acos(helixRatio)
 
   // Using the gear parameters, sketch an involute tooth spanning from the base diameter to the tip diameter
   return startSketchOn(offsetPlane(XY, offset = offsetHeight))
@@ -106,8 +108,9 @@ export fn helical(nTeeth: number(Count),
   baseRadius = baseDiameter / 2
   tipDiameter = pitchDiameter + 2 * module
 
-  // Compute twist angle so the tooth helix matches helixAngle over the gear height
-  twistAngle = 360 * gearHeight * tan(helixAngle) / (3.14 * pitchDiameter)
+  // Compute twist angle so the tooth helix matches helixAngle over the gear height.
+  heightToPitchRatio = (gearHeight / pitchDiameter): number(_)
+  twistAngle = (360deg * heightToPitchRatio * tan(helixAngle) / PI): number(deg)
 
   helicalGear = gearProfile(nTeeth, module, pressureAngle, helixAngle, offsetHeight = 0)
     |> extrude(length = gearHeight, twistAngle, twistAngleStep = 0)

--- a/rust/kcl-lib/tests/kcl_samples/planetary-gearset/artifact_commands.snap
+++ b/rust/kcl-lib/tests/kcl_samples/planetary-gearset/artifact_commands.snap
@@ -606,7 +606,7 @@ description: Artifact commands planetary-gearset.kcl
         },
         "total_rotation_angle": {
           "unit": "degrees",
-          "value": 14.850562361624158
+          "value": 14.843033759394757
         },
         "angle_step_size": {
           "unit": "degrees",
@@ -895,7 +895,7 @@ description: Artifact commands planetary-gearset.kcl
         },
         "total_rotation_angle": {
           "unit": "degrees",
-          "value": -14.850562361624158
+          "value": -14.843033759394757
         },
         "angle_step_size": {
           "unit": "degrees",

--- a/rust/kcl-lib/tests/kcl_samples/planetary-gearset/artifact_graph_flowchart.snap.md
+++ b/rust/kcl-lib/tests/kcl_samples/planetary-gearset/artifact_graph_flowchart.snap.md
@@ -114,12 +114,12 @@ flowchart LR
   62["SweepEdge Adjacent"]
   63["SweepEdge Opposite"]
   64["SweepEdge Adjacent"]
-  65["StartSketchOnPlane<br>[756, 809, 15]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 7 }, ReturnStatementArg, PipeBodyItem { index: 0 }]
-  66["StartSketchOnPlane<br>[756, 809, 15]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 7 }, ReturnStatementArg, PipeBodyItem { index: 0 }]
-  67["StartSketchOnPlane<br>[756, 809, 15]"]
-    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 7 }, ReturnStatementArg, PipeBodyItem { index: 0 }]
+  65["StartSketchOnPlane<br>[884, 937, 15]"]
+    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 8 }, ReturnStatementArg, PipeBodyItem { index: 0 }]
+  66["StartSketchOnPlane<br>[884, 937, 15]"]
+    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 8 }, ReturnStatementArg, PipeBodyItem { index: 0 }]
+  67["StartSketchOnPlane<br>[884, 937, 15]"]
+    %% [ProgramBodyItem { index: 0 }, VariableDeclarationDeclaration, VariableDeclarationInit, FunctionExpressionBody, FunctionExpressionBodyItem { index: 8 }, ReturnStatementArg, PipeBodyItem { index: 0 }]
   1 --- 2
   1 <--x 65
   2 --- 3

--- a/rust/kcl-lib/tests/kcl_samples/planetary-gearset/program_memory.snap
+++ b/rust/kcl-lib/tests/kcl_samples/planetary-gearset/program_memory.snap
@@ -24,10 +24,10 @@ description: Variables in memory after executing planetary-gearset.kcl
           "id": "[uuid]",
           "sourceRange": [],
           "tag": {
-            "commentStart": 1035,
-            "end": 1041,
+            "commentStart": 1163,
+            "end": 1169,
             "moduleId": 15,
-            "start": 1035,
+            "start": 1163,
             "type": "TagDeclarator",
             "value": "seg01"
           },
@@ -70,10 +70,10 @@ description: Variables in memory after executing planetary-gearset.kcl
               8.732661536483969
             ],
             "tag": {
-              "commentStart": 1035,
-              "end": 1041,
+              "commentStart": 1163,
+              "end": 1169,
               "moduleId": 15,
-              "start": 1035,
+              "start": 1163,
               "type": "TagDeclarator",
               "value": "seg01"
             },


### PR DESCRIPTION
ZK found a problem, where units of measurement could interfere with the gear function. Thanks @jacebrowning for reporting and giving me all the context I needed to fix it.

First commit adds a failing test. Second commit makes the test pass.