### PR TITLE
Fix draft center arc self-snapping

### DIFF
--- a/src/machines/sketchSolve/tools/centerArcToolImpl.spec.ts
+++ b/src/machines/sketchSolve/tools/centerArcToolImpl.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import {
   createArcActor,
   finalizeArcActor,
+  getArcPointIdsForSegment,
   projectPointOntoArcRadius,
   sendResultToParent,
   storeCreatedArcResult,
@@ -157,6 +158,30 @@ function createArcApiObject({
 }
 
 describe('centerArcToolImpl', () => {
+  describe('getArcPointIdsForSegment', () => {
+    it('returns center, start, and end point ids for the active draft arc', () => {
+      const centerPoint = createPointApiObject({ id: 1, x: 0, y: 0 })
+      const startPoint = createPointApiObject({ id: 2, x: 10, y: 0 })
+      const endPoint = createPointApiObject({ id: 3, x: 0, y: 10 })
+      const arcObj = createArcApiObject({
+        id: 4,
+        center: 1,
+        start: 2,
+        end: 3,
+      })
+      const sceneGraphDelta = createSceneGraphDelta([
+        centerPoint,
+        startPoint,
+        endPoint,
+        arcObj,
+      ])
+
+      expect(
+        getArcPointIdsForSegment(sceneGraphDelta.new_graph.objects, 4)
+      ).toEqual([1, 2, 3])
+    })
+  })
+
   describe('projectPointOntoArcRadius', () => {
     it('should project a point onto the circle defined by center and start', () => {
       const center: [number, number] = [0, 0]

--- a/src/machines/sketchSolve/tools/centerArcToolImpl.ts
+++ b/src/machines/sketchSolve/tools/centerArcToolImpl.ts
@@ -1,4 +1,5 @@
 import type {
+  ApiObject,
   SceneGraphDelta,
   SegmentCtor,
   SourceDelta,
@@ -86,6 +87,26 @@ type ToolAssignArgs<TActor extends ProvidedActor = any> = AssignArgs<
   ToolEvents,
   TActor
 >
+
+export function getArcPointIdsForSegment(
+  objects: ApiObject[],
+  arcId: number | undefined
+): number[] {
+  if (arcId === undefined) {
+    return []
+  }
+
+  const arcObj = objects[arcId]
+  if (!isArcSegment(arcObj)) {
+    return []
+  }
+
+  return [
+    arcObj.kind.segment.center,
+    arcObj.kind.segment.start,
+    arcObj.kind.segment.end,
+  ]
+}
 
 ////////////// --Actions-- //////////////////
 
@@ -237,8 +258,8 @@ export function animateArcEndPointListener({ self, context }: ToolActionArgs) {
           sketchId: context.sketchId,
           mousePosition: [twoD.x, twoD.y],
           mouseEvent: args.mouseEvent,
-          excludedPointIds:
-            context.arcEndPointId === undefined ? [] : [context.arcEndPointId],
+          getExcludedPointIds: (currentSketchObjects) =>
+            getArcPointIdsForSegment(currentSketchObjects, context.arcId),
         })
         sendHoveredSnappingCandidate(self, snappingCandidate)
         updateToolSnappingPreview({
@@ -362,8 +383,8 @@ export function animateArcEndPointListener({ self, context }: ToolActionArgs) {
           sketchId: context.sketchId,
           mousePosition,
           mouseEvent: args.mouseEvent,
-          excludedPointIds:
-            context.arcEndPointId === undefined ? [] : [context.arcEndPointId],
+          getExcludedPointIds: (currentSketchObjects) =>
+            getArcPointIdsForSegment(currentSketchObjects, context.arcId),
         })
         const [x, y] = snappingCandidate?.position ?? mousePosition
         self.send({


### PR DESCRIPTION
Fixes arc coincident (point line) snapping while adding an arc.

When placing the final point of a center arc, snapping could see the draft arc itself and create a no-op coincident constraint against its own point/segment `coincident([arc1.start, arc1.start])`. This now excludes the active draft arc’s center, start, and end points from snap candidates during endpoint animation, so snapping falls through to real nearby geometry instead.

Added a focused unit test for resolving the active arc point IDs used by that exclusion.




https://github.com/user-attachments/assets/47d6a5ee-0b20-41e9-a86b-cc751e17f79c

