### PR TITLE
Make command system registry-managed

### DIFF
--- a/e2e/playwright/testing-settings.spec.ts
+++ b/e2e/playwright/testing-settings.spec.ts
@@ -709,6 +709,7 @@ test.describe(
         const toolbar = page.locator('menu').filter({ hasText: 'Start Sketch' })
 
         await test.step(`Test setup`, async () => {
+          await page.emulateMedia({ colorScheme: 'light' })
           await page.setBodyDimensions({ width: 1200, height: 500 })
           await homePage.goToModelingScene()
           await u.waitForPageLoad()

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -1,8 +1,68 @@
-import { withAPIBaseURL } from '@src/lib/withBaseURL'
+import type { UserResponse } from '@kittycad/lib/dist/types/src'
+import {
+  Registry,
+  type RegistryItem,
+  Slot,
+  defineRegistryItem,
+  pluginsValueSpec,
+  provideService,
+} from '@kittycad/registry'
+import { type Signal, effect, signal } from '@preact/signals-core'
+import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
 import { KclManager, ZDSProject } from '@src/lang/KclManager'
+import { initialiseWasm } from '@src/lang/wasmUtils'
+import { MachineManager } from '@src/lib/MachineManager'
+import { createAuthCommands } from '@src/lib/commandBarConfigs/authCommandConfig'
+import { createProjectCommands } from '@src/lib/commandBarConfigs/projectsCommandConfig'
+import type { Debugger } from '@src/lib/debugger'
+import { EngineDebugger } from '@src/lib/debugger'
+import { isPlaywright } from '@src/lib/isPlaywright'
+import {
+  type Layout,
+  createLayoutWithMetadata,
+  defaultLayout,
+  loadLayout,
+  saveLayout,
+  setLayoutSaveHandler,
+} from '@src/lib/layout'
+import { playwrightLayoutConfig } from '@src/lib/layout/configs/playwright'
+import type { Project } from '@src/lib/project'
 import RustContext from '@src/lib/rustContext'
-import { uuidv4 } from '@src/lib/utils'
+import {
+  type SettingsType,
+  createSettings,
+} from '@src/lib/settings/initialSettings'
 import type { SaveSettingsPayload } from '@src/lib/settings/settingsTypes'
+import {
+  getAllCurrentSettings,
+  jsAppSettings,
+} from '@src/lib/settings/settingsUtils'
+import { err, reportRejection } from '@src/lib/trap'
+import { uuidv4 } from '@src/lib/utils'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+import { withAPIBaseURL } from '@src/lib/withBaseURL'
+import { authMachine } from '@src/machines/authMachine'
+import {
+  BILLING_CONTEXT_DEFAULTS,
+  billingMachine,
+} from '@src/machines/billingMachine'
+import {
+  type SettingsActorType,
+  getOnlySettingsFromContext,
+  settingsMachine,
+} from '@src/machines/settingsMachine'
+import { systemIOMachineImpl } from '@src/machines/systemIO/systemIOMachineImpl'
+import type { SystemIOActor } from '@src/machines/systemIO/utils'
+import { ConnectionManager } from '@src/network/connectionManager'
+import {
+  type CommandSystemService,
+  commandSystemService,
+  provideCommand,
+} from '@src/registry/contracts/commands'
+import { machineManagerService } from '@src/registry/contracts/machineManager'
+import { settingsValueSpec } from '@src/registry/contracts/settings'
+import { provideWasmPromise } from '@src/registry/contracts/wasm'
+import { coreRegistryItems } from '@src/registry/registry'
 import { useSelector } from '@xstate/react'
 import type {
   ActorRefFrom,
@@ -11,62 +71,34 @@ import type {
   Subscription,
 } from 'xstate'
 import { createActor } from 'xstate'
-import { createAuthCommands } from '@src/lib/commandBarConfigs/authCommandConfig'
-import { createProjectCommands } from '@src/lib/commandBarConfigs/projectsCommandConfig'
-import {
-  createSettings,
-  type SettingsType,
-} from '@src/lib/settings/initialSettings'
-import { authMachine } from '@src/machines/authMachine'
-import {
-  BILLING_CONTEXT_DEFAULTS,
-  billingMachine,
-} from '@src/machines/billingMachine'
-import {
-  getOnlySettingsFromContext,
-  type SettingsActorType,
-  settingsMachine,
-} from '@src/machines/settingsMachine'
-import { systemIOMachineImpl } from '@src/machines/systemIO/systemIOMachineImpl'
-import {
-  type CommandBarActorType,
-  commandBarMachine,
-} from '@src/machines/commandBarMachine'
-import { ConnectionManager } from '@src/network/connectionManager'
-import type { Debugger } from '@src/lib/debugger'
-import { EngineDebugger } from '@src/lib/debugger'
-import { initialiseWasm } from '@src/lang/wasmUtils'
-import {
-  createLayoutWithMetadata,
-  defaultLayout,
-  loadLayout,
-  saveLayout,
-  setLayoutSaveHandler,
-  type Layout,
-} from '@src/lib/layout'
-import { playwrightLayoutConfig } from '@src/lib/layout/configs/playwright'
-import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
-import { type Signal, signal, effect } from '@preact/signals-core'
-import {
-  getAllCurrentSettings,
-  jsAppSettings,
-} from '@src/lib/settings/settingsUtils'
-import { isPlaywright } from '@src/lib/isPlaywright'
-import { MachineManager } from '@src/lib/MachineManager'
-import { err, reportRejection } from '@src/lib/trap'
-import type { Project } from '@src/lib/project'
-import { settingsValueSpec } from '@src/registry/contracts/settings'
-import { Registry, pluginsValueSpec } from '@kittycad/registry'
-import type { UserResponse } from '@kittycad/lib/dist/types/src'
-import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
-import type { SystemIOActor } from '@src/machines/systemIO/utils'
-import { coreRegistryItems } from '@src/registry/registry'
 
 const DEFAULT_LAYOUT_CONFIG_NAME = 'default'
 const PLAYWRIGHT_LAYOUT_CONFIG_NAME = 'test'
+const appCommandsSlot = new Slot()
 
 function isPlaywrightRuntime() {
   return typeof window !== 'undefined' && isPlaywright()
+}
+
+function createAppRegistryItems({
+  wasmPromise,
+  machineManager,
+}: {
+  wasmPromise: Promise<ModuleType>
+  machineManager: MachineManager
+}): RegistryItem[] {
+  return [
+    defineRegistryItem({
+      id: 'app.wasm-promise',
+      provides: [provideWasmPromise(wasmPromise)],
+    }),
+    defineRegistryItem({
+      id: 'app.machine-manager',
+      providesServices: [provideService(machineManagerService, machineManager)],
+    }),
+    appCommandsSlot.of(),
+    ...coreRegistryItems,
+  ]
 }
 
 // We set some of our singletons on the window for debugging and E2E tests
@@ -88,11 +120,7 @@ export type AppAuthSystem = {
   useUser: () => UserResponse | undefined
 }
 
-export type AppCommandSystem = {
-  actor: CommandBarActorType
-  send: CommandBarActorType['send']
-  useState: () => SnapshotFrom<CommandBarActorType>
-}
+export type AppCommandSystem = CommandSystemService
 
 export type AppSettingsSystem = {
   actor: SettingsActorType
@@ -194,16 +222,19 @@ export class App implements AppSubsystems {
       },
     }).start()
 
-    // Initialize global commands
-    this.commands.actor.send({
-      type: 'Add commands',
-      data: {
-        commands: [
-          ...createAuthCommands({ authActor: this.auth.actor }),
-          ...createProjectCommands({ systemIOActor: this.systemIOActor }),
+    this.registry.reconfigure(appCommandsSlot, [
+      defineRegistryItem({
+        id: 'app.global-commands',
+        provides: [
+          ...createAuthCommands({ authActor: this.auth.actor }).map(
+            provideCommand
+          ),
+          ...createProjectCommands({ systemIOActor: this.systemIOActor }).map(
+            provideCommand
+          ),
         ],
-      },
-    })
+      }),
+    ])
 
     this.singletons = this.buildSingletons()
     this.lastSettings = getAllCurrentSettings(
@@ -237,28 +268,17 @@ export class App implements AppSubsystems {
         })
       : new MachineManager() // Instantiate with no-op functions
 
-    const commandBarActor = createActor(commandBarMachine, {
-      input: {
-        commands: [],
-        wasmInstancePromise: wasmPromise,
-        machineManager,
-      },
-    }).start()
-
-    const commands: AppCommandSystem = {
-      actor: commandBarActor,
-      send: commandBarActor.send.bind(this),
-      useState: () => useSelector(commandBarActor, (state) => state),
-    }
-
     const appRegistry = new Registry()
-    appRegistry.configure(coreRegistryItems)
+    appRegistry.configure(
+      createAppRegistryItems({ wasmPromise, machineManager })
+    )
+    const commands = appRegistry.get(commandSystemService)
     const extensionSettings = appRegistry.get(settingsValueSpec)
 
     const settingsActor = createActor(settingsMachine, {
       input: {
         ...createSettings(extensionSettings),
-        commandBarActor: commandBarActor,
+        commandBarActor: commands.actor,
         extensionSettings,
         wasmInstancePromise: wasmPromise,
       },

--- a/src/registry/contracts/commands.ts
+++ b/src/registry/contracts/commands.ts
@@ -1,0 +1,29 @@
+import {
+  appendValueSpec,
+  defineContract,
+  defineService,
+  provide,
+} from '@kittycad/registry'
+import type { Command } from '@src/lib/commandTypes'
+import type { CommandBarActorType } from '@src/machines/commandBarMachine'
+import type { SnapshotFrom } from 'xstate'
+
+export type CommandSystemService = {
+  actor: CommandBarActorType
+  send: CommandBarActorType['send']
+  useState: () => SnapshotFrom<CommandBarActorType>
+}
+
+export const commandKey = (command: Command) =>
+  `${command.groupId}:${String(command.name)}`
+
+export const commandsContract = defineContract({
+  commandSystemService: defineService<CommandSystemService>('command-system'),
+  commandsValueSpec: appendValueSpec<Command>('commands'),
+})
+
+export const { commandSystemService, commandsValueSpec } = commandsContract
+
+export function provideCommand(command: Command) {
+  return provide(commandsValueSpec, command, { key: commandKey(command) })
+}

--- a/src/registry/contracts/machineManager.ts
+++ b/src/registry/contracts/machineManager.ts
@@ -1,0 +1,8 @@
+import { defineContract, defineService } from '@kittycad/registry'
+import type { MachineManager } from '@src/lib/MachineManager'
+
+export const machineManagerContract = defineContract({
+  machineManagerService: defineService<MachineManager>('machine-manager'),
+})
+
+export const { machineManagerService } = machineManagerContract

--- a/src/registry/contracts/wasm.ts
+++ b/src/registry/contracts/wasm.ts
@@ -1,0 +1,15 @@
+import { defineContract, firstWinsValueSpec, provide } from '@kittycad/registry'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+
+export const wasmContract = defineContract({
+  wasmPromiseValueSpec: firstWinsValueSpec<Promise<ModuleType> | undefined>(
+    'wasm-promise',
+    undefined
+  ),
+})
+
+export const { wasmPromiseValueSpec } = wasmContract
+
+export function provideWasmPromise(wasmPromise: Promise<ModuleType>) {
+  return provide(wasmPromiseValueSpec, wasmPromise, { key: 'wasm-promise' })
+}

--- a/src/registry/extensions/commands/index.test.ts
+++ b/src/registry/extensions/commands/index.test.ts
@@ -1,0 +1,60 @@
+import {
+  Registry,
+  Slot,
+  defineRegistryItem,
+  provideService,
+} from '@kittycad/registry'
+import { MachineManager } from '@src/lib/MachineManager'
+import type { Command } from '@src/lib/commandTypes'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+import {
+  commandSystemService,
+  provideCommand,
+} from '@src/registry/contracts/commands'
+import { machineManagerService } from '@src/registry/contracts/machineManager'
+import { provideWasmPromise } from '@src/registry/contracts/wasm'
+import { describe, expect, it, vi } from 'vitest'
+import commandsExtension from '.'
+
+describe('commands extension', () => {
+  it('syncs registry command contributions into the command system service', () => {
+    const commandsSlot = new Slot()
+    const command: Command = {
+      groupId: 'test',
+      name: 'test-command',
+      needsReview: false,
+      onSubmit: vi.fn(),
+    }
+    const commandItem = defineRegistryItem({
+      id: 'test-command-item',
+      provides: [provideCommand(command)],
+    })
+
+    const registry = new Registry()
+    registry.configure([
+      defineRegistryItem({
+        id: 'test-wasm-promise',
+        provides: [provideWasmPromise(Promise.resolve({} as ModuleType))],
+      }),
+      defineRegistryItem({
+        id: 'test-machine-manager',
+        providesServices: [
+          provideService(machineManagerService, new MachineManager()),
+        ],
+      }),
+      commandsExtension,
+      commandsSlot.of(commandItem),
+    ])
+
+    const commandSystem = registry.get(commandSystemService)
+    expect(commandSystem.actor.getSnapshot().context.commands).toEqual([
+      command,
+    ])
+
+    registry.reconfigure(commandsSlot, [])
+
+    expect(commandSystem.actor.getSnapshot().context.commands).toEqual([])
+
+    registry[Symbol.dispose]()
+  })
+})

--- a/src/registry/extensions/commands/index.ts
+++ b/src/registry/extensions/commands/index.ts
@@ -1,0 +1,95 @@
+import {
+  defineRegistryItemFactory,
+  defineRuntimeRegistryItem,
+  provideService,
+} from '@kittycad/registry'
+import { effect } from '@preact/signals-core'
+import type { Command } from '@src/lib/commandTypes'
+import { commandBarMachine } from '@src/machines/commandBarMachine'
+import {
+  type CommandSystemService,
+  commandSystemService,
+  commandsValueSpec,
+} from '@src/registry/contracts/commands'
+import { machineManagerService } from '@src/registry/contracts/machineManager'
+import { wasmPromiseValueSpec } from '@src/registry/contracts/wasm'
+import { useSelector } from '@xstate/react'
+import { createActor } from 'xstate'
+
+const commandsExtension = defineRegistryItemFactory((ctx) => {
+  const machineManagerSignal = ctx.services.signal(machineManagerService)
+  const wasmPromiseSignal = ctx.valueSpecs.signal(wasmPromiseValueSpec)
+  const commandsSignal = ctx.valueSpecs.signal(commandsValueSpec)
+
+  let commandBarActor: CommandSystemService['actor'] | undefined
+  let stopCommandsEffect: (() => void) | undefined
+  let registeredCommands: readonly Command[] = []
+
+  const ensureActor = () => {
+    if (commandBarActor) {
+      return commandBarActor
+    }
+
+    const machineManager = machineManagerSignal.value
+    if (!machineManager) {
+      throw new Error('Missing machine manager service.')
+    }
+
+    const wasmPromise = wasmPromiseSignal.value
+    if (!wasmPromise) {
+      throw new Error('Missing WASM promise registry value.')
+    }
+
+    commandBarActor = createActor(commandBarMachine, {
+      input: {
+        commands: [],
+        wasmInstancePromise: wasmPromise,
+        machineManager,
+      },
+    }).start()
+
+    stopCommandsEffect = effect(() => {
+      const nextCommands = commandsSignal.value
+
+      if (registeredCommands.length > 0) {
+        commandBarActor?.send({
+          type: 'Remove commands',
+          data: { commands: [...registeredCommands] },
+        })
+      }
+
+      if (nextCommands.length > 0) {
+        commandBarActor?.send({
+          type: 'Add commands',
+          data: { commands: [...nextCommands] },
+        })
+      }
+
+      registeredCommands = nextCommands
+    })
+
+    return commandBarActor
+  }
+
+  const serviceImpl: CommandSystemService = {
+    get actor() {
+      return ensureActor()
+    },
+    send: ((...args: Parameters<CommandSystemService['send']>) =>
+      ensureActor().send(...args)) as CommandSystemService['send'],
+    useState: () => useSelector(ensureActor(), (state) => state),
+  }
+
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'commands-extension',
+      providesServices: [provideService(commandSystemService, serviceImpl)],
+      dispose: () => {
+        stopCommandsEffect?.()
+        commandBarActor?.stop()
+      },
+    }),
+  }
+}, 'commands-extension')
+
+export default commandsExtension

--- a/src/registry/registry.ts
+++ b/src/registry/registry.ts
@@ -1,25 +1,37 @@
 import type { RegistryItem } from '@kittycad/registry'
 
-type PluginModule = {
+type RegistryItemModule = {
   default?: RegistryItem
   order?: number
 }
 
-const pluginModules: Record<string, PluginModule> = import.meta.glob(
-  './plugins/*/index.ts',
-  {
+const bundledRegistryItemModules: Record<string, RegistryItemModule> =
+  import.meta.glob(['./extensions/*/index.ts', './plugins/*/index.ts'], {
     eager: true,
-  }
-)
+  })
 
-// Core app plugins discovered from src/registry/plugins/*/index.ts.
-// Keep ordering deterministic so adding folders does not create unstable load order.
-export const coreRegistryItems: RegistryItem[] = Object.entries(pluginModules)
+const bundledRegistryItemKindOrder = (path: string) =>
+  path.includes('/plugins/') ? 1 : 0
+
+// Core app registry items discovered from src/registry/extensions/*/index.ts
+// and src/registry/plugins/*/index.ts.
+//
+// Extensions are always-on app infrastructure. Plugins are user-visible,
+// runtime-toggleable bundles that may depend on extension contracts.
+export const coreRegistryItems: RegistryItem[] = Object.entries(
+  bundledRegistryItemModules
+)
   .map(([path, mod]) => ({
     path,
+    kindOrder: bundledRegistryItemKindOrder(path),
     order: mod.order ?? 0,
-    plugin: mod.default,
+    item: mod.default,
   }))
-  .filter((entry) => entry.plugin !== undefined)
-  .sort((a, b) => a.order - b.order || a.path.localeCompare(b.path))
-  .map((entry) => entry.plugin as RegistryItem)
+  .filter((entry) => entry.item !== undefined)
+  .sort(
+    (a, b) =>
+      a.kindOrder - b.kindOrder ||
+      a.order - b.order ||
+      a.path.localeCompare(b.path)
+  )
+  .map((entry) => entry.item as RegistryItem)


### PR DESCRIPTION
## Summary

This PR moves the command system toward the new registry architecture, allowing extension and plugins to start contributing commands. Codex written.

Commands are now registered through a `commandsValueSpec`, and the command bar is exposed as a registry-owned `commandSystemService`. This lets bundled extensions and future plugins contribute commands through the registry instead of needing to send an event to the command bar actor.

## What Changed

- Added a `commands` contract with `commandsValueSpec` and `commandSystemService`.
- Added reusable contracts for `wasmPromiseValueSpec` and `machineManagerService`.
- Added an always-on bundled `commands` extension under `src/registry/extensions`.
- Updated `app.ts` to resolve `app.commands` from the registry service.
- Moved startup auth/project commands into registry contributions.
- Updated registry discovery to load always-on extensions separately from toggleable plugins.

## Direction

This keeps `App` as the compatibility facade while moving subsystem ownership into registry items over time. ValueSpecs handle composed contributions like commands; Services expose long-lived capabilities like the command system and machine manager.