### PR TITLE
Fix stale sketch editor execution overwrites

### DIFF
--- a/e2e/playwright/sketch-solve-edit.spec.ts
+++ b/e2e/playwright/sketch-solve-edit.spec.ts
@@ -723,6 +723,164 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
     })
   })
 
+  test('keeps newer copied sketch block edits when stale execution finishes', async ({
+    page,
+    context,
+    homePage,
+    scene,
+    cmdBar,
+    editor,
+    toolbar,
+  }) => {
+    const INITIAL_CODE = `sketch001 = sketch(on = XY) {
+  line1 = line(start = [var 0mm, var 0mm], end = [var 10mm, var 0mm])
+}
+`
+    const copiedLine =
+      '  line2 = line(start = [var 10mm, var 0mm], end = [var 10mm, var 5mm])'
+    const editedLine =
+      '  line2 = line(start = [var 10mm, var 0mm], end = [var 10mm, var 8mm])'
+    const getWriteToFileCalls = async () =>
+      page.evaluate(() => {
+        const calls = Reflect.get(window, 'kclWriteToFileCallsForTest')
+        if (!Array.isArray(calls)) return []
+        return calls.filter((call): call is string => typeof call === 'string')
+      })
+
+    await test.step('Set up a sketch and enter sketch edit mode', async () => {
+      await context.addInitScript(
+        async ({ code }) => {
+          localStorage.setItem('persistCode', code)
+        },
+        {
+          code: INITIAL_CODE,
+        }
+      )
+
+      await page.setBodyDimensions({ width: 1200, height: 600 })
+      await homePage.goToModelingScene()
+      await scene.settled(cmdBar)
+      await editor.expectEditor.toContain('sketch001 = sketch(on = XY) {')
+
+      await toolbar.openFeatureTreePane()
+      await expect(page.getByText('Building feature tree')).not.toBeVisible({
+        timeout: 10000,
+      })
+      const sketchOperation = await toolbar.getFeatureTreeOperation(
+        'sketch001',
+        0
+      )
+      await sketchOperation.dblclick()
+      await page.waitForTimeout(600)
+      await expect(toolbar.exitSketchBtn).toBeEnabled()
+    })
+
+    await test.step('Delay the next sketch execution and observe editor saves', async () => {
+      await page.evaluate(() => {
+        const writeToFileCalls: string[] = []
+        const originalWriteToFile = window.kclManager.writeToFile.bind(
+          window.kclManager
+        )
+        /*
+         * This is only a spy on the save path. The test still edits through
+         * CodeMirror with editor.replaceCodeByTyping, so CodeMirror decides when
+         * to write. Recording writeToFile calls here proves raw typing still
+         * reaches the normal save listener, and that the delayed execution does
+         * not add a stale out-of-band save afterward.
+         */
+        window.kclManager.writeToFile = (async (
+          ...args: Parameters<typeof window.kclManager.writeToFile>
+        ) => {
+          const [newCode = window.kclManager.code] = args
+          writeToFileCalls.push(newCode)
+          return originalWriteToFile(...args)
+        }) satisfies typeof window.kclManager.writeToFile
+        Reflect.set(window, 'kclWriteToFileCallsForTest', writeToFileCalls)
+
+        const originalHackSetProgram = window.rustContext.hackSetProgram.bind(
+          window.rustContext
+        )
+        let shouldDelayNextHackSetProgram = true
+        let releaseDelayedHackSetProgram: (() => void) | undefined
+
+        window.addEventListener('release-delayed-sketch-execution', () => {
+          releaseDelayedHackSetProgram?.()
+        })
+
+        const delayedHackSetProgram: typeof window.rustContext.hackSetProgram =
+          async (...args) => {
+            if (shouldDelayNextHackSetProgram) {
+              shouldDelayNextHackSetProgram = false
+              window.dispatchEvent(
+                new Event('delayed-sketch-execution-started')
+              )
+              await new Promise<void>((resolve) => {
+                releaseDelayedHackSetProgram = resolve
+              })
+            }
+
+            return originalHackSetProgram(...args)
+          }
+
+        window.rustContext.hackSetProgram = delayedHackSetProgram
+      })
+    })
+
+    await test.step('Copy a sketch line, then edit its endpoint before execution returns', async () => {
+      const delayedExecutionStarted = page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            window.addEventListener(
+              'delayed-sketch-execution-started',
+              () => resolve(),
+              { once: true }
+            )
+          })
+      )
+
+      await editor.replaceCodeByTyping('\n}', `\n${copiedLine}\n}`)
+      await delayedExecutionStarted
+      await editor.expectEditor.toContain(copiedLine)
+
+      await editor.replaceCodeByTyping(
+        'end = [var 10mm, var 5mm]',
+        'end = [var 10mm, var 8mm]'
+      )
+      await editor.expectEditor.toContain(editedLine)
+
+      await expect
+        .poll(async () => {
+          const writeToFileCalls = await getWriteToFileCalls()
+          return writeToFileCalls.at(-1) ?? ''
+        })
+        .toContain(editedLine)
+      const writeToFileCountBeforeStaleExecutionReturns = (
+        await getWriteToFileCalls()
+      ).length
+
+      await page.evaluate(() => {
+        window.dispatchEvent(new Event('release-delayed-sketch-execution'))
+      })
+      await page.waitForTimeout(100)
+
+      const writeToFileCallsAfterStaleExecutionReturns =
+        await getWriteToFileCalls()
+      expect(writeToFileCallsAfterStaleExecutionReturns).toHaveLength(
+        writeToFileCountBeforeStaleExecutionReturns
+      )
+      expect(writeToFileCallsAfterStaleExecutionReturns.at(-1)).toContain(
+        editedLine
+      )
+    })
+
+    await test.step('The newer endpoint value should still be in the editor', async () => {
+      const currentCode = await editor.getCurrentCode()
+
+      expect(currentCode).toContain(editedLine)
+      expect(currentCode).not.toContain(copiedLine)
+    })
+  })
+
   test('undoing center arcs removes one arc at a time in sketch solve mode', async ({
     page,
     context,

--- a/e2e/playwright/sketch-solve-edit.spec.ts
+++ b/e2e/playwright/sketch-solve-edit.spec.ts
@@ -724,6 +724,146 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
     })
   })
 
