### PR TITLE
Fallback to https://zoo.dev/docs when `${BASE_URL}/docs` fails

### DIFF
--- a/src/lib/openWindow.test.ts
+++ b/src/lib/openWindow.test.ts
@@ -6,56 +6,16 @@ describe('getExternalURLWithDocsFallback', () => {
     vi.restoreAllMocks()
   })
 
-  it('returns the configured docs URL when it fetches successfully', async () => {
+  it('falls back to production docs when the configured docs URL fails', async () => {
     const fetchMock = vi
       .spyOn(globalThis, 'fetch')
-      .mockResolvedValue(new Response())
+      .mockRejectedValue(new Error('Failed to fetch'))
 
     await expect(
       getExternalURLWithDocsFallback('https://dev.zoo.dev/docs')
-    ).resolves.toBe('https://dev.zoo.dev/docs')
+    ).resolves.toBe('https://zoo.dev/docs')
     expect(fetchMock).toHaveBeenCalledWith('https://dev.zoo.dev/docs', {
       method: 'HEAD',
     })
-  })
-
-  it('falls back to production docs when the configured docs URL returns an error status', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(null, { status: 404 })
-    )
-
-    await expect(
-      getExternalURLWithDocsFallback('https://dev.zoo.dev/docs')
-    ).resolves.toBe('https://zoo.dev/docs')
-  })
-
-  it('falls back to production docs when the configured docs URL fails to fetch', async () => {
-    vi.spyOn(globalThis, 'fetch').mockRejectedValue(
-      new Error('Failed to fetch')
-    )
-
-    await expect(
-      getExternalURLWithDocsFallback('https://dev.zoo.dev/docs')
-    ).resolves.toBe('https://zoo.dev/docs')
-  })
-
-  it('does not fetch deeper docs URLs', async () => {
-    const fetchMock = vi.spyOn(globalThis, 'fetch')
-
-    await expect(
-      getExternalURLWithDocsFallback(
-        'https://dev.zoo.dev/docs/kcl-lang?tab=all#types'
-      )
-    ).resolves.toBe('https://dev.zoo.dev/docs/kcl-lang?tab=all#types')
-    expect(fetchMock).not.toHaveBeenCalled()
-  })
-
-  it('does not fetch non-docs URLs', async () => {
-    const fetchMock = vi.spyOn(globalThis, 'fetch')
-
-    await expect(
-      getExternalURLWithDocsFallback('https://dev.zoo.dev/account')
-    ).resolves.toBe('https://dev.zoo.dev/account')
-    expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/openWindow.test.ts
+++ b/src/lib/openWindow.test.ts
@@ -16,8 +16,17 @@ describe('getExternalURLWithDocsFallback', () => {
     ).resolves.toBe('https://dev.zoo.dev/docs')
     expect(fetchMock).toHaveBeenCalledWith('https://dev.zoo.dev/docs', {
       method: 'HEAD',
-      mode: 'no-cors',
     })
+  })
+
+  it('falls back to production docs when the configured docs URL returns an error status', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 404 })
+    )
+
+    await expect(
+      getExternalURLWithDocsFallback('https://dev.zoo.dev/docs')
+    ).resolves.toBe('https://zoo.dev/docs')
   })
 
   it('falls back to production docs when the configured docs URL fails to fetch', async () => {

--- a/src/lib/openWindow.test.ts
+++ b/src/lib/openWindow.test.ts
@@ -1,0 +1,52 @@
+import { getExternalURLWithDocsFallback } from '@src/lib/openWindow'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('getExternalURLWithDocsFallback', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns the configured docs URL when it fetches successfully', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response())
+
+    await expect(
+      getExternalURLWithDocsFallback('https://dev.zoo.dev/docs')
+    ).resolves.toBe('https://dev.zoo.dev/docs')
+    expect(fetchMock).toHaveBeenCalledWith('https://dev.zoo.dev/docs', {
+      method: 'HEAD',
+      mode: 'no-cors',
+    })
+  })
+
+  it('falls back to production docs when the configured docs URL fails to fetch', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+      new Error('Failed to fetch')
+    )
+
+    await expect(
+      getExternalURLWithDocsFallback('https://dev.zoo.dev/docs')
+    ).resolves.toBe('https://zoo.dev/docs')
+  })
+
+  it('does not fetch deeper docs URLs', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+
+    await expect(
+      getExternalURLWithDocsFallback(
+        'https://dev.zoo.dev/docs/kcl-lang?tab=all#types'
+      )
+    ).resolves.toBe('https://dev.zoo.dev/docs/kcl-lang?tab=all#types')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch non-docs URLs', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+
+    await expect(
+      getExternalURLWithDocsFallback('https://dev.zoo.dev/account')
+    ).resolves.toBe('https://dev.zoo.dev/account')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/openWindow.ts
+++ b/src/lib/openWindow.ts
@@ -41,14 +41,13 @@ export async function getExternalURLWithDocsFallback(
     return url
   }
 
-  // Don't bother with fetch check if they're the same.
-  if (parsedURL.href === docsFallbackURL) {
+  if (parsedURL.href === docsFallbackURL || parsedURL.pathname !== '/docs') {
     return url
   }
 
   try {
-    await fetch(url, { method: 'HEAD', mode: 'no-cors' })
-    return url
+    const response = await fetch(url, { method: 'HEAD' })
+    return response.ok ? url : docsFallbackURL
   } catch {
     return docsFallbackURL
   }

--- a/src/lib/openWindow.ts
+++ b/src/lib/openWindow.ts
@@ -1,25 +1,55 @@
 import type { MouseEventHandler } from 'react'
 
+import { generateDomainsFromBaseDomain } from '@src/env'
 import { reportRejection } from '@src/lib/trap'
 
+const docsFallbackURL = `${generateDomainsFromBaseDomain('zoo.dev').SITE_URL}/docs`
+
 export const openExternalBrowserIfDesktop = (to?: string) =>
-  function (e) {
+  async function (e) {
     if (window.electron) {
       // currentTarget could be a few different things
-      window.electron
-        .openExternal(to || e.currentTarget?.href)
-        .catch(reportRejection)
       e.preventDefault()
       e.stopPropagation()
+      const targetURL = to || e.currentTarget?.href
+      if (!targetURL) {
+        return false
+      }
+      const url = await getExternalURLWithDocsFallback(targetURL)
+      window.electron.openExternal(url).catch(reportRejection)
       return false
     }
   } as MouseEventHandler<HTMLAnchorElement>
 
 // Open a new browser window desktop style or browser style.
 export default async function openWindow(url: string) {
+  const reachableURL = await getExternalURLWithDocsFallback(url)
   if (window.electron) {
-    await window.electron.openExternal(url)
+    await window.electron.openExternal(reachableURL)
   } else {
-    window.open(url, '_blank')
+    window.open(reachableURL, '_blank')
+  }
+}
+
+export async function getExternalURLWithDocsFallback(
+  url: string
+): Promise<string> {
+  let parsedURL: URL
+  try {
+    parsedURL = new URL(url)
+  } catch {
+    return url
+  }
+
+  // Don't bother with fetch check if they're the same.
+  if (parsedURL.href === docsFallbackURL) {
+    return url
+  }
+
+  try {
+    await fetch(url, { method: 'HEAD', mode: 'no-cors' })
+    return url
+  } catch {
+    return docsFallbackURL
   }
 }


### PR DESCRIPTION
Hit at Tatonka