### PR TITLE
Avoid panic when sketch tags are shadowed

### DIFF
--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -525,7 +525,9 @@ fn update_memory_for_tags_of_geometry(result: &mut KclValue, exec_state: &mut Ex
             for (name, tag) in value.tags.iter() {
                 if exec_state.stack().cur_frame_contains(name) {
                     exec_state.mut_stack().update(name, |v, _| {
-                        v.as_mut_tag().unwrap().merge_info(tag);
+                        if let Some(existing_tag) = v.as_mut_tag() {
+                            existing_tag.merge_info(tag);
+                        }
                     });
                 } else {
                     exec_state
@@ -602,7 +604,9 @@ fn update_memory_for_tags_of_geometry(result: &mut KclValue, exec_state: &mut Ex
 
                     if exec_state.stack().cur_frame_contains(&tag.name) {
                         exec_state.mut_stack().update(&tag.name, |v, _| {
-                            v.as_mut_tag().unwrap().merge_info(&tag_id);
+                            if let Some(existing_tag) = v.as_mut_tag() {
+                                existing_tag.merge_info(&tag_id);
+                            }
                         });
                     } else if !is_sketch_block || !is_part_of_sketch {
                         // The above condition is saying that we add a tag to

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -3610,6 +3610,45 @@ sketch(on = XY) {
         parse_execute(&code).await.unwrap();
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_shadowed_get_opposite_edge_binding_does_not_panic() {
+        let code = r#"startX = 2
+
+baseSketch = sketch(on = XY) {
+  yoyo = line(start = [startX, 0], end = [7, 6])
+  line2 = line(start = [7, 6], end = [7, 12])
+  hi = line(start = [7, 12], end = [startX, 0])
+}
+
+baseRegion = region(point = [5.5, 6], sketch = baseSketch)
+myExtrude = extrude(
+  baseRegion,
+  length = 5,
+  tagEnd = $endCap,
+  tagStart = $startCap,
+)
+yodawg = getCommonEdge(faces = [
+  baseRegion.tags.hi,
+  baseRegion.tags.yoyo
+])
+
+cutSketch = sketch(on = YZ) {
+  myDisambigutator = line(start = [-3.29, 4.75], end = [2.03, 2.44])
+  myDisambigutator2 = line(start = [2.03, 2.44], end = [-3.49, 0.31])
+  line3 = line(start = [-3.49, 0.31], end = [-3.29, 4.75])
+}
+
+cutRegion = region(point = [-1.5833333333, 2.5], sketch = cutSketch)
+extrude001 = extrude(cutRegion, length = 5)
+solid001 = subtract(myExtrude, tools = extrude001)
+
+yoyo = getOppositeEdge(baseRegion.tags.hi)
+fillet(solid001, radius = 0.1, tags = yoyo)
+"#;
+
+        parse_execute(code).await.unwrap();
+    }
+
     // END Mock Execution tests
 
     // Sketch constraint report tests


### PR DESCRIPTION
Resolves https://github.com/KittyCAD/modeling-app/issues/11387

This fixes a panic I ran into when `getOppositeEdge` or similar is not inlined.

The repro looked like this:

```kcl
yoyo = getOppositeEdge(baseRegion.tags.hi)
fillet(solid001, radius = 0.1, tags = yoyo)
```

In this case `yoyo` originally exists as a sketch tag, then later gets rebound to the result of `getOppositeEdge(...)`. During geometry/tag propagation we were still assuming that any current binding with that name had to be a `TagIdentifier`, and we ended up hitting `as_mut_tag().unwrap()`.

The change here is small:

- if the existing binding is still a tag, keep merging tag info as before
- if that name has been shadowed by some non-tag value, skip the merge instead of panicking
- add a Rust regression test for the reported `getOppositeEdge` shadowing case

This seemed like the narrowest fix that addresses the panic. That said open to other solutions.
