### PR TITLE
Missing Join Surfaces icon in toolbar

### DIFF
--- a/src/lib/toolbar.ts
+++ b/src/lib/toolbar.ts
@@ -811,6 +811,7 @@ export function buildToolbarConfig(
                   data: { name: 'Join Surfaces', groupId: 'modeling' },
                 }),
               status: 'available',
+              icon: 'joinSurfaces',
               title: 'Join Surfaces',
               description: 'Join surfaces together.',
               links: [


### PR DESCRIPTION
Reported by @max-mrgrsk at https://kittycadworkspace.slack.com/archives/C06L2RHP9SL/p1777376838714889

<img width="164" height="127" alt="image" src="https://github.com/user-attachments/assets/9894cd31-1958-4a59-9bec-949a169434fe" />
