### PR TITLE
Update ZK test to use the mock reply marker

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -39,4 +39,5 @@ extend-ignore-identifiers-re = [
 ]
 extend-ignore-re = [
   "@xstate-layout .*",
+  "ZOO_MAGIC_STRING_TRIGGER_MOCK_REPLY_[A-F0-9]+",
 ]

--- a/e2e/playwright/zookeeper.spec.ts
+++ b/e2e/playwright/zookeeper.spec.ts
@@ -1,6 +1,10 @@
 import { expect, test } from '@e2e/playwright/zoo-test'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 
+// See text-to-cad/text_to_cad/zookeeper_magic_bypass.py
+const ZK_MOCK_REPLY_MARKER =
+  'ZOO_MAGIC_STRING_TRIGGER_MOCK_REPLY_D39D279C6F84FA63AD49364FDEFB4A27D0E15BA7FB0975D4D6E003A8A594E460'
+
 test.describe('Zookeeper tests', { tag: ['@desktop', '@web'] }, () => {
   test('Happy path: new project, easy prompt, good result', async ({
     page,
@@ -20,7 +24,7 @@ test.describe('Zookeeper tests', { tag: ['@desktop', '@web'] }, () => {
       await toolbar.openPane(DefaultLayoutPaneID.TTC)
       await copilot.setMode('fast')
       await copilot.conversationInput.fill(
-        'make a 10x10x10cm cube centered on the origin, name the last variable "cube"'
+        `make a 10x10x10cm cube centered on the origin, name the last variable "cube" [${ZK_MOCK_REPLY_MARKER}]`
       )
       await copilot.submitButton.click()
       await expect(copilot.placeHolderResponse).toBeVisible()


### PR DESCRIPTION
Needs to merge after <https://github.com/KittyCAD/text-to-cad/pull/3273> deploys