### PR TITLE
[CODEX] Show Markdown files in the code pane

### DIFF
--- a/src/components/layout/areas/KclEditorPane.tsx
+++ b/src/components/layout/areas/KclEditorPane.tsx
@@ -1,18 +1,37 @@
+import { defaultKeymap } from '@codemirror/commands'
+import { searchKeymap } from '@codemirror/search'
+import { EditorState } from '@codemirror/state'
+import {
+  EditorView,
+  drawSelection,
+  highlightActiveLine,
+  highlightSpecialChars,
+  keymap,
+  lineNumbers,
+} from '@codemirror/view'
 import { Menu } from '@headlessui/react'
-import { useConvertToVariable } from '@src/hooks/useToolbarGuards'
-import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
-import { useApp, useSingletons } from '@src/lib/boot'
-import { withSiteBaseURL } from '@src/lib/withBaseURL'
-import toast from 'react-hot-toast'
-import styles from './KclEditorMenu.module.css'
-import { useEffect, useRef } from 'react'
-import { reportRejection, trap } from '@src/lib/trap'
-import type { AreaTypeComponentProps } from '@src/lib/layout'
+import { useSignals } from '@preact/signals-react/runtime'
+import { CustomIcon } from '@src/components/CustomIcon'
 import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
 import { HeaderMenu } from '@src/components/layout/Panel/HeaderMenu'
-import { CustomIcon } from '@src/components/CustomIcon'
-import { hotkeyDisplay } from '@src/lib/hotkeys'
+import { editorTheme } from '@src/editor/plugins/theme'
 import usePlatform from '@src/hooks/usePlatform'
+import { useConvertToVariable } from '@src/hooks/useToolbarGuards'
+import {
+  type ActiveTextFile,
+  activeTextFileSignal,
+  clearActiveTextFile,
+} from '@src/lib/activeTextFile'
+import { useApp, useSingletons } from '@src/lib/boot'
+import { hotkeyDisplay } from '@src/lib/hotkeys'
+import type { AreaTypeComponentProps } from '@src/lib/layout'
+import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
+import { getResolvedTheme } from '@src/lib/theme'
+import { reportRejection, trap } from '@src/lib/trap'
+import { withSiteBaseURL } from '@src/lib/withBaseURL'
+import { useEffect, useRef } from 'react'
+import toast from 'react-hot-toast'
+import styles from './KclEditorMenu.module.css'
 
 type Singletons = ReturnType<typeof useSingletons>
 