+  test('treats fresh direct editor sketch executions as derived source updates', async ({
+    page,
+    context,
+    homePage,
+    scene,
+    cmdBar,
+    editor,
+    toolbar,
+  }) => {
+    const INITIAL_CODE = `sketch001 = sketch(on = XY) {
+  line1 = line(start = [var 0mm, var 0mm], end = [var 10mm, var 0mm])
+}
+`
+    const addedLine =
+      '  line2 = line(start = [var 10mm, var 0mm], end = [var 10mm, var 5mm])'
+    const getDirectEditorOutcomeForLine = async (line: string) =>
+      page.evaluate((expectedLine) => {
+        const events = Reflect.get(window, 'directEditorOutcomesForTest')
+        if (!Array.isArray(events)) return null
+        return (
+          events.find(
+            (
+              event
+            ): event is {
+              sourceText: string
+              updateEditor: unknown
+              writeToDisk: unknown
+              addToHistory: unknown
+            } =>
+              typeof event === 'object' &&
+              event !== null &&
+              'sourceText' in event &&
+              typeof event.sourceText === 'string' &&
+              event.sourceText.includes(expectedLine)
+          ) ?? null
+        )
+      }, line)
+    const getUpdateCodeEditorCalls = async () =>
+      page.evaluate(() => {
+        const calls = Reflect.get(window, 'updateCodeEditorCallsForTest')
+        if (!Array.isArray(calls)) return []
+        return calls.filter((call): call is string => typeof call === 'string')
+      })
+
+    await test.step('Set up a sketch and enter sketch edit mode', async () => {
+      await context.addInitScript(
+        async ({ code }) => {
+          localStorage.setItem('persistCode', code)
+        },
+        {
+          code: INITIAL_CODE,
+        }
+      )
+
+      await page.setBodyDimensions({ width: 1200, height: 600 })
+      await homePage.goToModelingScene()
+      await scene.settled(cmdBar)
+      await editor.expectEditor.toContain('sketch001 = sketch(on = XY) {')
+
+      await toolbar.openFeatureTreePane()
+      await expect(page.getByText('Building feature tree')).not.toBeVisible({
+        timeout: 10000,
+      })
+      const sketchOperation = await toolbar.getFeatureTreeOperation(
+        'sketch001',
+        0
+      )
+      await sketchOperation.dblclick()
+      await page.waitForTimeout(600)
+      await expect(toolbar.exitSketchBtn).toBeEnabled()
+    })
+
+    await test.step('Observe the fresh direct-editor execution result', async () => {
+      await page.evaluate(() => {
+        const directEditorOutcomes: Array<{
+          sourceText: string
+          updateEditor: unknown
+          writeToDisk: unknown
+          addToHistory: unknown
+        }> = []
+        const updateCodeEditorCalls: string[] = []
+
+        const originalSendModelingEvent =
+          window.kclManager.sendModelingEvent.bind(window.kclManager)
+        window.kclManager.sendModelingEvent = ((
+          ...args: Parameters<typeof window.kclManager.sendModelingEvent>
+        ) => {
+          const [event] = args
+          if (event.type === 'update sketch outcome') {
+            directEditorOutcomes.push({
+              sourceText: event.data.sourceDelta.text,
+              updateEditor: event.data.updateEditor,
+              writeToDisk: event.data.writeToDisk,
+              addToHistory: event.data.addToHistory,
+            })
+          }
+
+          return originalSendModelingEvent(...args)
+        }) satisfies typeof window.kclManager.sendModelingEvent
+
+        const originalUpdateCodeEditor =
+          window.kclManager.updateCodeEditor.bind(window.kclManager)
+        window.kclManager.updateCodeEditor = ((
+          ...args: Parameters<typeof window.kclManager.updateCodeEditor>
+        ) => {
+          const [code] = args
+          updateCodeEditorCalls.push(code)
+          return originalUpdateCodeEditor(...args)
+        }) satisfies typeof window.kclManager.updateCodeEditor
+
+        Reflect.set(window, 'directEditorOutcomesForTest', directEditorOutcomes)
+        Reflect.set(
+          window,
+          'updateCodeEditorCallsForTest',
+          updateCodeEditorCalls
+        )
+      })
+    })
+
+    await test.step('Type KCL and let its current execution finish', async () => {
+      await editor.replaceCodeByTyping('\n}', `\n${addedLine}\n}`)
+      await editor.expectEditor.toContain(addedLine)
+
+      await expect
+        .poll(async () => getDirectEditorOutcomeForLine(addedLine))
+        .toEqual({
+          sourceText: expect.stringContaining(addedLine),
+          updateEditor: false,
+          writeToDisk: false,
+          addToHistory: false,
+        })
+
+      const updateCodeEditorCalls = await getUpdateCodeEditorCalls()
+      expect(
+        updateCodeEditorCalls.some((code) => code.includes(addedLine))
+      ).toBe(false)
+      await editor.expectEditor.toContain(addedLine)
+    })
+  })
+
   test('keeps newer copied sketch block edits when stale execution finishes', async ({
     page,
     context,

--- a/e2e/playwright/sketch-solve-edit.spec.ts
+++ b/e2e/playwright/sketch-solve-edit.spec.ts
@@ -739,34 +739,34 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
 `
     const addedLine =
       '  line2 = line(start = [var 10mm, var 0mm], end = [var 10mm, var 5mm])'
-    const getDirectEditorOutcomeForLine = async (line: string) =>
-      page.evaluate((expectedLine) => {
-        const events = Reflect.get(window, 'directEditorOutcomesForTest')
-        if (!Array.isArray(events)) return null
-        return (
-          events.find(
-            (
-              event
-            ): event is {
-              sourceText: string
-              updateEditor: unknown
-              writeToDisk: unknown
-              addToHistory: unknown
-            } =>
-              typeof event === 'object' &&
-              event !== null &&
-              'sourceText' in event &&
-              typeof event.sourceText === 'string' &&
-              event.sourceText.includes(expectedLine)
-          ) ?? null
-        )
-      }, line)
-    const getUpdateCodeEditorCalls = async () =>
-      page.evaluate(() => {
-        const calls = Reflect.get(window, 'updateCodeEditorCallsForTest')
-        if (!Array.isArray(calls)) return []
-        return calls.filter((call): call is string => typeof call === 'string')
-      })
+    const isDirectEditorOutcome = (
+      event: unknown
+    ): event is {
+      sourceText: string
+      updateEditor: unknown
+      writeToDisk: unknown
+      addToHistory: unknown
+    } =>
+      typeof event === 'object' &&
+      event !== null &&
+      'sourceText' in event &&
+      typeof event.sourceText === 'string'
+    const getDirectEditorOutcomeForLine = async (line: string) => {
+      const events = await page.evaluate(() =>
+        Reflect.get(window, 'directEditorOutcomesForTest')
+      )
+      if (!isArray(events)) return null
+      return events
+        .filter(isDirectEditorOutcome)
+        .find((event) => event.sourceText.includes(line))
+    }
+    const getUpdateCodeEditorCalls = async () => {
+      const calls = await page.evaluate(() =>
+        Reflect.get(window, 'updateCodeEditorCallsForTest')
+      )
+      if (!isArray(calls)) return []
+      return calls.filter((call): call is string => typeof call === 'string')
+    }
 
     await test.step('Set up a sketch and enter sketch edit mode', async () => {
       await context.addInitScript(

--- a/e2e/playwright/sketch-solve-edit.spec.ts
+++ b/e2e/playwright/sketch-solve-edit.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@e2e/playwright/zoo-test'
 import type { Page } from '@playwright/test'
 import type { SceneFixture } from '@e2e/playwright/fixtures/sceneFixture'
+import { isArray } from '@src/lib/utils'
 
 /**
  * Extract a specific line from code string (1-based line number).
@@ -740,12 +741,13 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
       '  line2 = line(start = [var 10mm, var 0mm], end = [var 10mm, var 5mm])'
     const editedLine =
       '  line2 = line(start = [var 10mm, var 0mm], end = [var 10mm, var 8mm])'
-    const getWriteToFileCalls = async () =>
-      page.evaluate(() => {
-        const calls = Reflect.get(window, 'kclWriteToFileCallsForTest')
-        if (!Array.isArray(calls)) return []
-        return calls.filter((call): call is string => typeof call === 'string')
-      })
+    const getWriteToFileCalls = async () => {
+      const calls = await page.evaluate(() =>
+        Reflect.get(window, 'kclWriteToFileCallsForTest')
+      )
+      if (!isArray(calls)) return []
+      return calls.filter((call): call is string => typeof call === 'string')
+    }
 
     await test.step('Set up a sketch and enter sketch edit mode', async () => {
       await context.addInitScript(

--- a/src/components/CommandBar/CommandArgOptionInput.tsx
+++ b/src/components/CommandBar/CommandArgOptionInput.tsx
@@ -47,7 +47,7 @@ function CommandArgOptionInput({
   )
   const inputRef = useRef<HTMLInputElement>(null)
   const formRef = useRef<HTMLFormElement>(null)
-  const [shouldSubmitOnChange, setShouldSubmitOnChange] = useState(false)
+  const shouldSubmitOnChange = useRef(false)
   const [selectedOption, setSelectedOption] = useState<
     CommandArgumentOption<unknown>
   >(currentOption || resolvedOptions[0])
@@ -104,7 +104,8 @@ function CommandArgOptionInput({
     setSelectedOption(option)
 
     // But we only submit the value itself
-    if (shouldSubmitOnChange) {
+    if (shouldSubmitOnChange.current) {
+      shouldSubmitOnChange.current = false
       onSubmit(option.value)
     }
   }
@@ -123,9 +124,9 @@ function CommandArgOptionInput({
       ref={formRef}
       onKeyDownCapture={(e) => {
         if (e.key === 'Enter') {
-          setShouldSubmitOnChange(true)
+          shouldSubmitOnChange.current = true
         } else {
-          setShouldSubmitOnChange(false)
+          shouldSubmitOnChange.current = false
         }
       }}
     >
@@ -158,9 +159,9 @@ function CommandArgOptionInput({
               }
 
               if (event.key === 'Enter') {
-                setShouldSubmitOnChange(true)
+                shouldSubmitOnChange.current = true
               } else {
-                setShouldSubmitOnChange(false)
+                shouldSubmitOnChange.current = false
               }
             }}
             value={query}
@@ -182,7 +183,7 @@ function CommandArgOptionInput({
             static
             className="overflow-y-auto max-h-96 cursor-pointer"
             onMouseDown={() => {
-              setShouldSubmitOnChange(true)
+              shouldSubmitOnChange.current = true
             }}
           >
             {filteredOptions?.map((option) => (

--- a/src/lang/KclManager.spec.ts
+++ b/src/lang/KclManager.spec.ts
@@ -46,6 +46,24 @@ function createDiagnostic(
   }
 }
 
+function createEmptySceneGraphDelta(): SceneGraphDelta {
+  return {
+    new_graph: [] as unknown as SceneGraphDelta['new_graph'],
+    new_objects: [],
+    invalidates_ids: true,
+    exec_outcome: [] as unknown as SceneGraphDelta['exec_outcome'],
+  }
+}
+
+function enableSketchSolveEditorExecution(kclManager: KclManager) {
+  kclManager.modelingState = {
+    matches: (value: unknown) => value === 'sketchSolveMode',
+  } as unknown as KclManager['modelingState']
+  kclManager.engineCommandManager.connection = {
+    connected: true,
+  } as unknown as typeof kclManager.engineCommandManager.connection
+}
+
 afterEach(() => {
   vi.clearAllMocks()
   vi.clearAllTimers()
@@ -320,6 +338,118 @@ describe('KclManager diagnostics', () => {
     })
 
     expect(kclManager.hasEditsSinceLastExecutionSignal.value).toBe(false)
+  })
+
+  it('marks fresh direct sketch editor executions as derived source updates', async () => {
+    vi.useFakeTimers()
+
+    const { kclManager } = createKclManagerTestHarness('base')
+    const sceneGraphDelta = createEmptySceneGraphDelta()
+    const checkpointId = 55
+    const modelingSendSpy = vi.fn()
+    enableSketchSolveEditorExecution(kclManager)
+    kclManager.modelingSend = modelingSendSpy
+
+    vi.spyOn(kclManager, 'executeCode').mockResolvedValue(undefined)
+    vi.spyOn(kclManager.rustContext, 'hackSetProgram').mockResolvedValue({
+      type: 'Success',
+      sceneGraph: sceneGraphDelta.new_graph,
+      execOutcome: sceneGraphDelta.exec_outcome,
+      checkpointId,
+    } as Awaited<ReturnType<typeof kclManager.rustContext.hackSetProgram>>)
+
+    kclManager.editorView.dispatch({
+      changes: { from: 4, to: 4, insert: ' fresh' },
+    })
+
+    await vi.advanceTimersByTimeAsync(1000)
+    await flushPromises()
+
+    expect(modelingSendSpy).toHaveBeenCalledTimes(1)
+    expect(modelingSendSpy).toHaveBeenCalledWith({
+      type: 'update sketch outcome',
+      data: {
+        sourceDelta: { text: 'base fresh' },
+        sceneGraphDelta,
+        updateEditor: false,
+        writeToDisk: false,
+        addToHistory: false,
+        checkpointId,
+      },
+    })
+  })
+
+  it('drops direct sketch editor executions that go stale while parsing executes', async () => {
+    vi.useFakeTimers()
+
+    const { kclManager } = createKclManagerTestHarness('base')
+    const deferredExecution = createDeferred<undefined>()
+    const modelingSendSpy = vi.fn()
+    enableSketchSolveEditorExecution(kclManager)
+    kclManager.modelingSend = modelingSendSpy
+
+    vi.spyOn(kclManager, 'executeCode').mockReturnValue(
+      deferredExecution.promise
+    )
+    const hackSetProgramSpy = vi.spyOn(kclManager.rustContext, 'hackSetProgram')
+
+    kclManager.editorView.dispatch({
+      changes: { from: 4, to: 4, insert: ' stale' },
+    })
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(kclManager.code).toBe('base stale')
+
+    kclManager.editorView.dispatch({
+      changes: { from: 10, to: 10, insert: ' newer' },
+    })
+    deferredExecution.resolve(undefined)
+    await flushPromises()
+
+    expect(kclManager.code).toBe('base stale newer')
+    expect(hackSetProgramSpy).not.toHaveBeenCalled()
+    expect(modelingSendSpy).not.toHaveBeenCalled()
+  })
+
+  it('drops direct sketch editor executions that go stale while Rust updates the program', async () => {
+    vi.useFakeTimers()
+
+    const { kclManager } = createKclManagerTestHarness('base')
+    const sceneGraphDelta = createEmptySceneGraphDelta()
+    const deferredSetProgram =
+      createDeferred<
+        Awaited<ReturnType<typeof kclManager.rustContext.hackSetProgram>>
+      >()
+    const modelingSendSpy = vi.fn()
+    enableSketchSolveEditorExecution(kclManager)
+    kclManager.modelingSend = modelingSendSpy
+
+    vi.spyOn(kclManager, 'executeCode').mockResolvedValue(undefined)
+    const hackSetProgramSpy = vi
+      .spyOn(kclManager.rustContext, 'hackSetProgram')
+      .mockReturnValue(deferredSetProgram.promise)
+
+    kclManager.editorView.dispatch({
+      changes: { from: 4, to: 4, insert: ' stale' },
+    })
+
+    await vi.advanceTimersByTimeAsync(1000)
+    await flushPromises()
+    expect(hackSetProgramSpy).toHaveBeenCalledTimes(1)
+
+    kclManager.editorView.dispatch({
+      changes: { from: 10, to: 10, insert: ' newer' },
+    })
+    deferredSetProgram.resolve({
+      type: 'Success',
+      sceneGraph: sceneGraphDelta.new_graph,
+      execOutcome: sceneGraphDelta.exec_outcome,
+      checkpointId: 55,
+    } as Awaited<ReturnType<typeof kclManager.rustContext.hackSetProgram>>)
+    await flushPromises()
+
+    expect(kclManager.code).toBe('base stale newer')
+    expect(modelingSendSpy).not.toHaveBeenCalled()
   })
 
   it('debounces repeated programmatic updates so only the latest buffer is written', async () => {

--- a/src/lang/KclManager.spec.ts
+++ b/src/lang/KclManager.spec.ts
@@ -58,7 +58,7 @@ function createEmptySceneGraphDelta(): SceneGraphDelta {
 function enableSketchSolveEditorExecution(kclManager: KclManager) {
   kclManager.modelingState = {
     matches: (value: unknown) => value === 'sketchSolveMode',
-  } as unknown as KclManager['modelingState']
+  } as unknown as NonNullable<KclManager['modelingState']>
   kclManager.engineCommandManager.connection = {
     connected: true,
   } as unknown as typeof kclManager.engineCommandManager.connection

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -1225,7 +1225,11 @@ export class KclManager extends File {
       if (isDirectSketchHistoryReplay) return
       if (shouldSkipExecutionForAnnotation) return
 
-      this.deferredExecution({ newCode, shouldResetCamera })
+      this.deferredExecution({
+        newCode,
+        shouldResetCamera,
+        requestedUserDocumentVersion: this._userDocumentVersion,
+      })
     }
   })
 
@@ -1233,9 +1237,11 @@ export class KclManager extends File {
     async ({
       newCode,
       shouldResetCamera,
+      requestedUserDocumentVersion,
     }: {
       newCode: string
       shouldResetCamera: boolean
+      requestedUserDocumentVersion: number
     }) => {
       if (!this._automaticallyRenderEnabled) {
         return
@@ -1247,11 +1253,28 @@ export class KclManager extends File {
       // should be clean up.
       try {
         if (this.modelingState?.matches('sketchSolveMode')) {
+          const isCurrentDirectEditorExecution = () =>
+            requestedUserDocumentVersion === this._userDocumentVersion &&
+            this.code === newCode
+
+          /*
+           * Direct CodeMirror edits are already present in the editor before this
+           * async work starts. `newCode` is the snapshot we executed, not an
+           * authoritative edit we can replay later. If the user keeps typing while
+           * executeCode or hackSetProgram awaits, the finished result belongs to an
+           * older document and must not update scene checkpoints or be forwarded to
+           * updateSketchOutcome. That event is also used by sketch tools, where
+           * sourceDelta is real generated KCL; letting this stale editor snapshot
+           * take that path is what overwrote freshly typed sketch lines.
+           */
           await this.executeCode(newCode)
+          if (!isCurrentDirectEditorExecution()) return
+
           const setProgramOutcome = await this.rustContext.hackSetProgram(
             this.ast,
             jsAppSettings(this.systemDeps.settings)
           )
+          if (!isCurrentDirectEditorExecution()) return
 
           if (setProgramOutcome.type === 'Success') {
             // Convert SceneGraph to SceneGraphDelta and send to sketch solve machine
@@ -1302,6 +1325,8 @@ export class KclManager extends File {
               data: {
                 sourceDelta: kclSource,
                 sceneGraphDelta,
+                updateEditor: false,
+                writeToDisk: false,
                 addToHistory: false,
                 checkpointId: directEditCheckpointId,
               },
@@ -1489,6 +1514,7 @@ export class KclManager extends File {
             this.deferredExecution({
               newCode: effect.value.redoCode,
               shouldResetCamera: effect.value.options.shouldResetCamera,
+              requestedUserDocumentVersion: this._userDocumentVersion,
             })
           }
 

--- a/src/machines/sketchSolve/sketchSolveImpl.spec.ts
+++ b/src/machines/sketchSolve/sketchSolveImpl.spec.ts
@@ -1,12 +1,12 @@
+import { topLevelRange } from '@src/lang/util'
 import {
   sendToActorIfActive,
   updateHoveredId,
   updateSelectedCodeHighlight,
-  updateSelectedIdsFromCodeSelection,
   updateSelectedIds,
+  updateSelectedIdsFromCodeSelection,
   updateSketchOutcome,
 } from '@src/machines/sketchSolve/sketchSolveImpl'
-import { topLevelRange } from '@src/lang/util'
 import {
   createLineApiObject,
   createPointApiObject,
@@ -357,6 +357,45 @@ describe('updateSketchOutcome', () => {
     )
     expect(updateCodeEditor.mock.invocationCallOrder[0]).toBeLessThan(
       syncSketchSolveOutcome.mock.invocationCallOrder[0]
+    )
+  })
+
+  test('does not rewrite the editor for direct CodeMirror execution outcomes', () => {
+    const setSketchSolveDiagnostics = vi.fn()
+    const dispatch = vi.fn()
+    const updateCodeEditor = vi.fn()
+    const syncSketchSolveOutcome = vi.fn()
+    const sceneGraphDelta = createSceneGraphDelta([])
+
+    updateSketchOutcome({
+      context: {
+        kclManager: {
+          code: 'newer editor code',
+          dispatch,
+          setSketchSolveDiagnostics,
+          updateCodeEditor,
+          syncSketchSolveOutcome,
+        },
+        selectedIds: [],
+        duringAreaSelectIds: [],
+      },
+      event: {
+        type: 'update sketch outcome',
+        data: {
+          sourceDelta: { text: 'executed editor snapshot' },
+          sceneGraphDelta,
+          updateEditor: false,
+          writeToDisk: false,
+          addToHistory: false,
+        },
+      },
+    } as unknown as Parameters<typeof updateSketchOutcome>[0])
+
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    expect(updateCodeEditor).not.toHaveBeenCalled()
+    expect(syncSketchSolveOutcome).toHaveBeenCalledWith(
+      'executed editor snapshot',
+      sceneGraphDelta
     )
   })
 

--- a/src/machines/sketchSolve/sketchSolveImpl.ts
+++ b/src/machines/sketchSolve/sketchSolveImpl.ts
@@ -180,12 +180,22 @@ export type UpdateSketchOutcomeEvent = {
      */
     debounceEditorUpdate?: boolean
     /**
+     * Defaults to true because most sketch-solve outcomes come from point/click
+     * tools whose Rust-generated sourceDelta is the new source of truth. Direct
+     * CodeMirror executions set this false: their sourceDelta is only the
+     * already-typed snapshot that produced the sceneGraphDelta, so replaying it
+     * back into CodeMirror later can overwrite newer user edits.
+     */
+    updateEditor?: boolean
+    /**
      * Defaults to true. Set to false to skip persisting to disk, which is useful
      * for high-frequency preview/drag updates.
      */
     writeToDisk?: boolean
     /**
-     * Defaults to the same value as `writeToDisk`.
+     * Defaults to the same value as `writeToDisk` when `updateEditor` is true.
+     * Ignored when `updateEditor` is false because there is no editor write to
+     * attach a history entry to.
      */
     addToHistory?: boolean
     checkpointId?: number | null
@@ -1274,13 +1284,21 @@ export function updateSketchOutcome({ event, context }: SolveAssignArgs) {
     ],
   }
 
-  const shouldWriteToDisk = event.data.writeToDisk !== false
-  const shouldAddToHistory = event.data.addToHistory ?? shouldWriteToDisk
+  const shouldUpdateEditor = event.data.updateEditor !== false
+  // Disk/history writes are coupled to editor writes here. When an outcome is
+  // derived from direct editor text, the file already follows the editor through
+  // the normal CodeMirror listener, and this async outcome may be older than the
+  // current document. Never let that snapshot become a second writer.
+  const shouldWriteToDisk =
+    shouldUpdateEditor && event.data.writeToDisk !== false
+  const shouldAddToHistory =
+    shouldUpdateEditor && (event.data.addToHistory ?? shouldWriteToDisk)
   const isCheckpointOnlyCommit =
     shouldAddToHistory &&
     event.data.checkpointId != null &&
     context.kclManager.code === event.data.sourceDelta.text
   const shouldDispatchSceneImmediately =
+    !shouldUpdateEditor ||
     context.kclManager.code !== event.data.sourceDelta.text ||
     isCheckpointOnlyCommit
 
@@ -1300,6 +1318,28 @@ export function updateSketchOutcome({ event, context }: SolveAssignArgs) {
         effects: [] as StateEffect<unknown>[],
       }
     : additionalSpec
+
+  if (!shouldUpdateEditor) {
+    /*
+     * This is the direct CodeMirror edit path. The editor is already the source
+     * of truth, and KclManager has already checked that this async execution is
+     * still fresh before sending the event. Keep the derived scene/diagnostic
+     * state in sync, but do not write source text back through CodeMirror or
+     * disk. A source write here turns an old execution snapshot into an editor
+     * command, which is the exact stale overwrite bug this path prevents.
+     */
+    context.kclManager.syncSketchSolveOutcome(
+      event.data.sourceDelta.text,
+      sceneGraphDelta
+    )
+
+    return {
+      sketchExecOutcome: {
+        sourceDelta: event.data.sourceDelta,
+        sceneGraphDelta,
+      },
+    }
+  }
 
   // Update editor - debounce only if explicitly requested (e.g., for single-click that might be double-click)
   // This allows frequent updates (dragging handles) to be immediate, while others can be debounce


### PR DESCRIPTION
Direct CodeMirror edits in sketch-solve mode were being sent back through update sketch outcome as sourceDelta text. That event is also used by point-and-click sketch tools, where sourceDelta is authoritative generated KCL and updating the editor is correct. For direct editor edits, though, sourceDelta is only the snapshot that produced an async execution result.

When that execution finished after a newer user edit, updateSketchOutcome saw currentCode != sourceDelta.text and treated the stale snapshot as a source edit, rewriting CodeMirror and scheduling a disk write. That could replace freshly typed or copied sketch lines with older endpoint values.

Capture the user document version for direct editor executions, drop stale outcomes before they touch sketch state, and mark fresh direct-editor outcomes as derived so they update scene and diagnostic state without rewriting CodeMirror or disk. Tool-generated sketch outcomes still default to authoritative editor updates.

Add Playwright coverage for copied sketch-line edits while execution is in flight, plus a unit guard that updateEditor=false never rewrites the editor.