### PR TITLE
Fix lint in CI to check without the artifact-graph feature

### DIFF
--- a/rust/justfile
+++ b/rust/justfile
@@ -4,9 +4,12 @@ kcl_lib_flags := "-p kcl-lib --features artifact-graph"
 
 # Run the same lint checks we run in CI.
 lint:
+    # All features.
     cargo clippy --workspace --all-targets --all-features -- -D warnings
-    # Ensure we can build without extra feature flags.
+    # Default features.
     cargo clippy -p kcl-lib --all-targets -- -D warnings
+    # Minimal features that actually still build.
+    cargo clippy -p kcl-lib --all-targets --no-default-features --features engine,cli -- -D warnings
 
 lint-fix:
     cargo clippy --workspace --all-targets --all-features --fix

--- a/rust/kcl-lib/src/execution/cache.rs
+++ b/rust/kcl-lib/src/execution/cache.rs
@@ -176,7 +176,7 @@ pub(crate) struct SketchModeState {
     /// Sticky per-constraint state persisted across sketch-mode mock solves.
     pub constraint_state: IndexMap<ObjectId, IndexMap<ConstraintKey, ConstraintState>>,
     /// The scene objects.
-    #[cfg_attr(not(feature = "artifact-graph"), expect(dead_code))]
+    #[cfg_attr(not(feature = "artifact-graph"), allow(dead_code))]
     pub scene_objects: Vec<Object>,
 }
 

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -3150,6 +3150,8 @@ impl Node<BinaryExpression> {
                             }
                         }
                         SketchConstraintKind::Distance { points, label_position } => {
+                            #[cfg(not(feature = "artifact-graph"))]
+                            let _ = label_position;
                             let range = self.as_source_range();
                             let p0 = &points[0];
                             let p1 = &points[1];
@@ -3530,6 +3532,8 @@ impl Node<BinaryExpression> {
                             }
                         }
                         SketchConstraintKind::HorizontalDistance { points, label_position } => {
+                            #[cfg(not(feature = "artifact-graph"))]
+                            let _ = label_position;
                             let range = self.as_source_range();
                             let p0 = &points[0];
                             let p1 = &points[1];
@@ -3649,6 +3653,8 @@ impl Node<BinaryExpression> {
                             }
                         }
                         SketchConstraintKind::VerticalDistance { points, label_position } => {
+                            #[cfg(not(feature = "artifact-graph"))]
+                            let _ = label_position;
                             let range = self.as_source_range();
                             let p0 = &points[0];
                             let p1 = &points[1];

--- a/rust/kcl-lib/src/std/constraints.rs
+++ b/rust/kcl-lib/src/std/constraints.rs
@@ -2571,6 +2571,7 @@ pub async fn vertical_distance(exec_state: &mut ExecState, args: Args) -> Result
 #[derive(Debug, Clone, Copy)]
 struct MidpointPointVars {
     coords: [SketchVarId; 2],
+    #[cfg(feature = "artifact-graph")]
     object_id: ObjectId,
 }
 
@@ -2579,17 +2580,20 @@ enum MidpointTargetVars {
     Line {
         start: [SketchVarId; 2],
         end: [SketchVarId; 2],
+        #[cfg(feature = "artifact-graph")]
         object_id: ObjectId,
     },
     Arc {
         center: [SketchVarId; 2],
         start: [SketchVarId; 2],
         end: [SketchVarId; 2],
+        #[cfg(feature = "artifact-graph")]
         object_id: ObjectId,
     },
 }
 
 impl MidpointTargetVars {
+    #[cfg(feature = "artifact-graph")]
     fn object_id(self) -> ObjectId {
         match self {
             Self::Line { object_id, .. } | Self::Arc { object_id, .. } => object_id,
@@ -2628,6 +2632,7 @@ fn extract_midpoint_point(segment_value: &KclValue, range: crate::SourceRange) -
 
     Ok(MidpointPointVars {
         coords: [*point_x, *point_y],
+        #[cfg(feature = "artifact-graph")]
         object_id: unsolved.object_id,
     })
 }
@@ -2669,6 +2674,7 @@ fn extract_midpoint_target(
             Ok(MidpointTargetVars::Line {
                 start: [*start_x, *start_y],
                 end: [*end_x, *end_y],
+                #[cfg(feature = "artifact-graph")]
                 object_id: unsolved.object_id,
             })
         }
@@ -2692,6 +2698,7 @@ fn extract_midpoint_target(
                 center: [*center_x, *center_y],
                 start: [*start_x, *start_y],
                 end: [*end_x, *end_y],
+                #[cfg(feature = "artifact-graph")]
                 object_id: unsolved.object_id,
             })
         }
@@ -3477,6 +3484,7 @@ pub async fn tangent(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
 #[derive(Debug, Clone, Copy)]
 struct SymmetricPointVars {
     coords: [SketchVarId; 2],
+    #[cfg(feature = "artifact-graph")]
     object_id: ObjectId,
 }
 
@@ -3485,6 +3493,7 @@ struct SymmetricPointVars {
 struct SymmetricLineVars {
     start: [SketchVarId; 2],
     end: [SketchVarId; 2],
+    #[cfg(feature = "artifact-graph")]
     object_id: ObjectId,
 }
 
@@ -3493,6 +3502,7 @@ struct SymmetricArcVars {
     center: [SketchVarId; 2],
     start: [SketchVarId; 2],
     end: [SketchVarId; 2],
+    #[cfg(feature = "artifact-graph")]
     object_id: ObjectId,
 }
 
@@ -3500,6 +3510,7 @@ struct SymmetricArcVars {
 struct SymmetricCircleVars {
     center: [SketchVarId; 2],
     start: [SketchVarId; 2],
+    #[cfg(feature = "artifact-graph")]
     object_id: ObjectId,
 }
 
@@ -3559,6 +3570,7 @@ fn extract_symmetric_input(segment_value: &KclValue, range: crate::SourceRange) 
             };
             Ok(SymmetricInput::Point(SymmetricPointVars {
                 coords: [*x, *y],
+                #[cfg(feature = "artifact-graph")]
                 object_id: unsolved.object_id,
             }))
         }
@@ -3578,6 +3590,7 @@ fn extract_symmetric_input(segment_value: &KclValue, range: crate::SourceRange) 
             Ok(SymmetricInput::Line(SymmetricLineVars {
                 start: [*start_x, *start_y],
                 end: [*end_x, *end_y],
+                #[cfg(feature = "artifact-graph")]
                 object_id: unsolved.object_id,
             }))
         }
@@ -3600,6 +3613,7 @@ fn extract_symmetric_input(segment_value: &KclValue, range: crate::SourceRange) 
                 center: [*center_x, *center_y],
                 start: [*start_x, *start_y],
                 end: [*end_x, *end_y],
+                #[cfg(feature = "artifact-graph")]
                 object_id: unsolved.object_id,
             }))
         }
@@ -3619,6 +3633,7 @@ fn extract_symmetric_input(segment_value: &KclValue, range: crate::SourceRange) 
             Ok(SymmetricInput::Circle(SymmetricCircleVars {
                 center: [*center_x, *center_y],
                 start: [*start_x, *start_y],
+                #[cfg(feature = "artifact-graph")]
                 object_id: unsolved.object_id,
             }))
         }
@@ -3666,6 +3681,7 @@ fn extract_symmetric_axis_line(
     Ok(SymmetricLineVars {
         start: [*start_x, *start_y],
         end: [*end_x, *end_y],
+        #[cfg(feature = "artifact-graph")]
         object_id: unsolved.object_id,
     })
 }


### PR DESCRIPTION
Since #10880, we haven't been linting without the `artifact-graph` feature in CI, so several issues have since been merged.