### PR TITLE
Allow more variation in pixels before failing snapshots

### DIFF
--- a/e2e/playwright/snapshot-tests.spec.ts
+++ b/e2e/playwright/snapshot-tests.spec.ts
@@ -11,7 +11,7 @@ function screenshotName(step: number, name: string, mode: Themes) {
 }
 
 const screenshotOptions = (page: Page) => ({
-  maxDiffPixels: 100,
+  maxDiffPixels: 300,
   mask: lowerRightMasks(page),
 })
 


### PR DESCRIPTION
In https://github.com/KittyCAD/modeling-app/pull/11354, the screenshot size was increased to include the feature tree. The diff failure threshold should be increased as well to maintain the reliability of this test: https://test-analysis-bot.corp.zoo.dev/projects/KittyCAD/modeling-app/tests/17999?branch=accept-bigger-diff