### PR TITLE
Fix broken links in docs to solver module

### DIFF
--- a/docs/kcl-std-legacy/types/std-types-Segment.md
+++ b/docs/kcl-std-legacy/types/std-types-Segment.md
@@ -9,7 +9,7 @@ layout: manual
 
 A segment in a sketch created in a sketch block. It may be a line, arc, point, or other segment type.
 
-See the sketch2 module for functions that create segments and the region function for examples using segments to create a region that can be extruded.
+See the solver module for functions that create segments and the region function for examples using segments to create a region that can be extruded.
 
 
 

--- a/docs/kcl-std-sketch-solve/types/std-types-Segment.md
+++ b/docs/kcl-std-sketch-solve/types/std-types-Segment.md
@@ -9,7 +9,7 @@ layout: manual
 
 A segment in a sketch created in a sketch block. It may be a line, arc, point, or other segment type.
 
-See the sketch2 module for functions that create segments and the region function for examples using segments to create a region that can be extruded.
+See the solver module for functions that create segments and the region function for examples using segments to create a region that can be extruded.
 
 
 

--- a/docs/kcl-std/functions/std-solver-fixed.md
+++ b/docs/kcl-std/functions/std-solver-fixed.md
@@ -13,6 +13,6 @@ solver::fixed
 
 `fixed()` is an alias for `coincident()`. By convention, `fixed()` is used when one of the points is a known location, not solved with constraints and not another point in the sketch.
 
-See [coincident()](/docs/kcl-std/functions/std-sketch2-coincident) for more info.
+See [coincident()](/docs/kcl-std/functions/std-solver-coincident) for more info.
 
 

--- a/docs/kcl-std/types/std-types-Segment.md
+++ b/docs/kcl-std/types/std-types-Segment.md
@@ -9,7 +9,7 @@ layout: manual
 
 A segment in a sketch created in a sketch block. It may be a line, arc, point, or other segment type.
 
-See the [sketch2 module](/docs/kcl-std/modules/std-sketch2) for functions that create segments and the [region function](/docs/kcl-std/functions/std-sketch2-region) for examples using segments to create a region that can be extruded.
+See the [solver module](/docs/kcl-std/modules/std-solver) for functions that create segments and the [region function](/docs/kcl-std/functions/std-sketch-region) for examples using segments to create a region that can be extruded.
 
 
 

--- a/rust/kcl-lib/std/solver.kcl
+++ b/rust/kcl-lib/std/solver.kcl
@@ -462,7 +462,7 @@ export fn midpoint(
 ///
 /// `fixed()` is an alias for `coincident()`. By convention, `fixed()` is used when one of the points is a known location, not solved with constraints and not another point in the sketch.
 ///
-/// See [coincident()](/docs/kcl-std/functions/std-sketch2-coincident) for more info.
+/// See [coincident()](/docs/kcl-std/functions/std-solver-coincident) for more info.
 @(doc_category = "functions")
 export fixed = coincident
 

--- a/rust/kcl-lib/std/types.kcl
+++ b/rust/kcl-lib/std/types.kcl
@@ -223,7 +223,7 @@ export type Plane
 
 /// A segment in a sketch created in a sketch block. It may be a line, arc, point, or other segment type.
 ///
-/// See the [sketch2 module](/docs/kcl-std/modules/std-sketch2) for functions that create segments and the [region function](/docs/kcl-std/functions/std-sketch2-region) for examples using segments to create a region that can be extruded.
+/// See the [solver module](/docs/kcl-std/modules/std-solver) for functions that create segments and the [region function](/docs/kcl-std/functions/std-sketch-region) for examples using segments to create a region that can be extruded.
 @(impl = std_rust_constrainable, experimental = true)
 export type Segment
 


### PR DESCRIPTION
Thanks to https://github.com/KittyCAD/documentation/pull/858.