### PR TITLE
(fix): autoexpand args for `sketch`

### DIFF
--- a/rust/kcl-lib/src/parsing/parser.rs
+++ b/rust/kcl-lib/src/parsing/parser.rs
@@ -3837,17 +3837,17 @@ fn is_callee_sketch_block(callee: &Name) -> bool {
     callee.name.name == SketchBlock::CALLEE_NAME && !callee.abs_path && callee.path.is_empty()
 }
 
-fn sketch_block_arg_shorthand_label(arg: &Expr) -> Option<Node<Identifier>> {
+fn is_sketch_block_arg_shorthand(arg: &Expr) -> bool {
     let Expr::Name(name) = arg else {
-        return None;
+        return false;
     };
     if name.abs_path || !name.path.is_empty() {
-        return None;
+        return false;
     }
     if name.name.name != crate::execution::SKETCH_BLOCK_PARAM_ON {
-        return None;
+        return false;
     }
-    Some(name.name.clone())
+    true
 }
 
 fn fn_call_or_sketch_block(i: &mut TokenSlice) -> ModalResult<Expr> {
@@ -3876,11 +3876,11 @@ fn fn_call_or_sketch_block(i: &mut TokenSlice) -> ModalResult<Expr> {
                 },
         } = fn_call;
         if let Some(unlabeled) = unlabeled {
-            if let Some(label) = sketch_block_arg_shorthand_label(&unlabeled) {
+            if is_sketch_block_arg_shorthand(&unlabeled) {
                 arguments.insert(
                     0,
                     LabeledArg {
-                        label: Some(label),
+                        label: None,
                         arg: unlabeled,
                     },
                 );
@@ -4287,7 +4287,7 @@ e
         };
         assert_eq!(sketch_block.arguments.len(), 1);
         let arg = &sketch_block.arguments[0];
-        assert_eq!(arg.label.as_ref().unwrap().name, "on");
+        assert!(arg.label.is_none());
         assert_eq!(arg.arg.ident_name(), Some("on"));
     }
 

--- a/rust/kcl-lib/src/parsing/parser.rs
+++ b/rust/kcl-lib/src/parsing/parser.rs
@@ -3837,6 +3837,19 @@ fn is_callee_sketch_block(callee: &Name) -> bool {
     callee.name.name == SketchBlock::CALLEE_NAME && !callee.abs_path && callee.path.is_empty()
 }
 
+fn sketch_block_arg_shorthand_label(arg: &Expr) -> Option<Node<Identifier>> {
+    let Expr::Name(name) = arg else {
+        return None;
+    };
+    if name.abs_path || !name.path.is_empty() {
+        return None;
+    }
+    if name.name.name != crate::execution::SKETCH_BLOCK_PARAM_ON {
+        return None;
+    }
+    Some(name.name.clone())
+}
+
 fn fn_call_or_sketch_block(i: &mut TokenSlice) -> ModalResult<Expr> {
     let fn_call = fn_call_kw.parse_next(i)?;
     if is_callee_sketch_block(&fn_call.callee) && peek((opt(whitespace), open_brace)).parse_next(i).is_ok() {
@@ -3857,16 +3870,26 @@ fn fn_call_or_sketch_block(i: &mut TokenSlice) -> ModalResult<Expr> {
                 CallExpressionKw {
                     callee: _,
                     unlabeled,
-                    arguments,
+                    mut arguments,
                     non_code_meta,
                     digest: _,
                 },
         } = fn_call;
         if let Some(unlabeled) = unlabeled {
-            ParseContext::err(CompilationIssue::err(
-                unlabeled.into(),
-                "Sketch blocks cannot have an unlabeled argument. Use a labeled argument instead, like `on = XY`.",
-            ));
+            if let Some(label) = sketch_block_arg_shorthand_label(&unlabeled) {
+                arguments.insert(
+                    0,
+                    LabeledArg {
+                        label: Some(label),
+                        arg: unlabeled,
+                    },
+                );
+            } else {
+                ParseContext::err(CompilationIssue::err(
+                    unlabeled.into(),
+                    "Sketch blocks cannot have an unlabeled argument. Use a labeled argument instead, like `on = XY`.",
+                ));
+            }
         }
         return Ok(Expr::SketchBlock(Box::new(Node {
             start,
@@ -4252,6 +4275,20 @@ e
         let tokens = tokens.as_slice();
         let actual = in_ctx(|| fn_call_or_sketch_block.parse(tokens)).unwrap();
         assert!(matches!(actual, Expr::SketchBlock { .. }));
+    }
+
+    #[test]
+    fn parse_sketch_block_arg_shorthand() {
+        let tokens = crate::parsing::token::lex("sketch(on) {}", ModuleId::default()).unwrap();
+        let tokens = tokens.as_slice();
+        let actual = in_ctx(|| fn_call_or_sketch_block.parse(tokens)).unwrap();
+        let Expr::SketchBlock(sketch_block) = actual else {
+            panic!("not a sketch block")
+        };
+        assert_eq!(sketch_block.arguments.len(), 1);
+        let arg = &sketch_block.arguments[0];
+        assert_eq!(arg.label.as_ref().unwrap().name, "on");
+        assert_eq!(arg.arg.ident_name(), Some("on"));
     }
 
     #[test]

--- a/rust/kcl-lib/src/unparser.rs
+++ b/rust/kcl-lib/src/unparser.rs
@@ -1481,6 +1481,18 @@ export import a, b as bbb from "a.kcl"
     }
 
     #[test]
+    fn test_recast_sketch_block_with_arg_shorthand() {
+        let input = r#"on = XY
+sketch(on) {
+  return 0
+}
+"#;
+        let program = crate::parsing::top_level_parse(input).unwrap();
+        let output = program.recast_top(&Default::default(), 0);
+        assert_eq!(output, input);
+    }
+
+    #[test]
     fn test_recast_sketch_block_with_statements_in_block() {
         let input = r#"sketch() {
   // Comments inside block.


### PR DESCRIPTION
Allows for `sketch(on)` and expands it into `sketch(on = on)`. This mimics behaviour of other KCL functions and their treatment of arguments. 


Closes #10168 