### PR TITLE
Hide the Zookeeper setting on the user level

### DIFF
--- a/src/lib/settings/initialSettings.tsx
+++ b/src/lib/settings/initialSettings.tsx
@@ -183,6 +183,7 @@ function createCoreSettings() {
        */
       zookeeperMode: new Setting<MlCopilotMode>({
         defaultValue: DEFAULT_ML_COPILOT_MODE,
+        hideOnLevel: 'user',
         validate: (v) => v === 'fast' || v === 'thoughtful',
         description: 'The default reasoning mode for Zookeeper.',
         commandConfig: {


### PR DESCRIPTION
This setting is currently project-only so should be hidden at the user level, where it serves no purpose and changes are not persisted.