### PR TITLE
Eject users from sketch solve mode when Zookeeper makes updates

### DIFF
--- a/src/components/OpenedProject.tsx
+++ b/src/components/OpenedProject.tsx
@@ -1,12 +1,8 @@
-import type { Project } from '@src/lib/project'
-import { useSelector } from '@xstate/react'
-import { useEffect, useMemo, useState } from 'react'
-import toast from 'react-hot-toast'
-import { useHotkeys } from 'react-hotkeys-hook'
-import ModalContainer from 'react-modal-promise'
-import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
+import { useSignalEffect } from '@preact/signals-react'
+import { useSignals } from '@preact/signals-react/runtime'
 import { AppHeader } from '@src/components/AppHeader'
 import { CommandBarOpenButton } from '@src/components/CommandBarOpenButton'
+import { ExperimentalFeaturesMenu } from '@src/components/ExperimentalFeaturesMenu'
 import { useLspContext } from '@src/components/LspProvider'
 import { useNetworkHealthStatus } from '@src/components/NetworkHealthIndicator'
 import { useNetworkMachineStatus } from '@src/components/NetworkMachineIndicator'
@@ -19,12 +15,16 @@ import {
 } from '@src/components/StatusBar/defaultStatusBarItems'
 import type { StatusBarItemType } from '@src/components/StatusBar/statusBarTypes'
 import { UndoRedoButtons } from '@src/components/UndoRedoButtons'
+import { UnitsMenu } from '@src/components/UnitsMenu'
 import { WasmErrToast } from '@src/components/WasmErrToast'
+import { ZookeeperCreditsMenu } from '@src/components/ZookeeperCreditsMenu'
+import { getMlEphantProjectReloadBehavior } from '@src/components/openedProjectUtils'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
 import { useEngineConnectionSubscriptions } from '@src/hooks/useEngineConnectionSubscriptions'
 import { useHotKeyListener } from '@src/hooks/useHotKeyListener'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { useQueryParamEffects } from '@src/hooks/useQueryParamEffects'
