### PR TITLE
Emit a warning if CSG bodies don't overlap at all

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2580,9 +2580,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.189"
+version = "0.2.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03349615e4d1455f337228f4eff9982090c7cd8aa01b23d9964bdc2a2db15ad3"
+checksum = "64de85fb38082d752777827f4fb0410bbe6a26b2832b4e943ba3f889a84a9e39"
 dependencies = [
  "anyhow",
  "bon",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,7 +28,7 @@ kittycad = { version = "0.4.11", default-features = false, features = [
   "js",
   "requests",
 ] }
-kittycad-modeling-cmds = { version = "0.2.189", features = [
+kittycad-modeling-cmds = { version = "0.2.193", features = [
   "ts-rs",
   "websocket",
 ] }

--- a/rust/kcl-lib/e2e/executor/inputs/no_csg_overlap.kcl
+++ b/rust/kcl-lib/e2e/executor/inputs/no_csg_overlap.kcl
@@ -1,0 +1,34 @@
+@warnings(deny = csgNoIntersection)
+
+sketch001 = sketch(on = XY) {
+  line1 = line(start = [var -1.45mm, var 1.89mm], end = [var -7.48mm, var -2.93mm])
+  line2 = line(start = [var -7.48mm, var -2.93mm], end = [var 1.5mm, var -7.67mm])
+  coincident([line1.end, line2.start])
+  line3 = line(start = [var 1.5mm, var -7.67mm], end = [var 7.52mm, var -2.85mm])
+  coincident([line2.end, line3.start])
+  line4 = line(start = [var 7.52mm, var -2.85mm], end = [var -1.45mm, var 1.89mm])
+  coincident([line3.end, line4.start])
+  coincident([line4.end, line1.start])
+  line5 = line(start = [var -7.48mm, var -2.93mm], end = [var 7.52mm, var -2.85mm], construction = true)
+  coincident([line5.start, line2.start])
+  coincident([line5.end, line4.start])
+  line6 = line(start = [var -1.45mm, var 1.89mm], end = [var 1.5mm, var -7.67mm], construction = true)
+  coincident([line6.start, line4.end])
+  coincident([line6.end, line3.start])
+  distance([line6.start, line6.end]) == 10
+  distance([line5.start, line5.end]) == 15
+  parallel([line1, line3])
+  parallel([line2, line4])
+  perpendicular([line6, line5])
+  coincident([line6.start, ORIGIN])
+  vertical(line6)
+}
+hidden001 = hide(sketch001)
+region001 = region(point = [-3.7486132mm, -2.5020801mm], sketch = sketch001)
+extrude001 = extrude(region001, length = 5)
+
+cb2 = clone(extrude001)
+  |> translate(x = 20)
+
+subtract([extrude001], tools = [cb2])
+

--- a/rust/kcl-lib/e2e/executor/main.rs
+++ b/rust/kcl-lib/e2e/executor/main.rs
@@ -2024,6 +2024,24 @@ async fn kcl_test_error_no_auth_websocket() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn kcl_test_error_no_csg_overlap() {
+    // Test that if you do a CSG operation where the bodies don't have any overlap,
+    // you get a warning about it. That warning can be upgraded to an error, if the
+    // user configures it to.
+    let code = kcl_input!("no_csg_overlap");
+
+    let result = execute_and_snapshot(code, None).await;
+    let err = result.unwrap_err();
+    let err = err.as_kcl_error().unwrap();
+    // The error message should be meaningful.
+    assert!(
+        err.message().contains("The bodies in this subtraction had no overlap"),
+        "actual: {}",
+        err.message()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn kcl_test_ensure_nothing_left_in_batch_single_file() {
     let code = r#"@settings(defaultLengthUnit = in)
 // Set units in inches (in)

--- a/rust/kcl-lib/src/execution/annotations.rs
+++ b/rust/kcl-lib/src/execution/annotations.rs
@@ -70,10 +70,11 @@ pub(crate) const WARN_IGNORED_Z_AXIS: &str = "ignoredZAxis";
 pub(crate) const WARN_SOLVER: &str = "solver";
 pub(crate) const WARN_SHOULD_BE_PERCENTAGE: &str = "shouldBePercentage";
 pub(crate) const WARN_INVALID_MATH: &str = "invalidMath";
+pub(crate) const WARN_CSG_NO_INTERSECTION: &str = "csgNoIntersection";
 pub(crate) const WARN_UNNECESSARY_CLOSE: &str = "unnecessaryClose";
 pub(crate) const WARN_UNUSED_TAGS: &str = "unusedTags";
 pub(crate) const WARN_NOT_YET_SUPPORTED: &str = "notYetSupported";
-pub(super) const WARN_VALUES: [&str; 11] = [
+pub(super) const WARN_VALUES: [&str; 12] = [
     WARN_UNKNOWN_UNITS,
     WARN_ANGLE_UNITS,
     WARN_UNKNOWN_ATTR,
@@ -85,6 +86,7 @@ pub(super) const WARN_VALUES: [&str; 11] = [
     WARN_INVALID_MATH,
     WARN_UNNECESSARY_CLOSE,
     WARN_NOT_YET_SUPPORTED,
+    WARN_CSG_NO_INTERSECTION,
 ];
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Deserialize, Serialize, ts_rs::TS)]

--- a/rust/kcl-lib/src/std/csg.rs
+++ b/rust/kcl-lib/src/std/csg.rs
@@ -1,6 +1,7 @@
 //! Constructive Solid Geometry (CSG) operations.
 
 use anyhow::Result;
+use kcl_error::CompilationIssue;
 use kcmc::ModelingCmd;
 use kcmc::each_cmd as mcmd;
 use kcmc::length_unit::LengthUnit;
@@ -19,6 +20,7 @@ use crate::execution::ExecState;
 use crate::execution::KclValue;
 use crate::execution::ModelingCmdMeta;
 use crate::execution::Solid;
+use crate::execution::annotations;
 use crate::execution::types::RuntimeType;
 use crate::std::Args;
 use crate::std::patterns::GeometryTrait;
@@ -108,6 +110,16 @@ pub(crate) async fn inner_union(
         )));
     };
 
+    if !boolean_resp.any_intersections {
+        exec_state.warn(
+            CompilationIssue::err(
+                args.source_range,
+                "The bodies in this union had no overlap. This usually indicates a problem in your model, these bodies were probably intended to intersect somewhere.".to_string(),
+            ),
+            annotations::WARN_CSG_NO_INTERSECTION,
+        );
+    }
+
     // If we have more solids, set those as well.
     for extra_solid_id in boolean_resp.extra_solid_ids {
         if extra_solid_id == solid_out_id {
@@ -196,6 +208,15 @@ pub(crate) async fn inner_intersect(
             vec![args.source_range],
         )));
     };
+    if !boolean_resp.any_intersections {
+        exec_state.warn(
+            CompilationIssue::err(
+                args.source_range,
+                "The bodies in this intersection had no overlap. This usually indicates a problem in your model, these bodies were probably intended to intersect somewhere.".to_string(),
+            ),
+            annotations::WARN_CSG_NO_INTERSECTION,
+        );
+    }
 
     // If we have more solids, set those as well.
     for extra_solid_id in boolean_resp.extra_solid_ids {
@@ -288,6 +309,16 @@ pub(crate) async fn inner_subtract(
             vec![args.source_range],
         )));
     };
