### PR TITLE
Ensure Zookeeper is updated when releasing ZDS

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -138,10 +138,9 @@ Release PR: ???
 
 <details><summary>Instructions</summary><br>
 
-If there are documentation changes, merge the corresponding Dependabot PRs [here](https://github.com/KittyCAD/website/pulls/app%2Fdependabot) for the website.
-You can trigger Dependabot to check for updates [here](https://github.com/KittyCAD/website/network/updates/17261214/jobs).
+Merge the latest `documentation` Dependabot PR [here](https://github.com/KittyCAD/website/pulls?q=is%3Apr+documentation). If none are present, click **Check for updates** [here](https://github.com/KittyCAD/website/network/updates/17261214/jobs).
 
-Paste that link to the PR below or replace `???` with `N/A`.
+Paste a link to the PR below or replace `???` with `N/A`.
 
 </details><br>
 
@@ -155,7 +154,7 @@ Clone https://github.com/KittyCAD/cli and update its dependencies on `kittycad-m
 
 After merging, run `make tag` and follow its instructions. This should publish a CLI release. Then open <https://github.com/KittyCAD/homebrew-kittycad/pulls> and merge the automatic PR to bump the release in Homebrew.
 
-Paste link to the PR below.
+Paste a link to the PR below.
 
 </details><br>
 
@@ -167,9 +166,20 @@ Release PR: ???
 
 Clone https://github.com/KittyCAD/api and update its dependencies on `kittycad-modeling-cmds` and `kcl-lib` to the latest versions. Next, run `just redo-openapi` to make sure the OpenAPI spec gets generated from any types we might be exposing from these libs. Open a PR and merge it to main.
 
-Paste link to the PR below.
+Paste a link to the PR below.
 
 </details><br>
 
 Release PR: ???
 
+# Zookeeper
+
+<details><summary>Instructions</summary><br>
+
+Merge the corresponding `zoo-kcl` Dependabot PR [here](https://github.com/KittyCAD/text-to-cad/pulls?q=is%3Apr+zoo-kcl). If none are present, click **Check for updates** [here](https://github.com/KittyCAD/text-to-cad/network/updates/27829916/jobs).
+
+Paste a link to the PR below.
+
+</details><br>
+
+Release PR: ???


### PR DESCRIPTION
Similar to how we notify `@cloud`, we should notify `@ml` as well to ensure no Dependabot PRs are missed.