@@ -45,14 +64,116 @@ export const KclEditorPane = (props: AreaTypeComponentProps) => {
 }
 
 export const KclEditorPaneContents = () => {
+  useSignals()
   const { kclManager } = useSingletons()
+  const activeTextFile = activeTextFileSignal.value
   const editorParent = useRef<HTMLDivElement>(null)
+
   useEffect(() => {
+    return () => {
+      clearActiveTextFile()
+    }
+  }, [])
+
+  useEffect(() => {
+    if (activeTextFile) {
+      return
+    }
     editorParent.current?.appendChild(kclManager.editorView.dom)
-  }, [kclManager.editorView.dom])
+  }, [activeTextFile, kclManager.editorView.dom])
+
+  if (activeTextFile) {
+    return <ReadOnlyTextFileEditor activeTextFile={activeTextFile} />
+  }
 
   return (
-    <div className="relative">
+    <div className="relative h-full">
+      <div
+        id="code-mirror-override"
+        className="absolute inset-0 pr-1"
+        ref={editorParent}
+      />
+    </div>
+  )
+}
+
+const textFileEditorTheme = EditorView.theme({
+  '&': {
+    height: '100%',
+    color: 'inherit',
+  },
+  '.cm-scroller': {
+    fontFamily:
+      'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+  },
+  '.cm-content': {
+    paddingBlock: '0.5rem',
+  },
+  '.cm-line': {
+    paddingInline: '0.5rem',
+  },
+  '&.cm-focused': {
+    outline: 'none',
+  },
+})
+
+function ReadOnlyTextFileEditor({
+  activeTextFile,
+}: {
+  activeTextFile: ActiveTextFile
+}) {
+  const { settings } = useApp()
+  const settingsValues = settings.useSettings()
+  const resolvedTheme = getResolvedTheme(settingsValues.app.theme.current)
+  const editorParent = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!editorParent.current || activeTextFile.status !== 'ready') {
+      return
+    }
+
+    const editor = new EditorView({
+      state: EditorState.create({
+        doc: activeTextFile.text,
+        extensions: [
+          editorTheme[resolvedTheme],
+          textFileEditorTheme,
+          EditorState.readOnly.of(true),
+          EditorView.editable.of(false),
+          EditorView.lineWrapping,
+          drawSelection(),
+          lineNumbers(),
+          highlightSpecialChars(),
+          highlightActiveLine(),
+          keymap.of([...defaultKeymap, ...searchKeymap]),
+        ],
+      }),
+      parent: editorParent.current,
+    })
+
+    return () => {
+      editor.destroy()
+    }
+  }, [activeTextFile, resolvedTheme])
+
+  if (activeTextFile.status === 'loading') {
+    return (
+      <div className="h-full p-3 text-sm text-chalkboard-70 dark:text-chalkboard-30">
+        Loading {activeTextFile.name}...
+      </div>
+    )
+  }
+
+  if (activeTextFile.status === 'error') {
+    return (
+      <div className="h-full p-3 text-sm text-destroy-80">
+        Failed to open {activeTextFile.name}: {activeTextFile.error}
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative h-full">
       <div
         id="code-mirror-override"
         className="absolute inset-0 pr-1"
@@ -82,6 +203,17 @@ function copyKclCodeToClipboard(kclManager: Singletons['kclManager']) {
 }
 
 export const KclEditorMenu = () => {
+  useSignals()
+  const activeTextFile = activeTextFileSignal.value
+
+  if (activeTextFile) {
+    return null
+  }
+
+  return <KclEditorKclMenu />
+}
+
+const KclEditorKclMenu = () => {
   const { commands, settings } = useApp()
   const { kclManager } = useSingletons()
   const platform = usePlatform()

--- a/src/components/layout/areas/ProjectExplorerPane.tsx
+++ b/src/components/layout/areas/ProjectExplorerPane.tsx
@@ -1,34 +1,41 @@
-import fsZds from '@src/lib/fs-zds'
-import type { Project } from '@src/lib/project'
-import type { FileExplorerEntry } from '@src/components/Explorer/utils'
 import { FileExplorerHeaderActions } from '@src/components/Explorer/FileExplorerHeaderActions'
 import { ProjectExplorer } from '@src/components/Explorer/ProjectExplorer'
+import type { FileExplorerEntry } from '@src/components/Explorer/utils'
 import { addPlaceHoldersForNewFileAndFolder } from '@src/components/Explorer/utils'
 import { ToastInsert } from '@src/components/ToastInsert'
-import { relevantFileExtensions } from '@src/lang/wasmUtils'
-import { FILE_EXT, INSERT_FOREIGN_TOAST_ID } from '@src/lib/constants'
-import {
-  getEXTNoPeriod,
-  isExtensionARelevantExtension,
-  parentPathRelativeToProject,
-} from '@src/lib/paths'
-import { useApp, useSingletons } from '@src/lib/boot'
-import {
-  useFolders,
-  useProjectDirectoryPath,
-} from '@src/machines/systemIO/hooks'
-import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
-import { useState, use, useEffect, useRef, useCallback } from 'react'
-import toast from 'react-hot-toast'
 import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
+import { useModelingContext } from '@src/hooks/useModelingContext'
+import { relevantFileExtensions } from '@src/lang/wasmUtils'
+import {
+  clearActiveTextFile,
+  openActiveTextFile,
+} from '@src/lib/activeTextFile'
+import { useApp, useSingletons } from '@src/lib/boot'
+import { FILE_EXT, INSERT_FOREIGN_TOAST_ID } from '@src/lib/constants'
+import fsZds from '@src/lib/fs-zds'
 import {
   type AreaTypeComponentProps,
   DefaultLayoutPaneID,
   getOpenPanes,
   togglePaneLayoutNode,
 } from '@src/lib/layout'
-import { useModelingContext } from '@src/hooks/useModelingContext'
+import {
+  getEXTNoPeriod,
+  isExtensionARelevantExtension,
+  parentPathRelativeToProject,
+} from '@src/lib/paths'
+import type { Project } from '@src/lib/project'
 import { reportRejection } from '@src/lib/trap'
+import {
+  useFolders,
+  useProjectDirectoryPath,
+} from '@src/machines/systemIO/hooks'
+import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
+import { use, useCallback, useEffect, useRef, useState } from 'react'
+import toast from 'react-hot-toast'
+
+const isMarkdownFile = (entry: FileExplorerEntry) =>
+  entry.children == null && entry.path.toLowerCase().endsWith('.md')
 
 export function ProjectExplorerPane(props: AreaTypeComponentProps) {
   const { commands, project, systemIOActor, layout } = useApp()
@@ -44,7 +51,6 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
     send: modelingSend,
     actor: modelingActor,
   } = useModelingContext()
-
   useEffect(() => {
     // Have no idea why the project loader data doesn't have the children from the ls on disk
     // That means it is a different object or cached incorrectly?
@@ -98,7 +104,7 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
       if (
         !projectRef.current?.value.name ||
         entry.children != null ||
-        !entry.path.endsWith(FILE_EXT)
+        (!entry.path.endsWith(FILE_EXT) && !isMarkdownFile(entry))
       ) {
         return
       }
@@ -128,6 +134,7 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
       entry.children == null &&
       entry.path.endsWith(FILE_EXT)
     ) {
+      clearActiveTextFile()
       const name = projectRef.current.value.name.slice()
 
       const navigateHelper = () => {
@@ -157,6 +164,9 @@ export function ProjectExplorerPane(props: AreaTypeComponentProps) {
         // immediately navigate
         navigateHelper()
       }
+    } else if (isMarkdownFile(entry)) {
+      openCodeEditorPaneIfClosed()
+      openActiveTextFile(entry.path).catch(reportRejection)
     } else if (isRelevantFile(entry.path) && projectRef.current?.value.path) {
       // Allow insert if it is a importable file
       toast.custom(

--- a/src/lib/activeTextFile.ts
+++ b/src/lib/activeTextFile.ts
@@ -1,0 +1,68 @@
+import { signal } from '@preact/signals-core'
+import fsZds from '@src/lib/fs-zds'
+
+export type ActiveTextFile =
+  | {
+      path: string
+      name: string
+      text: string
+      status: 'ready'
+    }
+  | {
+      path: string
+      name: string
+      text: ''
+      status: 'loading'
+    }
+  | {
+      path: string
+      name: string
+      text: ''
+      status: 'error'
+      error: string
+    }
+
+export const activeTextFileSignal = signal<ActiveTextFile | null>(null)
+
+let latestOpenRequestId = 0
+
+export function clearActiveTextFile() {
+  latestOpenRequestId += 1
+  activeTextFileSignal.value = null
+}
+
+export async function openActiveTextFile(path: string) {
+  const requestId = ++latestOpenRequestId
+  const name = fsZds.basename(path)
+
+  activeTextFileSignal.value = {
+    path,
+    name,
+    text: '',
+    status: 'loading',
+  }
+
+  try {
+    const text = await fsZds.readFile(path, { encoding: 'utf-8' })
+    if (requestId !== latestOpenRequestId) {
+      return
+    }
+    activeTextFileSignal.value = {
+      path,
+      name,
+      text,
+      status: 'ready',
+    }
+  } catch (error) {
+    if (requestId !== latestOpenRequestId) {
+      return
+    }
+    activeTextFileSignal.value = {
+      path,
+      name,
+      text: '',
+      status: 'error',
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}


### PR DESCRIPTION
first step and proof of concept towards [Markdown file support in file and code panes](https://github.com/orgs/KittyCAD/projects/52/views/3?pane=issue&itemId=184384998&issue=KittyCAD%7Croadmap%7C431) (made w codex)

## Summary
- Allow `.md` files selected in the project explorer to open in the code pane.
- Add a lightweight active text file signal that reads Markdown through `fsZds`.
- Render Markdown in a separate read-only CodeMirror view so the KCL editor, executing path, LSP behavior, and KCL manager remain untouched.
- Clear the Markdown view when switching back to a `.kcl` file or closing the code pane.

## Scope
This is read-only Markdown viewing for the MVP. Creating or editing Markdown files is intentionally out of scope.
