### PR TITLE
Add `engineScene` status bar execution indicators

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -203,6 +203,16 @@ export default defineConfig([
     },
   },
   {
+    files: [
+      'src/registry/extensions/**/*.{ts,tsx}',
+      'src/registry/plugins/**/*.{ts,tsx}',
+    ],
+
+    rules: {
+      'no-restricted-imports': 'off',
+    },
+  },
+  {
     files: ['packages/**/*.{ts,tsx}', 'rust/**/*.ts'],
     extends: compat.extends(),
 

--- a/src/components/OpenedProject.tsx
+++ b/src/components/OpenedProject.tsx
@@ -1,7 +1,6 @@
 import { useSignalEffect } from '@preact/signals-react'
 import { useSignals } from '@preact/signals-react/runtime'
 import { AppHeader } from '@src/components/AppHeader'
-import { ExperimentalFeaturesMenu } from '@src/components/ExperimentalFeaturesMenu'
 import { useLspContext } from '@src/components/LspProvider'
 import { useNetworkHealthStatus } from '@src/components/NetworkHealthIndicator'
 import { useNetworkMachineStatus } from '@src/components/NetworkMachineIndicator'
@@ -12,7 +11,6 @@ import {
 } from '@src/components/StatusBar/defaultStatusBarItems'
 import type { StatusBarItemType } from '@src/components/StatusBar/statusBarTypes'
 import { UndoRedoButtons } from '@src/components/UndoRedoButtons'
-import { UnitsMenu } from '@src/components/UnitsMenu'
 import { WasmErrToast } from '@src/components/WasmErrToast'
 import { ZookeeperCreditsMenu } from '@src/components/ZookeeperCreditsMenu'
 import { getMlEphantProjectReloadBehavior } from '@src/components/openedProjectUtils'
@@ -21,13 +19,12 @@ import { useEngineConnectionSubscriptions } from '@src/hooks/useEngineConnection
 import { useHotKeyListener } from '@src/hooks/useHotKeyListener'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { useQueryParamEffects } from '@src/hooks/useQueryParamEffects'
-import { useApp, useSingletons } from '@src/lib/boot'
 import {
   autoUpdateDownloadProgressSignal,
   autoUpdateReadySignal,
 } from '@src/lib/autoUpdate'
+import { useApp, useSingletons } from '@src/lib/boot'
 import {
-  DEFAULT_EXPERIMENTAL_FEATURES,
   ONBOARDING_TOAST_ID,
   WASM_INIT_FAILED_TOAST_ID,
 } from '@src/lib/constants'
@@ -44,7 +41,6 @@ import { useDefaultAreaLibrary } from '@src/lib/layout/defaultAreaLibrary'
 import { PATHS } from '@src/lib/paths'
 import type { Project } from '@src/lib/project'
 import { resetCameraPosition } from '@src/lib/resetCameraPosition'
-import { getSelectionTypeDisplayText } from '@src/lib/selections'
 import { maybeWriteToDisk } from '@src/lib/telemetry'
 import { reportRejection } from '@src/lib/trap'
 import { withSiteBaseURL } from '@src/lib/withBaseURL'
@@ -55,8 +51,12 @@ import {
   MlEphantManagerTransitions,
 } from '@src/machines/mlEphantManagerMachine'
 import { useFolders, useLastOperation } from '@src/machines/systemIO/hooks'
-import { statusBarGlobalItemsValueSpec } from '@src/registry/contracts/statusBar'
 import { SystemIOMachineStates } from '@src/machines/systemIO/utils'
+import {
+  statusBarGlobalItemsValueSpec,
+  statusBarLocalItemsValueSpec,
+} from '@src/registry/contracts/statusBar'
+import { filterEngineSceneStatusBarItems } from '@src/registry/extensions/engineScene/statusBar'
 import {
   TutorialRequestToast,
   needsToOnboard,
@@ -185,6 +185,10 @@ export function OpenedProject() {
 
   const settingsValues = settings.useSettings()
   const machineApiEnabled = settingsValues.app.machineApi.current
+  const registryLocalStatusBarItems = filterEngineSceneStatusBarItems(
+    registry.signal(statusBarLocalItemsValueSpec).value,
+    settingsValues
+  )
   const authToken = auth.useToken()
   const onboardingStatus =
     settingsValues.app.onboardingStatus.current ||
@@ -341,19 +345,6 @@ export function OpenedProject() {
     }
   }, [])
 
-  const experimentalFeaturesLevel =
-    kclManager.fileSettings.experimentalFeatures ??
-    DEFAULT_EXPERIMENTAL_FEATURES
-  const experimentalFeaturesLocalStatusBarItems: StatusBarItemType[] =
-    experimentalFeaturesLevel.type !== 'Deny'
-      ? [
-          {
-            id: 'experimental-features',
-            component: ExperimentalFeaturesMenu,
-          },
-        ]
-      : []
-
   const zookeeperLocalStatusBarItems: StatusBarItemType[] = useMemo(
     () =>
       getOpenPanes({ rootLayout: layout.signal.value }).includes(
@@ -445,24 +436,7 @@ export function OpenedProject() {
                   },
                 ] satisfies StatusBarItemType[])
               : []),
