### PR TITLE
(fix): moves engine op batches to be per task/process

### DIFF
--- a/rust/kcl-lib/e2e/executor/cache.rs
+++ b/rust/kcl-lib/e2e/executor/cache.rs
@@ -491,8 +491,7 @@ async fn kcl_test_cache_empty_file_pop_cache_empty_file_planes_work() {
     let outcome = ctx.run_with_caching(program).await.unwrap();
 
     // Ensure nothing is left in the batch
-    assert!(ctx.engine.batch().read().await.is_empty());
-    assert!(ctx.engine.batch_end().read().await.is_empty());
+    assert!(ctx.engine_batch.is_empty().await);
 
     // Ensure the planes work, and we can show or hide them.
     // Hide/show the grid.
@@ -503,6 +502,7 @@ async fn kcl_test_cache_empty_file_pop_cache_empty_file_planes_work() {
 
     ctx.engine
         .send_modeling_cmd(
+            &ctx.engine_batch,
             uuid::Uuid::new_v4(),
             Default::default(),
             &ModelingCmd::from(
@@ -519,6 +519,7 @@ async fn kcl_test_cache_empty_file_pop_cache_empty_file_planes_work() {
     // Raw dog clear the scene entirely.
     ctx.engine
         .send_modeling_cmd(
+            &ctx.engine_batch,
             uuid::Uuid::new_v4(),
             Default::default(),
             &ModelingCmd::from(mcmd::SceneClearAll::builder().build()),
@@ -536,6 +537,7 @@ async fn kcl_test_cache_empty_file_pop_cache_empty_file_planes_work() {
     // Ensure we can show a plane.
     ctx.engine
         .send_modeling_cmd(
+            &ctx.engine_batch,
             uuid::Uuid::new_v4(),
             Default::default(),
             &ModelingCmd::from(

--- a/rust/kcl-lib/e2e/executor/main.rs
+++ b/rust/kcl-lib/e2e/executor/main.rs
@@ -2064,8 +2064,7 @@ sketch000 = startSketchOn(XY)
     ctx.run(&program, &mut exec_state).await.unwrap();
 
     // Ensure nothing is left in the batch
-    assert!(ctx.engine.batch().read().await.is_empty());
-    assert!(ctx.engine.batch_end().read().await.is_empty());
+    assert!(ctx.engine_batch.is_empty().await);
 
     ctx.close().await;
 }
@@ -2087,8 +2086,7 @@ async fn kcl_test_ensure_nothing_left_in_batch_multi_file() {
     ctx.run(&program, &mut exec_state).await.unwrap();
 
     // Ensure nothing is left in the batch
-    assert!(ctx.engine.batch().read().await.is_empty());
-    assert!(ctx.engine.batch_end().read().await.is_empty());
+    assert!(ctx.engine_batch.is_empty().await);
 
     ctx.close().await;
 }

--- a/rust/kcl-lib/src/engine/conn.rs
+++ b/rust/kcl-lib/src/engine/conn.rs
@@ -27,6 +27,7 @@ use uuid::Uuid;
 
 use crate::SourceRange;
 use crate::engine::AsyncTasks;
+use crate::engine::EngineBatchContext;
 use crate::engine::EngineManager;
 use crate::engine::EngineStats;
 use crate::errors::KclError;
@@ -51,8 +52,6 @@ pub struct EngineConnection {
     #[allow(dead_code)]
     tcp_read_handle: Arc<TcpReadHandle>,
     socket_health: Arc<RwLock<SocketHealth>>,
-    batch: Arc<RwLock<Vec<(WebSocketRequest, SourceRange)>>>,
-    batch_end: Arc<RwLock<IndexMap<uuid::Uuid, (WebSocketRequest, SourceRange)>>>,
     ids_of_async_commands: Arc<RwLock<IndexMap<Uuid, SourceRange>>>,
 
     /// The default planes for the scene.
@@ -383,8 +382,6 @@ impl EngineConnection {
             responses: response_information,
             pending_errors,
             socket_health,
-            batch: Arc::new(RwLock::new(Vec::new())),
-            batch_end: Arc::new(RwLock::new(IndexMap::new())),
             ids_of_async_commands,
             default_planes: Default::default(),
             session_data,
@@ -397,14 +394,6 @@ impl EngineConnection {
 
 #[async_trait::async_trait]
 impl EngineManager for EngineConnection {
-    fn batch(&self) -> Arc<RwLock<Vec<(WebSocketRequest, SourceRange)>>> {
-        self.batch.clone()
-    }
-
-    fn batch_end(&self) -> Arc<RwLock<IndexMap<uuid::Uuid, (WebSocketRequest, SourceRange)>>> {
-        self.batch_end.clone()
-    }
-
     fn responses(&self) -> Arc<RwLock<IndexMap<Uuid, WebSocketResponse>>> {
         self.responses.responses.clone()
     }
@@ -446,11 +435,14 @@ impl EngineManager for EngineConnection {
 
     async fn clear_scene_post_hook(
         &self,
+        batch_context: &EngineBatchContext,
         id_generator: &mut IdGenerator,
         source_range: SourceRange,
     ) -> Result<(), KclError> {
         // Remake the default planes, since they would have been removed after the scene was cleared.
-        let new_planes = self.new_default_planes(id_generator, source_range).await?;
+        let new_planes = self
+            .new_default_planes(batch_context, id_generator, source_range)
+            .await?;
         *self.default_planes.write().await = Some(new_planes);
 
         Ok(())

--- a/rust/kcl-lib/src/engine/conn_mock.rs
+++ b/rust/kcl-lib/src/engine/conn_mock.rs
@@ -22,6 +22,7 @@ use uuid::Uuid;
 
 use crate::SourceRange;
 use crate::engine::AsyncTasks;
+use crate::engine::EngineBatchContext;
 use crate::engine::EngineStats;
 use crate::errors::KclError;
 use crate::exec::DefaultPlanes;
@@ -29,8 +30,6 @@ use crate::execution::IdGenerator;
 
 #[derive(Debug, Clone)]
 pub struct EngineConnection {
-    batch: Arc<RwLock<Vec<(WebSocketRequest, SourceRange)>>>,
-    batch_end: Arc<RwLock<IndexMap<uuid::Uuid, (WebSocketRequest, SourceRange)>>>,
     ids_of_async_commands: Arc<RwLock<IndexMap<Uuid, SourceRange>>>,
     responses: Arc<RwLock<IndexMap<Uuid, WebSocketResponse>>>,
     /// The default planes for the scene.
@@ -42,8 +41,6 @@ pub struct EngineConnection {
 impl EngineConnection {
     pub fn new() -> Result<EngineConnection> {
         Ok(EngineConnection {
-            batch: Arc::new(RwLock::new(Vec::new())),
-            batch_end: Arc::new(RwLock::new(IndexMap::new())),
             ids_of_async_commands: Arc::new(RwLock::new(IndexMap::new())),
             responses: Arc::new(RwLock::new(IndexMap::new())),
             default_planes: Default::default(),
@@ -55,14 +52,6 @@ impl EngineConnection {
 
 #[async_trait::async_trait]
 impl crate::engine::EngineManager for EngineConnection {
-    fn batch(&self) -> Arc<RwLock<Vec<(WebSocketRequest, SourceRange)>>> {
-        self.batch.clone()
-    }
-
-    fn batch_end(&self) -> Arc<RwLock<IndexMap<uuid::Uuid, (WebSocketRequest, SourceRange)>>> {
-        self.batch_end.clone()
-    }
-
     fn responses(&self) -> Arc<RwLock<IndexMap<Uuid, WebSocketResponse>>> {
         self.responses.clone()
     }
@@ -85,6 +74,7 @@ impl crate::engine::EngineManager for EngineConnection {
 
     async fn clear_scene_post_hook(
         &self,
+        _batch_context: &EngineBatchContext,
         _id_generator: &mut IdGenerator,
         _source_range: SourceRange,
     ) -> Result<(), KclError> {

--- a/rust/kcl-lib/src/engine/conn_wasm.rs
+++ b/rust/kcl-lib/src/engine/conn_wasm.rs
@@ -15,6 +15,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::SourceRange;
 use crate::engine::AsyncTasks;
+use crate::engine::EngineBatchContext;
 use crate::engine::EngineStats;
 use crate::errors::KclError;
 use crate::errors::KclErrorDetails;
@@ -55,8 +56,6 @@ extern "C" {
 pub struct EngineConnection {
     manager: Arc<EngineCommandManager>,
     response_context: Arc<ResponseContext>,
-    batch: Arc<RwLock<Vec<(WebSocketRequest, SourceRange)>>>,
-    batch_end: Arc<RwLock<IndexMap<uuid::Uuid, (WebSocketRequest, SourceRange)>>>,
     ids_of_async_commands: Arc<RwLock<IndexMap<Uuid, SourceRange>>>,
     /// The default planes for the scene.
     default_planes: Arc<RwLock<Option<DefaultPlanes>>>,
@@ -126,8 +125,6 @@ impl EngineConnection {
         #[allow(clippy::arc_with_non_send_sync)]
         Ok(EngineConnection {
             manager: Arc::new(manager),
-            batch: Arc::new(RwLock::new(Vec::new())),
-            batch_end: Arc::new(RwLock::new(IndexMap::new())),
             response_context,
             ids_of_async_commands: Arc::new(RwLock::new(IndexMap::new())),
             default_planes: Default::default(),
@@ -260,14 +257,6 @@ impl EngineConnection {
 
 #[async_trait::async_trait]
 impl crate::engine::EngineManager for EngineConnection {
-    fn batch(&self) -> Arc<RwLock<Vec<(WebSocketRequest, SourceRange)>>> {
-        self.batch.clone()
-    }
-
-    fn batch_end(&self) -> Arc<RwLock<IndexMap<uuid::Uuid, (WebSocketRequest, SourceRange)>>> {
-        self.batch_end.clone()
-    }
-
     fn responses(&self) -> Arc<RwLock<IndexMap<Uuid, WebSocketResponse>>> {
         self.response_context.responses.clone()
     }
@@ -290,11 +279,14 @@ impl crate::engine::EngineManager for EngineConnection {
 
     async fn clear_scene_post_hook(
         &self,
+        batch_context: &EngineBatchContext,
         id_generator: &mut IdGenerator,
         source_range: SourceRange,
     ) -> Result<(), KclError> {
         // Remake the default planes, since they would have been removed after the scene was cleared.
-        let new_planes = self.new_default_planes(id_generator, source_range).await?;
+        let new_planes = self
+            .new_default_planes(batch_context, id_generator, source_range)
+            .await?;
         *self.default_planes.write().await = Some(new_planes);
 
         // Start a new session.

--- a/rust/kcl-lib/src/engine/mod.rs
+++ b/rust/kcl-lib/src/engine/mod.rs
@@ -106,7 +106,77 @@ lazy_static::lazy_static! {
                     z_axis: Point3d::new(-1.0,  0.0, 0.0, None),
                 },
             ),
-        ]);
+    ]);
+}
+
+/// Per-execution buffer for modeling commands that must preserve temporal order.
+///
+/// A single execution can enqueue commands whose source ranges come from multiple
+/// modules. The ownership boundary is the execution task carrying this context,
+/// not the module id embedded in a source range.
+#[derive(Debug, Clone)]
+pub struct EngineBatchContext {
+    batch: Arc<RwLock<Vec<(WebSocketRequest, SourceRange)>>>,
+    batch_end: Arc<RwLock<IndexMap<Uuid, (WebSocketRequest, SourceRange)>>>,
+}
+
+impl Default for EngineBatchContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EngineBatchContext {
+    pub fn new() -> Self {
+        Self {
+            batch: Arc::new(RwLock::new(Vec::new())),
+            batch_end: Arc::new(RwLock::new(IndexMap::new())),
+        }
+    }
+
+    pub async fn is_empty(&self) -> bool {
+        self.batch.read().await.is_empty() && self.batch_end.read().await.is_empty()
+    }
+
+    async fn clear(&self) {
+        self.batch.write().await.clear();
+        self.batch_end.write().await.clear();
+    }
+
+    async fn push(&self, req: WebSocketRequest, source_range: SourceRange) {
+        self.batch.write().await.push((req, source_range));
+    }
+
+    async fn extend(&self, requests: Vec<(WebSocketRequest, SourceRange)>) {
+        self.batch.write().await.extend(requests);
+    }
+
+    async fn insert_end(&self, id: Uuid, req: WebSocketRequest, source_range: SourceRange) {
+        self.batch_end.write().await.insert(id, (req, source_range));
+    }
+
+    pub(crate) async fn move_batch_end_to_batch(&self, ids: Vec<Uuid>) {
+        let mut moved = Vec::new();
+        {
+            let mut batch_end = self.batch_end.write().await;
+            for id in ids {
+                let Some(item) = batch_end.shift_remove(&id) else {
+                    continue;
+                };
+                moved.push(item);
+            }
+        }
+
+        self.extend(moved).await;
+    }
+
+    async fn take_batch(&self) -> Vec<(WebSocketRequest, SourceRange)> {
+        std::mem::take(&mut *self.batch.write().await)
+    }
+
+    async fn take_batch_end(&self) -> IndexMap<Uuid, (WebSocketRequest, SourceRange)> {
+        std::mem::take(&mut *self.batch_end.write().await)
+    }
 }
 
 #[derive(Default, Debug)]
@@ -126,12 +196,6 @@ impl Clone for EngineStats {
 
 #[async_trait::async_trait]
 pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
-    /// Get the batch of commands to be sent to the engine.
-    fn batch(&self) -> Arc<RwLock<Vec<(WebSocketRequest, SourceRange)>>>;
-
-    /// Get the batch of end commands to be sent to the engine.
-    fn batch_end(&self) -> Arc<RwLock<IndexMap<uuid::Uuid, (WebSocketRequest, SourceRange)>>>;
-
     /// Get the command responses from the engine.
     fn responses(&self) -> Arc<RwLock<IndexMap<Uuid, WebSocketResponse>>>;
 
@@ -140,16 +204,6 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
 
     /// Get the async tasks we are waiting for.
     fn async_tasks(&self) -> AsyncTasks;
-
-    /// Take the batch of commands that have accumulated so far and clear them.
-    async fn take_batch(&self) -> Vec<(WebSocketRequest, SourceRange)> {
-        std::mem::take(&mut *self.batch().write().await)
-    }
-
-    /// Take the batch of end commands that have accumulated so far and clear them.
-    async fn take_batch_end(&self) -> IndexMap<Uuid, (WebSocketRequest, SourceRange)> {
-        std::mem::take(&mut *self.batch_end().write().await)
-    }
 
     /// Take the ids of async commands that have accumulated so far and clear them.
     async fn take_ids_of_async_commands(&self) -> IndexMap<Uuid, SourceRange> {
@@ -169,6 +223,7 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
     /// Get the default planes, creating them if they don't exist.
     async fn default_planes(
         &self,
+        batch_context: &EngineBatchContext,
         id_generator: &mut IdGenerator,
         source_range: SourceRange,
     ) -> Result<DefaultPlanes, KclError> {
@@ -179,7 +234,9 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
             }
         } // drop the read lock
 
-        let new_planes = self.new_default_planes(id_generator, source_range).await?;
+        let new_planes = self
+            .new_default_planes(batch_context, id_generator, source_range)
+            .await?;
         *self.get_default_planes().write().await = Some(new_planes.clone());
 
         Ok(new_planes)
@@ -189,13 +246,13 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
     /// (These really only apply to wasm for now).
     async fn clear_scene_post_hook(
         &self,
+        batch_context: &EngineBatchContext,
         id_generator: &mut IdGenerator,
         source_range: SourceRange,
     ) -> Result<(), crate::errors::KclError>;
 
-    async fn clear_queues(&self) {
-        self.batch().write().await.clear();
-        self.batch_end().write().await.clear();
+    async fn clear_queues(&self, batch_context: &EngineBatchContext) {
+        batch_context.clear().await;
         self.ids_of_async_commands().write().await.clear();
         self.async_tasks().clear().await;
     }
@@ -226,13 +283,15 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
 
     async fn clear_scene(
         &self,
+        batch_context: &EngineBatchContext,
         id_generator: &mut IdGenerator,
         source_range: SourceRange,
     ) -> Result<(), crate::errors::KclError> {
         // Clear any batched commands leftover from previous scenes.
-        self.clear_queues().await;
+        self.clear_queues(batch_context).await;
 
         self.batch_modeling_cmd(
+            batch_context,
             id_generator.next_uuid(),
             source_range,
             &ModelingCmd::SceneClearAll(mcmd::SceneClearAll::default()),
@@ -241,10 +300,11 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
 
         // Flush the batch queue, so clear is run right away.
         // Otherwise the hooks below won't work.
-        self.flush_batch(false, source_range).await?;
+        self.flush_batch(batch_context, false, source_range).await?;
 
         // Do the after clear scene hook.
-        self.clear_scene_post_hook(id_generator, source_range).await?;
+        self.clear_scene_post_hook(batch_context, id_generator, source_range)
+            .await?;
 
         Ok(())
     }
@@ -301,7 +361,7 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
     }
 
     /// Ensure ALL async commands have been completed.
-    async fn ensure_async_commands_completed(&self) -> Result<(), KclError> {
+    async fn ensure_async_commands_completed(&self, batch_context: &EngineBatchContext) -> Result<(), KclError> {
         // Check if all async commands have been completed.
         let ids = self.take_ids_of_async_commands().await;
 
@@ -323,7 +383,7 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
         }
 
         // Flush the batch to make sure nothing remains.
-        self.flush_batch(true, SourceRange::default()).await?;
+        self.flush_batch(batch_context, true, SourceRange::default()).await?;
 
         Ok(())
     }
@@ -331,11 +391,13 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
     /// Set the visibility of edges.
     async fn set_edge_visibility(
         &self,
+        batch_context: &EngineBatchContext,
         visible: bool,
         source_range: SourceRange,
         id_generator: &mut IdGenerator,
     ) -> Result<(), crate::errors::KclError> {
         self.batch_modeling_cmd(
+            batch_context,
             id_generator.next_uuid(),
             source_range,
             &ModelingCmd::from(mcmd::EdgeLinesVisible::builder().hidden(!visible).build()),
@@ -348,24 +410,31 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
     /// Re-run the command to apply the settings.
     async fn reapply_settings(
         &self,
+        batch_context: &EngineBatchContext,
         settings: &crate::ExecutorSettings,
         source_range: SourceRange,
         id_generator: &mut IdGenerator,
         grid_scale_unit: GridScaleBehavior,
     ) -> Result<(), crate::errors::KclError> {
         // Set the edge visibility.
-        self.set_edge_visibility(settings.highlight_edges, source_range, id_generator)
+        self.set_edge_visibility(batch_context, settings.highlight_edges, source_range, id_generator)
             .await?;
 
         // Send the command to show the grid.
 
-        self.modify_grid(!settings.show_grid, grid_scale_unit, source_range, id_generator)
-            .await?;
+        self.modify_grid(
+            batch_context,
+            !settings.show_grid,
+            grid_scale_unit,
+            source_range,
+            id_generator,
+        )
+        .await?;
 
         // We do not have commands for changing ssao on the fly.
 
         // Flush the batch queue, so the settings are applied right away.
-        self.flush_batch(false, source_range).await?;
+        self.flush_batch(batch_context, false, source_range).await?;
 
         Ok(())
     }
@@ -373,6 +442,7 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
     // Add a modeling command to the batch but don't fire it right away.
     async fn batch_modeling_cmd(
         &self,
+        batch_context: &EngineBatchContext,
         id: uuid::Uuid,
         source_range: SourceRange,
         cmd: &ModelingCmd,
@@ -383,7 +453,7 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
         });
 
         // Add cmd to the batch.
-        self.batch().write().await.push((req, source_range));
+        batch_context.push(req, source_range).await;
         self.stats().commands_batched.fetch_add(1, Ordering::Relaxed);
 
         Ok(())
@@ -395,6 +465,7 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
     // if specific commands are run before others.
     async fn batch_modeling_cmds(
         &self,
+        batch_context: &EngineBatchContext,
         source_range: SourceRange,
         cmds: &[ModelingCmdReq],
     ) -> Result<(), crate::errors::KclError> {
@@ -406,7 +477,7 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
         self.stats()
             .commands_batched
             .fetch_add(extended_cmds.len(), Ordering::Relaxed);
-        self.batch().write().await.extend(extended_cmds);
+        batch_context.extend(extended_cmds).await;
 
         Ok(())
     }
@@ -416,6 +487,7 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
     /// engine will eat the ID and we can't reference it for other commands.
     async fn batch_end_cmd(
         &self,
+        batch_context: &EngineBatchContext,
         id: uuid::Uuid,
         source_range: SourceRange,
         cmd: &ModelingCmd,
@@ -426,7 +498,7 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
         });
 
         // Add cmd to the batch end.
-        self.batch_end().write().await.insert(id, (req, source_range));
+        batch_context.insert_end(id, req, source_range).await;
         self.stats().commands_batched.fetch_add(1, Ordering::Relaxed);
         Ok(())
     }
@@ -434,11 +506,12 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
     /// Send the modeling cmd and wait for the response.
     async fn send_modeling_cmd(
         &self,
+        batch_context: &EngineBatchContext,
         id: uuid::Uuid,
         source_range: SourceRange,
         cmd: &ModelingCmd,
     ) -> Result<OkWebSocketResponseData, crate::errors::KclError> {
-        let mut requests = self.take_batch().await.clone();
+        let mut requests = batch_context.take_batch().await;
 
         // Add the command to the batch.
         requests.push((
@@ -591,17 +664,18 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
     /// Force flush the batch queue.
     async fn flush_batch(
         &self,
+        batch_context: &EngineBatchContext,
         // Whether or not to flush the end commands as well.
         // We only do this at the very end of the file.
         batch_end: bool,
         source_range: SourceRange,
     ) -> Result<OkWebSocketResponseData, crate::errors::KclError> {
         let all_requests = if batch_end {
-            let mut requests = self.take_batch().await.clone();
-            requests.extend(self.take_batch_end().await.values().cloned());
+            let mut requests = batch_context.take_batch().await;
+            requests.extend(batch_context.take_batch_end().await.values().cloned());
             requests
         } else {
-            self.take_batch().await
+            batch_context.take_batch().await
         };
 
         self.run_batch(all_requests, source_range).await
@@ -609,6 +683,7 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
 
     async fn make_default_plane(
         &self,
+        batch_context: &EngineBatchContext,
         plane_id: uuid::Uuid,
         info: &PlaneInfo,
         color: Option<Color>,
@@ -619,6 +694,7 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
         let default_size = 100.0;
 
         self.batch_modeling_cmd(
+            batch_context,
             plane_id,
             source_range,
             &ModelingCmd::from(
@@ -637,6 +713,7 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
         if let Some(color) = color {
             // Set the color.
             self.batch_modeling_cmd(
+                batch_context,
                 id_generator.next_uuid(),
                 source_range,
                 &ModelingCmd::from(mcmd::PlaneSetColor::builder().color(color).plane_id(plane_id).build()),
@@ -649,6 +726,7 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
 
     async fn new_default_planes(
         &self,
+        batch_context: &EngineBatchContext,
         id_generator: &mut IdGenerator,
         source_range: SourceRange,
     ) -> Result<DefaultPlanes, KclError> {
@@ -685,13 +763,13 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
             })?;
             planes.insert(
                 name,
-                self.make_default_plane(plane_id, info, color, source_range, id_generator)
+                self.make_default_plane(batch_context, plane_id, info, color, source_range, id_generator)
                     .await?,
             );
         }
 
         // Flush the batch queue, so these planes are created right away.
-        self.flush_batch(false, source_range).await?;
+        self.flush_batch(batch_context, false, source_range).await?;
 
         Ok(DefaultPlanes {
             xy: planes[&PlaneName::Xy],
@@ -789,6 +867,7 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
 
     async fn modify_grid(
         &self,
+        batch_context: &EngineBatchContext,
         hidden: bool,
         grid_scale_behavior: GridScaleBehavior,
         source_range: SourceRange,
@@ -796,6 +875,7 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
     ) -> Result<(), KclError> {
         // Hide/show the grid.
         self.batch_modeling_cmd(
+            batch_context,
             id_generator.next_uuid(),
             source_range,
             &ModelingCmd::from(
@@ -808,6 +888,7 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
         .await?;
 
         self.batch_modeling_cmd(
+            batch_context,
             id_generator.next_uuid(),
             source_range,
             &grid_scale_behavior.into_modeling_cmd(),
@@ -816,6 +897,7 @@ pub trait EngineManager: std::fmt::Debug + Send + Sync + 'static {
 
         // Hide/show the grid scale text.
         self.batch_modeling_cmd(
+            batch_context,
             id_generator.next_uuid(),
             source_range,
             &ModelingCmd::from(

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -4678,6 +4678,7 @@ d = b + c
                     })
                     .unwrap(),
             )),
+            engine_batch: crate::engine::EngineBatchContext::default(),
             fs: Arc::new(crate::fs::FileManager::new()),
             settings: ExecutorSettings {
                 project_directory: Some(crate::TypedPath(tmpdir.path().into())),

--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -1195,6 +1195,7 @@ mod test {
                 .collect::<IndexMap<_, _>>();
             let exec_ctxt = ExecutorContext {
                 engine: Arc::new(Box::new(crate::engine::conn_mock::EngineConnection::new().unwrap())),
+                engine_batch: crate::engine::EngineBatchContext::default(),
                 fs: Arc::new(crate::fs::FileManager::new()),
                 settings: Default::default(),
                 context_type: ContextType::Mock,

--- a/rust/kcl-lib/src/execution/freedom_analysis_tests.rs
+++ b/rust/kcl-lib/src/execution/freedom_analysis_tests.rs
@@ -14,6 +14,7 @@ async fn run_with_freedom_analysis(kcl: &str) -> Vec<(ObjectId, Freedom)> {
 
     let exec_ctxt = ExecutorContext {
         engine: Arc::new(Box::new(EngineConnection::new().unwrap())),
+        engine_batch: crate::engine::EngineBatchContext::default(),
         fs: Arc::new(crate::fs::FileManager::new()),
         settings: ExecutorSettings::default(),
         context_type: ContextType::Mock,

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -75,6 +75,7 @@ use crate::NodePath;
 use crate::SourceRange;
 #[cfg(feature = "artifact-graph")]
 use crate::collections::AhashIndexSet;
+use crate::engine::EngineBatchContext;
 use crate::engine::EngineManager;
 use crate::engine::GridScaleBehavior;
 use crate::errors::KclError;
@@ -755,6 +756,7 @@ pub enum ContextType {
 #[derive(Debug, Clone)]
 pub struct ExecutorContext {
     pub engine: Arc<Box<dyn EngineManager>>,
+    pub engine_batch: EngineBatchContext,
     pub fs: Arc<FileManager>,
     pub settings: ExecutorSettings,
     pub context_type: ContextType,
@@ -879,9 +881,20 @@ impl ExecutorContext {
     ) -> Self {
         ExecutorContext {
             engine,
+            engine_batch: EngineBatchContext::default(),
             fs,
             settings,
             context_type: ContextType::Live,
+        }
+    }
+
+    fn clone_with_fresh_execution_batch(&self) -> Self {
+        Self {
+            engine: self.engine.clone(),
+            engine_batch: EngineBatchContext::new(),
+            fs: self.fs.clone(),
+            settings: self.settings.clone(),
+            context_type: self.context_type.clone(),
         }
     }
 
@@ -932,6 +945,7 @@ impl ExecutorContext {
     pub async fn new_mock(settings: Option<ExecutorSettings>) -> Self {
         ExecutorContext {
             engine: Arc::new(Box::new(crate::engine::conn_mock::EngineConnection::new().unwrap())),
+            engine_batch: EngineBatchContext::default(),
             fs: Arc::new(FileManager::new()),
             settings: settings.unwrap_or_default(),
             context_type: ContextType::Mock,
@@ -942,6 +956,7 @@ impl ExecutorContext {
     pub fn new_mock(engine: Arc<Box<dyn EngineManager>>, fs: Arc<FileManager>, settings: ExecutorSettings) -> Self {
         ExecutorContext {
             engine,
+            engine_batch: EngineBatchContext::default(),
             fs,
             settings,
             context_type: ContextType::Mock,
@@ -965,6 +980,7 @@ impl ExecutorContext {
 
         Ok(ExecutorContext {
             engine: mock_engine,
+            engine_batch: EngineBatchContext::default(),
             fs,
             settings,
             context_type: ContextType::Mock,
@@ -975,6 +991,7 @@ impl ExecutorContext {
     pub fn new_forwarded_mock(engine: Arc<Box<dyn EngineManager>>) -> Self {
         ExecutorContext {
             engine,
+            engine_batch: EngineBatchContext::default(),
             fs: Arc::new(FileManager::new()),
             settings: Default::default(),
             context_type: ContextType::MockCustomForwarded,
@@ -1051,7 +1068,7 @@ impl ExecutorContext {
         exec_state.global.artifacts.clear();
 
         self.engine
-            .clear_scene(&mut exec_state.mod_local.id_generator, source_range)
+            .clear_scene(&self.engine_batch, &mut exec_state.mod_local.id_generator, source_range)
             .await?;
         // The engine errors out if you toggle OIT with SSAO off.
         // So ignore OIT settings if SSAO is off.
@@ -1212,6 +1229,7 @@ impl ExecutorContext {
                             && self
                                 .engine
                                 .reapply_settings(
+                                    &self.engine_batch,
                                     &self.settings,
                                     Default::default(),
                                     &mut cached_state.main.exec_state.id_generator,
@@ -1241,6 +1259,7 @@ impl ExecutorContext {
                             if self
                                 .engine
                                 .reapply_settings(
+                                    &self.engine_batch,
                                     &self.settings,
                                     Default::default(),
                                     &mut cached_state.main.exec_state.id_generator,
@@ -1298,6 +1317,7 @@ impl ExecutorContext {
                         if self
                             .engine
                             .reapply_settings(
+                                &self.engine_batch,
                                 &self.settings,
                                 Default::default(),
                                 &mut cached_state.main.exec_state.id_generator,
@@ -1480,7 +1500,7 @@ impl ExecutorContext {
                 );
 
                 let repr = repr.clone();
-                let exec_ctxt = self.clone();
+                let exec_ctxt = self.clone_with_fresh_execution_batch();
                 let results_tx = results_tx.clone();
 
                 let exec_module = async |exec_ctxt: &ExecutorContext,
@@ -1724,6 +1744,7 @@ impl ExecutorContext {
         };
         self.engine
             .reapply_settings(
+                &self.engine_batch,
                 &self.settings,
                 Default::default(),
                 exec_state.id_generator(),
@@ -1858,17 +1879,20 @@ impl ExecutorContext {
         }
 
         // Ensure all the async commands completed.
-        self.engine.ensure_async_commands_completed().await.map_err(|e| {
-            match &exec_result {
-                Ok(env_ref) => (e, Some(*env_ref)),
-                // Prefer the execution error.
-                Err((exec_err, env_ref)) => (exec_err.clone(), *env_ref),
-            }
-        })?;
+        self.engine
+            .ensure_async_commands_completed(&self.engine_batch)
+            .await
+            .map_err(|e| {
+                match &exec_result {
+                    Ok(env_ref) => (e, Some(*env_ref)),
+                    // Prefer the execution error.
+                    Err((exec_err, env_ref)) => (exec_err.clone(), *env_ref),
+                }
+            })?;
 
         // If we errored out and early-returned, there might be commands which haven't been executed
         // and should be dropped.
-        self.engine.clear_queues().await;
+        self.engine.clear_queues(&self.engine_batch).await;
 
         match exec_state.build_artifact_graph(&self.engine, program).await {
             Ok(_) => exec_result,
@@ -1910,6 +1934,7 @@ impl ExecutorContext {
         // Zoom to fit.
         self.engine
             .send_modeling_cmd(
+                &self.engine_batch,
                 uuid::Uuid::new_v4(),
                 crate::execution::SourceRange::default(),
                 &ModelingCmd::from(
@@ -1927,6 +1952,7 @@ impl ExecutorContext {
         let resp = self
             .engine
             .send_modeling_cmd(
+                &self.engine_batch,
                 uuid::Uuid::new_v4(),
                 crate::execution::SourceRange::default(),
                 &ModelingCmd::from(mcmd::TakeSnapshot::builder().format(ImageFormat::Png).build()),
@@ -1953,6 +1979,7 @@ impl ExecutorContext {
         let resp = self
             .engine
             .send_modeling_cmd(
+                &self.engine_batch,
                 uuid::Uuid::new_v4(),
                 crate::SourceRange::default(),
                 &kittycad_modeling_cmds::ModelingCmd::Export(
@@ -2076,6 +2103,7 @@ pub(crate) async fn parse_execute_with_project_dir(
                 ))
             },
         )?)),
+        engine_batch: EngineBatchContext::default(),
         fs: Arc::new(crate::fs::FileManager::new()),
         settings: ExecutorSettings {
             project_directory,

--- a/rust/kcl-lib/src/execution/modeling.rs
+++ b/rust/kcl-lib/src/execution/modeling.rs
@@ -97,7 +97,10 @@ impl ExecState {
             range: meta.source_range,
             command: cmd.clone(),
         });
-        meta.ctx.engine.batch_modeling_cmd(id, meta.source_range, &cmd).await
+        meta.ctx
+            .engine
+            .batch_modeling_cmd(&meta.ctx.engine_batch, id, meta.source_range, &cmd)
+            .await
     }
 
     /// Add multiple modeling commands to the batch but don't fire them right
@@ -118,7 +121,10 @@ impl ExecState {
                 command: cmd_req.cmd.clone(),
             });
         }
-        meta.ctx.engine.batch_modeling_cmds(meta.source_range, cmds).await
+        meta.ctx
+            .engine
+            .batch_modeling_cmds(&meta.ctx.engine_batch, meta.source_range, cmds)
+            .await
     }
 
     /// Add a modeling command to the batch that gets executed at the end of the
@@ -141,7 +147,10 @@ impl ExecState {
             range: meta.source_range,
             command: cmd.clone(),
         });
-        meta.ctx.engine.batch_end_cmd(id, meta.source_range, &cmd).await
+        meta.ctx
+            .engine
+            .batch_end_cmd(&meta.ctx.engine_batch, id, meta.source_range, &cmd)
+            .await
     }
 
     /// Send the modeling cmd and wait for the response.
@@ -160,7 +169,10 @@ impl ExecState {
             range: meta.source_range,
             command: cmd.clone(),
         });
-        meta.ctx.engine.send_modeling_cmd(id, meta.source_range, &cmd).await
+        meta.ctx
+            .engine
+            .send_modeling_cmd(&meta.ctx.engine_batch, id, meta.source_range, &cmd)
+            .await
     }
 
     /// Send the modeling cmd async and don't wait for the response.
@@ -194,7 +206,10 @@ impl ExecState {
         if self.is_in_sketch_block() {
             return Err(no_modeling_in_sketch_block_error(meta.source_range));
         }
-        meta.ctx.engine.flush_batch(batch_end, meta.source_range).await
+        meta.ctx
+            .engine
+            .flush_batch(&meta.ctx.engine_batch, batch_end, meta.source_range)
+            .await
     }
 
     /// Flush just the fillets and chamfers for this specific SolidSet.
@@ -294,16 +309,8 @@ impl ExecState {
         }
 
         // We want to move these fillets and chamfers from batch_end to batch so they get executed
-        // before what ever we call next.
-        for id in ids {
-            // Pop it off the batch_end and add it to the batch.
-            let Some(item) = meta.ctx.engine.batch_end().write().await.shift_remove(&id) else {
-                // It might be in the batch already.
-                continue;
-            };
-            // Add it to the batch.
-            meta.ctx.engine.batch().write().await.push(item);
-        }
+        // before whatever we call next.
+        meta.ctx.engine_batch.move_batch_end_to_batch(ids).await;
 
         // Run flush.
         // Yes, we do need to actually flush the batch here, or references will fail later.

--- a/rust/kcl-lib/src/lib.rs
+++ b/rust/kcl-lib/src/lib.rs
@@ -91,6 +91,7 @@ mod wasm;
 
 pub use coredump::CoreDump;
 pub use engine::AsyncTasks;
+pub use engine::EngineBatchContext;
 pub use engine::EngineManager;
 pub use engine::EngineStats;
 pub use errors::BacktraceItem;

--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -328,6 +328,7 @@ async fn execute_and_export_impl(input: KclInput, export_format: FileExportForma
     let resp = ctx
         .engine
         .send_modeling_cmd(
+            &ctx.engine_batch,
             uuid::Uuid::new_v4(),
             kcl_lib::SourceRange::default(),
             &kittycad_modeling_cmds::ModelingCmd::Export(
@@ -524,7 +525,8 @@ async fn import(ctx: &ExecutorContext, filepaths: Vec<String>, format: InputForm
     let resp = ctx
         .engine
         .send_modeling_cmd(
-            Uuid::new_v4().into(),
+            &ctx.engine_batch,
+            Uuid::new_v4(),
             Default::default(),
             &kcmc::ModelingCmd::ImportFiles(kcmc::ImportFiles::builder().files(files).format(format).build()),
         )
@@ -681,12 +683,12 @@ async fn take_snaps(
             let view_cmd = kcmc::DefaultCameraLookAt::from(camera);
             let view_cmd = kcmc::ModelingCmd::DefaultCameraLookAt(view_cmd);
             ctx.engine
-                .send_modeling_cmd(uuid::Uuid::new_v4(), Default::default(), &view_cmd)
+                .send_modeling_cmd(&ctx.engine_batch, uuid::Uuid::new_v4(), Default::default(), &view_cmd)
                 .await?;
         } else {
             let view_cmd = kcmc::ModelingCmd::ViewIsometric(kcmc::ViewIsometric::builder().padding(0.0).build());
             ctx.engine
-                .send_modeling_cmd(uuid::Uuid::new_v4(), Default::default(), &view_cmd)
+                .send_modeling_cmd(&ctx.engine_batch, uuid::Uuid::new_v4(), Default::default(), &view_cmd)
                 .await?;
         }
         let data_bytes = snapshot(ctx, image_format, pre_snap.padding, zoom).await?;
@@ -699,6 +701,7 @@ async fn snapshot(ctx: &ExecutorContext, image_format: ImageFormat, padding: f32
     // Set orthographic projection
     ctx.engine
         .send_modeling_cmd(
+            &ctx.engine_batch,
             uuid::Uuid::new_v4(),
             kcl_lib::SourceRange::default(),
             &kittycad_modeling_cmds::ModelingCmd::DefaultCameraSetOrthographic(
@@ -711,6 +714,7 @@ async fn snapshot(ctx: &ExecutorContext, image_format: ImageFormat, padding: f32
     if zoom {
         ctx.engine
             .send_modeling_cmd(
+                &ctx.engine_batch,
                 uuid::Uuid::new_v4(),
                 kcl_lib::SourceRange::default(),
                 &kittycad_modeling_cmds::ModelingCmd::ZoomToFit(
@@ -728,6 +732,7 @@ async fn snapshot(ctx: &ExecutorContext, image_format: ImageFormat, padding: f32
     let resp = ctx
         .engine
         .send_modeling_cmd(
+            &ctx.engine_batch,
             uuid::Uuid::new_v4(),
             kcl_lib::SourceRange::default(),
             &kittycad_modeling_cmds::ModelingCmd::TakeSnapshot(
@@ -768,6 +773,7 @@ async fn measure_model_properties(
         let volume_resp = ctx
             .engine
             .send_modeling_cmd(
+                &ctx.engine_batch,
                 uuid::Uuid::new_v4(),
                 kcl_lib::SourceRange::default(),
                 &ModelingCmd::from(volume_req),
@@ -788,6 +794,7 @@ async fn measure_model_properties(
         let mass_resp = ctx
             .engine
             .send_modeling_cmd(
+                &ctx.engine_batch,
                 uuid::Uuid::new_v4(),
                 kcl_lib::SourceRange::default(),
                 &ModelingCmd::from(mass_req),
@@ -808,6 +815,7 @@ async fn measure_model_properties(
         let center_of_mass_resp = ctx
             .engine
             .send_modeling_cmd(
+                &ctx.engine_batch,
                 uuid::Uuid::new_v4(),
                 kcl_lib::SourceRange::default(),
                 &ModelingCmd::from(center_of_mass_req),
@@ -828,6 +836,7 @@ async fn measure_model_properties(
         let density_resp = ctx
             .engine
             .send_modeling_cmd(
+                &ctx.engine_batch,
                 uuid::Uuid::new_v4(),
                 kcl_lib::SourceRange::default(),
                 &ModelingCmd::from(density_req),
@@ -848,6 +857,7 @@ async fn measure_model_properties(
         let surface_area_resp = ctx
             .engine
             .send_modeling_cmd(
+                &ctx.engine_batch,
                 uuid::Uuid::new_v4(),
                 kcl_lib::SourceRange::default(),
                 &ModelingCmd::from(surface_area_req),
@@ -868,6 +878,7 @@ async fn measure_model_properties(
         let bb_resp = ctx
             .engine
             .send_modeling_cmd(
+                &ctx.engine_batch,
                 uuid::Uuid::new_v4(),
                 kcl_lib::SourceRange::default(),
                 &ModelingCmd::from(bb_req),
@@ -895,6 +906,7 @@ async fn get_bounding_box(
     let bounding_box_resp = ctx
         .engine
         .send_modeling_cmd(
+            &ctx.engine_batch,
             uuid::Uuid::new_v4(),
             kcl_lib::SourceRange::default(),
             &ModelingCmd::from(

--- a/rust/kcl-to-core/src/conn_mock_core.rs
+++ b/rust/kcl-to-core/src/conn_mock_core.rs
@@ -25,8 +25,6 @@ const CPP_PREFIX: &str = "const double scaleFactor = 100;\n";
 
 #[derive(Debug, Clone)]
 pub struct EngineConnection {
-    batch: Arc<RwLock<Vec<(WebSocketRequest, kcl_lib::SourceRange)>>>,
-    batch_end: Arc<RwLock<IndexMap<uuid::Uuid, (WebSocketRequest, kcl_lib::SourceRange)>>>,
     core_test: Arc<RwLock<String>>,
     ids_of_async_commands: Arc<RwLock<IndexMap<Uuid, kcl_lib::SourceRange>>>,
     /// The default planes for the scene.
@@ -40,8 +38,6 @@ impl EngineConnection {
         result.write().await.push_str(CPP_PREFIX);
 
         Ok(EngineConnection {
-            batch: Arc::new(RwLock::new(Vec::new())),
-            batch_end: Arc::new(RwLock::new(IndexMap::new())),
             core_test: result,
             default_planes: Default::default(),
             ids_of_async_commands: Arc::new(RwLock::new(IndexMap::new())),
@@ -376,14 +372,6 @@ fn codegen_cpp_repl_uuid_setters(reps_id: &str, entity_ids: &[uuid::Uuid]) -> St
 
 #[async_trait::async_trait]
 impl kcl_lib::EngineManager for EngineConnection {
-    fn batch(&self) -> Arc<RwLock<Vec<(WebSocketRequest, kcl_lib::SourceRange)>>> {
-        self.batch.clone()
-    }
-
-    fn batch_end(&self) -> Arc<RwLock<IndexMap<uuid::Uuid, (WebSocketRequest, kcl_lib::SourceRange)>>> {
-        self.batch_end.clone()
-    }
-
     fn responses(&self) -> Arc<RwLock<IndexMap<Uuid, WebSocketResponse>>> {
         Arc::new(RwLock::new(IndexMap::new()))
     }
@@ -406,6 +394,7 @@ impl kcl_lib::EngineManager for EngineConnection {
 
     async fn clear_scene_post_hook(
         &self,
+        _batch_context: &kcl_lib::EngineBatchContext,
         _id_generator: &mut IdGenerator,
         _source_range: kcl_lib::SourceRange,
     ) -> Result<(), KclError> {


### PR DESCRIPTION
This fixes a race condition where having multiple KCL modules would cause an "Object not found" engine error.