### PR TITLE
Refactor `useOnPageIdle` to consider `kclManager.isExecuting`

### DIFF
--- a/src/hooks/network/useOnPageIdle.spec.tsx
+++ b/src/hooks/network/useOnPageIdle.spec.tsx
@@ -1,0 +1,143 @@
+import { renderHook, act } from '@testing-library/react'
+import { beforeEach, afterEach, describe, expect, test, vi } from 'vitest'
+
+const hookMocks = vi.hoisted(() => {
+  const state = {
+    streamIdleMode: 5_000,
+    modelingValue: 'idle',
+    kclManager: null as any,
+  }
+
+  return {
+    state,
+    useApp: () => ({
+      settings: {
+        useSettings: () => ({
+          app: {
+            streamIdleMode: {
+              current: state.streamIdleMode,
+            },
+          },
+        }),
+      },
+    }),
+    useSingletons: () => ({
+      kclManager: state.kclManager,
+    }),
+    useModelingContext: () => ({
+      state: {
+        matches: (value: string) => value === state.modelingValue,
+      },
+    }),
+  }
+})
+
+vi.mock('@src/lib/boot', () => ({
+  useApp: hookMocks.useApp,
+  useSingletons: hookMocks.useSingletons,
+}))
+
+vi.mock('@src/hooks/useModelingContext', () => ({
+  useModelingContext: hookMocks.useModelingContext,
+}))
+
+import { useOnPageIdle } from '@src/hooks/network/useOnPageIdle'
+
+async function advance(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms)
+  })
+}
+
+describe('useOnPageIdle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    hookMocks.state.streamIdleMode = 5_000
+    hookMocks.state.modelingValue = 'idle'
+    hookMocks.state.kclManager = {
+      isExecuting: false,
+      sceneInfra: {
+        camControls: {
+          saveRemoteCameraState: vi.fn().mockResolvedValue(undefined),
+          clearOldCameraState: vi.fn(),
+          oldCameraState: null,
+        },
+      },
+      engineCommandManager: {
+        tearDown: vi.fn(),
+      },
+    }
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+  })
+
+  test('does not disconnect while KCL is executing', async () => {
+    hookMocks.state.kclManager.isExecuting = true
+
+    const startCallback = vi.fn()
+    const idleCallback = vi.fn()
+
+    const { unmount } = renderHook(() =>
+      useOnPageIdle({
+        startCallback,
+        idleCallback,
+      })
+    )
+
+    await advance(30_000)
+
+    expect(
+      hookMocks.state.kclManager.sceneInfra.camControls.saveRemoteCameraState
+    ).not.toHaveBeenCalled()
+    expect(
+      hookMocks.state.kclManager.engineCommandManager.tearDown
+    ).not.toHaveBeenCalled()
+    expect(idleCallback).not.toHaveBeenCalled()
+
+    unmount()
+  })
+
+  test('starts the idle countdown only after KCL finishes executing', async () => {
+    const startCallback = vi.fn()
+    const idleCallback = vi.fn()
+
+    const { unmount } = renderHook(() =>
+      useOnPageIdle({
+        startCallback,
+        idleCallback,
+      })
+    )
+
+    await advance(4_000)
+    expect(
+      hookMocks.state.kclManager.engineCommandManager.tearDown
+    ).not.toHaveBeenCalled()
+
+    hookMocks.state.kclManager.isExecuting = true
+    await advance(10_000)
+    expect(
+      hookMocks.state.kclManager.engineCommandManager.tearDown
+    ).not.toHaveBeenCalled()
+
+    hookMocks.state.kclManager.isExecuting = false
+    await advance(5_000)
+    expect(
+      hookMocks.state.kclManager.engineCommandManager.tearDown
+    ).not.toHaveBeenCalled()
+
+    await advance(1_000)
+
+    expect(
+      hookMocks.state.kclManager.sceneInfra.camControls.saveRemoteCameraState
+    ).toHaveBeenCalledTimes(1)
+    expect(
+      hookMocks.state.kclManager.engineCommandManager.tearDown
+    ).toHaveBeenCalledTimes(1)
+    expect(idleCallback).toHaveBeenCalledTimes(1)
+
+    unmount()
+  })
+})

--- a/src/hooks/network/useOnPageIdle.tsx
+++ b/src/hooks/network/useOnPageIdle.tsx
@@ -1,6 +1,5 @@
-import { KclManagerEvents } from '@src/lang/KclManager'
 import { useApp, useSingletons } from '@src/lib/boot'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef } from 'react'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { EngineDebugger } from '@src/lib/debugger'
 
