### PR TITLE
Set CodSpeed mode for cargo bench workflow (fix cargo bench)

### DIFF
--- a/.github/workflows/cargo-bench.yml
+++ b/.github/workflows/cargo-bench.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v4.14.0
         with:
+          mode: simulation
           working-directory: rust
           run: cargo codspeed run
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/rust/kcl-lib/benches/frontend.rs
+++ b/rust/kcl-lib/benches/frontend.rs
@@ -68,12 +68,14 @@ fn bench_edit_segments(c: &mut Criterion) {
                         .await
                         .unwrap(),
                 );
-                mock_ctx.close().await;
                 Ok::<(), anyhow::Error>(())
             }) {
                 panic!("Failed to execute program: {err}");
             }
-        })
+        });
+        rt.block_on(async {
+            mock_ctx.close().await;
+        });
     });
 }
 


### PR DESCRIPTION
Mode is needed for CodSpeedHQ/action@v4 https://github.com/CodSpeedHQ/action, not sure how it happened that we upgraded without setting the mode, or they made a breaking changes? anyway

Available CodSpeed Action v4 modes are:

- simulation: CPU simulation. This is the recommended default in CodSpeed’s docs.
- walltime: Real elapsed-time measurement, intended for CodSpeed Macro Runners / bare-metal runners.

Simulation makes sense for us.

Also made a change to mock_ctx.