### PR TITLE
Update Zookeeper test to no longer wait for reasoning

### DIFF
--- a/e2e/playwright/zookeeper.spec.ts
+++ b/e2e/playwright/zookeeper.spec.ts
@@ -29,24 +29,16 @@ test.describe('Zookeeper tests', { tag: ['@desktop', '@web'] }, () => {
       await copilot.submitButton.click()
       await expect(copilot.placeHolderResponse).toBeVisible()
       await expect(copilot.placeHolderResponse).not.toBeVisible({
-        timeout: 120_000,
-      })
-      await expect(copilot.thinkingView).toBeVisible()
-      await expect(copilot.thinkingView).not.toBeVisible({
-        timeout: 120_000,
+        timeout: 30_000,
       })
 
       await toolbar.closePane(DefaultLayoutPaneID.TTC)
       await toolbar.openPane(DefaultLayoutPaneID.Code)
-      await expect(editor.codeContent).toContainText(
-        /startSketchOn|sketch\(on =/
-      )
-      await editor.expectEditor.toContain('extrude')
-      await editor.expectEditor.toContain('10')
-      await scene.settled(cmdBar)
+      await expect(editor.codeContent).toContainText('sketch')
 
       await toolbar.closePane(DefaultLayoutPaneID.Code)
       await toolbar.openPane(DefaultLayoutPaneID.FeatureTree)
+      await scene.settled(cmdBar)
       const extrude = await toolbar.getFeatureTreeOperation('cube', 0)
       await expect(extrude).toBeVisible()
     })


### PR DESCRIPTION
We switched to a mock reply in https://github.com/KittyCAD/modeling-app/pull/11351 so the reasoning step may disappear before we can wait for it.

Here's an example of it failing: https://test-analysis-bot.corp.zoo.dev/projects/KittyCAD/modeling-app/tests/14436/results/93563152?expand=true