+
+    if !boolean_resp.any_intersections {
+        exec_state.warn(
+            CompilationIssue::err(
+                args.source_range,
+                "The bodies in this subtraction had no overlap. This usually indicates a problem in your model, these bodies were probably intended to intersect somewhere.".to_string(),
+            ),
+            annotations::WARN_CSG_NO_INTERSECTION,
+        );
+    }
 
     // If we have more solids, set those as well.
     for extra_solid_id in boolean_resp.extra_solid_ids {
@@ -421,6 +452,15 @@ pub(crate) async fn inner_imprint(
             vec![args.source_range],
         )));
     };
+    if !boolean_resp.any_intersections {
+        exec_state.warn(
+            CompilationIssue::err(
+                args.source_range,
+                "The bodies in this split had no overlap. This usually indicates a problem in your model, these bodies were probably intended to intersect somewhere.".to_string(),
+            ),
+            annotations::WARN_CSG_NO_INTERSECTION,
+        );
+    }
 
     // If we have more solids, set those as well.
     for extra_solid_id in boolean_resp.extra_solid_ids {


### PR DESCRIPTION
These two bodies don't intersect at all:

<img width="571" height="347" alt="Screenshot 2026-05-01 at 6 53 46 PM" src="https://github.com/user-attachments/assets/3d7cc967-9841-4015-9b22-1e62990eb016" />

If you tried to subtract one from the other, it would succeed but probably not be what you meant to do. "Firing blanks," as Jordan put it.

Now that generates a warning:

<img width="502" height="187" alt="no_overlap" src="https://github.com/user-attachments/assets/6ae5dfda-9609-4ed8-9528-4d05a042ebad" />

I'm open to nitpicks about the error message text.

Closes https://github.com/KittyCAD/modeling-app/issues/11282