### PR TITLE
KCL: Explain how to fully constrain a circle in the docs.

### DIFF
--- a/docs/kcl-std-legacy/functions/std-solver-circle.md
+++ b/docs/kcl-std-legacy/functions/std-solver-circle.md
@@ -15,7 +15,10 @@ solver::circle(
 ): Segment
 ```
 
-
+The starting point is currently free to float around the circumference of the circle.
+So if you want to fully constrain the circle, you'll need to fix the start point
+to somewhere along the circumference. We suggest adding `vertical([myCircle.start, myCircle.center])`
+or `horizontal([myCircle.start, myCircle.center])`.
 
 ### Arguments
 

--- a/docs/kcl-std-sketch-solve/functions/std-solver-circle.md
+++ b/docs/kcl-std-sketch-solve/functions/std-solver-circle.md
@@ -15,7 +15,10 @@ solver::circle(
 ): Segment
 ```
 
-
+The starting point is currently free to float around the circumference of the circle.
+So if you want to fully constrain the circle, you'll need to fix the start point
+to somewhere along the circumference. We suggest adding `vertical([myCircle.start, myCircle.center])`
+or `horizontal([myCircle.start, myCircle.center])`.
 
 ### Arguments
 

--- a/docs/kcl-std/functions/std-solver-circle.md
+++ b/docs/kcl-std/functions/std-solver-circle.md
@@ -15,7 +15,10 @@ solver::circle(
 ): Segment
 ```
 
-
+The starting point is currently free to float around the circumference of the circle.
+So if you want to fully constrain the circle, you'll need to fix the start point
+to somewhere along the circumference. We suggest adding `vertical([myCircle.start, myCircle.center])`
+or `horizontal([myCircle.start, myCircle.center])`.
 
 ### Arguments
 

--- a/rust/kcl-lib/std/solver.kcl
+++ b/rust/kcl-lib/std/solver.kcl
@@ -126,6 +126,11 @@ export fn arc(
 /// Create a circle in a sketch. The circle segment always has a starting point
 /// and sweeps counterclockwise from it.
 ///
+///
+/// The starting point is currently free to float around the circumference of the circle.
+/// So if you want to fully constrain the circle, you'll need to fix the start point
+/// to somewhere along the circumference. We suggest adding `vertical([myCircle.start, myCircle.center])`
+/// or `horizontal([myCircle.start, myCircle.center])`.
 /// ```kcl,sketchSolve
 /// profile = sketch(on = XY) {
 ///   circle1 = circle(start = [var 2mm, var 0mm], center = [var 0mm, var 0mm], construction = true)


### PR DESCRIPTION
Adds this to the KCL docs:

> The starting point is currently free to float around the circumference of the circle.
> So if you want to fully constrain the circle, you'll need to fix the start point
> to somewhere along the circumference. We suggest adding `vertical([myCircle.start, myCircle.center])`
> or `horizontal([myCircle.start, myCircle.center])`.