### PR TITLE
Write to disk after drag

### DIFF
--- a/src/lang/KclManager.spec.ts
+++ b/src/lang/KclManager.spec.ts
@@ -215,6 +215,32 @@ describe('KclManager diagnostics', () => {
     })
   })
 
+  it('writes to file for same-code sketch checkpoint commits', () => {
+    const previewCode = 'drag preview source'
+    const { kclManager } = createKclManagerTestHarness(previewCode)
+    const writeToFileSpy = vi
+      .spyOn(kclManager, 'writeToFile')
+      .mockResolvedValue(undefined)
+    ;(kclManager as any).lastCommittedCode = 'source before drag'
+    ;(kclManager as any).lastCommittedSketchCheckpointId = 2
+
+    kclManager.updateCodeEditor(
+      previewCode,
+      {
+        shouldExecute: false,
+        shouldWriteToDisk: true,
+        shouldResetCamera: false,
+      },
+      {
+        sketchCheckpointId: 3,
+      }
+    )
+
+    expect(writeToFileSpy).toHaveBeenCalledWith(previewCode, undefined, {
+      suppressConflictToast: true,
+    })
+  })
+
   it('does not write to file when the code is unchanged and shouldWriteToDisk is false', () => {
     const { kclManager } = createKclManagerTestHarness('persist me')
     const writeToFileSpy = vi

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -2901,6 +2901,7 @@ export class KclManager extends File {
       if (shouldCreateCheckpointOnlyHistoryCommit) {
         this.editorView.dispatch({
           annotations: [
+            updateOutsideEditorEvent,
             Transaction.addToHistory.of(true),
             isolateHistory.of('full'),
             ...(additionalSpec?.annotations || []),
@@ -2922,6 +2923,7 @@ export class KclManager extends File {
                 sketchCheckpointId: additionalSpec?.sketchCheckpointId,
               },
             }),
+            requestWriteToFile.of(resolvedOptions.shouldWriteToDisk),
           ],
         })
       } else {


### PR DESCRIPTION
Came from this thread https://kittycadworkspace.slack.com/archives/C04KFV6NKL0/p1777744774451909

Sketch Solve drag previews update the editor with `shouldWriteToDisk: false`. On mouse-up, the committed source can already match the editor, so `KclManager.updateCodeEditor()` takes the same-code sketch checkpoint path. That path preserved checkpoint history, but skipped `requestWriteToFile`, so the final drag commit was not persisted until a later manual editor change.

This keeps the checkpoint-only history behavior and also emits `requestWriteToFile` when that same-code commit requests a disk write. The dispatch is marked with `updateOutsideEditorEvent` like other programmatic editor updates.



https://github.com/user-attachments/assets/cb1edab7-a1d8-4e70-96eb-4adbf11bf4b0

