### PR TITLE
Add deprecated_since attribute in KCL stdlib

### DIFF
--- a/docs/kcl-std-legacy/functions/std-sketch-angledLine.md
+++ b/docs/kcl-std-legacy/functions/std-sketch-angledLine.md
@@ -5,6 +5,8 @@ excerpt: "Draw a line segment relative to the current origin using the polar mea
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Draw a line segment relative to the current origin using the polar measure of some angle and distance.
 
 ```kcl
@@ -20,7 +22,7 @@ angledLine(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 ### Arguments

--- a/docs/kcl-std-legacy/functions/std-sketch-angledLineThatIntersects.md
+++ b/docs/kcl-std-legacy/functions/std-sketch-angledLineThatIntersects.md
@@ -5,6 +5,8 @@ excerpt: "Draw an angled line from the current origin, constructing a line segme
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Draw an angled line from the current origin, constructing a line segment such that the newly created line intersects the desired target line segment.
 
 ```kcl
@@ -17,7 +19,7 @@ angledLineThatIntersects(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 ### Arguments

--- a/docs/kcl-std-legacy/functions/std-sketch-arc.md
+++ b/docs/kcl-std-legacy/functions/std-sketch-arc.md
@@ -5,6 +5,8 @@ excerpt: "Draw a curved line segment along an imaginary circle."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Draw a curved line segment along an imaginary circle.
 
 ```kcl
@@ -20,7 +22,7 @@ arc(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 The arc is constructed such that the current position of the sketch is

--- a/docs/kcl-std-legacy/functions/std-sketch-bezierCurve.md
+++ b/docs/kcl-std-legacy/functions/std-sketch-bezierCurve.md
@@ -5,6 +5,8 @@ excerpt: "Draw a smooth, continuous, curved line segment from the current origin
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Draw a smooth, continuous, curved line segment from the current origin to the desired (x, y), using a number of control points to shape the curve's shape.
 
 ```kcl
@@ -20,7 +22,7 @@ bezierCurve(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve. The sketch-solve version
 of bezier curve is still under development.
 

--- a/docs/kcl-std-legacy/functions/std-sketch-circle.md
+++ b/docs/kcl-std-legacy/functions/std-sketch-circle.md
@@ -5,6 +5,8 @@ excerpt: "Construct a 2-dimensional circle, of the specified radius, centered at
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Construct a 2-dimensional circle, of the specified radius, centered at the provided (x, y) origin point.
 
 ```kcl
@@ -17,7 +19,7 @@ circle(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 ### Arguments

--- a/docs/kcl-std-legacy/functions/std-sketch-circleThreePoint.md
+++ b/docs/kcl-std-legacy/functions/std-sketch-circleThreePoint.md
@@ -5,6 +5,8 @@ excerpt: "Construct a circle derived from 3 points."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Construct a circle derived from 3 points.
 
 ```kcl
@@ -17,7 +19,7 @@ circleThreePoint(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 ### Arguments

--- a/docs/kcl-std-legacy/functions/std-sketch-close.md
+++ b/docs/kcl-std-legacy/functions/std-sketch-close.md
@@ -5,6 +5,8 @@ excerpt: "Construct a line segment from the current origin back to the profile's
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Construct a line segment from the current origin back to the profile's origin, ensuring the resulting 2-dimensional sketch is not open-ended.
 
 ```kcl
@@ -14,7 +16,7 @@ close(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 If you want to perform some 3-dimensional operation on a sketch, like

--- a/docs/kcl-std-legacy/functions/std-sketch-involuteCircular.md
+++ b/docs/kcl-std-legacy/functions/std-sketch-involuteCircular.md
@@ -5,6 +5,8 @@ excerpt: "Extend the current sketch with a new involute circular curve."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Extend the current sketch with a new involute circular curve.
 
 ```kcl
@@ -20,9 +22,9 @@ involuteCircular(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
-sketch-solve. The sketch-solve version
-of involute circular is still under development.
+This is part of sketch v1 and is deprecated in favor of
+sketch-solve and the
+gear module.
 
 ### Arguments
 

--- a/docs/kcl-std-legacy/functions/std-sketch-line.md
+++ b/docs/kcl-std-legacy/functions/std-sketch-line.md
@@ -5,6 +5,8 @@ excerpt: "Extend the current sketch with a new straight line."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Extend the current sketch with a new straight line.
 
 ```kcl
@@ -16,7 +18,7 @@ line(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 ### Arguments

--- a/docs/kcl-std-legacy/functions/std-sketch-polygon.md
+++ b/docs/kcl-std-legacy/functions/std-sketch-polygon.md
@@ -5,6 +5,8 @@ excerpt: "Create a regular polygon with the specified number of sides that is ei
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Create a regular polygon with the specified number of sides that is either inscribed or circumscribed around a circle of the specified radius.
 
 ```kcl
@@ -17,7 +19,7 @@ polygon(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 ### Arguments

--- a/docs/kcl-std-legacy/functions/std-sketch-rectangle.md
+++ b/docs/kcl-std-legacy/functions/std-sketch-rectangle.md
@@ -5,6 +5,8 @@ excerpt: "Sketch a rectangle."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Sketch a rectangle.
 
 ```kcl
@@ -17,7 +19,7 @@ rectangle(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 A rectangle can be defined by its width, height, and location. Either the center or corner must be provided, but not both, to specify its location.

--- a/docs/kcl-std-legacy/functions/std-sketch-startProfile.md
+++ b/docs/kcl-std-legacy/functions/std-sketch-startProfile.md
@@ -5,6 +5,8 @@ excerpt: "Start a new profile at a given point."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Start a new profile at a given point.
 
 ```kcl
@@ -15,7 +17,7 @@ startProfile(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 ### Arguments

--- a/docs/kcl-std-legacy/functions/std-sketch-startSketchOn.md
+++ b/docs/kcl-std-legacy/functions/std-sketch-startSketchOn.md
@@ -5,6 +5,8 @@ excerpt: "Start a new 2-dimensional sketch on a specific plane or face."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Start a new 2-dimensional sketch on a specific plane or face.
 
 ```kcl
@@ -17,7 +19,7 @@ startSketchOn(
 ): Plane | Face
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 ### Sketch on Face Behavior

--- a/docs/kcl-std-legacy/functions/std-sketch-subtract2d.md
+++ b/docs/kcl-std-legacy/functions/std-sketch-subtract2d.md
@@ -5,6 +5,8 @@ excerpt: "Use a 2-dimensional sketch to cut a hole in another 2-dimensional sket
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Use a 2-dimensional sketch to cut a hole in another 2-dimensional sketch.
 
 ```kcl
@@ -14,7 +16,7 @@ subtract2d(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 ### Arguments

--- a/docs/kcl-std-legacy/functions/std-sketch-tangentialArc.md
+++ b/docs/kcl-std-legacy/functions/std-sketch-tangentialArc.md
@@ -5,6 +5,8 @@ excerpt: "Starting at the current sketch's origin, draw a curved line segment al
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Starting at the current sketch's origin, draw a curved line segment along some part of an imaginary circle until it reaches the desired (x, y) coordinates.
 
 ```kcl
@@ -19,7 +21,7 @@ tangentialArc(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 When using radius and angle, draw a curved line segment along part of an

--- a/docs/kcl-std-legacy/functions/std-sketch-xLine.md
+++ b/docs/kcl-std-legacy/functions/std-sketch-xLine.md
@@ -5,6 +5,8 @@ excerpt: "Draw a line relative to the current origin to a specified distance awa
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Draw a line relative to the current origin to a specified distance away from the current position along the 'x' axis.
 
 ```kcl
@@ -16,7 +18,7 @@ xLine(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 ### Arguments

--- a/docs/kcl-std-legacy/functions/std-sketch-yLine.md
+++ b/docs/kcl-std-legacy/functions/std-sketch-yLine.md
@@ -5,6 +5,8 @@ excerpt: "Draw a line relative to the current origin to a specified distance awa
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Draw a line relative to the current origin to a specified distance away from the current position along the 'y' axis.
 
 ```kcl
@@ -16,7 +18,7 @@ yLine(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 ### Arguments

--- a/docs/kcl-std-sketch-solve/functions/std-sketch-angledLine.md
+++ b/docs/kcl-std-sketch-solve/functions/std-sketch-angledLine.md
@@ -5,6 +5,8 @@ excerpt: "Draw a line segment relative to the current origin using the polar mea
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Draw a line segment relative to the current origin using the polar measure of some angle and distance.
 
 ```kcl
@@ -20,7 +22,7 @@ angledLine(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 ### Arguments

--- a/docs/kcl-std-sketch-solve/functions/std-sketch-angledLineThatIntersects.md
+++ b/docs/kcl-std-sketch-solve/functions/std-sketch-angledLineThatIntersects.md
@@ -5,6 +5,8 @@ excerpt: "Draw an angled line from the current origin, constructing a line segme
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Draw an angled line from the current origin, constructing a line segment such that the newly created line intersects the desired target line segment.
 
 ```kcl
@@ -17,7 +19,7 @@ angledLineThatIntersects(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 ### Arguments

--- a/docs/kcl-std-sketch-solve/functions/std-sketch-arc.md
+++ b/docs/kcl-std-sketch-solve/functions/std-sketch-arc.md
@@ -5,6 +5,8 @@ excerpt: "Draw a curved line segment along an imaginary circle."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Draw a curved line segment along an imaginary circle.
 
 ```kcl
@@ -20,7 +22,7 @@ arc(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 The arc is constructed such that the current position of the sketch is

--- a/docs/kcl-std-sketch-solve/functions/std-sketch-bezierCurve.md
+++ b/docs/kcl-std-sketch-solve/functions/std-sketch-bezierCurve.md
@@ -5,6 +5,8 @@ excerpt: "Draw a smooth, continuous, curved line segment from the current origin
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Draw a smooth, continuous, curved line segment from the current origin to the desired (x, y), using a number of control points to shape the curve's shape.
 
 ```kcl
@@ -20,7 +22,7 @@ bezierCurve(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve. The sketch-solve version
 of bezier curve is still under development.
 

--- a/docs/kcl-std-sketch-solve/functions/std-sketch-circle.md
+++ b/docs/kcl-std-sketch-solve/functions/std-sketch-circle.md
@@ -5,6 +5,8 @@ excerpt: "Construct a 2-dimensional circle, of the specified radius, centered at
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Construct a 2-dimensional circle, of the specified radius, centered at the provided (x, y) origin point.
 
 ```kcl
@@ -17,7 +19,7 @@ circle(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 ### Arguments

--- a/docs/kcl-std-sketch-solve/functions/std-sketch-circleThreePoint.md
+++ b/docs/kcl-std-sketch-solve/functions/std-sketch-circleThreePoint.md
@@ -5,6 +5,8 @@ excerpt: "Construct a circle derived from 3 points."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Construct a circle derived from 3 points.
 
 ```kcl
@@ -17,7 +19,7 @@ circleThreePoint(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 ### Arguments

--- a/docs/kcl-std-sketch-solve/functions/std-sketch-close.md
+++ b/docs/kcl-std-sketch-solve/functions/std-sketch-close.md
@@ -5,6 +5,8 @@ excerpt: "Construct a line segment from the current origin back to the profile's
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Construct a line segment from the current origin back to the profile's origin, ensuring the resulting 2-dimensional sketch is not open-ended.
 
 ```kcl
@@ -14,7 +16,7 @@ close(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 If you want to perform some 3-dimensional operation on a sketch, like

--- a/docs/kcl-std-sketch-solve/functions/std-sketch-involuteCircular.md
+++ b/docs/kcl-std-sketch-solve/functions/std-sketch-involuteCircular.md
@@ -5,6 +5,8 @@ excerpt: "Extend the current sketch with a new involute circular curve."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Extend the current sketch with a new involute circular curve.
 
 ```kcl
@@ -20,9 +22,9 @@ involuteCircular(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
-sketch-solve. The sketch-solve version
-of involute circular is still under development.
+This is part of sketch v1 and is deprecated in favor of
+sketch-solve and the
+gear module.
 
 ### Arguments
 

--- a/docs/kcl-std-sketch-solve/functions/std-sketch-line.md
+++ b/docs/kcl-std-sketch-solve/functions/std-sketch-line.md
@@ -5,6 +5,8 @@ excerpt: "Extend the current sketch with a new straight line."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Extend the current sketch with a new straight line.
 
 ```kcl
@@ -16,7 +18,7 @@ line(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 ### Arguments

--- a/docs/kcl-std-sketch-solve/functions/std-sketch-polygon.md
+++ b/docs/kcl-std-sketch-solve/functions/std-sketch-polygon.md
@@ -5,6 +5,8 @@ excerpt: "Create a regular polygon with the specified number of sides that is ei
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Create a regular polygon with the specified number of sides that is either inscribed or circumscribed around a circle of the specified radius.
 
 ```kcl
@@ -17,7 +19,7 @@ polygon(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 ### Arguments

--- a/docs/kcl-std-sketch-solve/functions/std-sketch-rectangle.md
+++ b/docs/kcl-std-sketch-solve/functions/std-sketch-rectangle.md
@@ -5,6 +5,8 @@ excerpt: "Sketch a rectangle."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Sketch a rectangle.
 
 ```kcl
@@ -17,7 +19,7 @@ rectangle(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 A rectangle can be defined by its width, height, and location. Either the center or corner must be provided, but not both, to specify its location.

--- a/docs/kcl-std-sketch-solve/functions/std-sketch-startProfile.md
+++ b/docs/kcl-std-sketch-solve/functions/std-sketch-startProfile.md
@@ -5,6 +5,8 @@ excerpt: "Start a new profile at a given point."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Start a new profile at a given point.
 
 ```kcl
@@ -15,7 +17,7 @@ startProfile(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 ### Arguments

--- a/docs/kcl-std-sketch-solve/functions/std-sketch-startSketchOn.md
+++ b/docs/kcl-std-sketch-solve/functions/std-sketch-startSketchOn.md
@@ -5,6 +5,8 @@ excerpt: "Start a new 2-dimensional sketch on a specific plane or face."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Start a new 2-dimensional sketch on a specific plane or face.
 
 ```kcl
@@ -17,7 +19,7 @@ startSketchOn(
 ): Plane | Face
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 ### Sketch on Face Behavior

--- a/docs/kcl-std-sketch-solve/functions/std-sketch-subtract2d.md
+++ b/docs/kcl-std-sketch-solve/functions/std-sketch-subtract2d.md
@@ -5,6 +5,8 @@ excerpt: "Use a 2-dimensional sketch to cut a hole in another 2-dimensional sket
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Use a 2-dimensional sketch to cut a hole in another 2-dimensional sketch.
 
 ```kcl
@@ -14,7 +16,7 @@ subtract2d(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 ### Arguments

--- a/docs/kcl-std-sketch-solve/functions/std-sketch-tangentialArc.md
+++ b/docs/kcl-std-sketch-solve/functions/std-sketch-tangentialArc.md
@@ -5,6 +5,8 @@ excerpt: "Starting at the current sketch's origin, draw a curved line segment al
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Starting at the current sketch's origin, draw a curved line segment along some part of an imaginary circle until it reaches the desired (x, y) coordinates.
 
 ```kcl
@@ -19,7 +21,7 @@ tangentialArc(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 When using radius and angle, draw a curved line segment along part of an

--- a/docs/kcl-std-sketch-solve/functions/std-sketch-xLine.md
+++ b/docs/kcl-std-sketch-solve/functions/std-sketch-xLine.md
@@ -5,6 +5,8 @@ excerpt: "Draw a line relative to the current origin to a specified distance awa
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Draw a line relative to the current origin to a specified distance away from the current position along the 'x' axis.
 
 ```kcl
@@ -16,7 +18,7 @@ xLine(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 ### Arguments

--- a/docs/kcl-std-sketch-solve/functions/std-sketch-yLine.md
+++ b/docs/kcl-std-sketch-solve/functions/std-sketch-yLine.md
@@ -5,6 +5,8 @@ excerpt: "Draw a line relative to the current origin to a specified distance awa
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Draw a line relative to the current origin to a specified distance away from the current position along the 'y' axis.
 
 ```kcl
@@ -16,7 +18,7 @@ yLine(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 sketch-solve.
 
 ### Arguments

--- a/docs/kcl-std/functions/std-sketch-angledLine.md
+++ b/docs/kcl-std/functions/std-sketch-angledLine.md
@@ -5,6 +5,8 @@ excerpt: "Draw a line segment relative to the current origin using the polar mea
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Draw a line segment relative to the current origin using the polar measure of some angle and distance.
 
 ```kcl
@@ -20,7 +22,7 @@ angledLine(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 
 ### Arguments

--- a/docs/kcl-std/functions/std-sketch-angledLineThatIntersects.md
+++ b/docs/kcl-std/functions/std-sketch-angledLineThatIntersects.md
@@ -5,6 +5,8 @@ excerpt: "Draw an angled line from the current origin, constructing a line segme
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Draw an angled line from the current origin, constructing a line segment such that the newly created line intersects the desired target line segment.
 
 ```kcl
@@ -17,7 +19,7 @@ angledLineThatIntersects(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 
 ### Arguments

--- a/docs/kcl-std/functions/std-sketch-arc.md
+++ b/docs/kcl-std/functions/std-sketch-arc.md
@@ -5,6 +5,8 @@ excerpt: "Draw a curved line segment along an imaginary circle."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Draw a curved line segment along an imaginary circle.
 
 ```kcl
@@ -20,7 +22,7 @@ arc(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 
 The arc is constructed such that the current position of the sketch is

--- a/docs/kcl-std/functions/std-sketch-bezierCurve.md
+++ b/docs/kcl-std/functions/std-sketch-bezierCurve.md
@@ -5,6 +5,8 @@ excerpt: "Draw a smooth, continuous, curved line segment from the current origin
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Draw a smooth, continuous, curved line segment from the current origin to the desired (x, y), using a number of control points to shape the curve's shape.
 
 ```kcl
@@ -20,7 +22,7 @@ bezierCurve(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver). The sketch-solve version
 of bezier curve is still under development.
 

--- a/docs/kcl-std/functions/std-sketch-circle.md
+++ b/docs/kcl-std/functions/std-sketch-circle.md
@@ -5,6 +5,8 @@ excerpt: "Construct a 2-dimensional circle, of the specified radius, centered at
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Construct a 2-dimensional circle, of the specified radius, centered at the provided (x, y) origin point.
 
 ```kcl
@@ -17,7 +19,7 @@ circle(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 
 ### Arguments

--- a/docs/kcl-std/functions/std-sketch-circleThreePoint.md
+++ b/docs/kcl-std/functions/std-sketch-circleThreePoint.md
@@ -5,6 +5,8 @@ excerpt: "Construct a circle derived from 3 points."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Construct a circle derived from 3 points.
 
 ```kcl
@@ -17,7 +19,7 @@ circleThreePoint(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 
 ### Arguments

--- a/docs/kcl-std/functions/std-sketch-close.md
+++ b/docs/kcl-std/functions/std-sketch-close.md
@@ -5,6 +5,8 @@ excerpt: "Construct a line segment from the current origin back to the profile's
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Construct a line segment from the current origin back to the profile's origin, ensuring the resulting 2-dimensional sketch is not open-ended.
 
 ```kcl
@@ -14,7 +16,7 @@ close(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 
 If you want to perform some 3-dimensional operation on a sketch, like

--- a/docs/kcl-std/functions/std-sketch-involuteCircular.md
+++ b/docs/kcl-std/functions/std-sketch-involuteCircular.md
@@ -5,6 +5,8 @@ excerpt: "Extend the current sketch with a new involute circular curve."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Extend the current sketch with a new involute circular curve.
 
 ```kcl
@@ -20,9 +22,9 @@ involuteCircular(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
-[sketch-solve](/docs/kcl-std/modules/std-solver). The sketch-solve version
-of involute circular is still under development.
+This is part of sketch v1 and is deprecated in favor of
+[sketch-solve](/docs/kcl-std/modules/std-solver) and the
+[gear module](/docs/kcl-std/modules/std-gear).
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-sketch-line.md
+++ b/docs/kcl-std/functions/std-sketch-line.md
@@ -5,6 +5,8 @@ excerpt: "Extend the current sketch with a new straight line."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Extend the current sketch with a new straight line.
 
 ```kcl
@@ -16,7 +18,7 @@ line(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 
 ### Arguments

--- a/docs/kcl-std/functions/std-sketch-polygon.md
+++ b/docs/kcl-std/functions/std-sketch-polygon.md
@@ -5,6 +5,8 @@ excerpt: "Create a regular polygon with the specified number of sides that is ei
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Create a regular polygon with the specified number of sides that is either inscribed or circumscribed around a circle of the specified radius.
 
 ```kcl
@@ -17,7 +19,7 @@ polygon(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 
 ### Arguments

--- a/docs/kcl-std/functions/std-sketch-rectangle.md
+++ b/docs/kcl-std/functions/std-sketch-rectangle.md
@@ -5,6 +5,8 @@ excerpt: "Sketch a rectangle."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Sketch a rectangle.
 
 ```kcl
@@ -17,7 +19,7 @@ rectangle(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 
 A rectangle can be defined by its width, height, and location. Either the center or corner must be provided, but not both, to specify its location.

--- a/docs/kcl-std/functions/std-sketch-startProfile.md
+++ b/docs/kcl-std/functions/std-sketch-startProfile.md
@@ -5,6 +5,8 @@ excerpt: "Start a new profile at a given point."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Start a new profile at a given point.
 
 ```kcl
@@ -15,7 +17,7 @@ startProfile(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 
 ### Arguments

--- a/docs/kcl-std/functions/std-sketch-startSketchOn.md
+++ b/docs/kcl-std/functions/std-sketch-startSketchOn.md
@@ -5,6 +5,8 @@ excerpt: "Start a new 2-dimensional sketch on a specific plane or face."
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Start a new 2-dimensional sketch on a specific plane or face.
 
 ```kcl
@@ -17,7 +19,7 @@ startSketchOn(
 ): Plane | Face
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 
 ### Sketch on Face Behavior

--- a/docs/kcl-std/functions/std-sketch-subtract2d.md
+++ b/docs/kcl-std/functions/std-sketch-subtract2d.md
@@ -5,6 +5,8 @@ excerpt: "Use a 2-dimensional sketch to cut a hole in another 2-dimensional sket
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Use a 2-dimensional sketch to cut a hole in another 2-dimensional sketch.
 
 ```kcl
@@ -14,7 +16,7 @@ subtract2d(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 
 ### Arguments

--- a/docs/kcl-std/functions/std-sketch-tangentialArc.md
+++ b/docs/kcl-std/functions/std-sketch-tangentialArc.md
@@ -5,6 +5,8 @@ excerpt: "Starting at the current sketch's origin, draw a curved line segment al
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Starting at the current sketch's origin, draw a curved line segment along some part of an imaginary circle until it reaches the desired (x, y) coordinates.
 
 ```kcl
@@ -19,7 +21,7 @@ tangentialArc(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 
 When using radius and angle, draw a curved line segment along part of an

--- a/docs/kcl-std/functions/std-sketch-xLine.md
+++ b/docs/kcl-std/functions/std-sketch-xLine.md
@@ -5,6 +5,8 @@ excerpt: "Draw a line relative to the current origin to a specified distance awa
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Draw a line relative to the current origin to a specified distance away from the current position along the 'x' axis.
 
 ```kcl
@@ -16,7 +18,7 @@ xLine(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 
 ### Arguments

--- a/docs/kcl-std/functions/std-sketch-yLine.md
+++ b/docs/kcl-std/functions/std-sketch-yLine.md
@@ -5,6 +5,8 @@ excerpt: "Draw a line relative to the current origin to a specified distance awa
 layout: manual
 ---
 
+**WARNING:** This function is deprecated as of KCL 2.0.
+
 Draw a line relative to the current origin to a specified distance away from the current position along the 'y' axis.
 
 ```kcl
@@ -16,7 +18,7 @@ yLine(
 ): Sketch
 ```
 
-This is part of sketch v1 and is soft deprecated in favor of
+This is part of sketch v1 and is deprecated in favor of
 [sketch-solve](/docs/kcl-std/modules/std-solver).
 
 ### Arguments

--- a/rust/kcl-lib/src/docs/gen_std_tests.rs
+++ b/rust/kcl-lib/src/docs/gen_std_tests.rs
@@ -14,6 +14,7 @@ use super::kcl_doc::ExampleProperties;
 use super::kcl_doc::ExampleSketchSyntax;
 use super::kcl_doc::FnData;
 use super::kcl_doc::ModData;
+use super::kcl_doc::Properties;
 use super::kcl_doc::TyData;
 use super::kcl_doc::remove_md_links;
 use crate::ConnectionError;
@@ -27,6 +28,15 @@ mod type_formatter;
 fn escape_frontmatter_value(value: &str) -> String {
     // YAML frontmatter is double-quoted in templates, so escape backslashes and quotes.
     value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn check_deprecation_attrs(qual_name: &str, props: &Properties) -> Result<()> {
+    if props.deprecated && props.deprecated_since.is_some() {
+        return Err(anyhow::anyhow!(
+            "{qual_name} has both `deprecated` and `deprecated_since` set; only one may be specified"
+        ));
+    }
+    Ok(())
 }
 
 fn init_handlebars() -> Result<handlebars::Handlebars<'static>> {
@@ -334,6 +344,8 @@ fn generate_type_from_kcl(
         return Ok(());
     }
 
+    check_deprecation_attrs(&ty.qual_name, &ty.properties)?;
+
     let hbs = init_handlebars()?;
 
     let examples: Vec<serde_json::Value> = ty
@@ -351,6 +363,7 @@ fn generate_type_from_kcl(
         "summary": sanitize_markdown_links(flavor, ty.summary.clone()),
         "description": sanitize_markdown_links(flavor, ty.description.clone()),
         "deprecated": ty.properties.deprecated,
+        "deprecated_since": ty.properties.deprecated_since.as_ref().map(ToString::to_string),
         "experimental": ty.properties.experimental,
         "examples": examples,
     });
@@ -430,6 +443,8 @@ fn generate_function_from_kcl(
         return Ok(());
     }
 
+    check_deprecation_attrs(&function.qual_name, &function.properties)?;
+
     let hbs = init_handlebars()?;
 
     let examples: Vec<serde_json::Value> = function
@@ -470,6 +485,7 @@ fn generate_function_from_kcl(
         "summary": sanitize_markdown_links(flavor, function.summary.clone()),
         "description": sanitize_markdown_links(flavor, function.description.clone()),
         "deprecated": function.properties.deprecated,
+        "deprecated_since": function.properties.deprecated_since.as_ref().map(ToString::to_string),
         "experimental": function.properties.experimental,
         "fn_signature": function.preferred_name.clone() + &function.fn_signature(),
         "examples": examples,
@@ -515,6 +531,9 @@ fn generate_const_from_kcl(
     if cnst.properties.doc_hidden {
         return Ok(());
     }
+
+    check_deprecation_attrs(&cnst.qual_name, &cnst.properties)?;
+
     let hbs = init_handlebars()?;
 
     let examples: Vec<serde_json::Value> = cnst
@@ -531,6 +550,7 @@ fn generate_const_from_kcl(
         "summary": sanitize_markdown_links(flavor, cnst.summary.clone()),
         "description": sanitize_markdown_links(flavor, cnst.description.clone()),
         "deprecated": cnst.properties.deprecated,
+        "deprecated_since": cnst.properties.deprecated_since.as_ref().map(ToString::to_string),
         "experimental": cnst.properties.experimental,
         "type_": cnst.ty,
         "type_desc": cnst.ty.as_ref().map(|t| {

--- a/rust/kcl-lib/src/docs/kcl_doc.rs
+++ b/rust/kcl-lib/src/docs/kcl_doc.rs
@@ -17,6 +17,7 @@ use tower_lsp::lsp_types::SignatureInformation;
 
 use crate::ModuleId;
 use crate::execution::annotations;
+use crate::execution::annotations::VersionConstraint;
 use crate::parsing::ast::types::Annotation;
 use crate::parsing::ast::types::Expr;
 use crate::parsing::ast::types::ImportSelector;
@@ -425,6 +426,7 @@ impl ConstData {
             properties: Properties {
                 exported: !var.visibility.is_default(),
                 deprecated: false,
+                deprecated_since: None,
                 experimental: false,
                 doc_hidden: false,
                 impl_kind: annotations::Impl::Kcl,
@@ -522,6 +524,7 @@ impl ModData {
             properties: Properties {
                 exported: false,
                 deprecated: false,
+                deprecated_since: None,
                 experimental: false,
                 doc_hidden: false,
                 impl_kind: Default::default(),
@@ -612,6 +615,7 @@ impl FnData {
             properties: Properties {
                 exported: !var.visibility.is_default(),
                 deprecated: false,
+                deprecated_since: None,
                 experimental: false,
                 doc_hidden: false,
                 impl_kind: annotations::Impl::Kcl,
@@ -801,6 +805,9 @@ impl DocCategory {
 #[derive(Debug, Clone)]
 pub struct Properties {
     pub deprecated: bool,
+    /// Constraint on the KCL version at or after which this item is deprecated,
+    /// e.g. "2.0".
+    pub deprecated_since: Option<VersionConstraint>,
     pub experimental: bool,
     pub doc_hidden: bool,
     #[allow(dead_code)]
@@ -1090,6 +1097,7 @@ impl TyData {
             properties: Properties {
                 exported: !ty.visibility.is_default(),
                 deprecated: false,
+                deprecated_since: None,
                 experimental: false,
                 doc_hidden: false,
                 impl_kind: annotations::Impl::Kcl,
@@ -1168,6 +1176,7 @@ trait ApplyMeta {
         examples: Vec<(String, ExampleProperties)>,
     );
     fn deprecated(&mut self, deprecated: bool);
+    fn deprecated_since(&mut self, deprecated_since: Option<VersionConstraint>);
     fn experimental(&mut self, experimental: bool);
     fn doc_hidden(&mut self, doc_hidden: bool);
     fn impl_kind(&mut self, impl_kind: annotations::Impl);
@@ -1311,6 +1320,13 @@ trait ApplyMeta {
                                 self.deprecated(b);
                             }
                         }
+                        annotations::DEPRECATED_SINCE => {
+                            if let Some(s) = p.value.literal_str()
+                                && let Some(v) = VersionConstraint::parse(s)
+                            {
+                                self.deprecated_since(Some(v));
+                            }
+                        }
                         annotations::EXPERIMENTAL => {
                             if let Some(b) = p.value.literal_bool() {
                                 self.experimental(b);
@@ -1352,6 +1368,10 @@ impl ApplyMeta for ConstData {
         self.properties.deprecated = deprecated;
     }
 
+    fn deprecated_since(&mut self, deprecated_since: Option<VersionConstraint>) {
+        self.properties.deprecated_since = deprecated_since;
+    }
+
     fn experimental(&mut self, experimental: bool) {
         self.properties.experimental = experimental;
     }
@@ -1381,6 +1401,10 @@ impl ApplyMeta for FnData {
 
     fn deprecated(&mut self, deprecated: bool) {
         self.properties.deprecated = deprecated;
+    }
+
+    fn deprecated_since(&mut self, deprecated_since: Option<VersionConstraint>) {
+        self.properties.deprecated_since = deprecated_since;
     }
 
     fn experimental(&mut self, experimental: bool) {
@@ -1416,6 +1440,10 @@ impl ApplyMeta for ModData {
         assert!(!deprecated);
     }
 
+    fn deprecated_since(&mut self, deprecated_since: Option<VersionConstraint>) {
+        assert!(deprecated_since.is_none());
+    }
+
     fn experimental(&mut self, experimental: bool) {
         self.properties.experimental = experimental;
     }
@@ -1445,6 +1473,10 @@ impl ApplyMeta for TyData {
 
     fn deprecated(&mut self, deprecated: bool) {
         self.properties.deprecated = deprecated;
+    }
+
+    fn deprecated_since(&mut self, deprecated_since: Option<VersionConstraint>) {
+        self.properties.deprecated_since = deprecated_since;
     }
 
     fn experimental(&mut self, experimental: bool) {
@@ -1483,6 +1515,10 @@ impl ApplyMeta for ArgData {
     }
 
     fn deprecated(&mut self, _deprecated: bool) {
+        unreachable!();
+    }
+
+    fn deprecated_since(&mut self, _deprecated_since: Option<VersionConstraint>) {
         unreachable!();
     }
 

--- a/rust/kcl-lib/src/docs/templates/const.hbs
+++ b/rust/kcl-lib/src/docs/templates/const.hbs
@@ -9,6 +9,10 @@ layout: manual
 **WARNING:** This constant is deprecated.
 
 {{/if}}
+{{#if deprecated_since}}
+**WARNING:** This constant is deprecated as of KCL {{deprecated_since}}.
+
+{{/if}}
 {{#if experimental}}
 **WARNING:** This constant is experimental and may change or be removed.
 

--- a/rust/kcl-lib/src/docs/templates/function.hbs
+++ b/rust/kcl-lib/src/docs/templates/function.hbs
@@ -9,6 +9,10 @@ layout: manual
 **WARNING:** This function is deprecated.
 
 {{/if}}
+{{#if deprecated_since}}
+**WARNING:** This function is deprecated as of KCL {{deprecated_since}}.
+
+{{/if}}
 {{#if experimental}}
 **WARNING:** This function is experimental and may change or be removed.
 

--- a/rust/kcl-lib/src/docs/templates/kclType.hbs
+++ b/rust/kcl-lib/src/docs/templates/kclType.hbs
@@ -9,6 +9,10 @@ layout: manual
 **WARNING:** This type is deprecated.
 
 {{/if}}
+{{#if deprecated_since}}
+**WARNING:** This type is deprecated as of KCL {{deprecated_since}}.
+
+{{/if}}
 {{#if experimental}}
 **WARNING:** This type is experimental and may change or be removed.
 

--- a/rust/kcl-lib/src/execution/annotations.rs
+++ b/rust/kcl-lib/src/execution/annotations.rs
@@ -1,5 +1,6 @@
 //! Data on available annotations.
 
+use std::fmt;
 use std::str::FromStr;
 
 use kittycad_modeling_cmds::coord::KITTYCAD;
@@ -30,6 +31,7 @@ pub(crate) const SETTINGS_EXPERIMENTAL_FEATURES: &str = "experimentalFeatures";
 
 pub(super) const NO_PRELUDE: &str = "no_std";
 pub(crate) const DEPRECATED: &str = "deprecated";
+pub(crate) const DEPRECATED_SINCE: &str = "deprecated_since";
 pub(crate) const DOC_CATEGORY: &str = "doc_category";
 pub(crate) const EXPERIMENTAL: &str = "experimental";
 pub(crate) const INCLUDE_IN_FEATURE_TREE: &str = "feature_tree";
@@ -265,10 +267,13 @@ pub(super) fn expect_number(expr: &Expr) -> Result<String, KclError> {
     )))
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FnAttrs {
     pub impl_: Impl,
     pub deprecated: bool,
+    /// Constraint marking a KCL version at or after which this item is
+    /// deprecated, e.g. "2.0".
+    pub deprecated_since: Option<VersionConstraint>,
     pub experimental: bool,
     pub include_in_feature_tree: bool,
 }
@@ -278,10 +283,60 @@ impl Default for FnAttrs {
         Self {
             impl_: Impl::default(),
             deprecated: false,
+            deprecated_since: None,
             experimental: false,
             include_in_feature_tree: true,
         }
     }
+}
+
+/// A constraint on a KCL version, e.g. the threshold that `@(deprecated_since =
+/// "2.0")` describes. Stored as the parsed component list so comparisons are
+/// numeric, not lexical.
+///
+/// Distinct from the concrete `kclVersion` set in `@settings(...)`: this type
+/// represents a version *boundary*, and we expect to grow more constraint kinds
+/// (e.g., "deprecated up until version X") in the future. Comparisons against a
+/// concrete version are expressed via the free `version_*` functions below
+/// rather than `Ord` so the direction of comparison stays explicit at every
+/// call site.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VersionConstraint(Vec<u32>);
+
+impl VersionConstraint {
+    /// Parse a dotted version string like "1.0" or "2.1.3". Returns `None` for empty
+    /// input or any component that doesn't parse as a non-negative integer.
+    pub fn parse(s: &str) -> Option<Self> {
+        let parts: Vec<u32> = s
+            .split('.')
+            .map(|p| p.parse::<u32>().ok())
+            .collect::<Option<Vec<_>>>()?;
+        if parts.is_empty() { None } else { Some(Self(parts)) }
+    }
+}
+
+impl fmt::Display for VersionConstraint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut first = true;
+        for n in &self.0 {
+            if !first {
+                f.write_str(".")?;
+            }
+            write!(f, "{n}")?;
+            first = false;
+        }
+        Ok(())
+    }
+}
+
+/// Returns true when the concrete `version` (e.g., from `@settings(kclVersion = ...)`)
+/// is greater than or equal to the `constraint`. Returns false if `version` cannot be
+/// parsed as a dotted integer version.
+pub(crate) fn version_ge(version: &str, constraint: &VersionConstraint) -> bool {
+    let Some(parsed): Option<Vec<u32>> = version.split('.').map(|p| p.parse::<u32>().ok()).collect() else {
+        return false;
+    };
+    parsed >= constraint.0
 }
 
 pub(super) fn get_fn_attrs(
@@ -324,6 +379,28 @@ pub(super) fn get_fn_attrs(
                 continue;
             }
 
+            if &*p.key.name == DEPRECATED_SINCE {
+                let Some(s) = p.value.literal_str() else {
+                    return Err(KclError::new_semantic(KclErrorDetails::new(
+                        format!("Expected a version string for {DEPRECATED_SINCE}, e.g., \"2.0\""),
+                        vec![source_range],
+                    )));
+                };
+                let Some(constraint) = VersionConstraint::parse(s) else {
+                    return Err(KclError::new_semantic(KclErrorDetails::new(
+                        format!(
+                            "Invalid version string for {DEPRECATED_SINCE}: `{s}`; expected a dotted integer version, e.g., \"2.0\""
+                        ),
+                        vec![source_range],
+                    )));
+                };
+                if result.is_none() {
+                    result = Some(FnAttrs::default());
+                }
+                result.as_mut().unwrap().deprecated_since = Some(constraint);
+                continue;
+            }
+
             // doc_category is handled by the docs generator, not execution.
             if &*p.key.name == DOC_CATEGORY {
                 continue;
@@ -351,7 +428,7 @@ pub(super) fn get_fn_attrs(
 
             return Err(KclError::new_semantic(KclErrorDetails::new(
                 format!(
-                    "Invalid attribute, expected one of: {IMPL}, {DEPRECATED}, {DOC_CATEGORY}, {EXPERIMENTAL}, {INCLUDE_IN_FEATURE_TREE}, found `{}`",
+                    "Invalid attribute, expected one of: {IMPL}, {DEPRECATED}, {DEPRECATED_SINCE}, {DOC_CATEGORY}, {EXPERIMENTAL}, {INCLUDE_IN_FEATURE_TREE}, found `{}`",
                     &*p.key.name,
                 ),
                 vec![source_range],
@@ -360,4 +437,47 @@ pub(super) fn get_fn_attrs(
     }
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vc(s: &str) -> VersionConstraint {
+        VersionConstraint::parse(s).unwrap()
+    }
+
+    #[test]
+    fn version_constraint_parse_handles_typical_inputs() {
+        assert_eq!(VersionConstraint::parse("1.0"), Some(VersionConstraint(vec![1, 0])));
+        assert_eq!(VersionConstraint::parse("2"), Some(VersionConstraint(vec![2])));
+        assert_eq!(
+            VersionConstraint::parse("2.1.3"),
+            Some(VersionConstraint(vec![2, 1, 3]))
+        );
+        assert_eq!(VersionConstraint::parse(""), None);
+        assert_eq!(VersionConstraint::parse("1.x"), None);
+        assert_eq!(VersionConstraint::parse("1.-1"), None);
+    }
+
+    #[test]
+    fn version_constraint_display_round_trips() {
+        assert_eq!(vc("1.0").to_string(), "1.0");
+        assert_eq!(vc("2.1.3").to_string(), "2.1.3");
+        assert_eq!(vc("2").to_string(), "2");
+    }
+
+    #[test]
+    fn version_ge_compares_components_numerically() {
+        assert!(version_ge("1.0", &vc("1.0")));
+        assert!(version_ge("2.0", &vc("1.0")));
+        assert!(version_ge("2.0", &vc("2.0")));
+        assert!(version_ge("10.0", &vc("2.0")));
+        assert!(version_ge("2.1", &vc("2.0")));
+        assert!(!version_ge("1.0", &vc("2.0")));
+        assert!(!version_ge("2.0", &vc("2.1")));
+        assert!(!version_ge("1.99", &vc("2.0")));
+        // An unparsable concrete version never satisfies the constraint.
+        assert!(!version_ge("bogus", &vc("1.0")));
+    }
 }

--- a/rust/kcl-lib/src/execution/annotations.rs
+++ b/rust/kcl-lib/src/execution/annotations.rs
@@ -397,7 +397,11 @@ pub(super) fn get_fn_attrs(
                 if result.is_none() {
                     result = Some(FnAttrs::default());
                 }
-                result.as_mut().unwrap().deprecated_since = Some(constraint);
+                if let Some(fn_attrs) = result.as_mut() {
+                    fn_attrs.deprecated_since = Some(constraint);
+                } else {
+                    debug_assert!(false, "fn_attrs should have been set");
+                }
                 continue;
             }
 

--- a/rust/kcl-lib/src/execution/annotations.rs
+++ b/rust/kcl-lib/src/execution/annotations.rs
@@ -343,7 +343,8 @@ pub(super) fn get_fn_attrs(
     annotations: &[Node<Annotation>],
     source_range: SourceRange,
 ) -> Result<Option<FnAttrs>, KclError> {
-    let mut result = None;
+    let mut found_attrs = false;
+    let mut fn_attrs = FnAttrs::default();
     for attr in annotations {
         if attr.name.is_some() || attr.properties.is_none() {
             continue;
@@ -352,11 +353,8 @@ pub(super) fn get_fn_attrs(
             if &*p.key.name == IMPL
                 && let Some(s) = p.value.ident_name()
             {
-                if result.is_none() {
-                    result = Some(FnAttrs::default());
-                }
-
-                result.as_mut().unwrap().impl_ = Impl::from_str(s).map_err(|_| {
+                found_attrs = true;
+                fn_attrs.impl_ = Impl::from_str(s).map_err(|_| {
                     KclError::new_semantic(KclErrorDetails::new(
                         format!(
                             "Invalid value for {} attribute, expected one of: {}",
@@ -372,10 +370,8 @@ pub(super) fn get_fn_attrs(
             if &*p.key.name == DEPRECATED
                 && let Some(b) = p.value.literal_bool()
             {
-                if result.is_none() {
-                    result = Some(FnAttrs::default());
-                }
-                result.as_mut().unwrap().deprecated = b;
+                found_attrs = true;
+                fn_attrs.deprecated = b;
                 continue;
             }
 
@@ -394,14 +390,8 @@ pub(super) fn get_fn_attrs(
                         vec![source_range],
                     )));
                 };
-                if result.is_none() {
-                    result = Some(FnAttrs::default());
-                }
-                if let Some(fn_attrs) = result.as_mut() {
-                    fn_attrs.deprecated_since = Some(constraint);
-                } else {
-                    debug_assert!(false, "fn_attrs should have been set");
-                }
+                found_attrs = true;
+                fn_attrs.deprecated_since = Some(constraint);
                 continue;
             }
 
@@ -413,20 +403,16 @@ pub(super) fn get_fn_attrs(
             if &*p.key.name == EXPERIMENTAL
                 && let Some(b) = p.value.literal_bool()
             {
-                if result.is_none() {
-                    result = Some(FnAttrs::default());
-                }
-                result.as_mut().unwrap().experimental = b;
+                found_attrs = true;
+                fn_attrs.experimental = b;
                 continue;
             }
 
             if &*p.key.name == INCLUDE_IN_FEATURE_TREE
                 && let Some(b) = p.value.literal_bool()
             {
-                if result.is_none() {
-                    result = Some(FnAttrs::default());
-                }
-                result.as_mut().unwrap().include_in_feature_tree = b;
+                found_attrs = true;
+                fn_attrs.include_in_feature_tree = b;
                 continue;
             }
 
@@ -440,7 +426,7 @@ pub(super) fn get_fn_attrs(
         }
     }
 
-    Ok(result)
+    Ok(if found_attrs { Some(fn_attrs) } else { None })
 }
 
 #[cfg(test)]

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -40,6 +40,7 @@ use crate::execution::UnsolvedExpr;
 use crate::execution::UnsolvedSegment;
 use crate::execution::UnsolvedSegmentKind;
 use crate::execution::annotations;
+use crate::execution::annotations::FnAttrs;
 use crate::execution::cad_op::OpKclValue;
 use crate::execution::control_continue;
 use crate::execution::early_return;
@@ -1056,10 +1057,18 @@ impl ExecutorContext {
             Expr::BinaryExpression(binary_expression) => binary_expression.get_result(exec_state, self).await?,
             Expr::FunctionExpression(function_expression) => {
                 let attrs = annotations::get_fn_attrs(annotations, metadata.source_range)?;
-                let experimental = attrs.map(|a| a.experimental).unwrap_or_default();
+                let experimental = attrs
+                    .as_ref()
+                    .map(|a| a.experimental)
+                    // Use the default for the field, not the bool type.
+                    .unwrap_or_else(|| FnAttrs::default().experimental);
 
                 // Check the KCL @(feature_tree = ) annotation.
-                let include_in_feature_tree = attrs.unwrap_or_default().include_in_feature_tree;
+                let include_in_feature_tree = attrs
+                    .as_ref()
+                    .map(|a| a.include_in_feature_tree)
+                    // Use the default for the field, not the bool type.
+                    .unwrap_or_else(|| FnAttrs::default().include_in_feature_tree);
                 let (mut closure, placeholder_env_ref) = if let Some(attrs) = attrs
                     && (attrs.impl_ == annotations::Impl::Rust
                         || attrs.impl_ == annotations::Impl::RustConstrainable

--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -289,6 +289,22 @@ impl FunctionSource {
                 ),
                 annotations::WARN_DEPRECATED,
             );
+        } else if let Some(since) = &self.deprecated_since
+            && annotations::version_ge(&exec_state.mod_local.settings.kcl_version, since)
+        {
+            exec_state.warn(
+                CompilationIssue::err(
+                    callsite,
+                    format!(
+                        "{} is deprecated as of KCL {since}. See the docs for a recommended replacement.",
+                        match &fn_name {
+                            Some(n) => format!("`{n}`"),
+                            None => "This function".to_owned(),
+                        }
+                    ),
+                ),
+                annotations::WARN_DEPRECATED,
+            );
         }
         if self.experimental {
             exec_state.warn_experimental(

--- a/rust/kcl-lib/src/execution/kcl_value.rs
+++ b/rust/kcl-lib/src/execution/kcl_value.rs
@@ -178,6 +178,10 @@ pub struct FunctionSource {
     pub named_args: IndexMap<String, NamedParam>,
     pub return_type: Option<Node<Type>>,
     pub deprecated: bool,
+    /// Constraint on the KCL version at which this function is deprecated, e.g.
+    /// "2.0". When the active `kclVersion` is at or after this, calls trigger a
+    /// deprecation warning.
+    pub deprecated_since: Option<crate::execution::annotations::VersionConstraint>,
     pub experimental: bool,
     pub include_in_feature_tree: bool,
     pub std_props: Option<StdFnProps>,
@@ -205,6 +209,7 @@ impl FunctionSource {
             named_args,
             return_type: ast.return_type.clone(),
             deprecated: attrs.deprecated,
+            deprecated_since: attrs.deprecated_since,
             experimental: attrs.experimental,
             include_in_feature_tree: attrs.include_in_feature_tree,
             std_props: Some(props),
@@ -225,6 +230,7 @@ impl FunctionSource {
             named_args,
             return_type: ast.return_type.clone(),
             deprecated: false,
+            deprecated_since: None,
             experimental,
             include_in_feature_tree,
             std_props,

--- a/rust/kcl-lib/src/execution/kcl_value.rs
+++ b/rust/kcl-lib/src/execution/kcl_value.rs
@@ -34,6 +34,7 @@ use crate::execution::UnsolvedExpr;
 use crate::execution::annotations::FnAttrs;
 use crate::execution::annotations::SETTINGS;
 use crate::execution::annotations::SETTINGS_UNIT_LENGTH;
+use crate::execution::annotations::VersionConstraint;
 use crate::execution::annotations::{self};
 use crate::execution::types::NumericType;
 use crate::execution::types::PrimitiveType;
@@ -181,7 +182,7 @@ pub struct FunctionSource {
     /// Constraint on the KCL version at which this function is deprecated, e.g.
     /// "2.0". When the active `kclVersion` is at or after this, calls trigger a
     /// deprecation warning.
-    pub deprecated_since: Option<crate::execution::annotations::VersionConstraint>,
+    pub deprecated_since: Option<VersionConstraint>,
     pub experimental: bool,
     pub include_in_feature_tree: bool,
     pub std_props: Option<StdFnProps>,

--- a/rust/kcl-lib/std/sketch.kcl
+++ b/rust/kcl-lib/std/sketch.kcl
@@ -9,7 +9,7 @@
 
 /// Start a new 2-dimensional sketch on a specific plane or face.
 ///
-/// This is part of sketch v1 and is soft deprecated in favor of
+/// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 ///
 /// ### Sketch on Face Behavior
@@ -272,7 +272,7 @@
 ///
 /// tower = extrude(sideSketch, length = 1mm)
 /// ```
-@(impl = std_rust, feature_tree = true)
+@(impl = std_rust, feature_tree = true, deprecated_since = "2.0")
 export fn startSketchOn(
   /// Profile whose start is being used.
   @planeOrSolid: Solid | Plane,
@@ -288,7 +288,7 @@ export fn startSketchOn(
 
 /// Start a new profile at a given point.
 ///
-/// This is part of sketch v1 and is soft deprecated in favor of
+/// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 ///
 /// ```kcl,legacySketch
@@ -342,7 +342,7 @@ export fn startSketchOn(
 ///   |> line(end = [-10, 0])
 ///   |> close()
 /// ```
-@(impl = std_rust, feature_tree = false)
+@(impl = std_rust, feature_tree = false, deprecated_since = "2.0")
 export fn startProfile(
   /// What to start the profile on.
   @startProfileOn: Plane | Face,
@@ -355,7 +355,7 @@ export fn startProfile(
 
 /// Sketch a rectangle.
 ///
-/// This is part of sketch v1 and is soft deprecated in favor of
+/// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 ///
 /// A rectangle can be defined by its width, height, and location. Either the center or corner must be provided, but not both, to specify its location.
@@ -371,7 +371,7 @@ export fn startProfile(
 ///   |> rectangle(corner = [0, 0], width = 10, height = 5)
 //    |> extrude(length = 2)
 /// ```
-@(impl = std_rust, feature_tree = false)
+@(impl = std_rust, feature_tree = false, deprecated_since = "2.0")
 export fn rectangle(
   /// Sketch to extend, or plane or surface to sketch on.
   @sketchOrSurface: Sketch | Plane | Face,
@@ -393,7 +393,7 @@ export fn rectangle(
 /// Construct a 2-dimensional circle, of the specified radius, centered at
 /// the provided (x, y) origin point.
 ///
-/// This is part of sketch v1 and is soft deprecated in favor of
+/// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 ///
 /// ```kcl,legacySketch
@@ -414,7 +414,7 @@ export fn rectangle(
 ///
 /// example = extrude(exampleSketch, length = 5)
 /// ```
-@(impl = std_rust, feature_tree = false)
+@(impl = std_rust, feature_tree = false, deprecated_since = "2.0")
 export fn circle(
   /// Sketch to extend, or plane or surface to sketch on.
   @sketchOrSurface: Sketch | Plane | Face,
@@ -1312,7 +1312,7 @@ export fn getBoundedEdge(
 
 /// Construct a circle derived from 3 points.
 ///
-/// This is part of sketch v1 and is soft deprecated in favor of
+/// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 ///
 /// ```kcl,legacySketch
@@ -1320,7 +1320,7 @@ export fn getBoundedEdge(
 ///   |> circleThreePoint(p1 = [10,10], p2 = [20,8], p3 = [15,5])
 ///   |> extrude(length = 5)
 /// ```
-@(impl = std_rust, feature_tree = false)
+@(impl = std_rust, feature_tree = false, deprecated_since = "2.0")
 export fn circleThreePoint(
   /// Plane or surface to sketch on.
   @sketchOrSurface: Sketch | Plane | Face,
@@ -1336,7 +1336,7 @@ export fn circleThreePoint(
 
 /// Create a regular polygon with the specified number of sides that is either inscribed or circumscribed around a circle of the specified radius.
 ///
-/// This is part of sketch v1 and is soft deprecated in favor of
+/// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 ///
 /// ```kcl,legacySketch
@@ -1363,7 +1363,7 @@ export fn circleThreePoint(
 ///   )
 /// example = extrude(square, length = 5)
 /// ```
-@(impl = std_rust, feature_tree = false)
+@(impl = std_rust, feature_tree = false, deprecated_since = "2.0")
 export fn polygon(
   /// Plane or surface to sketch on.
   @sketchOrSurface: Sketch | Plane | Face,
@@ -2308,9 +2308,9 @@ export fn profileStartY(
 
 /// Extend the current sketch with a new involute circular curve.
 ///
-/// This is part of sketch v1 and is soft deprecated in favor of
-/// [sketch-solve](/docs/kcl-std/modules/std-solver). The sketch-solve version
-/// of involute circular is still under development.
+/// This is part of sketch v1 and is deprecated in favor of
+/// [sketch-solve](/docs/kcl-std/modules/std-solver) and the
+/// [gear module](/docs/kcl-std/modules/std-gear).
 ///
 /// ```kcl,legacySketch
 /// a = 10
@@ -2364,7 +2364,7 @@ export fn profileStartY(
 ///   // Extrude the gear to the specified height
 ///   |> extrude(length = gearHeight)
 /// ```
-@(impl = std_rust, feature_tree = false)
+@(impl = std_rust, feature_tree = false, deprecated_since = "2.0")
 export fn involuteCircular(
   /// Which sketch should this path be added to?
   @sketch: Sketch,
@@ -2390,7 +2390,7 @@ export fn involuteCircular(
 
 /// Extend the current sketch with a new straight line.
 ///
-/// This is part of sketch v1 and is soft deprecated in favor of
+/// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 ///
 /// ```kcl,legacySketch
@@ -2415,7 +2415,7 @@ export fn involuteCircular(
 ///   |> close()
 ///   |> extrude(length = 5)
 /// ```
-@(impl = std_rust, feature_tree = false)
+@(impl = std_rust, feature_tree = false, deprecated_since = "2.0")
 export fn line(
   /// Which sketch should this path be added to?
   @sketch: Sketch,
@@ -2431,7 +2431,7 @@ export fn line(
 /// Draw a line relative to the current origin to a specified distance away
 /// from the current position along the 'x' axis.
 ///
-/// This is part of sketch v1 and is soft deprecated in favor of
+/// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 ///
 /// ```kcl,legacySketch
@@ -2453,7 +2453,7 @@ export fn line(
 ///
 /// example = extrude(exampleSketch, length = 10)
 /// ```
-@(impl = std_rust, feature_tree = false)
+@(impl = std_rust, feature_tree = false, deprecated_since = "2.0")
 export fn xLine(
   /// Which sketch should this path be added to?
   @sketch: Sketch,
@@ -2469,7 +2469,7 @@ export fn xLine(
 /// Draw a line relative to the current origin to a specified distance away
 /// from the current position along the 'y' axis.
 ///
-/// This is part of sketch v1 and is soft deprecated in favor of
+/// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 ///
 /// ```kcl,legacySketch
@@ -2486,7 +2486,7 @@ export fn xLine(
 ///
 /// example = extrude(exampleSketch, length = 10)
 /// ```
-@(impl = std_rust, feature_tree = false)
+@(impl = std_rust, feature_tree = false, deprecated_since = "2.0")
 export fn yLine(
   /// Which sketch should this path be added to?
   @sketch: Sketch,
@@ -2502,7 +2502,7 @@ export fn yLine(
 /// Draw a line segment relative to the current origin using the polar
 /// measure of some angle and distance.
 ///
-/// This is part of sketch v1 and is soft deprecated in favor of
+/// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 ///
 /// ```kcl,legacySketch
@@ -2519,7 +2519,7 @@ export fn yLine(
 ///
 /// example = extrude(exampleSketch, length = 10)
 /// ```
-@(impl = std_rust, feature_tree = false)
+@(impl = std_rust, feature_tree = false, deprecated_since = "2.0")
 export fn angledLine(
   /// Which sketch should this path be added to?
   @sketch: Sketch,
@@ -2543,7 +2543,7 @@ export fn angledLine(
 /// such that the newly created line intersects the desired target line
 /// segment.
 ///
-/// This is part of sketch v1 and is soft deprecated in favor of
+/// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 ///
 /// ```kcl,legacySketch
@@ -2561,7 +2561,7 @@ export fn angledLine(
 ///
 /// example = extrude(exampleSketch, length = 10)
 /// ```
-@(impl = std_rust, feature_tree = false)
+@(impl = std_rust, feature_tree = false, deprecated_since = "2.0")
 export fn angledLineThatIntersects(
   /// Which sketch should this path be added to?
   @sketch: Sketch,
@@ -2578,7 +2578,7 @@ export fn angledLineThatIntersects(
 /// Construct a line segment from the current origin back to the profile's
 /// origin, ensuring the resulting 2-dimensional sketch is not open-ended.
 ///
-/// This is part of sketch v1 and is soft deprecated in favor of
+/// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 ///
 /// If you want to perform some 3-dimensional operation on a sketch, like
@@ -2604,7 +2604,7 @@ export fn angledLineThatIntersects(
 ///
 /// example = extrude(exampleSketch, length = 10)
 /// ```
-@(impl = std_rust, feature_tree = false)
+@(impl = std_rust, feature_tree = false, deprecated_since = "2.0")
 export fn close(
   /// The sketch you want to close.
   @sketch: Sketch,
@@ -2614,7 +2614,7 @@ export fn close(
 
 /// Draw a curved line segment along an imaginary circle.
 ///
-/// This is part of sketch v1 and is soft deprecated in favor of
+/// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 ///
 /// The arc is constructed such that the current position of the sketch is
@@ -2649,7 +2649,7 @@ export fn close(
 ///   |> close()
 /// example = extrude(exampleSketch, length = 10)
 /// ```
-@(impl = std_rust, feature_tree = false)
+@(impl = std_rust, feature_tree = false, deprecated_since = "2.0")
 export fn arc(
   /// Which sketch should this path be added to?
   @sketch: Sketch,
@@ -2676,7 +2676,7 @@ export fn arc(
 /// some part of an imaginary circle until it reaches the desired (x, y)
 /// coordinates.
 ///
-/// This is part of sketch v1 and is soft deprecated in favor of
+/// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 ///
 /// When using radius and angle, draw a curved line segment along part of an
@@ -2729,7 +2729,7 @@ export fn arc(
 ///
 /// example = extrude(exampleSketch, length = 10)
 /// ```
-@(impl = std_rust, feature_tree = false)
+@(impl = std_rust, feature_tree = false, deprecated_since = "2.0")
 export fn tangentialArc(
   /// Which sketch should this path be added to?
   @sketch: Sketch,
@@ -2752,7 +2752,7 @@ export fn tangentialArc(
 /// the desired (x, y), using a number of control points to shape the curve's
 /// shape.
 ///
-/// This is part of sketch v1 and is soft deprecated in favor of
+/// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver). The sketch-solve version
 /// of bezier curve is still under development.
 ///
@@ -2780,7 +2780,7 @@ export fn tangentialArc(
 ///   |> close()
 ///   |> extrude(length = 10)
 /// ```
-@(impl = std_rust, feature_tree = false)
+@(impl = std_rust, feature_tree = false, deprecated_since = "2.0")
 export fn bezierCurve(
   /// Which sketch should this path be added to?
   @sketch: Sketch,
@@ -2802,7 +2802,7 @@ export fn bezierCurve(
 
 /// Use a 2-dimensional sketch to cut a hole in another 2-dimensional sketch.
 ///
-/// This is part of sketch v1 and is soft deprecated in favor of
+/// This is part of sketch v1 and is deprecated in favor of
 /// [sketch-solve](/docs/kcl-std/modules/std-solver).
 ///
 /// ```kcl,legacySketch
@@ -2834,7 +2834,7 @@ export fn bezierCurve(
 ///     |> subtract2d(tool = squareHoleSketch())
 /// example = extrude(exampleSketch, length = 1)
 /// ```
-@(impl = std_rust, feature_tree = true)
+@(impl = std_rust, feature_tree = true, deprecated_since = "2.0")
 export fn subtract2d(
   /// Which sketch should this path be added to?
   @sketch: Sketch,


### PR DESCRIPTION
Resolves #11429.

```
@(deprecated_since = "2.0")
export fn startSketchOn() {}
```

Sketch v1 functions that were soft deprecated before are now deprecated in version 2.0.

When a KCL file has `@settings(kclVersion = 2.0)`, calling the function now generates a warning.

<img width="531" height="229" alt="Screenshot 2026-05-04 at 7 33 22 PM" src="https://github.com/user-attachments/assets/88528f71-8edc-4a17-9c69-7001ab78a344" />
