### PR TITLE
Add readable X/Y/Z labels to the view gizmo

### DIFF
--- a/src/components/gizmo/AxisGizmo.tsx
+++ b/src/components/gizmo/AxisGizmo.tsx
@@ -2,7 +2,6 @@ import { useApp, useSingletons } from '@src/lib/boot'
 import { useEffect, useRef } from 'react'
 import type { MutableRefObject } from 'react'
 
-import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
 import { ViewControlContextMenu } from '@src/components/ViewControlMenu'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { AxisNames } from '@src/lib/constants'
@@ -36,6 +35,8 @@ export default function AxisGizmo() {
   const raycasterIntersect = useRef<Intersection | null>(null)
   const cameraPassiveUpdateTimer = useRef(0)
   const disableOrbitRef = useRef(false)
+  const isPointerOverRef = useRef(false)
+  const isHoverRefreshPausedRef = useRef(false)
 
   // Temporary fix for #4040:
   // Disable gizmo orbiting in sketch mode
@@ -63,6 +64,9 @@ export default function AxisGizmo() {
 
     const canvas = canvasRef.current
     const wrapperElement = wrapperRef.current
+    isPointerOverRef.current = false
+    isHoverRefreshPausedRef.current = false
+
     const renderer = new WebGLRenderer({
       canvas,
       antialias: true,
@@ -80,6 +84,14 @@ export default function AxisGizmo() {
 
     const raycaster = new Raycaster()
     const raycasterObjects = [...gizmoAxisHeads]
+    const resetRayCast = () => {
+      for (const object of raycasterObjects) {
+        object.scale.setScalar(1)
+      }
+      updateAxisLabelHover(axisLabelObjects)
+      raycasterIntersect.current = null
+      renderGizmo(renderer, scene, camera)
+    }
     const doRayCast = (mouse: Vector2) => {
       // If orbits are disabled, skip click logic
       if (!disableOrbitRef.current) {
@@ -94,26 +106,59 @@ export default function AxisGizmo() {
           axisLabelObjects
         )
       } else {
-        for (const object of raycasterObjects) {
-          object.scale.setScalar(1)
-        }
-        updateAxisLabelHover(axisLabelObjects)
-        raycasterIntersect.current = null // Clear intersection
+        resetRayCast()
       }
+    }
+    const updateHoverAtMouse = (mouse: Vector2) => {
+      if (isHoverRefreshPausedRef.current) {
+        return
+      }
+      doRayCast(mouse)
+    }
+
+    const clock = new Clock()
+    const clientCamera = kclManager.sceneInfra.camControls.camera
+    const currentQuaternion = new Quaternion().copy(clientCamera.quaternion)
+    const mouse = new Vector2()
+    mouse.x = 1 // fix initial mouse position issue
+    let isDisposed = false
+    const refreshHoverAfterCameraUpdate = () => {
+      if (isDisposed) {
+        return
+      }
+
+      isHoverRefreshPausedRef.current = false
+      currentQuaternion.copy(
+        kclManager.sceneInfra.camControls.camera.quaternion
+      )
+      camera.position.set(0, 0, 1).applyQuaternion(currentQuaternion)
+      camera.quaternion.copy(currentQuaternion)
+      if (isPointerOverRef.current) {
+        doRayCast(mouse)
+      } else {
+        resetRayCast()
+      }
+    }
+    const onAxisClick = (axisName: AxisNames) => {
+      isHoverRefreshPausedRef.current = true
+      resetRayCast()
+      void kclManager.sceneInfra.camControls
+        .updateCameraToAxis(axisName)
+        .catch(reportRejection)
+        .finally(refreshHoverAfterCameraUpdate)
     }
 
     const { disposeMouseEvents } = initializeMouseEvents(
       canvas,
       raycasterIntersect,
-      kclManager.sceneInfra,
       disableOrbitRef,
-      doRayCast,
+      isPointerOverRef,
+      updateHoverAtMouse,
+      resetRayCast,
+      onAxisClick,
+      mouse,
       wrapperElement
     )
-
-    const clock = new Clock()
-    const clientCamera = kclManager.sceneInfra.camControls.camera
-    const currentQuaternion = new Quaternion().copy(clientCamera.quaternion)
 
     const animate = () => {
       const delta = clock.getDelta()
@@ -124,7 +169,11 @@ export default function AxisGizmo() {
         delta,
         cameraPassiveUpdateTimer
       )
-      renderGizmo(renderer, scene, camera)
+      if (isPointerOverRef.current && !isHoverRefreshPausedRef.current) {
+        doRayCast(mouse)
+      } else {
+        renderGizmo(renderer, scene, camera)
+      }
     }
     kclManager.sceneInfra.camControls.cameraChange.add(animate)
 
@@ -135,6 +184,9 @@ export default function AxisGizmo() {
     renderGizmo(renderer, scene, camera)
 
     return () => {
+      isDisposed = true
+      isPointerOverRef.current = false
+      isHoverRefreshPausedRef.current = false
       renderer.forceContextLoss()
       renderer.dispose()
       disposeMouseEvents()
@@ -369,19 +421,25 @@ const quaternionsEqual = (
 const initializeMouseEvents = (
   canvas: HTMLCanvasElement,
   raycasterIntersect: MutableRefObject<Intersection | null>,
-  sceneInfra: SceneInfra,
   disableOrbitRef: MutableRefObject<boolean>,
-  doRayCast: (mouse: Vector2) => void,
+  isPointerOverRef: MutableRefObject<boolean>,
+  updateHoverAtMouse: (mouse: Vector2) => void,
+  resetRayCast: () => void,
+  onAxisClick: (axisName: AxisNames) => void,
+  mouse: Vector2,
   wrapperElement: HTMLDivElement
-): { mouse: Vector2; disposeMouseEvents: () => void } => {
-  const mouse = new Vector2()
-  mouse.x = 1 // fix initial mouse position issue
-
+): { disposeMouseEvents: () => void } => {
   const handleMouseMove = (event: MouseEvent) => {
+    isPointerOverRef.current = true
     const { left, top, width, height } = canvas.getBoundingClientRect()
     mouse.x = ((event.clientX - left) / width) * 2 - 1
     mouse.y = ((event.clientY - top) / height) * -2 + 1
-    doRayCast(mouse)
+    updateHoverAtMouse(mouse)
+  }
+
+  const handleMouseLeave = () => {
+    isPointerOverRef.current = false
+    resetRayCast()
   }
 
   const handleClick = () => {
@@ -390,19 +448,21 @@ const initializeMouseEvents = (
       return
     }
     const axisName = raycasterIntersect.current.object.name as AxisNames
-    sceneInfra.camControls.updateCameraToAxis(axisName).catch(reportRejection)
+    onAxisClick(axisName)
   }
 
   // Add the event listener to the div wrapper around the canvas
   wrapperElement.addEventListener('mousemove', handleMouseMove)
+  wrapperElement.addEventListener('mouseleave', handleMouseLeave)
   wrapperElement.addEventListener('click', handleClick)
 
   const disposeMouseEvents = () => {
     wrapperElement.removeEventListener('mousemove', handleMouseMove)
+    wrapperElement.removeEventListener('mouseleave', handleMouseLeave)
     wrapperElement.removeEventListener('click', handleClick)
   }
 
-  return { mouse, disposeMouseEvents }
+  return { disposeMouseEvents }
 }
 
 const updateRayCaster = (

--- a/src/components/gizmo/AxisGizmo.tsx
+++ b/src/components/gizmo/AxisGizmo.tsx
@@ -6,7 +6,7 @@ import { ViewControlContextMenu } from '@src/components/ViewControlMenu'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { AxisNames } from '@src/lib/constants'
 import { reportRejection } from '@src/lib/trap'
-import type { ColorRepresentation, Intersection, Object3D } from 'three'
+import type { ColorRepresentation, Intersection } from 'three'
 import {
   BoxGeometry,
   CanvasTexture,
@@ -17,8 +17,8 @@ import {
   OrthographicCamera,
   Quaternion,
   Raycaster,
+  SRGBColorSpace,
   Scene,
-  SphereGeometry,
   Sprite,
   SpriteMaterial,
   Vector2,
@@ -78,19 +78,17 @@ export default function AxisGizmo() {
 
     const scene = new Scene()
     const camera = createCamera()
-    const { gizmoAxes, gizmoAxisHeads, gizmoAxisLabels, axisLabelObjects } =
-      createGizmo()
-    scene.add(...gizmoAxes, ...gizmoAxisHeads, ...gizmoAxisLabels)
+    const { gizmoAxisPairs } = createGizmo()
+    scene.add(...gizmoAxisPairs.flatMap(({ axis, head }) => [axis, head]))
 
     const raycaster = new Raycaster()
-    const raycasterObjects = [...gizmoAxisHeads]
+    const raycasterObjects = gizmoAxisPairs.map(({ head }) => head)
     const resetRayCast = () => {
       for (const object of raycasterObjects) {
-        object.scale.setScalar(1)
+        setAxisHeadScale(object)
       }
-      updateAxisLabelHover(axisLabelObjects)
       raycasterIntersect.current = null
-      renderer.render(scene, camera)
+      renderGizmoScene(gizmoAxisPairs, renderer, scene, camera)
     }
     const doRayCast = (mouse: Vector2) => {
       // If orbits are disabled, skip click logic
@@ -103,7 +101,7 @@ export default function AxisGizmo() {
           raycasterIntersect,
           renderer,
           scene,
-          axisLabelObjects
+          gizmoAxisPairs
         )
       } else {
         resetRayCast()
@@ -172,7 +170,7 @@ export default function AxisGizmo() {
       if (isPointerOverRef.current && !isHoverRefreshPausedRef.current) {
         doRayCast(mouse)
       } else {
-        renderer.render(scene, camera)
+        renderGizmoScene(gizmoAxisPairs, renderer, scene, camera)
       }
     }
     kclManager.sceneInfra.camControls.cameraChange.add(animate)
@@ -181,7 +179,7 @@ export default function AxisGizmo() {
     const q = kclManager.sceneInfra.camControls.camera.quaternion
     camera.position.set(0, 0, 1).applyQuaternion(q)
     camera.quaternion.copy(q)
-    renderer.render(scene, camera)
+    renderGizmoScene(gizmoAxisPairs, renderer, scene, camera)
 
     return () => {
       isDisposed = true
@@ -212,15 +210,17 @@ const FRUSTUM_SIZE = 0.5
 const AXIS_LENGTH = 0.35
 const AXIS_WIDTH = 0.02
 const AXIS_HEAD_RADIUS = 0.085
+const AXIS_STEM_LENGTH = AXIS_LENGTH - AXIS_HEAD_RADIUS * 0.9
 const AXIS_HOVER_SCALE = 1.5
+const AXIS_HEAD_WORLD_SIZE = AXIS_HEAD_RADIUS * 2
+const AXIS_HEAD_TEXTURE_SIZE = 64
+const AXIS_HEAD_VIEWBOX_SIZE = 16
+const AXIS_HEAD_CENTER = AXIS_HEAD_VIEWBOX_SIZE / 2
+const AXIS_HEAD_CIRCLE_RADIUS = 7.5
 const AXIS_LABEL_FONT_SIZE = 9
 const AXIS_LABEL_CONTOUR_WIDTH = 1.2
 const AXIS_LABEL_FILL_COLOR = '#fcfcfc'
-const AXIS_LABEL_CENTER = 8
 const AXIS_LABEL_CENTER_Y = 8.5
-const AXIS_LABEL_VIEWBOX_SIZE = 16
-const AXIS_LABEL_TEXTURE_SIZE = 64
-const AXIS_LABEL_WORLD_SIZE = AXIS_LABEL_VIEWBOX_SIZE / CANVAS_SIZE
 enum AxisColors {
   X = '#fa6668',
   Y = '#11eb6b',
@@ -229,7 +229,11 @@ enum AxisColors {
 }
 type AxisLabel = 'X' | 'Y' | 'Z'
 type PositiveAxisName = AxisNames.X | AxisNames.Y | AxisNames.Z
-type AxisLabelObjects = Partial<Record<PositiveAxisName, Sprite>>
+type AxisRotation = 'x' | 'y' | 'z'
+type GizmoAxisPair = {
+  axis: Mesh
+  head: Sprite
+}
 const POSITIVE_AXIS_NAMES = [AxisNames.X, AxisNames.Y, AxisNames.Z] as const
 const AXIS_LABELS: Record<PositiveAxisName, AxisLabel> = {
   [AxisNames.X]: 'X',
@@ -241,6 +245,10 @@ const AXIS_LABEL_CONTOUR_COLORS: Record<PositiveAxisName, string> = {
   [AxisNames.Y]: '#0bb858',
   [AxisNames.Z]: '#4d68c0',
 }
+const isPositiveAxisName = (
+  axisName: AxisNames
+): axisName is PositiveAxisName =>
+  POSITIVE_AXIS_NAMES.includes(axisName as PositiveAxisName)
 const AXIS_HEAD_POSITIONS: Record<AxisNames, [number, number, number]> = {
   [AxisNames.X]: [AXIS_LENGTH, 0, 0],
   [AxisNames.Y]: [0, AXIS_LENGTH, 0],
@@ -249,6 +257,39 @@ const AXIS_HEAD_POSITIONS: Record<AxisNames, [number, number, number]> = {
   [AxisNames.NEG_Y]: [0, -AXIS_LENGTH, 0],
   [AxisNames.NEG_Z]: [0, 0, -AXIS_LENGTH],
 }
+const GIZMO_AXIS_DEFINITIONS: {
+  name: AxisNames
+  color: AxisColors
+  rotation: number
+  axis: AxisRotation
+}[] = [
+  { name: AxisNames.X, color: AxisColors.X, rotation: 0, axis: 'z' },
+  { name: AxisNames.Y, color: AxisColors.Y, rotation: Math.PI / 2, axis: 'z' },
+  {
+    name: AxisNames.Z,
+    color: AxisColors.Z,
+    rotation: -Math.PI / 2,
+    axis: 'y',
+  },
+  {
+    name: AxisNames.NEG_X,
+    color: AxisColors.Gray,
+    rotation: Math.PI,
+    axis: 'z',
+  },
+  {
+    name: AxisNames.NEG_Y,
+    color: AxisColors.Gray,
+    rotation: -Math.PI / 2,
+    axis: 'z',
+  },
+  {
+    name: AxisNames.NEG_Z,
+    color: AxisColors.Gray,
+    rotation: Math.PI / 2,
+    axis: 'y',
+  },
+]
 const createCamera = (): OrthographicCamera => {
   return new OrthographicCamera(
     -FRUSTUM_SIZE,
@@ -261,32 +302,14 @@ const createCamera = (): OrthographicCamera => {
 }
 
 const createGizmo = () => {
-  const gizmoAxes = [
-    createAxis(AXIS_LENGTH, AXIS_WIDTH, AxisColors.X, 0, 'z'),
-    createAxis(AXIS_LENGTH, AXIS_WIDTH, AxisColors.Y, Math.PI / 2, 'z'),
-    createAxis(AXIS_LENGTH, AXIS_WIDTH, AxisColors.Z, -Math.PI / 2, 'y'),
-    createAxis(AXIS_LENGTH, AXIS_WIDTH, AxisColors.Gray, Math.PI, 'z'),
-    createAxis(AXIS_LENGTH, AXIS_WIDTH, AxisColors.Gray, -Math.PI / 2, 'z'),
-    createAxis(AXIS_LENGTH, AXIS_WIDTH, AxisColors.Gray, Math.PI / 2, 'y'),
-  ]
+  const gizmoAxisPairs = GIZMO_AXIS_DEFINITIONS.map(
+    ({ name, color, rotation, axis }) => ({
+      axis: createAxis(AXIS_STEM_LENGTH, AXIS_WIDTH, color, rotation, axis),
+      head: createAxisHead(name, color),
+    })
+  )
 
-  const gizmoAxisHeads = [
-    createAxisHead(AxisNames.X, AxisColors.X),
-    createAxisHead(AxisNames.Y, AxisColors.Y),
-    createAxisHead(AxisNames.Z, AxisColors.Z),
-    createAxisHead(AxisNames.NEG_X, AxisColors.Gray),
-    createAxisHead(AxisNames.NEG_Y, AxisColors.Gray),
-    createAxisHead(AxisNames.NEG_Z, AxisColors.Gray),
-  ]
-
-  const axisLabelObjects: AxisLabelObjects = {}
-  const gizmoAxisLabels = POSITIVE_AXIS_NAMES.map((axisName) => {
-    const labelObject = createAxisLabel(axisName)
-    axisLabelObjects[axisName] = labelObject
-    return labelObject
-  })
-
-  return { gizmoAxes, gizmoAxisHeads, gizmoAxisLabels, axisLabelObjects }
+  return { gizmoAxisPairs }
 }
 
 const createAxis = (
@@ -294,87 +317,118 @@ const createAxis = (
   width: number,
   color: ColorRepresentation,
   rotation = 0,
-  axis = 'x'
+  axis: AxisRotation = 'x'
 ): Mesh => {
   const geometry = new BoxGeometry(length, width, width)
   geometry.translate(length / 2, 0, 0)
-  const material = new MeshBasicMaterial({ color: new Color(color) })
+  const material = new MeshBasicMaterial({
+    color: new Color(color),
+    transparent: true,
+    depthTest: false,
+    depthWrite: false,
+  })
   const mesh = new Mesh(geometry, material)
-  mesh.rotation[axis as 'x' | 'y' | 'z'] = rotation
+  mesh.rotation[axis] = rotation
   return mesh
 }
 
-const createAxisHead = (name: AxisNames, color: ColorRepresentation): Mesh => {
-  const geometry = new SphereGeometry(AXIS_HEAD_RADIUS, 48, 24)
-  const material = new MeshBasicMaterial({ color: new Color(color) })
-  const mesh = new Mesh(geometry, material)
+const createAxisHead = (
+  name: AxisNames,
+  color: ColorRepresentation
+): Sprite => {
+  const texture = createAxisHeadTexture(name, color)
+  const material = new SpriteMaterial({
+    map: texture,
+    transparent: true,
+    depthTest: false,
+    depthWrite: false,
+  })
+  const sprite = new Sprite(material)
   const position = AXIS_HEAD_POSITIONS[name]
 
-  mesh.position.set(position[0], position[1], position[2])
-  mesh.updateMatrixWorld()
-  mesh.name = name
-  return mesh
+  sprite.position.set(position[0], position[1], position[2])
+  setAxisHeadScale(sprite)
+  sprite.name = name
+  return sprite
 }
 
-const createAxisLabel = (axisName: PositiveAxisName): Sprite => {
-  const labelCenterY =
-    axisName === AxisNames.Y ? AXIS_LABEL_CENTER_Y + 0.25 : AXIS_LABEL_CENTER_Y
+const createAxisHeadTexture = (
+  axisName: AxisNames,
+  color: ColorRepresentation
+) => {
   const canvas = document.createElement('canvas')
-  canvas.width = AXIS_LABEL_TEXTURE_SIZE
-  canvas.height = AXIS_LABEL_TEXTURE_SIZE
+  canvas.width = AXIS_HEAD_TEXTURE_SIZE
+  canvas.height = AXIS_HEAD_TEXTURE_SIZE
 
   const context = canvas.getContext('2d')
   if (context) {
-    const textureScale = AXIS_LABEL_TEXTURE_SIZE / AXIS_LABEL_VIEWBOX_SIZE
+    const textureScale = AXIS_HEAD_TEXTURE_SIZE / AXIS_HEAD_VIEWBOX_SIZE
     context.scale(textureScale, textureScale)
-    context.font = `800 ${AXIS_LABEL_FONT_SIZE}px Inter, system-ui, sans-serif`
-    context.textAlign = 'center'
-    context.textBaseline = 'middle'
-    context.lineJoin = 'round'
-    context.lineWidth = AXIS_LABEL_CONTOUR_WIDTH
-    context.strokeStyle = AXIS_LABEL_CONTOUR_COLORS[axisName]
-    context.fillStyle = AXIS_LABEL_FILL_COLOR
-    context.strokeText(AXIS_LABELS[axisName], AXIS_LABEL_CENTER, labelCenterY)
-    context.fillText(AXIS_LABELS[axisName], AXIS_LABEL_CENTER, labelCenterY)
+
+    context.fillStyle = new Color(color).getStyle()
+    context.beginPath()
+    context.arc(
+      AXIS_HEAD_CENTER,
+      AXIS_HEAD_CENTER,
+      AXIS_HEAD_CIRCLE_RADIUS,
+      0,
+      Math.PI * 2
+    )
+    context.fill()
+
+    if (isPositiveAxisName(axisName)) {
+      const labelCenterY =
+        axisName === AxisNames.Y
+          ? AXIS_LABEL_CENTER_Y + 0.25
+          : AXIS_LABEL_CENTER_Y
+
+      context.font = `800 ${AXIS_LABEL_FONT_SIZE}px Inter, system-ui, sans-serif`
+      context.textAlign = 'center'
+      context.textBaseline = 'middle'
+      context.lineJoin = 'round'
+      context.lineWidth = AXIS_LABEL_CONTOUR_WIDTH
+      context.strokeStyle = AXIS_LABEL_CONTOUR_COLORS[axisName]
+      context.fillStyle = AXIS_LABEL_FILL_COLOR
+      context.strokeText(AXIS_LABELS[axisName], AXIS_HEAD_CENTER, labelCenterY)
+      context.fillText(AXIS_LABELS[axisName], AXIS_HEAD_CENTER, labelCenterY)
+    }
   }
 
   const texture = new CanvasTexture(canvas)
-  const labelObject = new Sprite(
-    new SpriteMaterial({
-      map: texture,
-      transparent: true,
-      depthTest: false,
-      depthWrite: false,
-    })
-  )
-  const [x, y, z] = AXIS_HEAD_POSITIONS[axisName]
-  labelObject.position.set(x, y, z)
-  setAxisLabelScale(labelObject)
-  labelObject.renderOrder = 1
-
-  return labelObject
+  texture.colorSpace = SRGBColorSpace
+  return texture
 }
 
-const updateAxisLabelHover = (
-  axisLabelObjects: AxisLabelObjects,
-  hoveredAxisName?: AxisNames
+const setAxisHeadScale = (axisHead: Sprite, scale = 1) => {
+  const size = AXIS_HEAD_WORLD_SIZE * scale
+  axisHead.scale.set(size, size, 1)
+}
+
+const renderGizmoScene = (
+  axisPairs: GizmoAxisPair[],
+  renderer: WebGLRenderer,
+  scene: Scene,
+  camera: OrthographicCamera
 ) => {
-  for (const axisName of POSITIVE_AXIS_NAMES) {
-    const labelObject = axisLabelObjects[axisName]
-    if (!labelObject) {
-      continue
-    }
-
-    setAxisLabelScale(
-      labelObject,
-      hoveredAxisName === axisName ? AXIS_HOVER_SCALE : 1
-    )
-  }
+  updateAxisPairRenderOrder(axisPairs, camera)
+  renderer.render(scene, camera)
 }
 
-const setAxisLabelScale = (labelObject: Sprite, scale = 1) => {
-  const size = AXIS_LABEL_WORLD_SIZE * scale
-  labelObject.scale.set(size, size, 1)
+const updateAxisPairRenderOrder = (
+  axisPairs: GizmoAxisPair[],
+  camera: OrthographicCamera
+) => {
+  axisPairs.sort(
+    (a, b) =>
+      a.head.position.dot(camera.position) -
+      b.head.position.dot(camera.position)
+  )
+
+  axisPairs.forEach(({ axis, head }, index) => {
+    const renderOrder = index * 2
+    axis.renderOrder = renderOrder
+    head.renderOrder = renderOrder + 1
+  })
 }
 
 const updateCameraOrientation = (
@@ -458,30 +512,27 @@ const initializeMouseEvents = (
 }
 
 const updateRayCaster = (
-  objects: Object3D[],
+  objects: Sprite[],
   raycaster: Raycaster,
   mouse: Vector2,
   camera: OrthographicCamera,
   raycasterIntersect: MutableRefObject<Intersection | null>,
   renderer: WebGLRenderer,
   scene: Scene,
-  axisLabelObjects: AxisLabelObjects
+  axisPairs: GizmoAxisPair[]
 ) => {
   raycaster.setFromCamera(mouse, camera)
   const intersects = raycaster.intersectObjects(objects)
   const hoveredObject = intersects[0]?.object
 
   for (const object of objects) {
-    object.scale.setScalar(object === hoveredObject ? AXIS_HOVER_SCALE : 1)
+    setAxisHeadScale(object, object === hoveredObject ? AXIS_HOVER_SCALE : 1)
   }
   if (intersects.length) {
-    const axisName = intersects[0].object.name as AxisNames
-    updateAxisLabelHover(axisLabelObjects, axisName)
     raycasterIntersect.current = intersects[0] // filter first object
   } else {
-    updateAxisLabelHover(axisLabelObjects)
     raycasterIntersect.current = null
   }
 
-  renderer.render(scene, camera)
+  renderGizmoScene(axisPairs, renderer, scene, camera)
 }

--- a/src/components/gizmo/AxisGizmo.tsx
+++ b/src/components/gizmo/AxisGizmo.tsx
@@ -10,6 +10,7 @@ import { reportRejection } from '@src/lib/trap'
 import type { ColorRepresentation, Intersection, Object3D } from 'three'
 import {
   BoxGeometry,
+  CanvasTexture,
   Clock,
   Color,
   Mesh,
@@ -19,13 +20,11 @@ import {
   Raycaster,
   Scene,
   SphereGeometry,
+  Sprite,
+  SpriteMaterial,
   Vector2,
   WebGLRenderer,
 } from 'three'
-import {
-  CSS2DObject,
-  CSS2DRenderer,
-} from 'three/examples/jsm/renderers/CSS2DRenderer'
 
 export default function AxisGizmo() {
   const { settings } = useApp()
@@ -72,17 +71,10 @@ export default function AxisGizmo() {
     })
     renderer.setSize(CANVAS_SIZE, CANVAS_SIZE)
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
-    const labelRenderer = new CSS2DRenderer()
-    labelRenderer.setSize(CANVAS_SIZE, CANVAS_SIZE)
-    labelRenderer.domElement.style.position = 'absolute'
-    labelRenderer.domElement.style.inset = '0'
-    labelRenderer.domElement.style.pointerEvents = 'none'
-    labelRenderer.domElement.setAttribute('aria-hidden', 'true')
-    wrapperElement.append(labelRenderer.domElement)
 
     const scene = new Scene()
     const camera = createCamera()
-    const { gizmoAxes, gizmoAxisHeads, gizmoAxisLabels, axisLabelElements } =
+    const { gizmoAxes, gizmoAxisHeads, gizmoAxisLabels, axisLabelObjects } =
       createGizmo()
     scene.add(...gizmoAxes, ...gizmoAxisHeads, ...gizmoAxisLabels)
 
@@ -99,14 +91,13 @@ export default function AxisGizmo() {
           raycasterIntersect,
           renderer,
           scene,
-          labelRenderer,
-          axisLabelElements
+          axisLabelObjects
         )
       } else {
         for (const object of raycasterObjects) {
           object.scale.setScalar(1)
         }
-        updateAxisLabelHover(axisLabelElements)
+        updateAxisLabelHover(axisLabelObjects)
         raycasterIntersect.current = null // Clear intersection
       }
     }
@@ -133,7 +124,7 @@ export default function AxisGizmo() {
         delta,
         cameraPassiveUpdateTimer
       )
-      renderGizmo(renderer, labelRenderer, scene, camera)
+      renderGizmo(renderer, scene, camera)
     }
     kclManager.sceneInfra.camControls.cameraChange.add(animate)
 
@@ -141,10 +132,9 @@ export default function AxisGizmo() {
     const q = kclManager.sceneInfra.camControls.camera.quaternion
     camera.position.set(0, 0, 1).applyQuaternion(q)
     camera.quaternion.copy(q)
-    renderGizmo(renderer, labelRenderer, scene, camera)
+    renderGizmo(renderer, scene, camera)
 
     return () => {
-      labelRenderer.domElement.remove()
       renderer.forceContextLoss()
       renderer.dispose()
       disposeMouseEvents()
@@ -173,8 +163,12 @@ const AXIS_HEAD_RADIUS = 0.085
 const AXIS_HOVER_SCALE = 1.5
 const AXIS_LABEL_FONT_SIZE = 9
 const AXIS_LABEL_CONTOUR_WIDTH = 1.2
+const AXIS_LABEL_FILL_COLOR = '#fcfcfc'
 const AXIS_LABEL_CENTER = 8
 const AXIS_LABEL_CENTER_Y = 8.5
+const AXIS_LABEL_VIEWBOX_SIZE = 16
+const AXIS_LABEL_TEXTURE_SIZE = 64
+const AXIS_LABEL_WORLD_SIZE = AXIS_LABEL_VIEWBOX_SIZE / CANVAS_SIZE
 enum AxisColors {
   X = '#fa6668',
   Y = '#11eb6b',
@@ -183,8 +177,7 @@ enum AxisColors {
 }
 type AxisLabel = 'X' | 'Y' | 'Z'
 type PositiveAxisName = AxisNames.X | AxisNames.Y | AxisNames.Z
-type AxisLabelElement = SVGSVGElement
-type AxisLabelElements = Partial<Record<PositiveAxisName, AxisLabelElement>>
+type AxisLabelObjects = Partial<Record<PositiveAxisName, Sprite>>
 const POSITIVE_AXIS_NAMES = [AxisNames.X, AxisNames.Y, AxisNames.Z] as const
 const AXIS_LABELS: Record<PositiveAxisName, AxisLabel> = {
   [AxisNames.X]: 'X',
@@ -204,8 +197,6 @@ const AXIS_HEAD_POSITIONS: Record<AxisNames, [number, number, number]> = {
   [AxisNames.NEG_Y]: [0, -AXIS_LENGTH, 0],
   [AxisNames.NEG_Z]: [0, 0, -AXIS_LENGTH],
 }
-const SVG_NAMESPACE = 'http://www.w3.org/2000/svg'
-
 const createCamera = (): OrthographicCamera => {
   return new OrthographicCamera(
     -FRUSTUM_SIZE,
@@ -236,14 +227,14 @@ const createGizmo = () => {
     createAxisHead(AxisNames.NEG_Z, AxisColors.Gray),
   ]
 
-  const axisLabelElements: AxisLabelElements = {}
+  const axisLabelObjects: AxisLabelObjects = {}
   const gizmoAxisLabels = POSITIVE_AXIS_NAMES.map((axisName) => {
-    const { labelObject, labelElement } = createAxisLabel(axisName)
-    axisLabelElements[axisName] = labelElement
+    const labelObject = createAxisLabel(axisName)
+    axisLabelObjects[axisName] = labelObject
     return labelObject
   })
 
-  return { gizmoAxes, gizmoAxisHeads, gizmoAxisLabels, axisLabelElements }
+  return { gizmoAxes, gizmoAxisHeads, gizmoAxisLabels, axisLabelObjects }
 }
 
 const createAxis = (
@@ -273,75 +264,73 @@ const createAxisHead = (name: AxisNames, color: ColorRepresentation): Mesh => {
   return mesh
 }
 
-const createAxisLabel = (
-  axisName: PositiveAxisName
-): { labelObject: CSS2DObject; labelElement: AxisLabelElement } => {
-  const labelWrapper = document.createElement('div')
-  labelWrapper.className = 'pointer-events-none'
-
-  const labelElement = document.createElementNS(SVG_NAMESPACE, 'svg')
-  labelElement.setAttribute('viewBox', '0 0 16 16')
-  labelElement.setAttribute('width', '16')
-  labelElement.setAttribute('height', '16')
-  labelElement.classList.add('block', 'h-4', 'w-4', 'select-none')
-  labelElement.style.overflow = 'visible'
-  labelElement.style.transformOrigin = 'center'
-
-  const labelText = document.createElementNS(SVG_NAMESPACE, 'text')
+const createAxisLabel = (axisName: PositiveAxisName): Sprite => {
   const labelCenterY =
     axisName === AxisNames.Y ? AXIS_LABEL_CENTER_Y + 0.25 : AXIS_LABEL_CENTER_Y
-  labelText.textContent = AXIS_LABELS[axisName]
-  labelText.setAttribute('x', String(AXIS_LABEL_CENTER))
-  labelText.setAttribute('y', String(labelCenterY))
-  labelText.setAttribute('fill', 'var(--chalkboard-10)')
-  labelText.setAttribute('stroke', AXIS_LABEL_CONTOUR_COLORS[axisName])
-  labelText.setAttribute('stroke-width', String(AXIS_LABEL_CONTOUR_WIDTH))
-  labelText.setAttribute('stroke-linejoin', 'round')
-  labelText.setAttribute('font-family', 'inherit')
-  labelText.setAttribute('font-size', String(AXIS_LABEL_FONT_SIZE))
-  labelText.setAttribute('font-weight', '800')
-  labelText.setAttribute('letter-spacing', '0')
-  labelText.setAttribute('paint-order', 'stroke fill')
-  labelText.setAttribute('text-anchor', 'middle')
-  labelText.setAttribute('dominant-baseline', 'central')
-  labelText.setAttribute('alignment-baseline', 'middle')
-  labelElement.append(labelText)
-  labelWrapper.append(labelElement)
+  const canvas = document.createElement('canvas')
+  canvas.width = AXIS_LABEL_TEXTURE_SIZE
+  canvas.height = AXIS_LABEL_TEXTURE_SIZE
 
-  const labelObject = new CSS2DObject(labelWrapper)
+  const context = canvas.getContext('2d')
+  if (context) {
+    const textureScale = AXIS_LABEL_TEXTURE_SIZE / AXIS_LABEL_VIEWBOX_SIZE
+    context.scale(textureScale, textureScale)
+    context.font = `800 ${AXIS_LABEL_FONT_SIZE}px Inter, system-ui, sans-serif`
+    context.textAlign = 'center'
+    context.textBaseline = 'middle'
+    context.lineJoin = 'round'
+    context.lineWidth = AXIS_LABEL_CONTOUR_WIDTH
+    context.strokeStyle = AXIS_LABEL_CONTOUR_COLORS[axisName]
+    context.fillStyle = AXIS_LABEL_FILL_COLOR
+    context.strokeText(AXIS_LABELS[axisName], AXIS_LABEL_CENTER, labelCenterY)
+    context.fillText(AXIS_LABELS[axisName], AXIS_LABEL_CENTER, labelCenterY)
+  }
+
+  const texture = new CanvasTexture(canvas)
+  const labelObject = new Sprite(
+    new SpriteMaterial({
+      map: texture,
+      transparent: true,
+      depthTest: false,
+      depthWrite: false,
+    })
+  )
   const [x, y, z] = AXIS_HEAD_POSITIONS[axisName]
   labelObject.position.set(x, y, z)
-  labelObject.center.set(0.5, 0.5)
+  setAxisLabelScale(labelObject)
+  labelObject.renderOrder = 1
 
-  return { labelObject, labelElement }
+  return labelObject
 }
 
 const renderGizmo = (
   renderer: WebGLRenderer,
-  labelRenderer: CSS2DRenderer,
   scene: Scene,
   camera: OrthographicCamera
 ) => {
   renderer.render(scene, camera)
-  labelRenderer.render(scene, camera)
 }
 
 const updateAxisLabelHover = (
-  axisLabelElements: AxisLabelElements,
+  axisLabelObjects: AxisLabelObjects,
   hoveredAxisName?: AxisNames
 ) => {
   for (const axisName of POSITIVE_AXIS_NAMES) {
-    const labelElement = axisLabelElements[axisName]
-    if (!labelElement) {
+    const labelObject = axisLabelObjects[axisName]
+    if (!labelObject) {
       continue
     }
 
-    if (hoveredAxisName === axisName) {
-      labelElement.style.transform = `scale(${AXIS_HOVER_SCALE})`
-    } else {
-      labelElement.style.removeProperty('transform')
-    }
+    setAxisLabelScale(
+      labelObject,
+      hoveredAxisName === axisName ? AXIS_HOVER_SCALE : 1
+    )
   }
+}
+
+const setAxisLabelScale = (labelObject: Sprite, scale = 1) => {
+  const size = AXIS_LABEL_WORLD_SIZE * scale
+  labelObject.scale.set(size, size, 1)
 }
 
 const updateCameraOrientation = (
@@ -424,8 +413,7 @@ const updateRayCaster = (
   raycasterIntersect: MutableRefObject<Intersection | null>,
   renderer: WebGLRenderer,
   scene: Scene,
-  labelRenderer: CSS2DRenderer,
-  axisLabelElements: AxisLabelElements
+  axisLabelObjects: AxisLabelObjects
 ) => {
   raycaster.setFromCamera(mouse, camera)
   const intersects = raycaster.intersectObjects(objects)
@@ -436,12 +424,12 @@ const updateRayCaster = (
   }
   if (intersects.length) {
     const axisName = intersects[0].object.name as AxisNames
-    updateAxisLabelHover(axisLabelElements, axisName)
+    updateAxisLabelHover(axisLabelObjects, axisName)
     raycasterIntersect.current = intersects[0] // filter first object
   } else {
-    updateAxisLabelHover(axisLabelElements)
+    updateAxisLabelHover(axisLabelObjects)
     raycasterIntersect.current = null
   }
 
-  renderGizmo(renderer, labelRenderer, scene, camera)
+  renderGizmo(renderer, scene, camera)
 }

--- a/src/components/gizmo/AxisGizmo.tsx
+++ b/src/components/gizmo/AxisGizmo.tsx
@@ -169,9 +169,10 @@ const CANVAS_SIZE = 80
 const FRUSTUM_SIZE = 0.5
 const AXIS_LENGTH = 0.35
 const AXIS_WIDTH = 0.02
+const AXIS_HEAD_RADIUS = 0.085
 const AXIS_HOVER_SCALE = 1.5
-const AXIS_LABEL_FONT_SIZE = 7
-const AXIS_LABEL_CONTOUR_WIDTH = 1
+const AXIS_LABEL_FONT_SIZE = 9
+const AXIS_LABEL_CONTOUR_WIDTH = 1.2
 const AXIS_LABEL_CENTER = 8
 const AXIS_LABEL_CENTER_Y = 8.5
 enum AxisColors {
@@ -261,7 +262,7 @@ const createAxis = (
 }
 
 const createAxisHead = (name: AxisNames, color: ColorRepresentation): Mesh => {
-  const geometry = new SphereGeometry(0.065, 16, 8)
+  const geometry = new SphereGeometry(AXIS_HEAD_RADIUS, 16, 8)
   const material = new MeshBasicMaterial({ color: new Color(color) })
   const mesh = new Mesh(geometry, material)
   const position = AXIS_HEAD_POSITIONS[name]
@@ -284,13 +285,14 @@ const createAxisLabel = (
   labelElement.setAttribute('height', '16')
   labelElement.classList.add('block', 'h-4', 'w-4', 'select-none')
   labelElement.style.overflow = 'visible'
-  labelElement.style.transform = 'scale(1)'
   labelElement.style.transformOrigin = 'center'
 
   const labelText = document.createElementNS(SVG_NAMESPACE, 'text')
+  const labelCenterY =
+    axisName === AxisNames.Y ? AXIS_LABEL_CENTER_Y + 0.25 : AXIS_LABEL_CENTER_Y
   labelText.textContent = AXIS_LABELS[axisName]
   labelText.setAttribute('x', String(AXIS_LABEL_CENTER))
-  labelText.setAttribute('y', String(AXIS_LABEL_CENTER_Y))
+  labelText.setAttribute('y', String(labelCenterY))
   labelText.setAttribute('fill', 'var(--chalkboard-10)')
   labelText.setAttribute('stroke', AXIS_LABEL_CONTOUR_COLORS[axisName])
   labelText.setAttribute('stroke-width', String(AXIS_LABEL_CONTOUR_WIDTH))
@@ -334,8 +336,11 @@ const updateAxisLabelHover = (
       continue
     }
 
-    const scale = hoveredAxisName === axisName ? AXIS_HOVER_SCALE : 1
-    labelElement.style.transform = `scale(${scale})`
+    if (hoveredAxisName === axisName) {
+      labelElement.style.transform = `scale(${AXIS_HOVER_SCALE})`
+    } else {
+      labelElement.style.removeProperty('transform')
+    }
   }
 }
 
@@ -424,14 +429,14 @@ const updateRayCaster = (
 ) => {
   raycaster.setFromCamera(mouse, camera)
   const intersects = raycaster.intersectObjects(objects)
+  const hoveredObject = intersects[0]?.object
 
   for (const object of objects) {
-    object.scale.setScalar(1)
+    object.scale.setScalar(object === hoveredObject ? AXIS_HOVER_SCALE : 1)
   }
   if (intersects.length) {
     const axisName = intersects[0].object.name as AxisNames
     updateAxisLabelHover(axisLabelElements, axisName)
-    intersects[0].object.scale.setScalar(AXIS_HOVER_SCALE)
     raycasterIntersect.current = intersects[0] // filter first object
   } else {
     updateAxisLabelHover(axisLabelElements)

--- a/src/components/gizmo/AxisGizmo.tsx
+++ b/src/components/gizmo/AxisGizmo.tsx
@@ -305,7 +305,7 @@ const createAxis = (
 }
 
 const createAxisHead = (name: AxisNames, color: ColorRepresentation): Mesh => {
-  const geometry = new SphereGeometry(AXIS_HEAD_RADIUS, 16, 8)
+  const geometry = new SphereGeometry(AXIS_HEAD_RADIUS, 48, 24)
   const material = new MeshBasicMaterial({ color: new Color(color) })
   const mesh = new Mesh(geometry, material)
   const position = AXIS_HEAD_POSITIONS[name]

--- a/src/components/gizmo/AxisGizmo.tsx
+++ b/src/components/gizmo/AxisGizmo.tsx
@@ -90,7 +90,7 @@ export default function AxisGizmo() {
       }
       updateAxisLabelHover(axisLabelObjects)
       raycasterIntersect.current = null
-      renderGizmo(renderer, scene, camera)
+      renderer.render(scene, camera)
     }
     const doRayCast = (mouse: Vector2) => {
       // If orbits are disabled, skip click logic
@@ -172,7 +172,7 @@ export default function AxisGizmo() {
       if (isPointerOverRef.current && !isHoverRefreshPausedRef.current) {
         doRayCast(mouse)
       } else {
-        renderGizmo(renderer, scene, camera)
+        renderer.render(scene, camera)
       }
     }
     kclManager.sceneInfra.camControls.cameraChange.add(animate)
@@ -181,7 +181,7 @@ export default function AxisGizmo() {
     const q = kclManager.sceneInfra.camControls.camera.quaternion
     camera.position.set(0, 0, 1).applyQuaternion(q)
     camera.quaternion.copy(q)
-    renderGizmo(renderer, scene, camera)
+    renderer.render(scene, camera)
 
     return () => {
       isDisposed = true
@@ -355,14 +355,6 @@ const createAxisLabel = (axisName: PositiveAxisName): Sprite => {
   return labelObject
 }
 
-const renderGizmo = (
-  renderer: WebGLRenderer,
-  scene: Scene,
-  camera: OrthographicCamera
-) => {
-  renderer.render(scene, camera)
-}
-
 const updateAxisLabelHover = (
   axisLabelObjects: AxisLabelObjects,
   hoveredAxisName?: AxisNames
@@ -491,5 +483,5 @@ const updateRayCaster = (
     raycasterIntersect.current = null
   }
 
-  renderGizmo(renderer, scene, camera)
+  renderer.render(scene, camera)
 }

--- a/src/components/gizmo/AxisGizmo.tsx
+++ b/src/components/gizmo/AxisGizmo.tsx
@@ -7,7 +7,6 @@ import { ViewControlContextMenu } from '@src/components/ViewControlMenu'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { AxisNames } from '@src/lib/constants'
 import { reportRejection } from '@src/lib/trap'
-import { isArray } from '@src/lib/utils'
 import type { ColorRepresentation, Intersection, Object3D } from 'three'
 import {
   BoxGeometry,
@@ -104,7 +103,9 @@ export default function AxisGizmo() {
           axisLabelElements
         )
       } else {
-        resetAxisObjectScales(raycasterObjects)
+        for (const object of raycasterObjects) {
+          object.scale.setScalar(1)
+        }
         updateAxisLabelHover(axisLabelElements)
         raycasterIntersect.current = null // Clear intersection
       }
@@ -268,8 +269,6 @@ const createAxisHead = (name: AxisNames, color: ColorRepresentation): Mesh => {
   mesh.position.set(position[0], position[1], position[2])
   mesh.updateMatrixWorld()
   mesh.name = name
-  mesh.userData.axisName = name
-  mesh.userData.baseScale = [1, 1, 1]
   return mesh
 }
 
@@ -313,40 +312,6 @@ const createAxisLabel = (
   labelObject.center.set(0.5, 0.5)
 
   return { labelObject, labelElement }
-}
-
-const getAxisName = (object: Object3D): AxisNames | undefined => {
-  return Object.values(AxisNames).find((axisName) => {
-    return object.userData.axisName === axisName
-  })
-}
-
-const getBaseScale = (object: Object3D): [number, number, number] => {
-  if (
-    isArray(object.userData.baseScale) &&
-    object.userData.baseScale.length === 3
-  ) {
-    const [x, y, z] = object.userData.baseScale
-    if (
-      typeof x === 'number' &&
-      typeof y === 'number' &&
-      typeof z === 'number'
-    ) {
-      return [x, y, z]
-    }
-  }
-  return [1, 1, 1]
-}
-
-const setAxisObjectScale = (object: Object3D, scale: number) => {
-  const [x, y, z] = getBaseScale(object)
-  object.scale.set(x * scale, y * scale, z * scale)
-}
-
-const resetAxisObjectScales = (objects: Object3D[]) => {
-  for (const object of objects) {
-    setAxisObjectScale(object, 1)
-  }
 }
 
 const renderGizmo = (
@@ -430,10 +395,7 @@ const initializeMouseEvents = (
     if (disableOrbitRef.current || !raycasterIntersect.current) {
       return
     }
-    const axisName = getAxisName(raycasterIntersect.current.object)
-    if (!axisName) {
-      return
-    }
+    const axisName = raycasterIntersect.current.object.name as AxisNames
     sceneInfra.camControls.updateCameraToAxis(axisName).catch(reportRejection)
   }
 
@@ -463,17 +425,13 @@ const updateRayCaster = (
   raycaster.setFromCamera(mouse, camera)
   const intersects = raycaster.intersectObjects(objects)
 
-  resetAxisObjectScales(objects)
+  for (const object of objects) {
+    object.scale.setScalar(1)
+  }
   if (intersects.length) {
-    const axisName = getAxisName(intersects[0].object)
+    const axisName = intersects[0].object.name as AxisNames
     updateAxisLabelHover(axisLabelElements, axisName)
-    if (axisName) {
-      for (const object of objects) {
-        if (getAxisName(object) === axisName) {
-          setAxisObjectScale(object, AXIS_HOVER_SCALE)
-        }
-      }
-    }
+    intersects[0].object.scale.setScalar(AXIS_HOVER_SCALE)
     raycasterIntersect.current = intersects[0] // filter first object
   } else {
     updateAxisLabelHover(axisLabelElements)

--- a/src/components/gizmo/AxisGizmo.tsx
+++ b/src/components/gizmo/AxisGizmo.tsx
@@ -1,9 +1,14 @@
+import { useApp, useSingletons } from '@src/lib/boot'
 import { useEffect, useRef } from 'react'
 import type { MutableRefObject } from 'react'
-import { useApp, useSingletons } from '@src/lib/boot'
 
+import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
+import { ViewControlContextMenu } from '@src/components/ViewControlMenu'
 import { useModelingContext } from '@src/hooks/useModelingContext'
-import type { Camera, ColorRepresentation, Intersection, Object3D } from 'three'
+import { AxisNames } from '@src/lib/constants'
+import { reportRejection } from '@src/lib/trap'
+import { isArray } from '@src/lib/utils'
+import type { ColorRepresentation, Intersection, Object3D } from 'three'
 import {
   BoxGeometry,
   Clock,
@@ -18,17 +23,17 @@ import {
   Vector2,
   WebGLRenderer,
 } from 'three'
-import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
-import { AxisNames } from '@src/lib/constants'
-import { reportRejection } from '@src/lib/trap'
-import { ViewControlContextMenu } from '@src/components/ViewControlMenu'
+import {
+  CSS2DObject,
+  CSS2DRenderer,
+} from 'three/examples/jsm/renderers/CSS2DRenderer'
 
 export default function AxisGizmo() {
   const { settings } = useApp()
   const { kclManager } = useSingletons()
   const { state: modelingState } = useModelingContext()
   const settingsValues = settings.useSettings()
-  const wrapperRef = useRef<HTMLDivElement>(null!)
+  const wrapperRef = useRef<HTMLDivElement | null>(null)
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const raycasterIntersect = useRef<Intersection | null>(null)
   const cameraPassiveUpdateTimer = useRef(0)
@@ -54,9 +59,12 @@ export default function AxisGizmo() {
   }, [modelingState, settingsValues.app.allowOrbitInSketchMode.current])
 
   useEffect(() => {
-    if (!canvasRef.current) return
+    if (!canvasRef.current || !wrapperRef.current) {
+      return
+    }
 
     const canvas = canvasRef.current
+    const wrapperElement = wrapperRef.current
     const renderer = new WebGLRenderer({
       canvas,
       antialias: true,
@@ -65,11 +73,19 @@ export default function AxisGizmo() {
     })
     renderer.setSize(CANVAS_SIZE, CANVAS_SIZE)
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
+    const labelRenderer = new CSS2DRenderer()
+    labelRenderer.setSize(CANVAS_SIZE, CANVAS_SIZE)
+    labelRenderer.domElement.style.position = 'absolute'
+    labelRenderer.domElement.style.inset = '0'
+    labelRenderer.domElement.style.pointerEvents = 'none'
+    labelRenderer.domElement.setAttribute('aria-hidden', 'true')
+    wrapperElement.append(labelRenderer.domElement)
 
     const scene = new Scene()
     const camera = createCamera()
-    const { gizmoAxes, gizmoAxisHeads } = createGizmo()
-    scene.add(...gizmoAxes, ...gizmoAxisHeads)
+    const { gizmoAxes, gizmoAxisHeads, gizmoAxisLabels, axisLabelElements } =
+      createGizmo()
+    scene.add(...gizmoAxes, ...gizmoAxisHeads, ...gizmoAxisLabels)
 
     const raycaster = new Raycaster()
     const raycasterObjects = [...gizmoAxisHeads]
@@ -83,10 +99,13 @@ export default function AxisGizmo() {
           camera,
           raycasterIntersect,
           renderer,
-          scene
+          scene,
+          labelRenderer,
+          axisLabelElements
         )
       } else {
-        raycasterObjects.forEach((object) => object.scale.set(1, 1, 1)) // Reset scales
+        resetAxisObjectScales(raycasterObjects)
+        updateAxisLabelHover(axisLabelElements)
         raycasterIntersect.current = null // Clear intersection
       }
     }
@@ -97,12 +116,12 @@ export default function AxisGizmo() {
       kclManager.sceneInfra,
       disableOrbitRef,
       doRayCast,
-      wrapperRef
+      wrapperElement
     )
 
     const clock = new Clock()
     const clientCamera = kclManager.sceneInfra.camControls.camera
-    let currentQuaternion = new Quaternion().copy(clientCamera.quaternion)
+    const currentQuaternion = new Quaternion().copy(clientCamera.quaternion)
 
     const animate = () => {
       const delta = clock.getDelta()
@@ -113,7 +132,7 @@ export default function AxisGizmo() {
         delta,
         cameraPassiveUpdateTimer
       )
-      renderer.render(scene, camera)
+      renderGizmo(renderer, labelRenderer, scene, camera)
     }
     kclManager.sceneInfra.camControls.cameraChange.add(animate)
 
@@ -121,9 +140,10 @@ export default function AxisGizmo() {
     const q = kclManager.sceneInfra.camControls.camera.quaternion
     camera.position.set(0, 0, 1).applyQuaternion(q)
     camera.quaternion.copy(q)
-    renderer.render(scene, camera)
+    renderGizmo(renderer, labelRenderer, scene, camera)
 
     return () => {
+      labelRenderer.domElement.remove()
       renderer.forceContextLoss()
       renderer.dispose()
       disposeMouseEvents()
@@ -136,7 +156,7 @@ export default function AxisGizmo() {
       ref={wrapperRef}
       aria-label="View orientation gizmo"
       data-testid={`gizmo${disableOrbitRef.current ? '-disabled' : ''}`}
-      className="grid place-content-center rounded-full overflow-hidden border border-solid border-primary/50 pointer-events-auto bg-chalkboard-10/70 dark:bg-chalkboard-100/80 backdrop-blur-sm"
+      className="relative grid place-content-center rounded-full overflow-hidden border border-solid border-primary/50 pointer-events-auto bg-chalkboard-10/70 dark:bg-chalkboard-100/80 backdrop-blur-sm"
     >
       <canvas ref={canvasRef} />
       <ViewControlContextMenu menuTargetElement={wrapperRef} />
@@ -148,12 +168,41 @@ const CANVAS_SIZE = 80
 const FRUSTUM_SIZE = 0.5
 const AXIS_LENGTH = 0.35
 const AXIS_WIDTH = 0.02
+const AXIS_HOVER_SCALE = 1.5
+const AXIS_LABEL_FONT_SIZE = 7
+const AXIS_LABEL_CONTOUR_WIDTH = 1
+const AXIS_LABEL_CENTER = 8
+const AXIS_LABEL_CENTER_Y = 8.5
 enum AxisColors {
   X = '#fa6668',
   Y = '#11eb6b',
   Z = '#6689ef',
   Gray = '#c6c7c2',
 }
+type AxisLabel = 'X' | 'Y' | 'Z'
+type PositiveAxisName = AxisNames.X | AxisNames.Y | AxisNames.Z
+type AxisLabelElement = SVGSVGElement
+type AxisLabelElements = Partial<Record<PositiveAxisName, AxisLabelElement>>
+const POSITIVE_AXIS_NAMES = [AxisNames.X, AxisNames.Y, AxisNames.Z] as const
+const AXIS_LABELS: Record<PositiveAxisName, AxisLabel> = {
+  [AxisNames.X]: 'X',
+  [AxisNames.Y]: 'Y',
+  [AxisNames.Z]: 'Z',
+}
+const AXIS_LABEL_CONTOUR_COLORS: Record<PositiveAxisName, string> = {
+  [AxisNames.X]: '#c94f52',
+  [AxisNames.Y]: '#0bb858',
+  [AxisNames.Z]: '#4d68c0',
+}
+const AXIS_HEAD_POSITIONS: Record<AxisNames, [number, number, number]> = {
+  [AxisNames.X]: [AXIS_LENGTH, 0, 0],
+  [AxisNames.Y]: [0, AXIS_LENGTH, 0],
+  [AxisNames.Z]: [0, 0, AXIS_LENGTH],
+  [AxisNames.NEG_X]: [-AXIS_LENGTH, 0, 0],
+  [AxisNames.NEG_Y]: [0, -AXIS_LENGTH, 0],
+  [AxisNames.NEG_Z]: [0, 0, -AXIS_LENGTH],
+}
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg'
 
 const createCamera = (): OrthographicCamera => {
   return new OrthographicCamera(
@@ -177,15 +226,22 @@ const createGizmo = () => {
   ]
 
   const gizmoAxisHeads = [
-    createAxisHead(AxisNames.X, AxisColors.X, [AXIS_LENGTH, 0, 0]),
-    createAxisHead(AxisNames.Y, AxisColors.Y, [0, AXIS_LENGTH, 0]),
-    createAxisHead(AxisNames.Z, AxisColors.Z, [0, 0, AXIS_LENGTH]),
-    createAxisHead(AxisNames.NEG_X, AxisColors.Gray, [-AXIS_LENGTH, 0, 0]),
-    createAxisHead(AxisNames.NEG_Y, AxisColors.Gray, [0, -AXIS_LENGTH, 0]),
-    createAxisHead(AxisNames.NEG_Z, AxisColors.Gray, [0, 0, -AXIS_LENGTH]),
+    createAxisHead(AxisNames.X, AxisColors.X),
+    createAxisHead(AxisNames.Y, AxisColors.Y),
+    createAxisHead(AxisNames.Z, AxisColors.Z),
+    createAxisHead(AxisNames.NEG_X, AxisColors.Gray),
+    createAxisHead(AxisNames.NEG_Y, AxisColors.Gray),
+    createAxisHead(AxisNames.NEG_Z, AxisColors.Gray),
   ]
 
-  return { gizmoAxes, gizmoAxisHeads }
+  const axisLabelElements: AxisLabelElements = {}
+  const gizmoAxisLabels = POSITIVE_AXIS_NAMES.map((axisName) => {
+    const { labelObject, labelElement } = createAxisLabel(axisName)
+    axisLabelElements[axisName] = labelElement
+    return labelObject
+  })
+
+  return { gizmoAxes, gizmoAxisHeads, gizmoAxisLabels, axisLabelElements }
 }
 
 const createAxis = (
@@ -203,19 +259,119 @@ const createAxis = (
   return mesh
 }
 
-const createAxisHead = (
-  name: AxisNames,
-  color: ColorRepresentation,
-  position: number[]
-): Mesh => {
+const createAxisHead = (name: AxisNames, color: ColorRepresentation): Mesh => {
   const geometry = new SphereGeometry(0.065, 16, 8)
   const material = new MeshBasicMaterial({ color: new Color(color) })
   const mesh = new Mesh(geometry, material)
+  const position = AXIS_HEAD_POSITIONS[name]
 
   mesh.position.set(position[0], position[1], position[2])
   mesh.updateMatrixWorld()
   mesh.name = name
+  mesh.userData.axisName = name
+  mesh.userData.baseScale = [1, 1, 1]
   return mesh
+}
+
+const createAxisLabel = (
+  axisName: PositiveAxisName
+): { labelObject: CSS2DObject; labelElement: AxisLabelElement } => {
+  const labelWrapper = document.createElement('div')
+  labelWrapper.className = 'pointer-events-none'
+
+  const labelElement = document.createElementNS(SVG_NAMESPACE, 'svg')
+  labelElement.setAttribute('viewBox', '0 0 16 16')
+  labelElement.setAttribute('width', '16')
+  labelElement.setAttribute('height', '16')
+  labelElement.classList.add('block', 'h-4', 'w-4', 'select-none')
+  labelElement.style.overflow = 'visible'
+  labelElement.style.transform = 'scale(1)'
+  labelElement.style.transformOrigin = 'center'
+
+  const labelText = document.createElementNS(SVG_NAMESPACE, 'text')
+  labelText.textContent = AXIS_LABELS[axisName]
+  labelText.setAttribute('x', String(AXIS_LABEL_CENTER))
+  labelText.setAttribute('y', String(AXIS_LABEL_CENTER_Y))
+  labelText.setAttribute('fill', 'var(--chalkboard-10)')
+  labelText.setAttribute('stroke', AXIS_LABEL_CONTOUR_COLORS[axisName])
+  labelText.setAttribute('stroke-width', String(AXIS_LABEL_CONTOUR_WIDTH))
+  labelText.setAttribute('stroke-linejoin', 'round')
+  labelText.setAttribute('font-family', 'inherit')
+  labelText.setAttribute('font-size', String(AXIS_LABEL_FONT_SIZE))
+  labelText.setAttribute('font-weight', '800')
+  labelText.setAttribute('letter-spacing', '0')
+  labelText.setAttribute('paint-order', 'stroke fill')
+  labelText.setAttribute('text-anchor', 'middle')
+  labelText.setAttribute('dominant-baseline', 'central')
+  labelText.setAttribute('alignment-baseline', 'middle')
+  labelElement.append(labelText)
+  labelWrapper.append(labelElement)
+
+  const labelObject = new CSS2DObject(labelWrapper)
+  const [x, y, z] = AXIS_HEAD_POSITIONS[axisName]
+  labelObject.position.set(x, y, z)
+  labelObject.center.set(0.5, 0.5)
+
+  return { labelObject, labelElement }
+}
+
+const getAxisName = (object: Object3D): AxisNames | undefined => {
+  return Object.values(AxisNames).find((axisName) => {
+    return object.userData.axisName === axisName
+  })
+}
+
+const getBaseScale = (object: Object3D): [number, number, number] => {
+  if (
+    isArray(object.userData.baseScale) &&
+    object.userData.baseScale.length === 3
+  ) {
+    const [x, y, z] = object.userData.baseScale
+    if (
+      typeof x === 'number' &&
+      typeof y === 'number' &&
+      typeof z === 'number'
+    ) {
+      return [x, y, z]
+    }
+  }
+  return [1, 1, 1]
+}
+
+const setAxisObjectScale = (object: Object3D, scale: number) => {
+  const [x, y, z] = getBaseScale(object)
+  object.scale.set(x * scale, y * scale, z * scale)
+}
+
+const resetAxisObjectScales = (objects: Object3D[]) => {
+  for (const object of objects) {
+    setAxisObjectScale(object, 1)
+  }
+}
+
+const renderGizmo = (
+  renderer: WebGLRenderer,
+  labelRenderer: CSS2DRenderer,
+  scene: Scene,
+  camera: OrthographicCamera
+) => {
+  renderer.render(scene, camera)
+  labelRenderer.render(scene, camera)
+}
+
+const updateAxisLabelHover = (
+  axisLabelElements: AxisLabelElements,
+  hoveredAxisName?: AxisNames
+) => {
+  for (const axisName of POSITIVE_AXIS_NAMES) {
+    const labelElement = axisLabelElements[axisName]
+    if (!labelElement) {
+      continue
+    }
+
+    const scale = hoveredAxisName === axisName ? AXIS_HOVER_SCALE : 1
+    labelElement.style.transform = `scale(${scale})`
+  }
 }
 
 const updateCameraOrientation = (
@@ -241,7 +397,7 @@ const updateCameraOrientation = (
 const quaternionsEqual = (
   q1: Quaternion,
   q2: Quaternion,
-  tolerance: number = 0.001
+  tolerance = 0.001
 ): boolean => {
   return (
     Math.abs(q1.x - q2.x) < tolerance &&
@@ -257,7 +413,7 @@ const initializeMouseEvents = (
   sceneInfra: SceneInfra,
   disableOrbitRef: MutableRefObject<boolean>,
   doRayCast: (mouse: Vector2) => void,
-  wrapperRef: React.MutableRefObject<HTMLDivElement>
+  wrapperElement: HTMLDivElement
 ): { mouse: Vector2; disposeMouseEvents: () => void } => {
   const mouse = new Vector2()
   mouse.x = 1 // fix initial mouse position issue
@@ -271,19 +427,23 @@ const initializeMouseEvents = (
 
   const handleClick = () => {
     // If orbits are disabled, skip click logic
-    if (disableOrbitRef.current || !raycasterIntersect.current) return
-    const axisName = raycasterIntersect.current.object.name as AxisNames
+    if (disableOrbitRef.current || !raycasterIntersect.current) {
+      return
+    }
+    const axisName = getAxisName(raycasterIntersect.current.object)
+    if (!axisName) {
+      return
+    }
     sceneInfra.camControls.updateCameraToAxis(axisName).catch(reportRejection)
   }
 
   // Add the event listener to the div wrapper around the canvas
-  wrapperRef.current.addEventListener('mousemove', handleMouseMove)
-  wrapperRef.current.addEventListener('click', handleClick)
-  const wrapperRefClosure = wrapperRef.current
+  wrapperElement.addEventListener('mousemove', handleMouseMove)
+  wrapperElement.addEventListener('click', handleClick)
 
   const disposeMouseEvents = () => {
-    wrapperRefClosure.removeEventListener('mousemove', handleMouseMove)
-    wrapperRefClosure.removeEventListener('click', handleClick)
+    wrapperElement.removeEventListener('mousemove', handleMouseMove)
+    wrapperElement.removeEventListener('click', handleClick)
   }
 
   return { mouse, disposeMouseEvents }
@@ -293,21 +453,32 @@ const updateRayCaster = (
   objects: Object3D[],
   raycaster: Raycaster,
   mouse: Vector2,
-  camera: Camera,
+  camera: OrthographicCamera,
   raycasterIntersect: MutableRefObject<Intersection | null>,
   renderer: WebGLRenderer,
-  scene: Scene
+  scene: Scene,
+  labelRenderer: CSS2DRenderer,
+  axisLabelElements: AxisLabelElements
 ) => {
   raycaster.setFromCamera(mouse, camera)
   const intersects = raycaster.intersectObjects(objects)
 
-  objects.forEach((object) => object.scale.set(1, 1, 1))
+  resetAxisObjectScales(objects)
   if (intersects.length) {
-    intersects[0].object.scale.set(1.5, 1.5, 1.5)
+    const axisName = getAxisName(intersects[0].object)
+    updateAxisLabelHover(axisLabelElements, axisName)
+    if (axisName) {
+      for (const object of objects) {
+        if (getAxisName(object) === axisName) {
+          setAxisObjectScale(object, AXIS_HOVER_SCALE)
+        }
+      }
+    }
     raycasterIntersect.current = intersects[0] // filter first object
   } else {
+    updateAxisLabelHover(axisLabelElements)
     raycasterIntersect.current = null
   }
 
-  renderer.render(scene, camera)
+  renderGizmo(renderer, labelRenderer, scene, camera)
 }


### PR DESCRIPTION
closes: https://github.com/KittyCAD/modeling-app/issues/5923

pimps: https://github.com/KittyCAD/modeling-app/pull/2354

<img width="99" height="105" alt="Screenshot 2026-05-05 at 23 06 41" src="https://github.com/user-attachments/assets/9f0e12cb-8193-49b9-84f6-4797a61f1568" />


<img width="141" height="130" alt="Screenshot 2026-05-06 at 13 37 50" src="https://github.com/user-attachments/assets/568ea768-c6f9-4519-8bf6-5a6185b4e136" />


## Summary

- Adds X/Y/Z labels to the positive axis heads in the view orientation gizmo.
- Uses Three.js `CSS2DRenderer` with centered SVG text so labels stay sharp and anchored to the same 3D axis-head positions as the bubbles.
- Adds per-axis darker colored contours around the white letters for improved readability.
- Keeps label hover scaling in sync with the existing axis bubble hover scaling.

