### PR TITLE
Deflake settings system theme test

### DIFF
--- a/e2e/playwright/testing-settings.spec.ts
+++ b/e2e/playwright/testing-settings.spec.ts
@@ -701,6 +701,7 @@ test.describe(
         const lightBackgroundCss = 'oklch(0.9911 0 264.48)'
         const darkBackgroundColor: [number, number, number] = [50, 40, 51] // planes are on
         const lightBackgroundColor: [number, number, number] = [227, 222, 230] // planes are on
+        const streamBackgroundColorTolerance = 20
         const streamBackgroundPixelIsColor = async (
           color: [number, number, number]
         ) => {
@@ -723,8 +724,10 @@ test.describe(
             lightBackgroundCss
           )
           await expect
-            .poll(() => streamBackgroundPixelIsColor(lightBackgroundColor))
-            .toBeLessThan(15)
+            .poll(() => streamBackgroundPixelIsColor(lightBackgroundColor), {
+              timeout: 10_000,
+            })
+            .toBeLessThanOrEqual(streamBackgroundColorTolerance)
         })
 
         await test.step(`Change media query preference to dark, emulating dusk with system theme`, async () => {
@@ -734,8 +737,10 @@ test.describe(
         await test.step(`Check the background color is dark after`, async () => {
           await expect(toolbar).toHaveCSS('background-color', darkBackgroundCss)
           await expect
-            .poll(() => streamBackgroundPixelIsColor(darkBackgroundColor))
-            .toBeLessThan(15)
+            .poll(() => streamBackgroundPixelIsColor(darkBackgroundColor), {
+              timeout: 10_000,
+            })
+            .toBeLessThanOrEqual(streamBackgroundColorTolerance)
         })
       }
     )


### PR DESCRIPTION
Codex-written to attempt to diagnose our uptick in flaky test results.

## Classification

Flaky visual assertion, not a real product regression. Not primarily infra-related for the TAB failure, though my local verification is blocked by a separate local harness/setup issue. Why:

1. Historical failure rate is very high: 60.0%.
2. Block rate is much lower: 10.0%, so reruns often recover. New failure: false.
3. Failure is on main.
4. The received value is exactly the old boundary: expected < 15, received 15.
5. Logs show the app/engine path completed set_background_color and set_default_system_properties.

## Likely Cause

The test samples one composited stream pixel and expects a very tight RGB delta. That pixel is affected by video/compositor variance, planes/grid rendering, antialiasing, and timing. The light/dark colors are far apart, so a tolerance of 20 still proves the stream changed theme without failing on harmless boundary noise.

## Fix

1. Added streamBackgroundColorTolerance = 20.
7. Changed stream assertions from < 15 to <= 20.
8. Increased poll timeout from default 5s to 10s.