### PR TITLE
Add deprecated_since on function parameters and deprecate legacyMethod in KCL 2

### DIFF
--- a/docs/kcl-std-legacy/functions/std-solid-chamfer.md
+++ b/docs/kcl-std-legacy/functions/std-solid-chamfer.md
@@ -33,7 +33,7 @@ a sharp, straight transitional edge.
 | `secondLength` | `number(Length)` | Chamfering cuts away two faces to create a third face. If this argument isn't given, the lengths chamfered away from both the first and second face are both given by `length`. If this argument _is_ given, it determines how much is cut away from the second face. Incompatible with `angle`. | No |
 | `angle` | `number(Angle)` | Chamfering cuts away two faces to create a third face. This argument determines the angle between the two cut edges. Requires `length`, incompatible with `secondLength`. The valid range is 0deg < angle < 90deg. | No |
 | `tag` | `TagDecl` | Create a new tag which refers to this chamfer | No |
-| `legacyMethod` | `bool` | You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
+| `legacyMethod` | `bool` | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
 
 ### Returns
 

--- a/docs/kcl-std-legacy/functions/std-solid-fillet.md
+++ b/docs/kcl-std-legacy/functions/std-solid-fillet.md
@@ -31,7 +31,7 @@ will smoothly blend the transition.
 | `tags` | `[Edge; 1+]` | The paths you want to fillet | Yes |
 | `tolerance` | `number(Length)` | Defines the smallest distance below which two entities are considered coincident, intersecting, coplanar, or similar. For most use cases, it should not be changed from its default value of 10^-7 millimeters. | No |
 | `tag` | `TagDecl` | Create a new tag which refers to this fillet | No |
-| `legacyMethod` | `bool` | You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
+| `legacyMethod` | `bool` | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
 
 ### Returns
 

--- a/docs/kcl-std-legacy/functions/std-solid-intersect.md
+++ b/docs/kcl-std-legacy/functions/std-solid-intersect.md
@@ -26,7 +26,7 @@ verifying fit, and analyzing overlapping geometries in assemblies.
 |----------|------|-------------|----------|
 | `solids` | `[Solid; 2+]` | The solids to intersect. | Yes |
 | `tolerance` | `number(Length)` | Defines the smallest distance below which two entities are considered coincident, intersecting, coplanar, or similar. For most use cases, it should not be changed from its default value of 10^-7 millimeters. | No |
-| `legacyMethod` | `bool` | You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
+| `legacyMethod` | `bool` | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
 
 ### Returns
 

