### PR TITLE
Remove error-prone PartialEq implementation

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2580,9 +2580,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.188"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48546fb3c3ac68d7d586d1e446ffe015778412c7a60640a2f50ead8f63234ffe"
+checksum = "03349615e4d1455f337228f4eff9982090c7cd8aa01b23d9964bdc2a2db15ad3"
 dependencies = [
  "anyhow",
  "bon",
@@ -2609,9 +2609,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds-macros"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb9bb1a594541b878adc1c8dcb821328774bf7aa09b65b104a206b1291a5235c"
+checksum = "eb4ba190f74f6d32f4607ecac4bdebd4a935d4943b8ca8369305e6e7a59b5976"
 dependencies = [
  "kittycad-modeling-cmds-macros-impl",
  "proc-macro2",
@@ -2621,9 +2621,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds-macros-impl"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb4ee23cc996aa2dca7584d410e8826e08161e1ac4335bb646d5ede33f37cb3"
+checksum = "743b6533d1848de67e3455a28614a2b7896807ab0d3358ccd3ea1863de3c4e6b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,7 +28,7 @@ kittycad = { version = "0.4.11", default-features = false, features = [
   "js",
   "requests",
 ] }
-kittycad-modeling-cmds = { version = "0.2.188", features = [
+kittycad-modeling-cmds = { version = "0.2.189", features = [
   "ts-rs",
   "websocket",
 ] }

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -126,8 +126,7 @@ pub(super) struct ArtifactState {}
 
 /// Artifact state for a single module.
 #[cfg(feature = "artifact-graph")]
-#[derive(Debug, Clone, Default, Serialize)]
-#[cfg_attr(not(feature = "snapshot-engine-responses"), derive(PartialEq))]
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
 pub struct ModuleArtifactState {
     /// Internal map of UUIDs to exec artifacts.
     pub artifacts: IndexMap<ArtifactId, Artifact>,
@@ -154,25 +153,6 @@ pub struct ModuleArtifactState {
     pub artifact_id_to_scene_object: IndexMap<ArtifactId, ObjectId>,
     /// Solutions for sketch variables.
     pub var_solutions: Vec<(SourceRange, Number)>,
-}
-
-// It's error-prone to implement this manually. New fields are likely to be
-// forgotten. So we only use this implementation when the feature is enabled.
-#[cfg(feature = "snapshot-engine-responses")]
-impl PartialEq for ModuleArtifactState {
-    fn eq(&self, other: &Self) -> bool {
-        self.artifacts == other.artifacts
-            && self.unprocessed_commands == other.unprocessed_commands
-            && self.commands == other.commands
-            // WebSocketResponse type doesn't implement `PartialEq`.
-            // && self.responses == other.responses
-            && self.operations == other.operations
-            && self.object_id_generator == other.object_id_generator
-            && self.scene_objects == other.scene_objects
-            && self.source_range_to_object == other.source_range_to_object
-            && self.artifact_id_to_scene_object == other.artifact_id_to_scene_object
-            && self.var_solutions == other.var_solutions
-    }
 }
 
 #[cfg(not(feature = "artifact-graph"))]


### PR DESCRIPTION
The required `PartialEq` is implemented in modeling-api now.

- https://github.com/KittyCAD/modeling-api/pull/1175
- https://github.com/KittyCAD/modeling-api/pull/1170