### PR TITLE
Reset Zookeeper conversation mapping on clear chat

### DIFF
--- a/e2e/playwright/zookeeper.spec.ts
+++ b/e2e/playwright/zookeeper.spec.ts
@@ -43,8 +43,7 @@ test.describe('Zookeeper tests', { tag: ['@desktop', '@web'] }, () => {
       await expect(extrude).toBeVisible()
     })
   })
-  // TODO: Fix the regression cased by https://github.com/KittyCAD/modeling-app/pull/11488
-  test.fail(
+  test(
     'Chat history can be cleared',
     { tag: ['@desktop', '@web'] },
     async ({ page, homePage, scene, toolbar, cmdBar, copilot }) => {

--- a/src/components/layout/areas/MlEphantConversationPane.spec.tsx
+++ b/src/components/layout/areas/MlEphantConversationPane.spec.tsx
@@ -30,7 +30,10 @@ import type {
   MlCopilotModeOption,
 } from '@src/machines/mlEphantManagerMachine'
 import { MlEphantManagerTransitions } from '@src/machines/mlEphantManagerMachine'
-import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
+import {
+  SystemIOMachineEvents,
+  SystemIOMachineStates,
+} from '@src/machines/systemIO/utils'
 
 const completedConversation: Conversation = {
   exchanges: [
@@ -107,20 +110,86 @@ const createFakeActor = ({
 
 const createFakeSystemIOActor = ({
   mlEphantConversations = undefined,
+  completeSavesAutomatically = true,
 }: {
   mlEphantConversations?: Map<string, string>
-} = {}) => ({
-  getSnapshot: () => ({
-    value: 'idle',
+  completeSavesAutomatically?: boolean
+} = {}) => {
+  type SaveConversationEvent = {
+    type: SystemIOMachineEvents
+    data?: { projectId?: string; conversationId?: string }
+  }
+  let snapshot = {
+    value: SystemIOMachineStates.idle,
     context: {
       mlEphantConversations,
     },
-  }),
-  subscribe: () => ({
-    unsubscribe: vi.fn(),
-  }),
-  send: vi.fn(),
-})
+  }
+  let pendingSaveEvent: SaveConversationEvent | undefined
+  const listeners = new Set<(next: typeof snapshot) => void>()
+  const notify = () => listeners.forEach((listener) => listener(snapshot))
+  const completeSave = () => {
+    if (pendingSaveEvent === undefined) {
+      return
+    }
+
+    const nextConversations = new Map(snapshot.context.mlEphantConversations)
+    const projectId = pendingSaveEvent.data?.projectId
+    if (projectId !== undefined) {
+      if (
+        pendingSaveEvent.type ===
+        SystemIOMachineEvents.deleteMlEphantConversation
+      ) {
+        nextConversations.delete(projectId)
+      } else if (pendingSaveEvent.data?.conversationId !== undefined) {
+        nextConversations.set(projectId, pendingSaveEvent.data.conversationId)
+      }
+    }
+    pendingSaveEvent = undefined
+    snapshot = {
+      value: SystemIOMachineStates.idle,
+      context: {
+        mlEphantConversations: nextConversations,
+      },
+    }
+    notify()
+  }
+
+  return {
+    getSnapshot: () => snapshot,
+    subscribe: (listener?: (next: typeof snapshot) => void) => {
+      if (listener !== undefined) {
+        listeners.add(listener)
+      }
+      return {
+        unsubscribe: () => {
+          if (listener !== undefined) {
+            listeners.delete(listener)
+          }
+        },
+      }
+    },
+    completeSave,
+    send: vi.fn((event: SaveConversationEvent) => {
+      if (
+        event.type !== SystemIOMachineEvents.saveMlEphantConversations &&
+        event.type !== SystemIOMachineEvents.deleteMlEphantConversation
+      ) {
+        return
+      }
+
+      snapshot = {
+        ...snapshot,
+        value: SystemIOMachineStates.savingMlEphantConversations,
+      }
+      notify()
+      pendingSaveEvent = event
+      if (completeSavesAutomatically) {
+        completeSave()
+      }
+    }),
+  }
+}
 
 const createStatefulClearChatActor = () => {
   let snapshot: FakeMlEphantSnapshot = {
@@ -453,6 +522,52 @@ describe('MlEphantConversationPane', () => {
       expect.objectContaining({
         type: MlEphantManagerTransitions.CacheSetupAndConnect,
         conversationId: 'old-conversation-id',
+      })
+    )
+  })
+
+  test('waits for the saved project conversation delete before starting a fresh one', () => {
+    const mlEphantManagerActor = createStatefulClearChatActor()
+    const systemIOActor = createFakeSystemIOActor({
+      mlEphantConversations: new Map([['project-id', 'old-conversation-id']]),
+      completeSavesAutomatically: false,
+    })
+
+    renderPane({
+      mlEphantManagerActor,
+      systemIOActor,
+      settingsMetaId: 'project-id',
+      theProject: {
+        name: 'sample-project',
+        path: '/tmp/sample-project',
+      },
+    })
+    mlEphantManagerActor.send.mockClear()
+    systemIOActor.send.mockClear()
+
+    fireEvent.click(screen.getByRole('button', { name: /Clear chat/ }))
+
+    expect(systemIOActor.send).toHaveBeenCalledWith({
+      type: SystemIOMachineEvents.deleteMlEphantConversation,
+      data: {
+        projectId: 'project-id',
+      },
+    })
+    expect(mlEphantManagerActor.send).toHaveBeenCalledWith({
+      type: MlEphantManagerTransitions.ConversationClose,
+    })
+    expect(mlEphantManagerActor.send).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MlEphantManagerTransitions.CacheSetupAndConnect,
+      })
+    )
+
+    systemIOActor.completeSave()
+
+    expect(mlEphantManagerActor.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MlEphantManagerTransitions.CacheSetupAndConnect,
+        conversationId: undefined,
       })
     )
   })

--- a/src/components/layout/areas/MlEphantConversationPane.spec.tsx
+++ b/src/components/layout/areas/MlEphantConversationPane.spec.tsx
@@ -30,6 +30,7 @@ import type {
   MlCopilotModeOption,
 } from '@src/machines/mlEphantManagerMachine'
 import { MlEphantManagerTransitions } from '@src/machines/mlEphantManagerMachine'
+import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 
 const completedConversation: Conversation = {
   exchanges: [
@@ -50,6 +51,27 @@ const completedConversation: Conversation = {
   ],
 }
 
+type FakeMlEphantSnapshot = {
+  value: string
+  context: {
+    abruptlyClosed: boolean
+    awaitingResponse: boolean
+    conversation?: Conversation
+    conversationId?: string
+    defaultMode?: MlCopilotModeId
+    modeOptions?: MlCopilotModeOption[]
+  }
+  matches: (state: unknown) => boolean
+}
+
+type FakeMlEphantActor = {
+  getSnapshot: () => FakeMlEphantSnapshot
+  subscribe: (listener?: (next: FakeMlEphantSnapshot) => void) => {
+    unsubscribe: () => void
+  }
+  send: ReturnType<typeof vi.fn>
+}
+
 const createFakeActor = ({
   conversation = completedConversation,
   defaultMode = undefined,
@@ -60,8 +82,8 @@ const createFakeActor = ({
   defaultMode?: MlCopilotModeId
   modeOptions?: MlCopilotModeOption[]
   value?: string
-} = {}) => {
-  const snapshot = {
+} = {}): FakeMlEphantActor => {
+  const snapshot: FakeMlEphantSnapshot = {
     value,
     context: {
       abruptlyClosed: false,
@@ -71,7 +93,7 @@ const createFakeActor = ({
       defaultMode,
       modeOptions,
     },
-    matches: (state: string) => state === value,
+    matches: (state: unknown) => state === value,
   }
 
   return {
@@ -99,6 +121,57 @@ const createFakeSystemIOActor = ({
   }),
   send: vi.fn(),
 })
+
+const createStatefulClearChatActor = () => {
+  let snapshot: FakeMlEphantSnapshot = {
+    value: 'ready',
+    context: {
+      abruptlyClosed: false,
+      awaitingResponse: false,
+      conversation: completedConversation,
+      conversationId: 'old-conversation-id',
+      defaultMode: undefined,
+      modeOptions: undefined,
+    },
+    matches: (state: unknown) => state === snapshot.value,
+  }
+  const listeners = new Set<(next: FakeMlEphantSnapshot) => void>()
+
+  const actor: FakeMlEphantActor = {
+    getSnapshot: () => snapshot,
+    subscribe: (listener?: (next: FakeMlEphantSnapshot) => void) => {
+      if (listener !== undefined) {
+        listeners.add(listener)
+      }
+      return {
+        unsubscribe: () => {
+          if (listener !== undefined) {
+            listeners.delete(listener)
+          }
+        },
+      }
+    },
+    send: vi.fn((event: { type: string }) => {
+      if (event.type !== MlEphantManagerTransitions.ConversationClose) {
+        return
+      }
+
+      snapshot = {
+        ...snapshot,
+        value: 'await',
+        context: {
+          ...snapshot.context,
+          awaitingResponse: false,
+          conversation: undefined,
+          conversationId: undefined,
+        },
+      }
+      listeners.forEach((listener) => listener(snapshot))
+    }),
+  }
+
+  return actor
+}
 
 const renderPane = ({
   mlEphantManagerActor = createFakeActor(),
@@ -337,6 +410,49 @@ describe('MlEphantConversationPane', () => {
       expect.objectContaining({
         type: MlEphantManagerTransitions.CacheSetupAndConnect,
         conversationId: 'conversation-id',
+      })
+    )
+  })
+
+  test('clearing chat forgets the saved project conversation before starting a fresh one', () => {
+    const mlEphantManagerActor = createStatefulClearChatActor()
+    const systemIOActor = createFakeSystemIOActor({
+      mlEphantConversations: new Map([['project-id', 'old-conversation-id']]),
+    })
+
+    renderPane({
+      mlEphantManagerActor,
+      systemIOActor,
+      settingsMetaId: 'project-id',
+      theProject: {
+        name: 'sample-project',
+        path: '/tmp/sample-project',
+      },
+    })
+    mlEphantManagerActor.send.mockClear()
+    systemIOActor.send.mockClear()
+
+    fireEvent.click(screen.getByRole('button', { name: /Clear chat/ }))
+
+    expect(systemIOActor.send).toHaveBeenCalledWith({
+      type: SystemIOMachineEvents.deleteMlEphantConversation,
+      data: {
+        projectId: 'project-id',
+      },
+    })
+    expect(mlEphantManagerActor.send).toHaveBeenCalledWith({
+      type: MlEphantManagerTransitions.ConversationClose,
+    })
+    expect(mlEphantManagerActor.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MlEphantManagerTransitions.CacheSetupAndConnect,
+        conversationId: undefined,
+      })
+    )
+    expect(mlEphantManagerActor.send).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MlEphantManagerTransitions.CacheSetupAndConnect,
+        conversationId: 'old-conversation-id',
       })
     )
   })

--- a/src/components/layout/areas/MlEphantConversationPane.tsx
+++ b/src/components/layout/areas/MlEphantConversationPane.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState, useRef, useCallback } from 'react'
 import {
   type SystemIOActor,
   SystemIOMachineEvents,
+  SystemIOMachineStates,
 } from '@src/machines/systemIO/utils'
 import {
   MlEphantConversation,
@@ -241,8 +242,21 @@ export const MlEphantConversationPane = (props: {
   }
 
   const onClickClearChat = () => {
+    let closedConversation = props.mlEphantManagerActor
+      .getSnapshot()
+      .matches(S.Await)
+    let clearedConversationMapping = true
+    let sentDeleteConversationMapping = false
     let startedFreshConversation = false
     let sub: ReturnType<typeof props.mlEphantManagerActor.subscribe> | undefined
+    let systemIOSub:
+      | ReturnType<typeof props.systemIOActor.subscribe>
+      | undefined
+
+    const cleanupSubscriptions = () => {
+      sub?.unsubscribe()
+      systemIOSub?.unsubscribe()
+    }
 
     const startFreshConversation = () => {
       if (startedFreshConversation) {
@@ -254,7 +268,14 @@ export const MlEphantConversationPane = (props: {
         refParentSend: props.mlEphantManagerActor.send,
         conversationId: undefined,
       })
-      sub?.unsubscribe()
+      cleanupSubscriptions()
+    }
+
+    const maybeStartFreshConversation = () => {
+      if (!closedConversation || !clearedConversationMapping) {
+        return
+      }
+      startFreshConversation()
     }
 
     isClearingChat.current = true
@@ -262,26 +283,55 @@ export const MlEphantConversationPane = (props: {
     setQueue([])
     const projectId = props.settings.meta.id.current
     if (projectId !== undefined && projectId !== uuidNIL) {
-      props.systemIOActor.send({
-        type: SystemIOMachineEvents.deleteMlEphantConversation,
-        data: {
-          projectId,
-        },
+      clearedConversationMapping = false
+      const maybeDeleteConversationMapping = () => {
+        if (sentDeleteConversationMapping) {
+          return
+        }
+        if (
+          props.systemIOActor.getSnapshot().value !== SystemIOMachineStates.idle
+        ) {
+          return
+        }
+
+        sentDeleteConversationMapping = true
+        props.systemIOActor.send({
+          type: SystemIOMachineEvents.deleteMlEphantConversation,
+          data: {
+            projectId,
+          },
+        })
+      }
+
+      systemIOSub = props.systemIOActor.subscribe((next) => {
+        if (!sentDeleteConversationMapping) {
+          maybeDeleteConversationMapping()
+          return
+        }
+        if (next.value !== SystemIOMachineStates.idle) {
+          return
+        }
+
+        clearedConversationMapping = true
+        maybeStartFreshConversation()
       })
+      maybeDeleteConversationMapping()
     }
     sub = props.mlEphantManagerActor.subscribe((next) => {
       if (!next.matches(S.Await)) {
         return
       }
 
-      startFreshConversation()
+      closedConversation = true
+      maybeStartFreshConversation()
     })
     props.mlEphantManagerActor.send({
       type: MlEphantManagerTransitions.ConversationClose,
     })
 
     if (props.mlEphantManagerActor.getSnapshot().matches(S.Await)) {
-      startFreshConversation()
+      closedConversation = true
+      maybeStartFreshConversation()
     }
   }
 

--- a/src/components/layout/areas/MlEphantConversationPane.tsx
+++ b/src/components/layout/areas/MlEphantConversationPane.tsx
@@ -59,6 +59,7 @@ export const MlEphantConversationPane = (props: {
   )
   const [queue, setQueue] = useState<QueuedMessage[]>([])
   const isSubmittingFromQueue = useRef(false)
+  const isClearingChat = useRef(false)
   const steeredId = useRef<string | null>(null)
 
   let conversation = useSelector(props.mlEphantManagerActor, (actor) => {
@@ -240,26 +241,55 @@ export const MlEphantConversationPane = (props: {
   }
 
   const onClickClearChat = () => {
-    steeredId.current = null
-    setQueue([])
-    props.mlEphantManagerActor.send({
-      type: MlEphantManagerTransitions.ConversationClose,
-    })
-    const sub = props.mlEphantManagerActor.subscribe((next) => {
-      if (!next.matches(S.Await)) {
+    let startedFreshConversation = false
+    let sub: ReturnType<typeof props.mlEphantManagerActor.subscribe> | undefined
+
+    const startFreshConversation = () => {
+      if (startedFreshConversation) {
         return
       }
-
+      startedFreshConversation = true
       props.mlEphantManagerActor.send({
         type: MlEphantManagerTransitions.CacheSetupAndConnect,
         refParentSend: props.mlEphantManagerActor.send,
         conversationId: undefined,
       })
-      sub.unsubscribe()
+      sub?.unsubscribe()
+    }
+
+    isClearingChat.current = true
+    steeredId.current = null
+    setQueue([])
+    const projectId = props.settings.meta.id.current
+    if (projectId !== undefined && projectId !== uuidNIL) {
+      props.systemIOActor.send({
+        type: SystemIOMachineEvents.deleteMlEphantConversation,
+        data: {
+          projectId,
+        },
+      })
+    }
+    sub = props.mlEphantManagerActor.subscribe((next) => {
+      if (!next.matches(S.Await)) {
+        return
+      }
+
+      startFreshConversation()
     })
+    props.mlEphantManagerActor.send({
+      type: MlEphantManagerTransitions.ConversationClose,
+    })
+
+    if (props.mlEphantManagerActor.getSnapshot().matches(S.Await)) {
+      startFreshConversation()
+    }
   }
 
   const tryToGetExchanges = () => {
+    if (isClearingChat.current) {
+      return
+    }
+
     const mlEphantConversations =
       props.systemIOActor.getSnapshot().context.mlEphantConversations
 
@@ -329,6 +359,14 @@ export const MlEphantConversationPane = (props: {
           }) || mlEphantManagerActorSnapshot.value === S.Await) === false
 
         const { context } = mlEphantManagerActorSnapshot
+
+        if (
+          isClearingChat.current &&
+          context.conversationId !== undefined &&
+          context.conversation !== undefined
+        ) {
+          isClearingChat.current = false
+        }
 
         if (
           mlEphantManagerActorSnapshot.matches(

--- a/src/machines/systemIO/hooks.ts
+++ b/src/machines/systemIO/hooks.ts
@@ -6,7 +6,6 @@ import { type MlEphantManagerActor } from '@src/machines/mlEphantManagerMachine'
 import {
   type SystemIOActor,
   SystemIOMachineEvents,
-  SystemIOMachineStates,
 } from '@src/machines/systemIO/utils'
 import { useSelector } from '@xstate/react'
 import { useEffect } from 'react'
@@ -78,13 +77,6 @@ export const useProjectIdToConversationId = (
         return
       }
       if (settings2.meta.id.current === uuidNIL) {
-        return
-      }
-      const systemIOActorSnapshot = systemIOActor.getSnapshot()
-      if (
-        systemIOActorSnapshot.value ===
-        SystemIOMachineStates.savingMlEphantConversations
-      ) {
         return
       }
       if (next.context.conversationId === undefined) {

--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -313,6 +313,12 @@ export const systemIOMachine = setup({
           }
         }
       | {
+          type: SystemIOMachineEvents.deleteMlEphantConversation
+          data: {
+            projectId: string
+          }
+        }
+      | {
           type: SystemIOMachineEvents.done_saveMlEphantConversations
           output: SystemIOContext['mlEphantConversations']
         },
@@ -751,15 +757,35 @@ export const systemIOMachine = setup({
       async (args: {
         input: {
           context: SystemIOContext
-          event: {
-            data: {
-              projectId: string
-              conversationId: string
-            }
-          }
+          event:
+            | {
+                type: SystemIOMachineEvents.saveMlEphantConversations
+                data: {
+                  projectId: string
+                  conversationId: string
+                }
+              }
+            | {
+                type: SystemIOMachineEvents.deleteMlEphantConversation
+                data: {
+                  projectId: string
+                }
+              }
         }
       }) => {
-        return new Map()
+        const next = new Map(args.input.context.mlEphantConversations)
+        if (
+          args.input.event.type ===
+          SystemIOMachineEvents.deleteMlEphantConversation
+        ) {
+          next.delete(args.input.event.data.projectId)
+        } else {
+          next.set(
+            args.input.event.data.projectId,
+            args.input.event.data.conversationId
+          )
+        }
+        return next
       }
     ),
   },
@@ -901,6 +927,9 @@ export const systemIOMachine = setup({
           target: SystemIOMachineStates.gettingMlEphantConversations,
         },
         [SystemIOMachineEvents.saveMlEphantConversations]: {
+          target: SystemIOMachineStates.savingMlEphantConversations,
+        },
+        [SystemIOMachineEvents.deleteMlEphantConversation]: {
           target: SystemIOMachineStates.savingMlEphantConversations,
         },
       },
@@ -1784,11 +1813,24 @@ export const systemIOMachine = setup({
       },
     },
     [SystemIOMachineStates.savingMlEphantConversations]: {
+      on: {
+        [SystemIOMachineEvents.saveMlEphantConversations]: {
+          target: SystemIOMachineStates.savingMlEphantConversations,
+          reenter: true,
+        },
+        [SystemIOMachineEvents.deleteMlEphantConversation]: {
+          target: SystemIOMachineStates.savingMlEphantConversations,
+          reenter: true,
+        },
+      },
       invoke: {
         id: SystemIOMachineActors.saveMlEphantConversations,
         src: SystemIOMachineActors.saveMlEphantConversations,
         input: ({ event, context }) => {
-          assertEvent(event, SystemIOMachineEvents.saveMlEphantConversations)
+          assertEvent(event, [
+            SystemIOMachineEvents.saveMlEphantConversations,
+            SystemIOMachineEvents.deleteMlEphantConversation,
+          ])
           return {
             context,
             event,

--- a/src/machines/systemIO/systemIOMachineImpl.ts
+++ b/src/machines/systemIO/systemIOMachineImpl.ts
@@ -36,6 +36,7 @@ import type {
 import {
   NO_PROJECT_DIRECTORY,
   SystemIOMachineActors,
+  SystemIOMachineEvents,
   jsonToMlConversations,
   mlConversationsToJson,
   collectProjectFiles,
@@ -964,21 +965,36 @@ export const systemIOMachineImpl = systemIOMachine.provide({
       async (args: {
         input: {
           context: SystemIOContext
-          event: {
-            data: {
-              projectId: string
-              conversationId: string
-            }
-          }
+          event:
+            | {
+                type: SystemIOMachineEvents.saveMlEphantConversations
+                data: {
+                  projectId: string
+                  conversationId: string
+                }
+              }
+            | {
+                type: SystemIOMachineEvents.deleteMlEphantConversation
+                data: {
+                  projectId: string
+                }
+              }
         }
       }) => {
-        const next: Map<any, any> = new Map(
+        const next = new Map<string, string>(
           args.input.context.mlEphantConversations
         )
-        next.set(
-          args.input.event.data.projectId,
-          args.input.event.data.conversationId
-        )
+        if (
+          args.input.event.type ===
+          SystemIOMachineEvents.deleteMlEphantConversation
+        ) {
+          next.delete(args.input.event.data.projectId)
+        } else {
+          next.set(
+            args.input.event.data.projectId,
+            args.input.event.data.conversationId
+          )
+        }
         const json = mlConversationsToJson(next)
         const te = new TextEncoder()
         await fsZds.writeFile(

--- a/src/machines/systemIO/utils.ts
+++ b/src/machines/systemIO/utils.ts
@@ -132,6 +132,7 @@ export enum SystemIOMachineEvents {
   done_getMlEphantConversations = donePrefix + 'get ml-ephant conversations',
   saveMlEphantConversations = 'save ml-ephant conversations',
   done_saveMlEphantConversations = donePrefix + 'save ml-ephant conversations',
+  deleteMlEphantConversation = 'delete ml-ephant conversation',
 }
 
 export enum SystemIOMachineActions {


### PR DESCRIPTION
Clear chat already requested a fresh Zookeeper conversation, but the saved project-to-conversation mapping could immediately hydrate the old conversation again after PR #11488 fixed normal close cleanup.

Add an explicit SystemIO delete event for the project conversation mapping, suppress stale hydration while the fresh setup is in flight, and let the new assigned conversation id persist through the existing sync hook.

Unmark the desktop/web chat-history regression as expected-failing and add focused pane coverage for clearing the saved mapping before starting a fresh conversation.