### PR TITLE
(fix): incorrect flagging of toRadians function

### DIFF
--- a/rust/kcl-lib/src/execution/types.rs
+++ b/rust/kcl-lib/src/execution/types.rs
@@ -2670,6 +2670,24 @@ d = cos(1rad)
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn prelude_exposes_unit_converters_unqualified() {
+        let program = r#"
+cornerAngle = 360deg / 6
+rad = 5mm
+sideLen = rad * sin(toRadians(cornerAngle / 2)) * 2
+"#;
+
+        let result = parse_execute(program).await.unwrap();
+        assert!(
+            result.exec_state.issues().is_empty(),
+            "{:?}",
+            result.exec_state.issues()
+        );
+
+        assert_value_and_type("sideLen", &result, 5.0, NumericType::mm());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn coerce_nested_array() {
         let (ctx, mut exec_state) = new_exec_state().await;
 

--- a/rust/kcl-lib/src/lsp/tests.rs
+++ b/rust/kcl-lib/src/lsp/tests.rs
@@ -2503,6 +2503,48 @@ async fn test_kcl_lsp_diagnostic_has_lints() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_kcl_lsp_unqualified_to_radians_has_no_diagnostics() {
+    let server = kcl_lsp_server(false).await.unwrap();
+
+    server
+        .did_open(tower_lsp::lsp_types::DidOpenTextDocumentParams {
+            text_document: tower_lsp::lsp_types::TextDocumentItem {
+                uri: "file:///to-radians.kcl".try_into().unwrap(),
+                language_id: "kcl".to_string(),
+                version: 1,
+                text: r#"cornerAngle = 360deg / 6
+rad = 5mm
+sideLen = rad * sin(toRadians(cornerAngle / 2)) * 2"#
+                    .to_string(),
+            },
+        })
+        .await;
+
+    let diagnostics = server
+        .diagnostic(tower_lsp::lsp_types::DocumentDiagnosticParams {
+            text_document: tower_lsp::lsp_types::TextDocumentIdentifier {
+                uri: "file:///to-radians.kcl".try_into().unwrap(),
+            },
+            partial_result_params: Default::default(),
+            work_done_progress_params: Default::default(),
+            identifier: None,
+            previous_result_id: None,
+        })
+        .await
+        .unwrap();
+
+    if let tower_lsp::lsp_types::DocumentDiagnosticReportResult::Report(diagnostics) = diagnostics {
+        if let tower_lsp::lsp_types::DocumentDiagnosticReport::Full(diagnostics) = diagnostics {
+            assert_eq!(diagnostics.full_document_diagnostic_report.items.len(), 0);
+        } else {
+            panic!("Expected full diagnostics");
+        }
+    } else {
+        panic!("Expected diagnostics");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_copilot_lsp_set_editor_info() {
     let server = copilot_lsp_server().await.unwrap();
 

--- a/rust/kcl-lib/std/prelude.kcl
+++ b/rust/kcl-lib/std/prelude.kcl
@@ -15,7 +15,7 @@
 
 export import * from "std::types"
 export import "std::gdt"
-export import "std::units"
+export import * from "std::units"
 export import * from "std::array"
 export import * from "std::math"
 export import * from "std::sketch"


### PR DESCRIPTION

Import statement in prelude was importing the module and not using glob. 


Closes: #7285 