-            {
-              id: 'selection',
-              'data-testid': 'selection-status',
-              element: 'text',
-              label:
-                getSelectionTypeDisplayText(
-                  kclManager.astSignal.value,
-                  modelingState.context.selectionRanges
-                ) ?? 'No selection',
-              toolTip: {
-                children: 'Currently selected geometry',
-              },
-            },
-            {
-              id: 'units',
-              component: UnitsMenu,
-            },
-            ...experimentalFeaturesLocalStatusBarItems,
+            ...registryLocalStatusBarItems,
             ...zookeeperLocalStatusBarItems,
             ...defaultLocalStatusBarItems,
           ]}

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -736,6 +736,7 @@ export class KclManager extends File {
       code: this._code,
       hasEditsSinceLastExecution: this._hasEditsSinceLastExecution,
       isExecuting: this._isExecuting,
+      executionElapsedMs: this._executionElapsedMs,
       selectionStatusLabel: this._selectionStatusLabel,
       showExperimentalFeaturesStatusBarItem:
         this._showExperimentalFeaturesStatusBarItem,
@@ -913,6 +914,10 @@ export class KclManager extends File {
   private _cancelTokens: Map<number, boolean> = new Map()
   private _executeIsStale: ExecuteArgs | null = null
   private _isExecuting = signal(false)
+  private _executionElapsedMs = signal(0)
+  private executionStartedAtMs: number | null = null
+  private executionTimerIntervalId: ReturnType<typeof setInterval> | undefined =
+    undefined
   get isExecuting() {
     return this._isExecuting.value
   }
@@ -1081,6 +1086,7 @@ export class KclManager extends File {
 
   set isExecuting(isExecuting) {
     this._isExecuting.value = isExecuting
+    this.updateExecutionTimer(isExecuting)
     // If we have finished executing, but the execute is stale, we should
     // execute again.
     if (!isExecuting && this.executeIsStale && this.sceneEntitiesManager) {
@@ -1088,6 +1094,35 @@ export class KclManager extends File {
       this.executeIsStale = null
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       this.executeAst(args)
+    }
+  }
+
+  private updateExecutionTimer(isExecuting: boolean) {
+    if (isExecuting) {
+      if (this.executionStartedAtMs !== null) {
+        return
+      }
+
+      this.executionStartedAtMs = Date.now()
+      this._executionElapsedMs.value = 0
+      this.executionTimerIntervalId = setInterval(() => {
+        if (this.executionStartedAtMs === null) {
+          return
+        }
+
+        this._executionElapsedMs.value = Date.now() - this.executionStartedAtMs
+      }, 100)
+      return
+    }
+
+    if (this.executionTimerIntervalId !== undefined) {
+      clearInterval(this.executionTimerIntervalId)
+      this.executionTimerIntervalId = undefined
+    }
+
+    if (this.executionStartedAtMs !== null) {
+      this._executionElapsedMs.value = Date.now() - this.executionStartedAtMs
+      this.executionStartedAtMs = null
     }
   }
 

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -34,6 +34,7 @@ import type { ArtifactIndex } from '@src/lib/artifactIndex'
 import { buildArtifactIndex } from '@src/lib/artifactIndex'
 import {
   DEFAULT_DEFAULT_LENGTH_UNIT,
+  DEFAULT_EXPERIMENTAL_FEATURES,
   EXECUTE_AST_INTERRUPT_ERROR_MESSAGE,
 } from '@src/lib/constants'
 import fsZds from '@src/lib/fs-zds'
@@ -48,6 +49,10 @@ import {
   jsAppSettings,
 } from '@src/lib/settings/settingsUtils'
 
+import {
+  FALLBACK_SKETCH_CHECKPOINT_LIMIT,
+  createHistoryExtension,
+} from '@src/editor/historyConfig'
 import { EngineDebugger } from '@src/lib/debugger'
 import {
   type handleSelectionBatch as handleSelectionBatchFn,
@@ -63,10 +68,6 @@ import type {
   Selections,
 } from '@src/machines/modelingSharedTypes'
 import type { ConnectionManager } from '@src/network/connectionManager'
-import {
-  createHistoryExtension,
-  FALLBACK_SKETCH_CHECKPOINT_LIMIT,
-} from '@src/editor/historyConfig'
 
 import {
   invertedEffects,
@@ -133,6 +134,7 @@ import {
   operationsStateField,
   setOperationsEffect,
 } from '@src/editor/plugins/operations'
+import { sketchCheckpointHistoryEffect } from '@src/editor/plugins/sketchCheckpoints'
 import {
   appSettingsThemeEffect,
   editorTheme,
@@ -141,17 +143,16 @@ import {
 } from '@src/editor/plugins/theme'
 import { requestWriteToFile } from '@src/editor/plugins/write'
 import { projectFsManager } from '@src/lang/std/fileSystemManager'
-import { getAutomaticallyRenderEnabledFromSettings } from '@src/lib/automaticRendering'
 import type { App } from '@src/lib/app'
+import { getAutomaticallyRenderEnabledFromSettings } from '@src/lib/automaticRendering'
 import { isCodeTheSame, normalizeLineEndings } from '@src/lib/codeEditor'
-import type { ExecutingEditorService } from '@src/registry/contracts/executingEditor'
-import { sketchCheckpointHistoryEffect } from '@src/editor/plugins/sketchCheckpoints'
 import { bracket } from '@src/lib/exampleKcl'
 import { setKclVersion } from '@src/lib/kclVersion'
 import { getStringAfterLastSeparator } from '@src/lib/paths'
 import type { FileEntry, Project } from '@src/lib/project'
 import { resetCameraPosition } from '@src/lib/resetCameraPosition'
 import { createThumbnailPNGOnDesktop } from '@src/lib/screenshot'
+import { getSelectionTypeDisplayText } from '@src/lib/selections'
 import { type Themes, getOppositeTheme, getResolvedTheme } from '@src/lib/theme'
 import type { CommandBarActorType } from '@src/machines/commandBarMachine'
 import type {
@@ -159,6 +160,7 @@ import type {
   modelingMachine,
 } from '@src/machines/modelingMachine'
 import type { SettingsActorType } from '@src/machines/settingsMachine'
+import type { ExecutingEditorService } from '@src/registry/contracts/executingEditor'
 import toast from 'react-hot-toast'
 
 interface ExecuteArgs {
@@ -734,6 +736,11 @@ export class KclManager extends File {
       code: this._code,
       hasEditsSinceLastExecution: this._hasEditsSinceLastExecution,
       isExecuting: this._isExecuting,
+      selectionStatusLabel: this._selectionStatusLabel,
+      showExperimentalFeaturesStatusBarItem:
+        this._showExperimentalFeaturesStatusBarItem,
+      getPendingCommandCount: () =>
+        Object.keys(this.engineCommandManager.pendingCommands).length,
       executeCode: (code) => this.executeCode(code),
       updateCode: (code, options) => this.updateCodeEditor(code, options),
     }
@@ -793,6 +800,14 @@ export class KclManager extends File {
     otherSelections: [],
     graphSelections: [],
   }
+  private _selectionRangesSignal = signal<Selections>(this._selectionRanges)
+  private _selectionStatusLabel = computed(
+    () =>
+      getSelectionTypeDisplayText(
+        this._ast.value,
+        this._selectionRangesSignal.value
+      ) ?? 'No selection'
+  )
   undoDepth = signal(0)
   redoDepth = signal(0)
   undoListenerEffect = EditorView.updateListener.of((vu) => {
@@ -885,6 +900,16 @@ export class KclManager extends File {
   private _astParseFailed = false
   private _switchedFiles = false
   private _fileSettings: KclSettingsAnnotation = {}
+  private _fileSettingsSignal = signal<KclSettingsAnnotation>(
+    this._fileSettings
+  )
+  private _showExperimentalFeaturesStatusBarItem = computed(
+    () =>
+      (
+        this._fileSettingsSignal.value.experimentalFeatures ??
+        DEFAULT_EXPERIMENTAL_FEATURES
+      ).type !== 'Deny'
+  )
   private _cancelTokens: Map<number, boolean> = new Map()
   private _executeIsStale: ExecuteArgs | null = null
   private _isExecuting = signal(false)
@@ -2349,6 +2374,7 @@ export class KclManager extends File {
 
   set fileSettings(settings: KclSettingsAnnotation) {
     this._fileSettings = settings
+    this._fileSettingsSignal.value = settings
     this.sceneInfra.baseUnit =
       settings?.defaultLengthUnit || DEFAULT_DEFAULT_LENGTH_UNIT
   }
@@ -2440,6 +2466,7 @@ export class KclManager extends File {
   }
   set selectionRanges(selectionRanges: Selections) {
     this._selectionRanges = selectionRanges
+    this._selectionRangesSignal.value = selectionRanges
   }
   set modelingSend(send: (eventInfo: ModelingMachineEvent) => void) {
     this._modelingSend = send

--- a/src/registry/contracts/executingEditor.ts
+++ b/src/registry/contracts/executingEditor.ts
@@ -13,6 +13,7 @@ export interface ExecutingEditorService {
   readonly code: ReadonlySignal<string>
   readonly hasEditsSinceLastExecution: ReadonlySignal<boolean>
   readonly isExecuting: ReadonlySignal<boolean>
+  readonly executionElapsedMs: ReadonlySignal<number>
   readonly selectionStatusLabel: ReadonlySignal<string>
   readonly showExperimentalFeaturesStatusBarItem: ReadonlySignal<boolean>
   getPendingCommandCount(): number

--- a/src/registry/contracts/executingEditor.ts
+++ b/src/registry/contracts/executingEditor.ts
@@ -1,5 +1,5 @@
-import type { ReadonlySignal } from '@preact/signals-core'
 import { defineContract, defineService } from '@kittycad/registry'
+import type { ReadonlySignal } from '@preact/signals-core'
 
 export interface ExecutingEditorUpdateOptions {
   shouldExecute?: boolean
@@ -13,6 +13,9 @@ export interface ExecutingEditorService {
   readonly code: ReadonlySignal<string>
   readonly hasEditsSinceLastExecution: ReadonlySignal<boolean>
   readonly isExecuting: ReadonlySignal<boolean>
+  readonly selectionStatusLabel: ReadonlySignal<string>
+  readonly showExperimentalFeaturesStatusBarItem: ReadonlySignal<boolean>
+  getPendingCommandCount(): number
   executeCode(code?: string): Promise<void>
   updateCode(code: string, options?: ExecutingEditorUpdateOptions): void
 }

--- a/src/registry/contracts/statusBar.spec.ts
+++ b/src/registry/contracts/statusBar.spec.ts
@@ -1,0 +1,84 @@
+import { Registry, defineRegistryItem, provide } from '@kittycad/registry'
+import type { StatusBarItemType } from '@src/components/StatusBar/statusBarTypes'
+import {
+  nullableStatusBarItem,
+  statusBarGlobalItemsValueSpec,
+  statusBarLocalItemsValueSpec,
+} from '@src/registry/contracts/statusBar'
+import { describe, expect, it } from 'vitest'
+
+const statusItem = (id: string, order: number): StatusBarItemType => ({
+  id,
+  order,
+  element: 'text',
+  label: id,
+})
+
+describe('status bar registry contract', () => {
+  it('sorts nullable global items after static items, then by order', () => {
+    const registry = new Registry()
+    registry.configure([
+      defineRegistryItem({
+        provides: [
+          provide(statusBarGlobalItemsValueSpec, statusItem('static-high', 20)),
+          provide(
+            statusBarGlobalItemsValueSpec,
+            nullableStatusBarItem(statusItem('nullable-low', 0))
+          ),
+          provide(statusBarGlobalItemsValueSpec, statusItem('static-low', 10)),
+          provide(
+            statusBarGlobalItemsValueSpec,
+            nullableStatusBarItem(statusItem('nullable-high', 30))
+          ),
+        ],
+      }),
+    ])
+
+    expect(
+      registry.get(statusBarGlobalItemsValueSpec).map((item) => item.id)
+    ).toEqual(['static-low', 'static-high', 'nullable-low', 'nullable-high'])
+  })
+
+  it('sorts nullable local items before static items, then by order', () => {
+    const registry = new Registry()
+    registry.configure([
+      defineRegistryItem({
+        provides: [
+          provide(statusBarLocalItemsValueSpec, statusItem('static-high', 20)),
+          provide(
+            statusBarLocalItemsValueSpec,
+            nullableStatusBarItem(statusItem('nullable-low', 0))
+          ),
+          provide(statusBarLocalItemsValueSpec, statusItem('static-low', 10)),
+          provide(
+            statusBarLocalItemsValueSpec,
+            nullableStatusBarItem(statusItem('nullable-high', 30))
+          ),
+        ],
+      }),
+    ])
+
+    expect(
+      registry.get(statusBarLocalItemsValueSpec).map((item) => item.id)
+    ).toEqual(['nullable-low', 'nullable-high', 'static-low', 'static-high'])
+  })
+
+  it('omits empty nullable contributions', () => {
+    const registry = new Registry()
+    registry.configure([
+      defineRegistryItem({
+        provides: [
+          provide(
+            statusBarLocalItemsValueSpec,
+            nullableStatusBarItem(statusItem('visible', 10))
+          ),
+          provide(statusBarLocalItemsValueSpec, nullableStatusBarItem(null)),
+        ],
+      }),
+    ])
+
+    expect(
+      registry.get(statusBarLocalItemsValueSpec).map((item) => item.id)
+    ).toEqual(['visible'])
+  })
+})

--- a/src/registry/contracts/statusBar.ts
+++ b/src/registry/contracts/statusBar.ts
@@ -1,25 +1,85 @@
-import type { StatusBarItemType } from '@src/components/StatusBar/statusBarTypes'
 import { defineContract, defineValueSpec } from '@kittycad/registry'
+import type { StatusBarItemType } from '@src/components/StatusBar/statusBarTypes'
 
-const sortByOrderProperty = (inputs: readonly StatusBarItemType[]) =>
-  inputs.toSorted((a, b) => (a.order || 0) - (b.order || 0))
+type NullableStatusBarItemContribution = {
+  type: 'nullable-status-bar-item'
+  item: StatusBarItemType | null
+}
+
+type StatusBarItemContribution =
+  | StatusBarItemType
+  | NullableStatusBarItemContribution
+  | null
+
+export const nullableStatusBarItem = (
+  item: StatusBarItemType | null
+): NullableStatusBarItemContribution => ({
+  type: 'nullable-status-bar-item',
+  item,
+})
+
+const isNullableStatusBarItemContribution = (
+  input: StatusBarItemContribution
+): input is NullableStatusBarItemContribution =>
+  input !== null && 'type' in input && input.type === 'nullable-status-bar-item'
+
+const byOrder = (a: StatusBarItemType, b: StatusBarItemType) =>
+  (a.order || 0) - (b.order || 0)
+
+const sortByOrderProperty = (
+  inputs: readonly StatusBarItemContribution[],
+  nullablePosition: 'start' | 'end'
+) => {
+  const staticItems: StatusBarItemType[] = []
+  const nullableItems: StatusBarItemType[] = []
+
+  for (const input of inputs) {
+    if (input === null) {
+      continue
+    }
+
+    if (isNullableStatusBarItemContribution(input)) {
+      if (input.item !== null) {
+        nullableItems.push(input.item)
+      }
+      continue
+    }
+
+    staticItems.push(input)
+  }
+
+  const sortedStaticItems = staticItems.toSorted(byOrder)
+  const sortedNullableItems = nullableItems.toSorted(byOrder)
+
+  return nullablePosition === 'start'
+    ? [...sortedNullableItems, ...sortedStaticItems]
+    : [...sortedStaticItems, ...sortedNullableItems]
+}
+
+const sortGlobalStatusBarItems = (
+  inputs: readonly StatusBarItemContribution[]
+) => sortByOrderProperty(inputs, 'end')
+
+const sortLocalStatusBarItems = (
+  inputs: readonly StatusBarItemContribution[]
+) => sortByOrderProperty(inputs, 'start')
 
 export const statusBarContract = defineContract({
   statusBarGlobalItemsValueSpec: defineValueSpec<
-    StatusBarItemType,
+    StatusBarItemContribution,
     StatusBarItemType[]
   >({
     name: 'status-bar-global',
     defaultValue: [],
-    combine: sortByOrderProperty,
+    combine: sortGlobalStatusBarItems,
   }),
   statusBarLocalItemsValueSpec: defineValueSpec<
-    StatusBarItemType,
+    StatusBarItemContribution,
     StatusBarItemType[]
   >({
     name: 'status-bar-local',
     defaultValue: [],
-    combine: sortByOrderProperty,
+    combine: sortLocalStatusBarItems,
   }),
 })
 

--- a/src/registry/extensions/engineScene/EngineExecutionStatusTooltip.tsx
+++ b/src/registry/extensions/engineScene/EngineExecutionStatusTooltip.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react'
+
+export function EngineExecutionStatusTooltip({
+  getPendingCommandCount,
+}: {
+  getPendingCommandCount: () => number
+}) {
+  const [pendingCommandCount, setPendingCommandCount] = useState(
+    getPendingCommandCount
+  )
+
+  useEffect(() => {
+    const updatePendingCommandCount = () => {
+      setPendingCommandCount(getPendingCommandCount())
+    }
+
+    updatePendingCommandCount()
+    const intervalId = window.setInterval(updatePendingCommandCount, 100)
+
+    return () => window.clearInterval(intervalId)
+  }, [getPendingCommandCount])
+
+  return (
+    <span className="whitespace-nowrap">
+      Engine executing. Pending commands: {pendingCommandCount}
+    </span>
+  )
+}

--- a/src/registry/extensions/engineScene/EngineExecutionStatusTooltip.tsx
+++ b/src/registry/extensions/engineScene/EngineExecutionStatusTooltip.tsx
@@ -1,10 +1,27 @@
+import type { ReadonlySignal } from '@preact/signals-core'
+import { useSignals } from '@preact/signals-react/runtime'
 import { useEffect, useState } from 'react'
 
+function formatExecutionDuration(elapsedMs: number) {
+  const totalSeconds = Math.max(0, elapsedMs) / 1000
+
+  if (totalSeconds < 60) {
+    return `${totalSeconds.toFixed(1)}s`
+  }
+
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = Math.floor(totalSeconds % 60)
+  return `${minutes}m ${seconds.toString().padStart(2, '0')}s`
+}
+
 export function EngineExecutionStatusTooltip({
+  executionElapsedMs,
   getPendingCommandCount,
 }: {
+  executionElapsedMs: ReadonlySignal<number>
   getPendingCommandCount: () => number
 }) {
+  useSignals()
   const [pendingCommandCount, setPendingCommandCount] = useState(
     getPendingCommandCount
   )
@@ -21,8 +38,12 @@ export function EngineExecutionStatusTooltip({
   }, [getPendingCommandCount])
 
   return (
-    <span className="whitespace-nowrap">
-      Engine executing. Pending commands: {pendingCommandCount}
-    </span>
+    <>
+      <p className="text-sm">
+        Engine executing for {formatExecutionDuration(executionElapsedMs.value)}
+        .
+      </p>
+      <p className="text-sm text-2">Pending commands: {pendingCommandCount}</p>
+    </>
   )
 }

--- a/src/registry/extensions/engineScene/constants.ts
+++ b/src/registry/extensions/engineScene/constants.ts
@@ -1,0 +1,2 @@
+export const ENGINE_SCENE_EXECUTION_STATUS_BAR_ITEM_ID =
+  'engine-scene.executing'

--- a/src/registry/extensions/engineScene/index.test.ts
+++ b/src/registry/extensions/engineScene/index.test.ts
@@ -1,0 +1,110 @@
+import {
+  Registry,
+  defineRegistryItem,
+  provideService,
+} from '@kittycad/registry'
+import { signal } from '@preact/signals-core'
+import type { ExecutingEditorService } from '@src/registry/contracts/executingEditor'
+import { executingEditorService } from '@src/registry/contracts/executingEditor'
+import { settingsValueSpec } from '@src/registry/contracts/settings'
+import { statusBarLocalItemsValueSpec } from '@src/registry/contracts/statusBar'
+import { describe, expect, it, vi } from 'vitest'
+import engineSceneExtension from '.'
+import { ENGINE_SCENE_EXECUTION_STATUS_BAR_ITEM_ID } from './constants'
+
+function createExecutingEditorService(
+  isExecuting = signal(false),
+  showExperimentalFeaturesStatusBarItem = signal(true)
+): ExecutingEditorService {
+  return {
+    code: signal(''),
+    hasEditsSinceLastExecution: signal(false),
+    isExecuting,
+    selectionStatusLabel: signal('No selection'),
+    showExperimentalFeaturesStatusBarItem,
+    getPendingCommandCount: vi.fn(() => 0),
+    executeCode: vi.fn(),
+    updateCode: vi.fn(),
+  }
+}
+
+describe('engineScene extension', () => {
+  it('contributes the executing spinner setting disabled by default', () => {
+    const registry = new Registry()
+    registry.configure([engineSceneExtension])
+
+    const setting = registry
+      .get(settingsValueSpec)
+      .modeling.showExecutingSpinner.createSetting()
+
+    expect(setting.default).toBe(false)
+  })
+
+  it('contributes ordered engine scene local status bar items', () => {
+    const isExecuting = signal(false)
+    const registry = new Registry()
+    registry.configure([
+      defineRegistryItem({
+        id: 'test-executing-editor-service',
+        providesServices: [
+          provideService(
+            executingEditorService,
+            createExecutingEditorService(isExecuting)
+          ),
+        ],
+      }),
+      engineSceneExtension,
+    ])
+
+    expect(
+      registry.get(statusBarLocalItemsValueSpec).map((item) => item.id)
+    ).toEqual(['selection', 'units', 'experimental-features'])
+
+    isExecuting.value = true
+
+    expect(
+      registry.get(statusBarLocalItemsValueSpec).map((item) => item.id)
+    ).toEqual([
+      ENGINE_SCENE_EXECUTION_STATUS_BAR_ITEM_ID,
+      'selection',
+      'units',
+      'experimental-features',
+    ])
+
+    isExecuting.value = false
+
+    expect(
+      registry.get(statusBarLocalItemsValueSpec).map((item) => item.id)
+    ).toEqual(['selection', 'units', 'experimental-features'])
+  })
+
+  it('hides the experimental features item when file settings deny it', () => {
+    const showExperimentalFeaturesStatusBarItem = signal(false)
+    const registry = new Registry()
+    registry.configure([
+      defineRegistryItem({
+        id: 'test-executing-editor-service',
+        providesServices: [
+          provideService(
+            executingEditorService,
+            createExecutingEditorService(
+              signal(false),
+              showExperimentalFeaturesStatusBarItem
+            )
+          ),
+        ],
+      }),
+      engineSceneExtension,
+    ])
+
+    expect(
+      registry.get(statusBarLocalItemsValueSpec).map((item) => item.id)
+    ).toEqual(['selection', 'units'])
+
+    showExperimentalFeaturesStatusBarItem.value = true
+
+    expect(
+      registry.get(statusBarLocalItemsValueSpec).map((item) => item.id)
+    ).toEqual(['selection', 'units', 'experimental-features'])
+  })
+})

--- a/src/registry/extensions/engineScene/index.test.ts
+++ b/src/registry/extensions/engineScene/index.test.ts
@@ -20,6 +20,7 @@ function createExecutingEditorService(
     code: signal(''),
     hasEditsSinceLastExecution: signal(false),
     isExecuting,
+    executionElapsedMs: signal(0),
     selectionStatusLabel: signal('No selection'),
     showExperimentalFeaturesStatusBarItem,
     getPendingCommandCount: vi.fn(() => 0),

--- a/src/registry/extensions/engineScene/index.ts
+++ b/src/registry/extensions/engineScene/index.ts
@@ -1,0 +1,146 @@
+import {
+  defineRegistryItemFactory,
+  defineRuntimeRegistryItem,
+  provide,
+} from '@kittycad/registry'
+import { computed } from '@preact/signals-core'
+import { defineBooleanExtensionSetting } from '@src/lib/settings/extensionSettings'
+import { executingEditorService } from '@src/registry/contracts/executingEditor'
+import { settingsValueSpec } from '@src/registry/contracts/settings'
+import {
+  nullableStatusBarItem,
+  statusBarLocalItemsValueSpec,
+} from '@src/registry/contracts/statusBar'
+import { Suspense, createElement, lazy } from 'react'
+import { EngineExecutionStatusTooltip } from './EngineExecutionStatusTooltip'
+import { ENGINE_SCENE_EXECUTION_STATUS_BAR_ITEM_ID } from './constants'
+
+const UnitsMenu = lazy(async () => {
+  const { UnitsMenu } = await import('@src/components/UnitsMenu')
+  return { default: UnitsMenu }
+})
+
+const ExperimentalFeaturesMenu = lazy(async () => {
+  const { ExperimentalFeaturesMenu } = await import(
+    '@src/components/ExperimentalFeaturesMenu'
+  )
+  return { default: ExperimentalFeaturesMenu }
+})
+
+const EngineSceneUnitsMenu = () =>
+  createElement(Suspense, { fallback: null }, createElement(UnitsMenu))
+
+const EngineSceneExperimentalFeaturesMenu = () =>
+  createElement(
+    Suspense,
+    { fallback: null },
+    createElement(ExperimentalFeaturesMenu)
+  )
+
+/**
+ * Engine scene extension.
+ *
+ * Future home for the whole engine scene layout and modeling state machine
+ * behavior. For now it contributes the execution spinner status item and the
+ * setting that controls whether users see it.
+ */
+const engineSceneExtension = defineRegistryItemFactory((ctx) => {
+  const executionService = ctx.services.signal(executingEditorService)
+  const selectionStatusBarItem = computed(() =>
+    nullableStatusBarItem(
+      executionService.value
+        ? {
+            id: 'selection',
+            'data-testid': 'selection-status',
+            element: 'text' as const,
+            label: executionService.value.selectionStatusLabel.value,
+            order: 10,
+            toolTip: {
+              children: 'Currently selected geometry',
+            },
+          }
+        : null
+    )
+  )
+  const experimentalFeaturesStatusBarItem = computed(() =>
+    nullableStatusBarItem(
+      executionService.value?.showExperimentalFeaturesStatusBarItem.value
+        ? {
+            id: 'experimental-features',
+            component: EngineSceneExperimentalFeaturesMenu,
+            order: 30,
+          }
+        : null
+    )
+  )
+  const unitsStatusBarItem = computed(() =>
+    nullableStatusBarItem(
+      executionService.value
+        ? {
+            id: 'units',
+            component: EngineSceneUnitsMenu,
+            order: 20,
+          }
+        : null
+    )
+  )
+  const executionStatusBarItem = computed(() =>
+    nullableStatusBarItem(
+      executionService.value?.isExecuting.value
+        ? {
+            id: ENGINE_SCENE_EXECUTION_STATUS_BAR_ITEM_ID,
+            'data-testid': 'engine-executing-status',
+            element: 'text' as const,
+            icon: 'loading' as const,
+            label: 'Engine executing',
+            hideLabel: true,
+            order: 0,
+            toolTip: {
+              children: createElement(EngineExecutionStatusTooltip, {
+                getPendingCommandCount: () =>
+                  executionService.value?.getPendingCommandCount() ?? 0,
+              }),
+            },
+          }
+        : null
+    )
+  )
+
+  return {
+    item: defineRuntimeRegistryItem({
+      id: 'engine-scene-extension',
+      provides: [
+        provide(settingsValueSpec, {
+          modeling: {
+            showExecutingSpinner: defineBooleanExtensionSetting({
+              defaultValue: false,
+              title: 'Show executing spinner',
+              description:
+                'Whether to show a status bar spinner while the engine is processing commands.',
+              commandConfig: {
+                inputType: 'boolean',
+              },
+              userToml: {
+                sectionKey: 'modeling',
+                tomlKey: 'show_executing_spinner',
+              },
+              projectToml: {
+                sectionKey: 'modeling',
+                tomlKey: 'show_executing_spinner',
+              },
+            }),
+          },
+        }),
+        provide(statusBarLocalItemsValueSpec, selectionStatusBarItem),
+        provide(statusBarLocalItemsValueSpec, unitsStatusBarItem),
+        provide(
+          statusBarLocalItemsValueSpec,
+          experimentalFeaturesStatusBarItem
+        ),
+        provide(statusBarLocalItemsValueSpec, executionStatusBarItem),
+      ],
+    }),
+  }
+}, 'engine-scene-extension')
+
+export default engineSceneExtension

--- a/src/registry/extensions/engineScene/index.ts
+++ b/src/registry/extensions/engineScene/index.ts
@@ -86,23 +86,28 @@ const engineSceneExtension = defineRegistryItemFactory((ctx) => {
   )
   const executionStatusBarItem = computed(() =>
     nullableStatusBarItem(
-      executionService.value?.isExecuting.value
-        ? {
-            id: ENGINE_SCENE_EXECUTION_STATUS_BAR_ITEM_ID,
-            'data-testid': 'engine-executing-status',
-            element: 'text' as const,
-            icon: 'loading' as const,
-            label: 'Engine executing',
-            hideLabel: true,
-            order: 0,
-            toolTip: {
-              children: createElement(EngineExecutionStatusTooltip, {
-                getPendingCommandCount: () =>
-                  executionService.value?.getPendingCommandCount() ?? 0,
-              }),
-            },
-          }
-        : null
+      (() => {
+        const service = executionService.value
+
+        return service?.isExecuting.value
+          ? {
+              id: ENGINE_SCENE_EXECUTION_STATUS_BAR_ITEM_ID,
+              'data-testid': 'engine-executing-status',
+              element: 'text' as const,
+              icon: 'loading' as const,
+              label: 'Engine executing',
+              hideLabel: true,
+              order: 0,
+              toolTip: {
+                children: createElement(EngineExecutionStatusTooltip, {
+                  executionElapsedMs: service.executionElapsedMs,
+                  getPendingCommandCount: () =>
+                    executionService.value?.getPendingCommandCount() ?? 0,
+                }),
+              },
+            }
+          : null
+      })()
     )
   )
 

--- a/src/registry/extensions/engineScene/statusBar.ts
+++ b/src/registry/extensions/engineScene/statusBar.ts
@@ -1,0 +1,27 @@
+import type { StatusBarItemType } from '@src/components/StatusBar/statusBarTypes'
+import type { SettingsType } from '@src/lib/settings/initialSettings'
+import { ENGINE_SCENE_EXECUTION_STATUS_BAR_ITEM_ID } from './constants'
+
+type ModelingSettingsWithExecutingSpinner = SettingsType['modeling'] & {
+  showExecutingSpinner?: { current: boolean }
+}
+
+function isExecutingSpinnerSettingEnabled(settingsValues: SettingsType) {
+  return (
+    (settingsValues.modeling as ModelingSettingsWithExecutingSpinner)
+      .showExecutingSpinner?.current === true
+  )
+}
+
+export function filterEngineSceneStatusBarItems(
+  items: StatusBarItemType[],
+  settingsValues: SettingsType
+) {
+  const showExecutingSpinner = isExecutingSpinnerSettingEnabled(settingsValues)
+
+  return items.filter(
+    (item) =>
+      item.id !== ENGINE_SCENE_EXECUTION_STATUS_BAR_ITEM_ID ||
+      showExecutingSpinner
+  )
+}

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -9,9 +9,9 @@ import {
   useSearchParams,
 } from 'react-router-dom'
 
+import { BillingDialog } from '@kittycad/react-shared'
 import { ActionButton } from '@src/components/ActionButton'
 import { AppHeader } from '@src/components/AppHeader'
-import { BillingDialog } from '@kittycad/react-shared'
 import Loading from '@src/components/Loading'
 import { useNetworkMachineStatus } from '@src/components/NetworkMachineIndicator'
 import ProjectCard from '@src/components/ProjectCard/ProjectCard'
@@ -26,17 +26,20 @@ import {
   defaultLocalStatusBarItems,
 } from '@src/components/StatusBar/defaultStatusBarItems'
 import Tooltip from '@src/components/Tooltip'
+import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
 import { useMenuListener } from '@src/hooks/useMenu'
 import { useQueryParamEffects } from '@src/hooks/useQueryParamEffects'
 import {
   autoUpdateDownloadProgressSignal,
   autoUpdateReadySignal,
 } from '@src/lib/autoUpdate'
+import { useApp, useSingletons } from '@src/lib/boot'
 import { isDesktop } from '@src/lib/isDesktop'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
 import { PATHS } from '@src/lib/paths'
 import { markOnce } from '@src/lib/performance'
 import type { Project } from '@src/lib/project'
+import type { SettingsType } from '@src/lib/settings/initialSettings'
 import {
   getNextSearchParams,
   getSortFunction,
@@ -50,23 +53,20 @@ import {
   useFolders,
   useState as useSystemIOState,
 } from '@src/machines/systemIO/hooks'
+import type { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
 import {
   SystemIOMachineEvents,
   SystemIOMachineStates,
 } from '@src/machines/systemIO/utils'
 import type { WebContentSendPayload } from '@src/menu/channels'
+import { statusBarGlobalItemsValueSpec } from '@src/registry/contracts/statusBar'
 import {
   acceptOnboarding,
   needsToOnboard,
   onDismissOnboardingInvite,
 } from '@src/routes/Onboarding/utils'
-import { useApp, useSingletons } from '@src/lib/boot'
-import type { SettingsType } from '@src/lib/settings/initialSettings'
-import type { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
 import type { ActorRefFrom } from 'xstate'
 import { waitFor } from 'xstate'
-import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
-import { statusBarGlobalItemsValueSpec } from '@src/registry/contracts/statusBar'
 
 type ReadWriteProjectState = {
   value: boolean


### PR DESCRIPTION
Adds a new engineScene registry extension for modeling-scene local status bar items. An enterprise customer wanted to have the ability inspect the behavior of execution: how long it was taking, if it was still going, etc.

Changes:
1. Registers local status bar items from engineScene:
    1. engine execution spinner
    2. current selection indicator
    3. units menu
    4. experimental features menu
2. Adds `modeling.showExecutingSpinner` setting, defaulting off, to control whether the execution spinner appears.
3. Extends executingEditorService with execution metadata:
    1. pending command count
    2. elapsed execution timer
    3. selection status label
    4. experimental-features visibility
4. Shows pending command count and elapsed execution time in the spinner tooltip.
5. Updates status bar value spec sorting so nullable/dynamic items group at the stable edge:
    1. global nullable items sort after static items
    2. local nullable items sort before static items
    3. Adds focused tests for status bar ordering and engineScene contributions.
6. Exempt extensions and plugins from our "absolute import paths" ESLint rule, they should be as contained as possible.

## Demo

https://github.com/user-attachments/assets/de62ece7-893e-4a91-8674-d09c56623ac6


