### PR TITLE
Codex: Fix empty Project Files pane on foreign projects  

### DIFF
--- a/src/components/SystemIOMachineLogicListener.tsx
+++ b/src/components/SystemIOMachineLogicListener.tsx
@@ -201,11 +201,19 @@ export function SystemIOMachineLogicListener() {
   const useApplicationProjectDirectory = () => {
     useEffect(() => {
       if (pathname === PATHS.HOME || pathname === PATHS.HOME_SETTINGS) {
+        const requestedProjectDirectoryPath =
+          settingsValues.app.projectDirectory.current || ''
+        if (
+          systemIOActor.getSnapshot().context.projectDirectoryPath ===
+          requestedProjectDirectoryPath
+        ) {
+          return
+        }
+
         systemIOActor.send({
           type: SystemIOMachineEvents.setProjectDirectoryPath,
           data: {
-            requestedProjectDirectoryPath:
-              settingsValues.app.projectDirectory.current || '',
+            requestedProjectDirectoryPath,
           },
         })
       }

--- a/src/components/SystemIOMachineLogicListener.tsx
+++ b/src/components/SystemIOMachineLogicListener.tsx
@@ -227,6 +227,9 @@ export function SystemIOMachineLogicListener() {
   }
 
   const useWatchingApplicationProjectDirectory = () => {
+    const activeProjectDirectoryPath =
+      projectDirectoryPath || settingsValues.app.projectDirectory.current
+
     useFileSystemWatcher(
       async (eventType, targetPath) => {
         // Gotcha: Chokidar is buggy. It will emit addDir or add on files that did not get created.
@@ -256,9 +259,7 @@ export function SystemIOMachineLogicListener() {
           })
         }
       },
-      settingsValues.app.projectDirectory.current
-        ? [settingsValues.app.projectDirectory.current]
-        : []
+      activeProjectDirectoryPath ? [activeProjectDirectoryPath] : []
     )
   }
 

--- a/src/components/layout/areas/ProjectExplorerPane.tsx
+++ b/src/components/layout/areas/ProjectExplorerPane.tsx
@@ -46,9 +46,12 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
   } = useModelingContext()
 
   useEffect(() => {
-    // Have no idea why the project loader data doesn't have the children from the ls on disk
-    // That means it is a different object or cached incorrectly?
-    if (!project || !file || !projects) {
+    projectRef.current = project?.projectIORefSignal
+  }, [project?.projectIORefSignal])
+
+  useEffect(() => {
+    if (!project || !file) {
+      setTheProject(null)
       return
     }
 
@@ -56,21 +59,24 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
       systemIOActor.send({
         type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
       })
-      return
     }
 
-    // You need to find the real project in the storage from the loader information since the loader Project is not hydrated
-    const foundProject = projects.find((p) => {
-      return p.name === project?.name
+    const openedProject = project.projectIORefSignal.value
+    const foundProject = projects?.find((p) => {
+      return p.path === openedProject.path
     })
+    const projectForExplorer = foundProject ?? openedProject
 
-    if (!foundProject) {
+    const duplicated = structuredClone(projectForExplorer)
+    if (!duplicated.children) {
+      setTheProject(null)
       return
     }
 
-    // Duplicate the state to not edit the raw data
-    const duplicated = structuredClone(foundProject)
-    addPlaceHoldersForNewFileAndFolder(duplicated.children, foundProject.path)
+    addPlaceHoldersForNewFileAndFolder(
+      duplicated.children,
+      projectForExplorer.path
+    )
     setTheProject(duplicated)
   }, [file, projects, project, systemIOActor])
 
@@ -108,9 +114,12 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
   )
 
   const onRowClicked = (entry: FileExplorerEntry) => {
+    const explorerProjectDirectoryPath = theProject
+      ? fsZds.dirname(theProject.path)
+      : projectDirectoryPath
     const requestedFileName = parentPathRelativeToProject(
       entry.path,
-      projectDirectoryPath
+      explorerProjectDirectoryPath
     )
 
     const RELEVANT_FILE_EXTENSIONS = relevantFileExtensions(wasmInstance)
@@ -226,7 +235,9 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
             onRowEnter={onRowClicked}
             canNavigate={true}
             readOnly={false}
-            overrideApplicationProjectDirectory={projectDirectoryPath}
+            overrideApplicationProjectDirectory={
+              fsZds.dirname(theProject.path) || projectDirectoryPath
+            }
           />
         </div>
       ) : (

--- a/src/components/layout/areas/ProjectExplorerPane.tsx
+++ b/src/components/layout/areas/ProjectExplorerPane.tsx
@@ -55,12 +55,6 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
       return
     }
 
-    if (projects === undefined) {
-      systemIOActor.send({
-        type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-      })
-    }
-
     const openedProject = project.projectIORefSignal.value
     const foundProject = projects?.find((p) => {
       return p.path === openedProject.path

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -259,9 +259,6 @@ export const homeLoader =
       return redirect(PATHS.INDEX)
     }
 
-    app.systemIOActor.send({
-      type: SystemIOMachineEvents.readFoldersFromProjectDirectory,
-    })
     app.closeProject()
     app.settings.actor.send({
       type: 'clear.project',

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -212,7 +212,13 @@ export const fileLoader =
     )
 
     const appProjectDir = settings.settings.app.projectDirectory.current
-    const requestedProjectDirectoryPath = project.path.includes(appProjectDir)
+    const appProjectDirWithSep = appProjectDir.endsWith(fsZds.sep)
+      ? appProjectDir
+      : `${appProjectDir}${fsZds.sep}`
+    const projectIsInAppProjectDir =
+      project.path === appProjectDir ||
+      Boolean(appProjectDir && project.path.startsWith(appProjectDirWithSep))
+    const requestedProjectDirectoryPath = projectIsInAppProjectDir
       ? appProjectDir
       : getParentAbsolutePath(project.path) // Fallback to parent directory if foreign to app project dir
     app.systemIOActor.send({

--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -907,6 +907,10 @@ export const systemIOMachine = setup({
     },
     [SystemIOMachineStates.readingFolders]: {
       on: {
+        [SystemIOMachineEvents.setProjectDirectoryPath]: {
+          target: SystemIOMachineStates.checkingReadWrite,
+          actions: [SystemIOMachineActions.setProjectDirectoryPath],
+        },
         [SystemIOMachineEvents.bulkImportProjectFilesAndNavigateToFile]: {
           target:
             SystemIOMachineStates.bulkImportingProjectFilesAndNavigateToFile,
@@ -1136,6 +1140,11 @@ export const systemIOMachine = setup({
     },
     [SystemIOMachineStates.checkingReadWrite]: {
       on: {
+        [SystemIOMachineEvents.setProjectDirectoryPath]: {
+          target: SystemIOMachineStates.checkingReadWrite,
+          reenter: true,
+          actions: [SystemIOMachineActions.setProjectDirectoryPath],
+        },
         [SystemIOMachineEvents.bulkImportProjectFilesAndNavigateToFile]: {
           target:
             SystemIOMachineStates.bulkImportingProjectFilesAndNavigateToFile,

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -418,13 +418,13 @@ export const systemIOMachineImpl = systemIOMachine.provide({
       const requestedCode = input.requestedCode
       const folders = input.context.folders
 
-      if (!folders) {
-        return Promise.reject(new Error('no folders'))
-      }
-
       let newProjectName = requestedProjectName
 
       if (!newProjectName) {
+        if (!folders) {
+          return Promise.reject(new Error('no folders'))
+        }
+
         newProjectName = getUniqueProjectName(
           input.context.defaultProjectFolderName,
           folders
@@ -433,7 +433,7 @@ export const systemIOMachineImpl = systemIOMachine.provide({
 
       const needsInterpolated = doesProjectNameNeedInterpolated(newProjectName)
       if (needsInterpolated) {
-        const nextIndex = getNextProjectIndex(newProjectName, folders)
+        const nextIndex = getNextProjectIndex(newProjectName, folders ?? [])
         newProjectName = interpolateProjectNameWithIndex(
           newProjectName,
           nextIndex

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -119,24 +119,29 @@ const Home = () => {
   const onboardingStatus = settingsValues.app.onboardingStatus.current
 
   useEffect(() => {
-    systemIOActor.send({
-      type: SystemIOMachineEvents.setProjectDirectoryPath,
-      data: {
-        requestedProjectDirectoryPath:
-          settingsValues.app?.projectDirectory?.current,
-      },
-    })
-    void waitFor(systemIOActor, (state) =>
-      state.matches(SystemIOMachineStates.idle)
-    ).then(() => {
+    let cancelled = false
+    const requestedProjectDirectoryPath =
+      settingsValues.app?.projectDirectory?.current || ''
+    const setProjectDirectoryPath = () => {
       systemIOActor.send({
         type: SystemIOMachineEvents.setProjectDirectoryPath,
         data: {
-          requestedProjectDirectoryPath:
-            settingsValues.app?.projectDirectory?.current,
+          requestedProjectDirectoryPath,
         },
       })
+    }
+
+    setProjectDirectoryPath()
+    void waitFor(systemIOActor, (state) =>
+      state.matches(SystemIOMachineStates.idle)
+    ).then(() => {
+      if (!cancelled) {
+        setProjectDirectoryPath()
+      }
     })
+    return () => {
+      cancelled = true
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
   }, [settingsValues.app?.projectDirectory?.current])
 

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -64,7 +64,6 @@ import { useApp, useSingletons } from '@src/lib/boot'
 import type { SettingsType } from '@src/lib/settings/initialSettings'
 import type { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
 import type { ActorRefFrom } from 'xstate'
-import { waitFor } from 'xstate'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
 import { statusBarGlobalItemsValueSpec } from '@src/registry/contracts/statusBar'
 
@@ -117,33 +116,6 @@ const Home = () => {
   const settingsValues = settings.useSettings()
   const machineApiEnabled = settingsValues.app.machineApi.current
   const onboardingStatus = settingsValues.app.onboardingStatus.current
-
-  useEffect(() => {
-    let cancelled = false
-    const requestedProjectDirectoryPath =
-      settingsValues.app?.projectDirectory?.current || ''
-    const setProjectDirectoryPath = () => {
-      systemIOActor.send({
-        type: SystemIOMachineEvents.setProjectDirectoryPath,
-        data: {
-          requestedProjectDirectoryPath,
-        },
-      })
-    }
-
-    setProjectDirectoryPath()
-    void waitFor(systemIOActor, (state) =>
-      state.matches(SystemIOMachineStates.idle)
-    ).then(() => {
-      if (!cancelled) {
-        setProjectDirectoryPath()
-      }
-    })
-    return () => {
-      cancelled = true
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-  }, [settingsValues.app?.projectDirectory?.current])
 
   // Menu listeners
   const cb = (data: WebContentSendPayload) => {


### PR DESCRIPTION
Fixes #11452

To test:
- grab a build at https://github.com/KittyCAD/modeling-app/actions/runs/25389638599?pr=11454
- download a KCL project
- open it with the CLI or file explorer Open with...