### PR TITLE
Fix manual job-level e2e retry

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -375,7 +375,7 @@ jobs:
         if: ${{ !cancelled() && (success() || failure()) }}
         continue-on-error: true
         with:
-          name: test-results-${{ env.OS_NAME }}-${{ matrix.shardIndex }}-${{ github.sha }}
+          name: test-results-desktop-${{ env.OS_NAME }}-${{ matrix.shardIndex }}-${{ github.sha }}
           path: test-results/
 
       - name: npm run test:e2e:desktop

--- a/e2e/playwright/editor-tests.spec.ts
+++ b/e2e/playwright/editor-tests.spec.ts
@@ -92,7 +92,7 @@ sketch001 = startSketchOn(XY)
     await page.keyboard.up('ControlOrMeta')
 
     await expect(page.locator('.cm-content')).toHaveText(
-      `@settings(defaultLengthUnit = in)
+      `foobar @settings(defaultLengthUnit = in)
 sketch001 = startSketchOn(XY)
   |> startProfile(at = [-10, -10])
   |> line(end = [20, 0])

--- a/e2e/playwright/editor-tests.spec.ts
+++ b/e2e/playwright/editor-tests.spec.ts
@@ -92,7 +92,7 @@ sketch001 = startSketchOn(XY)
     await page.keyboard.up('ControlOrMeta')
 
     await expect(page.locator('.cm-content')).toHaveText(
-      `foobar @settings(defaultLengthUnit = in)
+      `@settings(defaultLengthUnit = in)
 sketch001 = startSketchOn(XY)
   |> startProfile(at = [-10, -10])
   |> line(end = [20, 0])

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
   workers: workers,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
-    [process.env.CI ? 'dot' : 'list'],
+    ['list'],
     ['json', { outputFile: './test-results/report.json' }],
     ['html'],
     ['./e2e/playwright/lib/api-reporter.ts'],

--- a/playwright.electron.config.ts
+++ b/playwright.electron.config.ts
@@ -44,7 +44,7 @@ export default defineConfig({
   workers: workers,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
-    ['dot'],
+    ['list'],
     ['json', { outputFile: './test-results/report.json' }],
     ['html'],
     ['./e2e/playwright/lib/api-reporter.ts'],


### PR DESCRIPTION
I also think we should stick with the `'list'` reporter everywhere for e2e tests, which typically take longer to run. The `'dot'` reporter buffers lines on CI, making it difficult to know which tests are running.


---

With this fix, here is evidence that we can manually rerun a single test: https://github.com/KittyCAD/modeling-app/actions/runs/25382624520/job/74443597486