### PR TITLE
Show Zookeeper attachments beneath user prompts

### DIFF
--- a/src/components/ExchangeCard.tsx
+++ b/src/components/ExchangeCard.tsx
@@ -196,6 +196,8 @@ type RequestCardProps = Exchange['request'] & {
   userAvatar?: ReactNode
 }
 
+const MAX_VISIBLE_ATTACHMENTS = 2
+
 const hasVisibleChildren = (children: ReactNode) => {
   return (
     (children instanceof Array && children.length > 0) ||
@@ -236,19 +238,60 @@ export const ChatBubble = (props: {
 }
 
 export const RequestCard = (props: RequestCardProps) => {
+  const [showAllAttachments, setShowAllAttachments] = useState(false)
+
   if (!isMlCopilotUserRequest(props)) {
     return null
   }
 
+  const additionalFiles = props.additional_files ?? []
+  const hasHiddenAttachments = additionalFiles.length > MAX_VISIBLE_ATTACHMENTS
+  const visibleAttachments = showAllAttachments
+    ? additionalFiles
+    : additionalFiles.slice(0, MAX_VISIBLE_ATTACHMENTS)
+
   return (
-    <ChatBubble
-      side={'right'}
-      userAvatar={props.userAvatar}
-      dataTestId="ml-request-chat-bubble"
-      className="pt-2 pb-2"
-    >
-      {props.content}
-    </ChatBubble>
+    <>
+      <ChatBubble
+        side={'right'}
+        userAvatar={props.userAvatar}
+        dataTestId="ml-request-chat-bubble"
+        className="pt-2 pb-2"
+      >
+        {props.content}
+      </ChatBubble>
+      {additionalFiles.length > 0 && (
+        <div className="flex justify-end pr-9">
+          <div
+            className="flex flex-col items-end gap-1"
+            data-testid="ml-request-chat-bubble-attachments"
+          >
+            <div className="w-full text-right text-xs font-medium text-chalkboard-70 dark:text-chalkboard-40">
+              Attachments
+            </div>
+            {visibleAttachments.map((file, index) => (
+              <div
+                key={`${file.name}-${index}`}
+                className="flex items-center gap-1 rounded-sm border border-chalkboard-30 dark:border-chalkboard-70 px-2 py-1 text-xs"
+              >
+                <CustomIcon name="paperclip" className="w-3 h-3 shrink-0" />
+                <span className="min-w-0 truncate">{file.name}</span>
+              </div>
+            ))}
+            {hasHiddenAttachments && (
+              <button
+                type="button"
+                onClick={() => setShowAllAttachments(!showAllAttachments)}
+                className="pt-1 pb-1 text-xs"
+                aria-expanded={showAllAttachments}
+              >
+                {showAllAttachments ? '- collapse' : '+ more'}
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </>
   )
 }
 

--- a/src/components/MlEphantConversation.spec.tsx
+++ b/src/components/MlEphantConversation.spec.tsx
@@ -307,6 +307,141 @@ describe('MlEphantConversation', () => {
     ).toBeInTheDocument()
   })
 
+  test('renders user message additional files as attachments under the prompt', () => {
+    const conversation: Conversation = {
+      exchanges: [
+        {
+          request: {
+            type: 'user',
+            content: 'Use these reference files',
+            additional_files: [
+              {
+                name: 'front-view.png',
+                mimetype: 'image/png',
+                data: [1, 2, 3],
+              },
+              {
+                name: 'requirements.pdf',
+                mimetype: 'application/pdf',
+                data: [4, 5, 6],
+              },
+            ],
+          },
+          responses: [],
+          deltasAggregated: '',
+        },
+      ],
+    }
+
+    render(
+      <MlEphantConversation
+        isLoading={false}
+        conversation={conversation}
+        onProcess={vi.fn()}
+        onClickClearChat={() => {}}
+        onReconnect={() => {}}
+        onCancel={() => {}}
+        needsReconnect={false}
+        disabled={false}
+        hasPromptCompleted={true}
+        contexts={[]}
+        isProcessing={false}
+        queue={[]}
+        onRemoveFromQueue={() => {}}
+        onSteer={() => {}}
+      />
+    )
+
+    const requestBubble = screen.getByTestId('ml-request-chat-bubble')
+    const attachments = screen.getByTestId('ml-request-chat-bubble-attachments')
+
+    expect(
+      within(requestBubble).getByText('Use these reference files')
+    ).toBeInTheDocument()
+    expect(
+      within(requestBubble).queryByText('Attachments')
+    ).not.toBeInTheDocument()
+    expect(within(attachments).getByText('Attachments')).toBeInTheDocument()
+    expect(within(attachments).getByText('front-view.png')).toBeInTheDocument()
+    expect(
+      within(attachments).getByText('requirements.pdf')
+    ).toBeInTheDocument()
+    expect(within(attachments).queryByText('+ more')).not.toBeInTheDocument()
+  })
+
+  test('expands and collapses user message attachments when there are more than two', () => {
+    const conversation: Conversation = {
+      exchanges: [
+        {
+          request: {
+            type: 'user',
+            content: 'Use these reference files',
+            additional_files: [
+              {
+                name: 'front-view.png',
+                mimetype: 'image/png',
+                data: [1, 2, 3],
+              },
+              {
+                name: 'requirements.pdf',
+                mimetype: 'application/pdf',
+                data: [4, 5, 6],
+              },
+              {
+                name: 'side-view.jpg',
+                mimetype: 'image/jpeg',
+                data: [7, 8, 9],
+              },
+            ],
+          },
+          responses: [],
+          deltasAggregated: '',
+        },
+      ],
+    }
+
+    render(
+      <MlEphantConversation
+        isLoading={false}
+        conversation={conversation}
+        onProcess={vi.fn()}
+        onClickClearChat={() => {}}
+        onReconnect={() => {}}
+        onCancel={() => {}}
+        needsReconnect={false}
+        disabled={false}
+        hasPromptCompleted={true}
+        contexts={[]}
+        isProcessing={false}
+        queue={[]}
+        onRemoveFromQueue={() => {}}
+        onSteer={() => {}}
+      />
+    )
+
+    const attachments = screen.getByTestId('ml-request-chat-bubble-attachments')
+
+    expect(within(attachments).getByText('front-view.png')).toBeInTheDocument()
+    expect(
+      within(attachments).getByText('requirements.pdf')
+    ).toBeInTheDocument()
+    expect(
+      within(attachments).queryByText('side-view.jpg')
+    ).not.toBeInTheDocument()
+
+    fireEvent.click(within(attachments).getByText('+ more'))
+
+    expect(within(attachments).getByText('side-view.jpg')).toBeInTheDocument()
+    expect(within(attachments).getByText('- collapse')).toBeInTheDocument()
+
+    fireEvent.click(within(attachments).getByText('- collapse'))
+
+    expect(
+      within(attachments).queryByText('side-view.jpg')
+    ).not.toBeInTheDocument()
+    expect(within(attachments).getByText('+ more')).toBeInTheDocument()
+  })
+
   test('renders the blocked reason from the API response without extra copy', () => {
     const blockedReason = `You need a payment method to keep using Zookeeper. Go to your [account](${withSiteBaseURL('/account')}) to fix this.`
 


### PR DESCRIPTION
Today users can only see what they uploaded through the reasoning messages - easy to miss!