### PR TITLE
KCL: Fix typo in error message

### DIFF
--- a/rust/kcl-lib/src/engine/conn.rs
+++ b/rust/kcl-lib/src/engine/conn.rs
@@ -225,7 +225,7 @@ impl EngineConnection {
         tcp_write
             .send(WsMsg::Binary(msg.into()))
             .await
-            .map_err(|e| anyhow!("could not send json over websocket: {e}"))?;
+            .map_err(|e| anyhow!("could not send MsgPack over websocket: {e}"))?;
         Ok(())
     }
 


### PR DESCRIPTION
It says 'json' but it's actually doing msgpack.