@@ -14,71 +13,78 @@ export const useOnPageIdle = ({
   const { settings } = useApp()
   const { kclManager } = useSingletons()
   const settingsValues = settings.useSettings()
-  const intervalId = useRef<NodeJS.Timeout | null>(null)
-  const [streamIdleMode, setStreamIdleMode] = useState(
-    settingsValues.app.streamIdleMode.current
-  )
+  const streamIdleMode = settingsValues.app.streamIdleMode.current
   const { state: modelingMachineState } = useModelingContext()
-  const IDLE_TIME_MS = Number(streamIdleMode)
-  // When streamIdleMode is changed, setup or teardown the timeouts
+  const intervalId = useRef<NodeJS.Timeout | null>(null)
+  const startCallbackRef = useRef(startCallback)
+  const idleCallbackRef = useRef(idleCallback)
+  const modelingMachineStateRef = useRef(modelingMachineState)
+  const idleTimeMsRef = useRef(Number(streamIdleMode))
+  const wasBusyRef = useRef(false)
   const timeoutStart = useRef<number | null>(null)
 
   useEffect(() => {
-    // When execution takes a long time, it's most likely a user will want to
-    // come back and be able to say, export the model. The issue with this is
-    // that means the application should NOT go into idle mode for a long time!
-    // We've picked 8 hours to coincide with the typical length of a workday.
-    const onLongExecution = () => {
-      setStreamIdleMode(1000 * 60 * 60 * 8)
-    }
-
-    kclManager.addEventListener(KclManagerEvents.LongExecution, onLongExecution)
-
     return () => {
-      kclManager.removeEventListener(
-        KclManagerEvents.LongExecution,
-        onLongExecution
-      )
-
-      // Clear it on page unmounting, not within the loop of dependencies...
       if (intervalId.current) {
         clearInterval(intervalId.current)
         intervalId.current = null
       }
     }
-  }, [kclManager])
+  }, [])
 
   useEffect(() => {
-    timeoutStart.current = streamIdleMode ? Date.now() : null
+    startCallbackRef.current = startCallback
+  }, [startCallback])
+
+  useEffect(() => {
+    idleCallbackRef.current = idleCallback
+  }, [idleCallback])
+
+  useEffect(() => {
+    modelingMachineStateRef.current = modelingMachineState
+  }, [modelingMachineState])
+
+  useEffect(() => {
+    idleTimeMsRef.current = Number(streamIdleMode)
+    timeoutStart.current = idleTimeMsRef.current ? Date.now() : null
   }, [streamIdleMode])
 
   useEffect(() => {
     if (intervalId.current) {
-      // we have a loop running don't clear it!
-      // we know this gets initialized once!
       return
     }
 
     // Check every 1 second to see if you are idle.
     const interval = setInterval(() => {
       void (async () => {
-        // Do not pause if the user is in the middle of an operation
-        if (!modelingMachineState.matches('idle')) {
-          // In fact, stop the timeout, because we don't want to trigger the
-          // pause when we exit the operation.
+        const idleTimeMs = idleTimeMsRef.current
+        if (!idleTimeMs) {
           timeoutStart.current = null
-        } else if (timeoutStart.current) {
+          wasBusyRef.current = false
+          return
+        }
+
+        const isBusy =
+          kclManager.isExecuting ||
+          !modelingMachineStateRef.current.matches('idle')
+
+        // Only start the idle timer once KCL execution and other modeling
+        // interactions have fully finished.
+        if (isBusy) {
+          timeoutStart.current = null
+          wasBusyRef.current = true
+          return
+        }
+
+        if (wasBusyRef.current) {
+          timeoutStart.current = Date.now()
+          wasBusyRef.current = false
+          return
+        }
+
+        if (timeoutStart.current) {
           const elapsed = Date.now() - timeoutStart.current
-          // Don't pause if we're already disconnected.
-          if (
-            // It's unnecessary to once again setup an event listener for
-            // offline/online to capture this state, when this state already
-            // exists on the window.navigator object. In hindsight it makes
-            // me (lee) regret we set React state variables such as
-            // isInternetConnected in other files when we could check this
-            // object instead.
-            elapsed >= IDLE_TIME_MS
-          ) {
+          if (elapsed >= idleTimeMs) {
             timeoutStart.current = null
             try {
               await kclManager.sceneInfra.camControls.saveRemoteCameraState()
@@ -94,38 +100,39 @@ export const useOnPageIdle = ({
             })
             // We do a full tear down at the moment.
             kclManager.engineCommandManager.tearDown()
-            idleCallback()
+            idleCallbackRef.current()
           }
         }
       })()
     }, 1_000)
     intervalId.current = interval
-  }, [
-    IDLE_TIME_MS,
-    idleCallback,
-    modelingMachineState,
-    kclManager.engineCommandManager,
-    kclManager.sceneInfra.camControls,
-  ])
+  }, [kclManager])
 
   useEffect(() => {
-    if (!streamIdleMode) return
+    if (!idleTimeMsRef.current) return
 
     const onAnyInput = () => {
       // Just in case it happens in the middle of the user turning off
       // idle mode.
-      if (!streamIdleMode) {
+      if (!idleTimeMsRef.current) {
         timeoutStart.current = null
         return
       }
-      startCallback()
-      timeoutStart.current = Date.now()
+      startCallbackRef.current()
+      timeoutStart.current =
+        kclManager.isExecuting ||
+        !modelingMachineStateRef.current.matches('idle')
+          ? null
+          : Date.now()
     }
 
     // It's possible after a reconnect, the user doesn't move their mouse at
     // all, meaning the timer is not reset to run. We need to set it every
     // time our effect dependencies change then.
-    timeoutStart.current = Date.now()
+    timeoutStart.current =
+      kclManager.isExecuting || !modelingMachineStateRef.current.matches('idle')
+        ? null
+        : Date.now()
 
     window.document.addEventListener('keydown', onAnyInput)
     window.document.addEventListener('keyup', onAnyInput)
@@ -148,5 +155,5 @@ export const useOnPageIdle = ({
       window.document.removeEventListener('touchend', onAnyInput)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-  }, [streamIdleMode])
+  }, [kclManager, streamIdleMode])
 }


### PR DESCRIPTION
Updates `useOnPageIdle.tsx` so the idle timer no longer counts while KCL is executing. The hook now treats `kclManager.isExecuting` and non-idle modeling-machine states as “busy”, clears the idle clock while busy, and starts the clock fresh when execution/interaction finishes. That makes “5 minutes before idle” mean “5 minutes after execution completes”.

Codex also removed the old long-execution override in that hook, since bumping the timeout to 8 hours after 5 minutes of execution conflicts with the behavior we asked for, and it fixed the stale-closure issue by moving the interval to live refs instead of a one-time closure over old state.