### PR TITLE
KCL lib compatibility with modeling-cmds 0.2.195 (face-api)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2580,9 +2580,9 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.193"
+version = "0.2.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64de85fb38082d752777827f4fb0410bbe6a26b2832b4e943ba3f889a84a9e39"
+checksum = "adea5e242fa7d56bc95a51df88654b5fe26d06f0f62b6619e3732440ec7d42e3"
 dependencies = [
  "anyhow",
  "bon",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,7 +28,7 @@ kittycad = { version = "0.4.11", default-features = false, features = [
   "js",
   "requests",
 ] }
-kittycad-modeling-cmds = { version = "0.2.193", features = [
+kittycad-modeling-cmds = { version = "0.2.195", features = [
   "ts-rs",
   "websocket",
 ] }

--- a/rust/kcl-lib/src/execution/artifact.rs
+++ b/rust/kcl-lib/src/execution/artifact.rs
@@ -1928,10 +1928,9 @@ fn artifacts_to_update(
             return Ok(return_arr);
         }
         ModelingCmd::EntityMakeHelixFromEdge(helix) => {
-            let edge_id = ArtifactId::new(helix.edge_id);
             let return_arr = vec![Artifact::Helix(Helix {
                 id,
-                axis_id: Some(edge_id),
+                axis_id: helix.edge_id.map(ArtifactId::new),
                 code_ref,
                 trajectory_sweep_id: None,
                 consumed: false,

--- a/rust/kcl-lib/src/std/extrude.rs
+++ b/rust/kcl-lib/src/std/extrude.rs
@@ -430,7 +430,10 @@ async fn inner_extrude(
                     ModelingCmd::from(
                         mcmd::ExtrudeToReference::builder()
                             .target(sketch_or_face_id.into())
-                            .reference(ExtrudeReference::EntityReference { entity_id: plane_id })
+                            .reference(ExtrudeReference::EntityReference {
+                                entity_id: Some(plane_id),
+                                entity_reference: None,
+                            })
                             .extrude_method(extrude_method)
                             .body_type(body_type)
                             .build(),
@@ -441,7 +444,10 @@ async fn inner_extrude(
                     ModelingCmd::from(
                         mcmd::ExtrudeToReference::builder()
                             .target(sketch_or_face_id.into())
-                            .reference(ExtrudeReference::EntityReference { entity_id: edge_id })
+                            .reference(ExtrudeReference::EntityReference {
+                                entity_id: Some(edge_id),
+                                entity_reference: None,
+                            })
                             .extrude_method(extrude_method)
                             .body_type(body_type)
                             .build(),
@@ -452,7 +458,10 @@ async fn inner_extrude(
                     ModelingCmd::from(
                         mcmd::ExtrudeToReference::builder()
                             .target(sketch_or_face_id.into())
-                            .reference(ExtrudeReference::EntityReference { entity_id: face_id })
+                            .reference(ExtrudeReference::EntityReference {
+                                entity_id: Some(face_id),
+                                entity_reference: None,
+                            })
                             .extrude_method(extrude_method)
                             .body_type(body_type)
                             .build(),
@@ -462,7 +471,8 @@ async fn inner_extrude(
                     mcmd::ExtrudeToReference::builder()
                         .target(sketch_or_face_id.into())
                         .reference(ExtrudeReference::EntityReference {
-                            entity_id: sketch_ref.id,
+                            entity_id: Some(sketch_ref.id),
+                            entity_reference: None,
                         })
                         .extrude_method(extrude_method)
                         .body_type(body_type)
@@ -471,7 +481,10 @@ async fn inner_extrude(
                 Point3dAxis3dOrGeometryReference::Solid(solid) => ModelingCmd::from(
                     mcmd::ExtrudeToReference::builder()
                         .target(sketch_or_face_id.into())
-                        .reference(ExtrudeReference::EntityReference { entity_id: solid.id })
+                        .reference(ExtrudeReference::EntityReference {
+                            entity_id: Some(solid.id),
+                            entity_reference: None,
+                        })
                         .extrude_method(extrude_method)
                         .body_type(body_type)
                         .build(),
@@ -483,7 +496,8 @@ async fn inner_extrude(
                         mcmd::ExtrudeToReference::builder()
                             .target(sketch_or_face_id.into())
                             .reference(ExtrudeReference::EntityReference {
-                                entity_id: tagged_edge_or_face_id,
+                                entity_id: Some(tagged_edge_or_face_id),
+                                entity_reference: None,
                             })
                             .extrude_method(extrude_method)
                             .body_type(body_type)


### PR DESCRIPTION
Related to
- https://github.com/KittyCAD/engine/pull/4194
- https://github.com/KittyCAD/modeling-api/pull/1163
- https://github.com/KittyCAD/modeling-app/pull/10602

This PR updates the Rust KCL workspace to consume latest `kittycad-modeling-cmds`, which contains the recently merged Face API command contract changes.

The KCL stdlib surface area is NOT intended to change here. The code changes are compatibility adapters for generated Rust command types whose internal shape changed in `modeling-cmds`.

### Why this is needed

The Face API work mostly adds new command shapes and endpoints, but some existing command payloads also changed to support entity-reference based topology queries.

`kcl-lib` constructs these command payloads directly when stdlib functions compile KCL into engine modeling commands. That means a generated Rust type change in `modeling-api` can require `kcl-lib` source changes even when KCL syntax and behavior stay the same.

This is needed so a new `kcl-lib` can be published against the latest `modeling-cmds`. Engine can then depend on a published `kcl-lib` version instead of a temporary modeling-app git branch.

### What changed

- Bumped `kittycad-modeling-cmds` from `0.2.193` to `0.2.195`.
- Updated `ExtrudeReference::EntityReference` construction to populate the new shape with `entity_id: Some(...)` and `entity_reference: None`.
- Updated helix artifact bookkeeping to handle `EntityMakeHelixFromEdge.edge_id` now being optional.

### Compatibility notes

These changes preserve the existing UUID-based path by filling `entity_id` and leaving the new `entity_reference` field unset.

That means existing KCL calls should continue to compile to the same effective engine behavior. This PR does not introduce new Face API KCL syntax or switch users onto the new topology-query payloads.

The helix change is also internal bookkeeping only. It preserves the previous artifact graph edge relationship when an edge id is present, and safely represents the new optional case when it is not.