+import { useApp, useSingletons } from '@src/lib/boot'
 import {
   DEFAULT_EXPERIMENTAL_FEATURES,
   ONBOARDING_TOAST_ID,
@@ -32,40 +32,41 @@ import {
 } from '@src/lib/constants'
 import useHotkeyWrapper from '@src/lib/hotkeyWrapper'
 import { isDesktop } from '@src/lib/isDesktop'
+import { isMobile } from '@src/lib/isMobile'
+import {
+  DefaultLayoutPaneID,
+  LayoutRootNode,
+  defaultLayout,
+  getOpenPanes,
+} from '@src/lib/layout'
+import { useDefaultActionLibrary } from '@src/lib/layout/defaultActionLibrary'
+import { useDefaultAreaLibrary } from '@src/lib/layout/defaultAreaLibrary'
 import { PATHS } from '@src/lib/paths'
+import type { Project } from '@src/lib/project'
+import { resetCameraPosition } from '@src/lib/resetCameraPosition'
 import { getSelectionTypeDisplayText } from '@src/lib/selections'
-import { useApp, useSingletons } from '@src/lib/boot'
 import { maybeWriteToDisk } from '@src/lib/telemetry'
 import { reportRejection } from '@src/lib/trap'
 import { withSiteBaseURL } from '@src/lib/withBaseURL'
 import { xStateValueToString } from '@src/lib/xStateValueToString'
 import { BillingTransition } from '@src/machines/billingMachine'
 import {
-  TutorialRequestToast,
-  useApplyRememberedOnboardingWorkflow,
-  needsToOnboard,
-} from '@src/routes/Onboarding/utils'
-import { SystemIOMachineStates } from '@src/machines/systemIO/utils'
-import {
-  defaultLayout,
-  DefaultLayoutPaneID,
-  getOpenPanes,
-  LayoutRootNode,
-} from '@src/lib/layout'
-import { useDefaultAreaLibrary } from '@src/lib/layout/defaultAreaLibrary'
-import { useDefaultActionLibrary } from '@src/lib/layout/defaultActionLibrary'
-import {
   MlEphantManagerReactContext,
   MlEphantManagerTransitions,
 } from '@src/machines/mlEphantManagerMachine'
-import { useSignalEffect } from '@preact/signals-react'
-import { UnitsMenu } from '@src/components/UnitsMenu'
-import { ExperimentalFeaturesMenu } from '@src/components/ExperimentalFeaturesMenu'
-import { ZookeeperCreditsMenu } from '@src/components/ZookeeperCreditsMenu'
-import { resetCameraPosition } from '@src/lib/resetCameraPosition'
-import { useSignals } from '@preact/signals-react/runtime'
-import { isMobile } from '@src/lib/isMobile'
 import { useFolders, useLastOperation } from '@src/machines/systemIO/hooks'
+import { SystemIOMachineStates } from '@src/machines/systemIO/utils'
+import {
+  TutorialRequestToast,
+  needsToOnboard,
+  useApplyRememberedOnboardingWorkflow,
+} from '@src/routes/Onboarding/utils'
+import { useSelector } from '@xstate/react'
+import { useEffect, useMemo, useState } from 'react'
+import toast from 'react-hot-toast'
+import { useHotkeys } from 'react-hotkeys-hook'
+import ModalContainer from 'react-modal-promise'
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 
 if (window.electron) {
   maybeWriteToDisk(window.electron)
@@ -81,7 +82,7 @@ export function OpenedProject() {
   const getSettings = settings.get
   const defaultAreaLibrary = useDefaultAreaLibrary()
   const defaultActionLibrary = useDefaultActionLibrary()
-  const { state: modelingState } = useModelingContext()
+  const { state: modelingState, send: modelingSend } = useModelingContext()
   useQueryParamEffects(kclManager)
   const [nativeFileMenuCreated, setNativeFileMenuCreated] = useState(false)
   const mlEphantManagerActor2 = MlEphantManagerReactContext.useActorRef()
@@ -130,21 +131,36 @@ export function OpenedProject() {
   // ZOOKEEPER BEHAVIOR EXCEPTION
   // Only fires on state changes, to deal with Zookeeper control.
   useEffect(() => {
-    if (systemIOState !== 'idle') return
-    if (kclManager.mlEphantManagerMachineBulkManipulatingFileSystem === false)
+    if (systemIOState !== 'idle') {
       return
+    }
+    if (kclManager.mlEphantManagerMachineBulkManipulatingFileSystem === false) {
+      return
+    }
+    const reloadBehavior = getMlEphantProjectReloadBehavior(modelingState)
+    kclManager.mlEphantManagerMachineBulkManipulatingFileSystem = false
+
+    if (reloadBehavior === 'exit-sketch-solve') {
+      toast(
+        'Zookeeper updated the project while sketch mode was active. Exiting sketch mode to reload safely.'
+      )
+      modelingSend({ type: 'Exit sketch' })
+      return
+    }
+
     kclManager
       .executeCode()
       .then(async () => {
-        await resetCameraPosition({
-          sceneInfra: kclManager.sceneInfra,
-          engineCommandManager: kclManager.engineCommandManager,
-          settingsActor,
-        })
+        if (reloadBehavior === 'execute-and-reset-camera') {
+          await resetCameraPosition({
+            sceneInfra: kclManager.sceneInfra,
+            engineCommandManager: kclManager.engineCommandManager,
+            settingsActor,
+          })
+        }
       })
       .catch(reportRejection)
-    kclManager.mlEphantManagerMachineBulkManipulatingFileSystem = false
-  }, [systemIOState, kclManager, settingsActor])
+  }, [systemIOState, kclManager, modelingState, modelingSend, settingsActor])
 
   // Run LSP file open hook when navigating between projects or files
   useEffect(() => {

--- a/src/components/openedProjectUtils.spec.ts
+++ b/src/components/openedProjectUtils.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { getMlEphantProjectReloadBehavior } from '@src/components/openedProjectUtils'
+
+describe('getMlEphantProjectReloadBehavior', () => {
+  it('exits sketch solve mode before reloading zookeeper edits', () => {
+    expect(
+      getMlEphantProjectReloadBehavior({
+        matches: (value) => value === 'sketchSolveMode',
+      })
+    ).toBe('exit-sketch-solve')
+  })
+
+  it('skips the forced camera reset in legacy sketch mode', () => {
+    expect(
+      getMlEphantProjectReloadBehavior({
+        matches: (value) => value === 'Sketch',
+      })
+    ).toBe('execute-without-camera-reset')
+  })
+
+  it('keeps the current behavior outside sketch mode', () => {
+    expect(
+      getMlEphantProjectReloadBehavior({
+        matches: () => false,
+      })
+    ).toBe('execute-and-reset-camera')
+  })
+})

--- a/src/components/openedProjectUtils.ts
+++ b/src/components/openedProjectUtils.ts
@@ -1,5 +1,5 @@
 export interface ModelingStateMatcher {
-  matches: (value: string) => boolean
+  matches: (...args: any[]) => boolean
 }
 
 export type MlEphantProjectReloadBehavior =

--- a/src/components/openedProjectUtils.ts
+++ b/src/components/openedProjectUtils.ts
@@ -1,0 +1,22 @@
+export interface ModelingStateMatcher {
+  matches: (value: string) => boolean
+}
+
+export type MlEphantProjectReloadBehavior =
+  | 'exit-sketch-solve'
+  | 'execute-without-camera-reset'
+  | 'execute-and-reset-camera'
+
+export function getMlEphantProjectReloadBehavior(
+  modelingState?: ModelingStateMatcher | null
+): MlEphantProjectReloadBehavior {
+  if (modelingState?.matches('sketchSolveMode')) {
+    return 'exit-sketch-solve'
+  }
+
+  if (modelingState?.matches('Sketch')) {
+    return 'execute-without-camera-reset'
+  }
+
+  return 'execute-and-reset-camera'
+}


### PR DESCRIPTION
This should be a low-risk way for us to keep the users safe from bad states until we can figure out a safer flow for zookeeper edits to take effect underneath the user. Codex written. Fixes #10837.