### PR TITLE
Add registry-backed layout extension points

### DIFF
--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -42,7 +42,10 @@ import {
   loadLayout,
   saveLayout,
   setLayoutSaveHandler,
+  createLayoutService,
+  createLayoutServiceRegistryItem,
   type Layout,
+  type LayoutService,
 } from '@src/lib/layout'
 import { playwrightLayoutConfig } from '@src/lib/layout/configs/playwright'
 import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
@@ -61,6 +64,7 @@ import type { UserResponse } from '@kittycad/lib/dist/types/src'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { SystemIOActor } from '@src/machines/systemIO/utils'
 import { coreRegistryItems } from '@src/registry/registry'
+import { layoutContributionsValueSpec } from '@src/registry/contracts/layout'
 
 const DEFAULT_LAYOUT_CONFIG_NAME = 'default'
 const PLAYWRIGHT_LAYOUT_CONFIG_NAME = 'test'
@@ -112,6 +116,7 @@ export type AppLayoutSystem = {
   get: () => Layout
   set: (l: Layout) => void
   reset: () => void
+  service: LayoutService
   saveEffectUnsubscribeFn: ReturnType<typeof effect>
 }
 
@@ -303,6 +308,7 @@ export class App implements AppSubsystems {
       ? playwrightLayoutConfig
       : defaultLayout
     const layoutSignal = signal<Layout>(runtimeDefaultLayout)
+    const layoutService = createLayoutService(layoutSignal)
     const layout: AppLayoutSystem = {
       signal: layoutSignal,
       get: () => layoutSignal.value,
@@ -312,12 +318,21 @@ export class App implements AppSubsystems {
       reset: () => {
         layoutSignal.value = structuredClone(runtimeDefaultLayout)
       },
+      service: layoutService,
       saveEffectUnsubscribeFn: effect(() =>
         saveLayout({ layout: layoutSignal.value, layoutName: layoutConfigName })
       ),
     }
+    appRegistry.configure([
+      ...coreRegistryItems,
+      createLayoutServiceRegistryItem(layoutService),
+    ])
 
     let hasHydratedLayout = false
+    const applyRegistryLayoutContributions = () =>
+      layoutService.applyContributions(
+        appRegistry.get(layoutContributionsValueSpec)
+      )
     const hydrateLayoutFromSettings = (
       snapshot: SnapshotFrom<typeof settingsActor>
     ) => {
@@ -360,9 +375,18 @@ export class App implements AppSubsystems {
       }
 
       hasHydratedLayout = true
+      applyRegistryLayoutContributions()
     }
     settingsActor.subscribe(hydrateLayoutFromSettings)
     hydrateLayoutFromSettings(settingsActor.getSnapshot())
+    effect(() => {
+      const contributions = appRegistry.signal(
+        layoutContributionsValueSpec
+      ).value
+      if (hasHydratedLayout) {
+        layoutService.applyContributions(contributions)
+      }
+    })
 
     return {
       wasmPromise,

--- a/src/lib/layout/components.tsx
+++ b/src/lib/layout/components.tsx
@@ -13,9 +13,9 @@ import type {
   Side,
   AreaTypeDefinition,
   ActionTypeDefinition,
-  ActionType,
+  AreaLibrary,
+  ActionLibrary,
 } from '@src/lib/layout/types'
-import { AreaType } from '@src/lib/layout/types'
 import type { ImperativePanelGroupHandle } from 'react-resizable-panels'
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels'
 import { CustomIcon } from '@src/components/CustomIcon'
@@ -68,8 +68,8 @@ import usePlatform from '@src/hooks/usePlatform'
 
 type WithoutRootLayout<T> = Omit<T, 'rootLayout'>
 interface LayoutState {
-  areaLibrary: Record<AreaType, AreaTypeDefinition>
-  actionLibrary: Record<ActionType, ActionTypeDefinition>
+  areaLibrary: AreaLibrary
+  actionLibrary: ActionLibrary
   updateSplitSizes: (props: WithoutRootLayout<IUpdateNodeSizes>) => void
   replaceLayoutNode: (props: WithoutRootLayout<IReplaceLayoutChildNode>) => void
   togglePane: (props: WithoutRootLayout<ITogglePane>) => void
@@ -77,26 +77,18 @@ interface LayoutState {
   enableContextMenus: boolean
 }
 
-const nullAreaLibrary = Object.fromEntries(
-  Object.values(AreaType).map((type) => [
-    type,
-    {
-      hide: () => false,
-      Component: () => <></>,
-    } satisfies AreaTypeDefinition,
-  ])
-  // TS is so annoying, I've held its hand the entire way to this type inference but Object.fromEntries widens the key to string
-) as unknown as Record<AreaType, AreaTypeDefinition>
+const missingAreaDefinition = {
+  hide: () => false,
+  Component: () => <></>,
+} satisfies AreaTypeDefinition
 
-const nullActionLibrary = Object.fromEntries(
-  Object.values(AreaType).map((type) => [
-    type,
-    {
-      execute: () => {},
-    } satisfies ActionTypeDefinition,
-  ])
-  // TS is so annoying, I've held its hand the entire way to this type inference but Object.fromEntries widens the key to string
-) as unknown as Record<ActionType, ActionTypeDefinition>
+const missingActionDefinition = {
+  execute: () => {},
+  useHidden: () => true,
+} satisfies ActionTypeDefinition
+
+const nullAreaLibrary: AreaLibrary = {}
+const nullActionLibrary: ActionLibrary = {}
 
 const LayoutStateContext = createContext<LayoutState>({
   areaLibrary: nullAreaLibrary,
@@ -225,7 +217,8 @@ function LayoutNode({
     case LayoutType.Panes:
       return <PaneLayout layout={layout} key={`node-${layout.id}`} />
     default: {
-      const { Component, ...props } = areaLibrary[layout.areaType]
+      const { Component, ...props } =
+        areaLibrary[layout.areaType] ?? missingAreaDefinition
       return <Component areaConfig={props} layout={layout} onClose={onClose} />
     }
   }
@@ -592,7 +585,8 @@ function NotificationBadge({ pane }: { pane: PaneChild }) {
 function ActionButton({ action, side }: { action: Action; side: Side }) {
   const { actionLibrary } = useLayoutState()
   const platform = usePlatform()
-  const resolvedAction = actionLibrary[action.actionType]
+  const resolvedAction =
+    actionLibrary[action.actionType] ?? missingActionDefinition
   const disabledReason = resolvedAction.useDisabled?.()
   const hidden = resolvedAction.useHidden?.()
   useHotkeys(resolvedAction.shortcut || '', () => resolvedAction.execute(), {

--- a/src/lib/layout/defaultActionLibrary.ts
+++ b/src/lib/layout/defaultActionLibrary.ts
@@ -1,18 +1,20 @@
 import { isDesktop } from '@src/lib/isDesktop'
 import { useReliesOnEngine } from '@src/hooks/useReliesOnEngine'
-import type { ActionType, ActionTypeDefinition } from '@src/lib/layout/types'
+import type { ActionLibrary } from '@src/lib/layout/types'
 import { useApp, useSingletons } from '@src/lib/boot'
 import { sendAddFileToProjectCommandForCurrentProject } from '@src/lib/commandBarConfigs/applicationCommandConfig'
 import { isMobile } from '@src/lib/isMobile'
+import { useSignals } from '@preact/signals-react/runtime'
+import { layoutActionLibraryValueSpec } from '@src/registry/contracts/layout'
 
-/**
- * For now we have strict action types but in future
- * we should make it possible to register your own in an extension.
- */
 export const useDefaultActionLibrary = () => {
-  const { commands, settings } = useApp()
+  useSignals()
+  const { commands, settings, registry } = useApp()
   const { kclManager } = useSingletons()
   const machineApiEnabled = settings.useSettings().app.machineApi.current
+  const registeredActionLibrary = registry.signal(
+    layoutActionLibraryValueSpec
+  ).value
 
   return Object.freeze({
     export: {
@@ -73,5 +75,6 @@ export const useDefaultActionLibrary = () => {
         }),
       useHidden: () => !isDesktop() || !machineApiEnabled,
     },
-  } satisfies Record<ActionType, ActionTypeDefinition>)
+    ...registeredActionLibrary,
+  } satisfies ActionLibrary)
 }

--- a/src/lib/layout/defaultAreaLibrary.tsx
+++ b/src/lib/layout/defaultAreaLibrary.tsx
@@ -2,7 +2,7 @@ import { useApp, useSingletons } from '@src/lib/boot'
 import { ConnectionStream } from '@src/components/ConnectionStream'
 import Gizmo from '@src/components/gizmo/Gizmo'
 import { Toolbar } from '@src/Toolbar'
-import type { AreaType, AreaTypeDefinition } from '@src/lib/layout/types'
+import type { AreaLibrary, AreaTypeDefinition } from '@src/lib/layout/types'
 import { kclErrorsByFilename } from '@src/lang/errors'
 import type { MouseEventHandler } from 'react'
 import { useCallback, useMemo, useState } from 'react'
@@ -20,6 +20,7 @@ import { useSignals } from '@preact/signals-react/runtime'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { DEFAULT_SKETCH_SOLVE_STREAM_DIMMING } from '@src/clientSideScene/ClientSideSceneComp'
 import { CustomIcon } from '@src/components/CustomIcon'
+import { layoutAreaLibraryValueSpec } from '@src/registry/contracts/layout'
 
 function ModelingArea() {
   const { auth } = useApp()
@@ -86,15 +87,14 @@ function ModelingArea() {
   )
 }
 
-/**
- * For now we have strict area types but in future
- * we should make it possible to register your own in an extension.
- */
 export const useDefaultAreaLibrary = () => {
   useSignals()
-  const { settings, layout } = useApp()
+  const { settings, layout, registry } = useApp()
   const { kclManager } = useSingletons()
   const getSettings = settings.get
+  const registeredAreaLibrary = registry.signal(
+    layoutAreaLibraryValueSpec
+  ).value
   const onCodeNotificationClick: MouseEventHandler = useCallback(
     (e) => {
       e.preventDefault()
@@ -189,8 +189,9 @@ export const useDefaultAreaLibrary = () => {
           shortcut: 'Shift + D',
           Component: DebugPane,
         },
-      } satisfies Record<AreaType, AreaTypeDefinition>),
-    [getSettings, kclManager, onCodeNotificationClick]
+        ...registeredAreaLibrary,
+      } satisfies AreaLibrary),
+    [getSettings, kclManager, onCodeNotificationClick, registeredAreaLibrary]
   )
 }
 
@@ -215,4 +216,4 @@ export const testAreaLibrary = Object.freeze({
   logs: testArea('Logs'),
   variables: testArea('Variables'),
   debug: testArea('Debug'),
-} satisfies Record<AreaType, AreaTypeDefinition>)
+} satisfies AreaLibrary)

--- a/src/lib/layout/index.ts
+++ b/src/lib/layout/index.ts
@@ -8,4 +8,5 @@ export {
 } from '@src/lib/layout/configs'
 export * from '@src/lib/layout/utils'
 export * from '@src/lib/layout/types'
+export * from '@src/lib/layout/service'
 export { LayoutRootNode } from '@src/lib/layout/components'

--- a/src/lib/layout/parse.test.ts
+++ b/src/lib/layout/parse.test.ts
@@ -64,12 +64,23 @@ describe('Layout utils', () => {
         )
       })
 
-      it('should error on missing or bad areaType', () => {
+      it('should parse extension areaType strings', () => {
+        const extensionAreaType = {
+          ...validSimpleLayout,
+          areaType: 'myExtension.myArea',
+        } as unknown as Layout
+
+        expect(parseLayoutInner(extensionAreaType)).toStrictEqual(
+          extensionAreaType
+        )
+      })
+
+      it('should error on missing or non-string areaType', () => {
         const { areaType: _, ...missingAreaType } = validSimpleLayout
 
         const badAreaType = {
           ...validSimpleLayout,
-          areaType: 'code',
+          areaType: 1,
         } as unknown as Layout
 
         expect(parseLayoutInner(badAreaType)).toBeInstanceOf(Error)
@@ -131,6 +142,15 @@ describe('Layout utils', () => {
       it('should parse valid action', () => {
         // Nothing should be altered if the layout is valid
         expect(parseAction(validAction)).toStrictEqual(validAction)
+      })
+
+      it('should parse extension actionType strings', () => {
+        const extensionAction = {
+          ...validAction,
+          actionType: 'myExtension.myAction',
+        } as unknown as Action
+
+        expect(parseAction(extensionAction)).toStrictEqual(extensionAction)
       })
 
       it('should heal a missing label', () => {

--- a/src/lib/layout/parse.ts
+++ b/src/lib/layout/parse.ts
@@ -1,5 +1,7 @@
 import type {
   Action,
+  ActionTypeId,
+  AreaTypeId,
   BaseLayout,
   Layout,
   LayoutWithMetadata,
@@ -9,8 +11,6 @@ import type {
   SimpleLayout,
   SplitLayout,
 } from '@src/lib/layout/types'
-import { ActionType } from '@src/lib/layout/types'
-import { AreaType } from '@src/lib/layout/types'
 import { LayoutType } from '@src/lib/layout/types'
 import { isArray } from '@src/lib/utils'
 import { isErr } from '@src/lib/trap'
@@ -61,11 +61,11 @@ export function parseLayoutInner(l: unknown): Layout | Error {
 function validateLayoutType(l: string): l is LayoutType {
   return Object.values(LayoutType).includes(l as LayoutType)
 }
-function validateAreaType(a: unknown): a is AreaType {
-  return Object.values(AreaType).includes(a as AreaType)
+function validateAreaType(a: unknown): a is AreaTypeId {
+  return typeof a === 'string' && a.length > 0
 }
-function validateActionType(a: unknown): a is ActionType {
-  return Object.values(ActionType).includes(a as ActionType)
+function validateActionType(a: unknown): a is ActionTypeId {
+  return typeof a === 'string' && a.length > 0
 }
 
 /** Basic record (object) type narrowing */

--- a/src/lib/layout/service.ts
+++ b/src/lib/layout/service.ts
@@ -1,0 +1,49 @@
+import type { Signal } from '@preact/signals-core'
+import type {
+  Layout,
+  LayoutContribution,
+  LayoutContributionResult,
+  LayoutService,
+} from '@src/lib/layout/types'
+import { applyLayoutContribution } from '@src/lib/layout/utils'
+import {
+  defineRegistryItem,
+  provideService,
+  type RegistryItemDefinition,
+} from '@kittycad/registry'
+import { layoutService as layoutServiceToken } from '@src/registry/contracts/layout'
+
+export function createLayoutService(
+  layoutSignal: Signal<Layout>
+): LayoutService {
+  function applyContributions(contributions: readonly LayoutContribution[]) {
+    const rootLayout = structuredClone(layoutSignal.peek())
+    const results: LayoutContributionResult[] = []
+
+    for (const contribution of contributions) {
+      results.push(applyLayoutContribution({ rootLayout, contribution }))
+    }
+
+    if (results.some((result) => result.applied)) {
+      layoutSignal.value = rootLayout
+    }
+
+    return results
+  }
+
+  return {
+    applyContribution(contribution) {
+      return applyContributions([contribution])[0]
+    },
+    applyContributions,
+  }
+}
+
+export function createLayoutServiceRegistryItem(
+  layoutService: LayoutService
+): RegistryItemDefinition {
+  return defineRegistryItem({
+    id: 'core.layout-service',
+    providesServices: [provideService(layoutServiceToken, layoutService)],
+  })
+}

--- a/src/lib/layout/types.ts
+++ b/src/lib/layout/types.ts
@@ -13,6 +13,9 @@ export enum AreaType {
   Debug = 'debug',
 }
 
+export type AreaTypeId = string
+export type AreaLibrary = Record<AreaTypeId, AreaTypeDefinition>
+
 export type AreaTypeComponentProps = {
   areaConfig: Omit<AreaTypeDefinition, 'Component'>
   layout: Layout
@@ -47,6 +50,9 @@ export enum ActionType {
   CommandBar = 'openCommandBar',
   Share = 'share',
 }
+
+export type ActionTypeId = string
+export type ActionLibrary = Record<ActionTypeId, ActionTypeDefinition>
 
 export type ActionTypeDefinition = {
   execute: () => void
@@ -93,7 +99,7 @@ export type SplitLayout = BaseLayout &
   }
 export type Action = HasIdAndLabel &
   WithIcon & {
-    actionType: ActionType
+    actionType: ActionTypeId
   }
 export type PaneChild = Layout & WithIcon
 export type PaneChildCssOverrides = Partial<{
@@ -119,7 +125,7 @@ export interface Closeable {
 }
 export type SimpleLayout = BaseLayout & {
   type: LayoutType.Simple
-  areaType: AreaType
+  areaType: AreaTypeId
 }
 export type Layout = SimpleLayout | SplitLayout | PaneLayout
 

--- a/src/lib/layout/types.ts
+++ b/src/lib/layout/types.ts
@@ -129,6 +129,47 @@ export type SimpleLayout = BaseLayout & {
 }
 export type Layout = SimpleLayout | SplitLayout | PaneLayout
 
+export type LayoutContributionPlacement = {
+  targetPaneId: string
+  position?: 'start' | 'end'
+  beforeId?: string
+  afterId?: string
+  index?: number
+}
+
+export type LayoutAreaContribution = {
+  id: string
+  kind: 'area'
+  pane: PaneChild
+  placement: LayoutContributionPlacement
+  initiallyOpen?: boolean
+}
+
+export type LayoutActionContribution = {
+  id: string
+  kind: 'action'
+  action: Action
+  placement: LayoutContributionPlacement
+}
+
+export type LayoutContribution =
+  | LayoutAreaContribution
+  | LayoutActionContribution
+
+export type LayoutContributionResult = {
+  applied: boolean
+  reason?: 'already-present' | 'target-not-found' | 'invalid-target' | 'applied'
+}
+
+export type LayoutService = {
+  applyContribution: (
+    contribution: LayoutContribution
+  ) => LayoutContributionResult
+  applyContributions: (
+    contributions: readonly LayoutContribution[]
+  ) => LayoutContributionResult[]
+}
+
 type LayoutVersion = `v${number}`
 
 /** add more fields as needed */

--- a/src/lib/layout/utils.test.ts
+++ b/src/lib/layout/utils.test.ts
@@ -5,6 +5,7 @@ import type {
   LayoutWithMetadata,
 } from '@src/lib/layout/types'
 import {
+  applyLayoutContribution,
   applyLayoutMigrationMap,
   closeAllPanes,
   setOpenPanes,
@@ -184,6 +185,124 @@ describe('Layout utils', () => {
 
       expect(layout).toHaveProperty('children[0].activeIndices', [0])
       expect(layout).toHaveProperty('children[1].activeIndices', [])
+    })
+  })
+
+  describe('layout contributions', () => {
+    it('inserts missing contributed areas into a target pane layout', () => {
+      const layout: Layout = {
+        id: 'root',
+        label: 'Root',
+        type: LayoutType.Panes,
+        side: 'inline-start',
+        activeIndices: [0],
+        sizes: [100],
+        splitOrientation: 'block',
+        children: [
+          {
+            id: 'existing-pane',
+            label: 'Existing',
+            type: LayoutType.Simple,
+            areaType: AreaType.Code,
+            icon: 'code',
+          },
+        ],
+      }
+
+      const result = applyLayoutContribution({
+        rootLayout: layout,
+        contribution: {
+          id: 'plugin-area-default',
+          kind: 'area',
+          pane: {
+            id: 'plugin-pane',
+            label: 'Plugin',
+            type: LayoutType.Simple,
+            areaType: 'plugin.area',
+            icon: 'stopwatch',
+          },
+          placement: {
+            targetPaneId: 'root',
+            afterId: 'existing-pane',
+          },
+          initiallyOpen: true,
+        },
+      })
+
+      expect(result).toStrictEqual({ applied: true, reason: 'applied' })
+      expect(layout).toHaveProperty('children[1].id', 'plugin-pane')
+      expect(layout).toHaveProperty('activeIndices', [0, 1])
+      expect(layout).toHaveProperty('sizes', [50, 50])
+    })
+
+    it('does not duplicate contributed areas already present anywhere in the layout', () => {
+      const layout = structuredClone(basicSplitLayout)
+
+      const result = applyLayoutContribution({
+        rootLayout: layout,
+        contribution: {
+          id: 'plugin-area-default',
+          kind: 'area',
+          pane: {
+            id: 'ttc',
+            label: 'Plugin',
+            type: LayoutType.Simple,
+            areaType: 'plugin.area',
+            icon: 'stopwatch',
+          },
+          placement: {
+            targetPaneId: 'root',
+          },
+        },
+      })
+
+      expect(result).toStrictEqual({
+        applied: false,
+        reason: 'already-present',
+      })
+    })
+
+    it('inserts missing contributed actions into a target pane layout', () => {
+      const layout: Layout = {
+        id: 'root',
+        label: 'Root',
+        type: LayoutType.Panes,
+        side: 'inline-start',
+        activeIndices: [],
+        sizes: [],
+        splitOrientation: 'block',
+        children: [],
+        actions: [
+          {
+            id: 'existing-action',
+            label: 'Existing',
+            icon: 'command',
+            actionType: 'existing.action',
+          },
+        ],
+      }
+
+      const result = applyLayoutContribution({
+        rootLayout: layout,
+        contribution: {
+          id: 'plugin-action-default',
+          kind: 'action',
+          action: {
+            id: 'plugin-action',
+            label: 'Plugin action',
+            icon: 'stopwatch',
+            actionType: 'plugin.action',
+          },
+          placement: {
+            targetPaneId: 'root',
+            beforeId: 'existing-action',
+          },
+        },
+      })
+
+      expect(result).toStrictEqual({ applied: true, reason: 'applied' })
+      expect(layout).toHaveProperty('actions[0].id', 'plugin-action')
+      expect(layout).toHaveProperty('actions[1].id', 'existing-action')
     })
   })
 

--- a/src/lib/layout/utils.ts
+++ b/src/lib/layout/utils.ts
@@ -6,6 +6,9 @@ import type {
   LayoutMigrationMap,
   LayoutTransformation,
   LayoutWithMetadata,
+  LayoutContribution,
+  LayoutContributionPlacement,
+  LayoutContributionResult,
   Orientation,
   PaneChild,
   Side,
@@ -250,6 +253,177 @@ export function findAndUpdateSplitSizes({
   }
 
   return rootLayout
+}
+
+function getInsertionIndex(
+  ids: readonly string[],
+  placement: LayoutContributionPlacement
+) {
+  if (
+    typeof placement.index === 'number' &&
+    Number.isInteger(placement.index)
+  ) {
+    return Math.min(Math.max(placement.index, 0), ids.length)
+  }
+
+  if (placement.beforeId) {
+    const beforeIndex = ids.indexOf(placement.beforeId)
+    if (beforeIndex >= 0) {
+      return beforeIndex
+    }
+  }
+
+  if (placement.afterId) {
+    const afterIndex = ids.indexOf(placement.afterId)
+    if (afterIndex >= 0) {
+      return afterIndex + 1
+    }
+  }
+
+  return placement.position === 'start' ? 0 : ids.length
+}
+
+function actionExists(rootLayout: Layout, actionId: string): boolean {
+  if (
+    rootLayout.type === LayoutType.Panes &&
+    rootLayout.actions?.some((action) => action.id === actionId)
+  ) {
+    return true
+  }
+
+  if ('children' in rootLayout && rootLayout.children) {
+    return rootLayout.children.some((child) => actionExists(child, actionId))
+  }
+
+  return false
+}
+
+function recomputePaneActiveState({
+  paneLayout,
+  activePaneIds,
+  sizeByPaneId,
+  insertedPaneId,
+  initiallyOpen,
+}: {
+  paneLayout: Extract<Layout, { type: LayoutType.Panes }>
+  activePaneIds: string[]
+  sizeByPaneId: Map<string, number>
+  insertedPaneId: string
+  initiallyOpen: boolean
+}) {
+  const nextActivePaneIds =
+    initiallyOpen && !activePaneIds.includes(insertedPaneId)
+      ? [...activePaneIds, insertedPaneId]
+      : activePaneIds
+
+  paneLayout.activeIndices = nextActivePaneIds
+    .map((id) => paneLayout.children.findIndex((child) => child.id === id))
+    .filter((index) => index >= 0)
+    .sort((a, b) => a - b)
+
+  if (!initiallyOpen) {
+    paneLayout.sizes = paneLayout.activeIndices.map((activeIndex) => {
+      const paneId = paneLayout.children[activeIndex]?.id
+      return paneId ? (sizeByPaneId.get(paneId) ?? 0) : 0
+    })
+    return
+  }
+
+  const openPaneCount = paneLayout.activeIndices.length
+  paneLayout.sizes = openPaneCount
+    ? new Array(openPaneCount).fill(100 / openPaneCount)
+    : []
+}
+
+export function applyLayoutContribution({
+  rootLayout,
+  contribution,
+}: {
+  rootLayout: Layout
+  contribution: LayoutContribution
+}): LayoutContributionResult {
+  if (contribution.kind === 'area') {
+    if (
+      findLayoutChildNode({ rootLayout, targetNodeId: contribution.pane.id })
+    ) {
+      return { applied: false, reason: 'already-present' }
+    }
+
+    const target = findLayoutChildNode({
+      rootLayout,
+      targetNodeId: contribution.placement.targetPaneId,
+    })
+
+    if (!target) {
+      return { applied: false, reason: 'target-not-found' }
+    }
+
+    if (target.type !== LayoutType.Panes) {
+      return { applied: false, reason: 'invalid-target' }
+    }
+
+    const activePaneIds = target.activeIndices
+      .map((activeIndex) => target.children[activeIndex]?.id)
+      .filter((id) => id !== undefined)
+    const sizeByPaneId = new Map(
+      target.activeIndices.map((activeIndex, sizeIndex) => [
+        target.children[activeIndex]?.id,
+        target.sizes[sizeIndex],
+      ])
+    )
+    const insertionIndex = getInsertionIndex(
+      target.children.map((child) => child.id),
+      contribution.placement
+    )
+
+    target.children.splice(
+      insertionIndex,
+      0,
+      structuredClone(contribution.pane)
+    )
+    recomputePaneActiveState({
+      paneLayout: target,
+      activePaneIds,
+      sizeByPaneId: new Map(
+        Array.from(sizeByPaneId.entries()).filter(
+          (entry): entry is [string, number] =>
+            entry[0] !== undefined && entry[1] !== undefined
+        )
+      ),
+      insertedPaneId: contribution.pane.id,
+      initiallyOpen: contribution.initiallyOpen ?? false,
+    })
+
+    return { applied: true, reason: 'applied' }
+  }
+
+  if (actionExists(rootLayout, contribution.action.id)) {
+    return { applied: false, reason: 'already-present' }
+  }
+
+  const target = findLayoutChildNode({
+    rootLayout,
+    targetNodeId: contribution.placement.targetPaneId,
+  })
+
+  if (!target) {
+    return { applied: false, reason: 'target-not-found' }
+  }
+
+  if (target.type !== LayoutType.Panes) {
+    return { applied: false, reason: 'invalid-target' }
+  }
+
+  const actions = target.actions ?? []
+  const insertionIndex = getInsertionIndex(
+    actions.map((action) => action.id),
+    contribution.placement
+  )
+
+  target.actions = [...actions]
+  target.actions.splice(insertionIndex, 0, structuredClone(contribution.action))
+
+  return { applied: true, reason: 'applied' }
 }
 
 /** Legacy prefix for localStorage persisted layout data */

--- a/src/registry/contracts/layout.ts
+++ b/src/registry/contracts/layout.ts
@@ -1,0 +1,16 @@
+import type { ActionLibrary, AreaLibrary } from '@src/lib/layout/types'
+import { defineContract, mergeObjectsValueSpec } from '@kittycad/registry'
+
+export const layoutContract = defineContract({
+  layoutAreaLibraryValueSpec: mergeObjectsValueSpec<AreaLibrary>(
+    'layout.areaLibrary',
+    {}
+  ),
+  layoutActionLibraryValueSpec: mergeObjectsValueSpec<ActionLibrary>(
+    'layout.actionLibrary',
+    {}
+  ),
+})
+
+export const { layoutAreaLibraryValueSpec, layoutActionLibraryValueSpec } =
+  layoutContract

--- a/src/registry/contracts/layout.ts
+++ b/src/registry/contracts/layout.ts
@@ -1,7 +1,18 @@
-import type { ActionLibrary, AreaLibrary } from '@src/lib/layout/types'
-import { defineContract, mergeObjectsValueSpec } from '@kittycad/registry'
+import type {
+  ActionLibrary,
+  AreaLibrary,
+  LayoutContribution,
+  LayoutService,
+} from '@src/lib/layout/types'
+import {
+  defineContract,
+  defineService,
+  defineValueSpec,
+  mergeObjectsValueSpec,
+} from '@kittycad/registry'
 
 export const layoutContract = defineContract({
+  layoutService: defineService<LayoutService>('layout.service'),
   layoutAreaLibraryValueSpec: mergeObjectsValueSpec<AreaLibrary>(
     'layout.areaLibrary',
     {}
@@ -10,7 +21,28 @@ export const layoutContract = defineContract({
     'layout.actionLibrary',
     {}
   ),
+  layoutContributionsValueSpec: defineValueSpec<
+    LayoutContribution,
+    readonly LayoutContribution[]
+  >({
+    name: 'layout.contributions',
+    defaultValue: [],
+    combine: (inputs) => {
+      const seen = new Set<string>()
+      return inputs.filter((contribution) => {
+        if (seen.has(contribution.id)) {
+          return false
+        }
+        seen.add(contribution.id)
+        return true
+      })
+    },
+  }),
 })
 
-export const { layoutAreaLibraryValueSpec, layoutActionLibraryValueSpec } =
-  layoutContract
+export const {
+  layoutService,
+  layoutAreaLibraryValueSpec,
+  layoutActionLibraryValueSpec,
+  layoutContributionsValueSpec,
+} = layoutContract


### PR DESCRIPTION
Widens layout area/action IDs to support extension-provided strings, adds registry contracts for area/action libraries and layout contributions, and introduces an app-owned layout service that idempotently applies plugin default areas/actions without removing user-customized layout nodes. Built on #11431, Codex written.