### PR TITLE
Fix sketch solve execution to work without artifact-graph feature

### DIFF
--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1264,8 +1264,6 @@ impl Node<SketchBlock> {
         };
         #[cfg(not(feature = "artifact-graph"))]
         let _ = on_object_id;
-        #[cfg(not(feature = "artifact-graph"))]
-        let _ = sketch_id;
         #[cfg(feature = "artifact-graph")]
         let sketch_ctor_on = sketch_on_frontend_plane(&self.arguments, on_object_id);
         #[cfg(feature = "artifact-graph")]
@@ -1324,15 +1322,12 @@ impl Node<SketchBlock> {
             self.prep_mem(exec_state.mut_stack().snapshot(), exec_state);
 
             // Track that we're executing a sketch block.
-            #[cfg(feature = "artifact-graph")]
             let initial_sketch_block_state = {
                 SketchBlockState {
                     sketch_id: Some(sketch_id),
                     ..Default::default()
                 }
             };
-            #[cfg(not(feature = "artifact-graph"))]
-            let initial_sketch_block_state = SketchBlockState::default();
 
             let original_value = exec_state.mod_local.sketch_block.replace(initial_sketch_block_state);
 

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -3762,4 +3762,24 @@ s2 = sketch(on = XZ) {
         assert_eq!(report.fully_constrained.len(), 1);
         assert_eq!(report.under_constrained.len(), 1);
     }
+
+    #[cfg(not(feature = "artifact-graph"))]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_sketch_solve_works_without_artifact_graph_feature() {
+        let code = r#"
+sketch001 = sketch(on = XY) {
+    line1 = line(start = [var -3.38mm, var 3.71mm], end = [var 4.29mm, var 3.59mm])
+    line2 = line(start = [var 4.29mm, var 3.59mm], end = [var 4.31mm, var -3.13mm])
+    coincident([line1.end, line2.start])
+    line3 = line(start = [var 4.31mm, var -3.13mm], end = [var -3.61mm, var -3.18mm])
+    coincident([line2.end, line3.start])
+    line4 = line(start = [var -3.61mm, var -3.18mm], end = [var -3.38mm, var 3.71mm])
+    coincident([line3.end, line4.start])
+    coincident([line4.end, line1.start])
+    circle1 = circle(start = [var -5.73mm, var 1.42mm], center = [var -7.07mm, var 1.47mm])
+    tangent([line4, circle1])
+}
+"#;
+        parse_execute(code).await.unwrap();
+    }
 }


### PR DESCRIPTION
I verified that this new test passes locally. Currently, CI doesn't run this test. We run our sim tests with the artifact graph feature enabled so that we can snapshot the artifact graph data structures. We can make a follow-up PR. Our cargo feature situation is a bit of a mess right now.