### PR TITLE
Fix design nits with share and publish dialogs

### DIFF
--- a/src/components/PublishDialog.tsx
+++ b/src/components/PublishDialog.tsx
@@ -324,7 +324,7 @@ export function PublishDialog({
           </section>
 
           <section className="border-t border-chalkboard-20/70 pt-4 dark:border-chalkboard-80/70">
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between sm:gap-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between sm:gap-4 md:gap-6">
               <div className="min-w-0 flex-1">
                 <p className="text-xs leading-5 text-chalkboard-60 dark:text-chalkboard-40">
                   {lastSubmittedText ? (
@@ -369,7 +369,11 @@ export function PublishDialog({
                 Element="button"
                 type="submit"
                 disabled={isSubmitting || publishDisabled}
-                className="shrink-0 self-end whitespace-nowrap py-0.5 sm:self-auto"
+                iconStart={{
+                  icon: 'share',
+                  bgClassName: '!bg-transparent',
+                }}
+                className="shrink-0 self-end whitespace-nowrap py-1 pl-0.5 pr-1.5 sm:self-auto !rounded-md"
               >
                 {isSubmitting
                   ? 'Submitting...'

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -90,7 +90,7 @@ export function ShareDialog({
                 bgClassName: '!bg-transparent',
                 size: 'sm',
               }}
-              className="shrink-0 whitespace-nowrap py-0.5 px-2"
+              className="shrink-0 whitespace-nowrap  py-1 pl-0.5 pr-1.5 !rounded-md"
               onClick={() => {
                 void handleCopyLink()
               }}


### PR DESCRIPTION
Fixes #11149.

<img width="309" height="134" alt="Screenshot 2026-04-27 at 9 29 51 AM" src="https://github.com/user-attachments/assets/14ead1a5-eab8-4ef9-847d-3f64bd3b562d" />
<img width="442" height="173" alt="Screenshot 2026-04-27 at 9 30 01 AM" src="https://github.com/user-attachments/assets/38ad4628-a4e5-4968-81a2-b26a6636c23b" />
