### PR TITLE
KCL: Treat WebSocket connection issues as Engine Hangup

### DIFF
--- a/rust/kcl-lib/src/engine/conn.rs
+++ b/rust/kcl-lib/src/engine/conn.rs
@@ -482,16 +482,19 @@ impl EngineManager for EngineConnection {
         // Wait for the request to be sent.
         rx.await
             .map_err(|e| {
-                KclError::new_engine(KclErrorDetails::new(
-                    format!("could not send request to the engine actor: {e}"),
-                    vec![source_range],
-                ))
+                KclError::new_engine_hangup(
+                    KclErrorDetails::new(
+                        format!("could not send request to the engine actor: {e}"),
+                        vec![source_range],
+                    ),
+                    None,
+                )
             })?
             .map_err(|e| {
-                KclError::new_engine(KclErrorDetails::new(
-                    format!("could not send request to the engine: {e}"),
-                    vec![source_range],
-                ))
+                KclError::new_engine_hangup(
+                    KclErrorDetails::new(format!("could not send request to the engine: {e}"), vec![source_range]),
+                    None,
+                )
             })?;
 
         Ok(())


### PR DESCRIPTION
This error path is about communicating with the engine over WebSocket, not the Engine staying online but erroring for a particular response.

I've seen this error when working with a Synera node, e.g.

```
could not send request to the engine: could not send json over websocket: WebSocket protocol error: Sending after closing is not
allowed
```

and it should signal that the WebSocket connection needs to be re-established.