--- a/docs/kcl-std-legacy/functions/std-solid-split.md
+++ b/docs/kcl-std-legacy/functions/std-solid-split.md
@@ -27,7 +27,7 @@ split(
 | `merge` | `bool` | Whether to merge the bodies into one after. Defaults to false. | No |
 | `keepTools` | `bool` | If false, the tool bodies will be removed from the scene. If true, they'll be kept. Defaults to false. | No |
 | `tools` | `[Solid]` | The tools to split the target bodies along. | No |
-| `legacyMethod` | `bool` | You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
+| `legacyMethod` | `bool` | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
 
 ### Returns
 

--- a/docs/kcl-std-legacy/functions/std-solid-subtract.md
+++ b/docs/kcl-std-legacy/functions/std-solid-subtract.md
@@ -29,7 +29,7 @@ and complex multi-body part modeling.
 | `solids` | `[Solid; 1+]` | The solids to use as the base to subtract from. | Yes |
 | `tools` | `[Solid]` | The solids to subtract. | Yes |
 | `tolerance` | `number(Length)` | Defines the smallest distance below which two entities are considered coincident, intersecting, coplanar, or similar. For most use cases, it should not be changed from its default value of 10^-7 millimeters. | No |
-| `legacyMethod` | `bool` | You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
+| `legacyMethod` | `bool` | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
 
 ### Returns
 

--- a/docs/kcl-std-legacy/functions/std-solid-union.md
+++ b/docs/kcl-std-legacy/functions/std-solid-union.md
@@ -23,7 +23,7 @@ union(
 |----------|------|-------------|----------|
 | `solids` | `[Solid; 2+]` | The solids to union. | Yes |
 | `tolerance` | `number(Length)` | Defines the smallest distance below which two entities are considered coincident, intersecting, coplanar, or similar. For most use cases, it should not be changed from its default value of 10^-7 millimeters. | No |
-| `legacyMethod` | `bool` | You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
+| `legacyMethod` | `bool` | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
 
 ### Returns
 

--- a/docs/kcl-std-sketch-solve/functions/std-solid-chamfer.md
+++ b/docs/kcl-std-sketch-solve/functions/std-solid-chamfer.md
@@ -33,7 +33,7 @@ a sharp, straight transitional edge.
 | `secondLength` | `number(Length)` | Chamfering cuts away two faces to create a third face. If this argument isn't given, the lengths chamfered away from both the first and second face are both given by `length`. If this argument _is_ given, it determines how much is cut away from the second face. Incompatible with `angle`. | No |
 | `angle` | `number(Angle)` | Chamfering cuts away two faces to create a third face. This argument determines the angle between the two cut edges. Requires `length`, incompatible with `secondLength`. The valid range is 0deg < angle < 90deg. | No |
 | `tag` | `TagDecl` | Create a new tag which refers to this chamfer | No |
-| `legacyMethod` | `bool` | You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
+| `legacyMethod` | `bool` | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
 
 ### Returns
 

--- a/docs/kcl-std-sketch-solve/functions/std-solid-fillet.md
+++ b/docs/kcl-std-sketch-solve/functions/std-solid-fillet.md
@@ -31,7 +31,7 @@ will smoothly blend the transition.
 | `tags` | `[Edge; 1+]` | The paths you want to fillet | Yes |
 | `tolerance` | `number(Length)` | Defines the smallest distance below which two entities are considered coincident, intersecting, coplanar, or similar. For most use cases, it should not be changed from its default value of 10^-7 millimeters. | No |
 | `tag` | `TagDecl` | Create a new tag which refers to this fillet | No |
-| `legacyMethod` | `bool` | You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
+| `legacyMethod` | `bool` | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
 
 ### Returns
 

--- a/docs/kcl-std-sketch-solve/functions/std-solid-intersect.md
+++ b/docs/kcl-std-sketch-solve/functions/std-solid-intersect.md
@@ -26,7 +26,7 @@ verifying fit, and analyzing overlapping geometries in assemblies.
 |----------|------|-------------|----------|
 | `solids` | `[Solid; 2+]` | The solids to intersect. | Yes |
 | `tolerance` | `number(Length)` | Defines the smallest distance below which two entities are considered coincident, intersecting, coplanar, or similar. For most use cases, it should not be changed from its default value of 10^-7 millimeters. | No |
-| `legacyMethod` | `bool` | You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
+| `legacyMethod` | `bool` | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
 
 ### Returns
 

--- a/docs/kcl-std-sketch-solve/functions/std-solid-split.md
+++ b/docs/kcl-std-sketch-solve/functions/std-solid-split.md
@@ -27,7 +27,7 @@ split(
 | `merge` | `bool` | Whether to merge the bodies into one after. Defaults to false. | No |
 | `keepTools` | `bool` | If false, the tool bodies will be removed from the scene. If true, they'll be kept. Defaults to false. | No |
 | `tools` | `[Solid]` | The tools to split the target bodies along. | No |
-| `legacyMethod` | `bool` | You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
+| `legacyMethod` | `bool` | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
 
 ### Returns
 

--- a/docs/kcl-std-sketch-solve/functions/std-solid-subtract.md
+++ b/docs/kcl-std-sketch-solve/functions/std-solid-subtract.md
@@ -29,7 +29,7 @@ and complex multi-body part modeling.
 | `solids` | `[Solid; 1+]` | The solids to use as the base to subtract from. | Yes |
 | `tools` | `[Solid]` | The solids to subtract. | Yes |
 | `tolerance` | `number(Length)` | Defines the smallest distance below which two entities are considered coincident, intersecting, coplanar, or similar. For most use cases, it should not be changed from its default value of 10^-7 millimeters. | No |
-| `legacyMethod` | `bool` | You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
+| `legacyMethod` | `bool` | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
 
 ### Returns
 

--- a/docs/kcl-std-sketch-solve/functions/std-solid-union.md
+++ b/docs/kcl-std-sketch-solve/functions/std-solid-union.md
@@ -23,7 +23,7 @@ union(
 |----------|------|-------------|----------|
 | `solids` | `[Solid; 2+]` | The solids to union. | Yes |
 | `tolerance` | `number(Length)` | Defines the smallest distance below which two entities are considered coincident, intersecting, coplanar, or similar. For most use cases, it should not be changed from its default value of 10^-7 millimeters. | No |
-| `legacyMethod` | `bool` | You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
+| `legacyMethod` | `bool` | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-solid-chamfer.md
+++ b/docs/kcl-std/functions/std-solid-chamfer.md
@@ -33,7 +33,7 @@ a sharp, straight transitional edge.
 | `secondLength` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | Chamfering cuts away two faces to create a third face. If this argument isn't given, the lengths chamfered away from both the first and second face are both given by `length`. If this argument _is_ given, it determines how much is cut away from the second face. Incompatible with `angle`. | No |
 | `angle` | [`number(Angle)`](/docs/kcl-std/types/std-types-number) | Chamfering cuts away two faces to create a third face. This argument determines the angle between the two cut edges. Requires `length`, incompatible with `secondLength`. The valid range is 0deg < angle < 90deg. | No |
 | `tag` | [`TagDecl`](/docs/kcl-std/types/std-types-TagDecl) | Create a new tag which refers to this chamfer | No |
-| `legacyMethod` | [`bool`](/docs/kcl-std/types/std-types-bool) | You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
+| `legacyMethod` | [`bool`](/docs/kcl-std/types/std-types-bool) | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-solid-fillet.md
+++ b/docs/kcl-std/functions/std-solid-fillet.md
@@ -31,7 +31,7 @@ will smoothly blend the transition.
 | `tags` | [[`Edge`](/docs/kcl-std/types/std-types-Edge); 1+] | The paths you want to fillet | Yes |
 | `tolerance` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | Defines the smallest distance below which two entities are considered coincident, intersecting, coplanar, or similar. For most use cases, it should not be changed from its default value of 10^-7 millimeters. | No |
 | `tag` | [`TagDecl`](/docs/kcl-std/types/std-types-TagDecl) | Create a new tag which refers to this fillet | No |
-| `legacyMethod` | [`bool`](/docs/kcl-std/types/std-types-bool) | You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
+| `legacyMethod` | [`bool`](/docs/kcl-std/types/std-types-bool) | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-solid-intersect.md
+++ b/docs/kcl-std/functions/std-solid-intersect.md
@@ -26,7 +26,7 @@ verifying fit, and analyzing overlapping geometries in assemblies.
 |----------|------|-------------|----------|
 | `solids` | [[`Solid`](/docs/kcl-std/types/std-types-Solid); 2+] | The solids to intersect. | Yes |
 | `tolerance` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | Defines the smallest distance below which two entities are considered coincident, intersecting, coplanar, or similar. For most use cases, it should not be changed from its default value of 10^-7 millimeters. | No |
-| `legacyMethod` | [`bool`](/docs/kcl-std/types/std-types-bool) | You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
+| `legacyMethod` | [`bool`](/docs/kcl-std/types/std-types-bool) | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-solid-split.md
+++ b/docs/kcl-std/functions/std-solid-split.md
@@ -27,7 +27,7 @@ split(
 | `merge` | [`bool`](/docs/kcl-std/types/std-types-bool) | Whether to merge the bodies into one after. Defaults to false. | No |
 | `keepTools` | [`bool`](/docs/kcl-std/types/std-types-bool) | If false, the tool bodies will be removed from the scene. If true, they'll be kept. Defaults to false. | No |
 | `tools` | [[`Solid`](/docs/kcl-std/types/std-types-Solid)] | The tools to split the target bodies along. | No |
-| `legacyMethod` | [`bool`](/docs/kcl-std/types/std-types-bool) | You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
+| `legacyMethod` | [`bool`](/docs/kcl-std/types/std-types-bool) | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-solid-subtract.md
+++ b/docs/kcl-std/functions/std-solid-subtract.md
@@ -29,7 +29,7 @@ and complex multi-body part modeling.
 | `solids` | [[`Solid`](/docs/kcl-std/types/std-types-Solid); 1+] | The solids to use as the base to subtract from. | Yes |
 | `tools` | [[`Solid`](/docs/kcl-std/types/std-types-Solid)] | The solids to subtract. | Yes |
 | `tolerance` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | Defines the smallest distance below which two entities are considered coincident, intersecting, coplanar, or similar. For most use cases, it should not be changed from its default value of 10^-7 millimeters. | No |
-| `legacyMethod` | [`bool`](/docs/kcl-std/types/std-types-bool) | You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
+| `legacyMethod` | [`bool`](/docs/kcl-std/types/std-types-bool) | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
 
 ### Returns
 

--- a/docs/kcl-std/functions/std-solid-union.md
+++ b/docs/kcl-std/functions/std-solid-union.md
@@ -23,7 +23,7 @@ union(
 |----------|------|-------------|----------|
 | `solids` | [[`Solid`](/docs/kcl-std/types/std-types-Solid); 2+] | The solids to union. | Yes |
 | `tolerance` | [`number(Length)`](/docs/kcl-std/types/std-types-number) | Defines the smallest distance below which two entities are considered coincident, intersecting, coplanar, or similar. For most use cases, it should not be changed from its default value of 10^-7 millimeters. | No |
-| `legacyMethod` | [`bool`](/docs/kcl-std/types/std-types-bool) | You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
+| `legacyMethod` | [`bool`](/docs/kcl-std/types/std-types-bool) | **Deprecated as of KCL 2.0.** You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm. If true, revert to older engine SSI algorithm. Defaults to false. | No |
 
 ### Returns
 

--- a/rust/kcl-lib/src/docs/gen_std_tests.rs
+++ b/rust/kcl-lib/src/docs/gen_std_tests.rs
@@ -475,6 +475,7 @@ fn generate_function_from_kcl(
                         .unwrap_or_default(),
                 ),
                 "required": arg.kind.required(),
+                "deprecated_since": arg.deprecated_since.as_ref().map(ToString::to_string),
             })
         })
         .collect::<Vec<_>>();

--- a/rust/kcl-lib/src/docs/kcl_doc.rs
+++ b/rust/kcl-lib/src/docs/kcl_doc.rs
@@ -870,6 +870,8 @@ pub struct ArgData {
     pub docs: Option<String>,
     /// If given, LSP should use these as completion items.
     pub snippet_array: Option<Vec<String>>,
+    /// Constraint on the KCL version at or after which this argument is deprecated.
+    pub deprecated_since: Option<VersionConstraint>,
 }
 
 impl fmt::Display for ArgData {
@@ -907,6 +909,7 @@ impl ArgData {
             } else {
                 ArgKind::Special
             },
+            deprecated_since: arg.deprecated_since.clone(),
         };
 
         for attr in &arg.identifier.outer_attrs {

--- a/rust/kcl-lib/src/docs/templates/function.hbs
+++ b/rust/kcl-lib/src/docs/templates/function.hbs
@@ -31,7 +31,7 @@ layout: manual
 | Name | Type | Description | Required |
 |----------|------|-------------|----------|
 {{#each args}}
-| `{{name}}` | `{{type_}}` | {{{firstLine description}}} | {{#if required}}Yes{{else}}No{{/if}} |
+| `{{name}}` | `{{type_}}` | {{#if deprecated_since}}**Deprecated as of KCL {{deprecated_since}}.** {{/if}}{{{firstLine description}}} | {{#if required}}Yes{{else}}No{{/if}} |
 {{/each}}
 {{/if}}
 

--- a/rust/kcl-lib/src/execution/annotations.rs
+++ b/rust/kcl-lib/src/execution/annotations.rs
@@ -300,7 +300,7 @@ impl Default for FnAttrs {
 /// concrete version are expressed via the free `version_*` functions below
 /// rather than `Ord` so the direction of comparison stays explicit at every
 /// call site.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 pub struct VersionConstraint(Vec<u32>);
 
 impl VersionConstraint {

--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -318,17 +318,35 @@ impl FunctionSource {
 
         let args = type_check_params_kw(fn_name.as_deref(), self, args, exec_state)?;
 
-        // Warn if experimental arguments are used after desugaring.
+        // Warn if experimental or deprecated arguments are used after desugaring.
         for (label, arg) in &args.labeled {
-            if let Some(param) = self.named_args.get(label.as_str())
-                && param.experimental
-            {
+            let Some(param) = self.named_args.get(label.as_str()) else {
+                continue;
+            };
+            if param.experimental {
                 exec_state.warn_experimental(
                     &match &fn_name {
                         Some(f) => format!("`{f}({label})`"),
                         None => label.to_owned(),
                     },
                     arg.source_range,
+                );
+            }
+            if let Some(since) = &param.deprecated_since
+                && annotations::version_ge(&exec_state.mod_local.settings.kcl_version, since)
+            {
+                let qualified = match &fn_name {
+                    Some(f) => format!("`{f}({label})`"),
+                    None => format!("`{label}`"),
+                };
+                exec_state.warn(
+                    CompilationIssue::err(
+                        arg.source_range,
+                        format!(
+                            "{qualified} is deprecated as of KCL {since}. See the docs for a recommended replacement."
+                        ),
+                    ),
+                    annotations::WARN_DEPRECATED,
                 );
             }
         }
@@ -892,6 +910,7 @@ fn type_check_params_kw(
         match fn_def.named_args.get(&label) {
             Some(NamedParam {
                 experimental: _,
+                deprecated_since: _,
                 default_value: def,
                 ty,
             }) => {
@@ -1070,6 +1089,7 @@ mod test {
         fn opt_param(s: &'static str) -> Parameter {
             Parameter {
                 experimental: false,
+                deprecated_since: None,
                 identifier: ident(s),
                 param_type: None,
                 default_value: Some(DefaultParamVal::none()),
@@ -1080,6 +1100,7 @@ mod test {
         fn req_param(s: &'static str) -> Parameter {
             Parameter {
                 experimental: false,
+                deprecated_since: None,
                 identifier: ident(s),
                 param_type: None,
                 default_value: None,

--- a/rust/kcl-lib/src/execution/kcl_value.rs
+++ b/rust/kcl-lib/src/execution/kcl_value.rs
@@ -169,6 +169,8 @@ where
 #[derive(Debug, Clone, PartialEq)]
 pub struct NamedParam {
     pub experimental: bool,
+    /// Constraint marking the KCL version at or after which this parameter is deprecated.
+    pub deprecated_since: Option<VersionConstraint>,
     pub default_value: Option<DefaultParamVal>,
     pub ty: Option<Type>,
 }
@@ -257,6 +259,7 @@ impl FunctionSource {
                 p.identifier.name.clone(),
                 NamedParam {
                     experimental: p.experimental,
+                    deprecated_since: p.deprecated_since.clone(),
                     default_value: p.default_value.clone(),
                     ty: p.param_type.as_ref().map(|t| t.inner.clone()),
                 },

--- a/rust/kcl-lib/src/parsing/ast/types/mod.rs
+++ b/rust/kcl-lib/src/parsing/ast/types/mod.rs
@@ -37,6 +37,7 @@ use crate::errors::KclError;
 use crate::execution::KclValue;
 use crate::execution::Metadata;
 use crate::execution::TagIdentifier;
+use crate::execution::annotations::VersionConstraint;
 use crate::execution::annotations::WarningLevel;
 use crate::execution::annotations::{self};
 use crate::execution::types::ArrayLen;
@@ -4062,6 +4063,11 @@ pub struct Parameter {
     /// Whether it's experimental.
     #[serde(default, skip_serializing_if = "is_false")]
     pub experimental: bool,
+    /// If set, this parameter is deprecated as of the given KCL version (e.g.,
+    /// "2.0"). The parser validates that this is a dotted integer version;
+    /// downstream code reparses it into a `VersionConstraint`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deprecated_since: Option<VersionConstraint>,
     /// The parameter's label or name.
     pub identifier: Node<Identifier>,
     /// The type of the parameter.
@@ -4805,6 +4811,7 @@ cylinder = startSketchOn(-XZ)
                     name: None,
                     params: vec![Parameter {
                         experimental: Default::default(),
+                        deprecated_since: None,
                         identifier: Node::no_src(Identifier {
                             name: "foo".to_owned(),
                             digest: None,
@@ -4826,6 +4833,7 @@ cylinder = startSketchOn(-XZ)
                     name: None,
                     params: vec![Parameter {
                         experimental: Default::default(),
+                        deprecated_since: None,
                         identifier: Node::no_src(Identifier {
                             name: "foo".to_owned(),
                             digest: None,
@@ -4848,6 +4856,7 @@ cylinder = startSketchOn(-XZ)
                     params: vec![
                         Parameter {
                             experimental: Default::default(),
+                            deprecated_since: None,
                             identifier: Node::no_src(Identifier {
                                 name: "foo".to_owned(),
                                 digest: None,
@@ -4859,6 +4868,7 @@ cylinder = startSketchOn(-XZ)
                         },
                         Parameter {
                             experimental: Default::default(),
+                            deprecated_since: None,
                             identifier: Node::no_src(Identifier {
                                 name: "bar".to_owned(),
                                 digest: None,

--- a/rust/kcl-lib/src/parsing/parser.rs
+++ b/rust/kcl-lib/src/parsing/parser.rs
@@ -39,7 +39,9 @@ use crate::TypedPath;
 use crate::errors::CompilationIssue;
 use crate::errors::Severity;
 use crate::errors::Tag;
+use crate::execution::annotations::DEPRECATED_SINCE;
 use crate::execution::annotations::EXPERIMENTAL;
+use crate::execution::annotations::VersionConstraint;
 use crate::execution::annotations::{self};
 use crate::execution::types::ArrayLen;
 use crate::parsing::PIPE_OPERATOR;
@@ -3750,17 +3752,33 @@ fn parameters(i: &mut TokenSlice) -> ModalResult<Vec<Parameter>> {
                     identifier.pre_comments = comments.inner;
                 }
                 let mut experimental = false;
+                let mut deprecated_since = None;
                 if let Some(attr) = attr {
                     if let Some(property) = attr.property(EXPERIMENTAL)
                         && let Some(value) = property.value.literal_bool()
                     {
                         experimental = value;
                     }
+                    if let Some(property) = attr.property(DEPRECATED_SINCE) {
+                        if let Some(s) = property.value.literal_str()
+                            && let Some(version) = VersionConstraint::parse(s)
+                        {
+                            deprecated_since = Some(version);
+                        } else {
+                            ParseContext::err(CompilationIssue::fatal(
+                                SourceRange::from(&property.value),
+                                format!(
+                                    "Invalid value for `{DEPRECATED_SINCE}`; expected a dotted integer version string, e.g., \"2.0\"",
+                                ),
+                            ));
+                        }
+                    }
                     identifier.outer_attrs.push(attr);
                 }
 
                 Ok(Parameter {
                     experimental,
+                    deprecated_since,
                     identifier,
                     param_type: type_,
                     default_value,
@@ -5634,6 +5652,7 @@ e
             (
                 vec![Parameter {
                     experimental: Default::default(),
+                    deprecated_since: None,
                     identifier: Node::no_src(Identifier {
                         name: "a".to_owned(),
                         digest: None,
@@ -5648,6 +5667,7 @@ e
             (
                 vec![Parameter {
                     experimental: Default::default(),
+                    deprecated_since: None,
                     identifier: Node::no_src(Identifier {
                         name: "a".to_owned(),
                         digest: None,
@@ -5663,6 +5683,7 @@ e
                 vec![
                     Parameter {
                         experimental: Default::default(),
+                        deprecated_since: None,
                         identifier: Node::no_src(Identifier {
                             name: "a".to_owned(),
                             digest: None,
@@ -5674,6 +5695,7 @@ e
                     },
                     Parameter {
                         experimental: Default::default(),
+                        deprecated_since: None,
                         identifier: Node::no_src(Identifier {
                             name: "b".to_owned(),
                             digest: None,
@@ -5690,6 +5712,7 @@ e
                 vec![
                     Parameter {
                         experimental: Default::default(),
+                        deprecated_since: None,
                         identifier: Node::no_src(Identifier {
                             name: "a".to_owned(),
                             digest: None,
@@ -5701,6 +5724,7 @@ e
                     },
                     Parameter {
                         experimental: Default::default(),
+                        deprecated_since: None,
                         identifier: Node::no_src(Identifier {
                             name: "b".to_owned(),
                             digest: None,

--- a/rust/kcl-lib/std/solid.kcl
+++ b/rust/kcl-lib/std/solid.kcl
@@ -106,6 +106,7 @@ export fn fillet(
   /// You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm.
   /// If true, revert to older engine SSI algorithm.
   /// Defaults to false.
+  @(deprecated_since = "2.0")
   legacyMethod?: bool,
 ): Solid {}
 
@@ -250,6 +251,7 @@ export fn chamfer(
   /// You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm.
   /// If true, revert to older engine SSI algorithm.
   /// Defaults to false.
+  @(deprecated_since = "2.0")
   legacyMethod?: bool,
 ): Solid {}
 
@@ -953,6 +955,7 @@ export fn union(
   /// You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm.
   /// If true, revert to older engine SSI algorithm.
   /// Defaults to false.
+  @(deprecated_since = "2.0")
   legacyMethod?: bool,
 ): [Solid; 1+] {}
 
@@ -1015,6 +1018,7 @@ export fn intersect(
   /// You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm.
   /// If true, revert to older engine SSI algorithm.
   /// Defaults to false.
+  @(deprecated_since = "2.0")
   legacyMethod?: bool,
 ): [Solid; 1+] {}
 
@@ -1174,6 +1178,7 @@ export fn subtract(
   /// You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm.
   /// If true, revert to older engine SSI algorithm.
   /// Defaults to false.
+  @(deprecated_since = "2.0")
   legacyMethod?: bool,
 ): [Solid; 1+] {}
 
@@ -1590,6 +1595,7 @@ export fn split(
   /// You probably shouldn't set this or care about this, it's for opting back into an older version of an engine algorithm.
   /// If true, revert to older engine SSI algorithm.
   /// Defaults to false.
+  @(deprecated_since = "2.0")
   legacyMethod?: bool,
 ): [Solid; 1+] {}
 


### PR DESCRIPTION
Resolves #11446.

We can now deprecate individual parameters starting at a KCL version.

```
export fn fillet(
  @(deprecated_since = "2.0")
  legacyMethod?: bool,
): Solid {}
```