### PR TITLE
Make executing editor optional, rename `KclManager` to `ExecutingEditor`, and stabilize file-route editor lifecycle

### DIFF
--- a/e2e/playwright/fixtures/editorFixture.ts
+++ b/e2e/playwright/fixtures/editorFixture.ts
@@ -193,7 +193,7 @@ export class EditorFixture {
     }
     await this.page.evaluate(
       ({ findCode, replaceCode }) => {
-        const editorView = window.app.singletons.executingEditor.editorView
+        const editorView = window.executingEditor.editorView
         const currentCode = editorView.state.doc.toString()
         const from = currentCode.indexOf(findCode)
         if (from === -1) {
@@ -232,7 +232,7 @@ export class EditorFixture {
     await expect(this.codeContent).not.toBeEmpty()
     return this.page.evaluate(
       (args: { text: string; placeCursor?: boolean }) => {
-        const editorView = window.app.singletons.executingEditor.editorView
+        const editorView = window.executingEditor.editorView
         const index = editorView.state.doc.toString().indexOf(args.text)
         editorView.focus()
         editorView.dispatch({

--- a/e2e/playwright/fixtures/editorFixture.ts
+++ b/e2e/playwright/fixtures/editorFixture.ts
@@ -193,7 +193,7 @@ export class EditorFixture {
     }
     await this.page.evaluate(
       ({ findCode, replaceCode }) => {
-        const editorView = window.app.singletons.kclManager.editorView
+        const editorView = window.app.singletons.executingEditor.editorView
         const currentCode = editorView.state.doc.toString()
         const from = currentCode.indexOf(findCode)
         if (from === -1) {
@@ -232,7 +232,7 @@ export class EditorFixture {
     await expect(this.codeContent).not.toBeEmpty()
     return this.page.evaluate(
       (args: { text: string; placeCursor?: boolean }) => {
-        const editorView = window.app.singletons.kclManager.editorView
+        const editorView = window.app.singletons.executingEditor.editorView
         const index = editorView.state.doc.toString().indexOf(args.text)
         editorView.focus()
         editorView.dispatch({

--- a/e2e/playwright/lib/console-error-whitelist.ts
+++ b/e2e/playwright/lib/console-error-whitelist.ts
@@ -100,7 +100,7 @@ export const isErrorWhitelisted = (exception: Error) => {
     +     at resolveTransaction (http://localhost:3000/node_modules/.vite/deps/chunk-3BHLKIA4.js?v=412eae63:2155:24)
     +     at _EditorState.update (http://localhost:3000/node_modules/.vite/deps/chunk-3BHLKIA4.js?v=412eae63:2281:12)
     +     at _EditorView.dispatch (http://localhost:3000/node_modules/.vite/deps/chunk-IZYF444B.js?v=412eae63:6988:148)
-    +     at KclManager.selectRange (http://localhost:3000/src/lang/KclSingleton.ts:1255:22)
+    +     at ExecutingEditor.selectRange (http://localhost:3000/src/lang/KclSingleton.ts:1255:22)
     +     at AST extrude (http://localhost:3000/src/machines/modelingMachine.ts:828:25)`,
       foundInSpec: 'e2e/playwright/editor-tests.spec.ts',
       project: 'Google Chrome',

--- a/e2e/playwright/sketch-solve-edit.spec.ts
+++ b/e2e/playwright/sketch-solve-edit.spec.ts
@@ -870,7 +870,7 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
           addToHistory: unknown
         }> = []
         const updateCodeEditorCalls: string[] = []
-        const { executingEditor } = window.app.singletons
+        const { executingEditor } = window
 
         const originalSendModelingEvent =
           executingEditor.sendModelingEvent.bind(executingEditor)
@@ -986,7 +986,7 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
     await test.step('Delay the next sketch execution and observe editor saves', async () => {
       await page.evaluate(() => {
         const writeToFileCalls: string[] = []
-        const { executingEditor } = window.app.singletons
+        const { executingEditor } = window
         const originalWriteToFile =
           executingEditor.writeToFile.bind(executingEditor)
         /*

--- a/e2e/playwright/sketch-solve-edit.spec.ts
+++ b/e2e/playwright/sketch-solve-edit.spec.ts
@@ -870,12 +870,12 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
           addToHistory: unknown
         }> = []
         const updateCodeEditorCalls: string[] = []
-        const { kclManager } = window.app.singletons
+        const { executingEditor } = window.app.singletons
 
         const originalSendModelingEvent =
-          kclManager.sendModelingEvent.bind(kclManager)
-        kclManager.sendModelingEvent = ((
-          ...args: Parameters<typeof kclManager.sendModelingEvent>
+          executingEditor.sendModelingEvent.bind(executingEditor)
+        executingEditor.sendModelingEvent = ((
+          ...args: Parameters<typeof executingEditor.sendModelingEvent>
         ) => {
           const [event] = args
           if (event.type === 'update sketch outcome') {
@@ -888,17 +888,17 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
           }
 
           return originalSendModelingEvent(...args)
-        }) satisfies typeof kclManager.sendModelingEvent
+        }) satisfies typeof executingEditor.sendModelingEvent
 
         const originalUpdateCodeEditor =
-          kclManager.updateCodeEditor.bind(kclManager)
-        kclManager.updateCodeEditor = ((
-          ...args: Parameters<typeof kclManager.updateCodeEditor>
+          executingEditor.updateCodeEditor.bind(executingEditor)
+        executingEditor.updateCodeEditor = ((
+          ...args: Parameters<typeof executingEditor.updateCodeEditor>
         ) => {
           const [code] = args
           updateCodeEditorCalls.push(code)
           return originalUpdateCodeEditor(...args)
-        }) satisfies typeof kclManager.updateCodeEditor
+        }) satisfies typeof executingEditor.updateCodeEditor
 
         Reflect.set(window, 'directEditorOutcomesForTest', directEditorOutcomes)
         Reflect.set(
@@ -986,8 +986,9 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
     await test.step('Delay the next sketch execution and observe editor saves', async () => {
       await page.evaluate(() => {
         const writeToFileCalls: string[] = []
-        const { kclManager } = window.app.singletons
-        const originalWriteToFile = kclManager.writeToFile.bind(kclManager)
+        const { executingEditor } = window.app.singletons
+        const originalWriteToFile =
+          executingEditor.writeToFile.bind(executingEditor)
         /*
          * This is only a spy on the save path. The test still edits through
          * CodeMirror with editor.replaceCodeByTyping, so CodeMirror decides when
@@ -995,13 +996,13 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
          * reaches the normal save listener, and that the delayed execution does
          * not add a stale out-of-band save afterward.
          */
-        kclManager.writeToFile = (async (
-          ...args: Parameters<typeof kclManager.writeToFile>
+        executingEditor.writeToFile = (async (
+          ...args: Parameters<typeof executingEditor.writeToFile>
         ) => {
-          const [newCode = kclManager.code] = args
+          const [newCode = executingEditor.code] = args
           writeToFileCalls.push(newCode)
           return originalWriteToFile(...args)
-        }) satisfies typeof kclManager.writeToFile
+        }) satisfies typeof executingEditor.writeToFile
         Reflect.set(window, 'kclWriteToFileCallsForTest', writeToFileCalls)
 
         const originalHackSetProgram = window.rustContext.hackSetProgram.bind(

--- a/e2e/playwright/test-utils.ts
+++ b/e2e/playwright/test-utils.ts
@@ -175,10 +175,10 @@ async function openKclCodePanel(page: Page) {
 
   // Code Mirror lazy loads text! Wowza! Let's force-load the text for tests.
   await page.evaluate(() => {
-    const { kclManager } = window.app.singletons
-    kclManager.editorView.dispatch({
+    const { executingEditor } = window.app.singletons
+    executingEditor.editorView.dispatch({
       selection: {
-        anchor: kclManager.editorView.state.doc.length,
+        anchor: executingEditor.editorView.state.doc.length,
       },
       scrollIntoView: true,
     })

--- a/e2e/playwright/test-utils.ts
+++ b/e2e/playwright/test-utils.ts
@@ -175,7 +175,7 @@ async function openKclCodePanel(page: Page) {
 
   // Code Mirror lazy loads text! Wowza! Let's force-load the text for tests.
   await page.evaluate(() => {
-    const { executingEditor } = window.app.singletons
+    const { executingEditor } = window
     executingEditor.editorView.dispatch({
       selection: {
         anchor: executingEditor.editorView.state.doc.length,

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -9,7 +9,7 @@ import ModelingPageProvider from '@src/components/ModelingPageProvider'
 import { OpenedProject } from '@src/components/OpenedProject'
 import { NetworkContext } from '@src/hooks/useNetworkContext'
 import { useNetworkStatus } from '@src/hooks/useNetworkStatus'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp } from '@src/lib/boot'
 import { isDesktop } from '@src/lib/isDesktop'
 import { TestLayout } from '@src/lib/layout/TestLayout'
 import makeUrlPathRelative from '@src/lib/makeUrlPathRelative'
@@ -39,8 +39,7 @@ const createRouter = isDesktop() ? createHashRouter : createBrowserRouter
 export const Router = () => {
   useSignals()
   const app = useApp()
-  const { executingEditor } = useSingletons()
-  const networkStatus = useNetworkStatus(executingEditor.engineCommandManager)
+  const networkStatus = useNetworkStatus(app.engineCommandManager)
   const routesProvidedByRegistry = app.registry.signal(routesValueSpec).value
   const router = useMemo(
     () =>

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -39,8 +39,8 @@ const createRouter = isDesktop() ? createHashRouter : createBrowserRouter
 export const Router = () => {
   useSignals()
   const app = useApp()
-  const { kclManager } = useSingletons()
-  const networkStatus = useNetworkStatus(kclManager.engineCommandManager)
+  const { executingEditor } = useSingletons()
+  const networkStatus = useNetworkStatus(executingEditor.engineCommandManager)
   const routesProvidedByRegistry = app.registry.signal(routesValueSpec).value
   const router = useMemo(
     () =>

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -18,7 +18,7 @@ import {
   getUnrenderedChangesDisabledReason,
   shouldDisableModelingForUnrenderedChanges,
 } from '@src/lib/automaticRendering'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { type HotkeySequence, hotkeyDisplay } from '@src/lib/hotkeys'
 import { isDesktop } from '@src/lib/isDesktop'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
@@ -76,7 +76,7 @@ const Toolbar_ = memo(
     const app = useApp()
     const keymap = app.registry.get(keymapService)
     const keymapTree = keymap.keymap.value
-    const { executingEditor } = useSingletons()
+    const executingEditor = useExecutingEditor()
     const platform = usePlatform()
     const executionService = app.registry.signal(executingEditorService).value
     const unrenderedExecuteHotkeyLabel = hotkeyDisplay(
@@ -1017,7 +1017,7 @@ const ToolbarItemTooltipRichContent = memo(
 // Making this toplevel Toolbar memo'd is no-op, because we use context
 // inside that causes a render anyway. Instead we memo the inner.
 export function Toolbar() {
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const { settings } = useApp()
   const settingsValues = settings.useSettings()
   const { state, send, context, actor } = useModelingContext()

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -76,7 +76,7 @@ const Toolbar_ = memo(
     const app = useApp()
     const keymap = app.registry.get(keymapService)
     const keymapTree = keymap.keymap.value
-    const { kclManager } = useSingletons()
+    const { executingEditor } = useSingletons()
     const platform = usePlatform()
     const executionService = app.registry.signal(executingEditorService).value
     const unrenderedExecuteHotkeyLabel = hotkeyDisplay(
@@ -84,7 +84,7 @@ const Toolbar_ = memo(
       platform
     )
     const toolbarConfig = useToolbarConfig()
-    const wasmInstance = use(kclManager.wasmInstancePromise)
+    const wasmInstance = use(executingEditor.wasmInstancePromise)
     const iconClassName =
       'group-disabled:text-chalkboard-50 !text-inherit dark:group-enabled:group-hover:!text-inherit'
     const bgClassName = '!bg-transparent'
@@ -95,18 +95,18 @@ const Toolbar_ = memo(
     const sketchPathId = useMemo(() => {
       if (
         isCursorInFunctionDefinition(
-          kclManager.ast,
+          executingEditor.ast,
           props.context.selectionRanges.graphSelections[0],
           wasmInstance
         )
       )
         return false
       return isCursorInSketchCommandRange(
-        kclManager.artifactGraph,
+        executingEditor.artifactGraph,
         props.context.selectionRanges
       )
       // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-    }, [kclManager.artifactGraph, props.context.selectionRanges])
+    }, [executingEditor.artifactGraph, props.context.selectionRanges])
 
     const toolbarButtonsRef = useRef<HTMLUListElement>(null)
     const [showRichContent, setShowRichContent] = useState(false)
@@ -193,7 +193,7 @@ const Toolbar_ = memo(
         modelingState: props.state,
         modelingSend: props.send,
         sketchPathId,
-        editorHasFocus: kclManager.editorView.hasFocus,
+        editorHasFocus: executingEditor.editorView.hasFocus,
         isActive: false, // Default value - individual items will override this
         keepSelection: false,
       }),
@@ -203,7 +203,7 @@ const Toolbar_ = memo(
         props.send,
         sketchPathId,
 
-        kclManager.editorView.hasFocus,
+        executingEditor.editorView.hasFocus,
       ]
     )
 
@@ -1017,7 +1017,7 @@ const ToolbarItemTooltipRichContent = memo(
 // Making this toplevel Toolbar memo'd is no-op, because we use context
 // inside that causes a render anyway. Instead we memo the inner.
 export function Toolbar() {
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const { settings } = useApp()
   const settingsValues = settings.useSettings()
   const { state, send, context, actor } = useModelingContext()
@@ -1028,7 +1028,7 @@ export function Toolbar() {
     shouldDisableModelingForUnrenderedChanges({
       settings: settingsValues,
       hasEditsSinceLastExecution:
-        kclManager.hasEditsSinceLastExecutionSignal.value,
+        executingEditor.hasEditsSinceLastExecutionSignal.value,
     })
 
   return (
@@ -1041,7 +1041,7 @@ export function Toolbar() {
       isStreamReady={isStreamReady}
       actor={actor}
       isStreamAcceptingInput={isStreamAcceptingInput}
-      isExecuting={kclManager.isExecutingSignal.value}
+      isExecuting={executingEditor.isExecutingSignal.value}
       disableModelingForUnrenderedChanges={disableModelingForUnrenderedChanges}
     />
   )

--- a/src/clientSideScene/ClientSideSceneComp.tsx
+++ b/src/clientSideScene/ClientSideSceneComp.tsx
@@ -57,7 +57,7 @@ function useShouldHideScene(): { hideClient: boolean; hideServer: boolean } {
 
   const { state } = useModelingContext()
   const {
-    kclManager: { sceneInfra },
+    executingEditor: { sceneInfra },
   } = useSingletons()
 
   useEffect(() => {
@@ -91,7 +91,7 @@ export const ClientSideScene = ({
   sketchSolveStreamDimming?: number
 }) => {
   const {
-    kclManager: { sceneEntitiesManager, sceneInfra, engineCommandManager },
+    executingEditor: { sceneEntitiesManager, sceneInfra, engineCommandManager },
   } = useSingletons()
   const { state, send, context } = useModelingContext()
   const { hideClient, hideServer } = useShouldHideScene()
@@ -338,8 +338,8 @@ const Overlay = ({
   overlayIndex: number
   pathToNodeString: string
 }) => {
-  const { kclManager } = useSingletons()
-  const wasmInstance = use(kclManager.wasmInstancePromise)
+  const { executingEditor } = useSingletons()
+  const wasmInstance = use(executingEditor.wasmInstancePromise)
   const { context, send, state } = useModelingContext()
 
   // Simple check directly from localStorage
@@ -352,7 +352,7 @@ const Overlay = ({
   // than what's available in the AST at the moment of query.
   // It eventually settles on being updated.
   const _node1 = getNodeFromPath<Node<CallExpressionKw>>(
-    kclManager.ast,
+    executingEditor.ast,
     overlay.pathToNode,
     wasmInstance,
     ['CallExpressionKw']
@@ -367,7 +367,7 @@ const Overlay = ({
 
   const constraints = getConstraintInfoKw(
     callExpression,
-    kclManager.codeSignal.value,
+    executingEditor.codeSignal.value,
     overlay.pathToNode,
     overlay.filterValue
   )
@@ -475,11 +475,11 @@ const SegmentMenu = ({
   pathToNode: PathToNode
   stdLibFnName: string
 }) => {
-  const { kclManager } = useSingletons()
-  const wasmInstance = use(kclManager.wasmInstancePromise)
+  const { executingEditor } = useSingletons()
+  const wasmInstance = use(executingEditor.wasmInstancePromise)
   const { send } = useModelingContext()
   const dependentSourceRanges = findUsesOfTagInPipe(
-    kclManager.ast,
+    executingEditor.ast,
     pathToNode,
     wasmInstance
   )
@@ -541,8 +541,8 @@ const ConstraintSymbol = ({
   verticalPosition: 'top' | 'bottom'
 }) => {
   const { commands } = useApp()
-  const { kclManager } = useSingletons()
-  const wasmInstance = use(kclManager.wasmInstancePromise)
+  const { executingEditor } = useSingletons()
+  const wasmInstance = use(executingEditor.wasmInstancePromise)
   const { context } = useModelingContext()
   const varNameMap: {
     [key in ConstrainInfo['type']]: {
@@ -626,9 +626,9 @@ const ConstraintSymbol = ({
   const implicitDesc = varNameMap[_type]?.implicitConstraintDesc
 
   const _node = useMemo(
-    () => getNodeFromPath<Expr>(kclManager.ast, pathToNode, wasmInstance),
+    () => getNodeFromPath<Expr>(executingEditor.ast, pathToNode, wasmInstance),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-    [kclManager.ast, pathToNode]
+    [executingEditor.ast, pathToNode]
   )
   if (err(_node)) return
   const node = _node.node
@@ -654,10 +654,10 @@ const ConstraintSymbol = ({
               : 'bg-primary/30 dark:bg-primary text-primary dark:text-chalkboard-10 dark:border-transparent group-hover:bg-primary/40 group-hover:border-primary/50 group-hover:brightness-125'
         } h-[26px] w-[26px] rounded-sm relative m-0 p-0`}
         onMouseEnter={() => {
-          kclManager.setHighlightRange([range])
+          executingEditor.setHighlightRange([range])
         }}
         onMouseLeave={() => {
-          kclManager.setHighlightRange([defaultSourceRange()])
+          executingEditor.setHighlightRange([defaultSourceRange()])
         }}
         // disabled={isConstrained || !convertToVarEnabled}
         // disabled={implicitDesc} TODO why does this change styles that are hard to override?
@@ -678,10 +678,10 @@ const ConstraintSymbol = ({
               },
             })
           } else if (isConstrained) {
-            const wasmInstance = await kclManager.wasmInstancePromise
+            const wasmInstance = await executingEditor.wasmInstancePromise
             try {
               const pResult = parse(
-                recast(kclManager.ast, wasmInstance),
+                recast(executingEditor.ast, wasmInstance),
                 wasmInstance
               )
               if (trap(pResult) || !resultIsOk(pResult))
@@ -701,8 +701,8 @@ const ConstraintSymbol = ({
               const transform = removeSingleConstraintInfo(
                 shallowPath,
                 argPosition,
-                kclManager.ast,
-                kclManager.variables,
+                executingEditor.ast,
+                executingEditor.variables,
                 removeSingleConstraint,
                 transformAstSketchLines,
                 wasmInstance
@@ -711,12 +711,12 @@ const ConstraintSymbol = ({
               if (!transform) return
               const { modifiedAst } = transform
 
-              await kclManager.updateAst(modifiedAst, true)
+              await executingEditor.updateAst(modifiedAst, true)
 
               // Code editor will be updated in the modelingMachine.
               const newCode = recast(modifiedAst, wasmInstance)
               if (err(newCode)) return
-              kclManager.updateCodeEditor(newCode)
+              executingEditor.updateCodeEditor(newCode)
             } catch (e) {
               console.log('error', e)
             }
@@ -796,7 +796,7 @@ const throttled = (sceneInfra: SceneInfra) =>
 export const CamDebugSettings = () => {
   const { commands } = useApp()
   const {
-    kclManager: { sceneInfra },
+    executingEditor: { sceneInfra },
   } = useSingletons()
   const [camSettings, setCamSettings] = useState<ReactCameraProperties>(
     sceneInfra.camControls.reactCameraProperties

--- a/src/clientSideScene/ClientSideSceneComp.tsx
+++ b/src/clientSideScene/ClientSideSceneComp.tsx
@@ -42,7 +42,7 @@ import type { ConstrainInfo } from '@src/lang/std/stdTypes'
 import { topLevelRange } from '@src/lang/util'
 import type { CallExpressionKw, Expr, PathToNode } from '@src/lang/wasm'
 import { parse, recast, resultIsOk } from '@src/lang/wasm'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { cameraMouseDragGuards } from '@src/lib/cameraControls'
 import type { CameraSystem } from '@src/lib/cameraControls'
 import { getSketchSolveToolIconMap, useToolbarConfig } from '@src/lib/toolbar'
@@ -56,9 +56,7 @@ function useShouldHideScene(): { hideClient: boolean; hideServer: boolean } {
   const [isTween, setIsTween] = useState(false)
 
   const { state } = useModelingContext()
-  const {
-    executingEditor: { sceneInfra },
-  } = useSingletons()
+  const { sceneInfra } = useExecutingEditor()
 
   useEffect(() => {
     sceneInfra.camControls.setIsCamMovingCallback(
@@ -90,9 +88,8 @@ export const ClientSideScene = ({
   enableTouchControls: boolean
   sketchSolveStreamDimming?: number
 }) => {
-  const {
-    executingEditor: { sceneEntitiesManager, sceneInfra, engineCommandManager },
-  } = useSingletons()
+  const { sceneEntitiesManager, sceneInfra, engineCommandManager } =
+    useExecutingEditor()
   const { state, send, context } = useModelingContext()
   const { hideClient, hideServer } = useShouldHideScene()
 
@@ -338,7 +335,7 @@ const Overlay = ({
   overlayIndex: number
   pathToNodeString: string
 }) => {
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const wasmInstance = use(executingEditor.wasmInstancePromise)
   const { context, send, state } = useModelingContext()
 
@@ -475,7 +472,7 @@ const SegmentMenu = ({
   pathToNode: PathToNode
   stdLibFnName: string
 }) => {
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const wasmInstance = use(executingEditor.wasmInstancePromise)
   const { send } = useModelingContext()
   const dependentSourceRanges = findUsesOfTagInPipe(
@@ -541,7 +538,7 @@ const ConstraintSymbol = ({
   verticalPosition: 'top' | 'bottom'
 }) => {
   const { commands } = useApp()
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const wasmInstance = use(executingEditor.wasmInstancePromise)
   const { context } = useModelingContext()
   const varNameMap: {
@@ -795,9 +792,7 @@ const throttled = (sceneInfra: SceneInfra) =>
 
 export const CamDebugSettings = () => {
   const { commands } = useApp()
-  const {
-    executingEditor: { sceneInfra },
-  } = useSingletons()
+  const { sceneInfra } = useExecutingEditor()
   const [camSettings, setCamSettings] = useState<ReactCameraProperties>(
     sceneInfra.camControls.reactCameraProperties
   )

--- a/src/clientSideScene/EditingConstraintInput.tsx
+++ b/src/clientSideScene/EditingConstraintInput.tsx
@@ -1,6 +1,6 @@
 import { KclInput } from '@src/components/KclInput'
 import { useModelingContext } from '@src/hooks/useModelingContext'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import { SKETCH_FILE_VERSION } from '@src/lib/constants'
 import { jsAppSettings } from '@src/lib/settings/settingsUtils'
 import type { modelingMachine } from '@src/machines/modelingMachine'
@@ -15,9 +15,7 @@ import { useCallback, useEffect, useState } from 'react'
 import type { SnapshotFrom, StateFrom } from 'xstate'
 
 export const EditingConstraintInput = () => {
-  const {
-    executingEditor: { sceneInfra, rustContext },
-  } = useSingletons()
+  const { sceneInfra, rustContext } = useExecutingEditor()
   const { state } = useModelingContext()
   const editingConstraintId = useSelector(
     state.children.sketchSolveMachine,

--- a/src/clientSideScene/EditingConstraintInput.tsx
+++ b/src/clientSideScene/EditingConstraintInput.tsx
@@ -16,7 +16,7 @@ import type { SnapshotFrom, StateFrom } from 'xstate'
 
 export const EditingConstraintInput = () => {
   const {
-    kclManager: { sceneInfra, rustContext },
+    executingEditor: { sceneInfra, rustContext },
   } = useSingletons()
   const { state } = useModelingContext()
   const editingConstraintId = useSelector(

--- a/src/clientSideScene/deleteSegment.ts
+++ b/src/clientSideScene/deleteSegment.ts
@@ -27,7 +27,7 @@ import {
 
 import type { SceneEntities } from '@src/clientSideScene/sceneEntities'
 import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { getPathsFromArtifact } from '@src/lang/std/artifactGraph'
 import type RustContext from '@src/lib/rustContext'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
@@ -40,16 +40,20 @@ export async function deleteSegmentsOrProfiles({
   pathToNodes: PathToNode[]
   sketchDetails: SketchDetails | null
   dependencies: {
-    kclManager: KclManager
+    executingEditor: ExecutingEditor
     rustContext: RustContext
     sceneEntitiesManager: SceneEntities
     sceneInfra: SceneInfra
   }
 }) {
-  let modifiedAst: Node<Program> | Error = dependencies.kclManager.ast
-  const wasmInstance = await dependencies.kclManager.wasmInstancePromise
+  let modifiedAst: Node<Program> | Error = dependencies.executingEditor.ast
+  const wasmInstance = await dependencies.executingEditor.wasmInstancePromise
   const dependentRanges = pathToNodes.flatMap((pathToNode) =>
-    findUsesOfTagInPipe(dependencies.kclManager.ast, pathToNode, wasmInstance)
+    findUsesOfTagInPipe(
+      dependencies.executingEditor.ast,
+      pathToNode,
+      wasmInstance
+    )
   )
 
   const shouldContinueSegDelete = dependentRanges.length
@@ -66,13 +70,13 @@ export async function deleteSegmentsOrProfiles({
   modifiedAst = deleteSegmentOrProfileFromPipeExpression(
     dependentRanges,
     modifiedAst,
-    dependencies.kclManager.variables,
-    dependencies.kclManager.code,
+    dependencies.executingEditor.variables,
+    dependencies.executingEditor.code,
     pathToNodes,
     getConstraintInfoKw,
     removeSingleConstraint,
     transformAstSketchLines,
-    await dependencies.kclManager.wasmInstancePromise
+    await dependencies.executingEditor.wasmInstancePromise
   )
   if (err(modifiedAst)) {
     return Promise.reject(modifiedAst)
@@ -101,7 +105,7 @@ export async function deleteSegmentsOrProfiles({
     modifiedAst,
     testExecute.execState.artifactGraph,
     sketchDetails,
-    await dependencies.kclManager.wasmInstancePromise
+    await dependencies.executingEditor.wasmInstancePromise
   )
 
   await dependencies.sceneEntitiesManager.updateAstAndRejigSketch(

--- a/src/clientSideScene/sceneEntities.ts
+++ b/src/clientSideScene/sceneEntities.ts
@@ -92,7 +92,7 @@ import {
   getTanPreviousPoint,
   segmentUtils,
 } from '@src/clientSideScene/segments'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { ARG_AT, ARG_END, ARG_END_ABSOLUTE } from '@src/lang/constants'
 import {
   createArrayExpression,
@@ -195,7 +195,7 @@ type Vec3Array = [number, number, number]
 export class SceneEntities {
   readonly engineCommandManager: ConnectionManager
   readonly sceneInfra: SceneInfra
-  readonly kclManager: KclManager
+  readonly executingEditor: ExecutingEditor
   readonly rustContext: RustContext
   commandBarActor: CommandBarActorType
   activeSegments: { [key: string]: Group } = {}
@@ -209,14 +209,14 @@ export class SceneEntities {
   constructor(
     engineCommandManager: ConnectionManager,
     sceneInfra: SceneInfra,
-    kclManager: KclManager,
+    executingEditor: ExecutingEditor,
     rustContext: RustContext,
     commandBarActor: CommandBarActorType,
     getSettings: typeof this.getSettings
   ) {
     this.engineCommandManager = engineCommandManager
     this.sceneInfra = sceneInfra
-    this.kclManager = kclManager
+    this.executingEditor = executingEditor
     this.rustContext = rustContext
     this.commandBarActor = commandBarActor
     this.getSettings = getSettings
@@ -261,7 +261,7 @@ export class SceneEntities {
   }
 
   onCamChange = async () => {
-    const wasmInstance = await this.kclManager.wasmInstancePromise
+    const wasmInstance = await this.executingEditor.wasmInstancePromise
     const orthoFactor = orthoScale(this.sceneInfra.camControls.camera)
     const callbacks: (() => SegmentOverlayPayload | null)[] = []
     Object.values(this.activeSegments).forEach((segment, _index) => {
@@ -793,23 +793,26 @@ export class SceneEntities {
         }
 
         const inserted = insertNewStartProfileAt(
-          this.kclManager.ast,
+          this.executingEditor.ast,
           sketchDetails.sketchNodePaths,
           sketchDetails.planeNodePath,
           startPoint,
           'end',
-          await this.kclManager.wasmInstancePromise
+          await this.executingEditor.wasmInstancePromise
         )
 
         if (trap(inserted)) return
         const { modifiedAst } = inserted
 
-        await this.kclManager.updateAst(modifiedAst, false)
-        await this.kclManager.updateEditorWithAstAndWriteToFile(modifiedAst, {
-          shouldAddToHistory: false,
-          shouldWriteToDisk: false,
-          allowProgrammaticDocumentChanges: true,
-        })
+        await this.executingEditor.updateAst(modifiedAst, false)
+        await this.executingEditor.updateEditorWithAstAndWriteToFile(
+          modifiedAst,
+          {
+            shouldAddToHistory: false,
+            shouldWriteToDisk: false,
+            allowProgrammaticDocumentChanges: true,
+          }
+        )
 
         // Now perform the caller-specified action
         afterClick(args, {
@@ -842,7 +845,7 @@ export class SceneEntities {
     truncatedAst: Node<Program>
     variableDeclarationName: string
   }> {
-    const wasmInstance = await this.kclManager.wasmInstancePromise
+    const wasmInstance = await this.executingEditor.wasmInstancePromise
     const prepared = this.prepareTruncatedAst(
       sketchNodePaths,
       wasmInstance,
@@ -861,8 +864,8 @@ export class SceneEntities {
     const sketchesInfo = getSketchesInfo({
       sketchNodePaths,
       variables: execState.variables,
-      kclManager: this.kclManager,
-      wasmInstance: await this.kclManager.wasmInstancePromise,
+      executingEditor: this.executingEditor,
+      wasmInstance: await this.executingEditor.wasmInstancePromise,
     })
 
     const group = new Group()
@@ -1018,7 +1021,7 @@ export class SceneEntities {
         const selection: Selections = computeSelectionFromSourceRangeAndAST(
           sourceRange,
           maybeModdedAst,
-          this.kclManager
+          this.executingEditor
         )
         if (!this.commandBarActor) {
           console.error('command bar actor not found.')
@@ -1037,7 +1040,7 @@ export class SceneEntities {
           sceneInfra: this.sceneInfra,
           selection,
           commandBarActor: this.commandBarActor,
-          kclManager: this.kclManager,
+          executingEditor: this.executingEditor,
           wasmInstance,
         })
         if (err(result)) return
@@ -1094,7 +1097,7 @@ export class SceneEntities {
     updateExtraSegments: typeof updateExtraSegmentsFn
   ) => {
     if (trap(modifiedAst)) return Promise.reject(modifiedAst)
-    const nextAst = await this.kclManager.updateAst(modifiedAst, false)
+    const nextAst = await this.executingEditor.updateAst(modifiedAst, false)
     this.sceneInfra.resetMouseListeners()
     await this.setupSketch({
       sketchEntryNodePath,
@@ -1133,8 +1136,8 @@ export class SceneEntities {
     origin: [number, number, number],
     segmentName: 'line' | 'tangentialArc' = 'line'
   ) => {
-    const wasmInstance = await this.kclManager.wasmInstancePromise
-    const _ast = structuredClone(this.kclManager.ast)
+    const wasmInstance = await this.executingEditor.wasmInstancePromise
+    const _ast = structuredClone(this.executingEditor.ast)
 
     const _node1 = getNodeFromPath<VariableDeclaration>(
       _ast,
@@ -1146,7 +1149,7 @@ export class SceneEntities {
     const variableDeclarationName = _node1.node?.declaration.id?.name || ''
 
     const sg = sketchFromKclValue(
-      this.kclManager.variables[variableDeclarationName],
+      this.executingEditor.variables[variableDeclarationName],
       variableDeclarationName
     )
     if (err(sg)) return Promise.reject(sg)
@@ -1155,7 +1158,7 @@ export class SceneEntities {
     const index = sg.paths.length // because we've added a new segment that's not in the memory yet, no need for `.length -1`
     const mod = addNewSketchLn({
       node: _ast,
-      variables: this.kclManager.variables,
+      variables: this.executingEditor.variables,
       input: {
         type: 'straight-segment',
         to: lastSeg.to,
@@ -1199,18 +1202,18 @@ export class SceneEntities {
         let intersection2d = intersectionPoint?.twoD
 
         let modifiedAst: Node<Program> | Error = structuredClone(
-          this.kclManager.ast
+          this.executingEditor.ast
         )
 
         const sketch = sketchFromPathToNode({
           pathToNode: sketchEntryNodePath,
-          variables: this.kclManager.variables,
-          kclManager: this.kclManager,
-          wasmInstance: await this.kclManager.wasmInstancePromise,
+          variables: this.executingEditor.variables,
+          executingEditor: this.executingEditor,
+          wasmInstance: await this.executingEditor.wasmInstancePromise,
         })
         if (err(sketch)) return Promise.reject(sketch)
         if (!sketch) return Promise.reject(new Error('No sketch found'))
-        const wasmInstance = await this.kclManager.wasmInstancePromise
+        const wasmInstance = await this.executingEditor.wasmInstancePromise
 
         let intersectsProfileStart = false
         if (intersection2d) {
@@ -1248,8 +1251,8 @@ export class SceneEntities {
             ])
 
             modifiedAst = addCallExpressionsToPipe({
-              node: this.kclManager.ast,
-              variables: this.kclManager.variables,
+              node: this.executingEditor.ast,
+              variables: this.executingEditor.variables,
               pathToNode: sketchEntryNodePath,
               expressions: [
                 segmentName === 'tangentialArc'
@@ -1265,7 +1268,7 @@ export class SceneEntities {
             if (trap(modifiedAst)) return Promise.reject(modifiedAst)
             modifiedAst = addCloseToPipe({
               node: modifiedAst,
-              variables: this.kclManager.variables,
+              variables: this.executingEditor.variables,
               pathToNode: sketchEntryNodePath,
               wasmInstance,
             })
@@ -1337,7 +1340,7 @@ export class SceneEntities {
 
             const tmp = addNewSketchLn({
               node: modifiedAst,
-              variables: this.kclManager.variables,
+              variables: this.executingEditor.variables,
               input: {
                 type: 'straight-segment',
                 from: [lastSegment.to[0], lastSegment.to[1]],
@@ -1346,7 +1349,7 @@ export class SceneEntities {
               fnName: resolvedFunctionName,
               pathToNode: sketchEntryNodePath,
               snaps,
-              wasmInstance: await this.kclManager.wasmInstancePromise,
+              wasmInstance: await this.executingEditor.wasmInstancePromise,
             })
             if (trap(tmp)) return Promise.reject(tmp)
             modifiedAst = tmp.modifiedAst
@@ -1360,7 +1363,7 @@ export class SceneEntities {
         await updateModelingState(
           modifiedAst,
           EXECUTION_TYPE_MOCK,
-          this.kclManager,
+          this.executingEditor,
           {
             // TODO: understand why this is needed
             skipErrorsOnMockExecution: true,
@@ -1403,7 +1406,7 @@ export class SceneEntities {
             variableDeclarationName,
           },
           mouseEvent: args.mouseEvent,
-          wasmInstance: await this.kclManager.wasmInstancePromise,
+          wasmInstance: await this.executingEditor.wasmInstancePromise,
         })
       },
     })
@@ -1416,8 +1419,8 @@ export class SceneEntities {
     sketchOrigin: [number, number, number],
     rectangleOrigin: [x: number, y: number]
   ): Promise<SketchDetailsUpdate | Error> => {
-    const wasmInstance = await this.kclManager.wasmInstancePromise
-    let _ast = structuredClone(this.kclManager.ast)
+    const wasmInstance = await this.executingEditor.wasmInstancePromise
+    let _ast = structuredClone(this.executingEditor.ast)
 
     const varDec = getNodeFromPath<VariableDeclarator>(
       _ast,
@@ -1466,9 +1469,9 @@ export class SceneEntities {
     _ast = pResult.program
 
     // do a quick mock execution to get the program memory up-to-date
-    const didReParse = await this.kclManager.executeAstMock(_ast)
+    const didReParse = await this.executingEditor.executeAstMock(_ast)
     if (err(didReParse)) return didReParse
-    await this.kclManager.updateEditorWithAstAndWriteToFile(_ast, {
+    await this.executingEditor.updateEditorWithAstAndWriteToFile(_ast, {
       shouldAddToHistory: false,
       shouldWriteToDisk: false,
       allowProgrammaticDocumentChanges: true,
@@ -1510,7 +1513,7 @@ export class SceneEntities {
       onMove: async (args) => {
         // Update the width and height of the draft rectangle
 
-        const wasmInstance = await this.kclManager.wasmInstancePromise
+        const wasmInstance = await this.executingEditor.wasmInstancePromise
 
         const nodePathWithCorrectedIndexForTruncatedAst =
           getPathNormalisedForTruncatedAst(
@@ -1543,7 +1546,7 @@ export class SceneEntities {
             x,
             y,
             tag,
-            await this.kclManager.wasmInstancePromise
+            await this.executingEditor.wasmInstancePromise
           )
         }
 
@@ -1588,7 +1591,7 @@ export class SceneEntities {
         // Commit the rectangle to the full AST/code and return to sketch.idle
         const twoD = args.intersectionPoint?.twoD
         if (!twoD || args.mouseEvent.button !== 0) return
-        const wasmInstance = await this.kclManager.wasmInstancePromise
+        const wasmInstance = await this.executingEditor.wasmInstancePromise
 
         const { snappedPoint } = this.getSnappedDragPoint(
           twoD,
@@ -1625,7 +1628,11 @@ export class SceneEntities {
         // lee: I had this at the bottom of the function, but it's
         // possible sketchFromKclValue "fails" when sketching on a face,
         // and this couldn't wouldn't run.
-        await updateModelingState(_ast, EXECUTION_TYPE_MOCK, this.kclManager)
+        await updateModelingState(
+          _ast,
+          EXECUTION_TYPE_MOCK,
+          this.executingEditor
+        )
         this.sceneInfra.modelingSend({ type: 'Finish rectangle' })
       },
     })
@@ -1643,13 +1650,13 @@ export class SceneEntities {
     sketchOrigin: [number, number, number],
     rectangleOrigin: [x: number, y: number]
   ): Promise<SketchDetailsUpdate | Error> => {
-    const wasmInstance = await this.kclManager.wasmInstancePromise
-    let _ast = structuredClone(this.kclManager.ast)
+    const wasmInstance = await this.executingEditor.wasmInstancePromise
+    let _ast = structuredClone(this.executingEditor.ast)
 
     const varDec = getNodeFromPath<VariableDeclarator>(
       _ast,
       planeNodePath,
-      await this.kclManager.wasmInstancePromise,
+      await this.executingEditor.wasmInstancePromise,
       'VariableDeclarator'
     )
 
@@ -1693,8 +1700,8 @@ export class SceneEntities {
     _ast = __recastAst.program
 
     // do a quick mock execution to get the program memory up-to-date
-    await this.kclManager.executeAstMock(_ast)
-    await this.kclManager.updateEditorWithAstAndWriteToFile(_ast, {
+    await this.executingEditor.executeAstMock(_ast)
+    await this.executingEditor.updateEditorWithAstAndWriteToFile(_ast, {
       shouldAddToHistory: false,
       shouldWriteToDisk: false,
       allowProgrammaticDocumentChanges: true,
@@ -1744,11 +1751,11 @@ export class SceneEntities {
         const _node = getNodeFromPath<VariableDeclaration>(
           truncatedAst,
           nodePathWithCorrectedIndexForTruncatedAst,
-          await this.kclManager.wasmInstancePromise,
+          await this.executingEditor.wasmInstancePromise,
           'VariableDeclaration'
         )
         if (trap(_node)) return Promise.reject(_node)
-        const wasmInstance = await this.kclManager.wasmInstancePromise
+        const wasmInstance = await this.executingEditor.wasmInstancePromise
         const sketchInit = _node.node?.declaration.init
 
         const { snappedPoint } = this.getSnappedDragPoint(
@@ -1768,7 +1775,7 @@ export class SceneEntities {
             tag,
             rectangleOrigin[0],
             rectangleOrigin[1],
-            await this.kclManager.wasmInstancePromise
+            await this.executingEditor.wasmInstancePromise
           )
           if (err(maybeError)) {
             return Promise.reject(maybeError)
@@ -1816,7 +1823,7 @@ export class SceneEntities {
         // Commit the rectangle to the full AST/code and return to sketch.idle
         const twoD = args.intersectionPoint?.twoD
         if (!twoD || args.mouseEvent.button !== 0) return
-        const wasmInstance = await this.kclManager.wasmInstancePromise
+        const wasmInstance = await this.executingEditor.wasmInstancePromise
 
         const { snappedPoint } = this.getSnappedDragPoint(
           twoD,
@@ -1860,7 +1867,11 @@ export class SceneEntities {
           // lee: I had this at the bottom of the function, but it's
           // possible sketchFromKclValue "fails" when sketching on a face,
           // and this couldn't wouldn't run.
-          await updateModelingState(_ast, EXECUTION_TYPE_MOCK, this.kclManager)
+          await updateModelingState(
+            _ast,
+            EXECUTION_TYPE_MOCK,
+            this.executingEditor
+          )
           this.sceneInfra.modelingSend({ type: 'Finish center rectangle' })
         }
       },
@@ -1880,8 +1891,8 @@ export class SceneEntities {
     point1: [x: number, y: number],
     point2: [x: number, y: number]
   ): Promise<SketchDetailsUpdate | Error> => {
-    const wasmInstance = await this.kclManager.wasmInstancePromise
-    let _ast = structuredClone(this.kclManager.ast)
+    const wasmInstance = await this.executingEditor.wasmInstancePromise
+    let _ast = structuredClone(this.executingEditor.ast)
 
     const varDec = getNodeFromPath<VariableDeclarator>(
       _ast,
@@ -1922,9 +1933,9 @@ export class SceneEntities {
     _ast = pResult.program
 
     // do a quick mock execution to get the program memory up-to-date
-    const didReParse = await this.kclManager.executeAstMock(_ast)
+    const didReParse = await this.executingEditor.executeAstMock(_ast)
     if (err(didReParse)) return didReParse
-    await this.kclManager.updateEditorWithAstAndWriteToFile(_ast, {
+    await this.executingEditor.updateEditorWithAstAndWriteToFile(_ast, {
       shouldAddToHistory: false,
       shouldWriteToDisk: false,
       allowProgrammaticDocumentChanges: true,
@@ -1950,18 +1961,18 @@ export class SceneEntities {
         const _node = getNodeFromPath<VariableDeclaration>(
           truncatedAst,
           nodePathWithCorrectedIndexForTruncatedAst,
-          await this.kclManager.wasmInstancePromise,
+          await this.executingEditor.wasmInstancePromise,
           'VariableDeclaration'
         )
         let modded = structuredClone(truncatedAst)
         if (trap(_node)) return
-        const wasmInstance = await this.kclManager.wasmInstancePromise
+        const wasmInstance = await this.executingEditor.wasmInstancePromise
         const sketchInit = _node.node.declaration.init
 
         if (sketchInit.type === 'CallExpressionKw') {
           const moddedResult = changeSketchArguments(
             modded,
-            this.kclManager.variables,
+            this.executingEditor.variables,
             {
               type: 'path',
               pathToNode: nodePathWithCorrectedIndexForTruncatedAst,
@@ -2028,18 +2039,18 @@ export class SceneEntities {
         const _node = getNodeFromPath<VariableDeclaration>(
           _ast,
           updatedEntryNodePath || [],
-          await this.kclManager.wasmInstancePromise,
+          await this.executingEditor.wasmInstancePromise,
           'VariableDeclaration'
         )
         if (trap(_node)) return
-        const wasmInstance = await this.kclManager.wasmInstancePromise
+        const wasmInstance = await this.executingEditor.wasmInstancePromise
         const sketchInit = _node.node?.declaration.init
 
         let modded = structuredClone(_ast)
         if (sketchInit.type === 'CallExpressionKw') {
           const moddedResult = changeSketchArguments(
             modded,
-            this.kclManager.variables,
+            this.executingEditor.variables,
             {
               type: 'path',
               pathToNode: updatedEntryNodePath,
@@ -2068,7 +2079,11 @@ export class SceneEntities {
           _ast = pResult.program
 
           // Update the primary AST and unequip the rectangle tool
-          await updateModelingState(_ast, EXECUTION_TYPE_MOCK, this.kclManager)
+          await updateModelingState(
+            _ast,
+            EXECUTION_TYPE_MOCK,
+            this.executingEditor
+          )
           this.sceneInfra.modelingSend({ type: 'Finish circle three point' })
         }
       },
@@ -2087,8 +2102,8 @@ export class SceneEntities {
     sketchOrigin: [number, number, number],
     center: [x: number, y: number]
   ): Promise<SketchDetailsUpdate | Error> => {
-    const wasmInstance = await this.kclManager.wasmInstancePromise
-    let _ast = structuredClone(this.kclManager.ast)
+    const wasmInstance = await this.executingEditor.wasmInstancePromise
+    let _ast = structuredClone(this.executingEditor.ast)
 
     const _node1 = getNodeFromPath<VariableDeclaration>(
       _ast,
@@ -2100,7 +2115,7 @@ export class SceneEntities {
     const variableDeclarationName = _node1.node?.declaration.id?.name || ''
 
     const sg = sketchFromKclValue(
-      this.kclManager.variables[variableDeclarationName],
+      this.executingEditor.variables[variableDeclarationName],
       variableDeclarationName
     )
     if (err(sg)) return Promise.reject(sg)
@@ -2121,7 +2136,7 @@ export class SceneEntities {
     // Use addNewSketchLn to append an arc to the existing sketch
     const mod = addNewSketchLn({
       node: _ast,
-      variables: this.kclManager.variables,
+      variables: this.executingEditor.variables,
       input: {
         type: 'arc-segment',
         from,
@@ -2141,9 +2156,9 @@ export class SceneEntities {
     _ast = pResult.program
 
     // do a quick mock execution to get the program memory up-to-date
-    const didReParse = await this.kclManager.executeAstMock(_ast)
+    const didReParse = await this.executingEditor.executeAstMock(_ast)
     if (err(didReParse)) return didReParse
-    await this.kclManager.updateEditorWithAstAndWriteToFile(_ast, {
+    await this.executingEditor.updateEditorWithAstAndWriteToFile(_ast, {
       shouldAddToHistory: false,
       shouldWriteToDisk: false,
       allowProgrammaticDocumentChanges: true,
@@ -2171,7 +2186,7 @@ export class SceneEntities {
         const _node = getNodeFromPath<VariableDeclaration>(
           truncatedAst,
           nodePathWithCorrectedIndexForTruncatedAst,
-          await this.kclManager.wasmInstancePromise,
+          await this.executingEditor.wasmInstancePromise,
           'VariableDeclaration'
         )
         let modded = structuredClone(truncatedAst)
@@ -2193,7 +2208,7 @@ export class SceneEntities {
 
           const moddedResult = changeSketchArguments(
             modded,
-            this.kclManager.variables,
+            this.executingEditor.variables,
             {
               type: 'path',
               pathToNode: nodePathWithCorrectedIndexForTruncatedAst,
@@ -2206,7 +2221,7 @@ export class SceneEntities {
               radius: radius,
               ccw: true,
             },
-            await this.kclManager.wasmInstancePromise
+            await this.executingEditor.wasmInstancePromise
           )
           if (err(moddedResult)) return
           modded = moddedResult.modifiedAst
@@ -2225,7 +2240,7 @@ export class SceneEntities {
 
         const varDecIndex = Number(sketchEntryNodePath[1][0])
 
-        const wasmInstance = await this.kclManager.wasmInstancePromise
+        const wasmInstance = await this.executingEditor.wasmInstancePromise
         this.updateSegment(
           sketch.start,
           0,
@@ -2282,7 +2297,7 @@ export class SceneEntities {
 
           const moddedResult = changeSketchArguments(
             modded,
-            this.kclManager.variables,
+            this.executingEditor.variables,
             {
               type: 'path',
               pathToNode: mod.pathToNode,
@@ -2308,7 +2323,11 @@ export class SceneEntities {
           _ast = pResult.program
 
           // Update the primary AST and unequip the arc tool
-          await updateModelingState(_ast, EXECUTION_TYPE_MOCK, this.kclManager)
+          await updateModelingState(
+            _ast,
+            EXECUTION_TYPE_MOCK,
+            this.executingEditor
+          )
           this.sceneInfra.modelingSend({ type: 'Finish arc' })
         }
       },
@@ -2327,8 +2346,8 @@ export class SceneEntities {
     sketchOrigin: [number, number, number],
     p2: [x: number, y: number]
   ): Promise<SketchDetailsUpdate | Error> => {
-    const wasmInstance = await this.kclManager.wasmInstancePromise
-    let _ast = structuredClone(this.kclManager.ast)
+    const wasmInstance = await this.executingEditor.wasmInstancePromise
+    let _ast = structuredClone(this.executingEditor.ast)
 
     const _node1 = getNodeFromPath<VariableDeclaration>(
       _ast,
@@ -2340,7 +2359,7 @@ export class SceneEntities {
     const variableDeclarationName = _node1.node?.declaration.id?.name || ''
 
     const sg = sketchFromKclValue(
-      this.kclManager.variables[variableDeclarationName],
+      this.executingEditor.variables[variableDeclarationName],
       variableDeclarationName
     )
     if (err(sg)) return Promise.reject(sg)
@@ -2353,7 +2372,7 @@ export class SceneEntities {
     // Use addNewSketchLn to append an arc to the existing sketch
     const mod = addNewSketchLn({
       node: _ast,
-      variables: this.kclManager.variables,
+      variables: this.executingEditor.variables,
       input: {
         type: 'circle-three-point-segment',
         p1,
@@ -2371,9 +2390,9 @@ export class SceneEntities {
     _ast = pResult.program
 
     // do a quick mock execution to get the program memory up-to-date
-    const didReParse = await this.kclManager.executeAstMock(_ast)
+    const didReParse = await this.executingEditor.executeAstMock(_ast)
     if (err(didReParse)) return didReParse
-    await this.kclManager.updateEditorWithAstAndWriteToFile(_ast, {
+    await this.executingEditor.updateEditorWithAstAndWriteToFile(_ast, {
       shouldAddToHistory: false,
       shouldWriteToDisk: false,
       allowProgrammaticDocumentChanges: true,
@@ -2401,7 +2420,7 @@ export class SceneEntities {
 
     this.sceneInfra.setCallbacks({
       onMove: async (args) => {
-        const wasmInstance = await this.kclManager.wasmInstancePromise
+        const wasmInstance = await this.executingEditor.wasmInstancePromise
         const nodePathWithCorrectedIndexForTruncatedAst =
           getPathNormalisedForTruncatedAst(mod.pathToNode, sketchNodePaths)
         const _node = getNodeFromPath<VariableDeclaration>(
@@ -2432,7 +2451,7 @@ export class SceneEntities {
         if (sketchInit.type === 'PipeExpression') {
           const moddedResult = changeSketchArguments(
             modded,
-            this.kclManager.variables,
+            this.executingEditor.variables,
             {
               type: 'path',
               pathToNode: nodePathWithCorrectedIndexForTruncatedAst,
@@ -2495,7 +2514,7 @@ export class SceneEntities {
         // Commit the arc to the full AST/code and return to sketch.idle
         const mousePoint = args.intersectionPoint?.twoD
         if (!mousePoint || args.mouseEvent.button !== 0) return
-        const wasmInstance = await this.kclManager.wasmInstancePromise
+        const wasmInstance = await this.executingEditor.wasmInstancePromise
 
         const _node = getNodeFromPath<VariableDeclaration>(
           _ast,
@@ -2516,7 +2535,7 @@ export class SceneEntities {
 
           const moddedResult = changeSketchArguments(
             modded,
-            this.kclManager.variables,
+            this.executingEditor.variables,
             {
               type: 'path',
               pathToNode: mod.pathToNode,
@@ -2561,7 +2580,7 @@ export class SceneEntities {
 
             const moddedResult = addCloseToPipe({
               node: modded,
-              variables: this.kclManager.variables,
+              variables: this.executingEditor.variables,
               pathToNode: sketchEntryNodePath,
               wasmInstance,
             })
@@ -2577,7 +2596,11 @@ export class SceneEntities {
           _ast = pResult.program
 
           // Update the primary AST and unequip the arc tool
-          await updateModelingState(_ast, EXECUTION_TYPE_MOCK, this.kclManager)
+          await updateModelingState(
+            _ast,
+            EXECUTION_TYPE_MOCK,
+            this.executingEditor
+          )
           if (intersectsProfileStart) {
             this.sceneInfra.modelingSend({ type: 'Close sketch' })
           } else {
@@ -2600,8 +2623,8 @@ export class SceneEntities {
     sketchOrigin: [number, number, number],
     circleCenter: [x: number, y: number]
   ): Promise<SketchDetailsUpdate | Error> => {
-    const wasmInstance = await this.kclManager.wasmInstancePromise
-    let _ast = structuredClone(this.kclManager.ast)
+    const wasmInstance = await this.executingEditor.wasmInstancePromise
+    let _ast = structuredClone(this.executingEditor.ast)
 
     const varDec = getNodeFromPath<VariableDeclarator>(
       _ast,
@@ -2647,9 +2670,9 @@ export class SceneEntities {
     _ast = pResult.program
 
     // do a quick mock execution to get the program memory up-to-date
-    const didReParse = await this.kclManager.executeAstMock(_ast)
+    const didReParse = await this.executingEditor.executeAstMock(_ast)
     if (err(didReParse)) return didReParse
-    await this.kclManager.updateEditorWithAstAndWriteToFile(_ast, {
+    await this.executingEditor.updateEditorWithAstAndWriteToFile(_ast, {
       shouldAddToHistory: false,
       shouldWriteToDisk: false,
       allowProgrammaticDocumentChanges: true,
@@ -2667,7 +2690,7 @@ export class SceneEntities {
 
     this.sceneInfra.setCallbacks({
       onMove: async (args) => {
-        const wasmInstance = await this.kclManager.wasmInstancePromise
+        const wasmInstance = await this.executingEditor.wasmInstancePromise
         const nodePathWithCorrectedIndexForTruncatedAst =
           getPathNormalisedForTruncatedAst(
             updatedEntryNodePath,
@@ -2689,7 +2712,7 @@ export class SceneEntities {
         if (sketchInit.type === 'CallExpressionKw') {
           const moddedResult = changeSketchArguments(
             modded,
-            this.kclManager.variables,
+            this.executingEditor.variables,
             {
               type: 'path',
               pathToNode: nodePathWithCorrectedIndexForTruncatedAst,
@@ -2751,7 +2774,7 @@ export class SceneEntities {
         // Commit the rectangle to the full AST/code and return to sketch.idle
         const cornerPoint = args.intersectionPoint?.twoD
         if (!cornerPoint || args.mouseEvent.button !== 0) return
-        const wasmInstance = await this.kclManager.wasmInstancePromise
+        const wasmInstance = await this.executingEditor.wasmInstancePromise
 
         const x = roundOff((cornerPoint.x || 0) - circleCenter[0])
         const y = roundOff((cornerPoint.y || 0) - circleCenter[1])
@@ -2769,7 +2792,7 @@ export class SceneEntities {
         if (sketchInit.type === 'CallExpressionKw') {
           const moddedResult = changeSketchArguments(
             modded,
-            this.kclManager.variables,
+            this.executingEditor.variables,
             {
               type: 'path',
               pathToNode: updatedEntryNodePath,
@@ -2791,14 +2814,18 @@ export class SceneEntities {
           if (err(newCode)) return
           const pResult = parse(
             newCode,
-            await this.kclManager.wasmInstancePromise
+            await this.executingEditor.wasmInstancePromise
           )
           if (trap(pResult) || !resultIsOk(pResult))
             return Promise.reject(pResult)
           _ast = pResult.program
 
           // Update the primary AST and unequip the rectangle tool
-          await updateModelingState(_ast, EXECUTION_TYPE_MOCK, this.kclManager)
+          await updateModelingState(
+            _ast,
+            EXECUTION_TYPE_MOCK,
+            this.executingEditor
+          )
           this.sceneInfra.modelingSend({ type: 'Finish circle' })
         }
       },
@@ -2835,7 +2862,7 @@ export class SceneEntities {
           await this.setupSketch({
             sketchEntryNodePath,
             sketchNodePaths,
-            maybeModdedAst: this.kclManager.ast,
+            maybeModdedAst: this.executingEditor.ast,
             up,
             forward,
             position,
@@ -2854,7 +2881,7 @@ export class SceneEntities {
         }
         // TODO: update the `updateCodeEditor` workflow to allow for writes to file
         // without execution so that we can drop this stray write to disk
-        await this.kclManager.writeToFile()
+        await this.executingEditor.writeToFile()
       },
       onDrag: async ({
         selected,
@@ -2863,7 +2890,7 @@ export class SceneEntities {
         intersects,
       }) => {
         if (mouseEvent.which !== 1) return
-        const wasmInstance = await this.kclManager.wasmInstancePromise
+        const wasmInstance = await this.executingEditor.wasmInstancePromise
 
         const group = getParentGroup(selected, [EXTRA_SEGMENT_HANDLE])
         if (group?.name === EXTRA_SEGMENT_HANDLE) {
@@ -2875,8 +2902,8 @@ export class SceneEntities {
 
           const sketch = sketchFromPathToNode({
             pathToNode,
-            variables: this.kclManager.variables,
-            kclManager: this.kclManager,
+            variables: this.executingEditor.variables,
+            executingEditor: this.executingEditor,
             wasmInstance,
           })
           if (trap(sketch)) return
@@ -2889,8 +2916,8 @@ export class SceneEntities {
           if (addingNewSegmentStatus === 'nothing') {
             const prevSegment = sketch.paths[pipeIndex - 2] // Is undefined when dragging the first segment
             const mod = addNewSketchLn({
-              node: this.kclManager.ast,
-              variables: this.kclManager.variables,
+              node: this.executingEditor.ast,
+              variables: this.executingEditor.variables,
               input: {
                 type: 'straight-segment',
                 to: [intersectionPoint.twoD.x, intersectionPoint.twoD.y],
@@ -2907,7 +2934,7 @@ export class SceneEntities {
             addingNewSegmentStatus = 'pending'
             if (trap(mod)) return
 
-            const didReParse = await this.kclManager.executeAstMock(
+            const didReParse = await this.executingEditor.executeAstMock(
               mod.modifiedAst
             )
             if (err(didReParse)) return
@@ -2915,7 +2942,7 @@ export class SceneEntities {
             this.setupSketch({
               sketchEntryNodePath: pathToNode,
               sketchNodePaths,
-              maybeModdedAst: this.kclManager.ast,
+              maybeModdedAst: this.executingEditor.ast,
               up,
               forward,
               position,
@@ -2967,8 +2994,8 @@ export class SceneEntities {
         const { selected } = args
         const event = getEventForSegmentSelection(
           selected,
-          this.kclManager.ast,
-          this.kclManager.artifactGraph,
+          this.executingEditor.ast,
+          this.executingEditor.artifactGraph,
           args.wasmInstance
         )
         if (!event) return
@@ -2985,8 +3012,8 @@ export class SceneEntities {
   ) => {
     return prepareTruncatedAst(
       sketchNodePaths,
-      ast || this.kclManager.ast,
-      this.kclManager.lastSuccessfulVariables,
+      ast || this.executingEditor.ast,
+      this.executingEditor.lastSuccessfulVariables,
       wasmInstance,
       draftSegment
     )
@@ -3330,7 +3357,7 @@ export class SceneEntities {
     )
     let modifiedAst = draftInfo
       ? draftInfo.truncatedAst
-      : { ...this.kclManager.ast }
+      : { ...this.executingEditor.ast }
 
     const nodePathWithCorrectedIndexForTruncatedAst =
       getPathNormalisedForTruncatedAst(pathToNode, sketchNodePaths)
@@ -3338,7 +3365,7 @@ export class SceneEntities {
     const _node = getNodeFromPath<Node<CallExpressionKw>>(
       modifiedAst,
       draftInfo ? nodePathWithCorrectedIndexForTruncatedAst : pathToNode,
-      await this.kclManager.wasmInstancePromise,
+      await this.executingEditor.wasmInstancePromise,
       ['CallExpressionKw']
     )
     if (trap(_node)) return
@@ -3508,19 +3535,19 @@ export class SceneEntities {
           to: dragTo,
           from,
         },
-        variables: this.kclManager.variables,
-        wasmInstance: await this.kclManager.wasmInstancePromise,
+        variables: this.executingEditor.variables,
+        wasmInstance: await this.executingEditor.wasmInstancePromise,
       })
     } else {
       modded = changeSketchArguments(
         modifiedAst,
-        this.kclManager.variables,
+        this.executingEditor.variables,
         {
           type: 'sourceRange',
           sourceRange: topLevelRange(node.start, node.end),
         },
         getChangeSketchInput(),
-        await this.kclManager.wasmInstancePromise
+        await this.executingEditor.wasmInstancePromise
       )
     }
     if (trap(modded)) return
@@ -3530,7 +3557,7 @@ export class SceneEntities {
       ? draftInfo
       : this.prepareTruncatedAst(
           sketchNodePaths || [],
-          await this.kclManager.wasmInstancePromise,
+          await this.executingEditor.wasmInstancePromise,
           modifiedAst
         )
     if (trap(info, { suppress: true })) return
@@ -3541,7 +3568,7 @@ export class SceneEntities {
       if (!draftInfo)
         // don't want to mod the user's code yet as they have't committed to the change yet
         // plus this would be the truncated ast being recast, it would be wrong
-        this.kclManager.updateCodeEditor(code)
+        this.executingEditor.updateCodeEditor(code)
 
       const { execState } = await executeAstMock({
         ast: truncatedAst,
@@ -3552,7 +3579,7 @@ export class SceneEntities {
       const sketchesInfo = getSketchesInfo({
         sketchNodePaths,
         variables,
-        kclManager: this.kclManager,
+        executingEditor: this.executingEditor,
         wasmInstance,
       })
       const callbacks: (() => SegmentOverlayPayload | null)[] = []
@@ -3783,7 +3810,7 @@ export class SceneEntities {
   mouseEnterLeaveCallbacks(updateExtraSegments: typeof updateExtraSegmentsFn) {
     return {
       onMouseEnter: async ({ selected }: OnMouseEnterLeaveArgs) => {
-        const wasmInstance = await this.kclManager.wasmInstancePromise
+        const wasmInstance = await this.executingEditor.wasmInstancePromise
         if ([X_AXIS, Y_AXIS].includes(selected?.userData?.type)) {
           const obj = selected as Mesh
           const mat = obj.material as MeshBasicMaterial
@@ -3796,7 +3823,7 @@ export class SceneEntities {
         )
         if (parent?.userData?.pathToNode) {
           const pResult = parse(
-            recast(this.kclManager.ast, wasmInstance),
+            recast(this.executingEditor.ast, wasmInstance),
             wasmInstance
           )
           if (trap(pResult) || !resultIsOk(pResult))
@@ -3810,7 +3837,7 @@ export class SceneEntities {
           )
           if (trap(_node, { suppress: true })) return
           const node = _node.node
-          this.kclManager.setHighlightRange([
+          this.executingEditor.setHighlightRange([
             topLevelRange(node.start, node.end),
           ])
           colorSegment(selected, SEGMENT_YELLOW)
@@ -3884,10 +3911,10 @@ export class SceneEntities {
           }
           return
         }
-        this.kclManager.setHighlightRange([defaultSourceRange()])
+        this.executingEditor.setHighlightRange([defaultSourceRange()])
       },
       onMouseLeave: async ({ selected }: OnMouseEnterLeaveArgs) => {
-        this.kclManager.setHighlightRange([defaultSourceRange()])
+        this.executingEditor.setHighlightRange([defaultSourceRange()])
         const parent = getParentGroup(
           selected,
           SEGMENT_BODIES_PLUS_PROFILE_START
@@ -3952,7 +3979,7 @@ export class SceneEntities {
               group: parent,
               scale: factor,
               sceneInfra: this.sceneInfra,
-              wasmInstance: await this.kclManager.wasmInstancePromise,
+              wasmInstance: await this.executingEditor.wasmInstancePromise,
             })
           }
         }
@@ -4252,16 +4279,16 @@ function prepareTruncatedAst(
 function sketchFromPathToNode({
   pathToNode,
   variables,
-  kclManager,
+  executingEditor,
   wasmInstance,
 }: {
   pathToNode: PathToNode
   variables: VariableMap
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   wasmInstance: ModuleType
 }): Sketch | null | Error {
   const _varDec = getNodeFromPath<VariableDeclarator>(
-    kclManager.ast,
+    executingEditor.ast,
     pathToNode,
     wasmInstance,
     'VariableDeclarator'
@@ -4329,12 +4356,12 @@ function massageFormats(
 function getSketchesInfo({
   sketchNodePaths,
   variables,
-  kclManager,
+  executingEditor,
   wasmInstance,
 }: {
   sketchNodePaths: PathToNode[]
   variables: VariableMap
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   wasmInstance: ModuleType
 }): {
   sketch: Sketch
@@ -4348,7 +4375,7 @@ function getSketchesInfo({
     const sketch = sketchFromPathToNode({
       pathToNode: path,
       variables,
-      kclManager,
+      executingEditor,
       wasmInstance,
     })
     if (err(sketch)) continue
@@ -4370,9 +4397,9 @@ function getSketchesInfo({
 function computeSelectionFromSourceRangeAndAST(
   sourceRange: SourceRange,
   ast: Node<Program>,
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
 ): Selections {
-  const artifactGraph = kclManager.artifactGraph
+  const artifactGraph = executingEditor.artifactGraph
   const artifact = getArtifactFromRange(sourceRange, artifactGraph) || undefined
   const selection: Selections = {
     graphSelections: [

--- a/src/clientSideScene/segments.ts
+++ b/src/clientSideScene/segments.ts
@@ -73,7 +73,7 @@ import {
   SEGMENT_LENGTH_LABEL_TEXT,
 } from '@src/clientSideScene/sceneUtils'
 import { angleLengthInfo } from '@src/components/Toolbar/angleLengthInfo'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { ARG_INTERIOR_ABSOLUTE } from '@src/lang/constants'
 import type { SegmentInputs } from '@src/lang/std/stdTypes'
 import type { Coords2d } from '@src/lang/util'
@@ -109,7 +109,7 @@ interface CreateSegmentArgs {
   sceneInfra: SceneInfra
   selection?: Selections
   commandBarActor: ActorRefFrom<typeof commandBarMachine>
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   wasmInstance: ModuleType
 }
 
@@ -162,7 +162,7 @@ class StraightSegment implements SegmentUtils {
     prevSegment,
     selection,
     commandBarActor,
-    kclManager,
+    executingEditor,
     wasmInstance,
   }) => {
     if (input.type !== 'straight-segment')
@@ -223,7 +223,7 @@ class StraightSegment implements SegmentUtils {
         scale,
         sceneInfra,
         commandBarActor,
-        kclManager,
+        executingEditor,
         wasmInstance,
       })
       segmentGroup.add(arrowGroup)
@@ -612,7 +612,7 @@ class CircleSegment implements SegmentUtils {
     isSelected,
     sceneInfra,
     commandBarActor,
-    kclManager,
+    executingEditor,
     wasmInstance,
   }) => {
     if (input.type !== 'arc-segment') {
@@ -659,7 +659,7 @@ class CircleSegment implements SegmentUtils {
       scale,
       sceneInfra,
       commandBarActor,
-      kclManager,
+      executingEditor,
       wasmInstance,
     })
 
@@ -1081,7 +1081,7 @@ class ArcSegment implements SegmentUtils {
     isSelected,
     sceneInfra,
     commandBarActor,
-    kclManager,
+    executingEditor,
     wasmInstance,
   }) => {
     if (input.type !== 'arc-segment') {
@@ -1124,7 +1124,7 @@ class ArcSegment implements SegmentUtils {
       scale,
       sceneInfra,
       commandBarActor,
-      kclManager,
+      executingEditor,
       wasmInstance,
     })
 
@@ -1180,7 +1180,7 @@ class ArcSegment implements SegmentUtils {
       scale,
       sceneInfra,
       commandBarActor,
-      kclManager,
+      executingEditor,
       wasmInstance,
     })
     endAngleLengthIndicator.name = 'endAngleLengthIndicator'
@@ -1800,7 +1800,7 @@ function createLengthIndicator({
   length = 0.1,
   sceneInfra,
   commandBarActor,
-  kclManager,
+  executingEditor,
   wasmInstance,
 }: {
   from: Coords2d
@@ -1809,7 +1809,7 @@ function createLengthIndicator({
   length?: number
   sceneInfra: SceneInfra
   commandBarActor: ActorRefFrom<typeof commandBarMachine>
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   wasmInstance: ModuleType
 }) {
   const lengthIndicatorGroup = new Group()
@@ -1847,7 +1847,7 @@ function createLengthIndicator({
         graphSelections: [selection.graphSelections[0]],
       },
       angleOrLength: 'setLength',
-      kclManager,
+      executingEditor,
       wasmInstance,
     })
     if (err(canConstrainLength) || !canConstrainLength.enabled) {

--- a/src/components/AstExplorer.tsx
+++ b/src/components/AstExplorer.tsx
@@ -6,13 +6,13 @@ import { getNodePathFromSourceRange } from '@src/lang/queryAstNodePathUtils'
 import { defaultSourceRange } from '@src/lang/sourceRange'
 import { codeRefFromRange } from '@src/lang/std/artifactGraph'
 import { topLevelRange } from '@src/lang/util'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import { codeToIdSelections } from '@src/lib/selections'
 import { trap } from '@src/lib/trap'
 import { isArray } from '@src/lib/utils'
 
 export function AstExplorer() {
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const wasmInstance = use(executingEditor.wasmInstancePromise)
   const { context } = useModelingContext()
   const pathToNode = getNodePathFromSourceRange(
@@ -101,7 +101,7 @@ function DisplayObj({
   node: any
 }) {
   const { send } = useModelingContext()
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const ref = useRef<HTMLPreElement>(null)
   const [hasCursor, setHasCursor] = useState(false)
   const [isCollapsed, setIsCollapsed] = useState(false)

--- a/src/components/AstExplorer.tsx
+++ b/src/components/AstExplorer.tsx
@@ -12,17 +12,17 @@ import { trap } from '@src/lib/trap'
 import { isArray } from '@src/lib/utils'
 
 export function AstExplorer() {
-  const { kclManager } = useSingletons()
-  const wasmInstance = use(kclManager.wasmInstancePromise)
+  const { executingEditor } = useSingletons()
+  const wasmInstance = use(executingEditor.wasmInstancePromise)
   const { context } = useModelingContext()
   const pathToNode = getNodePathFromSourceRange(
     // TODO maybe need to have callback to make sure it stays in sync
-    kclManager.ast,
+    executingEditor.ast,
     context.selectionRanges.graphSelections?.[0]?.codeRef?.range
   )
   const [filterKeys, setFilterKeys] = useState<string[]>(['start', 'end'])
 
-  const _node = getNodeFromPath(kclManager.ast, pathToNode, wasmInstance)
+  const _node = getNodeFromPath(executingEditor.ast, pathToNode, wasmInstance)
   if (trap(_node)) return
   const node = _node
 
@@ -54,12 +54,12 @@ export function AstExplorer() {
       <div
         className="h-full relative"
         onMouseLeave={(_e) => {
-          kclManager.setHighlightRange([defaultSourceRange()])
+          executingEditor.setHighlightRange([defaultSourceRange()])
         }}
       >
         <pre className="text-xs">
           <DisplayObj
-            obj={kclManager.ast}
+            obj={executingEditor.ast}
             filterKeys={filterKeys}
             node={node}
           />
@@ -101,7 +101,7 @@ function DisplayObj({
   node: any
 }) {
   const { send } = useModelingContext()
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const ref = useRef<HTMLPreElement>(null)
   const [hasCursor, setHasCursor] = useState(false)
   const [isCollapsed, setIsCollapsed] = useState(false)
@@ -126,21 +126,25 @@ function DisplayObj({
         hasCursor ? 'bg-violet-100/80 dark:bg-violet-100/25' : ''
       }`}
       onMouseEnter={(e) => {
-        kclManager.setHighlightRange([topLevelRange(obj?.start || 0, obj.end)])
+        executingEditor.setHighlightRange([
+          topLevelRange(obj?.start || 0, obj.end),
+        ])
         e.stopPropagation()
       }}
       onMouseMove={(e) => {
         e.stopPropagation()
-        kclManager.setHighlightRange([topLevelRange(obj?.start || 0, obj.end)])
+        executingEditor.setHighlightRange([
+          topLevelRange(obj?.start || 0, obj.end),
+        ])
       }}
       onClick={(e) => {
         const range = topLevelRange(obj?.start || 0, obj.end || 0)
         const idInfo = codeToIdSelections(
-          [{ codeRef: codeRefFromRange(range, kclManager.ast) }],
-          kclManager.artifactGraph,
-          kclManager.artifactIndex
+          [{ codeRef: codeRefFromRange(range, executingEditor.ast) }],
+          executingEditor.artifactGraph,
+          executingEditor.artifactIndex
         )[0]
-        const artifact = kclManager.artifactGraph.get(idInfo?.id || '')
+        const artifact = executingEditor.artifactGraph.get(idInfo?.id || '')
         if (!artifact) return
         send({
           type: 'Set selection',
@@ -148,7 +152,7 @@ function DisplayObj({
             selectionType: 'singleCodeCursor',
             selection: {
               artifact: artifact,
-              codeRef: codeRefFromRange(range, kclManager.ast),
+              codeRef: codeRefFromRange(range, executingEditor.ast),
             },
           },
         })

--- a/src/components/CommandBar/CommandBarKclInput.tsx
+++ b/src/components/CommandBar/CommandBarKclInput.tsx
@@ -32,7 +32,7 @@ import { varMentions } from '@src/lib/varCompletionExtension'
 import { Compartment, EditorState } from '@codemirror/state'
 import { editorTheme, themeCompartment } from '@src/editor/plugins/theme'
 import { useModelingContext } from '@src/hooks/useModelingContext'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import {
   noAutofillFormProps,
   noAutofillInputProps,
@@ -68,7 +68,7 @@ function CommandBarKclInput({
   arg,
   stepBack,
   onSubmit,
-  executingEditor: kclManager,
+  executingEditor: executingEditor,
 }: {
   arg: CommandArgument<unknown> & {
     inputType: 'kcl'
@@ -76,7 +76,7 @@ function CommandBarKclInput({
   }
   stepBack: () => void
   onSubmit: (event: unknown) => void
-  executingEditor: KclManager
+  executingEditor: ExecutingEditor
 }) {
   const { commands, settings, wasmPromise } = useApp()
   const wasmInstance = use(wasmPromise)
@@ -97,7 +97,7 @@ function CommandBarKclInput({
     const pathToNode = isPathToNode(nodeToEdit) ? nodeToEdit : undefined
     const node = pathToNode
       ? getNodeFromPath<Node<VariableDeclarator>>(
-          kclManager.ast,
+          executingEditor.ast,
           pathToNode,
           wasmInstance
         )
@@ -106,7 +106,10 @@ function CommandBarKclInput({
       ? [node.node.start, node.node.end, node.node.moduleId]
       : undefined
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-  }, [kclManager.ast, commandBarState.context.argumentsToSubmit.nodeToEdit])
+  }, [
+    executingEditor.ast,
+    commandBarState.context.argumentsToSubmit.nodeToEdit,
+  ])
   const defaultValue = useMemo(
     () =>
       arg.defaultValue
@@ -167,7 +170,7 @@ function CommandBarKclInput({
   useHotkeyWrapper(
     ['esc'],
     () => commands.send({ type: 'Close' }),
-    kclManager,
+    executingEditor,
     { enableOnFormTags: true, enableOnContentEditable: true }
   )
   const editorRef = useRef<HTMLDivElement>(null)
@@ -193,10 +196,10 @@ function CommandBarKclInput({
     initialVariableName,
     sourceRange: sourceRangeForPrevVariables,
     selectionRanges,
-    rustContext: kclManager.rustContext,
-    code: kclManager.codeSignal.value,
-    ast: kclManager.astSignal.value,
-    variables: kclManager.variablesSignal.value,
+    rustContext: executingEditor.rustContext,
+    code: executingEditor.codeSignal.value,
+    ast: executingEditor.astSignal.value,
+    variables: executingEditor.variablesSignal.value,
     options,
   })
 

--- a/src/components/CommandBar/CommandBarSelectionInput.tsx
+++ b/src/components/CommandBar/CommandBarSelectionInput.tsx
@@ -2,7 +2,7 @@ import { useSelector } from '@xstate/react'
 import { use, useEffect, useMemo, useRef, useState } from 'react'
 import type { StateFrom } from 'xstate'
 
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { noAutofillFormProps, noAutofillInputProps } from '@src/lib/autofill'
 import { useApp } from '@src/lib/boot'
 import type { CommandArgument } from '@src/lib/commandTypes'
@@ -25,23 +25,23 @@ function CommandBarSelectionInput({
   arg,
   stepBack,
   onSubmit,
-  executingEditor: kclManager,
+  executingEditor: executingEditor,
 }: {
   arg: CommandArgument<unknown> & { inputType: 'selection'; name: string }
   stepBack: () => void
   onSubmit: (data: unknown) => void
-  executingEditor: KclManager
+  executingEditor: ExecutingEditor
 }) {
   const { commands, wasmPromise } = useApp()
-  const engineCommandManager = kclManager.engineCommandManager
+  const engineCommandManager = executingEditor.engineCommandManager
   const wasmInstance = use(wasmPromise)
   const inputRef = useRef<HTMLInputElement>(null)
   const commandBarState = commands.useState()
   const [hasSubmitted, setHasSubmitted] = useState(false)
   const selection = useSelector(arg.machineActor, selectionSelector)
   const selectionsByType = useMemo(() => {
-    return getSelectionCountByType(kclManager.astSignal.value, selection)
-  }, [selection, kclManager.astSignal.value])
+    return getSelectionCountByType(executingEditor.astSignal.value, selection)
+  }, [selection, executingEditor.astSignal.value])
   const isArgRequired =
     arg.required instanceof Function
       ? arg.required(commandBarState.context)
@@ -59,7 +59,7 @@ function CommandBarSelectionInput({
   useEffect(() => {
     if (arg.selectionTypes.includes('plane') && !canSubmitSelection) {
       toSync(() => {
-        return kclManager.showPlanes()
+        return executingEditor.showPlanes()
       }, reportRejection)()
     }
 
@@ -67,11 +67,11 @@ function CommandBarSelectionInput({
       toSync(() => {
         const promises = [
           new Promise(() =>
-            kclManager.setSelectionFilterToDefault(wasmInstance, selection)
+            executingEditor.setSelectionFilterToDefault(wasmInstance, selection)
           ),
         ]
-        if (!kclManager._isAstEmpty(kclManager.ast)) {
-          promises.push(kclManager.hidePlanes())
+        if (!executingEditor._isAstEmpty(executingEditor.ast)) {
+          promises.push(executingEditor.hidePlanes())
         }
         return Promise.all(promises)
       }, reportRejection)()
@@ -149,9 +149,10 @@ function CommandBarSelectionInput({
   // Set selection filter if needed, and reset it when the component unmounts
   useEffect(() => {
     if (arg.selectionFilter) {
-      kclManager.setSelectionFilter(arg.selectionFilter, wasmInstance)
+      executingEditor.setSelectionFilter(arg.selectionFilter, wasmInstance)
     }
-    return () => kclManager.setSelectionFilterToDefault(wasmInstance, selection)
+    return () =>
+      executingEditor.setSelectionFilterToDefault(wasmInstance, selection)
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
   }, [arg.selectionFilter, wasmInstance])
 
@@ -164,8 +165,10 @@ function CommandBarSelectionInput({
         }
       >
         {canSubmitSelection
-          ? getSelectionTypeDisplayText(kclManager.astSignal.value, selection) +
-            ' selected'
+          ? getSelectionTypeDisplayText(
+              executingEditor.astSignal.value,
+              selection
+            ) + ' selected'
           : `Please select ${
               arg.multiple ? 'one or more ' : 'one '
             }${getSemanticSelectionType(arg.selectionTypes).join(' or ')}`}

--- a/src/components/CommandBar/CommandBarSelectionMixedInput.spec.tsx
+++ b/src/components/CommandBar/CommandBarSelectionMixedInput.spec.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { signal } from '@preact/signals-core'
 import CommandBarSelectionMixedInput from '@src/components/CommandBar/CommandBarSelectionMixedInput'
-import { KclManager } from '@src/lang/KclManager'
+import { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { App } from '@src/lib/app'
 import type { CommandArgument } from '@src/lib/commandTypes'
 
@@ -56,7 +56,7 @@ describe('CommandBarSelectionMixedInput', () => {
   describe('clearSelectionFirst behavior', () => {
     it('should send clear selection command when clearSelectionFirst is true', async () => {
       const app = App.getDefaultSystems()
-      const executingEditor = new KclManager('some-file', '', {
+      const executingEditor = new ExecutingEditor('some-file', '', {
         commandBar: app.commands.actor,
         settings: app.settings.actor,
         wasmInstancePromise: app.wasmPromise,
@@ -89,7 +89,7 @@ describe('CommandBarSelectionMixedInput', () => {
 
     it('should NOT send clear selection command when clearSelectionFirst is false', async () => {
       const app = App.getDefaultSystems()
-      const executingEditor = new KclManager('some-file', '', {
+      const executingEditor = new ExecutingEditor('some-file', '', {
         commandBar: app.commands.actor,
         settings: app.settings.actor,
         wasmInstancePromise: app.wasmPromise,
@@ -119,7 +119,7 @@ describe('CommandBarSelectionMixedInput', () => {
 
     it('should NOT send clear selection command when clearSelectionFirst is undefined', async () => {
       const app = App.getDefaultSystems()
-      const executingEditor = new KclManager('some-file', '', {
+      const executingEditor = new ExecutingEditor('some-file', '', {
         commandBar: app.commands.actor,
         settings: app.settings.actor,
         wasmInstancePromise: app.wasmPromise,
@@ -149,7 +149,7 @@ describe('CommandBarSelectionMixedInput', () => {
 
     it('should send clear selection command only once on mount', async () => {
       const app = App.getDefaultSystems()
-      const executingEditor = new KclManager('some-file', '', {
+      const executingEditor = new ExecutingEditor('some-file', '', {
         commandBar: app.commands.actor,
         settings: app.settings.actor,
         wasmInstancePromise: app.wasmPromise,
@@ -194,7 +194,7 @@ describe('CommandBarSelectionMixedInput', () => {
 
     it('should set hasClearedSelection state after clearing', async () => {
       const app = App.getDefaultSystems()
-      const executingEditor = new KclManager('some-file', '', {
+      const executingEditor = new ExecutingEditor('some-file', '', {
         commandBar: app.commands.actor,
         settings: app.settings.actor,
         wasmInstancePromise: app.wasmPromise,

--- a/src/components/CommandBar/CommandBarSelectionMixedInput.tsx
+++ b/src/components/CommandBar/CommandBarSelectionMixedInput.tsx
@@ -1,7 +1,7 @@
 import { useSelector } from '@xstate/react'
 import { use, useEffect, useMemo, useRef, useState } from 'react'
 
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { coerceSelectionsToBody } from '@src/lang/std/artifactGraph'
 import { noAutofillFormProps, noAutofillInputProps } from '@src/lib/autofill'
 import { useApp } from '@src/lib/boot'
@@ -25,17 +25,17 @@ export default function CommandBarSelectionMixedInput({
   arg,
   stepBack,
   onSubmit,
-  executingEditor: kclManager,
+  executingEditor: executingEditor,
 }: {
   arg: CommandArgument<unknown> & { inputType: 'selectionMixed'; name: string }
   stepBack: () => void
   onSubmit: (data: unknown) => void
-  executingEditor: KclManager
+  executingEditor: ExecutingEditor
 }) {
   const { commands, wasmPromise } = useApp()
   const wasmInstance = use(wasmPromise)
-  const engineCommandManager = kclManager.engineCommandManager
-  const sceneEntitiesManager = kclManager.sceneEntitiesManager
+  const engineCommandManager = executingEditor.engineCommandManager
+  const sceneEntitiesManager = executingEditor.sceneEntitiesManager
   const inputRef = useRef<HTMLInputElement>(null)
   const commandBarState = commands.useState()
   const [hasSubmitted, setHasSubmitted] = useState(false)
@@ -45,8 +45,8 @@ export default function CommandBarSelectionMixedInput({
   const selection: Selections = useSelector(arg.machineActor, selectionSelector)
 
   const selectionsByType = useMemo(() => {
-    return getSelectionCountByType(kclManager.ast, selection)
-  }, [selection, kclManager.ast])
+    return getSelectionCountByType(executingEditor.ast, selection)
+  }, [selection, executingEditor.ast])
 
   // Coerce selections to bodies if this argument requires bodies
   useEffect(() => {
@@ -69,7 +69,7 @@ export default function CommandBarSelectionMixedInput({
 
     const coercedSelections = coerceSelectionsToBody(
       selection,
-      kclManager.artifactGraph
+      executingEditor.artifactGraph
     )
     if (err(coercedSelections)) return // Coercion failed, skip update
 
@@ -142,7 +142,7 @@ export default function CommandBarSelectionMixedInput({
       setSelectionFilter({
         filter: arg.selectionFilter,
         engineCommandManager,
-        kclManager,
+        executingEditor,
         sceneEntitiesManager,
         selectionsToRestore: selection,
         handleSelectionBatchFn: handleSelectionBatch,
@@ -154,7 +154,7 @@ export default function CommandBarSelectionMixedInput({
         // Restore default filter with selections on cleanup
         setSelectionFilterToDefault({
           engineCommandManager,
-          kclManager,
+          executingEditor,
           sceneEntitiesManager,
           selectionsToRestore: selection,
           handleSelectionBatchFn: handleSelectionBatch,
@@ -168,7 +168,7 @@ export default function CommandBarSelectionMixedInput({
     hasCoercedSelections,
     wasmInstance,
     engineCommandManager,
-    kclManager,
+    executingEditor,
     sceneEntitiesManager,
   ])
 
@@ -236,8 +236,10 @@ export default function CommandBarSelectionMixedInput({
       >
         {canSubmitSelection &&
         (selection.graphSelections.length || selection.otherSelections.length)
-          ? getSelectionTypeDisplayText(kclManager.astSignal.value, selection) +
-            ' selected'
+          ? getSelectionTypeDisplayText(
+              executingEditor.astSignal.value,
+              selection
+            ) + ' selected'
           : 'Select code/objects, or skip'}
 
         {showSceneSelection && (

--- a/src/components/CommandBar/CommandBarVector2DInput.tsx
+++ b/src/components/CommandBar/CommandBarVector2DInput.tsx
@@ -1,6 +1,6 @@
 import { CustomIcon } from '@src/components/CustomIcon'
 import { Spinner } from '@src/components/Spinner'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { noAutofillFormProps, noAutofillInputProps } from '@src/lib/autofill'
 import { useApp } from '@src/lib/boot'
 import type { CommandArgument, KclCommandValue } from '@src/lib/commandTypes'
@@ -84,7 +84,7 @@ function CommandBarVector2DInput({
   arg,
   stepBack,
   onSubmit,
-  executingEditor: kclManager,
+  executingEditor: executingEditor,
 }: {
   arg: CommandArgument<unknown> & {
     inputType: 'vector2d'
@@ -92,11 +92,11 @@ function CommandBarVector2DInput({
   }
   stepBack: () => void
   onSubmit: (data: KclCommandValue) => void
-  executingEditor: KclManager
+  executingEditor: ExecutingEditor
 }) {
   const { commands, wasmPromise } = useApp()
   const wasmInstance = use(wasmPromise)
-  const rustContext = kclManager.rustContext
+  const rustContext = executingEditor.rustContext
   const commandBarState = commands.useState()
   const argumentValue = commandBarState.context.argumentsToSubmit[arg.name]
   const argMachineContext = useSelector(
@@ -160,9 +160,9 @@ function CommandBarVector2DInput({
     selectionRanges: { graphSelections: [], otherSelections: [] },
     rustContext: rustContext,
     options: calculateKclExpressionOptions,
-    code: kclManager.codeSignal.value,
-    ast: kclManager.astSignal.value,
-    variables: kclManager.variablesSignal.value,
+    code: executingEditor.codeSignal.value,
+    ast: executingEditor.astSignal.value,
+    variables: executingEditor.variablesSignal.value,
   })
 
   const yCalculation = useCalculateKclExpression({
@@ -170,9 +170,9 @@ function CommandBarVector2DInput({
     selectionRanges: { graphSelections: [], otherSelections: [] },
     rustContext: rustContext,
     options: calculateKclExpressionOptions,
-    code: kclManager.codeSignal.value,
-    ast: kclManager.astSignal.value,
-    variables: kclManager.variablesSignal.value,
+    code: executingEditor.codeSignal.value,
+    ast: executingEditor.astSignal.value,
+    variables: executingEditor.variablesSignal.value,
   })
 
   // DOM access for focus and keyboard navigation

--- a/src/components/CommandBar/CommandBarVector3DInput.tsx
+++ b/src/components/CommandBar/CommandBarVector3DInput.tsx
@@ -1,6 +1,6 @@
 import { CustomIcon } from '@src/components/CustomIcon'
 import { Spinner } from '@src/components/Spinner'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { noAutofillFormProps, noAutofillInputProps } from '@src/lib/autofill'
 import { useApp } from '@src/lib/boot'
 import type { CommandArgument, KclCommandValue } from '@src/lib/commandTypes'
@@ -78,7 +78,7 @@ function CommandBarVector3DInput({
   arg,
   stepBack,
   onSubmit,
-  executingEditor: kclManager,
+  executingEditor: executingEditor,
 }: {
   arg: CommandArgument<unknown> & {
     inputType: 'vector3d'
@@ -86,10 +86,10 @@ function CommandBarVector3DInput({
   }
   stepBack: () => void
   onSubmit: (data: KclCommandValue) => void
-  executingEditor: KclManager
+  executingEditor: ExecutingEditor
 }) {
   const { commands } = useApp()
-  const wasmInstance = use(kclManager.wasmInstancePromise)
+  const wasmInstance = use(executingEditor.wasmInstancePromise)
   const commandBarState = commands.useState()
   const argumentValue = commandBarState.context.argumentsToSubmit[arg.name]
   const previouslySetValue = isKclCommandValue(argumentValue)
@@ -139,31 +139,31 @@ function CommandBarVector3DInput({
   const xCalculation = useCalculateKclExpression({
     value: x,
     selectionRanges: { graphSelections: [], otherSelections: [] },
-    rustContext: kclManager.rustContext,
+    rustContext: executingEditor.rustContext,
     options: calculateKclExpressionOptions,
-    code: kclManager.codeSignal.value,
-    ast: kclManager.astSignal.value,
-    variables: kclManager.variablesSignal.value,
+    code: executingEditor.codeSignal.value,
+    ast: executingEditor.astSignal.value,
+    variables: executingEditor.variablesSignal.value,
   })
 
   const yCalculation = useCalculateKclExpression({
     value: y,
     selectionRanges: { graphSelections: [], otherSelections: [] },
-    rustContext: kclManager.rustContext,
+    rustContext: executingEditor.rustContext,
     options: calculateKclExpressionOptions,
-    code: kclManager.codeSignal.value,
-    ast: kclManager.astSignal.value,
-    variables: kclManager.variablesSignal.value,
+    code: executingEditor.codeSignal.value,
+    ast: executingEditor.astSignal.value,
+    variables: executingEditor.variablesSignal.value,
   })
 
   const zCalculation = useCalculateKclExpression({
     value: z,
     selectionRanges: { graphSelections: [], otherSelections: [] },
-    rustContext: kclManager.rustContext,
+    rustContext: executingEditor.rustContext,
     options: calculateKclExpressionOptions,
-    code: kclManager.codeSignal.value,
-    ast: kclManager.astSignal.value,
-    variables: kclManager.variablesSignal.value,
+    code: executingEditor.codeSignal.value,
+    ast: executingEditor.astSignal.value,
+    variables: executingEditor.variablesSignal.value,
   })
 
   // DOM access for focus and keyboard navigation
@@ -236,7 +236,7 @@ function CommandBarVector3DInput({
     const vectorExpression = `[${x.trim()}, ${y.trim()}, ${z.trim()}]`
 
     // Calculate the KCL expression
-    stringToKclExpression(vectorExpression, kclManager.rustContext, {
+    stringToKclExpression(vectorExpression, executingEditor.rustContext, {
       allowArrays: true,
     })
       .then((result) => {

--- a/src/components/ConnectionStream.tsx
+++ b/src/components/ConnectionStream.tsx
@@ -43,9 +43,9 @@ export const ConnectionStream = (props: {
 }) => {
   const { settings, project, wasmPromise, commands } = useApp()
   const wasmInstance = use(wasmPromise)
-  const { kclManager } = useSingletons()
-  const engineCommandManager = kclManager.engineCommandManager
-  const sceneInfra = kclManager.sceneInfra
+  const { executingEditor } = useSingletons()
+  const engineCommandManager = executingEditor.engineCommandManager
+  const sceneInfra = executingEditor.sceneInfra
   const [showManualConnect, setShowManualConnect] = useState(false)
   const isIdle = useRef(false)
   const [isSceneReady, setIsSceneReady] = useState(false)
@@ -126,22 +126,24 @@ export const ConnectionStream = (props: {
               // No entity selected. This is benign
               return
             }
-            const artifact = kclManager.artifactGraph.get(entity_id)
+            const artifact = executingEditor.artifactGraph.get(entity_id)
             if (artifact?.type === 'gdtAnnotation') {
               const operation = findOperationForArtifact({
                 artifact,
-                operations: getAllOperations(kclManager.operationsByModule),
+                operations: getAllOperations(
+                  executingEditor.operationsByModule
+                ),
               })
               if (!operation) {
                 return
               }
 
               await prepareEditCommand({
-                artifactGraph: kclManager.artifactGraph,
-                code: kclManager.code,
+                artifactGraph: executingEditor.artifactGraph,
+                code: executingEditor.code,
                 commandBarActor: commands.actor,
                 operation,
-                rustContext: kclManager.rustContext,
+                rustContext: executingEditor.rustContext,
                 artifact,
               })
               return
@@ -149,7 +151,7 @@ export const ConnectionStream = (props: {
 
             const sketchBlockArtifact = getSketchBlockForArtifact(
               artifact,
-              kclManager.artifactGraph
+              executingEditor.artifactGraph
             )
             if (sketchBlockArtifact) {
               sceneInfra.modelingSend({
@@ -165,8 +167,8 @@ export const ConnectionStream = (props: {
                 const regionSelection =
                   await getEngineRegionSelectionFromEntity(
                     entity_id,
-                    kclManager.artifactGraph,
-                    kclManager.ast,
+                    executingEditor.artifactGraph,
+                    executingEditor.ast,
                     engineCommandManager,
                     wasmInstance
                   )
@@ -189,7 +191,7 @@ export const ConnectionStream = (props: {
                 key: entity_id,
                 types: ['path', 'solid2d', 'segment', 'helix'],
               },
-              kclManager.artifactGraph
+              executingEditor.artifactGraph
             )
             if (err(path)) {
               return path
@@ -203,11 +205,11 @@ export const ConnectionStream = (props: {
         commands.actor,
         engineCommandManager,
         isNetworkOkay,
-        kclManager.artifactGraph,
-        kclManager.ast,
-        kclManager.code,
-        kclManager.operationsByModule,
-        kclManager.rustContext,
+        executingEditor.artifactGraph,
+        executingEditor.ast,
+        executingEditor.code,
+        executingEditor.operationsByModule,
+        executingEditor.rustContext,
         modelingMachineState,
         sceneInfra.camControls.wasDragging,
         sceneInfra.modelingSend,

--- a/src/components/ConnectionStream.tsx
+++ b/src/components/ConnectionStream.tsx
@@ -21,7 +21,7 @@ import {
   getSketchBlockForArtifact,
 } from '@src/lang/std/artifactGraph'
 import { getAllOperations } from '@src/lang/wasm'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { btnName } from '@src/lib/cameraControls'
 import { EngineDebugger } from '@src/lib/debugger'
 import { prepareEditCommand } from '@src/lib/featureTree'
@@ -43,7 +43,7 @@ export const ConnectionStream = (props: {
 }) => {
   const { settings, project, wasmPromise, commands } = useApp()
   const wasmInstance = use(wasmPromise)
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const engineCommandManager = executingEditor.engineCommandManager
   const sceneInfra = executingEditor.sceneInfra
   const [showManualConnect, setShowManualConnect] = useState(false)

--- a/src/components/DebugArtifactGraph.tsx
+++ b/src/components/DebugArtifactGraph.tsx
@@ -8,11 +8,11 @@ import type { ArtifactGraph } from '@src/lang/wasm'
 import { useSingletons } from '@src/lib/boot'
 
 export function DebugArtifactGraph() {
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const artifactGraphTree = useMemo(() => {
-    return computeTree(kclManager.artifactGraph)
+    return computeTree(executingEditor.artifactGraph)
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-  }, [kclManager.artifactGraph])
+  }, [executingEditor.artifactGraph])
 
   const filterKeys: string[] = ['codeRef', 'pathToNode']
   return (

--- a/src/components/DebugArtifactGraph.tsx
+++ b/src/components/DebugArtifactGraph.tsx
@@ -5,10 +5,10 @@ import { DebugDisplayArray } from '@src/components/DebugDisplayObj'
 import type { PlaneArtifactRich } from '@src/lang/std/artifactGraph'
 import { expandPlane } from '@src/lang/std/artifactGraph'
 import type { ArtifactGraph } from '@src/lang/wasm'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 
 export function DebugArtifactGraph() {
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const artifactGraphTree = useMemo(() => {
     return computeTree(executingEditor.artifactGraph)
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!

--- a/src/components/DebugSelections.tsx
+++ b/src/components/DebugSelections.tsx
@@ -22,10 +22,10 @@ import type { Selections } from '@src/machines/modelingSharedTypes'
 import { useMemo, useState } from 'react'
 import { use } from 'react'
 
-type SingletonDeps = Pick<ReturnType<typeof useSingletons>, 'kclManager'>
+type SingletonDeps = Pick<ReturnType<typeof useSingletons>, 'executingEditor'>
 
 async function clearSceneSelection(deps: SingletonDeps) {
-  await deps.kclManager.engineCommandManager.sendSceneCommand({
+  await deps.executingEditor.engineCommandManager.sendSceneCommand({
     type: 'modeling_cmd_req',
     cmd: {
       type: 'select_clear',
@@ -36,7 +36,7 @@ async function clearSceneSelection(deps: SingletonDeps) {
 
 // Pass in a list of scene ids to select in the 3d scene
 async function sceneSelection(ids: string[], deps: SingletonDeps) {
-  await deps.kclManager.engineCommandManager.sendSceneCommand({
+  await deps.executingEditor.engineCommandManager.sendSceneCommand({
     cmd_id: uuidv4(),
     type: 'modeling_cmd_req',
     cmd: {
@@ -112,7 +112,7 @@ async function selectCodeMirrorRange(range: SourceRange, deps: SingletonDeps) {
     ],
     otherSelections: [],
   }
-  deps.kclManager.selectRange(selections)
+  deps.executingEditor.selectRange(selections)
 }
 
 function codeRangeToIds(
@@ -122,7 +122,7 @@ function codeRangeToIds(
 ): string[] {
   if (!range) return []
 
-  const { kclManager } = deps
+  const { executingEditor } = deps
   const selections = {
     graphSelections: [
       {
@@ -149,13 +149,13 @@ function codeRangeToIds(
       graphSelections: [],
       otherSelections: [],
     },
-    isShiftDown: kclManager.isShiftDown,
-    ast: kclManager.ast,
-    artifactGraph: kclManager.artifactGraph,
-    artifactIndex: kclManager.artifactIndex,
+    isShiftDown: executingEditor.isShiftDown,
+    ast: executingEditor.ast,
+    artifactGraph: executingEditor.artifactGraph,
+    artifactIndex: executingEditor.artifactIndex,
     systemDeps: {
-      engineCommandManager: kclManager.engineCommandManager,
-      sceneEntitiesManager: kclManager.sceneEntitiesManager,
+      engineCommandManager: executingEditor.engineCommandManager,
+      sceneEntitiesManager: executingEditor.sceneEntitiesManager,
       wasmInstance: wasmInstance,
     },
   })
@@ -191,17 +191,17 @@ function getEntityIdsFromCmds(
 }
 
 function idToCodeRange(id: string, deps: SingletonDeps) {
-  const { kclManager } = deps
+  const { executingEditor } = deps
   if (id) {
-    const codeRefs = getCodeRefsByArtifactId(id, kclManager.artifactGraph)
+    const codeRefs = getCodeRefsByArtifactId(id, executingEditor.artifactGraph)
     if (codeRefs) {
       return codeRefs.map(({ range }) => range)
     }
   } else if (
-    !kclManager.highlightRange ||
-    (kclManager.highlightRange[0] &&
-      kclManager.highlightRange[0][0] !== 0 &&
-      kclManager.highlightRange[0][1] !== 0)
+    !executingEditor.highlightRange ||
+    (executingEditor.highlightRange[0] &&
+      executingEditor.highlightRange[0][0] !== 0 &&
+      executingEditor.highlightRange[0][1] !== 0)
   ) {
     return [defaultSourceRange()]
   }
@@ -209,24 +209,27 @@ function idToCodeRange(id: string, deps: SingletonDeps) {
 
 // Ported from the feature tree codebase
 function generateOperationList(deps: SingletonDeps) {
-  const { kclManager } = deps
+  const { executingEditor } = deps
   // If there are parse errors we show the last successful operations
   // and overlay a message on top of the pane
-  const parseErrors = kclManager.errors.filter((e) => e.kind !== 'engine')
+  const parseErrors = executingEditor.errors.filter((e) => e.kind !== 'engine')
 
   // If there are engine errors we show the successful operations
   // Errors return an operation list, so use the longest one if there are multiple
-  const longestErrorOperationList = kclManager.errors.reduce((acc, error) => {
-    return countOperations(error.operations) > countOperations(acc)
-      ? error.operations
-      : acc
-  }, emptyOperationsByModule())
+  const longestErrorOperationList = executingEditor.errors.reduce(
+    (acc, error) => {
+      return countOperations(error.operations) > countOperations(acc)
+        ? error.operations
+        : acc
+    },
+    emptyOperationsByModule()
+  )
 
   const unfilteredOperationList = !parseErrors.length
-    ? !kclManager.errors.length
-      ? kclManager.execState.operations
+    ? !executingEditor.errors.length
+      ? executingEditor.execState.operations
       : longestErrorOperationList
-    : kclManager.lastSuccessfulOperations
+    : executingEditor.lastSuccessfulOperations
 
   // We filter out operations that are not useful to show in the feature tree
   const operationList = groupOperationTypeStreaks(
@@ -258,12 +261,12 @@ function computeOperationList(
 }
 
 export function DebugSelections() {
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const singletonDeps: SingletonDeps = useMemo(
     () => ({
-      kclManager,
+      executingEditor,
     }),
-    [kclManager]
+    [executingEditor]
   )
   const [selectedId, _setSelectedId] = useState('')
   const [selectedRange, _setSelectedRange] = useState('')
@@ -275,17 +278,17 @@ export function DebugSelections() {
     _setSelectedId('')
     _setSelectedRange(range)
   }
-  const wasmInstance = use(kclManager.wasmInstancePromise)
+  const wasmInstance = use(executingEditor.wasmInstancePromise)
   const highlightMinor = 'bg-red-200 dark:bg-red-950'
   const highlightMajor = 'bg-red-100 dark:bg-red-800'
   const artifactGraphTree = useMemo(() => {
     return formatArtifactGraph(
-      kclManager.artifactGraph,
+      executingEditor.artifactGraph,
       wasmInstance,
       singletonDeps
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-  }, [kclManager.artifactGraph])
+  }, [executingEditor.artifactGraph])
 
   const operationList = useMemo(() => {
     return computeOperationList(
@@ -294,7 +297,7 @@ export function DebugSelections() {
       singletonDeps
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-  }, [kclManager.artifactGraph])
+  }, [executingEditor.artifactGraph])
   return (
     <details data-testid="debug-selections" className="relative">
       <summary>Selections Debugger</summary>

--- a/src/components/DebugSelections.tsx
+++ b/src/components/DebugSelections.tsx
@@ -1,5 +1,6 @@
 import { EditorSelection } from '@codemirror/state'
 import type { Operation } from '@rust/kcl-lib/bindings/Operation'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { defaultSourceRange } from '@src/lang/sourceRange'
 import { getCodeRefsByArtifactId } from '@src/lang/std/artifactGraph'
 import {
@@ -9,7 +10,7 @@ import {
   getOperationsForModule,
 } from '@src/lang/wasm'
 import type { ArtifactGraph, SourceRange } from '@src/lang/wasm'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import {
   filterOperations,
   groupOperationTypeStreaks,
@@ -22,7 +23,7 @@ import type { Selections } from '@src/machines/modelingSharedTypes'
 import { useMemo, useState } from 'react'
 import { use } from 'react'
 
-type SingletonDeps = Pick<ReturnType<typeof useSingletons>, 'executingEditor'>
+type SingletonDeps = { executingEditor: ExecutingEditor }
 
 async function clearSceneSelection(deps: SingletonDeps) {
   await deps.executingEditor.engineCommandManager.sendSceneCommand({
@@ -261,7 +262,7 @@ function computeOperationList(
 }
 
 export function DebugSelections() {
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const singletonDeps: SingletonDeps = useMemo(
     () => ({
       executingEditor,

--- a/src/components/EngineCommands.tsx
+++ b/src/components/EngineCommands.tsx
@@ -2,11 +2,11 @@ import { useEffect, useState } from 'react'
 
 import type { CommandLog } from '@src/lang/std/commandLog'
 import { noAutofillInputProps } from '@src/lib/autofill'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import { reportRejection } from '@src/lib/trap'
 
 export function useEngineCommands(): [CommandLog[], () => void] {
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const engineCommandManager = executingEditor.engineCommandManager
   const [engineCommands, setEngineCommands] = useState<CommandLog[]>(
     engineCommandManager.commandLogs
@@ -22,7 +22,7 @@ export function useEngineCommands(): [CommandLog[], () => void] {
 }
 
 export const EngineCommands = () => {
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const engineCommandManager = executingEditor.engineCommandManager
   const [engineCommands, clearEngineCommands] = useEngineCommands()
   const [containsFilter, setContainsFilter] = useState('')

--- a/src/components/EngineCommands.tsx
+++ b/src/components/EngineCommands.tsx
@@ -6,8 +6,8 @@ import { useSingletons } from '@src/lib/boot'
 import { reportRejection } from '@src/lib/trap'
 
 export function useEngineCommands(): [CommandLog[], () => void] {
-  const { kclManager } = useSingletons()
-  const engineCommandManager = kclManager.engineCommandManager
+  const { executingEditor } = useSingletons()
+  const engineCommandManager = executingEditor.engineCommandManager
   const [engineCommands, setEngineCommands] = useState<CommandLog[]>(
     engineCommandManager.commandLogs
   )
@@ -22,8 +22,8 @@ export function useEngineCommands(): [CommandLog[], () => void] {
 }
 
 export const EngineCommands = () => {
-  const { kclManager } = useSingletons()
-  const engineCommandManager = kclManager.engineCommandManager
+  const { executingEditor } = useSingletons()
+  const engineCommandManager = executingEditor.engineCommandManager
   const [engineCommands, clearEngineCommands] = useEngineCommands()
   const [containsFilter, setContainsFilter] = useState('')
   const [customCmd, setCustomCmd] = useState('')

--- a/src/components/ExperimentalFeaturesMenu.tsx
+++ b/src/components/ExperimentalFeaturesMenu.tsx
@@ -7,7 +7,7 @@ import { defaultStatusBarItemClassNames } from '@src/components/StatusBar/Status
 import Tooltip from '@src/components/Tooltip'
 import { updateModelingState } from '@src/lang/modelingWorkflows'
 import { setExperimentalFeatures } from '@src/lang/modifyAst/settings'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import {
   DEFAULT_EXPERIMENTAL_FEATURES,
   EXECUTION_TYPE_REAL,
@@ -16,7 +16,7 @@ import { warningLevels } from '@src/lib/settings/settingsTypes'
 import { err, reportRejection } from '@src/lib/trap'
 
 export function ExperimentalFeaturesMenu() {
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const currentLevel: WarningLevel =
     executingEditor.fileSettings.experimentalFeatures ??
     DEFAULT_EXPERIMENTAL_FEATURES

--- a/src/components/ExperimentalFeaturesMenu.tsx
+++ b/src/components/ExperimentalFeaturesMenu.tsx
@@ -16,9 +16,9 @@ import { warningLevels } from '@src/lib/settings/settingsTypes'
 import { err, reportRejection } from '@src/lib/trap'
 
 export function ExperimentalFeaturesMenu() {
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const currentLevel: WarningLevel =
-    kclManager.fileSettings.experimentalFeatures ??
+    executingEditor.fileSettings.experimentalFeatures ??
     DEFAULT_EXPERIMENTAL_FEATURES
 
   return (
@@ -50,9 +50,9 @@ export function ExperimentalFeaturesMenu() {
 
                         async function awaitWasmAndSetFlag() {
                           const newAst = setExperimentalFeatures(
-                            kclManager.code,
+                            executingEditor.code,
                             level,
-                            await kclManager.wasmInstancePromise
+                            await executingEditor.wasmInstancePromise
                           )
                           if (err(newAst)) {
                             toast.error(
@@ -62,7 +62,7 @@ export function ExperimentalFeaturesMenu() {
                             updateModelingState(
                               newAst,
                               EXECUTION_TYPE_REAL,
-                              kclManager
+                              executingEditor
                             )
                               .then((result) => {
                                 if (err(result)) {

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -17,7 +17,7 @@ import type {
 } from '@src/components/Explorer/utils'
 import { fsArchiveFile, fsMoveFile } from '@src/editor/plugins/fs'
 import { kclErrorsByFilename } from '@src/lang/errors'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import type { Command } from '@src/lib/commandTypes'
 import { FILE_EXT } from '@src/lib/constants'
 import { getNextFileName, sortFilesAndDirectories } from '@src/lib/desktopFS'
@@ -177,7 +177,7 @@ export const ProjectExplorer = ({
 }) => {
   const { commands, registry, settings, systemIOActor } = useApp()
   const keymap = registry.optional(keymapService)
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const errors = executingEditor.errorsSignal.value
   const settingsValues = settings.useSettings()
   const applicationProjectDirectory =

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -177,8 +177,8 @@ export const ProjectExplorer = ({
 }) => {
   const { commands, registry, settings, systemIOActor } = useApp()
   const keymap = registry.optional(keymapService)
-  const { kclManager } = useSingletons()
-  const errors = kclManager.errorsSignal.value
+  const { executingEditor } = useSingletons()
+  const errors = executingEditor.errorsSignal.value
   const settingsValues = settings.useSettings()
   const applicationProjectDirectory =
     settingsValues.app.projectDirectory.current
@@ -924,7 +924,7 @@ export const ProjectExplorer = ({
                       requestedProjectName: project.name,
                     },
                   })
-                  kclManager.addGlobalHistoryEvent(
+                  executingEditor.addGlobalHistoryEvent(
                     fsArchiveFile({
                       src,
                       target,
@@ -950,7 +950,7 @@ export const ProjectExplorer = ({
                       successMessage: 'Archived successfully',
                     },
                   })
-                  kclManager.addGlobalHistoryEvent(
+                  executingEditor.addGlobalHistoryEvent(
                     fsArchiveFile({
                       src,
                       target,
@@ -1027,7 +1027,7 @@ export const ProjectExplorer = ({
                     target,
                   },
                 })
-                kclManager.addGlobalHistoryEvent(
+                executingEditor.addGlobalHistoryEvent(
                   fsMoveFile({
                     src,
                     target,

--- a/src/components/HelpMenu.tsx
+++ b/src/components/HelpMenu.tsx
@@ -21,7 +21,7 @@ const HelpMenuDivider = () => (
 
 export function HelpMenu() {
   const { settings, systemIOActor } = useApp()
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const navigate = useNavigate()
   const filePath = useAbsoluteFilePath()
 
@@ -29,7 +29,7 @@ export function HelpMenu() {
     const props = {
       onboardingStatus: onboardingStartPath,
       navigate,
-      kclManager,
+      executingEditor,
       systemIOActor,
       settingsActor: settings.actor,
       executingPath: filePath,

--- a/src/components/HelpMenu.tsx
+++ b/src/components/HelpMenu.tsx
@@ -4,7 +4,7 @@ import { defaultStatusBarItemClassNames } from '@src/components/StatusBar/Status
 import Tooltip from '@src/components/Tooltip'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
 import { useMenuListener } from '@src/hooks/useMenu'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { isDesktop } from '@src/lib/isDesktop'
 import { onboardingStartPath } from '@src/lib/onboardingPaths'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
@@ -21,7 +21,7 @@ const HelpMenuDivider = () => (
 
 export function HelpMenu() {
   const { settings, systemIOActor } = useApp()
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const navigate = useNavigate()
   const filePath = useAbsoluteFilePath()
 

--- a/src/components/KclInput.tsx
+++ b/src/components/KclInput.tsx
@@ -24,11 +24,11 @@ export function KclInput(props: {
   style?: React.CSSProperties
 }) {
   const { settings: settingsSystem } = useApp()
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const settings = settingsSystem.useSettings()
-  const wasmInstance = use(kclManager.rustContext.wasmInstancePromise)
+  const wasmInstance = use(executingEditor.rustContext.wasmInstancePromise)
 
-  const variables = kclManager.variablesSignal.value
+  const variables = executingEditor.variablesSignal.value
 
   const containerRef = useRef<HTMLDivElement>(null)
   const editorRef = useRef<EditorView | null>(null)

--- a/src/components/KclInput.tsx
+++ b/src/components/KclInput.tsx
@@ -7,7 +7,7 @@ import { Compartment, EditorState } from '@codemirror/state'
 import { EditorView, keymap } from '@codemirror/view'
 import { editorTheme } from '@src/editor/plugins/theme'
 import { parse, resultIsOk } from '@src/lang/wasm'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { DUMMY_VARIABLE_NAME } from '@src/lib/kclHelpers'
 import { getResolvedTheme } from '@src/lib/theme'
 import { err } from '@src/lib/trap'
@@ -24,7 +24,7 @@ export function KclInput(props: {
   style?: React.CSSProperties
 }) {
   const { settings: settingsSystem } = useApp()
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const settings = settingsSystem.useSettings()
   const wasmInstance = use(executingEditor.rustContext.wasmInstancePromise)
 

--- a/src/components/LspProvider.tsx
+++ b/src/components/LspProvider.tsx
@@ -27,7 +27,7 @@ import type {
 import { LspWorker } from '@src/editor/plugins/lsp/types'
 import Worker from '@src/editor/plugins/lsp/worker.ts?worker'
 import { wasmUrl } from '@src/lang/wasmUtils'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { PROJECT_ENTRYPOINT } from '@src/lib/constants'
 import { PATHS } from '@src/lib/paths'
 import type { FileEntry } from '@src/lib/project'
@@ -73,7 +73,7 @@ type LspContext = {
 export const LspStateContext = createContext({} as LspContext)
 export const LspProvider = ({ children }: { children: React.ReactNode }) => {
   const { auth } = useApp()
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const [isKclLspReady, setIsKclLspReady] = useState(false)
   const [isCopilotLspReady, setIsCopilotLspReady] = useState(false)
 

--- a/src/components/LspProvider.tsx
+++ b/src/components/LspProvider.tsx
@@ -73,7 +73,7 @@ type LspContext = {
 export const LspStateContext = createContext({} as LspContext)
 export const LspProvider = ({ children }: { children: React.ReactNode }) => {
   const { auth } = useApp()
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const [isKclLspReady, setIsKclLspReady] = useState(false)
   const [isCopilotLspReady, setIsCopilotLspReady] = useState(false)
 
@@ -124,17 +124,22 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
   ])
 
   useMemo(() => {
-    if (!window.electron && isKclLspReady && kclLspClient && kclManager.code) {
+    if (
+      !window.electron &&
+      isKclLspReady &&
+      kclLspClient &&
+      executingEditor.code
+    ) {
       kclLspClient.textDocumentDidOpen({
         textDocument: {
           uri: `file:///${PROJECT_ENTRYPOINT}`,
           languageId: 'kcl',
           version: 1,
-          text: kclManager.code,
+          text: executingEditor.code,
         },
       })
     }
-  }, [kclLspClient, isKclLspReady, kclManager.code])
+  }, [kclLspClient, isKclLspReady, executingEditor.code])
 
   // Here we initialize the plugin which will start the client.
   // Now that we have multi-file support the name of the file is a dep of
@@ -181,14 +186,14 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
     if (kclLSP === null) {
       return
     }
-    kclManager.editorView.dispatch({
+    executingEditor.editorView.dispatch({
       effects: kclLspCompartment.reconfigure(Prec.highest(kclLSP)),
     })
     return () =>
-      kclManager.editorView.dispatch({
+      executingEditor.editorView.dispatch({
         effects: kclLspCompartment.reconfigure(Prec.highest([])),
       })
-  }, [kclLSP, kclManager.editorView])
+  }, [kclLSP, executingEditor.editorView])
 
   const { lspClient: copilotLspClient } = useMemo(() => {
     if (!token || token === '') {
@@ -242,17 +247,17 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
           client: copilotLspClient,
           allowHTMLContent: true,
         },
-        kclManager
+        executingEditor
       )
 
       // New code to just update the CodeMirror extensions directly.
-      kclManager.editorView.dispatch({
+      executingEditor.editorView.dispatch({
         effects: kclAutocompleteCompartment.reconfigure(Prec.highest(lsp)),
       })
       plugin = lsp
     }
     return plugin
-  }, [copilotLspClient, isCopilotLspReady, kclManager])
+  }, [copilotLspClient, isCopilotLspReady, executingEditor])
 
   let lspClients: LanguageServerClient[] = []
   if (kclLspClient) {
@@ -278,7 +283,7 @@ export const LspProvider = ({ children }: { children: React.ReactNode }) => {
         },
       })
     })
-    kclManager.clearGlobalHistory()
+    executingEditor.clearGlobalHistory()
 
     if (redirect) {
       void navigate(PATHS.HOME)

--- a/src/components/MlEphantConversation.spec.tsx
+++ b/src/components/MlEphantConversation.spec.tsx
@@ -24,7 +24,7 @@ vi.mock('@src/lib/desktop', () => ({
 // Mock useSingletons which requires heavy initialization
 vi.mock('@src/lib/boot', () => ({
   useSingletons: () => ({
-    kclManager: {
+    executingEditor: {
       astSignal: { value: null },
     },
   }),

--- a/src/components/MlEphantConversation.spec.tsx
+++ b/src/components/MlEphantConversation.spec.tsx
@@ -21,9 +21,9 @@ vi.mock('@src/lib/desktop', () => ({
   DESKTOP_OS_INFO: null,
 }))
 
-// Mock useSingletons which requires heavy initialization
+// Mock useExecutingEditor which requires heavy initialization
 vi.mock('@src/lib/boot', () => ({
-  useSingletons: () => ({
+  useExecutingEditor: () => ({
     executingEditor: {
       astSignal: { value: null },
     },

--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -57,9 +57,9 @@ export const ModelingMachineProvider = ({
   useSignals()
   const { machineManager, commands, settings, layout, project, registry } =
     useApp()
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const settingsActor = settings.actor
-  const wasmInstance = use(kclManager.wasmInstancePromise)
+  const wasmInstance = use(executingEditor.wasmInstancePromise)
   const settingsValues = settings.useSettings()
   const {
     app: { allowOrbitInSketchMode },
@@ -125,9 +125,9 @@ export const ModelingMachineProvider = ({
     {
       input: {
         machineManager,
-        engineCommandManager: kclManager.engineCommandManager,
-        kclManager,
-        rustContext: kclManager.rustContext,
+        engineCommandManager: executingEditor.engineCommandManager,
+        executingEditor,
+        rustContext: executingEditor.rustContext,
         commandBarActor: commands.actor,
         fileName: file?.name,
         projectRef: theProject,
@@ -196,7 +196,7 @@ export const ModelingMachineProvider = ({
   useSketchModeMenuEnableDisable(
     toolbarConfigurationName,
     overallState,
-    kclManager.isExecutingSignal.value,
+    executingEditor.isExecutingSignal.value,
     isStreamReady,
     [
       { menuLabel: 'View.Standard views' },
@@ -262,24 +262,24 @@ export const ModelingMachineProvider = ({
     }
   }, [modelingActor])
 
-  // Give the state back to the kclManager.
+  // Give the state back to the executingEditor.
   useEffect(() => {
-    kclManager.modelingSend = modelingSend
-  }, [modelingSend, kclManager])
+    executingEditor.modelingSend = modelingSend
+  }, [modelingSend, executingEditor])
 
   useEffect(() => {
-    kclManager.modelingState = modelingState
-  }, [modelingState, kclManager])
+    executingEditor.modelingState = modelingState
+  }, [modelingState, executingEditor])
 
   useEffect(() => {
-    kclManager.selectionRanges = modelingState.context.selectionRanges
-  }, [modelingState.context.selectionRanges, kclManager])
+    executingEditor.selectionRanges = modelingState.context.selectionRanges
+  }, [modelingState.context.selectionRanges, executingEditor])
 
   // When changing camera modes reset the camera to the default orientation to correct
   // the up vector otherwise the conconical orientation for the camera modes will be
   // wrong
   useEffect(() => {
-    kclManager.engineCommandManager.connection?.deferredPeerConnection?.promise
+    executingEditor.engineCommandManager.connection?.deferredPeerConnection?.promise
       .then(() => {
         if (
           previousCameraOrbit.current === null ||
@@ -292,7 +292,7 @@ export const ModelingMachineProvider = ({
         }
         previousCameraOrbit.current = cameraOrbit.current
         // Gotcha: This will absolutely brick E2E tests if called incorrectly.
-        kclManager.sceneInfra.camControls
+        executingEditor.sceneInfra.camControls
           .resetCameraPosition()
           .catch(reportRejection)
       })
@@ -306,18 +306,18 @@ export const ModelingMachineProvider = ({
         modelingSend({ type: 'Cancel' })
       }
     }
-    kclManager.engineCommandManager.connection?.addEventListener(
+    executingEditor.engineCommandManager.connection?.addEventListener(
       EngineConnectionEvents.ConnectionStateChanged,
       onConnectionStateChanged as EventListener
     )
     return () => {
-      kclManager.engineCommandManager.connection?.removeEventListener(
+      executingEditor.engineCommandManager.connection?.removeEventListener(
         EngineConnectionEvents.ConnectionStateChanged,
         onConnectionStateChanged as EventListener
       )
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-  }, [kclManager.engineCommandManager.connection, modelingSend])
+  }, [executingEditor.engineCommandManager.connection, modelingSend])
 
   useEffect(() => {
     const inSketchMode = modelingState.matches('Sketch')
@@ -327,7 +327,7 @@ export const ModelingMachineProvider = ({
       const targetId = modelingState.context.sketchDetails?.animateTargetId
       if (inSketchMode && targetId) {
         letEngineAnimateAndSyncCamAfter(
-          kclManager.engineCommandManager,
+          executingEditor.engineCommandManager,
           targetId
         )
           .then(() => {})
@@ -343,7 +343,7 @@ export const ModelingMachineProvider = ({
     // While you are in sketch mode you should be able to control the enable rotate
     // Once you exit it goes back to normal
     if (inSketchMode) {
-      kclManager.sceneInfra.camControls.enableRotate =
+      executingEditor.sceneInfra.camControls.enableRotate =
         allowOrbitInSketchMode.current
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
@@ -395,8 +395,8 @@ export const ModelingMachineProvider = ({
   })
   useHotkeys(['mod + alt + x'], () => {
     resetCameraPosition({
-      sceneInfra: kclManager.sceneInfra,
-      engineCommandManager: kclManager.engineCommandManager,
+      sceneInfra: executingEditor.sceneInfra,
+      engineCommandManager: executingEditor.engineCommandManager,
       settingsActor,
     }).catch(reportRejection)
   })
@@ -410,7 +410,7 @@ export const ModelingMachineProvider = ({
         data: { level: 'project', value: !snapToGrid.current },
       })
     },
-    kclManager
+    executingEditor
   )
 
   useHotkeys(
@@ -421,8 +421,8 @@ export const ModelingMachineProvider = ({
 
       e.preventDefault()
       const selection = selectAllInCurrentSketch(
-        kclManager.artifactGraph,
-        kclManager.sceneEntitiesManager
+        executingEditor.artifactGraph,
+        executingEditor.sceneEntitiesManager
       )
       modelingSend({
         type: 'Set selection',
@@ -440,7 +440,7 @@ export const ModelingMachineProvider = ({
     send: modelingSend,
     actor: modelingActor,
     commandBarConfig,
-    isExecuting: kclManager.isExecutingSignal.value,
+    isExecuting: executingEditor.isExecutingSignal.value,
     // TODO for when sketch tools are in the toolbar: This was added when we used one "Cancel" event,
     // but we need to support "SketchCancel" and basically
     // make this function take the actor or state so it

--- a/src/components/ModelingMachineProvider.tsx
+++ b/src/components/ModelingMachineProvider.tsx
@@ -15,7 +15,7 @@ import useHotkeyWrapper from '@src/lib/hotkeyWrapper'
 import { SNAP_TO_GRID_HOTKEY } from '@src/lib/hotkeys'
 
 import { useNetworkContext } from '@src/hooks/useNetworkContext'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { modelingMachineCommandConfig } from '@src/lib/commandBarConfigs/modelingCommandConfig'
 import type { Project } from '@src/lib/project'
 import { resetCameraPosition } from '@src/lib/resetCameraPosition'
@@ -57,7 +57,7 @@ export const ModelingMachineProvider = ({
   useSignals()
   const { machineManager, commands, settings, layout, project, registry } =
     useApp()
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const settingsActor = settings.actor
   const wasmInstance = use(executingEditor.wasmInstancePromise)
   const settingsValues = settings.useSettings()

--- a/src/components/ModelingPageProvider.tsx
+++ b/src/components/ModelingPageProvider.tsx
@@ -11,7 +11,7 @@ import {
   updateOutsideEditorEvent,
 } from '@src/lang/ExecutingEditor'
 import { sourceRangeToUtf16 } from '@src/lang/errors'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { createNamedViewsCommand } from '@src/lib/commandBarConfigs/namedViewsConfig'
 import { createRouteCommands } from '@src/lib/commandBarConfigs/routeCommandConfig'
 import { createStandardViewsCommands } from '@src/lib/commandBarConfigs/standardViewsConfig'
@@ -62,7 +62,7 @@ export const ModelingPageProvider = ({
 }) => {
   useSignals()
   const { auth, commands, settings, project, systemIOActor } = useApp()
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const wasmInstance = use(executingEditor.wasmInstancePromise)
   const navigate = useNavigate()
   const location = useLocation()

--- a/src/components/ModelingPageProvider.tsx
+++ b/src/components/ModelingPageProvider.tsx
@@ -9,7 +9,7 @@ import { useMenuListener } from '@src/hooks/useMenu'
 import {
   type PendingFeatureTreeSourceSelection,
   updateOutsideEditorEvent,
-} from '@src/lang/KclManager'
+} from '@src/lang/ExecutingEditor'
 import { sourceRangeToUtf16 } from '@src/lang/errors'
 import { useApp, useSingletons } from '@src/lib/boot'
 import { createNamedViewsCommand } from '@src/lib/commandBarConfigs/namedViewsConfig'
@@ -62,8 +62,8 @@ export const ModelingPageProvider = ({
 }) => {
   useSignals()
   const { auth, commands, settings, project, systemIOActor } = useApp()
-  const { kclManager } = useSingletons()
-  const wasmInstance = use(kclManager.wasmInstancePromise)
+  const { executingEditor } = useSingletons()
+  const wasmInstance = use(executingEditor.wasmInstancePromise)
   const navigate = useNavigate()
   const location = useLocation()
   const token = auth.useToken()
@@ -78,7 +78,10 @@ export const ModelingPageProvider = ({
       createNamedViewCommand,
       deleteNamedViewCommand,
       loadNamedViewCommand,
-    } = createNamedViewsCommand(kclManager.engineCommandManager, settingsActor)
+    } = createNamedViewsCommand(
+      executingEditor.engineCommandManager,
+      settingsActor
+    )
 
     const {
       topViewCommand,
@@ -88,7 +91,7 @@ export const ModelingPageProvider = ({
       bottomViewCommand,
       leftViewCommand,
       zoomToFitCommand,
-    } = createStandardViewsCommands(kclManager)
+    } = createStandardViewsCommands(executingEditor)
 
     const namedViewCommands = [
       createNamedViewCommand,
@@ -117,20 +120,20 @@ export const ModelingPageProvider = ({
         },
       })
     }
-  }, [commands, settingsActor, kclManager])
+  }, [commands, settingsActor, executingEditor])
 
   useEffect(() => {
     markOnce('code/didLoadFile')
   }, [])
 
   useEffect(() => {
-    const pending = kclManager.pendingFeatureTreeSourceSelection
+    const pending = executingEditor.pendingFeatureTreeSourceSelection
     if (!pending || !file?.path) {
       return
     }
 
     if (!isPendingFeatureTreeSelection(pending)) {
-      kclManager.pendingFeatureTreeSourceSelection = null
+      executingEditor.pendingFeatureTreeSourceSelection = null
       return
     }
 
@@ -138,10 +141,10 @@ export const ModelingPageProvider = ({
       return
     }
 
-    kclManager.pendingFeatureTreeSourceSelection = null
+    executingEditor.pendingFeatureTreeSourceSelection = null
 
-    const utf16Range = sourceRangeToUtf16(pending.range, kclManager.code)
-    kclManager.editorView.dispatch({
+    const utf16Range = sourceRangeToUtf16(pending.range, executingEditor.code)
+    executingEditor.editorView.dispatch({
       selection: EditorSelection.create([
         EditorSelection.cursor(utf16Range[0]),
       ]),
@@ -155,9 +158,9 @@ export const ModelingPageProvider = ({
     })
   }, [
     file?.path,
-    kclManager,
-    kclManager.code,
-    kclManager.pendingFeatureTreeSourceSelection,
+    executingEditor,
+    executingEditor.code,
+    executingEditor.pendingFeatureTreeSourceSelection,
   ])
 
   // Due to the route provider, i've moved this to the ModelingPageProvider instead of CommandBarProvider
@@ -208,7 +211,7 @@ export const ModelingPageProvider = ({
     authActor: auth.actor,
     commandBarActor: commands.actor,
     filePath,
-    kclManager,
+    executingEditor,
     navigate,
     settings: settingsValues,
     settingsActor,
@@ -249,7 +252,7 @@ export const ModelingPageProvider = ({
         file,
         code: project?.executingEditor.value?.state.doc.toString() ?? '',
       },
-      kclManager,
+      executingEditor,
       settings: {
         defaultUnit:
           settingsValues.modeling.defaultUnit.current ??
@@ -261,7 +264,7 @@ export const ModelingPageProvider = ({
       wasmInstance,
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-  }, [kclManager, project, file])
+  }, [executingEditor, project, file])
 
   useEffect(() => {
     commands.send({

--- a/src/components/OpenedProject.tsx
+++ b/src/components/OpenedProject.tsx
@@ -75,12 +75,12 @@ export function OpenedProject() {
   useSignals()
   const { auth, billing, settings, layout, project, systemIOActor, registry } =
     useApp()
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const settingsActor = settings.actor
   const defaultAreaLibrary = useDefaultAreaLibrary()
   const defaultActionLibrary = useDefaultActionLibrary()
   const { state: modelingState, send: modelingSend } = useModelingContext()
-  useQueryParamEffects(kclManager)
+  useQueryParamEffects(executingEditor)
   const [nativeFileMenuCreated, setNativeFileMenuCreated] = useState(false)
   const location = useLocation()
   const navigate = useNavigate()
@@ -127,11 +127,13 @@ export function OpenedProject() {
     if (systemIOState !== 'idle') {
       return
     }
-    if (kclManager.mlEphantManagerMachineBulkManipulatingFileSystem === false) {
+    if (
+      executingEditor.mlEphantManagerMachineBulkManipulatingFileSystem === false
+    ) {
       return
     }
     const reloadBehavior = getMlEphantProjectReloadBehavior(modelingState)
-    kclManager.mlEphantManagerMachineBulkManipulatingFileSystem = false
+    executingEditor.mlEphantManagerMachineBulkManipulatingFileSystem = false
 
     if (reloadBehavior === 'exit-sketch-solve') {
       toast(
@@ -141,19 +143,25 @@ export function OpenedProject() {
       return
     }
 
-    kclManager
+    executingEditor
       .executeCode()
       .then(async () => {
         if (reloadBehavior === 'execute-and-reset-camera') {
           await resetCameraPosition({
-            sceneInfra: kclManager.sceneInfra,
-            engineCommandManager: kclManager.engineCommandManager,
+            sceneInfra: executingEditor.sceneInfra,
+            engineCommandManager: executingEditor.engineCommandManager,
             settingsActor,
           })
         }
       })
       .catch(reportRejection)
-  }, [systemIOState, kclManager, modelingState, modelingSend, settingsActor])
+  }, [
+    systemIOState,
+    executingEditor,
+    modelingState,
+    modelingSend,
+    settingsActor,
+  ])
 
   // Run LSP file open hook when navigating between projects or files
   useEffect(() => {
@@ -163,7 +171,7 @@ export function OpenedProject() {
     )
   }, [onProjectOpen, projectName, projectPath, project])
 
-  useHotKeyListener(kclManager)
+  useHotKeyListener(executingEditor)
 
   const settingsValues = settings.useSettings()
   const machineApiEnabled = settingsValues.app.machineApi.current
@@ -189,19 +197,19 @@ export function OpenedProject() {
   // with the wrapper.
   useHotkeys('mod+z', (e) => {
     e.preventDefault()
-    kclManager.undo()
+    executingEditor.undo()
   })
   useHotkeys('mod+shift+z', (e) => {
     e.preventDefault()
-    kclManager.redo()
+    executingEditor.redo()
   })
 
   useHotkeyWrapper(
     ['alt + shift + f'],
     () => {
-      void kclManager.format()
+      void executingEditor.format()
     },
-    kclManager,
+    executingEditor,
     {
       enabled: !isDesktop(),
       enableOnContentEditable: true,
@@ -214,9 +222,9 @@ export function OpenedProject() {
   useHotkeyWrapper(
     ['ctrl + shift + c'],
     () => {
-      void kclManager.convertToVariable()
+      void executingEditor.convertToVariable()
     },
-    kclManager
+    executingEditor
   )
 
   useEngineConnectionSubscriptions()
@@ -253,7 +261,7 @@ export function OpenedProject() {
           TutorialRequestToast({
             onboardingStatus: settingsValues.app.onboardingStatus.current,
             navigate,
-            kclManager,
+            executingEditor,
             accountUrl: withSiteBaseURL('/account'),
             systemIOActor,
             settingsActor,
@@ -274,7 +282,7 @@ export function OpenedProject() {
     navigate,
     searchParams.size,
     authToken,
-    kclManager,
+    executingEditor,
     systemIOActor,
     settingsActor,
   ])
@@ -282,11 +290,11 @@ export function OpenedProject() {
   // This is, at time of writing, the only spot we need @preact/signals-react,
   // because we can't use the core `effect()` function for this signal, because
   // it is initially set to `true`, and will break the web app.
-  // TODO: get the loading pattern of KclManager in order so that it's for real available,
+  // TODO: get the loading pattern of ExecutingEditor in order so that it's for real available,
   // then you might be able to uninstall this package and stick to just using signals-core.
   useSignalEffect(() => {
     const needsWasmInitFailedToast =
-      !isDesktop() && kclManager.wasmInitFailedSignal.value
+      !isDesktop() && executingEditor.wasmInitFailedSignal.value
     if (needsWasmInitFailedToast) {
       toast.success(
         () =>
@@ -335,11 +343,11 @@ export function OpenedProject() {
     () => (
       <UndoRedoButtons
         data-testid="app-header-undo-redo"
-        kclManager={kclManager}
+        executingEditor={executingEditor}
         className="flex items-center px-2 border-x border-chalkboard-30 dark:border-chalkboard-80"
       />
     ),
-    [kclManager]
+    [executingEditor]
   )
 
   const notifications: boolean[] = Object.values(defaultAreaLibrary).map(
@@ -375,7 +383,7 @@ export function OpenedProject() {
             actionLibrary={defaultActionLibrary}
             showDebugPanel={settingsValues.debug.showPanel.current}
             notifications={notifications}
-            artifactGraph={kclManager.artifactGraph}
+            artifactGraph={executingEditor.artifactGraph}
           />
         </section>
         <StatusBar

--- a/src/components/OpenedProject.tsx
+++ b/src/components/OpenedProject.tsx
@@ -22,7 +22,7 @@ import {
   autoUpdateDownloadProgressSignal,
   autoUpdateReadySignal,
 } from '@src/lib/autoUpdate'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import {
   ONBOARDING_TOAST_ID,
   WASM_INIT_FAILED_TOAST_ID,
@@ -75,12 +75,12 @@ export function OpenedProject() {
   useSignals()
   const { auth, billing, settings, layout, project, systemIOActor, registry } =
     useApp()
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const settingsActor = settings.actor
   const defaultAreaLibrary = useDefaultAreaLibrary()
   const defaultActionLibrary = useDefaultActionLibrary()
   const { state: modelingState, send: modelingSend } = useModelingContext()
-  useQueryParamEffects(executingEditor)
+  useQueryParamEffects()
   const [nativeFileMenuCreated, setNativeFileMenuCreated] = useState(false)
   const location = useLocation()
   const navigate = useNavigate()
@@ -261,7 +261,6 @@ export function OpenedProject() {
           TutorialRequestToast({
             onboardingStatus: settingsValues.app.onboardingStatus.current,
             navigate,
-            executingEditor,
             accountUrl: withSiteBaseURL('/account'),
             systemIOActor,
             settingsActor,

--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -12,7 +12,7 @@ import { useLspContext } from '@src/components/LspProvider'
 import Tooltip from '@src/components/Tooltip'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
 import usePlatform from '@src/hooks/usePlatform'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { sendAddFileToProjectCommandForCurrentProject } from '@src/lib/commandBarConfigs/applicationCommandConfig'
 import { APP_NAME } from '@src/lib/constants'
 import { hotkeyDisplay } from '@src/lib/hotkeys'
@@ -65,7 +65,7 @@ function AppLogoLink({
   project?: IndexLoaderData['project']
   file?: IndexLoaderData['file']
 }) {
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const { onProjectClose } = useLspContext()
   const wrapperClassName =
     "cursor-pointer relative group-hover/home:before:outline h-full grid flex-none place-content-center group p-1.5 before:block before:content-[''] before:absolute before:inset-0 before:bottom-1 before:z-[-1] before:bg-primary before:rounded-b-sm"
@@ -107,7 +107,7 @@ function ProjectMenuPopover({
   file?: IndexLoaderData['file']
 }) {
   const { machineManager, commands, settings } = useApp()
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const machineApiEnabled = settings.useSettings().app.machineApi.current
   const platform = usePlatform()
   const navigate = useNavigate()

--- a/src/components/ProjectSidebarMenu.tsx
+++ b/src/components/ProjectSidebarMenu.tsx
@@ -65,7 +65,7 @@ function AppLogoLink({
   project?: IndexLoaderData['project']
   file?: IndexLoaderData['file']
 }) {
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const { onProjectClose } = useLspContext()
   const wrapperClassName =
     "cursor-pointer relative group-hover/home:before:outline h-full grid flex-none place-content-center group p-1.5 before:block before:content-[''] before:absolute before:inset-0 before:bottom-1 before:z-[-1] before:bg-primary before:rounded-b-sm"
@@ -88,7 +88,7 @@ function AppLogoLink({
       data-testid="app-logo"
       onClick={() => {
         onProjectClose(file || null, project?.path || null, false)
-        kclManager.switchedFiles = true
+        executingEditor.switchedFiles = true
       }}
       to={PATHS.HOME}
       className={wrapperClassName + ' hover:before:brightness-110'}
@@ -107,7 +107,7 @@ function ProjectMenuPopover({
   file?: IndexLoaderData['file']
 }) {
   const { machineManager, commands, settings } = useApp()
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const machineApiEnabled = settings.useSettings().app.machineApi.current
   const platform = usePlatform()
   const navigate = useNavigate()
@@ -255,7 +255,7 @@ function ProjectMenuPopover({
           className: !isDesktop() ? 'hidden' : '',
           onClick: () => {
             onProjectClose(file || null, project?.path || null, true)
-            kclManager.switchedFiles = true
+            executingEditor.switchedFiles = true
           },
         },
       ].filter(
@@ -270,7 +270,7 @@ function ProjectMenuPopover({
       machineApiEnabled,
       // eslint-disable-next-line @typescript-eslint/unbound-method
       commands.send,
-      kclManager.engineCommandManager,
+      executingEditor.engineCommandManager,
       onProjectClose,
       isDesktop,
     ]

--- a/src/components/PublishButton.tsx
+++ b/src/components/PublishButton.tsx
@@ -68,16 +68,13 @@ function PublishPopoverContent({
   const publishRequiresUsername = !isCheckingUser && !!token && !username
   const accountUrl = withSiteBaseURL('/account')
   const executingEditor = app.projectSignal.value?.executingEditor.value
-  if (!executingEditor) {
-    return null
-  }
-  const ast = executingEditor.astSignal.value
-  const kclEmpty = executingEditor.isAstBodyEmpty(ast)
-  const hasKclErrors = executingEditor.hasErrors()
-  const buttonDisabled = kclEmpty || hasKclErrors
+  const ast = executingEditor?.astSignal.value
+  const kclEmpty = ast ? executingEditor.isAstBodyEmpty(ast) : true
+  const hasKclErrors = executingEditor?.hasErrors() ?? false
+  const buttonDisabled = !executingEditor || kclEmpty || hasKclErrors
 
   const fetchPublicationDetails = useCallback(async () => {
-    if (!token || !project) {
+    if (!token || !project || !executingEditor) {
       return null
     }
 
@@ -126,6 +123,9 @@ function PublishPopoverContent({
     Required<ComponentProps<typeof PublishDialog>>['onSubmit']
   >(
     async (submission) => {
+      if (!executingEditor) {
+        return false
+      }
       const wasmInstance = await executingEditor.wasmInstancePromise
       const published = await publishCurrentProject({
         token,

--- a/src/components/PublishButton.tsx
+++ b/src/components/PublishButton.tsx
@@ -56,10 +56,10 @@ function PublishPopoverContent({
 }) {
   useSignals()
   const { auth } = app
-  const { kclManager } = app.singletons
-  const ast = kclManager.astSignal.value
-  const kclEmpty = kclManager.isAstBodyEmpty(ast)
-  const hasKclErrors = kclManager.hasErrors()
+  const { executingEditor } = app.singletons
+  const ast = executingEditor.astSignal.value
+  const kclEmpty = executingEditor.isAstBodyEmpty(ast)
+  const hasKclErrors = executingEditor.hasErrors()
   const authState = auth.useAuthState()
   const token = auth.useToken()
   const user = auth.useUser()
@@ -78,7 +78,7 @@ function PublishPopoverContent({
       return null
     }
 
-    const wasmInstance = await kclManager.wasmInstancePromise
+    const wasmInstance = await executingEditor.wasmInstancePromise
     const details = await getCurrentProjectPublicationDetails({
       token,
       project,
@@ -91,7 +91,7 @@ function PublishPopoverContent({
     }
 
     return details
-  }, [kclManager, project, token])
+  }, [executingEditor, project, token])
 
   useEffect(() => {
     let isCancelled = false
@@ -123,12 +123,12 @@ function PublishPopoverContent({
     Required<ComponentProps<typeof PublishDialog>>['onSubmit']
   >(
     async (submission) => {
-      const wasmInstance = await kclManager.wasmInstancePromise
+      const wasmInstance = await executingEditor.wasmInstancePromise
       const published = await publishCurrentProject({
         token,
         project,
-        currentFilePath: kclManager.path,
-        currentFileContents: kclManager.code,
+        currentFilePath: executingEditor.path,
+        currentFileContents: executingEditor.code,
         wasmInstance,
         submission,
       })
@@ -141,7 +141,7 @@ function PublishPopoverContent({
       setPublicationDetails(details)
       return true
     },
-    [fetchPublicationDetails, kclManager, project, token]
+    [fetchPublicationDetails, executingEditor, project, token]
   )
 
   return (

--- a/src/components/PublishButton.tsx
+++ b/src/components/PublishButton.tsx
@@ -56,10 +56,6 @@ function PublishPopoverContent({
 }) {
   useSignals()
   const { auth } = app
-  const { executingEditor } = app.singletons
-  const ast = executingEditor.astSignal.value
-  const kclEmpty = executingEditor.isAstBodyEmpty(ast)
-  const hasKclErrors = executingEditor.hasErrors()
   const authState = auth.useAuthState()
   const token = auth.useToken()
   const user = auth.useUser()
@@ -71,6 +67,13 @@ function PublishPopoverContent({
   const isCheckingUser = authState.matches('checkIfLoggedIn') && !!token
   const publishRequiresUsername = !isCheckingUser && !!token && !username
   const accountUrl = withSiteBaseURL('/account')
+  const executingEditor = app.projectSignal.value?.executingEditor.value
+  if (!executingEditor) {
+    return null
+  }
+  const ast = executingEditor.astSignal.value
+  const kclEmpty = executingEditor.isAstBodyEmpty(ast)
+  const hasKclErrors = executingEditor.hasErrors()
   const buttonDisabled = kclEmpty || hasKclErrors
 
   const fetchPublicationDetails = useCallback(async () => {

--- a/src/components/RouteProvider.tsx
+++ b/src/components/RouteProvider.tsx
@@ -1,7 +1,7 @@
 import { useSignals } from '@preact/signals-react/runtime'
 import { useAuthNavigation } from '@src/hooks/useAuthNavigation'
 import { useFileSystemWatcher } from '@src/hooks/useFileSystemWatcher'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { getAppSettingsFilePath } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
 import { PATHS, getStringAfterLastSeparator } from '@src/lib/paths'
@@ -16,7 +16,7 @@ export const RouteProviderContext = createContext({})
 export function RouteProvider({ children }: { children: ReactNode }) {
   useSignals()
   const { settings, project } = useApp()
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const settingsActor = settings.actor
   useAuthNavigation()
   const loadedProject = project?.projectIORefSignal.value

--- a/src/components/RouteProvider.tsx
+++ b/src/components/RouteProvider.tsx
@@ -16,7 +16,7 @@ export const RouteProviderContext = createContext({})
 export function RouteProvider({ children }: { children: ReactNode }) {
   useSignals()
   const { settings, project } = useApp()
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const settingsActor = settings.actor
   useAuthNavigation()
   const loadedProject = project?.projectIORefSignal.value
@@ -57,8 +57,8 @@ export function RouteProvider({ children }: { children: ReactNode }) {
       }
 
       // Earlier method, this doesn't hurt but it's not needed anymore..
-      if (kclManager.writeCausedByAppCheckedInFileTreeFileSystemWatcher) {
-        kclManager.writeCausedByAppCheckedInFileTreeFileSystemWatcher = false
+      if (executingEditor.writeCausedByAppCheckedInFileTreeFileSystemWatcher) {
+        executingEditor.writeCausedByAppCheckedInFileTreeFileSystemWatcher = false
         return
       }
 
@@ -66,18 +66,19 @@ export function RouteProvider({ children }: { children: ReactNode }) {
       // If the changes are caused by Zookeeper, ignore. The files are bulk
       // created, but because they are created one-by-one on disk, the system
       // races between reading and execution.
-      // The mlEphantManagerMachine will set a special exception in kclManager.
+      // The mlEphantManagerMachine will set a special exception in executingEditor.
       // Why not pull the actor context in here? Because this RouteProvider
       // is very high in the context tree, higher than mlEphant's.
-      if (kclManager.mlEphantManagerMachineBulkManipulatingFileSystem) return
+      if (executingEditor.mlEphantManagerMachineBulkManipulatingFileSystem)
+        return
 
       // We only react on files other than the currently-executing one here
       // because the currently-executing one is handled with its own watcher in
-      // KclManager. In future, all files and folders will watch themselves.
+      // ExecutingEditor. In future, all files and folders will watch themselves.
       if (loadedFile?.path !== path) {
         const fileNameWithExtension = getStringAfterLastSeparator(path)
         // Is the file from the change event type imported into the currently opened file
-        const isImportedInCurrentFile = kclManager.ast.body.some(
+        const isImportedInCurrentFile = executingEditor.ast.body.some(
           (n) =>
             n.type === 'ImportStatement' &&
             ((n.path.type === 'Kcl' &&
@@ -87,7 +88,7 @@ export function RouteProvider({ children }: { children: ReactNode }) {
         )
 
         const isInExecStateFilenames = Object.values(
-          kclManager.execState.filenames
+          executingEditor.execState.filenames
         ).some((filename) => {
           if (
             filename &&
@@ -101,12 +102,12 @@ export function RouteProvider({ children }: { children: ReactNode }) {
         })
         if (isImportedInCurrentFile || isInExecStateFilenames) {
           // Re execute the file you are in because an imported file was changed
-          await kclManager.executeAst()
+          await executingEditor.executeAst()
         }
       }
     },
     // This will build up for as many files you select and never remove until you exit the project to unmount the file watcher hook
-    kclManager.livePathsToWatch.value
+    executingEditor.livePathsToWatch.value
   )
 
   useFileSystemWatcher(

--- a/src/components/SetAngleLengthModal.tsx
+++ b/src/components/SetAngleLengthModal.tsx
@@ -46,7 +46,7 @@ export const SetAngleLengthModal = ({
   shouldCreateVariable: initialShouldCreateVariable = false,
   selectionRanges,
 }: SetAngleLengthModalProps) => {
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const [sign, setSign] = useState(initialValue.startsWith('-') ? -1 : 1)
   const [value, setValue] = useState(
     initialValue.startsWith('-') ? initialValue.substring(1) : initialValue
@@ -68,10 +68,10 @@ export const SetAngleLengthModal = ({
     value,
     initialVariableName: valueName,
     selectionRanges,
-    rustContext: kclManager.rustContext,
-    code: kclManager.codeSignal.value,
-    ast: kclManager.astSignal.value,
-    variables: kclManager.variablesSignal.value,
+    rustContext: executingEditor.rustContext,
+    code: executingEditor.codeSignal.value,
+    ast: executingEditor.astSignal.value,
+    variables: executingEditor.variablesSignal.value,
   })
   const isDisabled =
     (calcResult === 'NAN' || !isNewVariableNameUnique) && shouldCreateVariable

--- a/src/components/SetAngleLengthModal.tsx
+++ b/src/components/SetAngleLengthModal.tsx
@@ -10,7 +10,7 @@ import {
 } from '@src/components/AvailableVarsHelpers'
 import type { Expr } from '@src/lang/wasm'
 import { noAutofillInputProps } from '@src/lib/autofill'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import { useCalculateKclExpression } from '@src/lib/useCalculateKclExpression'
 import type { Selections } from '@src/machines/modelingSharedTypes'
 
@@ -46,7 +46,7 @@ export const SetAngleLengthModal = ({
   shouldCreateVariable: initialShouldCreateVariable = false,
   selectionRanges,
 }: SetAngleLengthModalProps) => {
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const [sign, setSign] = useState(initialValue.startsWith('-') ? -1 : 1)
   const [value, setValue] = useState(
     initialValue.startsWith('-') ? initialValue.substring(1) : initialValue

--- a/src/components/SetHorVertDistanceModal.tsx
+++ b/src/components/SetHorVertDistanceModal.tsx
@@ -49,7 +49,7 @@ export const GetInfoModal = ({
   initialVariableName,
   selectionRanges,
 }: GetInfoModalProps) => {
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const [sign, setSign] = useState(initialValue?.startsWith('-') ? -1 : 1)
   const [segName, setSegName] = useState(initialSegName)
   const [value, setValue] = useState(
@@ -72,10 +72,10 @@ export const GetInfoModal = ({
     value: value,
     initialVariableName,
     selectionRanges,
-    rustContext: kclManager.rustContext,
-    code: kclManager.codeSignal.value,
-    ast: kclManager.astSignal.value,
-    variables: kclManager.variablesSignal.value,
+    rustContext: executingEditor.rustContext,
+    code: executingEditor.codeSignal.value,
+    ast: executingEditor.astSignal.value,
+    variables: executingEditor.variablesSignal.value,
   })
 
   return (

--- a/src/components/SetHorVertDistanceModal.tsx
+++ b/src/components/SetHorVertDistanceModal.tsx
@@ -10,7 +10,7 @@ import {
 } from '@src/components/AvailableVarsHelpers'
 import type { Expr } from '@src/lang/wasm'
 import { noAutofillInputProps } from '@src/lib/autofill'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import { useCalculateKclExpression } from '@src/lib/useCalculateKclExpression'
 import type { Selections } from '@src/machines/modelingSharedTypes'
 
@@ -49,7 +49,7 @@ export const GetInfoModal = ({
   initialVariableName,
   selectionRanges,
 }: GetInfoModalProps) => {
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const [sign, setSign] = useState(initialValue?.startsWith('-') ? -1 : 1)
   const [segName, setSegName] = useState(initialSegName)
   const [value, setValue] = useState(

--- a/src/components/SetVarNameModal.tsx
+++ b/src/components/SetVarNameModal.tsx
@@ -30,16 +30,16 @@ export const SetVarNameModal = ({
   valueName,
   selectionRanges,
 }: SetVarNameModalProps) => {
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const { isNewVariableNameUnique, newVariableName, setNewVariableName } =
     useCalculateKclExpression({
       value: '',
       initialVariableName: valueName,
       selectionRanges,
-      rustContext: kclManager.rustContext,
-      code: kclManager.codeSignal.value,
-      ast: kclManager.astSignal.value,
-      variables: kclManager.variablesSignal.value,
+      rustContext: executingEditor.rustContext,
+      code: executingEditor.codeSignal.value,
+      ast: executingEditor.astSignal.value,
+      variables: executingEditor.variablesSignal.value,
     })
   const cancelButton = (
     <ActionButton

--- a/src/components/SetVarNameModal.tsx
+++ b/src/components/SetVarNameModal.tsx
@@ -5,7 +5,7 @@ import { type InstanceProps, create } from 'react-modal-promise'
 
 import { ActionButton } from '@src/components/ActionButton'
 import { CreateNewVariable } from '@src/components/AvailableVarsHelpers'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import { useCalculateKclExpression } from '@src/lib/useCalculateKclExpression'
 import { platform } from '@src/lib/utils'
 import type { Selections } from '@src/machines/modelingSharedTypes'
@@ -30,7 +30,7 @@ export const SetVarNameModal = ({
   valueName,
   selectionRanges,
 }: SetVarNameModalProps) => {
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const { isNewVariableNameUnique, newVariableName, setNewVariableName } =
     useCalculateKclExpression({
       value: '',

--- a/src/components/Settings/AllSettingsFields.tsx
+++ b/src/components/Settings/AllSettingsFields.tsx
@@ -2,7 +2,7 @@ import { ActionButton } from '@src/components/ActionButton'
 import { SettingsFieldInput } from '@src/components/Settings/SettingsFieldInput'
 import { SettingsSection } from '@src/components/Settings/SettingsSection'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { getSettingsFolderPaths } from '@src/lib/desktopFS'
 import { isDesktop } from '@src/lib/isDesktop'
 import { onboardingStartPath } from '@src/lib/onboardingPaths'
@@ -40,7 +40,7 @@ export const AllSettingsFields = forwardRef(
     scrollRef: ForwardedRef<HTMLDivElement>
   ) => {
     const { settings, layout, systemIOActor } = useApp()
-    const { executingEditor } = useSingletons()
+    const executingEditor = useExecutingEditor()
     const location = useLocation()
     const navigate = useNavigate()
     const context = settings.useSettings()

--- a/src/components/Settings/AllSettingsFields.tsx
+++ b/src/components/Settings/AllSettingsFields.tsx
@@ -40,7 +40,7 @@ export const AllSettingsFields = forwardRef(
     scrollRef: ForwardedRef<HTMLDivElement>
   ) => {
     const { settings, layout, systemIOActor } = useApp()
-    const { kclManager } = useSingletons()
+    const { executingEditor } = useSingletons()
     const location = useLocation()
     const navigate = useNavigate()
     const context = settings.useSettings()
@@ -67,7 +67,7 @@ export const AllSettingsFields = forwardRef(
       const props = {
         onboardingStatus: onboardingStartPath,
         navigate,
-        kclManager,
+        executingEditor,
         systemIOActor,
         settingsActor: settings.actor,
         executingPath,

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -70,13 +70,13 @@ function SharePopoverContent({
 }) {
   useSignals()
   const { auth, billing } = app
-  const { kclManager } = app.singletons
+  const { executingEditor } = app.singletons
   const token = auth.useToken()
   const billingContext = billing.useContext()
   const currentProject = app.projectSignal.value?.projectIORefSignal.value
   const allowOrgRestrict = !!billingContext.isOrg
   const allowPassword = !!billingContext.hasSubscription
-  const ast = kclManager.astSignal.value
+  const ast = executingEditor.astSignal.value
   const shareDisabled = ast.body.some((n) => n.type === 'ImportStatement')
 
   const onCopyShareLink = useCallback(
@@ -89,13 +89,13 @@ function SharePopoverContent({
     }) => {
       return copyFileShareLink({
         token,
-        code: kclManager.code,
+        code: executingEditor.code,
         name: currentProject?.name || '',
         isRestrictedToOrg,
         password: password || undefined,
       })
     },
-    [currentProject, kclManager, token]
+    [currentProject, executingEditor, token]
   )
 
   return (

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -76,11 +76,10 @@ function SharePopoverContent({
   const allowOrgRestrict = !!billingContext.isOrg
   const allowPassword = !!billingContext.hasSubscription
   const executingEditor = app.projectSignal.value?.executingEditor.value
-  if (!executingEditor) {
-    return null
-  }
-  const ast = executingEditor.astSignal.value
-  const shareDisabled = ast.body.some((n) => n.type === 'ImportStatement')
+  const ast = executingEditor?.astSignal.value
+  const shareDisabled =
+    !executingEditor ||
+    (ast?.body.some((n) => n.type === 'ImportStatement') ?? false)
 
   const onCopyShareLink = useCallback(
     async ({
@@ -90,6 +89,9 @@ function SharePopoverContent({
       isRestrictedToOrg: boolean
       password: string
     }) => {
+      if (!executingEditor) {
+        return false
+      }
       return copyFileShareLink({
         token,
         code: executingEditor.code,

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -70,12 +70,15 @@ function SharePopoverContent({
 }) {
   useSignals()
   const { auth, billing } = app
-  const { executingEditor } = app.singletons
   const token = auth.useToken()
   const billingContext = billing.useContext()
   const currentProject = app.projectSignal.value?.projectIORefSignal.value
   const allowOrgRestrict = !!billingContext.isOrg
   const allowPassword = !!billingContext.hasSubscription
+  const executingEditor = app.projectSignal.value?.executingEditor.value
+  if (!executingEditor) {
+    return null
+  }
   const ast = executingEditor.astSignal.value
   const shareDisabled = ast.body.some((n) => n.type === 'ImportStatement')
 

--- a/src/components/SystemIOMachineLogicListener.tsx
+++ b/src/components/SystemIOMachineLogicListener.tsx
@@ -34,7 +34,7 @@ import { useLocation } from 'react-router-dom'
 
 export function SystemIOMachineLogicListener() {
   const { settings, systemIOActor } = useApp()
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   // We gotta stop with this pattern. It doesn't scale. "Eager hook creation"
   const requestedProjectName = useRequestedProjectName()
   const requestedFileName = useRequestedFileName()
@@ -80,7 +80,7 @@ export function SystemIOMachineLogicListener() {
     // Open the requested file in the requested project
     onFileOpen(requestedFilePathWithExtension, requestedProjectDirectory)
 
-    kclManager.engineCommandManager.rejectAllModelingCommands(
+    executingEditor.engineCommandManager.rejectAllModelingCommands(
       EXECUTE_AST_INTERRUPT_ERROR_MESSAGE
     )
 
@@ -98,10 +98,10 @@ export function SystemIOMachineLogicListener() {
       requestedFilePathWithExtension &&
       filePathWithExtension !== requestedFilePathWithExtension
     ) {
-      kclManager.switchedFiles = true
+      executingEditor.switchedFiles = true
     }
 
-    kclManager.isExecuting = false
+    executingEditor.isExecuting = false
 
     const url = new URL(location.href)
     url.searchParams.delete(ASK_TO_OPEN_QUERY_PARAM)

--- a/src/components/SystemIOMachineLogicListener.tsx
+++ b/src/components/SystemIOMachineLogicListener.tsx
@@ -1,6 +1,6 @@
 import { useLspContext } from '@src/components/LspProvider'
 import { useFileSystemWatcher } from '@src/hooks/useFileSystemWatcher'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import {
   ASK_TO_OPEN_QUERY_PARAM,
   EXECUTE_AST_INTERRUPT_ERROR_MESSAGE,
@@ -34,7 +34,7 @@ import { useLocation } from 'react-router-dom'
 
 export function SystemIOMachineLogicListener() {
   const { settings, systemIOActor } = useApp()
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   // We gotta stop with this pattern. It doesn't scale. "Eager hook creation"
   const requestedProjectName = useRequestedProjectName()
   const requestedFileName = useRequestedFileName()

--- a/src/components/Toolbar/EqualAngle.tsx
+++ b/src/components/Toolbar/EqualAngle.tsx
@@ -1,4 +1,4 @@
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { toolTips } from '@src/lang/langHelpers'
 import { getNodeFromPath } from '@src/lang/queryAst'
 import { getNodePathFromSourceRange } from '@src/lang/queryAstNodePathUtils'
@@ -16,11 +16,11 @@ import type { Selections } from '@src/machines/modelingSharedTypes'
 
 export function equalAngleInfo({
   selectionRanges,
-  kclManager,
+  executingEditor,
   wasmInstance,
 }: {
   selectionRanges: Selections
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   wasmInstance: ModuleType
 }):
   | {
@@ -29,10 +29,14 @@ export function equalAngleInfo({
     }
   | Error {
   const paths = selectionRanges.graphSelections.map(({ codeRef }) =>
-    getNodePathFromSourceRange(kclManager.ast, codeRef.range)
+    getNodePathFromSourceRange(executingEditor.ast, codeRef.range)
   )
   const _nodes = paths.map((pathToNode) => {
-    const tmp = getNodeFromPath<Expr>(kclManager.ast, pathToNode, wasmInstance)
+    const tmp = getNodeFromPath<Expr>(
+      executingEditor.ast,
+      pathToNode,
+      wasmInstance
+    )
     if (err(tmp)) return tmp
     return tmp.node
   })
@@ -42,7 +46,7 @@ export function equalAngleInfo({
 
   const _varDecs = paths.map((pathToNode) => {
     const tmp = getNodeFromPath<VariableDeclarator>(
-      kclManager.ast,
+      executingEditor.ast,
       pathToNode,
       wasmInstance,
       'VariableDeclarator'
@@ -57,7 +61,7 @@ export function equalAngleInfo({
   const primaryLine = varDecs[0]
   const secondaryVarDecs = varDecs.slice(1)
   const isOthersLinkedToPrimary = secondaryVarDecs.every((secondary) =>
-    isSketchVariablesLinked(secondary, primaryLine, kclManager.ast)
+    isSketchVariablesLinked(secondary, primaryLine, executingEditor.ast)
   )
   const isAllTooltips = nodes.every(
     (node) =>
@@ -70,7 +74,7 @@ export function equalAngleInfo({
       ...selectionRanges,
       graphSelections: selectionRanges.graphSelections.slice(1),
     },
-    kclManager.ast,
+    executingEditor.ast,
     'equalAngle',
     wasmInstance
   )
@@ -86,11 +90,11 @@ export function equalAngleInfo({
 
 export function applyConstraintEqualAngle({
   selectionRanges,
-  kclManager,
+  executingEditor,
   wasmInstance,
 }: {
   selectionRanges: Selections
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   wasmInstance: ModuleType
 }):
   | {
@@ -98,15 +102,19 @@ export function applyConstraintEqualAngle({
       pathToNodeMap: PathToNodeMap
     }
   | Error {
-  const info = equalAngleInfo({ selectionRanges, kclManager, wasmInstance })
+  const info = equalAngleInfo({
+    selectionRanges,
+    executingEditor,
+    wasmInstance,
+  })
   if (err(info)) return info
   const { transforms } = info
 
   const transform = transformSecondarySketchLinesTagFirst({
-    ast: kclManager.ast,
+    ast: executingEditor.ast,
     selectionRanges,
     transformInfos: transforms,
-    memVars: kclManager.variables,
+    memVars: executingEditor.variables,
     wasmInstance,
   })
   if (err(transform)) return transform

--- a/src/components/Toolbar/Intersect.tsx
+++ b/src/components/Toolbar/Intersect.tsx
@@ -4,7 +4,7 @@ import {
   GetInfoModal,
   createInfoModal,
 } from '@src/components/SetHorVertDistanceModal'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { createVariableDeclaration } from '@src/lang/create'
 import { toolTips } from '@src/lang/langHelpers'
 import {
@@ -33,11 +33,11 @@ const getModalInfo = createInfoModal(GetInfoModal)
 
 export function intersectInfo({
   selectionRanges,
-  kclManager,
+  executingEditor,
   wasmInstance,
 }: {
   selectionRanges: Selections
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   wasmInstance: ModuleType
 }):
   | {
@@ -57,9 +57,9 @@ export function intersectInfo({
   const previousSegment =
     selectionRanges.graphSelections.length > 1 &&
     isLinesParallelAndConstrained(
-      kclManager.ast,
-      kclManager.artifactGraph,
-      kclManager.variables,
+      executingEditor.ast,
+      executingEditor.artifactGraph,
+      executingEditor.variables,
       selectionRanges.graphSelections[0],
       selectionRanges.graphSelections[1],
       wasmInstance
@@ -85,7 +85,7 @@ export function intersectInfo({
 
   const _nodes = _forcedSelectionRanges.graphSelections.map(({ codeRef }) => {
     const tmp = getNodeFromPath<Expr>(
-      kclManager.ast,
+      executingEditor.ast,
       codeRef.pathToNode,
       wasmInstance
     )
@@ -98,7 +98,7 @@ export function intersectInfo({
 
   const _varDecs = _forcedSelectionRanges.graphSelections.map(({ codeRef }) => {
     const tmp = getNodeFromPath<VariableDeclarator>(
-      kclManager.ast,
+      executingEditor.ast,
       codeRef.pathToNode,
       wasmInstance,
       'VariableDeclarator'
@@ -113,7 +113,7 @@ export function intersectInfo({
   const primaryLine = varDecs[0]
   const secondaryVarDecs = varDecs.slice(1)
   const isOthersLinkedToPrimary = secondaryVarDecs.every((secondary) =>
-    isSketchVariablesLinked(secondary, primaryLine, kclManager.ast)
+    isSketchVariablesLinked(secondary, primaryLine, executingEditor.ast)
   )
   const isAllTooltips = nodes.every(
     (node) =>
@@ -126,7 +126,7 @@ export function intersectInfo({
       ...selectionRanges,
       graphSelections: _forcedSelectionRanges.graphSelections.slice(1),
     },
-    kclManager.ast,
+    executingEditor.ast,
     'intersect',
     wasmInstance
   )
@@ -148,10 +148,10 @@ export function intersectInfo({
 
 export async function applyConstraintIntersect({
   selectionRanges,
-  kclManager,
+  executingEditor,
 }: {
   selectionRanges: Selections
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
 }): Promise<{
   modifiedAst: Node<Program>
   pathToNodeMap: PathToNodeMap
@@ -159,18 +159,18 @@ export async function applyConstraintIntersect({
 }> {
   const info = intersectInfo({
     selectionRanges,
-    kclManager,
-    wasmInstance: await kclManager.wasmInstancePromise,
+    executingEditor,
+    wasmInstance: await executingEditor.wasmInstancePromise,
   })
   if (err(info)) return Promise.reject(info)
   const { transforms, forcedSelectionRanges } = info
 
   const transform1 = transformSecondarySketchLinesTagFirst({
-    ast: structuredClone(kclManager.ast),
+    ast: structuredClone(executingEditor.ast),
     selectionRanges: forcedSelectionRanges,
     transformInfos: transforms,
-    memVars: kclManager.variables,
-    wasmInstance: await kclManager.wasmInstancePromise,
+    memVars: executingEditor.variables,
+    wasmInstance: await executingEditor.wasmInstancePromise,
   })
   if (err(transform1)) return Promise.reject(transform1)
   const { modifiedAst, tagInfo, valueUsedInTransform, pathToNodeMap } =
@@ -207,17 +207,17 @@ export async function applyConstraintIntersect({
   const finalValue = removeDoubleNegatives(
     valueNode,
     sign,
-    await kclManager.wasmInstancePromise,
+    await executingEditor.wasmInstancePromise,
     variableName
   )
   const transform2 = transformSecondarySketchLinesTagFirst({
-    ast: kclManager.ast,
+    ast: executingEditor.ast,
     selectionRanges: forcedSelectionRanges,
     transformInfos: transforms,
-    memVars: kclManager.variables,
+    memVars: executingEditor.variables,
     forceSegName: segName,
     forceValueUsedInTransform: finalValue,
-    wasmInstance: await kclManager.wasmInstancePromise,
+    wasmInstance: await executingEditor.wasmInstancePromise,
   })
   if (err(transform2)) return Promise.reject(transform2)
   const { modifiedAst: _modifiedAst, pathToNodeMap: _pathToNodeMap } =

--- a/src/components/Toolbar/RemoveConstrainingValues.tsx
+++ b/src/components/Toolbar/RemoveConstrainingValues.tsx
@@ -1,6 +1,6 @@
 import type { Node } from '@rust/kcl-lib/bindings/Node'
 
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { toolTips } from '@src/lang/langHelpers'
 import { getNodeFromPath } from '@src/lang/queryAst'
 import { codeRefFromRange } from '@src/lang/std/artifactGraph'
@@ -18,7 +18,7 @@ import type { Selection, Selections } from '@src/machines/modelingSharedTypes'
 
 export function removeConstrainingValuesInfo(
   pathToNodes: Array<PathToNode>,
-  kclManager: KclManager,
+  executingEditor: ExecutingEditor,
   wasmInstance: ModuleType
 ):
   | {
@@ -28,7 +28,11 @@ export function removeConstrainingValuesInfo(
     }
   | Error {
   const _nodes = pathToNodes.map((pathToNode) => {
-    const tmp = getNodeFromPath<Expr>(kclManager.ast, pathToNode, wasmInstance)
+    const tmp = getNodeFromPath<Expr>(
+      executingEditor.ast,
+      pathToNode,
+      wasmInstance
+    )
     if (tmp instanceof Error) return tmp
     return tmp.node
   })
@@ -42,7 +46,7 @@ export function removeConstrainingValuesInfo(
       (node): Selection => ({
         codeRef: codeRefFromRange(
           topLevelRange(node.start, node.end),
-          kclManager.ast
+          executingEditor.ast
         ),
       })
     ),
@@ -55,7 +59,7 @@ export function removeConstrainingValuesInfo(
 
   const transforms = getRemoveConstraintsTransforms(
     updatedSelectionRanges,
-    kclManager.ast,
+    executingEditor.ast,
     wasmInstance
   )
   if (err(transforms)) return transforms
@@ -67,12 +71,12 @@ export function removeConstrainingValuesInfo(
 export function applyRemoveConstrainingValues({
   selectionRanges,
   pathToNodes,
-  kclManager,
+  executingEditor,
   wasmInstance,
 }: {
   selectionRanges: Selections
   pathToNodes?: Array<PathToNode>
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   wasmInstance: ModuleType
 }):
   | {
@@ -87,17 +91,17 @@ export function applyRemoveConstrainingValues({
     })
   const constraint = removeConstrainingValuesInfo(
     pathToNodes,
-    kclManager,
+    executingEditor,
     wasmInstance
   )
   if (err(constraint)) return constraint
   const { transforms, updatedSelectionRanges } = constraint
 
   return transformAstSketchLines({
-    ast: kclManager.ast,
+    ast: executingEditor.ast,
     selectionRanges: updatedSelectionRanges,
     transformInfos: transforms,
-    memVars: kclManager.variables,
+    memVars: executingEditor.variables,
     referenceSegName: '',
     wasmInstance,
   })

--- a/src/components/Toolbar/SetAbsDistance.tsx
+++ b/src/components/Toolbar/SetAbsDistance.tsx
@@ -5,7 +5,7 @@ import {
   SetAngleLengthModal,
   createSetAngleLengthModal,
 } from '@src/components/SetAngleLengthModal'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { createName, createVariableDeclaration } from '@src/lang/create'
 import { toolTips } from '@src/lang/langHelpers'
 import { getNodeFromPath } from '@src/lang/queryAst'
@@ -28,12 +28,12 @@ type Constraint = 'xAbs' | 'yAbs' | 'snapToYAxis' | 'snapToXAxis'
 export function absDistanceInfo({
   selectionRanges,
   constraint,
-  kclManager,
+  executingEditor,
   wasmInstance,
 }: {
   selectionRanges: Selections
   constraint: Constraint
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   wasmInstance: ModuleType
 }):
   | {
@@ -49,7 +49,7 @@ export function absDistanceInfo({
         : 'yAbs'
   const _nodes = selectionRanges.graphSelections.map(({ codeRef }) => {
     const tmp = getNodeFromPath<Expr>(
-      kclManager.ast,
+      executingEditor.ast,
       codeRef.pathToNode,
       wasmInstance,
       ['CallExpressionKw']
@@ -69,7 +69,7 @@ export function absDistanceInfo({
 
   const transforms = getTransformInfos(
     selectionRanges,
-    kclManager.ast,
+    executingEditor.ast,
     disType,
     wasmInstance
   )
@@ -96,11 +96,11 @@ export function absDistanceInfo({
 export async function applyConstraintAbsDistance({
   selectionRanges,
   constraint,
-  kclManager,
+  executingEditor,
 }: {
   selectionRanges: Selections
   constraint: 'xAbs' | 'yAbs'
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
 }): Promise<{
   modifiedAst: Program
   pathToNodeMap: PathToNodeMap
@@ -109,19 +109,19 @@ export async function applyConstraintAbsDistance({
   const info = absDistanceInfo({
     selectionRanges,
     constraint,
-    kclManager,
-    wasmInstance: await kclManager.wasmInstancePromise,
+    executingEditor,
+    wasmInstance: await executingEditor.wasmInstancePromise,
   })
   if (err(info)) return Promise.reject(info)
   const transformInfos = info.transforms
 
   const transform1 = transformAstSketchLines({
-    ast: structuredClone(kclManager.ast),
+    ast: structuredClone(executingEditor.ast),
     selectionRanges,
     transformInfos,
-    memVars: kclManager.variables,
+    memVars: executingEditor.variables,
     referenceSegName: '',
-    wasmInstance: await kclManager.wasmInstancePromise,
+    wasmInstance: await executingEditor.wasmInstancePromise,
   })
   if (err(transform1)) return Promise.reject(transform1)
   const { valueUsedInTransform } = transform1
@@ -138,18 +138,18 @@ export async function applyConstraintAbsDistance({
   let finalValue = removeDoubleNegatives(
     valueNode,
     sign,
-    await kclManager.wasmInstancePromise,
+    await executingEditor.wasmInstancePromise,
     variableName
   )
 
   const transform2 = transformAstSketchLines({
-    ast: structuredClone(kclManager.ast),
+    ast: structuredClone(executingEditor.ast),
     selectionRanges,
     transformInfos,
-    memVars: kclManager.variables,
+    memVars: executingEditor.variables,
     referenceSegName: '',
     forceValueUsedInTransform: finalValue,
-    wasmInstance: await kclManager.wasmInstancePromise,
+    wasmInstance: await executingEditor.wasmInstancePromise,
   })
   if (err(transform2)) return Promise.reject(transform2)
   const { modifiedAst: _modifiedAst, pathToNodeMap } = transform2
@@ -177,12 +177,12 @@ export async function applyConstraintAbsDistance({
 export function applyConstraintAxisAlign({
   selectionRanges,
   constraint,
-  kclManager,
+  executingEditor,
   wasmInstance,
 }: {
   selectionRanges: Selections
   constraint: 'snapToYAxis' | 'snapToXAxis'
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   wasmInstance: ModuleType
 }):
   | {
@@ -193,7 +193,7 @@ export function applyConstraintAxisAlign({
   const info = absDistanceInfo({
     selectionRanges,
     constraint,
-    kclManager,
+    executingEditor,
     wasmInstance,
   })
   if (err(info)) return info
@@ -202,10 +202,10 @@ export function applyConstraintAxisAlign({
   let finalValue = createName(['turns'], 'ZERO')
 
   return transformAstSketchLines({
-    ast: structuredClone(kclManager.ast),
+    ast: structuredClone(executingEditor.ast),
     selectionRanges,
     transformInfos,
-    memVars: kclManager.variables,
+    memVars: executingEditor.variables,
     referenceSegName: '',
     forceValueUsedInTransform: finalValue,
     wasmInstance,

--- a/src/components/Toolbar/SetAngleBetween.tsx
+++ b/src/components/Toolbar/SetAngleBetween.tsx
@@ -3,7 +3,7 @@ import {
   GetInfoModal,
   createInfoModal,
 } from '@src/components/SetHorVertDistanceModal'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { createVariableDeclaration } from '@src/lang/create'
 import { toolTips } from '@src/lang/langHelpers'
 import { getNodeFromPath } from '@src/lang/queryAst'
@@ -29,11 +29,11 @@ const getModalInfo = createInfoModal(GetInfoModal)
 
 export function angleBetweenInfo({
   selectionRanges,
-  kclManager,
+  executingEditor,
   wasmInstance,
 }: {
   selectionRanges: Selections
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   wasmInstance: ModuleType
 }):
   | {
@@ -43,7 +43,7 @@ export function angleBetweenInfo({
   | Error {
   const _nodes = selectionRanges.graphSelections.map(({ codeRef }) => {
     const tmp = getNodeFromPath<Expr>(
-      kclManager.ast,
+      executingEditor.ast,
       codeRef.pathToNode,
       wasmInstance
     )
@@ -56,7 +56,7 @@ export function angleBetweenInfo({
 
   const _varDecs = selectionRanges.graphSelections.map(({ codeRef }) => {
     const tmp = getNodeFromPath<VariableDeclarator>(
-      kclManager.ast,
+      executingEditor.ast,
       codeRef.pathToNode,
       wasmInstance,
       'VariableDeclarator'
@@ -71,7 +71,7 @@ export function angleBetweenInfo({
   const primaryLine = varDecs[0]
   const secondaryVarDecs = varDecs.slice(1)
   const isOthersLinkedToPrimary = secondaryVarDecs.every((secondary) =>
-    isSketchVariablesLinked(secondary, primaryLine, kclManager.ast)
+    isSketchVariablesLinked(secondary, primaryLine, executingEditor.ast)
   )
   const isAllTooltips = nodes.every(
     (node) =>
@@ -84,7 +84,7 @@ export function angleBetweenInfo({
       ...selectionRanges,
       graphSelections: selectionRanges.graphSelections.slice(1),
     },
-    kclManager.ast,
+    executingEditor.ast,
     'setAngleBetween',
     wasmInstance
   )
@@ -100,10 +100,10 @@ export function angleBetweenInfo({
 
 export async function applyConstraintAngleBetween({
   selectionRanges,
-  kclManager,
+  executingEditor,
 }: {
   selectionRanges: Selections
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
 }): Promise<{
   modifiedAst: Program
   pathToNodeMap: PathToNodeMap
@@ -111,18 +111,18 @@ export async function applyConstraintAngleBetween({
 }> {
   const info = angleBetweenInfo({
     selectionRanges,
-    kclManager,
-    wasmInstance: await kclManager.wasmInstancePromise,
+    executingEditor,
+    wasmInstance: await executingEditor.wasmInstancePromise,
   })
   if (err(info)) return Promise.reject(info)
   const transformInfos = info.transforms
 
   const transformed1 = transformSecondarySketchLinesTagFirst({
-    ast: structuredClone(kclManager.ast),
+    ast: structuredClone(executingEditor.ast),
     selectionRanges,
     transformInfos,
-    memVars: kclManager.variables,
-    wasmInstance: await kclManager.wasmInstancePromise,
+    memVars: executingEditor.variables,
+    wasmInstance: await executingEditor.wasmInstancePromise,
   })
   if (err(transformed1)) return Promise.reject(transformed1)
   const { modifiedAst, tagInfo, valueUsedInTransform, pathToNodeMap } =
@@ -159,18 +159,18 @@ export async function applyConstraintAngleBetween({
   const finalValue = removeDoubleNegatives(
     valueNode,
     sign,
-    await kclManager.wasmInstancePromise,
+    await executingEditor.wasmInstancePromise,
     variableName
   )
   // transform again but forcing certain values
   const transformed2 = transformSecondarySketchLinesTagFirst({
-    ast: kclManager.ast,
+    ast: executingEditor.ast,
     selectionRanges,
     transformInfos,
-    memVars: kclManager.variables,
+    memVars: executingEditor.variables,
     forceSegName: segName,
     forceValueUsedInTransform: finalValue,
-    wasmInstance: await kclManager.wasmInstancePromise,
+    wasmInstance: await executingEditor.wasmInstancePromise,
   })
   if (err(transformed2)) return Promise.reject(transformed2)
   const { modifiedAst: _modifiedAst, pathToNodeMap: _pathToNodeMap } =

--- a/src/components/Toolbar/SetHorzVertDistance.tsx
+++ b/src/components/Toolbar/SetHorzVertDistance.tsx
@@ -5,7 +5,7 @@ import {
   GetInfoModal,
   createInfoModal,
 } from '@src/components/SetHorVertDistanceModal'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { createLiteral, createVariableDeclaration } from '@src/lang/create'
 import { toolTips } from '@src/lang/langHelpers'
 import { getNodeFromPath } from '@src/lang/queryAst'
@@ -32,12 +32,12 @@ const getModalInfo = createInfoModal(GetInfoModal)
 export function horzVertDistanceInfo({
   selectionRanges,
   constraint,
-  kclManager,
+  executingEditor,
   wasmInstance,
 }: {
   selectionRanges: Selections
   constraint: 'setHorzDistance' | 'setVertDistance'
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   wasmInstance: ModuleType
 }):
   | {
@@ -47,7 +47,7 @@ export function horzVertDistanceInfo({
   | Error {
   const _nodes = selectionRanges.graphSelections.map(({ codeRef }) => {
     const tmp = getNodeFromPath<Expr>(
-      kclManager.ast,
+      executingEditor.ast,
       codeRef.pathToNode,
       wasmInstance
     )
@@ -61,7 +61,7 @@ export function horzVertDistanceInfo({
 
   const _varDecs = selectionRanges.graphSelections.map(({ codeRef }) => {
     const tmp = getNodeFromPath<VariableDeclarator>(
-      kclManager.ast,
+      executingEditor.ast,
       codeRef.pathToNode,
       wasmInstance,
       'VariableDeclarator'
@@ -76,7 +76,7 @@ export function horzVertDistanceInfo({
   const primaryLine = varDecs[0]
   const secondaryVarDecs = varDecs.slice(1)
   const isOthersLinkedToPrimary = secondaryVarDecs.every((secondary) =>
-    isSketchVariablesLinked(secondary, primaryLine, kclManager.ast)
+    isSketchVariablesLinked(secondary, primaryLine, executingEditor.ast)
   )
   const isAllTooltips = nodes.every(
     (node) =>
@@ -89,7 +89,7 @@ export function horzVertDistanceInfo({
       ...selectionRanges,
       graphSelections: selectionRanges.graphSelections.slice(1),
     },
-    kclManager.ast,
+    executingEditor.ast,
     constraint,
     wasmInstance
   )
@@ -104,11 +104,11 @@ export function horzVertDistanceInfo({
 export async function applyConstraintHorzVertDistance({
   selectionRanges,
   constraint,
-  kclManager,
+  executingEditor,
 }: {
   selectionRanges: Selections
   constraint: 'setHorzDistance' | 'setVertDistance'
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
 }): Promise<{
   modifiedAst: Program
   pathToNodeMap: PathToNodeMap
@@ -117,17 +117,17 @@ export async function applyConstraintHorzVertDistance({
   const info = horzVertDistanceInfo({
     selectionRanges: selectionRanges,
     constraint,
-    kclManager,
-    wasmInstance: await kclManager.wasmInstancePromise,
+    executingEditor,
+    wasmInstance: await executingEditor.wasmInstancePromise,
   })
   if (err(info)) return Promise.reject(info)
   const transformInfos = info.transforms
   const transformed = transformSecondarySketchLinesTagFirst({
-    ast: structuredClone(kclManager.ast),
+    ast: structuredClone(executingEditor.ast),
     selectionRanges,
     transformInfos,
-    memVars: kclManager.variables,
-    wasmInstance: await kclManager.wasmInstancePromise,
+    memVars: executingEditor.variables,
+    wasmInstance: await executingEditor.wasmInstancePromise,
   })
   if (err(transformed)) return Promise.reject(transformed)
   const { modifiedAst, tagInfo, valueUsedInTransform, pathToNodeMap } =
@@ -162,18 +162,18 @@ export async function applyConstraintHorzVertDistance({
     let finalValue = removeDoubleNegatives(
       valueNode,
       sign,
-      await kclManager.wasmInstancePromise,
+      await executingEditor.wasmInstancePromise,
       variableName
     )
     // transform again but forcing certain values
     const transformed = transformSecondarySketchLinesTagFirst({
-      ast: kclManager.ast,
+      ast: executingEditor.ast,
       selectionRanges,
       transformInfos,
-      memVars: kclManager.variables,
+      memVars: executingEditor.variables,
       forceSegName: segName,
       forceValueUsedInTransform: finalValue,
-      wasmInstance: await kclManager.wasmInstancePromise,
+      wasmInstance: await executingEditor.wasmInstancePromise,
     })
 
     if (err(transformed)) return Promise.reject(transformed)
@@ -207,12 +207,12 @@ export function applyConstraintHorzVertAlign({
   selectionRanges,
   constraint,
   wasmInstance,
-  kclManager,
+  executingEditor,
 }: {
   selectionRanges: Selections
   constraint: 'setHorzDistance' | 'setVertDistance'
   wasmInstance: ModuleType
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
 }):
   | {
       modifiedAst: Node<Program>
@@ -222,17 +222,17 @@ export function applyConstraintHorzVertAlign({
   const info = horzVertDistanceInfo({
     selectionRanges,
     constraint,
-    kclManager,
+    executingEditor,
     wasmInstance,
   })
   if (err(info)) return info
   const transformInfos = info.transforms
   let finalValue = createLiteral(0, wasmInstance)
   const retval = transformSecondarySketchLinesTagFirst({
-    ast: kclManager.ast,
+    ast: executingEditor.ast,
     selectionRanges,
     transformInfos,
-    memVars: kclManager.variables,
+    memVars: executingEditor.variables,
     forceValueUsedInTransform: finalValue,
     wasmInstance,
   })

--- a/src/components/Toolbar/angleLengthInfo.ts
+++ b/src/components/Toolbar/angleLengthInfo.ts
@@ -1,4 +1,4 @@
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { isToolTip } from '@src/lang/langHelpers'
 import { getNodeFromPath } from '@src/lang/queryAst'
 import { getTransformInfos } from '@src/lang/std/sketchcombos'
@@ -11,12 +11,12 @@ import type { Selections } from '@src/machines/modelingSharedTypes'
 export function angleLengthInfo({
   selectionRanges,
   angleOrLength = 'setLength',
-  kclManager,
+  executingEditor,
   wasmInstance,
 }: {
   selectionRanges: Selections
   angleOrLength?: 'setLength' | 'setAngle'
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   wasmInstance: ModuleType
 }):
   | {
@@ -25,9 +25,12 @@ export function angleLengthInfo({
     }
   | Error {
   const nodes = selectionRanges.graphSelections.map(({ codeRef }) =>
-    getNodeFromPath<Expr>(kclManager.ast, codeRef.pathToNode, wasmInstance, [
-      'CallExpressionKw',
-    ])
+    getNodeFromPath<Expr>(
+      executingEditor.ast,
+      codeRef.pathToNode,
+      wasmInstance,
+      ['CallExpressionKw']
+    )
   )
   const _err1 = nodes.find(err)
   if (_err1 instanceof Error) return _err1
@@ -42,7 +45,7 @@ export function angleLengthInfo({
 
   const transforms = getTransformInfos(
     selectionRanges,
-    kclManager.ast,
+    executingEditor.ast,
     angleOrLength,
     wasmInstance
   )

--- a/src/components/Toolbar/setAngleLength.tsx
+++ b/src/components/Toolbar/setAngleLength.tsx
@@ -4,7 +4,7 @@ import {
   createSetAngleLengthModal,
 } from '@src/components/SetAngleLengthModal'
 import { angleLengthInfo } from '@src/components/Toolbar/angleLengthInfo'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import {
   createBinaryExpressionWithUnary,
   createLocalName,
@@ -27,21 +27,21 @@ const getModalInfo = createSetAngleLengthModal(SetAngleLengthModal)
 export async function applyConstraintLength({
   length,
   selectionRanges,
-  kclManager,
+  executingEditor,
 }: {
   length: KclCommandValue
   selectionRanges: Selections
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
 }): Promise<{
   modifiedAst: Program
   pathToNodeMap: PathToNodeMap
   exprInsertIndex: number
 }> {
-  const ast = kclManager.ast
+  const ast = executingEditor.ast
   const angleLength = angleLengthInfo({
     selectionRanges,
-    kclManager,
-    wasmInstance: await kclManager.wasmInstancePromise,
+    executingEditor,
+    wasmInstance: await executingEditor.wasmInstancePromise,
   })
   if (err(angleLength)) return Promise.reject(angleLength)
   const { transforms } = angleLength
@@ -71,10 +71,10 @@ export async function applyConstraintLength({
     ast,
     selectionRanges,
     transformInfos: transforms,
-    memVars: kclManager.variables,
+    memVars: executingEditor.variables,
     referenceSegName: '',
     forceValueUsedInTransform: distanceExpression,
-    wasmInstance: await kclManager.wasmInstancePromise,
+    wasmInstance: await executingEditor.wasmInstancePromise,
   })
   if (err(retval)) return Promise.reject(retval)
 
@@ -95,11 +95,11 @@ export async function applyConstraintLength({
 export async function applyConstraintAngleLength({
   selectionRanges,
   angleOrLength = 'setLength',
-  kclManager,
+  executingEditor,
 }: {
   selectionRanges: Selections
   angleOrLength?: 'setLength' | 'setAngle'
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
 }): Promise<{
   modifiedAst: Program
   pathToNodeMap: PathToNodeMap
@@ -108,19 +108,19 @@ export async function applyConstraintAngleLength({
   const angleLength = angleLengthInfo({
     selectionRanges,
     angleOrLength,
-    kclManager,
-    wasmInstance: await kclManager.wasmInstancePromise,
+    executingEditor,
+    wasmInstance: await executingEditor.wasmInstancePromise,
   })
   if (err(angleLength)) return Promise.reject(angleLength)
 
   const { transforms } = angleLength
   const sketched = transformAstSketchLines({
-    ast: structuredClone(kclManager.ast),
+    ast: structuredClone(executingEditor.ast),
     selectionRanges,
     transformInfos: transforms,
-    memVars: kclManager.variables,
+    memVars: executingEditor.variables,
     referenceSegName: '',
-    wasmInstance: await kclManager.wasmInstancePromise,
+    wasmInstance: await executingEditor.wasmInstancePromise,
   })
   if (err(sketched)) return Promise.reject(sketched)
   const { valueUsedInTransform } = sketched
@@ -177,7 +177,7 @@ export async function applyConstraintAngleLength({
   let finalValue = removeDoubleNegatives(
     valueNode,
     sign,
-    await kclManager.wasmInstancePromise,
+    await executingEditor.wasmInstancePromise,
     variableName
   )
   if (
@@ -188,13 +188,13 @@ export async function applyConstraintAngleLength({
   }
 
   const retval = transformAstSketchLines({
-    ast: structuredClone(kclManager.ast),
+    ast: structuredClone(executingEditor.ast),
     selectionRanges,
     transformInfos: transforms,
-    memVars: kclManager.variables,
+    memVars: executingEditor.variables,
     referenceSegName: '',
     forceValueUsedInTransform: finalValue,
-    wasmInstance: await kclManager.wasmInstancePromise,
+    wasmInstance: await executingEditor.wasmInstancePromise,
   })
   if (err(retval)) return Promise.reject(retval)
 

--- a/src/components/UndoRedoButtons.tsx
+++ b/src/components/UndoRedoButtons.tsx
@@ -2,16 +2,16 @@ import { useSignals } from '@preact/signals-react/runtime'
 import { CustomIcon } from '@src/components/CustomIcon'
 import Tooltip from '@src/components/Tooltip'
 import usePlatform from '@src/hooks/usePlatform'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { hotkeyDisplay } from '@src/lib/hotkeys'
 import { reportRejection } from '@src/lib/trap'
 import { refreshPage } from '@src/lib/utils'
 import { type HTMLProps, type MouseEventHandler } from 'react'
 
 export function UndoRedoButtons({
-  kclManager,
+  executingEditor,
   ...props
-}: HTMLProps<HTMLDivElement> & { kclManager: KclManager }) {
+}: HTMLProps<HTMLDivElement> & { executingEditor: ExecutingEditor }) {
   useSignals()
   return (
     <div {...props}>
@@ -19,17 +19,17 @@ export function UndoRedoButtons({
         label="Undo"
         keyboardShortcut="mod+z"
         iconName="arrowTurnLeft"
-        onClick={() => kclManager.undo()}
+        onClick={() => executingEditor.undo()}
         className="rounded-r-none"
-        disabled={kclManager.undoDepth.value === 0}
+        disabled={executingEditor.undoDepth.value === 0}
       />
       <UndoOrRedoButton
         label="Redo"
         keyboardShortcut="mod+shift+z"
         iconName="arrowTurnRight"
-        onClick={() => kclManager.redo()}
+        onClick={() => executingEditor.redo()}
         className="rounded-none"
-        disabled={kclManager.redoDepth.value === 0}
+        disabled={executingEditor.redoDepth.value === 0}
       />
       {/** TODO: Remove the refresh button when users don't need it so much. */}
       <UndoOrRedoButton

--- a/src/components/UnitsMenu.tsx
+++ b/src/components/UnitsMenu.tsx
@@ -6,14 +6,14 @@ import { defaultStatusBarItemClassNames } from '@src/components/StatusBar/Status
 import Tooltip from '@src/components/Tooltip'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { changeDefaultUnits } from '@src/lang/wasm'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import { DEFAULT_DEFAULT_LENGTH_UNIT } from '@src/lib/constants'
 import { baseUnitLabels, baseUnitsUnion } from '@src/lib/settings/settingsTypes'
 import { err } from '@src/lib/trap'
 import { OrthographicCamera } from 'three'
 
 export function UnitsMenu() {
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const wasmInstance = use(executingEditor.wasmInstancePromise)
   const [fileSettings, setFileSettings] = useState(executingEditor.fileSettings)
   const { state: modelingState } = useModelingContext()

--- a/src/components/UnitsMenu.tsx
+++ b/src/components/UnitsMenu.tsx
@@ -13,9 +13,9 @@ import { err } from '@src/lib/trap'
 import { OrthographicCamera } from 'three'
 
 export function UnitsMenu() {
-  const { kclManager } = useSingletons()
-  const wasmInstance = use(kclManager.wasmInstancePromise)
-  const [fileSettings, setFileSettings] = useState(kclManager.fileSettings)
+  const { executingEditor } = useSingletons()
+  const wasmInstance = use(executingEditor.wasmInstancePromise)
+  const [fileSettings, setFileSettings] = useState(executingEditor.fileSettings)
   const { state: modelingState } = useModelingContext()
   const inSketchMode = modelingState.matches('Sketch')
 
@@ -29,7 +29,7 @@ export function UnitsMenu() {
     if (!inSketchMode) {
       return
     }
-    const camera = kclManager.sceneInfra.camControls.camera
+    const camera = executingEditor.sceneInfra.camControls.camera
     if (!(camera instanceof OrthographicCamera)) {
       console.error(
         'Camera is not an OrthographicCamera, skipping ruler recalculation'
@@ -37,7 +37,7 @@ export function UnitsMenu() {
       return
     }
 
-    let rulerWidth = kclManager.sceneInfra.getPixelsPerBaseUnit(camera)
+    let rulerWidth = executingEditor.sceneInfra.getPixelsPerBaseUnit(camera)
     let displayValue = 1
 
     if (rulerWidth > 150 || rulerWidth < 20) {
@@ -50,12 +50,12 @@ export function UnitsMenu() {
     }
     setRulerWidth(rulerWidth)
     setRulerLabelValue(displayValue)
-  }, [inSketchMode, kclManager.sceneInfra])
+  }, [inSketchMode, executingEditor.sceneInfra])
 
   useEffect(() => {
     const unsubscribers = [
-      kclManager.sceneInfra.camControls.cameraChange.add(onCameraChange),
-      kclManager.sceneInfra.baseUnitChange.add(onCameraChange),
+      executingEditor.sceneInfra.camControls.cameraChange.add(onCameraChange),
+      executingEditor.sceneInfra.baseUnitChange.add(onCameraChange),
     ]
     onCameraChange()
     return () => {
@@ -63,16 +63,16 @@ export function UnitsMenu() {
     }
   }, [
     onCameraChange,
-    kclManager.sceneInfra.baseUnitChange,
-    kclManager.sceneInfra.camControls.cameraChange,
+    executingEditor.sceneInfra.baseUnitChange,
+    executingEditor.sceneInfra.camControls.cameraChange,
   ])
   useEffect(() => {
-    setFileSettings(kclManager.fileSettings)
+    setFileSettings(executingEditor.fileSettings)
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
   }, [
-    kclManager.fileSettings,
-    kclManager.sceneInfra.baseUnitChange,
-    kclManager.sceneInfra.camControls.cameraChange,
+    executingEditor.fileSettings,
+    executingEditor.sceneInfra.baseUnitChange,
+    executingEditor.sceneInfra.camControls.cameraChange,
   ])
 
   return (
@@ -109,7 +109,7 @@ export function UnitsMenu() {
                     className="flex items-center gap-2 m-0 py-1.5 px-2 cursor-pointer hover:bg-chalkboard-20 dark:hover:bg-chalkboard-80 border-none text-left"
                     onClick={() => {
                       const newCode = changeDefaultUnits(
-                        kclManager.code,
+                        executingEditor.code,
                         unit,
                         wasmInstance
                       )
@@ -118,7 +118,7 @@ export function UnitsMenu() {
                           `Failed to set per-file units: ${newCode.message}`
                         )
                       } else {
-                        kclManager.updateCodeEditor(newCode, {
+                        executingEditor.updateCodeEditor(newCode, {
                           shouldExecute: true,
                           shouldResetCamera: true,
                         })

--- a/src/components/ViewControlMenu.tsx
+++ b/src/components/ViewControlMenu.tsx
@@ -26,7 +26,7 @@ import toast from 'react-hot-toast'
 export function useViewControlMenuItems() {
   useSignals()
   const { settings, layout } = useApp()
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const { state: modelingState, send: modelingSend } = useModelingContext()
   const planeOrFaceId = getSelectedSketchTarget(
     modelingState.context.selectionRanges
@@ -60,7 +60,7 @@ export function useViewControlMenuItems() {
         <ContextMenuItem
           key={axisName}
           onClick={() => {
-            kclManager.sceneInfra.camControls
+            executingEditor.sceneInfra.camControls
               .updateCameraToAxis(axisName as AxisNames)
               .catch(reportRejection)
           }}
@@ -73,8 +73,8 @@ export function useViewControlMenuItems() {
       <ContextMenuItem
         onClick={() => {
           resetCameraPosition({
-            sceneInfra: kclManager.sceneInfra,
-            engineCommandManager: kclManager.engineCommandManager,
+            sceneInfra: executingEditor.sceneInfra,
+            engineCommandManager: executingEditor.engineCommandManager,
             settingsActor: settings.actor,
           }).catch(reportRejection)
         }}
@@ -143,7 +143,7 @@ export function useViewControlMenuItems() {
       <ContextMenuItem
         onClick={() => {
           if (planeOrFaceId) {
-            kclManager.sceneInfra.modelingSend({
+            executingEditor.sceneInfra.modelingSend({
               type: 'Enter sketch',
               data: { forceNewSketch: true, keepDefaultPlaneVisibility: true },
             })
@@ -151,7 +151,7 @@ export function useViewControlMenuItems() {
             void selectSketchPlane(
               planeOrFaceId,
               modelingState.context.store.useSketchSolveMode?.current,
-              kclManager
+              executingEditor
             )
           }
         }}
@@ -190,7 +190,7 @@ export function useViewControlMenuItems() {
       snapToGrid,
       gizmoType,
       layout.signal.value,
-      kclManager,
+      executingEditor,
       settings,
     ]
   )

--- a/src/components/ViewControlMenu.tsx
+++ b/src/components/ViewControlMenu.tsx
@@ -9,7 +9,7 @@ import {
 } from '@src/components/ContextMenu'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { getSelectedSketchTarget } from '@src/lang/queryAst'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import type { AxisNames } from '@src/lib/constants'
 import { VIEW_NAMES_SEMANTIC } from '@src/lib/constants'
 import { SNAP_TO_GRID_HOTKEY } from '@src/lib/hotkeys'
@@ -26,7 +26,7 @@ import toast from 'react-hot-toast'
 export function useViewControlMenuItems() {
   useSignals()
   const { settings, layout } = useApp()
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const { state: modelingState, send: modelingSend } = useModelingContext()
   const planeOrFaceId = getSelectedSketchTarget(
     modelingState.context.selectionRanges

--- a/src/components/gizmo/AxisGizmo.tsx
+++ b/src/components/gizmo/AxisGizmo.tsx
@@ -27,7 +27,7 @@ import {
 
 export default function AxisGizmo() {
   const { settings } = useApp()
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const { state: modelingState } = useModelingContext()
   const settingsValues = settings.useSettings()
   const wrapperRef = useRef<HTMLDivElement | null>(null)
@@ -115,7 +115,7 @@ export default function AxisGizmo() {
     }
 
     const clock = new Clock()
-    const clientCamera = kclManager.sceneInfra.camControls.camera
+    const clientCamera = executingEditor.sceneInfra.camControls.camera
     const currentQuaternion = new Quaternion().copy(clientCamera.quaternion)
     const mouse = new Vector2()
     mouse.x = 1 // fix initial mouse position issue
@@ -127,7 +127,7 @@ export default function AxisGizmo() {
 
       isHoverRefreshPausedRef.current = false
       currentQuaternion.copy(
-        kclManager.sceneInfra.camControls.camera.quaternion
+        executingEditor.sceneInfra.camControls.camera.quaternion
       )
       camera.position.set(0, 0, 1).applyQuaternion(currentQuaternion)
       camera.quaternion.copy(currentQuaternion)
@@ -140,7 +140,7 @@ export default function AxisGizmo() {
     const onAxisClick = (axisName: AxisNames) => {
       isHoverRefreshPausedRef.current = true
       resetRayCast()
-      void kclManager.sceneInfra.camControls
+      void executingEditor.sceneInfra.camControls
         .updateCameraToAxis(axisName)
         .catch(reportRejection)
         .finally(refreshHoverAfterCameraUpdate)
@@ -163,7 +163,7 @@ export default function AxisGizmo() {
       updateCameraOrientation(
         camera,
         currentQuaternion,
-        kclManager.sceneInfra.camControls.camera.quaternion,
+        executingEditor.sceneInfra.camControls.camera.quaternion,
         delta,
         cameraPassiveUpdateTimer
       )
@@ -173,10 +173,10 @@ export default function AxisGizmo() {
         renderGizmoScene(gizmoAxisPairs, renderer, scene, camera)
       }
     }
-    kclManager.sceneInfra.camControls.cameraChange.add(animate)
+    executingEditor.sceneInfra.camControls.cameraChange.add(animate)
 
     // Initialize camera orientation/position to match main camera for immediate render
-    const q = kclManager.sceneInfra.camControls.camera.quaternion
+    const q = executingEditor.sceneInfra.camControls.camera.quaternion
     camera.position.set(0, 0, 1).applyQuaternion(q)
     camera.quaternion.copy(q)
     renderGizmoScene(gizmoAxisPairs, renderer, scene, camera)
@@ -188,9 +188,9 @@ export default function AxisGizmo() {
       renderer.forceContextLoss()
       renderer.dispose()
       disposeMouseEvents()
-      kclManager.sceneInfra.camControls.cameraChange.remove(animate)
+      executingEditor.sceneInfra.camControls.cameraChange.remove(animate)
     }
-  }, [kclManager.sceneInfra])
+  }, [executingEditor.sceneInfra])
 
   return (
     <div

--- a/src/components/gizmo/AxisGizmo.tsx
+++ b/src/components/gizmo/AxisGizmo.tsx
@@ -1,4 +1,4 @@
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { useEffect, useRef } from 'react'
 import type { MutableRefObject } from 'react'
 
@@ -27,7 +27,7 @@ import {
 
 export default function AxisGizmo() {
   const { settings } = useApp()
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const { state: modelingState } = useModelingContext()
   const settingsValues = settings.useSettings()
   const wrapperRef = useRef<HTMLDivElement | null>(null)

--- a/src/components/gizmo/CubeGizmo.tsx
+++ b/src/components/gizmo/CubeGizmo.tsx
@@ -1,5 +1,5 @@
 import GizmoRenderer from '@src/components/gizmo/GizmoRenderer'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { useEffect, useRef, useState } from 'react'
 
 import { useModelingContext } from '@src/hooks/useModelingContext'
@@ -7,7 +7,7 @@ import { useResolvedTheme } from '@src/hooks/useResolvedTheme'
 
 export default function CubeGizmo() {
   const { settings } = useApp()
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const { state: modelingState } = useModelingContext()
   const settingsValues = settings.useSettings()
 

--- a/src/components/gizmo/CubeGizmo.tsx
+++ b/src/components/gizmo/CubeGizmo.tsx
@@ -7,7 +7,7 @@ import { useResolvedTheme } from '@src/hooks/useResolvedTheme'
 
 export default function CubeGizmo() {
   const { settings } = useApp()
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const { state: modelingState } = useModelingContext()
   const settingsValues = settings.useSettings()
 
@@ -32,14 +32,14 @@ export default function CubeGizmo() {
         canvasRef.current,
         initialIsPerspectiveRef.current,
         initialResolvedThemeRef.current,
-        kclManager.sceneInfra
+        executingEditor.sceneInfra
       )
     }
     return () => {
       renderer.current?.dispose()
       renderer.current = null
     }
-  }, [kclManager.sceneInfra])
+  }, [executingEditor.sceneInfra])
 
   // perspective changed
   // useEffect(() => {

--- a/src/components/layout/areas/BodiesPane.tsx
+++ b/src/components/layout/areas/BodiesPane.tsx
@@ -13,7 +13,7 @@ import {
   getCodeRefsByArtifactId,
 } from '@src/lang/std/artifactGraph'
 import { type ArtifactGraph, getAllOperations } from '@src/lang/wasm'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { EXPERIMENTAL_POINT_AND_CLICK_FLAG } from '@src/lib/constants'
 import { sendSelectionEvent } from '@src/lib/featureTree'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
@@ -32,7 +32,7 @@ type SolidArtifact = Artifact & { type: 'compositeSolid' | 'sweep' | 'pattern' }
 
 export function BodiesPane(props: AreaTypeComponentProps) {
   useSignals()
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const execState = executingEditor.execStateSignal.value
   const artifactGraph = execState.artifactGraph
   const operations = getAllOperations(execState.operations)
@@ -120,7 +120,7 @@ function BodyItem({
   patternIndex?: number
   showExperimentalPointAndClick?: boolean
 }) {
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const {
     actor: modelingActor,
     context: modelingContext,

--- a/src/components/layout/areas/BodiesPane.tsx
+++ b/src/components/layout/areas/BodiesPane.tsx
@@ -32,8 +32,8 @@ type SolidArtifact = Artifact & { type: 'compositeSolid' | 'sweep' | 'pattern' }
 
 export function BodiesPane(props: AreaTypeComponentProps) {
   useSignals()
-  const { kclManager } = useSingletons()
-  const execState = kclManager.execStateSignal.value
+  const { executingEditor } = useSingletons()
+  const execState = executingEditor.execStateSignal.value
   const artifactGraph = execState.artifactGraph
   const operations = getAllOperations(execState.operations)
   const bodies = getBodiesFromArtifactGraph(artifactGraph)
@@ -120,7 +120,7 @@ function BodyItem({
   patternIndex?: number
   showExperimentalPointAndClick?: boolean
 }) {
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const {
     actor: modelingActor,
     context: modelingContext,
@@ -147,10 +147,10 @@ function BodyItem({
     ? modelingContext.selectionRanges.graphSelections.some(
         (selection) => selection.engineEntityId === engineEntityId
       )
-    : kclManager.editorState.selection.main.from >=
-        toUtf16(sourceRange[0], kclManager.code) &&
-      kclManager.editorState.selection.main.to <=
-        toUtf16(sourceRange[1], kclManager.code)
+    : executingEditor.editorState.selection.main.from >=
+        toUtf16(sourceRange[0], executingEditor.code) &&
+      executingEditor.editorState.selection.main.to <=
+        toUtf16(sourceRange[1], executingEditor.code)
   const onSelect = () => {
     if (engineEntityId) {
       modelingSend({
@@ -166,7 +166,7 @@ function BodyItem({
     sendSelectionEvent(
       {
         sourceRange,
-        kclManager,
+        executingEditor,
         modelingSend,
       },
       true
@@ -206,8 +206,8 @@ function BodyItem({
               onSelect()
               if (hideOperation === undefined) {
                 onHide({
-                  ast: kclManager.ast,
-                  artifactGraph: kclManager.artifactGraph,
+                  ast: executingEditor.ast,
+                  artifactGraph: executingEditor.artifactGraph,
                   modelingActor,
                   objects: selections,
                 })
@@ -215,7 +215,7 @@ function BodyItem({
                 onUnhide({
                   hideOperation,
                   targetArtifact: artifact,
-                  kclManager,
+                  executingEditor,
                 })
                   .then((result) => {
                     if (err(result)) {

--- a/src/components/layout/areas/FeatureTreePane.tsx
+++ b/src/components/layout/areas/FeatureTreePane.tsx
@@ -84,7 +84,7 @@ type Singletons = ReturnType<typeof useSingletons>
 
 type ModuleInstanceOperation = Extract<Operation, { type: 'ModuleInstance' }>
 
-type SystemDeps = Pick<Singletons, 'kclManager'> & {
+type SystemDeps = Pick<Singletons, 'executingEditor'> & {
   commandBarActor: CommandBarActorType
   sceneInfra: SceneInfra
   sceneEntitiesManager: SceneEntities
@@ -142,9 +142,9 @@ export const FeatureTreePaneContents = memo(() => {
     UNRENDERED_EXECUTE_HOTKEY,
     platform
   )
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const executionService = app.registry.signal(executingEditorService).value
-  const { engineCommandManager, rustContext } = kclManager
+  const { engineCommandManager, rustContext } = executingEditor
   const {
     send: modelingSend,
     state: modelingState,
@@ -152,35 +152,35 @@ export const FeatureTreePaneContents = memo(() => {
   } = useModelingContext()
   const systemDeps: SystemDeps = useMemo(
     () => ({
-      kclManager,
-      sceneInfra: kclManager.sceneInfra,
-      sceneEntitiesManager: kclManager.sceneEntitiesManager,
+      executingEditor,
+      sceneInfra: executingEditor.sceneInfra,
+      sceneEntitiesManager: executingEditor.sceneEntitiesManager,
       rustContext,
       commandBarActor: commands.actor,
     }),
-    [kclManager, rustContext, commands.actor]
+    [executingEditor, rustContext, commands.actor]
   )
 
   const selectOperation = useCallback(
     (sourceRange: SourceRange) => {
       sendSelectionEvent({
-        sourceRange: sourceRangeToUtf16(sourceRange, kclManager.code),
-        kclManager,
+        sourceRange: sourceRangeToUtf16(sourceRange, executingEditor.code),
+        executingEditor,
         modelingSend,
       })
     },
-    [modelingSend, kclManager]
+    [modelingSend, executingEditor]
   )
 
   const sketchNoFace = modelingState.matches('Sketch no face')
-  const hasParseErrors = kclManager.hasParseErrors()
+  const hasParseErrors = executingEditor.hasParseErrors()
   const disableModelingForUnrenderedChanges =
     shouldDisableModelingForUnrenderedChanges({
       settings: settingsValues,
       hasEditsSinceLastExecution:
-        kclManager.hasEditsSinceLastExecutionSignal.value,
+        executingEditor.hasEditsSinceLastExecutionSignal.value,
     })
-  const diagnostics = kclManager.diagnosticsSignal.value
+  const diagnostics = executingEditor.diagnosticsSignal.value
   const parseDiagnostics = hasParseErrors
     ? diagnostics.filter((diagnostic) => diagnostic.severity === 'error')
     : []
@@ -189,7 +189,7 @@ export const FeatureTreePaneContents = memo(() => {
 
   // If there are engine errors we show the successful operations
   // Errors return an operation list, so use the longest one if there are multiple
-  const longestErrorOperationsByModule = kclManager.errors.reduce(
+  const longestErrorOperationsByModule = executingEditor.errors.reduce(
     (acc, error) => {
       return countOperations(error.operations) > countOperations(acc)
         ? error.operations
@@ -198,21 +198,21 @@ export const FeatureTreePaneContents = memo(() => {
     emptyOperationsByModule()
   )
 
-  const unfilteredOperationsByModule = kclManager.isExecuting
-    ? kclManager.operationsByModule
+  const unfilteredOperationsByModule = executingEditor.isExecuting
+    ? executingEditor.operationsByModule
     : !hasParseErrors
-      ? !kclManager.errors.length
-        ? kclManager.operationsByModule
+      ? !executingEditor.errors.length
+        ? executingEditor.operationsByModule
         : longestErrorOperationsByModule
-      : kclManager.lastSuccessfulOperations
+      : executingEditor.lastSuccessfulOperations
   // We use the code that corresponds to the operations. In case this is an
   // error on the first run, fall back to whatever is currently in the code
   // editor.
   const operationsCode = hasParseErrors
-    ? kclManager.lastSuccessfulCode || kclManager.codeSignal.value
+    ? executingEditor.lastSuccessfulCode || executingEditor.codeSignal.value
     : disableModelingForUnrenderedChanges
-      ? kclManager.lastSuccessfulCode || kclManager.codeSignal.value
-      : kclManager.codeSignal.value
+      ? executingEditor.lastSuccessfulCode || executingEditor.codeSignal.value
+      : executingEditor.codeSignal.value
   const isReadOnlyFeatureTree =
     hasParseErrors || disableModelingForUnrenderedChanges
 
@@ -224,20 +224,20 @@ export const FeatureTreePaneContents = memo(() => {
   const isShowingStaleFeatureTree = hasParseErrors && operationList.length > 0
 
   // Live execution tracking: expand only the active module branch.
-  const liveActiveModuleId = kclManager.liveActiveModuleId
+  const liveActiveModuleId = executingEditor.liveActiveModuleId
 
   function goToError() {
     const l = layout.signal.value
     if (!isCodePaneOpen(l)) {
       openCodePane(l, layout.set)
     }
-    kclManager.scrollToFirstErrorDiagnosticIfExists()
+    executingEditor.scrollToFirstErrorDiagnosticIfExists()
   }
 
   function applyParseQuickFix() {
     if (!firstParseDiagnostic || !firstParseAction) return
     firstParseAction.apply(
-      kclManager.editorView,
+      executingEditor.editorView,
       firstParseDiagnostic.from,
       firstParseDiagnostic.to
     )
@@ -250,7 +250,7 @@ export const FeatureTreePaneContents = memo(() => {
         className="absolute inset-0 p-1 box-border overflow-auto mr-1"
       >
         <>
-          {kclManager.isExecuting && (
+          {executingEditor.isExecuting && (
             <div className="text-xs bg-primary/10 text-primary py-2 px-2 rounded flex-none mb-2 border border-primary/20">
               Updating feature tree...
             </div>
@@ -273,7 +273,7 @@ export const FeatureTreePaneContents = memo(() => {
                   onClick={() => {
                     executionService?.executeCode().catch(reportRejection)
                   }}
-                  disabled={kclManager.isExecuting || !executionService}
+                  disabled={executingEditor.isExecuting || !executionService}
                   className="flex gap-1 items-center py-0 pl-0.5 pr-1 m-0 flex-none text-primary dark:text-primary border border-solid border-primary bg-primary/10 dark:bg-primary/20 hover:bg-primary/20 dark:hover:bg-primary/30 hover:border-primary active:border-primary disabled:cursor-wait disabled:opacity-70"
                 >
                   <CustomIcon name="play" className="w-5 h-5" />
@@ -752,28 +752,33 @@ const OperationItem = ({
   const app = useApp()
   const navigate = useNavigate()
   const { layout } = app
-  const { kclManager, commandBarActor } = systemDeps
+  const { executingEditor, commandBarActor } = systemDeps
   const useSketchSolveMode =
     modelingActor.getSnapshot().context.store.useSketchSolveMode?.current
-  const diagnostics = kclManager.diagnosticsSignal.value
-  const liveAst = kclManager.astSignal.value
-  const ast = kclManager.hasParseErrors() ? kclManager.lastGoodAst : liveAst
-  const wasmInstance = use(kclManager.wasmInstancePromise)
+  const diagnostics = executingEditor.diagnosticsSignal.value
+  const liveAst = executingEditor.astSignal.value
+  const ast = executingEditor.hasParseErrors()
+    ? executingEditor.lastGoodAst
+    : liveAst
+  const wasmInstance = use(executingEditor.wasmInstancePromise)
   const name = getOperationLabel(item)
   const sourceRange =
     'sourceRange' in item &&
-    sourceRangeToUtf16(sourceRangeFromRust(item.sourceRange), kclManager.code)
+    sourceRangeToUtf16(
+      sourceRangeFromRust(item.sourceRange),
+      executingEditor.code
+    )
   const isLiveLatest =
-    kclManager.liveLatestOperationKey === getOperationKey(item)
+    executingEditor.liveLatestOperationKey === getOperationKey(item)
   const isEditorSelected = useMemo(() => {
     if (!sourceRange) {
       return false
     }
 
-    return kclManager.editorState.selection.ranges.some(({ from, to }) => {
+    return executingEditor.editorState.selection.ranges.some(({ from, to }) => {
       return isOverlap(sourceRange, topLevelRange(from, to))
     })
-  }, [kclManager.editorState.selection, sourceRange])
+  }, [executingEditor.editorState.selection, sourceRange])
   const isSelected = isLiveLatest || isEditorSelected
   const valueDetail = useMemo(() => {
     return getFeatureTreeValueDetail(item, code)
@@ -812,12 +817,12 @@ const OperationItem = ({
         if (isOffsetPlane(item)) {
           const artifact = findOperationPlaneArtifact(
             item,
-            kclManager.artifactGraph
+            executingEditor.artifactGraph
           )
           const result = await selectSketchPlane(
             artifact?.id,
             useSketchSolveMode,
-            kclManager
+            executingEditor
           )
           if (err(result)) {
             console.error(result)
@@ -837,7 +842,7 @@ const OperationItem = ({
       sketchNoFace,
       onSelect,
       item,
-      kclManager,
+      executingEditor,
       useSketchSolveMode,
     ]
   )
@@ -852,7 +857,8 @@ const OperationItem = ({
         item.type === 'ModuleInstance'
           ? item.moduleId
           : (providedSourceRange?.[2] ?? item.sourceRange[2])
-      const targetModulePath = kclManager.execState.filenames[targetModuleId]
+      const targetModulePath =
+        executingEditor.execState.filenames[targetModuleId]
 
       const l = layout.signal.value
       if (!isCodePaneOpen(l)) {
@@ -862,7 +868,7 @@ const OperationItem = ({
       if (targetModulePath?.type === 'Local' && app.project) {
         const targetPath = targetModulePath.value
         if (app.project.executingPath !== targetPath) {
-          kclManager.pendingFeatureTreeSourceSelection = {
+          executingEditor.pendingFeatureTreeSourceSelection = {
             path: targetPath,
             range: providedSourceRange ?? item.sourceRange,
           }
@@ -878,7 +884,7 @@ const OperationItem = ({
 
       onSelect(targetRange)
     },
-    [app, item, kclManager, layout, navigate, onSelect]
+    [app, item, executingEditor, layout, navigate, onSelect]
   )
 
   const enterEditFlow = useCallback(() => {
@@ -893,7 +899,7 @@ const OperationItem = ({
       const artifact =
         getArtifactFromRange(
           item.sourceRange,
-          systemDeps.kclManager.artifactGraph
+          systemDeps.executingEditor.artifactGraph
         ) ?? undefined
       if (
         item.type === 'GroupBegin' &&
@@ -910,8 +916,8 @@ const OperationItem = ({
         return
       }
       prepareEditCommand({
-        artifactGraph: systemDeps.kclManager.artifactGraph,
-        code: systemDeps.kclManager.code,
+        artifactGraph: systemDeps.executingEditor.artifactGraph,
+        code: systemDeps.executingEditor.code,
         commandBarActor,
         operation: item,
         rustContext: systemDeps.rustContext,
@@ -923,8 +929,8 @@ const OperationItem = ({
     item,
     modelingActor,
     commandBarActor,
-    systemDeps.kclManager.artifactGraph,
-    systemDeps.kclManager.code,
+    systemDeps.executingEditor.artifactGraph,
+    systemDeps.executingEditor.code,
     systemDeps.rustContext,
   ])
 
@@ -1011,7 +1017,7 @@ const OperationItem = ({
       item.type === 'VariableDeclaration'
     ) {
       const maybeArtifact =
-        getArtifactFromRange(item.sourceRange, kclManager.artifactGraph) ??
+        getArtifactFromRange(item.sourceRange, executingEditor.artifactGraph) ??
         undefined
       sendDeleteCommand({
         artifact: maybeArtifact,
@@ -1030,15 +1036,15 @@ const OperationItem = ({
     if (isOffsetPlane(item)) {
       const artifact = findOperationPlaneArtifact(
         item,
-        kclManager.artifactGraph
+        executingEditor.artifactGraph
       )
       if (artifact?.id) {
-        kclManager.sceneInfra.modelingSend({
+        executingEditor.sceneInfra.modelingSend({
           type: 'Enter sketch',
           data: { forceNewSketch: true },
         })
 
-        void selectSketchPlane(artifact.id, useSketchSolveMode, kclManager)
+        void selectSketchPlane(artifact.id, useSketchSolveMode, executingEditor)
       }
     }
   }
@@ -1105,7 +1111,7 @@ const OperationItem = ({
                     if (item.type !== 'StdLibCall') return
                     await exportSketchToDxf(item, {
                       engineCommandManager,
-                      kclManager,
+                      executingEditor,
                       toast,
                       uuidv4,
                       base64Decode,
@@ -1128,7 +1134,7 @@ const OperationItem = ({
                     if (item.type !== 'StdLibCall') return
                     await exportSketchToDxf(item, {
                       engineCommandManager,
-                      kclManager,
+                      executingEditor,
                       toast,
                       uuidv4,
                       base64Decode,
@@ -1252,8 +1258,8 @@ const OperationItem = ({
 
   const visibilityState = resolveFeatureTreeVisibility({
     item,
-    operations: getAllOperations(kclManager.operationsByModule),
-    artifactGraph: kclManager.artifactGraph,
+    operations: getAllOperations(executingEditor.operationsByModule),
+    artifactGraph: executingEditor.artifactGraph,
   })
 
   return (
@@ -1344,15 +1350,15 @@ const OperationItem = ({
                   .then(() => {
                     if (visibilityState.hideOperation === undefined) {
                       onHide({
-                        ast: kclManager.ast,
-                        artifactGraph: kclManager.artifactGraph,
+                        ast: executingEditor.ast,
+                        artifactGraph: executingEditor.artifactGraph,
                         modelingActor,
                       })
                     } else if (visibilityState.targetArtifact !== undefined) {
                       onUnhide({
                         hideOperation: visibilityState.hideOperation,
                         targetArtifact: visibilityState.targetArtifact,
-                        kclManager,
+                        executingEditor,
                       })
                         .then((result) => {
                           if (err(result)) {
@@ -1382,7 +1388,7 @@ const DefaultPlanes = ({
   systemDeps: SystemDeps
   disabled?: boolean
 }) => {
-  const { rustContext, sceneInfra, kclManager } = systemDeps
+  const { rustContext, sceneInfra, executingEditor } = systemDeps
   const { state: modelingState, send } = useModelingContext()
   const sketchNoFace = modelingState.matches('Sketch no face')
   const selectedDefaultPlaneId = getSelectedDefaultPlane(
@@ -1395,7 +1401,7 @@ const DefaultPlanes = ({
         void selectSketchPlane(
           planeId,
           modelingState.context.store.useSketchSolveMode?.current,
-          kclManager
+          executingEditor
         )
       } else {
         const foundDefaultPlane =
@@ -1431,10 +1437,14 @@ const DefaultPlanes = ({
       void selectSketchPlane(
         planeId,
         modelingState.context.store.useSketchSolveMode?.current,
-        kclManager
+        executingEditor
       )
     },
-    [modelingState.context.store.useSketchSolveMode, sceneInfra, kclManager]
+    [
+      modelingState.context.store.useSketchSolveMode,
+      sceneInfra,
+      executingEditor,
+    ]
   )
 
   const defaultPlanes = rustContext.defaultPlanes

--- a/src/components/layout/areas/FeatureTreePane.tsx
+++ b/src/components/layout/areas/FeatureTreePane.tsx
@@ -4,6 +4,7 @@ import { type ContextMenu, ContextMenuItem } from '@src/components/ContextMenu'
 import type { CustomIconName } from '@src/components/CustomIcon'
 import { CustomIcon } from '@src/components/CustomIcon'
 import { useModelingContext } from '@src/hooks/useModelingContext'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { findOperationPlaneArtifact, isOffsetPlane } from '@src/lang/queryAst'
 import { sourceRangeFromRust } from '@src/lang/sourceRange'
 import { getArtifactFromRange } from '@src/lang/std/artifactGraph'
@@ -16,7 +17,7 @@ import {
   emptyOperationsByModule,
   getAllOperations,
 } from '@src/lang/wasm'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import {
   type OperationTreeNode,
   buildOperationTree,
@@ -80,11 +81,10 @@ import type { ConnectionManager } from '@src/network/connectionManager'
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import { useNavigate } from 'react-router-dom'
 
-type Singletons = ReturnType<typeof useSingletons>
-
 type ModuleInstanceOperation = Extract<Operation, { type: 'ModuleInstance' }>
 
-type SystemDeps = Pick<Singletons, 'executingEditor'> & {
+type SystemDeps = {
+  executingEditor: ExecutingEditor
   commandBarActor: CommandBarActorType
   sceneInfra: SceneInfra
   sceneEntitiesManager: SceneEntities
@@ -142,7 +142,7 @@ export const FeatureTreePaneContents = memo(() => {
     UNRENDERED_EXECUTE_HOTKEY,
     platform
   )
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const executionService = app.registry.signal(executingEditorService).value
   const { engineCommandManager, rustContext } = executingEditor
   const {

--- a/src/components/layout/areas/KclEditorPane.tsx
+++ b/src/components/layout/areas/KclEditorPane.tsx
@@ -45,11 +45,11 @@ export const KclEditorPane = (props: AreaTypeComponentProps) => {
 }
 
 export const KclEditorPaneContents = () => {
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const editorParent = useRef<HTMLDivElement>(null)
   useEffect(() => {
-    editorParent.current?.appendChild(kclManager.editorView.dom)
-  }, [kclManager.editorView.dom])
+    editorParent.current?.appendChild(executingEditor.editorView.dom)
+  }, [executingEditor.editorView.dom])
 
   return (
     <div className="relative">
@@ -62,8 +62,10 @@ export const KclEditorPaneContents = () => {
   )
 }
 
-function copyKclCodeToClipboard(kclManager: Singletons['kclManager']) {
-  if (!kclManager.codeSignal.value) {
+function copyKclCodeToClipboard(
+  executingEditor: Singletons['executingEditor']
+) {
+  if (!executingEditor.codeSignal.value) {
     toast.error('No code available to copy.')
     return
   }
@@ -74,7 +76,7 @@ function copyKclCodeToClipboard(kclManager: Singletons['kclManager']) {
   }
 
   navigator.clipboard
-    .writeText(kclManager.codeSignal.value)
+    .writeText(executingEditor.codeSignal.value)
     .then(() => toast.success(`Copied current file's code to clipboard.`))
     .catch((e) =>
       trap(new Error(`Failed to copy code to clipboard: ${e.message}`))
@@ -83,11 +85,11 @@ function copyKclCodeToClipboard(kclManager: Singletons['kclManager']) {
 
 export const KclEditorMenu = () => {
   const { commands, settings } = useApp()
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const platform = usePlatform()
   const settingsActor = settings.actor
   const { enable: convertToVarEnabled, handleClick: handleConvertToVarClick } =
-    useConvertToVariable(kclManager)
+    useConvertToVariable(executingEditor)
 
   return (
     <HeaderMenu>
@@ -95,7 +97,7 @@ export const KclEditorMenu = () => {
         <button
           type="button"
           onClick={() => {
-            kclManager.format().catch(reportRejection)
+            executingEditor.format().catch(reportRejection)
           }}
           className={styles.button}
         >
@@ -108,7 +110,7 @@ export const KclEditorMenu = () => {
       <Menu.Item>
         <button
           type="button"
-          onClick={() => copyKclCodeToClipboard(kclManager)}
+          onClick={() => copyKclCodeToClipboard(executingEditor)}
           className={styles.button}
         >
           <span>Copy code</span>

--- a/src/components/layout/areas/KclEditorPane.tsx
+++ b/src/components/layout/areas/KclEditorPane.tsx
@@ -4,7 +4,8 @@ import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
 import { HeaderMenu } from '@src/components/layout/Panel/HeaderMenu'
 import usePlatform from '@src/hooks/usePlatform'
 import { useConvertToVariable } from '@src/hooks/useToolbarGuards'
-import { useApp, useSingletons } from '@src/lib/boot'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { hotkeyDisplay } from '@src/lib/hotkeys'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
@@ -13,8 +14,6 @@ import { withSiteBaseURL } from '@src/lib/withBaseURL'
 import { useEffect, useRef } from 'react'
 import toast from 'react-hot-toast'
 import styles from './KclEditorMenu.module.css'
-
-type Singletons = ReturnType<typeof useSingletons>
 
 export const editorShortcutMeta = {
   formatCode: {
@@ -45,7 +44,7 @@ export const KclEditorPane = (props: AreaTypeComponentProps) => {
 }
 
 export const KclEditorPaneContents = () => {
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const editorParent = useRef<HTMLDivElement>(null)
   useEffect(() => {
     editorParent.current?.appendChild(executingEditor.editorView.dom)
@@ -62,9 +61,7 @@ export const KclEditorPaneContents = () => {
   )
 }
 
-function copyKclCodeToClipboard(
-  executingEditor: Singletons['executingEditor']
-) {
+function copyKclCodeToClipboard(executingEditor: ExecutingEditor) {
   if (!executingEditor.codeSignal.value) {
     toast.error('No code available to copy.')
     return
@@ -85,7 +82,7 @@ function copyKclCodeToClipboard(
 
 export const KclEditorMenu = () => {
   const { commands, settings } = useApp()
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const platform = usePlatform()
   const settingsActor = settings.actor
   const { enable: convertToVarEnabled, handleClick: handleConvertToVarClick } =

--- a/src/components/layout/areas/LoggingPanes.tsx
+++ b/src/components/layout/areas/LoggingPanes.tsx
@@ -2,7 +2,7 @@ import ReactJsonView from '@microlink/react-json-view'
 
 import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
 import { useResolvedTheme } from '@src/hooks/useResolvedTheme'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
 
 export function LogsPane(props: AreaTypeComponentProps) {
@@ -24,7 +24,7 @@ export function LogsPane(props: AreaTypeComponentProps) {
   )
 }
 export const LogsPaneContent = () => {
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const theme = useResolvedTheme()
   const logs = executingEditor.logsSignal.value
   return (

--- a/src/components/layout/areas/LoggingPanes.tsx
+++ b/src/components/layout/areas/LoggingPanes.tsx
@@ -24,9 +24,9 @@ export function LogsPane(props: AreaTypeComponentProps) {
   )
 }
 export const LogsPaneContent = () => {
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const theme = useResolvedTheme()
-  const logs = kclManager.logsSignal.value
+  const logs = executingEditor.logsSignal.value
   return (
     <div className="overflow-hidden">
       <div className="absolute inset-0 p-2 flex flex-col overflow-auto">

--- a/src/components/layout/areas/MemoryPane.tsx
+++ b/src/components/layout/areas/MemoryPane.tsx
@@ -12,14 +12,14 @@ import { useModelingContext } from '@src/hooks/useModelingContext'
 import { useResolvedTheme } from '@src/hooks/useResolvedTheme'
 import type { VariableMap } from '@src/lang/wasm'
 import { humanDisplayNumber, sketchFromKclValueOptional } from '@src/lang/wasm'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
 import { Reason, trap } from '@src/lib/trap'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { Suspense, use } from 'react'
 
 export const MemoryPaneMenu = () => {
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const variables = executingEditor.variablesSignal.value
 
   function copyProgramMemoryToClipboard() {
@@ -73,7 +73,7 @@ export function MemoryPane(props: AreaTypeComponentProps) {
 }
 
 export const MemoryPaneContents = () => {
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const theme = useResolvedTheme()
   const variables = executingEditor.variablesSignal.value
   const { state } = useModelingContext()

--- a/src/components/layout/areas/MemoryPane.tsx
+++ b/src/components/layout/areas/MemoryPane.tsx
@@ -19,8 +19,8 @@ import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { Suspense, use } from 'react'
 
 export const MemoryPaneMenu = () => {
-  const { kclManager } = useSingletons()
-  const variables = kclManager.variablesSignal.value
+  const { executingEditor } = useSingletons()
+  const variables = executingEditor.variablesSignal.value
 
   function copyProgramMemoryToClipboard() {
     if (globalThis && 'navigator' in globalThis) {
@@ -73,11 +73,11 @@ export function MemoryPane(props: AreaTypeComponentProps) {
 }
 
 export const MemoryPaneContents = () => {
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const theme = useResolvedTheme()
-  const variables = kclManager.variablesSignal.value
+  const variables = executingEditor.variablesSignal.value
   const { state } = useModelingContext()
-  const wasmInstance = use(kclManager.wasmInstancePromise)
+  const wasmInstance = use(executingEditor.wasmInstancePromise)
   const ProcessedMemory = processMemory(variables, wasmInstance)
 
   return (

--- a/src/components/layout/areas/MlEphantConversationPane.spec.tsx
+++ b/src/components/layout/areas/MlEphantConversationPane.spec.tsx
@@ -16,7 +16,7 @@ vi.mock('@src/lib/desktop', () => ({
 }))
 
 vi.mock('@src/lib/boot', () => ({
-  useSingletons: () => ({
+  useExecutingEditor: () => ({
     executingEditor: {
       astSignal: { value: null },
     },

--- a/src/components/layout/areas/MlEphantConversationPane.spec.tsx
+++ b/src/components/layout/areas/MlEphantConversationPane.spec.tsx
@@ -17,7 +17,7 @@ vi.mock('@src/lib/desktop', () => ({
 
 vi.mock('@src/lib/boot', () => ({
   useSingletons: () => ({
-    kclManager: {
+    executingEditor: {
       astSignal: { value: null },
     },
   }),
@@ -267,7 +267,7 @@ const renderPane = ({
       <MlEphantConversationPane
         mlEphantManagerActor={mlEphantManagerActor as any}
         systemIOActor={systemIOActor as any}
-        kclManager={
+        executingEditor={
           {
             code: '',
             execState: {
@@ -428,7 +428,7 @@ describe('MlEphantConversationPane', () => {
         <MlEphantConversationPane
           mlEphantManagerActor={mlEphantManagerActor as any}
           systemIOActor={systemIOActor as any}
-          kclManager={
+          executingEditor={
             {
               code: '',
               execState: {

--- a/src/components/layout/areas/MlEphantConversationPane.tsx
+++ b/src/components/layout/areas/MlEphantConversationPane.tsx
@@ -4,7 +4,7 @@ import {
 } from '@src/components/MlEphantConversation'
 import { MlEphantConversationWelcome } from '@src/components/MlEphantConversationWelcome'
 import type { useModelingContext } from '@src/hooks/useModelingContext'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { SEARCH_PARAM_ML_PROMPT_KEY } from '@src/lib/constants'
 import type { FileEntry, Project } from '@src/lib/project'
 import { activeFileRelativeToProject } from '@src/lib/promptToEdit'
@@ -43,7 +43,7 @@ const awaitingResponseSelector = (
 export const MlEphantConversationPane = (props: {
   mlEphantManagerActor: MlEphantManagerActor
   systemIOActor: SystemIOActor
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   theProject: Project | undefined
   contextModeling: ModelingMachineContext
   sendModeling: ReturnType<typeof useModelingContext>['send']
@@ -119,8 +119,8 @@ export const MlEphantConversationPane = (props: {
     const project: Project = props.theProject
 
     const projectFiles = await collectProjectFiles({
-      selectedFileContents: props.kclManager.code,
-      fileNames: props.kclManager.execState.filenames,
+      selectedFileContents: props.executingEditor.code,
+      fileNames: props.executingEditor.execState.filenames,
       projectContext: project,
     })
 
@@ -134,11 +134,11 @@ export const MlEphantConversationPane = (props: {
       applicationProjectDirectory: props.settings.app.projectDirectory.current,
       fileSelectedDuringPrompting: {
         entry: props.loaderFile,
-        content: props.kclManager.code,
+        content: props.executingEditor.code,
       },
       projectFiles,
       selections: props.contextModeling.selectionRanges,
-      artifactGraph: props.kclManager.artifactGraph,
+      artifactGraph: props.executingEditor.artifactGraph,
       mode,
       additionalFiles: attachments,
     })
@@ -437,8 +437,8 @@ export const MlEphantConversationPane = (props: {
 
           const currentLoaderFile = loaderFileRef.current
           void collectProjectFiles({
-            selectedFileContents: props.kclManager.code,
-            fileNames: props.kclManager.execState.filenames,
+            selectedFileContents: props.executingEditor.code,
+            fileNames: props.executingEditor.execState.filenames,
             projectContext: project,
           }).then((projectFiles) => {
             props.mlEphantManagerActor.send({

--- a/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
+++ b/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
@@ -4,7 +4,7 @@ import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
 import { HeaderMenu } from '@src/components/layout/Panel/HeaderMenu'
 import { MlEphantConversationPane } from '@src/components/layout/areas/MlEphantConversationPane'
 import { useModelingContext } from '@src/hooks/useModelingContext'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { browserSaveFile } from '@src/lib/browserSaveFile'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
 import { BillingTransition } from '@src/machines/billingMachine'
@@ -47,7 +47,7 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
   useSignals()
   const app = useApp()
   const { auth, billing, settings, project, systemIOActor } = app
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const settingsValues = settings.useSettings()
   const user = auth.useUser()
   const token = auth.useToken()

--- a/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
+++ b/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
@@ -47,7 +47,7 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
   useSignals()
   const app = useApp()
   const { auth, billing, settings, project, systemIOActor } = app
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const settingsValues = settings.useSettings()
   const user = auth.useUser()
   const token = auth.useToken()
@@ -76,12 +76,12 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
     mlEphantManagerActor,
     billing.actor,
     token,
-    kclManager.engineCommandManager,
+    executingEditor.engineCommandManager,
     (requestProps) => {
       const payload = prepareMlEphantNewFileRequest(requestProps)
 
       if (payload) {
-        kclManager.mlEphantManagerMachineBulkManipulatingFileSystem = true
+        executingEditor.mlEphantManagerMachineBulkManipulatingFileSystem = true
         systemIOActor.send({
           type: SystemIOMachineEvents.bulkCreateAndDeleteKCLFilesAndNavigateToFile,
           data: {
@@ -134,7 +134,7 @@ function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
         {...{
           mlEphantManagerActor: mlEphantManagerActor,
           systemIOActor,
-          kclManager,
+          executingEditor,
           contextModeling,
           sendModeling,
           sendBillingUpdate,

--- a/src/components/layout/areas/ProjectExplorerPane.tsx
+++ b/src/components/layout/areas/ProjectExplorerPane.tsx
@@ -6,7 +6,7 @@ import { ToastInsert } from '@src/components/ToastInsert'
 import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { relevantFileExtensions } from '@src/lang/wasmUtils'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { FILE_EXT, INSERT_FOREIGN_TOAST_ID } from '@src/lib/constants'
 import fsZds from '@src/lib/fs-zds'
 import {
@@ -32,7 +32,7 @@ import toast from 'react-hot-toast'
 
 export function ProjectExplorerPane(props: AreaTypeComponentProps) {
   const { commands, project, systemIOActor, layout } = useApp()
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const wasmInstance = use(executingEditor.wasmInstancePromise)
   const projects = useFolders()
   const projectDirectoryPath = useProjectDirectoryPath()

--- a/src/components/layout/areas/ProjectExplorerPane.tsx
+++ b/src/components/layout/areas/ProjectExplorerPane.tsx
@@ -32,8 +32,8 @@ import toast from 'react-hot-toast'
 
 export function ProjectExplorerPane(props: AreaTypeComponentProps) {
   const { commands, project, systemIOActor, layout } = useApp()
-  const { kclManager } = useSingletons()
-  const wasmInstance = use(kclManager.wasmInstancePromise)
+  const { executingEditor } = useSingletons()
+  const wasmInstance = use(executingEditor.wasmInstancePromise)
   const projects = useFolders()
   const projectDirectoryPath = useProjectDirectoryPath()
   const projectRef = useRef(project?.projectIORefSignal)

--- a/src/editor/historyConfig.ts
+++ b/src/editor/historyConfig.ts
@@ -12,7 +12,7 @@ import type { Extension } from '@codemirror/state'
 const CODEMIRROR_HISTORY_HEADROOM = 20
 
 // Conservative bootstrap value used before the wasm-backed checkpoint limit is
-// available. KclManager reconfigures both histories once wasm initialization
+// available. ExecutingEditor reconfigures both histories once wasm initialization
 // completes.
 // Source of truth for this is MAX_SKETCH_CHECKPOINTS in frontend.rs
 export const FALLBACK_SKETCH_CHECKPOINT_LIMIT = 100

--- a/src/editor/plugins/fs/index.ts
+++ b/src/editor/plugins/fs/index.ts
@@ -2,7 +2,7 @@ import { invertedEffects } from '@codemirror/commands'
 import type { Extension, Transaction } from '@codemirror/state'
 import { Annotation, Compartment, StateEffect } from '@codemirror/state'
 import type { TransactionSpecNoChanges } from '@src/editor/HistoryView'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import type { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
 import { SystemIOMachineEvents } from '@src/machines/systemIO/utils'
 import { EditorView } from 'codemirror'
@@ -56,7 +56,7 @@ export const fsMoveFile = (props: FSEffectProps) => h(moveFile.of(props))
  */
 export function buildFSHistoryExtension(
   systemIOActor: ActorRefFrom<typeof systemIOMachine>,
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
 ) {
   const fsWiredListener = EditorView.updateListener.of((vu) => {
     for (const tr of vu.transactions) {
@@ -83,7 +83,7 @@ export function buildFSHistoryExtension(
 
   // Note that the FS history extension is not on the EditorView for the code editor itself,
   // but rather the globalHistoryView.
-  kclManager.globalHistoryView.dispatch(
+  executingEditor.globalHistoryView.dispatch(
     {
       effects: [fsEffectCompartment.reconfigure(fsWiredListener)],
     },
@@ -92,7 +92,7 @@ export function buildFSHistoryExtension(
   )
   // Teardown
   return () => {
-    kclManager.globalHistoryView.dispatch(
+    executingEditor.globalHistoryView.dispatch(
       {
         effects: [fsEffectCompartment.reconfigure([])],
       },

--- a/src/editor/plugins/lsp/copilot/index.ts
+++ b/src/editor/plugins/lsp/copilot/index.ts
@@ -36,7 +36,7 @@ import type { CopilotAcceptCompletionParams } from '@rust/kcl-lib/bindings/Copil
 import type { CopilotCompletionResponse } from '@rust/kcl-lib/bindings/CopilotCompletionResponse'
 import type { CopilotLspCompletionParams } from '@rust/kcl-lib/bindings/CopilotLspCompletionParams'
 import type { CopilotRejectCompletionParams } from '@rust/kcl-lib/bindings/CopilotRejectCompletionParams'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 
 const copilotPluginAnnotation = Annotation.define<boolean>()
 export const copilotPluginEvent = copilotPluginAnnotation.of(true)
@@ -193,7 +193,7 @@ const completionDecoration = StateField.define<CompletionState>({
 export class CompletionRequester implements PluginValue {
   private client: LanguageServerClient
   /** This extension must carry around a reference to our manager singleton class, which is injected */
-  private kclManager: KclManager
+  private executingEditor: ExecutingEditor
   private lastPos: number = 0
 
   private queuedUids: string[] = []
@@ -210,15 +210,15 @@ export class CompletionRequester implements PluginValue {
   constructor(
     readonly view: EditorView,
     client: LanguageServerClient,
-    kclManager: KclManager
+    executingEditor: ExecutingEditor
   ) {
     this.client = client
-    this.kclManager = kclManager
+    this.executingEditor = executingEditor
   }
 
   update(viewUpdate: ViewUpdate) {
     // Make sure we are in a state where we can request completions.
-    if (!this.kclManager.copilotEnabled) {
+    if (!this.executingEditor.copilotEnabled) {
       return
     }
 
@@ -576,12 +576,12 @@ export class CompletionRequester implements PluginValue {
 
 export const copilotPlugin = (
   options: LanguageServerOptions,
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
 ): Extension => {
   let plugin: CompletionRequester | null = null
   const completionPlugin = ViewPlugin.define(
     (view) =>
-      (plugin = new CompletionRequester(view, options.client, kclManager))
+      (plugin = new CompletionRequester(view, options.client, executingEditor))
   )
 
   const domHandlers = EditorView.domEventHandlers({

--- a/src/hooks/network/useOnPageIdle.spec.tsx
+++ b/src/hooks/network/useOnPageIdle.spec.tsx
@@ -5,7 +5,7 @@ const hookMocks = vi.hoisted(() => {
   const state = {
     streamIdleMode: 5_000,
     modelingValue: 'idle',
-    kclManager: null as any,
+    executingEditor: null as any,
   }
 
   return {
@@ -22,7 +22,7 @@ const hookMocks = vi.hoisted(() => {
       },
     }),
     useSingletons: () => ({
-      kclManager: state.kclManager,
+      executingEditor: state.executingEditor,
     }),
     useModelingContext: () => ({
       state: {
@@ -54,7 +54,7 @@ describe('useOnPageIdle', () => {
     vi.useFakeTimers()
     hookMocks.state.streamIdleMode = 5_000
     hookMocks.state.modelingValue = 'idle'
-    hookMocks.state.kclManager = {
+    hookMocks.state.executingEditor = {
       isExecuting: false,
       sceneInfra: {
         camControls: {
@@ -75,7 +75,7 @@ describe('useOnPageIdle', () => {
   })
 
   test('does not disconnect while KCL is executing', async () => {
-    hookMocks.state.kclManager.isExecuting = true
+    hookMocks.state.executingEditor.isExecuting = true
 
     const startCallback = vi.fn()
     const idleCallback = vi.fn()
@@ -90,10 +90,11 @@ describe('useOnPageIdle', () => {
     await advance(30_000)
 
     expect(
-      hookMocks.state.kclManager.sceneInfra.camControls.saveRemoteCameraState
+      hookMocks.state.executingEditor.sceneInfra.camControls
+        .saveRemoteCameraState
     ).not.toHaveBeenCalled()
     expect(
-      hookMocks.state.kclManager.engineCommandManager.tearDown
+      hookMocks.state.executingEditor.engineCommandManager.tearDown
     ).not.toHaveBeenCalled()
     expect(idleCallback).not.toHaveBeenCalled()
 
@@ -113,28 +114,29 @@ describe('useOnPageIdle', () => {
 
     await advance(4_000)
     expect(
-      hookMocks.state.kclManager.engineCommandManager.tearDown
+      hookMocks.state.executingEditor.engineCommandManager.tearDown
     ).not.toHaveBeenCalled()
 
-    hookMocks.state.kclManager.isExecuting = true
+    hookMocks.state.executingEditor.isExecuting = true
     await advance(10_000)
     expect(
-      hookMocks.state.kclManager.engineCommandManager.tearDown
+      hookMocks.state.executingEditor.engineCommandManager.tearDown
     ).not.toHaveBeenCalled()
 
-    hookMocks.state.kclManager.isExecuting = false
+    hookMocks.state.executingEditor.isExecuting = false
     await advance(5_000)
     expect(
-      hookMocks.state.kclManager.engineCommandManager.tearDown
+      hookMocks.state.executingEditor.engineCommandManager.tearDown
     ).not.toHaveBeenCalled()
 
     await advance(1_000)
 
     expect(
-      hookMocks.state.kclManager.sceneInfra.camControls.saveRemoteCameraState
+      hookMocks.state.executingEditor.sceneInfra.camControls
+        .saveRemoteCameraState
     ).toHaveBeenCalledTimes(1)
     expect(
-      hookMocks.state.kclManager.engineCommandManager.tearDown
+      hookMocks.state.executingEditor.engineCommandManager.tearDown
     ).toHaveBeenCalledTimes(1)
     expect(idleCallback).toHaveBeenCalledTimes(1)
 

--- a/src/hooks/network/useOnPageIdle.spec.tsx
+++ b/src/hooks/network/useOnPageIdle.spec.tsx
@@ -21,7 +21,7 @@ const hookMocks = vi.hoisted(() => {
         }),
       },
     }),
-    useSingletons: () => ({
+    useExecutingEditor: () => ({
       executingEditor: state.executingEditor,
     }),
     useModelingContext: () => ({
@@ -34,7 +34,7 @@ const hookMocks = vi.hoisted(() => {
 
 vi.mock('@src/lib/boot', () => ({
   useApp: hookMocks.useApp,
-  useSingletons: hookMocks.useSingletons,
+  useExecutingEditor: hookMocks.useExecutingEditor,
 }))
 
 vi.mock('@src/hooks/useModelingContext', () => ({

--- a/src/hooks/network/useOnPageIdle.tsx
+++ b/src/hooks/network/useOnPageIdle.tsx
@@ -1,5 +1,5 @@
 import { useModelingContext } from '@src/hooks/useModelingContext'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { EngineDebugger } from '@src/lib/debugger'
 import { useEffect, useRef } from 'react'
 
@@ -11,7 +11,7 @@ export const useOnPageIdle = ({
   idleCallback: () => void
 }) => {
   const { settings } = useApp()
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const settingsValues = settings.useSettings()
   const streamIdleMode = settingsValues.app.streamIdleMode.current
   const { state: modelingMachineState } = useModelingContext()

--- a/src/hooks/network/useOnPageIdle.tsx
+++ b/src/hooks/network/useOnPageIdle.tsx
@@ -11,7 +11,7 @@ export const useOnPageIdle = ({
   idleCallback: () => void
 }) => {
   const { settings } = useApp()
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const settingsValues = settings.useSettings()
   const streamIdleMode = settingsValues.app.streamIdleMode.current
   const { state: modelingMachineState } = useModelingContext()
@@ -65,7 +65,7 @@ export const useOnPageIdle = ({
         }
 
         const isBusy =
-          kclManager.isExecuting ||
+          executingEditor.isExecuting ||
           !modelingMachineStateRef.current.matches('idle')
 
         // Only start the idle timer once KCL execution and other modeling
@@ -87,26 +87,26 @@ export const useOnPageIdle = ({
           if (elapsed >= idleTimeMs) {
             timeoutStart.current = null
             try {
-              await kclManager.sceneInfra.camControls.saveRemoteCameraState()
+              await executingEditor.sceneInfra.camControls.saveRemoteCameraState()
             } catch (e) {
               console.warn('unable to save old camera state on idle', e)
-              kclManager.sceneInfra.camControls.clearOldCameraState()
+              executingEditor.sceneInfra.camControls.clearOldCameraState()
             }
-            console.log(kclManager.sceneInfra.camControls.oldCameraState)
+            console.log(executingEditor.sceneInfra.camControls.oldCameraState)
             console.warn('detected idle, tearing down connection.')
             EngineDebugger.addLog({
               label: 'useOnPageIdle',
               message: 'Calling tearDown()',
             })
             // We do a full tear down at the moment.
-            kclManager.engineCommandManager.tearDown()
+            executingEditor.engineCommandManager.tearDown()
             idleCallbackRef.current()
           }
         }
       })()
     }, 1_000)
     intervalId.current = interval
-  }, [kclManager])
+  }, [executingEditor])
 
   useEffect(() => {
     if (!idleTimeMsRef.current) return
@@ -120,7 +120,7 @@ export const useOnPageIdle = ({
       }
       startCallbackRef.current()
       timeoutStart.current =
-        kclManager.isExecuting ||
+        executingEditor.isExecuting ||
         !modelingMachineStateRef.current.matches('idle')
           ? null
           : Date.now()
@@ -130,7 +130,8 @@ export const useOnPageIdle = ({
     // all, meaning the timer is not reset to run. We need to set it every
     // time our effect dependencies change then.
     timeoutStart.current =
-      kclManager.isExecuting || !modelingMachineStateRef.current.matches('idle')
+      executingEditor.isExecuting ||
+      !modelingMachineStateRef.current.matches('idle')
         ? null
         : Date.now()
 
@@ -155,5 +156,5 @@ export const useOnPageIdle = ({
       window.document.removeEventListener('touchend', onAnyInput)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-  }, [kclManager, streamIdleMode])
+  }, [executingEditor, streamIdleMode])
 }

--- a/src/hooks/network/useOnPageMounted.spec.tsx
+++ b/src/hooks/network/useOnPageMounted.spec.tsx
@@ -22,7 +22,7 @@ describe('useOnPageMounted', () => {
 
       // clean up test!
       result.current.resetGlobalEngineCommandManager(
-        singletons.kclManager.engineCommandManager
+        singletons.executingEditor.engineCommandManager
       )
     })
     test('should reset with helper function', async () => {
@@ -36,7 +36,7 @@ describe('useOnPageMounted', () => {
         { initialProps: { callback: callback_1 } }
       )
       result.current.resetGlobalEngineCommandManager(
-        singletons.kclManager.engineCommandManager
+        singletons.executingEditor.engineCommandManager
       )
       rerender({ callback: callback_2 })
       unmount()
@@ -44,7 +44,7 @@ describe('useOnPageMounted', () => {
       expect(callback_2).toHaveBeenCalledTimes(1)
       // clean up test!
       result.current.resetGlobalEngineCommandManager(
-        singletons.kclManager.engineCommandManager
+        singletons.executingEditor.engineCommandManager
       )
     })
     test('should fail to call the callback again, did not reset', async () => {
@@ -63,7 +63,7 @@ describe('useOnPageMounted', () => {
       expect(callback_2).toHaveBeenCalledTimes(0)
       // clean up test!
       result.current.resetGlobalEngineCommandManager(
-        singletons.kclManager.engineCommandManager
+        singletons.executingEditor.engineCommandManager
       )
     })
   })

--- a/src/hooks/network/useOnPageMounted.spec.tsx
+++ b/src/hooks/network/useOnPageMounted.spec.tsx
@@ -5,9 +5,9 @@ import { renderHook } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 
 describe('useOnPageMounted', () => {
-  const singletons = App.fromProvided({
+  const app = App.fromProvided({
     wasmPromise: Promise.resolve({} as ModuleType),
-  }).singletons
+  })
 
   describe('on mounted', () => {
     test('should run once', () => {
@@ -21,9 +21,7 @@ describe('useOnPageMounted', () => {
       expect(callback).toHaveBeenCalledTimes(1)
 
       // clean up test!
-      result.current.resetGlobalEngineCommandManager(
-        singletons.executingEditor.engineCommandManager
-      )
+      result.current.resetGlobalEngineCommandManager(app.engineCommandManager)
     })
     test('should reset with helper function', async () => {
       const callback_1 = vi.fn(() => 1)
@@ -35,17 +33,13 @@ describe('useOnPageMounted', () => {
           }),
         { initialProps: { callback: callback_1 } }
       )
-      result.current.resetGlobalEngineCommandManager(
-        singletons.executingEditor.engineCommandManager
-      )
+      result.current.resetGlobalEngineCommandManager(app.engineCommandManager)
       rerender({ callback: callback_2 })
       unmount()
       expect(callback_1).toHaveBeenCalledTimes(1)
       expect(callback_2).toHaveBeenCalledTimes(1)
       // clean up test!
-      result.current.resetGlobalEngineCommandManager(
-        singletons.executingEditor.engineCommandManager
-      )
+      result.current.resetGlobalEngineCommandManager(app.engineCommandManager)
     })
     test('should fail to call the callback again, did not reset', async () => {
       const callback_1 = vi.fn(() => 1)
@@ -62,9 +56,7 @@ describe('useOnPageMounted', () => {
       expect(callback_1).toHaveBeenCalledTimes(1)
       expect(callback_2).toHaveBeenCalledTimes(0)
       // clean up test!
-      result.current.resetGlobalEngineCommandManager(
-        singletons.executingEditor.engineCommandManager
-      )
+      result.current.resetGlobalEngineCommandManager(app.engineCommandManager)
     })
   })
 })

--- a/src/hooks/network/useTryConnect.tsx
+++ b/src/hooks/network/useTryConnect.tsx
@@ -1,6 +1,6 @@
 import type { useAppState } from '@src/AppState'
 import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { useSingletons } from '@src/lib/boot'
 import { NUMBER_OF_ENGINE_RETRIES } from '@src/lib/constants'
 import { EngineDebugger } from '@src/lib/debugger'
@@ -117,13 +117,13 @@ const setupSceneAndExecuteCodeAfterOpenedEngineConnection = async ({
   sceneInfra,
   settingsActor,
   engineCommandManager,
-  kclManager,
+  executingEditor,
   rustContext,
 }: {
   sceneInfra: SceneInfra
   settingsActor: SettingsActorType
   engineCommandManager: ConnectionManager
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   rustContext: RustContext
 }) => {
   const providedSettings = getSettingsFromActorContext(settingsActor)
@@ -133,19 +133,19 @@ const setupSceneAndExecuteCodeAfterOpenedEngineConnection = async ({
     message: 'rustContext.clearSceneAndBustCache()',
     metadata: {
       jsAppSettings: settings,
-      filePath: kclManager.path || undefined,
+      filePath: executingEditor.path || undefined,
     },
   })
   // Bust the cache always! A new connection has been made. The engine has no previous state
   await rustContext.clearSceneAndBustCache(
     settings,
-    kclManager.path || undefined
+    executingEditor.path || undefined
   )
   EngineDebugger.addLog({
     label: 'onEngineConnectionReadyForRequests',
-    message: 'kclManager.executeCode()',
+    message: 'executingEditor.executeCode()',
   })
-  await kclManager.executeCode()
+  await executingEditor.executeCode()
   // TODO: resolve the ~12 remaining dependent playwright tests on this functions isPlaywright() check
   // Once zoom to fit and view isometric work on empty scenes (only grid planes) we can improve the functions
   // business logic
@@ -191,7 +191,7 @@ async function tryConnecting({
   setShowManualConnect,
   sceneInfra,
   engineCommandManager,
-  kclManager,
+  executingEditor,
   rustContext,
 }: {
   isConnecting: React.RefObject<boolean>
@@ -206,7 +206,7 @@ async function tryConnecting({
   setShowManualConnect: React.Dispatch<React.SetStateAction<boolean>>
   sceneInfra: SceneInfra
   engineCommandManager: ConnectionManager
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   rustContext: RustContext
 }) {
   const connection = new Promise<string>((resolve, reject) => {
@@ -241,7 +241,7 @@ async function tryConnecting({
             sceneInfra,
             settingsActor,
             engineCommandManager,
-            kclManager,
+            executingEditor,
             rustContext,
           })
 
@@ -313,21 +313,21 @@ async function tryConnecting({
   return connection
 }
 export const useTryConnect = () => {
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const isConnecting = useRef(false)
   const numberOfConnectionAttempts = useRef(0)
   type TryConnectingArgs = Omit<
     Parameters<typeof tryConnecting>[0],
-    'engineCommandManager' | 'kclManager' | 'rustContext'
+    'engineCommandManager' | 'executingEditor' | 'rustContext'
   >
 
   return {
     tryConnecting: (args: TryConnectingArgs) =>
       tryConnecting({
         ...args,
-        engineCommandManager: kclManager.engineCommandManager,
-        kclManager,
-        rustContext: kclManager.rustContext,
+        engineCommandManager: executingEditor.engineCommandManager,
+        executingEditor,
+        rustContext: executingEditor.rustContext,
       }),
     isConnecting,
     numberOfConnectionAttempts,

--- a/src/hooks/network/useTryConnect.tsx
+++ b/src/hooks/network/useTryConnect.tsx
@@ -1,7 +1,7 @@
 import type { useAppState } from '@src/AppState'
 import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
 import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import { NUMBER_OF_ENGINE_RETRIES } from '@src/lib/constants'
 import { EngineDebugger } from '@src/lib/debugger'
 import { resetCameraPosition } from '@src/lib/resetCameraPosition'
@@ -313,7 +313,7 @@ async function tryConnecting({
   return connection
 }
 export const useTryConnect = () => {
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const isConnecting = useRef(false)
   const numberOfConnectionAttempts = useRef(0)
   type TryConnectingArgs = Omit<

--- a/src/hooks/useEngineConnectionSubscriptions.ts
+++ b/src/hooks/useEngineConnectionSubscriptions.ts
@@ -11,7 +11,7 @@ import { reportRejection } from '@src/lib/trap'
 
 export function useEngineConnectionSubscriptions() {
   const { send, context, state } = useModelingContext()
-  const { engineCommandManager, kclManager, rustContext, wasmInstance } =
+  const { engineCommandManager, executingEditor, rustContext, wasmInstance } =
     context
   const stateRef = useRef(state)
   stateRef.current = state
@@ -26,18 +26,20 @@ export function useEngineConnectionSubscriptions() {
         if (data?.entity_id) {
           const codeRefs = getCodeRefsByArtifactId(
             data.entity_id,
-            kclManager.artifactGraph
+            executingEditor.artifactGraph
           )
           if (codeRefs) {
-            kclManager.setHighlightRange(codeRefs.map(({ range }) => range))
+            executingEditor.setHighlightRange(
+              codeRefs.map(({ range }) => range)
+            )
           }
         } else if (
-          !kclManager.highlightRange ||
-          (kclManager.highlightRange[0] &&
-            kclManager.highlightRange[0][0] !== 0 &&
-            kclManager.highlightRange[0][1] !== 0)
+          !executingEditor.highlightRange ||
+          (executingEditor.highlightRange[0] &&
+            executingEditor.highlightRange[0][0] !== 0 &&
+            executingEditor.highlightRange[0][1] !== 0)
         ) {
-          kclManager.setHighlightRange([defaultSourceRange()])
+          executingEditor.setHighlightRange([defaultSourceRange()])
         }
       },
     })
@@ -55,7 +57,7 @@ export function useEngineConnectionSubscriptions() {
           }
           const event = await getEventForSelectWithPoint(engineEvent, {
             engineCommandManager,
-            kclManager,
+            executingEditor,
             rustContext,
             wasmInstance,
           })
@@ -77,7 +79,7 @@ export function useEngineConnectionSubscriptions() {
     }
   }, [
     context?.sketchEnginePathId,
-    kclManager,
+    executingEditor,
     send,
     engineCommandManager,
     rustContext,
@@ -94,7 +96,7 @@ export function useEngineConnectionSubscriptions() {
             void selectSketchPlane(
               data.entity_id,
               context.store.useSketchSolveMode?.current,
-              kclManager
+              executingEditor
             )
           }
         : () => {},
@@ -103,7 +105,7 @@ export function useEngineConnectionSubscriptions() {
   }, [
     context.store.useSketchSolveMode,
     state,
-    kclManager,
+    executingEditor,
     rustContext,
     engineCommandManager,
   ])
@@ -112,10 +114,10 @@ export function useEngineConnectionSubscriptions() {
   useEffect(() => {
     const unsubscribe = rustContext.planesCreated.add(() => {
       const vis = stateRef.current.context.defaultPlaneVisibility
-      void kclManager.setPlaneVisibilityByKey('xy', vis.xy)
-      void kclManager.setPlaneVisibilityByKey('xz', vis.xz)
-      void kclManager.setPlaneVisibilityByKey('yz', vis.yz)
+      void executingEditor.setPlaneVisibilityByKey('xy', vis.xy)
+      void executingEditor.setPlaneVisibilityByKey('xz', vis.xz)
+      void executingEditor.setPlaneVisibilityByKey('yz', vis.yz)
     })
     return unsubscribe
-  }, [kclManager, rustContext])
+  }, [executingEditor, rustContext])
 }

--- a/src/hooks/useHotKeyListener.ts
+++ b/src/hooks/useHotKeyListener.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 // Kurt's note: codeMirror styling overrides were needed to make this work
 // namely, the cursor needs to still be shown when the editor is not focused
 // search for code-mirror-override in the repo to find the relevant styles
@@ -8,14 +8,14 @@ import type { KclManager } from '@src/lang/KclManager'
 /**
  * @deprecated Prefer registering shortcuts through `keymapValueSpec`.
  */
-export function useHotKeyListener(kclManager: KclManager) {
+export function useHotKeyListener(executingEditor: ExecutingEditor) {
   const keyName = 'Shift'
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) =>
-      event.key === keyName && kclManager.setIsShiftDown(true)
+      event.key === keyName && executingEditor.setIsShiftDown(true)
     const handleKeyUp = (event: KeyboardEvent) =>
-      event.key === keyName && kclManager.setIsShiftDown(false)
-    const resetShiftKey = () => kclManager.setIsShiftDown(false)
+      event.key === keyName && executingEditor.setIsShiftDown(false)
+    const resetShiftKey = () => executingEditor.setIsShiftDown(false)
     const handleVisibilityChange = () => {
       if (document.hidden) {
         resetShiftKey()
@@ -35,5 +35,5 @@ export function useHotKeyListener(kclManager: KclManager) {
       window.removeEventListener('blur', resetShiftKey)
       document.removeEventListener('visibilitychange', handleVisibilityChange)
     }
-  }, [kclManager])
+  }, [executingEditor])
 }

--- a/src/hooks/useProjectsLoader.tsx
+++ b/src/hooks/useProjectsLoader.tsx
@@ -11,7 +11,7 @@ import { trap } from '@src/lib/trap'
 // Hook uses [number] to give users familiarity. It is meant to mimic a
 // dependency array, but is intended to only ever be used with 1 value.
 export const useProjectsLoader = (deps?: [number]) => {
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const [lastTs, setLastTs] = useState(-1)
   const [projectPaths, setProjectPaths] = useState<Project[]>([])
   const [projectsDir, setProjectsDir] = useState<string | undefined>(undefined)
@@ -24,14 +24,14 @@ export const useProjectsLoader = (deps?: [number]) => {
     }
     ;(async () => {
       const { configuration } = await loadAndValidateSettings(
-        kclManager.wasmInstancePromise
+        executingEditor.wasmInstancePromise
       )
       const _projectsDir = await ensureProjectDirectoryExists(configuration)
       setProjectsDir(_projectsDir)
 
       if (projectsDir) {
         const _projectPaths = await listProjects(
-          kclManager.wasmInstancePromise,
+          executingEditor.wasmInstancePromise,
           configuration
         )
         setProjectPaths(_projectPaths)

--- a/src/hooks/useProjectsLoader.tsx
+++ b/src/hooks/useProjectsLoader.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-import { useSingletons } from '@src/lib/boot'
+import { useApp } from '@src/lib/boot'
 import { ensureProjectDirectoryExists, listProjects } from '@src/lib/desktop'
 import type { Project } from '@src/lib/project'
 import { loadAndValidateSettings } from '@src/lib/settings/settingsUtils'
@@ -11,7 +11,7 @@ import { trap } from '@src/lib/trap'
 // Hook uses [number] to give users familiarity. It is meant to mimic a
 // dependency array, but is intended to only ever be used with 1 value.
 export const useProjectsLoader = (deps?: [number]) => {
-  const { executingEditor } = useSingletons()
+  const app = useApp()
   const [lastTs, setLastTs] = useState(-1)
   const [projectPaths, setProjectPaths] = useState<Project[]>([])
   const [projectsDir, setProjectsDir] = useState<string | undefined>(undefined)
@@ -23,17 +23,12 @@ export const useProjectsLoader = (deps?: [number]) => {
       setLastTs(deps[0])
     }
     ;(async () => {
-      const { configuration } = await loadAndValidateSettings(
-        executingEditor.wasmInstancePromise
-      )
+      const { configuration } = await loadAndValidateSettings(app.wasmPromise)
       const _projectsDir = await ensureProjectDirectoryExists(configuration)
       setProjectsDir(_projectsDir)
 
       if (projectsDir) {
-        const _projectPaths = await listProjects(
-          executingEditor.wasmInstancePromise,
-          configuration
-        )
+        const _projectPaths = await listProjects(app.wasmPromise, configuration)
         setProjectPaths(_projectPaths)
       }
     })().catch(trap)

--- a/src/hooks/useQueryParamEffects.ts
+++ b/src/hooks/useQueryParamEffects.ts
@@ -3,7 +3,7 @@ import toast from 'react-hot-toast'
 import { useSearchParams } from 'react-router-dom'
 import { waitFor } from 'xstate'
 
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { base64ToString } from '@src/lib/base64'
 import { useApp } from '@src/lib/boot'
 import type { ProjectsCommandSchema } from '@src/lib/commandBarConfigs/projectsCommandConfig'
@@ -50,7 +50,7 @@ export type CreateFileSchemaMethodOptional = Omit<
  * `?createFile`
  * "?cmd=<some-command-name>&groupId=<some-group-id>"
  */
-export function useQueryParamEffects(kclManager: KclManager) {
+export function useQueryParamEffects(executingEditor: ExecutingEditor) {
   const app = useApp()
   const { auth, commands } = app
   const authState = auth.useAuthState()

--- a/src/hooks/useQueryParamEffects.ts
+++ b/src/hooks/useQueryParamEffects.ts
@@ -3,7 +3,6 @@ import toast from 'react-hot-toast'
 import { useSearchParams } from 'react-router-dom'
 import { waitFor } from 'xstate'
 
-import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { base64ToString } from '@src/lib/base64'
 import { useApp } from '@src/lib/boot'
 import type { ProjectsCommandSchema } from '@src/lib/commandBarConfigs/projectsCommandConfig'
@@ -50,7 +49,7 @@ export type CreateFileSchemaMethodOptional = Omit<
  * `?createFile`
  * "?cmd=<some-command-name>&groupId=<some-group-id>"
  */
-export function useQueryParamEffects(executingEditor: ExecutingEditor) {
+export function useQueryParamEffects() {
   const app = useApp()
   const { auth, commands } = app
   const authState = auth.useAuthState()

--- a/src/hooks/useReliesOnEngine.tsx
+++ b/src/hooks/useReliesOnEngine.tsx
@@ -5,13 +5,13 @@ import { useSingletons } from '@src/lib/boot'
 import { EngineConnectionStateType } from '@src/network/utils'
 
 export function useReliesOnEngine(isExecuting: boolean) {
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const { overallState, immediateState } = useNetworkContext()
   const { isStreamReady } = useAppState()
   const reliesOnEngine =
     (overallState !== NetworkHealthState.Ok &&
       overallState !== NetworkHealthState.Weak) ||
-    kclManager.isExecutingSignal.value ||
+    executingEditor.isExecutingSignal.value ||
     immediateState.type !== EngineConnectionStateType.ConnectionEstablished ||
     !isStreamReady
 

--- a/src/hooks/useReliesOnEngine.tsx
+++ b/src/hooks/useReliesOnEngine.tsx
@@ -1,11 +1,11 @@
 import { useAppState } from '@src/AppState'
 import { useNetworkContext } from '@src/hooks/useNetworkContext'
 import { NetworkHealthState } from '@src/hooks/useNetworkStatus'
-import { useSingletons } from '@src/lib/boot'
+import { useExecutingEditor } from '@src/lib/boot'
 import { EngineConnectionStateType } from '@src/network/utils'
 
 export function useReliesOnEngine(isExecuting: boolean) {
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const { overallState, immediateState } = useNetworkContext()
   const { isStreamReady } = useAppState()
   const reliesOnEngine =

--- a/src/hooks/useStateMachineCommands.ts
+++ b/src/hooks/useStateMachineCommands.ts
@@ -6,7 +6,7 @@ import { useSignals } from '@preact/signals-react/runtime'
 import { useNetworkContext } from '@src/hooks/useNetworkContext'
 import { NetworkHealthState } from '@src/hooks/useNetworkStatus'
 import { shouldDisableModelingForUnrenderedChanges } from '@src/lib/automaticRendering'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import type {
   Command,
   StateMachineCommandSetConfig,
@@ -49,7 +49,7 @@ export default function useStateMachineCommands<
 }: UseStateMachineCommandsArgs<T, S>) {
   useSignals()
   const { commands, settings, userFeatures } = useApp()
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const showExperimentalCommands = userFeatures.useHas(
     EXPERIMENTAL_POINT_AND_CLICK_FLAG,
     false

--- a/src/hooks/useStateMachineCommands.ts
+++ b/src/hooks/useStateMachineCommands.ts
@@ -49,7 +49,7 @@ export default function useStateMachineCommands<
 }: UseStateMachineCommandsArgs<T, S>) {
   useSignals()
   const { commands, settings, userFeatures } = useApp()
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const showExperimentalCommands = userFeatures.useHas(
     EXPERIMENTAL_POINT_AND_CLICK_FLAG,
     false
@@ -61,7 +61,7 @@ export default function useStateMachineCommands<
     {
       settings: settingsValues,
       hasEditsSinceLastExecution:
-        kclManager.hasEditsSinceLastExecutionSignal.value,
+        executingEditor.hasEditsSinceLastExecutionSignal.value,
     }
   )
   const shouldDisableEngineCommands =

--- a/src/hooks/useToolbarGuards.ts
+++ b/src/hooks/useToolbarGuards.ts
@@ -5,7 +5,7 @@ import {
   createSetVarNameModal,
 } from '@src/components/SetVarNameModal'
 import { useModelingContext } from '@src/hooks/useModelingContext'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { moveValueIntoNewVariable } from '@src/lang/modifyAst'
 import { isNodeSafeToReplace } from '@src/lang/queryAst'
 import type { PathToNode, SourceRange } from '@src/lang/wasm'
@@ -16,17 +16,17 @@ import { toSync } from '@src/lib/utils'
 export const getVarNameModal = createSetVarNameModal(SetVarNameModal)
 
 export function useConvertToVariable(
-  kclManager: KclManager,
+  executingEditor: ExecutingEditor,
   range?: SourceRange
 ) {
-  const wasmInstance = use(kclManager.wasmInstancePromise)
-  const ast = kclManager.astSignal.value
+  const wasmInstance = use(executingEditor.wasmInstancePromise)
+  const ast = executingEditor.astSignal.value
   const { context } = useModelingContext()
   const [enable, setEnabled] = useState(false)
 
   useEffect(() => {
-    kclManager.convertToVariableEnabled = enable
-  }, [enable, kclManager])
+    executingEditor.convertToVariableEnabled = enable
+  }, [enable, executingEditor])
 
   useEffect(() => {
     // Return early if there are no selection ranges for whatever reason
@@ -63,17 +63,20 @@ export function useConvertToVariable(
       const { modifiedAst: _modifiedAst, pathToReplacedNode } =
         moveValueIntoNewVariable(
           ast,
-          kclManager.variables,
+          executingEditor.variables,
           range || context.selectionRanges.graphSelections[0]?.codeRef?.range,
           variableName,
           wasmInstance
         )
 
-      await kclManager.updateAst(_modifiedAst, true)
+      await executingEditor.updateAst(_modifiedAst, true)
 
-      const newCode = recast(_modifiedAst, await kclManager.wasmInstancePromise)
+      const newCode = recast(
+        _modifiedAst,
+        await executingEditor.wasmInstancePromise
+      )
       if (err(newCode)) return
-      kclManager.updateCodeEditor(newCode)
+      executingEditor.updateCodeEditor(newCode)
 
       return pathToReplacedNode
     } catch (e) {
@@ -81,7 +84,10 @@ export function useConvertToVariable(
     }
   }
 
-  kclManager.convertToVariableCallback = toSync(handleClick, reportRejection)
+  executingEditor.convertToVariableCallback = toSync(
+    handleClick,
+    reportRejection
+  )
 
   return { enable, handleClick }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,11 +35,11 @@ function launchApp(app: App) {
 function initSingletonBehavior(app: App) {
   const { singletons } = app
   markOnce('code/willAuth')
-  initializeWindowExceptionHandler(singletons.kclManager)
+  initializeWindowExceptionHandler(singletons.executingEditor)
 
   // Don't start the app machine until all these singletons
   // are initialized, and the wasm module is loaded.
-  singletons.kclManager.wasmInstancePromise
+  singletons.executingEditor.wasmInstancePromise
     .then((wasmInstance) => {
       // Application commands must be created after the initPromise because
       // it calls WASM functions to file extensions, this dependency is not available during initialization, it is an async dependency

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,15 +31,15 @@ function launchApp(app: App) {
   mountAppToReact(app)
 }
 
-/** initialize behaviors that rely on singletons */
+/** initialize behaviors that rely on the app core */
 function initSingletonBehavior(app: App) {
-  const { singletons } = app
   markOnce('code/willAuth')
-  initializeWindowExceptionHandler(singletons.executingEditor)
+  initializeWindowExceptionHandler(
+    () => app.project?.executingEditor.value ?? undefined
+  )
 
-  // Don't start the app machine until all these singletons
-  // are initialized, and the wasm module is loaded.
-  singletons.executingEditor.wasmInstancePromise
+  // Application commands need the WASM module for file extension helpers.
+  app.wasmPromise
     .then((wasmInstance) => {
       // Application commands must be created after the initPromise because
       // it calls WASM functions to file extensions, this dependency is not available during initialization, it is an async dependency

--- a/src/lang/ExecutingEditor.spec.ts
+++ b/src/lang/ExecutingEditor.spec.ts
@@ -4,13 +4,13 @@ import type {
   SourceDelta,
 } from '@rust/kcl-lib/bindings/FrontendApi'
 import { createEmptyAst } from '@src/editor/plugins/ast'
-import { File, KclManager } from '@src/lang/KclManager'
+import { ExecutingEditor, File } from '@src/lang/ExecutingEditor'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
-  createKclManagerTestHarness,
+  createExecutingEditorTestHarness,
   getLatestDispatchedDiagnostics,
-} from '@src/lang/testHelpers/kclManagerTestHarness'
+} from '@src/lang/testHelpers/executingEditorTestHarness'
 
 function createDeferred<T>() {
   let resolve!: (value: T) => void
@@ -55,13 +55,13 @@ function createEmptySceneGraphDelta(): SceneGraphDelta {
   }
 }
 
-function enableSketchSolveEditorExecution(kclManager: KclManager) {
-  kclManager.modelingState = {
+function enableSketchSolveEditorExecution(executingEditor: ExecutingEditor) {
+  executingEditor.modelingState = {
     matches: (value: unknown) => value === 'sketchSolveMode',
-  } as unknown as NonNullable<KclManager['modelingState']>
-  kclManager.engineCommandManager.connection = {
+  } as unknown as NonNullable<ExecutingEditor['modelingState']>
+  executingEditor.engineCommandManager.connection = {
     connected: true,
-  } as unknown as typeof kclManager.engineCommandManager.connection
+  } as unknown as typeof executingEditor.engineCommandManager.connection
 }
 
 afterEach(() => {
@@ -71,9 +71,9 @@ afterEach(() => {
   localStorage?.clear()
 })
 
-describe('KclManager diagnostics', () => {
+describe('ExecutingEditor diagnostics', () => {
   it('filters out duplicated diagnostics', () => {
-    const { kclManager } = createKclManagerTestHarness()
+    const { executingEditor } = createExecutingEditorTestHarness()
 
     const duplicatedDiagnostics: Diagnostic[] = [
       {
@@ -97,12 +97,12 @@ describe('KclManager diagnostics', () => {
     ]
 
     expect(
-      kclManager.makeUniqueDiagnostics(duplicatedDiagnostics)
+      executingEditor.makeUniqueDiagnostics(duplicatedDiagnostics)
     ).toStrictEqual([duplicatedDiagnostics[0]])
   })
 
   it('filters duplicated diagnostics while preserving distinct ones', () => {
-    const { kclManager } = createKclManagerTestHarness()
+    const { executingEditor } = createExecutingEditorTestHarness()
 
     const duplicatedDiagnostics: Diagnostic[] = [
       {
@@ -126,18 +126,18 @@ describe('KclManager diagnostics', () => {
     ]
 
     expect(
-      kclManager.makeUniqueDiagnostics(duplicatedDiagnostics)
+      executingEditor.makeUniqueDiagnostics(duplicatedDiagnostics)
     ).toStrictEqual([duplicatedDiagnostics[0], duplicatedDiagnostics[2]])
   })
 
   it('filters out diagnostics whose ranges are outside the current document', () => {
-    const { kclManager } = createKclManagerTestHarness('abcd')
-    const dispatchSpy = vi.spyOn(kclManager.editorView, 'dispatch')
+    const { executingEditor } = createExecutingEditorTestHarness('abcd')
+    const dispatchSpy = vi.spyOn(executingEditor.editorView, 'dispatch')
 
     const validDiagnostic = createDiagnostic(0, 2, 'valid')
     const staleDiagnostic = createDiagnostic(3, 5, 'stale')
 
-    kclManager.setDiagnostics([validDiagnostic, staleDiagnostic])
+    executingEditor.setDiagnostics([validDiagnostic, staleDiagnostic])
 
     expect(getLatestDispatchedDiagnostics(dispatchSpy.mock.calls)).toEqual([
       validDiagnostic,
@@ -145,8 +145,8 @@ describe('KclManager diagnostics', () => {
   })
 
   it('drops stale diagnostics after deleting code while diagnostics are present', () => {
-    const { kclManager } = createKclManagerTestHarness('0123456789')
-    const dispatchSpy = vi.spyOn(kclManager.editorView, 'dispatch')
+    const { executingEditor } = createExecutingEditorTestHarness('0123456789')
+    const dispatchSpy = vi.spyOn(executingEditor.editorView, 'dispatch')
 
     const baseDiagnostic = createDiagnostic(0, 2, 'base diagnostic')
     const staleBaseDiagnostic = createDiagnostic(8, 10, 'stale base diagnostic')
@@ -161,14 +161,14 @@ describe('KclManager diagnostics', () => {
       'stale sketch solve diagnostic'
     )
 
-    kclManager.diagnostics = [baseDiagnostic, staleBaseDiagnostic]
-    kclManager.setSketchSolveDiagnostics([
+    executingEditor.diagnostics = [baseDiagnostic, staleBaseDiagnostic]
+    executingEditor.setSketchSolveDiagnostics([
       sketchSolveDiagnostic,
       staleSketchSolveDiagnostic,
     ])
 
     expect(() =>
-      kclManager.updateCodeEditor('012', {
+      executingEditor.updateCodeEditor('012', {
         shouldExecute: false,
         shouldWriteToDisk: false,
         shouldResetCamera: false,
@@ -182,13 +182,13 @@ describe('KclManager diagnostics', () => {
   })
 
   it('deduplicates identical diagnostics across base and sketch-solve layers', () => {
-    const { kclManager } = createKclManagerTestHarness('abcdef')
-    const dispatchSpy = vi.spyOn(kclManager.editorView, 'dispatch')
+    const { executingEditor } = createExecutingEditorTestHarness('abcdef')
+    const dispatchSpy = vi.spyOn(executingEditor.editorView, 'dispatch')
 
     const duplicateDiagnostic = createDiagnostic(1, 4, 'duplicate')
 
-    kclManager.diagnostics = [duplicateDiagnostic]
-    kclManager.setSketchSolveDiagnostics([duplicateDiagnostic])
+    executingEditor.diagnostics = [duplicateDiagnostic]
+    executingEditor.setSketchSolveDiagnostics([duplicateDiagnostic])
 
     expect(getLatestDispatchedDiagnostics(dispatchSpy.mock.calls)).toEqual([
       duplicateDiagnostic,
@@ -196,8 +196,8 @@ describe('KclManager diagnostics', () => {
   })
 
   it('clears sketch-solve diagnostics without persisting them into the base diagnostics layer', () => {
-    const { kclManager } = createKclManagerTestHarness('abcdef')
-    const dispatchSpy = vi.spyOn(kclManager.editorView, 'dispatch')
+    const { executingEditor } = createExecutingEditorTestHarness('abcdef')
+    const dispatchSpy = vi.spyOn(executingEditor.editorView, 'dispatch')
 
     const baseDiagnostic = createDiagnostic(0, 2, 'base diagnostic')
     const sketchSolveDiagnostic = createDiagnostic(
@@ -206,9 +206,9 @@ describe('KclManager diagnostics', () => {
       'sketch solve diagnostic'
     )
 
-    kclManager.diagnostics = [baseDiagnostic]
-    kclManager.setSketchSolveDiagnostics([sketchSolveDiagnostic])
-    kclManager.setSketchSolveDiagnostics([])
+    executingEditor.diagnostics = [baseDiagnostic]
+    executingEditor.setSketchSolveDiagnostics([sketchSolveDiagnostic])
+    executingEditor.setSketchSolveDiagnostics([])
 
     expect(getLatestDispatchedDiagnostics(dispatchSpy.mock.calls)).toEqual([
       baseDiagnostic,
@@ -216,13 +216,13 @@ describe('KclManager diagnostics', () => {
   })
 
   it('writes to file when the code is unchanged and shouldWriteToDisk is true', () => {
-    const { kclManager } = createKclManagerTestHarness('persist me')
+    const { executingEditor } = createExecutingEditorTestHarness('persist me')
     const writeToFileSpy = vi
-      .spyOn(kclManager, 'writeToFile')
+      .spyOn(executingEditor, 'writeToFile')
       .mockResolvedValue(undefined)
 
-    const currentCode = kclManager.code
-    kclManager.updateCodeEditor(currentCode, {
+    const currentCode = executingEditor.code
+    executingEditor.updateCodeEditor(currentCode, {
       shouldWriteToDisk: true,
       shouldExecute: false,
       shouldResetCamera: false,
@@ -235,14 +235,14 @@ describe('KclManager diagnostics', () => {
 
   it('writes to file for same-code sketch checkpoint commits', () => {
     const previewCode = 'drag preview source'
-    const { kclManager } = createKclManagerTestHarness(previewCode)
+    const { executingEditor } = createExecutingEditorTestHarness(previewCode)
     const writeToFileSpy = vi
-      .spyOn(kclManager, 'writeToFile')
+      .spyOn(executingEditor, 'writeToFile')
       .mockResolvedValue(undefined)
-    ;(kclManager as any).lastCommittedCode = 'source before drag'
-    ;(kclManager as any).lastCommittedSketchCheckpointId = 2
+    ;(executingEditor as any).lastCommittedCode = 'source before drag'
+    ;(executingEditor as any).lastCommittedSketchCheckpointId = 2
 
-    kclManager.updateCodeEditor(
+    executingEditor.updateCodeEditor(
       previewCode,
       {
         shouldExecute: false,
@@ -260,13 +260,13 @@ describe('KclManager diagnostics', () => {
   })
 
   it('does not write to file when the code is unchanged and shouldWriteToDisk is false', () => {
-    const { kclManager } = createKclManagerTestHarness('persist me')
+    const { executingEditor } = createExecutingEditorTestHarness('persist me')
     const writeToFileSpy = vi
-      .spyOn(kclManager, 'writeToFile')
+      .spyOn(executingEditor, 'writeToFile')
       .mockResolvedValue(undefined)
 
-    const currentCode = kclManager.code
-    kclManager.updateCodeEditor(currentCode, {
+    const currentCode = executingEditor.code
+    executingEditor.updateCodeEditor(currentCode, {
       shouldWriteToDisk: false,
       shouldExecute: false,
       shouldResetCamera: false,
@@ -276,14 +276,14 @@ describe('KclManager diagnostics', () => {
   })
 
   it('does not implicitly autosave programmatic editor updates when shouldWriteToDisk is false', () => {
-    const { kclManager } = createKclManagerTestHarness('persist me')
+    const { executingEditor } = createExecutingEditorTestHarness('persist me')
     const writeToFileSpy = vi
-      .spyOn(kclManager, 'writeToFile')
+      .spyOn(executingEditor, 'writeToFile')
       .mockResolvedValue(undefined)
 
-    kclManager.engineCommandManager.started = true
+    executingEditor.engineCommandManager.started = true
 
-    kclManager.updateCodeEditor('changed programmatically', {
+    executingEditor.updateCodeEditor('changed programmatically', {
       shouldWriteToDisk: false,
       shouldExecute: false,
       shouldResetCamera: false,
@@ -295,22 +295,22 @@ describe('KclManager diagnostics', () => {
   it('debounces repeated direct editor edits down to one execution of the latest code', async () => {
     vi.useFakeTimers()
 
-    const { kclManager } = createKclManagerTestHarness('a')
+    const { executingEditor } = createExecutingEditorTestHarness('a')
     const executeCodeSpy = vi
-      .spyOn(kclManager, 'executeCode')
+      .spyOn(executingEditor, 'executeCode')
       .mockResolvedValue(undefined)
 
-    kclManager.engineCommandManager.started = false
-    kclManager.engineCommandManager.connection = { connected: true } as any
+    executingEditor.engineCommandManager.started = false
+    executingEditor.engineCommandManager.connection = { connected: true } as any
 
-    kclManager.editorView.dispatch({
+    executingEditor.editorView.dispatch({
       changes: { from: 1, to: 1, insert: 'b' },
     })
-    kclManager.editorView.dispatch({
+    executingEditor.editorView.dispatch({
       changes: { from: 2, to: 2, insert: 'c' },
     })
 
-    expect(kclManager.code).toBe('abc')
+    expect(executingEditor.code).toBe('abc')
     expect(executeCodeSpy).not.toHaveBeenCalled()
 
     await vi.advanceTimersByTimeAsync(999)
@@ -322,43 +322,43 @@ describe('KclManager diagnostics', () => {
   })
 
   it('tracks whether the editor differs from the last execution', () => {
-    const { kclManager } = createKclManagerTestHarness('a')
-    ;(kclManager as any).markCodeAsExecuted('a')
+    const { executingEditor } = createExecutingEditorTestHarness('a')
+    ;(executingEditor as any).markCodeAsExecuted('a')
 
-    expect(kclManager.hasEditsSinceLastExecutionSignal.value).toBe(false)
+    expect(executingEditor.hasEditsSinceLastExecutionSignal.value).toBe(false)
 
-    kclManager.editorView.dispatch({
+    executingEditor.editorView.dispatch({
       changes: { from: 1, to: 1, insert: 'b' },
     })
 
-    expect(kclManager.hasEditsSinceLastExecutionSignal.value).toBe(true)
+    expect(executingEditor.hasEditsSinceLastExecutionSignal.value).toBe(true)
 
-    kclManager.editorView.dispatch({
+    executingEditor.editorView.dispatch({
       changes: { from: 1, to: 2, insert: '' },
     })
 
-    expect(kclManager.hasEditsSinceLastExecutionSignal.value).toBe(false)
+    expect(executingEditor.hasEditsSinceLastExecutionSignal.value).toBe(false)
   })
 
   it('marks fresh direct sketch editor executions as derived source updates', async () => {
     vi.useFakeTimers()
 
-    const { kclManager } = createKclManagerTestHarness('base')
+    const { executingEditor } = createExecutingEditorTestHarness('base')
     const sceneGraphDelta = createEmptySceneGraphDelta()
     const checkpointId = 55
     const modelingSendSpy = vi.fn()
-    enableSketchSolveEditorExecution(kclManager)
-    kclManager.modelingSend = modelingSendSpy
+    enableSketchSolveEditorExecution(executingEditor)
+    executingEditor.modelingSend = modelingSendSpy
 
-    vi.spyOn(kclManager, 'executeCode').mockResolvedValue(undefined)
-    vi.spyOn(kclManager.rustContext, 'hackSetProgram').mockResolvedValue({
+    vi.spyOn(executingEditor, 'executeCode').mockResolvedValue(undefined)
+    vi.spyOn(executingEditor.rustContext, 'hackSetProgram').mockResolvedValue({
       type: 'Success',
       sceneGraph: sceneGraphDelta.new_graph,
       execOutcome: sceneGraphDelta.exec_outcome,
       checkpointId,
     })
 
-    kclManager.editorView.dispatch({
+    executingEditor.editorView.dispatch({
       changes: { from: 4, to: 4, insert: ' fresh' },
     })
 
@@ -382,31 +382,34 @@ describe('KclManager diagnostics', () => {
   it('drops direct sketch editor executions that go stale while parsing executes', async () => {
     vi.useFakeTimers()
 
-    const { kclManager } = createKclManagerTestHarness('base')
+    const { executingEditor } = createExecutingEditorTestHarness('base')
     const deferredExecution = createDeferred<undefined>()
     const modelingSendSpy = vi.fn()
-    enableSketchSolveEditorExecution(kclManager)
-    kclManager.modelingSend = modelingSendSpy
+    enableSketchSolveEditorExecution(executingEditor)
+    executingEditor.modelingSend = modelingSendSpy
 
-    vi.spyOn(kclManager, 'executeCode').mockReturnValue(
+    vi.spyOn(executingEditor, 'executeCode').mockReturnValue(
       deferredExecution.promise
     )
-    const hackSetProgramSpy = vi.spyOn(kclManager.rustContext, 'hackSetProgram')
+    const hackSetProgramSpy = vi.spyOn(
+      executingEditor.rustContext,
+      'hackSetProgram'
+    )
 
-    kclManager.editorView.dispatch({
+    executingEditor.editorView.dispatch({
       changes: { from: 4, to: 4, insert: ' stale' },
     })
 
     await vi.advanceTimersByTimeAsync(1000)
-    expect(kclManager.code).toBe('base stale')
+    expect(executingEditor.code).toBe('base stale')
 
-    kclManager.editorView.dispatch({
+    executingEditor.editorView.dispatch({
       changes: { from: 10, to: 10, insert: ' newer' },
     })
     deferredExecution.resolve(undefined)
     await flushPromises()
 
-    expect(kclManager.code).toBe('base stale newer')
+    expect(executingEditor.code).toBe('base stale newer')
     expect(hackSetProgramSpy).not.toHaveBeenCalled()
     expect(modelingSendSpy).not.toHaveBeenCalled()
   })
@@ -414,22 +417,22 @@ describe('KclManager diagnostics', () => {
   it('drops direct sketch editor executions that go stale while Rust updates the program', async () => {
     vi.useFakeTimers()
 
-    const { kclManager } = createKclManagerTestHarness('base')
+    const { executingEditor } = createExecutingEditorTestHarness('base')
     const sceneGraphDelta = createEmptySceneGraphDelta()
     const deferredSetProgram =
       createDeferred<
-        Awaited<ReturnType<typeof kclManager.rustContext.hackSetProgram>>
+        Awaited<ReturnType<typeof executingEditor.rustContext.hackSetProgram>>
       >()
     const modelingSendSpy = vi.fn()
-    enableSketchSolveEditorExecution(kclManager)
-    kclManager.modelingSend = modelingSendSpy
+    enableSketchSolveEditorExecution(executingEditor)
+    executingEditor.modelingSend = modelingSendSpy
 
-    vi.spyOn(kclManager, 'executeCode').mockResolvedValue(undefined)
+    vi.spyOn(executingEditor, 'executeCode').mockResolvedValue(undefined)
     const hackSetProgramSpy = vi
-      .spyOn(kclManager.rustContext, 'hackSetProgram')
+      .spyOn(executingEditor.rustContext, 'hackSetProgram')
       .mockReturnValue(deferredSetProgram.promise)
 
-    kclManager.editorView.dispatch({
+    executingEditor.editorView.dispatch({
       changes: { from: 4, to: 4, insert: ' stale' },
     })
 
@@ -437,7 +440,7 @@ describe('KclManager diagnostics', () => {
     await flushPromises()
     expect(hackSetProgramSpy).toHaveBeenCalledTimes(1)
 
-    kclManager.editorView.dispatch({
+    executingEditor.editorView.dispatch({
       changes: { from: 10, to: 10, insert: ' newer' },
     })
     deferredSetProgram.resolve({
@@ -448,22 +451,24 @@ describe('KclManager diagnostics', () => {
     })
     await flushPromises()
 
-    expect(kclManager.code).toBe('base stale newer')
+    expect(executingEditor.code).toBe('base stale newer')
     expect(modelingSendSpy).not.toHaveBeenCalled()
   })
 
   it('debounces repeated programmatic updates so only the latest buffer is written', async () => {
     vi.useFakeTimers()
 
-    const { kclManager } = createKclManagerTestHarness('start')
-    const writeSpy = vi.spyOn(kclManager, 'write').mockResolvedValue(undefined)
+    const { executingEditor } = createExecutingEditorTestHarness('start')
+    const writeSpy = vi
+      .spyOn(executingEditor, 'write')
+      .mockResolvedValue(undefined)
 
-    kclManager.path = '/tmp/kcl-manager-write-test.kcl'
-    ;(kclManager as any).markFileCodeAsSynced('start')
-    kclManager.engineCommandManager.started = true
+    executingEditor.path = '/tmp/kcl-manager-write-test.kcl'
+    ;(executingEditor as any).markFileCodeAsSynced('start')
+    executingEditor.engineCommandManager.started = true
     vi.spyOn(File.ioImplementations, 'read').mockResolvedValue('start')
 
-    kclManager.updateCodeEditor('first', {
+    executingEditor.updateCodeEditor('first', {
       shouldExecute: false,
       shouldWriteToDisk: true,
       shouldResetCamera: false,
@@ -471,7 +476,7 @@ describe('KclManager diagnostics', () => {
 
     await vi.advanceTimersByTimeAsync(500)
 
-    kclManager.updateCodeEditor('second', {
+    executingEditor.updateCodeEditor('second', {
       shouldExecute: false,
       shouldWriteToDisk: true,
       shouldResetCamera: false,
@@ -486,25 +491,25 @@ describe('KclManager diagnostics', () => {
   })
 
   it('reloads clean editor state from disk watcher updates', async () => {
-    const { kclManager } = createKclManagerTestHarness('from disk')
+    const { executingEditor } = createExecutingEditorTestHarness('from disk')
 
-    kclManager.path = '/tmp/kcl-manager-watch-test.kcl'
-    ;(kclManager as any).systemDeps.projectPath.value = '/tmp/project'
-    ;(kclManager as any).markFileCodeAsSynced('from disk')
+    executingEditor.path = '/tmp/kcl-manager-watch-test.kcl'
+    ;(executingEditor as any).systemDeps.projectPath.value = '/tmp/project'
+    ;(executingEditor as any).markFileCodeAsSynced('from disk')
 
     vi.spyOn(File.ioImplementations, 'read').mockResolvedValue('external edit')
 
-    const watchHandler = kclManager.onWatchEvent.at(-1)
+    const watchHandler = executingEditor.onWatchEvent.at(-1)
     expect(watchHandler).toBeDefined()
 
-    watchHandler?.('change', kclManager.path)
+    watchHandler?.('change', executingEditor.path)
     await flushPromises()
 
-    expect(kclManager.code).toBe('external edit')
+    expect(executingEditor.code).toBe('external edit')
   })
 
   it('arms disk watcher when reusing the singleton editor for an opened file', async () => {
-    const { kclManager } = createKclManagerTestHarness('')
+    const { executingEditor } = createExecutingEditorTestHarness('')
     const path = '/tmp/kcl-manager-watch-open-test.kcl'
     const readSpy = vi
       .spyOn(File.ioImplementations, 'read')
@@ -513,14 +518,14 @@ describe('KclManager diagnostics', () => {
       .spyOn(File.ioImplementations, 'watch')
       .mockImplementation(() => {})
 
-    const opened = await KclManager.fromFile(
+    const opened = await ExecutingEditor.fromFile(
       new File(path, 101),
-      (kclManager as any).systemDeps,
-      kclManager
+      (executingEditor as any).systemDeps,
+      executingEditor
     )
 
-    expect(opened).toBe(kclManager)
-    expect(kclManager.watching).toBe(true)
+    expect(opened).toBe(executingEditor)
+    expect(executingEditor.watching).toBe(true)
     expect(watchSpy).toHaveBeenCalledWith(
       path,
       expect.any(String),
@@ -532,24 +537,24 @@ describe('KclManager diagnostics', () => {
   })
 
   it('does not overwrite dirty editor state when an external reload resolves later', async () => {
-    const { kclManager } = createKclManagerTestHarness('local base')
+    const { executingEditor } = createExecutingEditorTestHarness('local base')
     const deferredRead = createDeferred<string>()
-    const updateCodeEditorSpy = vi.spyOn(kclManager, 'updateCodeEditor')
+    const updateCodeEditorSpy = vi.spyOn(executingEditor, 'updateCodeEditor')
 
-    kclManager.path = '/tmp/kcl-manager-watch-test.kcl'
-    ;(kclManager as any).systemDeps.projectPath.value = '/tmp/project'
-    ;(kclManager as any).markFileCodeAsSynced('local base')
+    executingEditor.path = '/tmp/kcl-manager-watch-test.kcl'
+    ;(executingEditor as any).systemDeps.projectPath.value = '/tmp/project'
+    ;(executingEditor as any).markFileCodeAsSynced('local base')
 
     vi.spyOn(File.ioImplementations, 'read').mockReturnValue(
       deferredRead.promise
     )
 
-    const watchHandler = kclManager.onWatchEvent.at(-1)
+    const watchHandler = executingEditor.onWatchEvent.at(-1)
     expect(watchHandler).toBeDefined()
 
-    watchHandler?.('change', kclManager.path)
+    watchHandler?.('change', executingEditor.path)
 
-    kclManager.updateCodeEditor('local newer', {
+    executingEditor.updateCodeEditor('local newer', {
       shouldExecute: false,
       shouldWriteToDisk: false,
       shouldResetCamera: false,
@@ -560,24 +565,25 @@ describe('KclManager diagnostics', () => {
     deferredRead.resolve('external edit')
     await flushPromises()
 
-    expect(kclManager.code).toBe('local newer')
+    expect(executingEditor.code).toBe('local newer')
     expect(updateCodeEditorSpy).toHaveBeenCalledTimes(1)
   })
 
   it('refuses to replace the editor with an empty AST unless deletion was explicit', async () => {
-    const { kclManager } = createKclManagerTestHarness('preserve me')
+    const { executingEditor } = createExecutingEditorTestHarness('preserve me')
     const writeToFileSpy = vi
-      .spyOn(kclManager, 'writeToFile')
+      .spyOn(executingEditor, 'writeToFile')
       .mockResolvedValue(undefined)
 
-    await kclManager.updateEditorWithAstAndWriteToFile(createEmptyAst())
+    await executingEditor.updateEditorWithAstAndWriteToFile(createEmptyAst())
 
-    expect(kclManager.code).toBe('preserve me')
+    expect(executingEditor.code).toBe('preserve me')
     expect(writeToFileSpy).not.toHaveBeenCalled()
   })
 
   it('drops stale sketch checkpoint restores when a newer local edit lands first', async () => {
-    const { kclManager } = createKclManagerTestHarness('checkpoint base')
+    const { executingEditor } =
+      createExecutingEditorTestHarness('checkpoint base')
     const deferredRestore = createDeferred<{
       kclSource: SourceDelta
       sceneGraphDelta: SceneGraphDelta
@@ -593,7 +599,7 @@ describe('KclManager diagnostics', () => {
         const data = event.data as {
           sourceDelta: SourceDelta
         }
-        kclManager.updateCodeEditor(data.sourceDelta.text, {
+        executingEditor.updateCodeEditor(data.sourceDelta.text, {
           shouldExecute: false,
           shouldWriteToDisk: false,
           shouldResetCamera: false,
@@ -602,18 +608,19 @@ describe('KclManager diagnostics', () => {
       }
     })
 
-    kclManager.modelingState = {
+    executingEditor.modelingState = {
       matches: (value: unknown) => value === 'sketchSolveMode',
     } as any
-    kclManager.modelingSend = modelingSendSpy
+    executingEditor.modelingSend = modelingSendSpy
 
-    vi.spyOn(kclManager.rustContext, 'restoreSketchCheckpoint').mockReturnValue(
-      deferredRestore.promise
-    )
+    vi.spyOn(
+      executingEditor.rustContext,
+      'restoreSketchCheckpoint'
+    ).mockReturnValue(deferredRestore.promise)
 
-    void (kclManager as any).restoreSketchCheckpointForHistory(42)
+    void (executingEditor as any).restoreSketchCheckpointForHistory(42)
 
-    kclManager.updateCodeEditor('local newer', {
+    executingEditor.updateCodeEditor('local newer', {
       shouldExecute: false,
       shouldWriteToDisk: false,
       shouldResetCamera: false,
@@ -631,7 +638,7 @@ describe('KclManager diagnostics', () => {
     })
     await flushPromises()
 
-    expect(kclManager.code).toBe('local newer')
+    expect(executingEditor.code).toBe('local newer')
     expect(modelingSendSpy).not.toHaveBeenCalled()
   })
 
@@ -640,21 +647,22 @@ describe('KclManager diagnostics', () => {
     const recoveredCode = 'last good preview'
     const preDragCheckpointId = 7
     const recoveredCheckpointId = 11
-    const { kclManager } = createKclManagerTestHarness(baselineCode)
+    const { executingEditor } = createExecutingEditorTestHarness(baselineCode)
     const modelingSendSpy = vi.fn()
 
-    kclManager.modelingState = {
+    executingEditor.modelingState = {
       matches: (value: unknown) => value === 'sketchSolveMode',
     } as any
-    kclManager.modelingSend = modelingSendSpy
-    ;(kclManager as any).lastCommittedCode = baselineCode
-    ;(kclManager as any).lastCommittedAdditionalSpec = {
+    executingEditor.modelingSend = modelingSendSpy
+    ;(executingEditor as any).lastCommittedCode = baselineCode
+    ;(executingEditor as any).lastCommittedAdditionalSpec = {
       sketchCheckpointId: preDragCheckpointId,
     }
-    ;(kclManager as any).lastCommittedSketchCheckpointId = preDragCheckpointId
+    ;(executingEditor as any).lastCommittedSketchCheckpointId =
+      preDragCheckpointId
 
     const restoreSketchCheckpointSpy = vi
-      .spyOn(kclManager.rustContext, 'restoreSketchCheckpoint')
+      .spyOn(executingEditor.rustContext, 'restoreSketchCheckpoint')
       .mockResolvedValue({
         kclSource: { text: baselineCode },
         sceneGraphDelta: {
@@ -665,14 +673,14 @@ describe('KclManager diagnostics', () => {
         },
       })
 
-    kclManager.updateCodeEditor(recoveredCode, {
+    executingEditor.updateCodeEditor(recoveredCode, {
       shouldExecute: false,
       shouldWriteToDisk: false,
       shouldResetCamera: false,
       shouldAddToHistory: false,
     })
 
-    kclManager.updateCodeEditor(
+    executingEditor.updateCodeEditor(
       recoveredCode,
       {
         shouldExecute: false,
@@ -683,14 +691,16 @@ describe('KclManager diagnostics', () => {
       }
     )
 
-    expect(kclManager.code).toBe(recoveredCode)
-    expect(kclManager.currentSketchCheckpointId).toBe(recoveredCheckpointId)
+    expect(executingEditor.code).toBe(recoveredCode)
+    expect(executingEditor.currentSketchCheckpointId).toBe(
+      recoveredCheckpointId
+    )
 
-    kclManager.undo()
+    executingEditor.undo()
     await flushPromises()
 
-    expect(kclManager.code).toBe(baselineCode)
-    expect(kclManager.currentSketchCheckpointId).toBe(preDragCheckpointId)
+    expect(executingEditor.code).toBe(baselineCode)
+    expect(executingEditor.currentSketchCheckpointId).toBe(preDragCheckpointId)
     expect(restoreSketchCheckpointSpy).toHaveBeenCalledWith(preDragCheckpointId)
     expect(modelingSendSpy).toHaveBeenCalledWith({
       type: 'update sketch outcome',
@@ -710,21 +720,24 @@ describe('KclManager diagnostics', () => {
   })
 
   it('drops stale ast-driven editor rewrites when the document changed while waiting', async () => {
-    const { kclManager } = createKclManagerTestHarness('x = 1')
-    const originalWasmPromise = kclManager.wasmInstancePromise
+    const { executingEditor } = createExecutingEditorTestHarness('x = 1')
+    const originalWasmPromise = executingEditor.wasmInstancePromise
     const deferredWasm = createDeferred<Awaited<typeof originalWasmPromise>>()
-    const ast = await kclManager.safeParse('x = 2')
+    const ast = await executingEditor.safeParse('x = 2')
 
     expect(ast).not.toBeNull()
 
-    kclManager.wasmInstancePromise = deferredWasm.promise
+    executingEditor.wasmInstancePromise = deferredWasm.promise
 
-    const pendingRewrite = kclManager.updateEditorWithAstAndWriteToFile(ast!, {
-      shouldExecute: false,
-      shouldWriteToDisk: false,
-    })
+    const pendingRewrite = executingEditor.updateEditorWithAstAndWriteToFile(
+      ast!,
+      {
+        shouldExecute: false,
+        shouldWriteToDisk: false,
+      }
+    )
 
-    kclManager.updateCodeEditor('local newer', {
+    executingEditor.updateCodeEditor('local newer', {
       shouldExecute: false,
       shouldWriteToDisk: false,
       shouldResetCamera: false,
@@ -734,26 +747,29 @@ describe('KclManager diagnostics', () => {
     deferredWasm.resolve(await originalWasmPromise)
     await pendingRewrite
 
-    expect(kclManager.code).toBe('local newer')
+    expect(executingEditor.code).toBe('local newer')
   })
 
   it('allows ast-driven editor rewrites to survive intermediate programmatic updates when requested', async () => {
-    const { kclManager } = createKclManagerTestHarness('x = 1')
-    const originalWasmPromise = kclManager.wasmInstancePromise
+    const { executingEditor } = createExecutingEditorTestHarness('x = 1')
+    const originalWasmPromise = executingEditor.wasmInstancePromise
     const deferredWasm = createDeferred<Awaited<typeof originalWasmPromise>>()
-    const ast = await kclManager.safeParse('x = 2')
+    const ast = await executingEditor.safeParse('x = 2')
 
     expect(ast).not.toBeNull()
 
-    kclManager.wasmInstancePromise = deferredWasm.promise
+    executingEditor.wasmInstancePromise = deferredWasm.promise
 
-    const pendingRewrite = kclManager.updateEditorWithAstAndWriteToFile(ast!, {
-      shouldExecute: false,
-      shouldWriteToDisk: false,
-      allowProgrammaticDocumentChanges: true,
-    })
+    const pendingRewrite = executingEditor.updateEditorWithAstAndWriteToFile(
+      ast!,
+      {
+        shouldExecute: false,
+        shouldWriteToDisk: false,
+        allowProgrammaticDocumentChanges: true,
+      }
+    )
 
-    kclManager.updateCodeEditor('intermediate programmatic', {
+    executingEditor.updateCodeEditor('intermediate programmatic', {
       shouldExecute: false,
       shouldWriteToDisk: false,
       shouldResetCamera: false,
@@ -763,23 +779,25 @@ describe('KclManager diagnostics', () => {
     deferredWasm.resolve(await originalWasmPromise)
     await pendingRewrite
 
-    expect(kclManager.code.trim()).toBe('x = 2')
+    expect(executingEditor.code.trim()).toBe('x = 2')
   })
 
   it('skips disk writes when the on-disk file changed since the last sync', async () => {
     vi.useFakeTimers()
 
     const path = '/tmp/kcl-manager-cas-write-test.kcl'
-    const { kclManager } = createKclManagerTestHarness('disk base')
-    const writeSpy = vi.spyOn(kclManager, 'write').mockResolvedValue(undefined)
+    const { executingEditor } = createExecutingEditorTestHarness('disk base')
+    const writeSpy = vi
+      .spyOn(executingEditor, 'write')
+      .mockResolvedValue(undefined)
 
-    kclManager.path = path
-    ;(kclManager as any).markFileCodeAsSynced('disk base')
-    kclManager.engineCommandManager.started = true
+    executingEditor.path = path
+    ;(executingEditor as any).markFileCodeAsSynced('disk base')
+    executingEditor.engineCommandManager.started = true
 
     vi.spyOn(File.ioImplementations, 'read').mockResolvedValue('external newer')
 
-    kclManager.updateCodeEditor('local newer', {
+    executingEditor.updateCodeEditor('local newer', {
       shouldExecute: false,
       shouldWriteToDisk: true,
       shouldResetCamera: false,
@@ -788,8 +806,8 @@ describe('KclManager diagnostics', () => {
     await vi.advanceTimersByTimeAsync(1000)
 
     expect(writeSpy).not.toHaveBeenCalled()
-    expect(kclManager.code).toBe('local newer')
-    expect((kclManager as any).hasUnsavedLocalChanges()).toBe(true)
+    expect(executingEditor.code).toBe('local newer')
+    expect((executingEditor as any).hasUnsavedLocalChanges()).toBe(true)
   })
 
   it('restores the local recovery snapshot when reopening a file after unsaved edits', async () => {
@@ -797,12 +815,12 @@ describe('KclManager diagnostics', () => {
 
     const path = '/tmp/kcl-manager-recovery-test.kcl'
     const recoveryKey = getRecoverySnapshotKey(path)
-    const { kclManager } = createKclManagerTestHarness('disk base')
+    const { executingEditor } = createExecutingEditorTestHarness('disk base')
 
-    kclManager.path = path
-    ;(kclManager as any).markFileCodeAsSynced('disk base')
+    executingEditor.path = path
+    ;(executingEditor as any).markFileCodeAsSynced('disk base')
 
-    kclManager.updateCodeEditor('recovered newer', {
+    executingEditor.updateCodeEditor('recovered newer', {
       shouldExecute: false,
       shouldWriteToDisk: false,
       shouldResetCamera: false,
@@ -817,9 +835,9 @@ describe('KclManager diagnostics', () => {
 
     vi.spyOn(File.ioImplementations, 'read').mockResolvedValue('disk base')
 
-    const reopened = await KclManager.fromFile(
+    const reopened = await ExecutingEditor.fromFile(
       new File(path, 99),
-      (kclManager as any).systemDeps
+      (executingEditor as any).systemDeps
     )
 
     expect(reopened.code).toBe('recovered newer')

--- a/src/lang/ExecutingEditor.ts
+++ b/src/lang/ExecutingEditor.ts
@@ -377,10 +377,11 @@ export class ZDSProject {
       return
     }
     const found = foundPathSignal[1]
+    this.#executingPath.value = foundPathSignal[0]
     if (found) {
       // TODO: Reconfigure the editor to be an executing one
+      this.app.setExecutingEditor(found)
     }
-    this.#executingPath.value = foundPathSignal[0]
   }
   findEditor(path: string) {
     return this.editors
@@ -408,6 +409,11 @@ export class ZDSProject {
     const found = foundEditor?.[1]
     if (found) {
       console.warn(`Attempted to overwrite editor with path "${path}"`)
+      if (isExecuting) {
+        this.executingPath = path
+        this.closeInactiveEditors(path)
+        this.executeEditorIfConnected(found)
+      }
       return found
     }
 
@@ -475,8 +481,37 @@ export class ZDSProject {
 
     if (isExecuting) {
       this.executingPath = path
+      this.closeInactiveEditors(path)
+      this.executeEditorIfConnected(newEditor)
     }
     return newEditor
+  }
+
+  private executeEditorIfConnected(editor: ExecutingEditor) {
+    if (!editor.engineCommandManager.connection?.connected) {
+      return
+    }
+
+    editor
+      .executeCode()
+      .then(() =>
+        resetCameraPosition({
+          sceneInfra: editor.sceneInfra,
+          engineCommandManager: editor.engineCommandManager,
+          settingsActor: this.app.settings.actor,
+        })
+      )
+      .catch(reportRejection)
+  }
+
+  private closeInactiveEditors(activePath: string) {
+    for (const [pathSignal, editor] of Array.from(this.editors.entries())) {
+      if (pathSignal.value === activePath) {
+        continue
+      }
+      editor.close()
+      this.editors.delete(pathSignal)
+    }
   }
 
   closeEditor(path: string) {
@@ -487,6 +522,10 @@ export class ZDSProject {
     }
     foundPathSignal[1].close()
     this.editors.delete(foundPathSignal[0])
+    if (this.#executingPath.value === foundPathSignal[0]) {
+      this.#executingPath.value = null
+      this.app.clearExecutingEditor()
+    }
   }
 
   closeAllEditors() {
@@ -494,6 +533,7 @@ export class ZDSProject {
       editor.close()
     }
     this.editors.clear()
+    this.#executingPath.value = null
   }
 
   /** Handle updates from the disk representation of the project */
@@ -755,6 +795,7 @@ export class ExecutingEditor extends File {
   }
   get executingEditorService(): ExecutingEditorService {
     return {
+      executingEditor: this,
       code: this._code,
       hasEditsSinceLastExecution: this._hasEditsSinceLastExecution,
       isExecuting: this._isExecuting,
@@ -1917,8 +1958,10 @@ export class ExecutingEditor extends File {
 
   /** Clean up listeners, watchers, etc */
   public close() {
+    this.cancelAllExecutions()
     clearTimeout(this.timeoutWriter)
     clearTimeout(this.timeoutRewatch)
+    clearTimeout(this.executionTimeoutId)
     this.settingsSubscription?.unsubscribe()
     this.flushRecoverySnapshot()
     this.unwatch()
@@ -3043,6 +3086,9 @@ export class ExecutingEditor extends File {
     })
   }
   localStoragePersistCode(): string {
+    return ExecutingEditor.localStoragePersistCode()
+  }
+  static localStoragePersistCode(): string {
     return safeLSGetItem(PERSIST_CODE_KEY) || ''
   }
   /**

--- a/src/lang/ExecutingEditor.ts
+++ b/src/lang/ExecutingEditor.ts
@@ -288,7 +288,7 @@ interface SystemDeps {
   keymap?: KeymapService
 }
 
-export enum KclManagerEvents {
+export enum ExecutingEditorEvents {
   LongExecution = 'long-execution',
 }
 
@@ -318,7 +318,7 @@ export class ZDSProject {
     return this.projectIORefSignal.value.name
   }
   /** Editors are referenced via Signal in case the file name itself is changed. */
-  public editors = new Map<Signal<string>, KclManager>()
+  public editors = new Map<Signal<string>, ExecutingEditor>()
   #executingPath = signal<Signal<string> | null>(null)
   public executingEditor = computed(() =>
     this.#executingPath.value
@@ -395,9 +395,9 @@ export class ZDSProject {
   async openEditor(
     path: string,
     /** TODO: Remove providedEditor, replace with options about if the editor is the executing one
-     * once the app can handle not having a KclManager.
+     * once the app can handle not having a ExecutingEditor.
      */
-    providedEditor?: KclManager,
+    providedEditor?: ExecutingEditor,
     /** TODO: Remove `providedCode` once no tests rely on initializing
      * editor state through localstorage.
      */
@@ -425,7 +425,7 @@ export class ZDSProject {
     }
 
     const foundFileIndex = this.files.findIndex((f) => f.path === path)
-    const newEditor = await KclManager.fromFile(
+    const newEditor = await ExecutingEditor.fromFile(
       foundFileIndex > -1
         ? this.files[foundFileIndex]
         : new File(path, this.nextFileId++),
@@ -675,7 +675,7 @@ export class File extends EventTarget {
   static encoder = new TextEncoder()
 }
 
-export class KclManager extends File {
+export class ExecutingEditor extends File {
   // SYSTEM DEPENDENCIES
 
   private _wasmInstance: ModuleType | null = null
@@ -713,7 +713,7 @@ export class KclManager extends File {
   private readonly _globalHistoryView: HistoryView
 
   /**
-   * The core state in KclManager are the code and the selection.
+   * The core state in ExecutingEditor are the code and the selection.
    * all other state should be derived from the code or selection in some way.
    */
   private _code = signal(bracket)
@@ -834,7 +834,7 @@ export class KclManager extends File {
     graphSelections: [],
   }
   /** a representation of selections used by modelingMachine */
-  private _selectionRanges: Selections = KclManager.emptySelectionRanges
+  private _selectionRanges: Selections = ExecutingEditor.emptySelectionRanges
   private _selectionRangesSignal = signal<Selections>(this._selectionRanges)
   selectionFilter = signal<EntityType[]>(defaultSelectionFilter)
   private _selectionStatusLabel = computed(
@@ -894,7 +894,7 @@ export class KclManager extends File {
    */
   #onWatchEvent = (_eventType: string, path: string) => {
     // TODO: We can remove this once we make it impossible to have
-    // a KclManager without a ZDSProject.
+    // a ExecutingEditor without a ZDSProject.
     if (
       path !== this.path ||
       !this.systemDeps.projectPath.value ||
@@ -1811,7 +1811,7 @@ export class KclManager extends File {
   static async fromFile(
     file: File,
     systemDeps: SystemDeps,
-    providedEditor?: KclManager,
+    providedEditor?: ExecutingEditor,
     providedCode?: string
   ) {
     const diskCode = normalizeLineEndings(providedCode || (await file.read()))
@@ -1822,7 +1822,12 @@ export class KclManager extends File {
         : diskCode
 
     if (!providedEditor) {
-      const editor = new KclManager(file.path, initialCode, systemDeps, file.id)
+      const editor = new ExecutingEditor(
+        file.path,
+        initialCode,
+        systemDeps,
+        file.id
+      )
       if (!isCodeTheSame(initialCode, diskCode)) {
         editor.markFileCodeAsSynced(diskCode)
       }
@@ -1856,7 +1861,7 @@ export class KclManager extends File {
     fileId = 0
   ) {
     super(path, fileId)
-    // Register our additional, KclManager-specific watch event handler
+    // Register our additional, ExecutingEditor-specific watch event handler
     this.onWatchEvent.push(this.#onWatchEvent)
     this.systemDeps = systemDeps
     const getSettings = () =>
@@ -2177,7 +2182,7 @@ export class KclManager extends File {
       if (this.sceneEntitiesManager) {
         setSelectionFilterToDefault({
           engineCommandManager: this.engineCommandManager,
-          kclManager: this,
+          executingEditor: this,
           sceneEntitiesManager: this.sceneEntitiesManager,
           wasmInstance: await this.systemDeps.wasmInstancePromise,
         })
@@ -2342,7 +2347,9 @@ export class KclManager extends File {
         return
       }
 
-      this.dispatchEvent(new CustomEvent(KclManagerEvents.LongExecution, {}))
+      this.dispatchEvent(
+        new CustomEvent(ExecutingEditorEvents.LongExecution, {})
+      )
     }, this.longExecutionTimeMs)
 
     await this.executeAst({ ast })
@@ -2512,7 +2519,7 @@ export class KclManager extends File {
   ) {
     setSelectionFilterToDefault({
       engineCommandManager: this.engineCommandManager,
-      kclManager: this,
+      executingEditor: this,
       sceneEntitiesManager: this.sceneEntitiesManager,
       selectionsToRestore,
       handleSelectionBatchFn: handleSelectionBatch,
@@ -2529,7 +2536,7 @@ export class KclManager extends File {
     setSelectionFilter({
       filter,
       engineCommandManager: this.engineCommandManager,
-      kclManager: this,
+      executingEditor: this,
       sceneEntitiesManager: this.sceneEntitiesManager,
       selectionsToRestore,
       handleSelectionBatchFn: handleSelectionBatch,
@@ -2538,7 +2545,7 @@ export class KclManager extends File {
   }
 
   async clearSelection() {
-    this._selectionRangesSignal.value = KclManager.emptySelectionRanges
+    this._selectionRangesSignal.value = ExecutingEditor.emptySelectionRanges
     return clearSceneSelection(this.engineCommandManager)
   }
 
@@ -3204,11 +3211,11 @@ export class KclManager extends File {
    */
   updateCodeEditor(
     code: string,
-    options: Partial<UpdateCodeEditorOptions> = KclManager.defaultUpdateCodeEditorOptions,
+    options: Partial<UpdateCodeEditorOptions> = ExecutingEditor.defaultUpdateCodeEditorOptions,
     additionalSpec?: UpdateCodeEditorAdditionalSpec
   ): void {
     const resolvedOptions: UpdateCodeEditorOptions = Object.assign(
-      structuredClone(KclManager.defaultUpdateCodeEditorOptions),
+      structuredClone(ExecutingEditor.defaultUpdateCodeEditorOptions),
       options
     )
 

--- a/src/lang/modelingWorkflows.ts
+++ b/src/lang/modelingWorkflows.ts
@@ -7,7 +7,7 @@
  */
 import type { Node } from '@rust/kcl-lib/bindings/Node'
 
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { executeAstMock } from '@src/lang/langHelpers'
 import type { PathToNode, Program } from '@src/lang/wasm'
 import type { ExecutionType } from '@src/lib/constants'
@@ -57,7 +57,7 @@ export async function mockExecAstAndReportErrors(
 export async function updateModelingState(
   ast: Node<Program>,
   executionType: ExecutionType,
-  kclManager: KclManager,
+  executingEditor: ExecutingEditor,
   options?: {
     focusPath?: Array<PathToNode>
     isDeleting?: boolean
@@ -71,39 +71,42 @@ export async function updateModelingState(
 
   // Step 0: Mock execute shit so we know it aint broke
   if (!options?.skipErrorsOnMockExecution) {
-    const res = await mockExecAstAndReportErrors(ast, kclManager.rustContext)
+    const res = await mockExecAstAndReportErrors(
+      ast,
+      executingEditor.rustContext
+    )
     if (err(res)) {
       return Promise.reject(res)
     }
   }
 
   // Step 1: Update AST without executing (prepare selections)
-  updatedAst = await kclManager.updateAst(
+  updatedAst = await executingEditor.updateAst(
     ast,
     false, // Execution handled separately for error resilience
     options
   )
 
   // Step 2: Update the code editor and save file
-  await kclManager.updateEditorWithAstAndWriteToFile(updatedAst.newAst, {
+  await executingEditor.updateEditorWithAstAndWriteToFile(updatedAst.newAst, {
     isDeleting: options?.isDeleting,
     allowProgrammaticDocumentChanges: true,
   })
 
   // Step 3: Set focus on the newly added code if needed
   if (updatedAst.selections) {
-    kclManager.selectRange(updatedAst.selections)
+    executingEditor.selectRange(updatedAst.selections)
   }
 
   // Step 4: Try to execute the new code
   // and continue regardless of errors
   try {
     if (executionType === EXECUTION_TYPE_REAL) {
-      await kclManager.executeAst({
+      await executingEditor.executeAst({
         ast: updatedAst.newAst,
       })
     } else if (executionType === EXECUTION_TYPE_MOCK) {
-      const didReParse = await kclManager.executeAstMock(updatedAst.newAst)
+      const didReParse = await executingEditor.executeAstMock(updatedAst.newAst)
       if (err(didReParse)) return reject(didReParse)
     } else if (executionType === EXECUTION_TYPE_NONE) {
       // No execution.

--- a/src/lang/modifyAst/boolean.spec.ts
+++ b/src/lang/modifyAst/boolean.spec.ts
@@ -1,4 +1,4 @@
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { addSplit, addSubtract } from '@src/lang/modifyAst/boolean'
 import { recast } from '@src/lang/wasm'
 import type RustContext from '@src/lib/rustContext'
@@ -15,7 +15,7 @@ import { buildTheWorldAndConnectToEngine } from '@src/unitTestUtils'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 
 let instanceInThisFile: ModuleType = null!
-let kclManagerInThisFile: KclManager = null!
+let executingEditorInThisFile: ExecutingEditor = null!
 let engineCommandManagerInThisFile: ConnectionManager = null!
 let rustContextInThisFile: RustContext = null!
 
@@ -30,10 +30,10 @@ beforeEach(async () => {
     return
   }
 
-  const { instance, kclManager, engineCommandManager, rustContext } =
+  const { instance, executingEditor, engineCommandManager, rustContext } =
     await buildTheWorldAndConnectToEngine()
   instanceInThisFile = instance
-  kclManagerInThisFile = kclManager
+  executingEditorInThisFile = executingEditor
   engineCommandManagerInThisFile = engineCommandManager
   rustContextInThisFile = rustContext
 })
@@ -46,12 +46,12 @@ async function getSolidsAndTools(
   solidIds: number[],
   toolIds: number[],
   instance: ModuleType,
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
 ) {
   const { artifactGraph, ast } = await getAstAndArtifactGraph(
     code,
     instance,
-    kclManager
+    executingEditor
   )
   // path selection is what p&c is doing with the filter (v. sweep)
   const paths = [...artifactGraph.values()].filter((n) => n.type === 'path')
@@ -84,7 +84,7 @@ describe('boolean', () => {
       solidIds: number[],
       toolIds: number[],
       instance: ModuleType,
-      kclManager: KclManager,
+      executingEditor: ExecutingEditor,
       rustContext: RustContext
     ) {
       const { ast, artifactGraph, solids, tools } = await getSolidsAndTools(
@@ -92,7 +92,7 @@ describe('boolean', () => {
         solidIds,
         toolIds,
         instance,
-        kclManager
+        executingEditor
       )
       const result = addSubtract({
         ast,
@@ -123,7 +123,7 @@ extrude002 = extrude(profile002, length = -1)`
         solidIds,
         toolIds,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         rustContextInThisFile
       )
       expect(newCode).toContain(code + '\n' + expectedNewLine)
@@ -145,7 +145,7 @@ startSketchOn(XZ)
         solidIds,
         toolIds,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         rustContextInThisFile
       )
       expect(newCode).toContain(code + '\n' + expectedNewLine)
@@ -168,7 +168,7 @@ extrude003 = extrude(profile003, length = -1)`
         solidIds,
         toolIds,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         rustContextInThisFile
       )
       expect(newCode).toContain(code + '\n' + expectedNewLine)
@@ -192,7 +192,7 @@ extrude003 = extrude(profile004, length = 20)`
         solidIds,
         toolIds,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         rustContextInThisFile
       )
       expect(newCode).toContain(code + '\n' + expectedNewLine)
@@ -227,7 +227,7 @@ extrude001 = extrude(profile001, length = -5, method = NEW)`
         solidIds,
         toolIds,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         rustContextInThisFile
       )
       // Note that this would fail without artifactTypeFilter: ['compositeSolid', 'sweep'] in addSubtract
@@ -264,7 +264,7 @@ extrude001 = extrude(profile001, length = -5, method = NEW)`
         targetIds,
         toolIds || [],
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const result = addSplit({
         ast,
@@ -412,7 +412,7 @@ surface002 = joinSurfaces([extrude002, extrude003, surface001])`
       const { ast, artifactGraph } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const firstSweep = [...artifactGraph.values()].find(
         (artifact) => artifact.type === 'sweep'

--- a/src/lang/modifyAst/deleteSelection.ts
+++ b/src/lang/modifyAst/deleteSelection.ts
@@ -2,7 +2,7 @@ import type {
   SceneGraphDelta,
   SourceDelta,
 } from '@rust/kcl-lib/bindings/FrontendApi'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { executeAstMock } from '@src/lang/langHelpers'
 import { updateModelingState } from '@src/lang/modelingWorkflows'
 import { deleteFromSelection } from '@src/lang/modifyAst/deleteFromSelection'
@@ -22,11 +22,11 @@ export async function deleteSelectionPromise({
 }: {
   selection: Selection
   systemDeps: {
-    kclManager: KclManager
+    executingEditor: ExecutingEditor
     rustContext: RustContext
   }
 }): Promise<Error | undefined> {
-  const ast = systemDeps.kclManager.ast
+  const ast = systemDeps.executingEditor.ast
 
   // Filtering on type here for Rust API based deletion, as this is the point of convergence
   // of deletion calls, from the feature tree but also Delete hotkey globally.
@@ -70,7 +70,7 @@ export async function deleteSelectionPromise({
       return e as Error
     }
 
-    systemDeps.kclManager.updateCodeEditor(result.kclSource.text, {
+    systemDeps.executingEditor.updateCodeEditor(result.kclSource.text, {
       shouldExecute: true,
       shouldWriteToDisk: true,
     })
@@ -81,11 +81,11 @@ export async function deleteSelectionPromise({
   const modifiedAst = await deleteFromSelection(
     ast,
     selection,
-    systemDeps.kclManager.variables,
-    systemDeps.kclManager.artifactGraph,
-    await systemDeps.kclManager.wasmInstancePromise,
-    systemDeps.kclManager.sceneEntitiesManager.getFaceDetails.bind(
-      systemDeps.kclManager.sceneEntitiesManager
+    systemDeps.executingEditor.variables,
+    systemDeps.executingEditor.artifactGraph,
+    await systemDeps.executingEditor.wasmInstancePromise,
+    systemDeps.executingEditor.sceneEntitiesManager.getFaceDetails.bind(
+      systemDeps.executingEditor.sceneEntitiesManager
     )
   )
   if (err(modifiedAst)) {
@@ -121,7 +121,7 @@ export async function deleteSelectionPromise({
   await updateModelingState(
     astToApply,
     EXECUTION_TYPE_REAL,
-    systemDeps.kclManager,
+    systemDeps.executingEditor,
     {
       isDeleting: true,
     }

--- a/src/lang/modifyAst/edges.spec.ts
+++ b/src/lang/modifyAst/edges.spec.ts
@@ -1,4 +1,4 @@
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { createPathToNodeForLastVariable } from '@src/lang/modifyAst'
 import {
   EdgeTreatmentType,
@@ -31,7 +31,7 @@ import { buildTheWorldAndConnectToEngine } from '@src/unitTestUtils'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 
 let instanceInThisFile: ModuleType = null!
-let kclManagerInThisFile: KclManager = null!
+let executingEditorInThisFile: ExecutingEditor = null!
 let rustContextInThisFile: RustContext = null!
 let engineCommandManagerInThisFile: ConnectionManager = null!
 
@@ -46,10 +46,10 @@ beforeEach(async () => {
     return
   }
 
-  const { instance, kclManager, engineCommandManager, rustContext } =
+  const { instance, executingEditor, engineCommandManager, rustContext } =
     await buildTheWorldAndConnectToEngine()
   instanceInThisFile = instance
-  kclManagerInThisFile = kclManager
+  executingEditorInThisFile = executingEditor
   rustContextInThisFile = rustContext
   engineCommandManagerInThisFile = engineCommandManager
 })
@@ -159,7 +159,7 @@ extrude002 = extrude([sketch002.line1, sketch002.line2], length = 5, bodyType = 
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         extrudedTriangle,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const selection = createSelectionFromArtifacts(
         [[...artifactGraph.values()].find((a) => a.type === 'sweepEdge')!],
@@ -288,7 +288,7 @@ hide([boxProfile, bottomProfile, lowerWallProfile, upperWallProfile, topProfile]
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const boxSolidStart = code.indexOf('boxSolid = extrude')
       const boxSolidEnd = code.indexOf('bottomPlane =')
@@ -336,7 +336,7 @@ hide([boxProfile, bottomProfile, lowerWallProfile, upperWallProfile, topProfile]
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         extrudedTriangle,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const sweep = [...artifactGraph.values()].find((a) => a.type === 'sweep')
       expect(sweep).toBeDefined()
@@ -381,7 +381,7 @@ fillet001 = fillet(extrude001, tags = edge001, radius = 1)`
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         extrudedTriangle,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const sweepEdge = [...artifactGraph.values()].find(
         (a) => a.type === 'sweepEdge'
@@ -436,7 +436,7 @@ fillet001 = fillet(
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         extrudedTriangle,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const selection = createSelectionFromArtifacts(
         [[...artifactGraph.values()].find((a) => a.type === 'sweepEdge')!],
@@ -484,7 +484,7 @@ ${extrudedTriangle}`
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const sweepEdge = [...artifactGraph.values()].find(
         (a) => a.type === 'sweepEdge'
@@ -527,7 +527,7 @@ ${extrudedTriangle}`
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         extrudedTriangleWithFillet,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const selection = createSelectionFromArtifacts(
         [[...artifactGraph.values()].find((a) => a.type === 'sweepEdge')!],
@@ -570,7 +570,7 @@ extrude001 = extrude(profile001, length = 20, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const sweepEdge = [...artifactGraph.values()].find(
         (a) => a.type === 'sweepEdge'
@@ -612,7 +612,7 @@ extrude001 = extrude(profile001, length = 20, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         twoExtrudedTriangles,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       // Get all sweep artifacts (bodies)
@@ -667,7 +667,7 @@ extrude001 = extrude(profile001, length = 20, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         revolvedCShapeWithRectangularProfile,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       // Find a sweepEdge from the revolve
@@ -709,7 +709,7 @@ extrude001 = extrude(profile001, length = 20, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         extrudedTriangle,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const selection = createSelectionFromArtifacts(
         [[...artifactGraph.values()].find((a) => a.type === 'sweepEdge')!],
@@ -739,7 +739,7 @@ extrude001 = extrude(profile001, length = 20, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         extrudedTriangle,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const sweep = [...artifactGraph.values()].find((a) => a.type === 'sweep')
       expect(sweep).toBeDefined()
@@ -784,7 +784,7 @@ chamfer001 = chamfer(extrude001, tags = edge001, length = 1)`
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         extrudedTriangle,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const sweepEdge = [...artifactGraph.values()].find(
         (a) => a.type === 'sweepEdge'
@@ -839,7 +839,7 @@ chamfer001 = chamfer(
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         extrudedTriangle,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const selection = createSelectionFromArtifacts(
         [[...artifactGraph.values()].find((a) => a.type === 'sweepEdge')!],
@@ -886,7 +886,7 @@ chamfer001 = chamfer(
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         extrudedTriangle,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const selection = createSelectionFromArtifacts(
         [[...artifactGraph.values()].find((a) => a.type === 'sweepEdge')!],
@@ -938,7 +938,7 @@ ${extrudedTriangle}`
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const sweepEdge = [...artifactGraph.values()].find(
         (a) => a.type === 'sweepEdge'
@@ -981,7 +981,7 @@ ${extrudedTriangle}`
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         extrudedTriangleWithChamfer,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const selection = createSelectionFromArtifacts(
         [[...artifactGraph.values()].find((a) => a.type === 'sweepEdge')!],
@@ -1015,7 +1015,7 @@ ${extrudedTriangle}`
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         twoExtrudedTriangles,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       // Get all sweep artifacts (bodies)
@@ -1070,7 +1070,7 @@ ${extrudedTriangle}`
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         revolvedCShapeWithRectangularProfile,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       // Find a sweepEdge from the revolve
@@ -1112,7 +1112,7 @@ ${extrudedTriangle}`
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         twoSurfacesForBlend,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const segments = [...artifactGraph.values()].filter(
@@ -1145,7 +1145,7 @@ ${extrudedTriangle}`
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         twoSurfacesForBlend,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const sweeps = [...artifactGraph.values()].filter(
@@ -1200,7 +1200,7 @@ ${extrudedTriangle}`
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         sketchSolveSurfacesForBlend,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const sweeps = [...artifactGraph.values()].filter(
@@ -1274,7 +1274,7 @@ ${extrudedTriangle}`
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         sketchSolveSweepEdgesAcrossExtrudesForBlend,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const sweeps = [...artifactGraph.values()].filter(
@@ -1399,7 +1399,7 @@ surface001 = flipSurface(extrude002)
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const sweeps = [...artifactGraph.values()].filter(
@@ -1453,7 +1453,7 @@ surface001 = flipSurface(extrude002)
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         sketchSolveSurfacesForBlend,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const sweeps = [...artifactGraph.values()].filter(
@@ -1507,7 +1507,7 @@ surface001 = flipSurface(extrude002)
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         sketchSolveSurfacesForBlend,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const sweeps = [...artifactGraph.values()].filter(
@@ -1561,7 +1561,7 @@ surface001 = flipSurface(extrude002)
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         twoSurfacesForBlend,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const singleEdge = [...artifactGraph.values()].find(
@@ -1588,16 +1588,16 @@ surface001 = flipSurface(extrude002)
     edgeTreatmentSnippet: string,
     expectedCode: string,
     instance: ModuleType,
-    kclManager: KclManager
+    executingEditor: ExecutingEditor
   ) => {
     // parse ast
     const ast = assertParse(code, instance)
 
     // update artifact graph
-    await kclManager.executeAst({ ast })
-    const artifactGraph = kclManager.artifactGraph
+    await executingEditor.executeAst({ ast })
+    const artifactGraph = executingEditor.artifactGraph
 
-    expect(kclManager.errors).toEqual([])
+    expect(executingEditor.errors).toEqual([])
 
     // define snippet range
     const edgeTreatmentRange = topLevelRange(
@@ -1671,7 +1671,7 @@ extrude001 = extrude(sketch001, length = -15)`
             edgeTreatmentSnippet,
             expectedCode,
             instanceInThisFile,
-            kclManagerInThisFile
+            executingEditorInThisFile
           )
         }, 10_000)
         it(`should delete a standalone assigned ${edgeTreatmentType} from a single segment`, async () => {
@@ -1699,7 +1699,7 @@ extrude001 = extrude(sketch001, length = -15)`
             edgeTreatmentSnippet,
             expectedCode,
             instanceInThisFile,
-            kclManagerInThisFile
+            executingEditorInThisFile
           )
         }, 10_000)
         it(`should delete a standalone ${edgeTreatmentType} without assignment from a single segment`, async () => {
@@ -1727,7 +1727,7 @@ extrude001 = extrude(sketch001, length = -15)`
             edgeTreatmentSnippet,
             expectedCode,
             instanceInThisFile,
-            kclManagerInThisFile
+            executingEditorInThisFile
           )
         }, 10_000)
         // getOppositeEdge and getNextAdjacentEdge cases
@@ -1756,7 +1756,7 @@ extrude001 = extrude(sketch001, length = -15)`
             edgeTreatmentSnippet,
             expectedCode,
             instanceInThisFile,
-            kclManagerInThisFile
+            executingEditorInThisFile
           )
         }, 10_000)
         it(`should delete a non-piped ${edgeTreatmentType} tagged with getNextAdjacentEdge`, async () => {
@@ -1784,7 +1784,7 @@ extrude001 = extrude(sketch001, length = -15)`
             edgeTreatmentSnippet,
             expectedCode,
             instanceInThisFile,
-            kclManagerInThisFile
+            executingEditorInThisFile
           )
         }, 10_000)
         // cases with several edge treatments
@@ -1819,7 +1819,7 @@ chamfer001 = chamfer(extrude001, length = 5, tags = [getOppositeEdge(seg01)])`
             edgeTreatmentSnippet,
             expectedCode,
             instanceInThisFile,
-            kclManagerInThisFile
+            executingEditorInThisFile
           )
         }, 10_000)
         it(`should delete a non-piped ${edgeTreatmentType} from a body with multiple treatments`, async () => {
@@ -1853,7 +1853,7 @@ chamfer001 = chamfer(extrude001, length = 5, tags = [getOppositeEdge(seg01)])`
             edgeTreatmentSnippet,
             expectedCode,
             instanceInThisFile,
-            kclManagerInThisFile
+            executingEditorInThisFile
           )
         }, 10_000)
         // Revolve-specific test
@@ -1892,7 +1892,7 @@ revolve001 = revolve(
             edgeTreatmentSnippet,
             expectedCode,
             instanceInThisFile,
-            kclManagerInThisFile
+            executingEditorInThisFile
           )
         }, 10_000)
         // Test deletion of geometrically impossible edge treatment

--- a/src/lang/modifyAst/faces.spec.ts
+++ b/src/lang/modifyAst/faces.spec.ts
@@ -1,4 +1,4 @@
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { createPathToNodeForLastVariable } from '@src/lang/modifyAst'
 import {
   addDeleteFace,
@@ -37,7 +37,7 @@ import { buildTheWorldAndConnectToEngine } from '@src/unitTestUtils'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 
 let instanceInThisFile: ModuleType = null!
-let kclManagerInThisFile: KclManager = null!
+let executingEditorInThisFile: ExecutingEditor = null!
 let engineCommandManagerInThisFile: ConnectionManager = null!
 let rustContextInThisFile: RustContext = null!
 
@@ -52,10 +52,10 @@ beforeEach(async () => {
     return
   }
 
-  const { instance, kclManager, engineCommandManager, rustContext } =
+  const { instance, executingEditor, engineCommandManager, rustContext } =
     await buildTheWorldAndConnectToEngine()
   instanceInThisFile = instance
-  kclManagerInThisFile = kclManager
+  executingEditorInThisFile = executingEditor
   engineCommandManagerInThisFile = engineCommandManager
   rustContextInThisFile = rustContext
 })
@@ -186,7 +186,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         cylinder,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const faces = getCapFromCylinder(artifactGraph)
       const thickness = (await stringToKclExpression(
@@ -226,7 +226,7 @@ extrude(p, length = 1000)`
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const faces = getCapFromCylinder(artifactGraph)
       const thickness = (await stringToKclExpression(
@@ -265,7 +265,7 @@ shell001 = shell(extrude001, faces = END, thickness = 1)
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const faces = getCapFromCylinder(artifactGraph)
       const thickness = (await stringToKclExpression(
@@ -297,7 +297,7 @@ shell001 = shell(extrude001, faces = END, thickness = 1)
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         box,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const faces = getWalls(artifactGraph, 2)
       const thickness = (await stringToKclExpression(
@@ -326,7 +326,7 @@ shell001 = shell(extrude001, faces = [seg01, seg02], thickness = 1)`)
         `${boxWithTwoTags}
 shell001 = shell(extrude001, faces = [seg01, seg02], thickness = 1)`,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const faces = getWalls(artifactGraph, 2)
       const thickness = (await stringToKclExpression(
@@ -357,7 +357,7 @@ shell001 = shell(extrude001, faces = [seg01, seg02], thickness = 2)`)
       const { ast, artifactGraph } = await getAstAndArtifactGraph(
         multiSolids,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const twoCaps = [...artifactGraph.values()]
         .filter((a) => a.type === 'cap' && a.subType === 'end')
@@ -404,7 +404,7 @@ extrude002 = extrude(profile002, length = 200)`
       const { ast, artifactGraph } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const firstCap = [...artifactGraph.values()]
         .filter((a) => a.type === 'cap' && a.subType === 'end')
@@ -452,7 +452,7 @@ shell001 = shell(extrude002, faces = capEnd001, thickness = 0.1)`)
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         cylinder,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const faces = getCapFromCylinder(artifactGraph)
       const result = addDeleteFace({
@@ -499,7 +499,7 @@ solid001 = subtract(extrude001, tools = extrude002)`
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const firstSweep = [...artifactGraph.values()].find(
@@ -568,7 +568,7 @@ solid001 = subtract(extrude001, tools = extrude002)`
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const firstSweep = [...artifactGraph.values()].find(
@@ -649,7 +649,7 @@ extrude001 = extrude(region001, length = 5)`
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         sketchBlockExtrude,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const wall = [...artifactGraph.values()].find((artifact) => {
@@ -725,7 +725,7 @@ extrude001 = extrude(
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const arcWall = [...artifactGraph.values()].find((artifact) => {
@@ -768,7 +768,7 @@ extrude001 = extrude(
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         bracket,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const faces = getWalls(artifactGraph, 1, 2)
       const result = addDeleteFace({
@@ -801,7 +801,7 @@ shell001 = shell(extrude001, faces = rectangleSegmentA001, thickness = 1)`
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         shell,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const wall = getWalls(artifactGraph, 1).graphSelections[0]
       const sweep = [...artifactGraph.values()].find((a) => a.type === 'sweep')
@@ -860,7 +860,7 @@ surface002 = deleteFace(loft002, faces = seg03)
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const capStart = [...artifactGraph.values()].find(
@@ -926,7 +926,7 @@ surface003 = deleteFace(loft002, faces = capStart001)`)
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         cylinder,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const face = getCapFromCylinder(artifactGraph)
       const cutAt = (await stringToKclExpression(
@@ -971,7 +971,7 @@ ${simpleHole}
         `${cylinderWithEndTag}
 ${simpleHole}`,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const face = getCapFromCylinder(artifactGraph)
       const cutAt = (await stringToKclExpression(
@@ -1023,7 +1023,7 @@ hole002 = hole::hole(
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         cylinder,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const face = getCapFromCylinder(artifactGraph)
       const cutAt = (await stringToKclExpression(
@@ -1085,7 +1085,7 @@ hole002 = hole::hole(
         `${cylinderWithEndTag}
 ${simpleHole}`,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const nodeToEdit = createPathToNodeForLastVariable(ast, false)
       const face = getCapFromCylinder(artifactGraph)
@@ -1173,7 +1173,7 @@ hole001 = hole::hole(
     const { operations } = await getAstAndArtifactGraph(
       code,
       instanceInThisFile,
-      kclManagerInThisFile
+      executingEditorInThisFile
     )
     const op = getAllOperations(operations).find(
       (o) => o.type === 'StdLibCall' && o.name === 'hole::hole'
@@ -1363,7 +1363,7 @@ shell001 = shell(extrude001, faces = END, thickness = 0.1)
       const { artifactGraph, operations } = await getAstAndArtifactGraph(
         circleProfileInVar,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const op = getAllOperations(operations).find(
         (o) => o.type === 'StdLibCall' && o.name === 'shell'
@@ -1404,7 +1404,7 @@ shell001 = shell(extrude001, faces = END, thickness = 0.1)
       const { artifactGraph, operations } = await getAstAndArtifactGraph(
         multiSolidsShell,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const lastTwoSweeps = [...artifactGraph.values()]
         .filter((a) => a.type === 'sweep')
@@ -1448,7 +1448,7 @@ plane002 = offsetPlane(plane001, offset = 2)`
       const { artifactGraph, operations } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const op = getAllOperations(operations).findLast(
         (o) => o.type === 'StdLibCall' && o.name === 'offsetPlane'
@@ -1472,7 +1472,7 @@ plane001 = offsetPlane(planeOf(extrude001, face = END), offset = 1)`
       const { artifactGraph, operations } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const op = getAllOperations(operations).find(
         (o) => o.type === 'StdLibCall' && o.name === 'offsetPlane'
@@ -1498,7 +1498,7 @@ plane002 = offsetPlane(plane001, offset = 1)`
       const { artifactGraph, operations } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const op = getAllOperations(operations).findLast(
         (o) => o.type === 'StdLibCall' && o.name === 'offsetPlane'
@@ -1522,7 +1522,7 @@ plane002 = offsetPlane(plane001, offset = 1)`
       const { artifactGraph, operations } = await getAstAndArtifactGraph(
         boxWithOneTagAndChamferAndPlane,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const op = getAllOperations(operations).find(
         (o) => o.type === 'StdLibCall' && o.name === 'offsetPlane'
@@ -1551,7 +1551,7 @@ plane001 = offsetPlane(planeOf(extrude001, face = faceId(extrude001, index = 6))
       const { artifactGraph, operations } = await getAstAndArtifactGraph(
         shellWithOffsetPlane,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const op = getAllOperations(operations).find(
         (o) => o.type === 'StdLibCall' && o.name === 'offsetPlane'
@@ -1576,7 +1576,7 @@ plane001 = offsetPlane(planeOf(extrude001, face = faceId(extrude001, index = 6))
         await getAstAndArtifactGraph(
           code,
           instanceInThisFile,
-          kclManagerInThisFile
+          executingEditorInThisFile
         )
       const offsetPlaneOp = getAllOperations(operations).findLast(
         (o) => o.type === 'StdLibCall' && o.name === 'offsetPlane'
@@ -1607,7 +1607,7 @@ plane001 = offsetPlane(planeOf(extrude001, face = faceId(extrude001, index = 6))
         const { artifactGraph, ast, variables } = await getAstAndArtifactGraph(
           '',
           instanceInThisFile,
-          kclManagerInThisFile
+          executingEditorInThisFile
         )
         const offset = (await stringToKclExpression(
           '1',
@@ -1674,7 +1674,7 @@ plane001 = offsetPlane(planeOf(extrude001, face = faceId(extrude001, index = 6))
       const { artifactGraph, ast, variables } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const offset = (await stringToKclExpression(
         '2',
@@ -1749,7 +1749,7 @@ plane002 = offsetPlane(plane001, offset = 3)`)
       const { artifactGraph, ast, variables } = await getAstAndArtifactGraph(
         cylinder,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const plane = getCapFromCylinder(artifactGraph)
       const offset = (await stringToKclExpression(
@@ -1815,7 +1815,7 @@ plane002 = offsetPlane(plane001, offset = 3)`)
       const { artifactGraph, ast, variables } = await getAstAndArtifactGraph(
         box,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const plane = getWalls(artifactGraph, 1)
       const offset = (await stringToKclExpression(
@@ -1890,7 +1890,7 @@ shell001 = shell(extrude001, faces = rectangleSegmentA001, thickness = 1)`
       const { artifactGraph, ast, variables } = await getAstAndArtifactGraph(
         shell,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const sweep = [...artifactGraph.values()].find((a) => a.type === 'sweep')
       const primitiveFace: NonCodeSelection = {
@@ -1980,7 +1980,7 @@ face001 = faceId(extrude001, index = 6)`
       const { artifactGraph, ast, variables } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const primitiveFace = [...artifactGraph.values()].find(
         (artifact) => artifact.type === 'primitiveFace'
@@ -2028,7 +2028,7 @@ plane002 = offsetPlane(plane001, offset = 2)`)
       const { artifactGraph, ast, variables } = await getAstAndArtifactGraph(
         boxWithOneTagAndChamfer,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const chamfer = [...artifactGraph.values()].find(
         (a) => a.type === 'edgeCut'
@@ -2098,7 +2098,7 @@ plane002 = offsetPlane(plane001, offset = 1)`)
       const { ast, artifactGraph } = await getAstAndArtifactGraph(
         boxWithOneTagAndChamfer,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const artifact = [...artifactGraph.values()].find(
         (a) => a.type === 'edgeCut'
@@ -2118,7 +2118,7 @@ plane002 = offsetPlane(plane001, offset = 1)`)
       const { ast, artifactGraph } = await getAstAndArtifactGraph(
         boxWithTwoTagsAndChamfer,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const artifact = [...artifactGraph.values()].find(
         (a) => a.type === 'edgeCut'

--- a/src/lang/modifyAst/gdt.spec.ts
+++ b/src/lang/modifyAst/gdt.spec.ts
@@ -1,4 +1,4 @@
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import {
   addAnnotationGdt,
   addCircularityGdt,
@@ -30,7 +30,7 @@ import { buildTheWorldAndConnectToEngine } from '@src/unitTestUtils'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 
 let instanceInThisFile: ModuleType = null!
-let kclManagerInThisFile: KclManager = null!
+let executingEditorInThisFile: ExecutingEditor = null!
 let engineCommandManagerInThisFile: ConnectionManager = null!
 let rustContextInThisFile: RustContext = null!
 
@@ -45,10 +45,10 @@ beforeEach(async () => {
     return
   }
 
-  const { instance, kclManager, engineCommandManager, rustContext } =
+  const { instance, executingEditor, engineCommandManager, rustContext } =
     await buildTheWorldAndConnectToEngine()
   instanceInThisFile = instance
-  kclManagerInThisFile = kclManager
+  executingEditorInThisFile = executingEditor
   engineCommandManagerInThisFile = engineCommandManager
   rustContextInThisFile = rustContext
 })
@@ -59,11 +59,11 @@ afterAll(() => {
 const executeCode = async (
   code: string,
   instance: ModuleType,
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
 ) => {
   const ast = assertParse(code, instance)
-  await kclManager.executeAst({ ast })
-  const artifactGraph = kclManager.artifactGraph
+  await executingEditor.executeAst({ ast })
+  const artifactGraph = executingEditor.artifactGraph
   await new Promise((resolve) => setTimeout(resolve, 100))
   return { ast, artifactGraph }
 }
@@ -155,7 +155,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         cylinder,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const faces = getCapFromCylinder(artifactGraph)
       const tolerance = await getKclCommandValue(
@@ -189,7 +189,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         box,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const faces = getWallsFromBox(artifactGraph, 3)
 
@@ -229,7 +229,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         twoBodies,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const faces = getEndCapsFromMultipleBodies(artifactGraph)
 
@@ -267,7 +267,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         box,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const walls = getWallsFromBox(artifactGraph, 3)
 
@@ -312,7 +312,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         cylinder,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const faces = getCapFromCylinder(artifactGraph)
 
@@ -366,7 +366,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         cylinder,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const faces = getCapFromCylinder(artifactGraph)
 
@@ -431,7 +431,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         twoBodies,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const faces = getEndCapsFromMultipleBodies(artifactGraph)
 
@@ -464,7 +464,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         boxWithOneTagAndChamfer,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       // Find the edgeCut artifact created by the chamfer operation
@@ -514,7 +514,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         boxWithOneTagAndFillet,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       // Find the fillet edgeCut artifact
@@ -569,7 +569,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         cylinder,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const objects = getCapFromCylinder(artifactGraph)
       const tolerance = await getKclCommandValue(
@@ -601,7 +601,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         box,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const objects = getWallsFromBox(artifactGraph, 3)
 
@@ -638,7 +638,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         box,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const face = [...artifactGraph.values()].find(
         (artifact) => artifact.type === 'cap'
@@ -679,7 +679,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         cylinder,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const objects = getCapFromCylinder(artifactGraph)
 
@@ -743,7 +743,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         cylinder,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const objects = getCapFromCylinder(artifactGraph)
       const tolerance = await getKclCommandValue(
@@ -775,7 +775,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         box,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const objects = getWallsFromBox(artifactGraph, 3)
 
@@ -812,7 +812,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         box,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const face = [...artifactGraph.values()].find(
         (artifact) => artifact.type === 'cap'
@@ -853,7 +853,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         cylinder,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const objects = getCapFromCylinder(artifactGraph)
 
@@ -917,7 +917,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         cylinder,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const objects = getCapFromCylinder(artifactGraph)
       const tolerance = await getKclCommandValue(
@@ -949,7 +949,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         box,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const objects = getWallsFromBox(artifactGraph, 3)
 
@@ -986,7 +986,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         box,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const face = [...artifactGraph.values()].find(
         (artifact) => artifact.type === 'cap'
@@ -1027,7 +1027,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         cylinder,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const objects = getCapFromCylinder(artifactGraph)
 
@@ -1091,7 +1091,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         box,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const edge = [...artifactGraph.values()].find(
         (artifact) => artifact.type === 'sweepEdge'
@@ -1143,7 +1143,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         box,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const face = [...artifactGraph.values()].find(
         (artifact) => artifact.type === 'cap'
@@ -1197,7 +1197,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         box,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const edge = [...artifactGraph.values()].find(
         (artifact) => artifact.type === 'sweepEdge'
@@ -1240,7 +1240,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         box,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const edges = [...artifactGraph.values()]
         .filter((artifact) => artifact.type === 'sweepEdge')
@@ -1284,7 +1284,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         box,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const edges = [...artifactGraph.values()]
         .filter((artifact) => artifact.type === 'sweepEdge')
@@ -1326,7 +1326,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         box,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const faces = [...artifactGraph.values()]
         .filter(
@@ -1370,7 +1370,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         box,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const face = [...artifactGraph.values()].find(
         (artifact) => artifact.type === 'cap' || artifact.type === 'wall'
@@ -1417,7 +1417,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         box,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const face = [...artifactGraph.values()].find(
         (artifact) => artifact.type === 'cap'
@@ -1471,7 +1471,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         boxWithOneTagAndChamfer,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const selections = [
         ...[...artifactGraph.values()].filter(
@@ -1523,7 +1523,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         boxWithOneTagAndChamfer,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const selections = [
         ...[...artifactGraph.values()].filter(
@@ -1564,7 +1564,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         cylinder,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const faces = getCapFromCylinder(artifactGraph)
       const name = 'A'
@@ -1593,7 +1593,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         box,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const faces = getWallsFromBox(artifactGraph, 1)
       const name = 'C'
@@ -1622,7 +1622,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         boxWithOneTagAndChamfer,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       // Find the chamfer edgeCut artifact
@@ -1668,7 +1668,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         box,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const faces = getWallsFromBox(artifactGraph, 2)
       const name = 'A'
@@ -1692,7 +1692,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         box,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const faces: Selections = { graphSelections: [], otherSelections: [] }
       const name = 'A'
@@ -1713,7 +1713,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         cylinder,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const faces = getCapFromCylinder(artifactGraph)
       const name = 'AB'
@@ -1736,7 +1736,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         cylinder,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const faces = getCapFromCylinder(artifactGraph)
       const name = ''
@@ -1758,7 +1758,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         cylinder,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const faces = getCapFromCylinder(artifactGraph)
       const name = '"'
@@ -1783,7 +1783,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { artifactGraph, ast } = await executeCode(
         cylinder,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const faces = getCapFromCylinder(artifactGraph)
       const name = 'A'

--- a/src/lang/modifyAst/gears.spec.ts
+++ b/src/lang/modifyAst/gears.spec.ts
@@ -1,4 +1,4 @@
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { createPathToNodeForLastVariable } from '@src/lang/modifyAst'
 import {
   addHelicalGear,
@@ -21,7 +21,7 @@ import { buildTheWorldAndNoEngineConnection } from '@src/unitTestUtils'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 
 let instanceInThisFile: ModuleType = null!
-let kclManagerInThisFile: KclManager = null!
+let executingEditorInThisFile: ExecutingEditor = null!
 let engineCommandManagerInThisFile: ConnectionManager = null!
 let rustContextInThisFile: RustContext = null!
 
@@ -36,10 +36,10 @@ beforeEach(async () => {
     return
   }
 
-  const { instance, kclManager, engineCommandManager, rustContext } =
+  const { instance, executingEditor, engineCommandManager, rustContext } =
     await buildTheWorldAndNoEngineConnection()
   instanceInThisFile = instance
-  kclManagerInThisFile = kclManager
+  executingEditorInThisFile = executingEditor
   engineCommandManagerInThisFile = engineCommandManager
   rustContextInThisFile = rustContext
 })
@@ -62,7 +62,7 @@ describe('gears.test.ts', () => {
       const { ast } = await getAstAndArtifactGraph(
         settings,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const result = addHelicalGear({
         ast,
@@ -97,7 +97,7 @@ gear001 = gear::helical(
       const { ast } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const result = addHelicalGear({
         ast,
@@ -127,7 +127,7 @@ gear001 = gear::helical(
       const { ast } = await getAstAndArtifactGraph(
         settings,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const result = addHerringboneGear({
         ast,
@@ -162,7 +162,7 @@ gear001 = gear::herringbone(
       const { ast } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const result = addHerringboneGear({
         ast,
@@ -192,7 +192,7 @@ gear001 = gear::herringbone(
       const { ast } = await getAstAndArtifactGraph(
         settings,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const result = addSpurGear({
         ast,
@@ -224,7 +224,7 @@ gear001 = gear::spur(
       const { ast } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const result = addSpurGear({
         ast,
@@ -252,7 +252,7 @@ gear001 = gear::spur(
       const { ast } = await getAstAndArtifactGraph(
         settings,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const result = addRingGear({
         ast,
@@ -287,7 +287,7 @@ gear001 = gear::ring(
       const { ast } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const result = addRingGear({
         ast,

--- a/src/lang/modifyAst/geometry.spec.ts
+++ b/src/lang/modifyAst/geometry.spec.ts
@@ -1,4 +1,4 @@
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { createPathToNodeForLastVariable } from '@src/lang/modifyAst'
 import { addHelix } from '@src/lang/modifyAst/geometry'
 import { recast } from '@src/lang/wasm'
@@ -18,7 +18,7 @@ import { buildTheWorldAndConnectToEngine } from '@src/unitTestUtils'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 
 let instanceInThisFile: ModuleType = null!
-let kclManagerInThisFile: KclManager = null!
+let executingEditorInThisFile: ExecutingEditor = null!
 let engineCommandManagerInThisFile: ConnectionManager = null!
 let rustContextInThisFile: RustContext = null!
 
@@ -33,10 +33,10 @@ beforeEach(async () => {
     return
   }
 
-  const { instance, kclManager, engineCommandManager, rustContext } =
+  const { instance, executingEditor, engineCommandManager, rustContext } =
     await buildTheWorldAndConnectToEngine()
   instanceInThisFile = instance
-  kclManagerInThisFile = kclManager
+  executingEditorInThisFile = executingEditor
   engineCommandManagerInThisFile = engineCommandManager
   rustContextInThisFile = rustContext
 })
@@ -57,7 +57,7 @@ describe('geometry.test.ts', () => {
       const { ast, artifactGraph } = await getAstAndArtifactGraph(
         '',
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const result = addHelix({
         ast,
@@ -99,7 +99,7 @@ describe('geometry.test.ts', () => {
       const { ast, artifactGraph } = await getAstAndArtifactGraph(
         '',
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const result = addHelix({
         ast,
@@ -148,7 +148,7 @@ describe('geometry.test.ts', () => {
       const { ast, artifactGraph } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const result = addHelix({
         ast,
@@ -205,7 +205,7 @@ helix001 = helix(
       const { ast, artifactGraph } = await getAstAndArtifactGraph(
         segmentInPath,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const segment = [...artifactGraph.values()].find(
         (n) => n.type === 'segment'
@@ -239,7 +239,7 @@ helix001 = helix(
       const { ast, artifactGraph } = await getAstAndArtifactGraph(
         helixFromSegmentInPath,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const segment = [...artifactGraph.values()].find(
         (n) => n.type === 'segment'
@@ -300,7 +300,7 @@ extrude001 = extrude(region001, length = 100)`
       const { ast, artifactGraph } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const segment = [...artifactGraph.values()].find(
         (n) => n.type === 'sweepEdge'
@@ -342,7 +342,7 @@ helix001 = helix(
       const { ast, artifactGraph } = await getAstAndArtifactGraph(
         helixFromSegmentInPath,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const segment = [...artifactGraph.values()].find(
         (n) => n.type === 'segment'
@@ -407,7 +407,7 @@ helix001 = helix(
       const { ast, artifactGraph } = await getAstAndArtifactGraph(
         cylinderExtrude,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const sweep = [...artifactGraph.values()].find((n) => n.type === 'sweep')
       const cylinder: Selections = {
@@ -444,7 +444,7 @@ helix001 = helix(
       const { ast, artifactGraph } = await getAstAndArtifactGraph(
         helixFromCylinder,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const sweep = [...artifactGraph.values()].find((n) => n.type === 'sweep')
       const cylinder: Selections = {

--- a/src/lang/modifyAst/pattern3D.spec.ts
+++ b/src/lang/modifyAst/pattern3D.spec.ts
@@ -1,4 +1,4 @@
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import {
   addPatternCircular3D,
   addPatternLinear3D,
@@ -19,7 +19,7 @@ import { buildTheWorldAndConnectToEngine } from '@src/unitTestUtils'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 
 let instanceInThisFile: ModuleType = null!
-let kclManagerInThisFile: KclManager = null!
+let executingEditorInThisFile: ExecutingEditor = null!
 let engineCommandManagerInThisFile: ConnectionManager = null!
 let rustContextInThisFile: RustContext = null!
 
@@ -34,10 +34,10 @@ beforeEach(async () => {
     return
   }
 
-  const { instance, kclManager, engineCommandManager, rustContext } =
+  const { instance, executingEditor, engineCommandManager, rustContext } =
     await buildTheWorldAndConnectToEngine()
   instanceInThisFile = instance
-  kclManagerInThisFile = kclManager
+  executingEditorInThisFile = executingEditor
   engineCommandManagerInThisFile = engineCommandManager
   rustContextInThisFile = rustContext
 })
@@ -48,15 +48,15 @@ afterAll(() => {
 async function getAstAndArtifactGraph(
   code: string,
   instance: ModuleType,
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
 ) {
   const ast = assertParse(code, instance)
-  await kclManager.executeAst({ ast })
+  await executingEditor.executeAst({ ast })
   const {
     artifactGraph,
     execState: { operations },
     variables,
-  } = kclManager
+  } = executingEditor
   await new Promise((resolve) => setTimeout(resolve, 100))
   return { ast, artifactGraph, operations, variables }
 }
@@ -91,12 +91,12 @@ describe('pattern3D.test.ts', () => {
   async function getAstAndSolidSelections(
     code: string,
     instance: ModuleType,
-    kclManager: KclManager
+    executingEditor: ExecutingEditor
   ) {
     const { ast, artifactGraph } = await getAstAndArtifactGraph(
       code,
       instance,
-      kclManager
+      executingEditor
     )
     // Filter for sweep artifacts that represent 3D solids
     const artifacts = [...artifactGraph.values()].filter(
@@ -121,7 +121,7 @@ example = extrude(exampleSketch, length = -5)
       const { ast, selections, artifactGraph } = await getAstAndSolidSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const result = addPatternCircular3D({
@@ -164,7 +164,7 @@ example = extrude(exampleSketch, length = -5)
       const { ast, selections, artifactGraph } = await getAstAndSolidSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const result = addPatternCircular3D({
@@ -205,7 +205,7 @@ example = extrude(exampleSketch, length = -5)
       const { ast, selections, artifactGraph } = await getAstAndSolidSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const result = addPatternCircular3D({
@@ -245,7 +245,7 @@ example = extrude(exampleSketch, length = -5)
       const { ast, selections, artifactGraph } = await getAstAndSolidSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const result = addPatternCircular3D({
@@ -292,7 +292,7 @@ example = extrude(exampleSketch, length = -5)
       const { ast, selections, artifactGraph } = await getAstAndSolidSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const result = addPatternCircular3D({
@@ -332,7 +332,7 @@ example = extrude(exampleSketch, length = -5)
       const { ast, selections, artifactGraph } = await getAstAndSolidSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const result = addPatternCircular3D({
@@ -379,7 +379,7 @@ example = extrude(exampleSketch, length = -5)
       const { ast, selections, artifactGraph } = await getAstAndSolidSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const result = addPatternCircular3D({
@@ -430,7 +430,7 @@ example = extrude(exampleSketch, length = -5)
       const { ast, selections, artifactGraph } = await getAstAndSolidSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       // Test the precedence by creating a mock axis that simulates the edge case
@@ -485,7 +485,7 @@ exampleSketch = startSketchOn(XZ)
       const { ast, selections, artifactGraph } = await getAstAndSolidSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const result = addPatternCircular3D({
@@ -528,7 +528,7 @@ startSketchOn(XY)
       const { ast, selections, artifactGraph } = await getAstAndSolidSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const result = addPatternCircular3D({
@@ -569,7 +569,7 @@ extrude(exampleSketch, length = -5)
       const { ast, selections, artifactGraph } = await getAstAndSolidSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const result = addPatternCircular3D({
@@ -611,7 +611,7 @@ example = extrude(exampleSketch, length = -5)
       const { ast, selections, artifactGraph } = await getAstAndSolidSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const result = addPatternLinear3D({
@@ -650,7 +650,7 @@ example = extrude(exampleSketch, length = -5)
       const { ast, selections, artifactGraph } = await getAstAndSolidSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const result = addPatternLinear3D({
@@ -689,7 +689,7 @@ example = extrude(exampleSketch, length = -5)
       const { ast, selections, artifactGraph } = await getAstAndSolidSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const result = addPatternLinear3D({
@@ -727,7 +727,7 @@ example = extrude(exampleSketch, length = -5)
       const { ast, selections, artifactGraph } = await getAstAndSolidSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const result = addPatternLinear3D({
@@ -770,7 +770,7 @@ example = extrude(exampleSketch, length = -5)
       const { ast, selections, artifactGraph } = await getAstAndSolidSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const result = addPatternLinear3D({
@@ -810,7 +810,7 @@ example = extrude(exampleSketch, length = -5)
       const { ast, selections, artifactGraph } = await getAstAndSolidSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const result = addPatternLinear3D({
@@ -851,7 +851,7 @@ example = extrude(exampleSketch, length = -5)
       const { ast, selections, artifactGraph } = await getAstAndSolidSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const result = addPatternLinear3D({
@@ -897,7 +897,7 @@ example = extrude(exampleSketch, length = -5)
       const { ast, selections, artifactGraph } = await getAstAndSolidSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       // Test the precedence by creating a mock axis that simulates the edge case
@@ -952,7 +952,7 @@ exampleSketch = startSketchOn(XZ)
       const { ast, selections, artifactGraph } = await getAstAndSolidSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const result = addPatternLinear3D({
@@ -995,7 +995,7 @@ startSketchOn(XY)
       const { ast, selections, artifactGraph } = await getAstAndSolidSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const result = addPatternLinear3D({
@@ -1036,7 +1036,7 @@ extrude(exampleSketch, length = -5)
       const { ast, selections, artifactGraph } = await getAstAndSolidSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const result = addPatternLinear3D({

--- a/src/lang/modifyAst/surfaces.spec.ts
+++ b/src/lang/modifyAst/surfaces.spec.ts
@@ -1,4 +1,4 @@
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { addFlipSurface, addJoinSurfaces } from '@src/lang/modifyAst/surfaces'
 import { type Artifact, recast } from '@src/lang/wasm'
 import type RustContext from '@src/lib/rustContext'
@@ -16,7 +16,7 @@ import { buildTheWorldAndConnectToEngine } from '@src/unitTestUtils'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 
 let instanceInThisFile: ModuleType = null!
-let kclManagerInThisFile: KclManager = null!
+let executingEditorInThisFile: ExecutingEditor = null!
 let engineCommandManagerInThisFile: ConnectionManager = null!
 let rustContextInThisFile: RustContext = null!
 
@@ -31,10 +31,10 @@ beforeEach(async () => {
     return
   }
 
-  const { instance, kclManager, engineCommandManager, rustContext } =
+  const { instance, executingEditor, engineCommandManager, rustContext } =
     await buildTheWorldAndConnectToEngine()
   instanceInThisFile = instance
-  kclManagerInThisFile = kclManager
+  executingEditorInThisFile = executingEditor
   engineCommandManagerInThisFile = engineCommandManager
   rustContextInThisFile = rustContext
 })
@@ -52,7 +52,7 @@ extrude001 = extrude(profile001, length = 1, bodyType = SURFACE)`
       const { ast, artifactGraph } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const artifact = [...artifactGraph.values()].find(
         (n) => n.type === 'path'
@@ -129,7 +129,7 @@ surface001 = joinSurfaces([blend001, blend002])`
       const { ast, artifactGraph } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const selectedSurface = [...artifactGraph.values()].find(
         (artifact) => artifact.type === 'compositeSolid'
@@ -167,7 +167,7 @@ extrude002 = extrude(profile002, length = 1, bodyType = SURFACE)`
       const { ast, artifactGraph } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const pathArtifacts = [...artifactGraph.values()].filter(
@@ -320,7 +320,7 @@ blend005 = blend([
       const { ast, artifactGraph } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       const blendArtifacts = [...artifactGraph.values()]

--- a/src/lang/modifyAst/sweeps.spec.ts
+++ b/src/lang/modifyAst/sweeps.spec.ts
@@ -1,5 +1,5 @@
 import type { Node } from '@rust/kcl-lib/bindings/Node'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { mockExecAstAndReportErrors } from '@src/lang/modelingWorkflows'
 import { createPathToNodeForLastVariable } from '@src/lang/modifyAst'
 import { getAxisExpression } from '@src/lang/modifyAst/geometry'
@@ -42,7 +42,7 @@ import {
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 
 let instanceInThisFile: ModuleType = null!
-let kclManagerInThisFile: KclManager = null!
+let executingEditorInThisFile: ExecutingEditor = null!
 let engineCommandManagerInThisFile: ConnectionManager = null!
 let rustContextInThisFile: RustContext = null!
 
@@ -57,10 +57,10 @@ beforeEach(async () => {
     return
   }
 
-  const { instance, kclManager, engineCommandManager, rustContext } =
+  const { instance, executingEditor, engineCommandManager, rustContext } =
     await buildTheWorldAndConnectToEngine()
   instanceInThisFile = instance
-  kclManagerInThisFile = kclManager
+  executingEditorInThisFile = executingEditor
   engineCommandManagerInThisFile = engineCommandManager
   rustContextInThisFile = rustContext
 })
@@ -125,7 +125,7 @@ profile002 = rectangle(
       const { ast, sketches, artifactGraph } = await getAstAndSketchSelections(
         circleProfileCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const length = await getKclCommandValue(
         '1',
@@ -152,7 +152,7 @@ profile002 = rectangle(
       const { ast, artifactGraph } = await getAstAndSketchSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const endCap = [...artifactGraph.values()].findLast(
         (a) => a.type === 'cap'
@@ -191,7 +191,7 @@ extrude001 = extrude(profile001, length = 2)`
       const { ast, artifactGraph } = await getAstAndSketchSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const endWall = [...artifactGraph.values()].findLast(
         (a) => a.type === 'wall'
@@ -342,7 +342,7 @@ extrude001 = extrude(profile002, length = 1)
       const { ast, artifactGraph } = await getAstAndSketchSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const profile = [...artifactGraph.values()].find(
         (a) => a.type === 'solid2d'
@@ -388,7 +388,7 @@ extrude002 = extrude([capEnd001, profile001], length = 1)`)
       const { ast, sketches, artifactGraph } = await getAstAndSketchSelections(
         circleProfileCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const length = await getKclCommandValue(
         '1',
@@ -416,7 +416,7 @@ extrude002 = extrude([capEnd001, profile001], length = 1)`)
       const { ast, sketches, artifactGraph } = await getAstAndSketchSelections(
         circleProfileCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const length = await getKclCommandValue(
         '10',
@@ -458,7 +458,7 @@ extrude002 = extrude([capEnd001, profile001], length = 1)`)
       const { ast, sketches, artifactGraph } = await getAstAndSketchSelections(
         circleProfileCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const length = await getKclCommandValue(
         '10',
@@ -522,7 +522,7 @@ extrude001 = extrude(profile001, length = 2, symmetric = false)`)
       const { ast, sketches, artifactGraph } = await getAstAndSketchSelections(
         circleProfileCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const length = await getKclCommandValue(
         '1',
@@ -550,7 +550,7 @@ extrude001 = extrude(profile001, length = 2, symmetric = false)`)
       const { ast, sketches, artifactGraph } = await getAstAndSketchSelections(
         circleProfileCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const length = await getKclCommandValue(
         '1',
@@ -578,7 +578,7 @@ extrude001 = extrude(profile001, length = 2, symmetric = false)`)
       const { ast, sketches, artifactGraph } = await getAstAndSketchSelections(
         circleProfileCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const length = await getKclCommandValue(
         '1',
@@ -606,7 +606,7 @@ extrude001 = extrude(profile001, length = 2, symmetric = false)`)
       const { ast, artifactGraph } = await getAstAndSketchSelections(
         triangleRegion,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const segment = createSelectionFromArtifacts(
         artifactGraph
@@ -642,7 +642,7 @@ extrude001 = extrude([s.line1, s.line2], length = 1, bodyType = SURFACE)`
       const { ast, sketches, artifactGraph } = await getAstAndSketchSelections(
         circleProfileCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const length = await getKclCommandValue(
         '1',
@@ -681,7 +681,7 @@ profile002 = circle(sketch002, center = [0, 0], radius = 0.1)`
       const { ast, artifactGraph, sketches } = await getAstAndSketchSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         1
       )
       const to = getWalls(artifactGraph, 1)
@@ -718,7 +718,7 @@ profile002 = circle(sketch002, center = [0, 0], radius = 0.1)`
       const { ast, artifactGraph, sketches } = await getAstAndSketchSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         1
       )
       const to = getWalls(artifactGraph, 1)
@@ -759,7 +759,7 @@ profile002 = circle(sketch002, center = [0, 0], radius = 0.1)`
       const { ast, artifactGraph, sketches } = await getAstAndSketchSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         1
       )
       const to = getCapFromCylinder(artifactGraph)
@@ -790,7 +790,7 @@ extrude002 = extrude(profile002, to = capEnd001)`)
       const { ast, sketches, artifactGraph } = await getAstAndSketchSelections(
         circleProfileCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const length = await getKclCommandValue(
         '10',
@@ -858,7 +858,7 @@ profile002 = circle(sketch002, center = [0, 0], radius = 0.1)`
       const { ast, artifactGraph, sketches } = await getAstAndSketchSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         1
       )
       const to = createSelectionFromArtifacts(
@@ -911,12 +911,12 @@ profile002 = startProfile(sketch002, at = [0, 0])
     async function getAstAndSketchesForSweep(
       code: string,
       instance: ModuleType,
-      kclManager: KclManager
+      executingEditor: ExecutingEditor
     ) {
       const { ast, artifactGraph } = await getAstAndArtifactGraph(
         code,
         instance,
-        kclManager
+        executingEditor
       )
       const artifact1 = [...artifactGraph.values()].find(
         (a) => a.type === 'path'
@@ -938,7 +938,7 @@ profile002 = startProfile(sketch002, at = [0, 0])
         await getAstAndSketchesForSweep(
           circleAndLineCode,
           instanceInThisFile,
-          kclManagerInThisFile
+          executingEditorInThisFile
         )
       const result = addSweep({
         ast,
@@ -1159,7 +1159,7 @@ sweep001 = sweep(region001, path = profile001, sectional = true)`
         await getAstAndSketchesForSweep(
           circleAndLineCode,
           instanceInThisFile,
-          kclManagerInThisFile
+          executingEditorInThisFile
         )
       const result = addSweep({
         ast,
@@ -1189,7 +1189,7 @@ s2 = sketch(on = XZ) {
       const { ast, artifactGraph } = await getAstAndSketchSelections(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const segment = createSelectionFromArtifacts(
         [artifactGraph.values().find((a) => a.type === 'segment')!],
@@ -1224,7 +1224,7 @@ s2 = sketch(on = XZ) {
         await getAstAndSketchesForSweep(
           circleAndLineCode,
           instanceInThisFile,
-          kclManagerInThisFile
+          executingEditorInThisFile
         )
       const sectional = true
       const relativeTo = 'SKETCH_PLANE'
@@ -1261,7 +1261,7 @@ sweep001 = sweep(
         await getAstAndSketchesForSweep(
           circleAndLineCodeWithSweep,
           instanceInThisFile,
-          kclManagerInThisFile
+          executingEditorInThisFile
         )
       const sectional = false
       const relativeTo = 'TRAJECTORY'
@@ -1306,7 +1306,7 @@ profile003 = startProfile(sketch002, at = [0, 0])
       const { ast, artifactGraph } = await getAstAndArtifactGraph(
         circleAndLineAndRectProfilesCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const artifacts = [...artifactGraph.values()].filter(
         (a) => a.type === 'path'
@@ -1350,7 +1350,7 @@ profile002 = circle(sketch002, center = [0, 0], radius = 20)
       const { ast, artifactGraph, sketches } = await getAstAndSketchSelections(
         twoCirclesCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       expect(sketches.graphSelections).toHaveLength(2)
       const result = addLoft({
@@ -1430,7 +1430,7 @@ t = sketch(on = plane001) {
       const { operations } = await getAstAndArtifactGraph(
         newCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const loft = getAllOperations(operations).find(
         (op) => op.type === 'StdLibCall' && op.name === 'loft'
@@ -1490,7 +1490,7 @@ loft001 = loft([region001, region002])`
       const { ast, artifactGraph, sketches } = await getAstAndSketchSelections(
         twoCirclesCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       expect(sketches.graphSelections).toHaveLength(2)
       const result = addLoft({
@@ -1564,7 +1564,7 @@ profile002 = startProfile(sketch002, at = [-0.75, -3.04])
       const { ast, artifactGraph, sketches } = await getAstAndSketchSelections(
         openPaths,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       expect(sketches.graphSelections).toHaveLength(2)
       const result = addLoft({
@@ -1588,7 +1588,7 @@ profile002 = startProfile(sketch002, at = [-0.75, -3.04])
       const { ast, artifactGraph, sketches } = await getAstAndSketchSelections(
         twoCirclesCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       expect(sketches.graphSelections).toHaveLength(2)
       const result = addLoft({
@@ -1613,7 +1613,7 @@ loft001 = loft([profile001, profile002])`
       const { ast, artifactGraph, sketches } = await getAstAndSketchSelections(
         twoCirclesCodeWithLoft,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       expect(sketches.graphSelections).toHaveLength(2)
       const vDegree = await getKclCommandValue(
@@ -1648,7 +1648,7 @@ profile001 = circle(sketch001, center = [3, 0], radius = 1)`
       const { ast, artifactGraph, sketches } = await getAstAndSketchSelections(
         circleCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       expect(sketches.graphSelections).toHaveLength(1)
       const angle = await getKclCommandValue(
@@ -1759,7 +1759,7 @@ revolve001 = revolve(region001, angle = 10, axis = X)`
       const { ast, artifactGraph, sketches } = await getAstAndSketchSelections(
         circleCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       expect(sketches.graphSelections).toHaveLength(1)
       const angle = await getKclCommandValue(
@@ -1795,7 +1795,7 @@ revolve001 = revolve(region001, angle = 10, axis = X)`
       const { ast, artifactGraph } = await getAstAndSketchSelections(
         triangleRegion,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const segment = createSelectionFromArtifacts(
         [artifactGraph.values().find((a) => a.type === 'segment')!],
@@ -1831,7 +1831,7 @@ revolve001 = revolve(
       const { ast, artifactGraph, sketches } = await getAstAndSketchSelections(
         circleCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       expect(sketches.graphSelections).toHaveLength(1)
       const angle = await getKclCommandValue(
@@ -1866,7 +1866,7 @@ revolve001 = revolve(
       const { ast, artifactGraph, sketches } = await getAstAndSketchSelections(
         circleCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       expect(sketches.graphSelections).toHaveLength(1)
       const angle = await getKclCommandValue(
@@ -1901,7 +1901,7 @@ revolve001 = revolve(
       const { ast, artifactGraph, sketches } = await getAstAndSketchSelections(
         circleAndRectProfilesCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const angle = await getKclCommandValue(
         '10',
@@ -1940,7 +1940,7 @@ sketch002 = startSketchOn(extrude001, face = rectangleSegmentA001)
       const { ast, artifactGraph } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const artifacts = [...artifactGraph.values()]
       const circleArtifact = artifacts.findLast((a) => a.type === 'path')
@@ -1988,7 +1988,7 @@ sketch002 = startSketchOn(XY)
       const { ast, artifactGraph } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const artifacts = [...artifactGraph.values()]
       const circleArtifact = artifacts.findLast((a) => a.type === 'path')
@@ -2158,7 +2158,7 @@ revolve001 = revolve(profile001, angle = 10, axis = X)`
 profile001 = startProfile(sketch001, at = [0, 0])
   |> xLine(length = 1)`,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const edgeArtifact = [...artifactGraph.values()].find(
         (a) => a.type === 'segment'

--- a/src/lang/modifyAst/tagManagement.spec.ts
+++ b/src/lang/modifyAst/tagManagement.spec.ts
@@ -1,4 +1,4 @@
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { modifyAstWithTagsForSelection } from '@src/lang/modifyAst/tagManagement'
 import { type ArtifactGraph, assertParse, recast } from '@src/lang/wasm'
 import { err } from '@src/lib/trap'
@@ -9,7 +9,7 @@ import { buildTheWorldAndConnectToEngine } from '@src/unitTestUtils'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 
 let instanceInThisFile: ModuleType = null!
-let kclManagerInThisFile: KclManager = null!
+let executingEditorInThisFile: ExecutingEditor = null!
 let engineCommandManagerInThisFile: ConnectionManager = null!
 
 /**
@@ -23,10 +23,10 @@ beforeEach(async () => {
     return
   }
 
-  const { instance, kclManager, engineCommandManager } =
+  const { instance, executingEditor, engineCommandManager } =
     await buildTheWorldAndConnectToEngine()
   instanceInThisFile = instance
-  kclManagerInThisFile = kclManager
+  executingEditorInThisFile = executingEditor
   engineCommandManagerInThisFile = engineCommandManager
 })
 afterAll(() => {
@@ -36,11 +36,11 @@ afterAll(() => {
 const executeCode = async (
   code: string,
   instance: ModuleType,
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
 ) => {
   const ast = assertParse(code, instance)
-  await kclManager.executeAst({ ast })
-  const artifactGraph = kclManager.artifactGraph
+  await executingEditor.executeAst({ ast })
+  const artifactGraph = executingEditor.artifactGraph
   await new Promise((resolve) => setTimeout(resolve, 100))
   return { ast, artifactGraph }
 }
@@ -172,7 +172,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { ast, artifactGraph } = await executeCode(
         basicExampleCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       // Find an edge artifact
       const selectionResult = await createSelectionWithFirstMatchingArtifact(
@@ -204,7 +204,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { ast, artifactGraph } = await executeCode(
         basicExampleCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       // Find an edge artifact
       const selectionResult = await createSelectionWithFirstMatchingArtifact(
@@ -236,7 +236,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { ast, artifactGraph } = await executeCode(
         basicExampleCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       // Find an edge artifact
       const selectionResult = await createSelectionWithFirstMatchingArtifact(
@@ -269,7 +269,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { ast, artifactGraph } = await executeCode(
         basicExampleCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       // Find an edge artifact
       const selectionResult = await createSelectionWithFirstMatchingArtifact(
@@ -301,7 +301,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { ast, artifactGraph } = await executeCode(
         basicExampleCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       // Find an edge artifact
       const selectionResult = await createSelectionWithFirstMatchingArtifact(
@@ -332,7 +332,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { ast, artifactGraph } = await executeCode(
         basicExampleCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       // Find an edge artifact
       const selectionResult = await createSelectionWithFirstMatchingArtifact(
@@ -366,7 +366,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { ast, artifactGraph } = await executeCode(
         basicExampleCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       // Find a wall face artifact
       const wallArtifact = [...artifactGraph.values()].find(
@@ -403,7 +403,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { ast, artifactGraph } = await executeCode(
         basicExampleCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       // Find a cap face artifact
       const selectionResult = await createSelectionWithFirstMatchingArtifact(
@@ -438,7 +438,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { ast, artifactGraph } = await executeCode(
         boxWithOneTagAndChamfer,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       // Find an edgeCut face artifact (created by chamfer)
       const selectionResult = await createSelectionWithFirstMatchingArtifact(
@@ -472,7 +472,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { ast, artifactGraph } = await executeCode(
         boxWithOneTagAndChamfer,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       // Find the chamfer edgeCut artifact
@@ -505,7 +505,7 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
       const { ast, artifactGraph } = await executeCode(
         boxWithOneTagAndFillet,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
 
       // Find the fillet edgeCut artifact

--- a/src/lang/modifyAst/transforms.spec.ts
+++ b/src/lang/modifyAst/transforms.spec.ts
@@ -1,4 +1,4 @@
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import {
   addAppearance,
   addClone,
@@ -37,7 +37,7 @@ import { buildTheWorldAndConnectToEngine } from '@src/unitTestUtils'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 
 let instanceInThisFile: ModuleType = null!
-let kclManagerInThisFile: KclManager = null!
+let executingEditorInThisFile: ExecutingEditor = null!
 let engineCommandManagerInThisFile: ConnectionManager = null!
 let rustContextInThisFile: RustContext = null!
 
@@ -52,10 +52,10 @@ beforeEach(async () => {
     return
   }
 
-  const { instance, kclManager, engineCommandManager, rustContext } =
+  const { instance, executingEditor, engineCommandManager, rustContext } =
     await buildTheWorldAndConnectToEngine()
   instanceInThisFile = instance
-  kclManagerInThisFile = kclManager
+  executingEditorInThisFile = executingEditor
   engineCommandManagerInThisFile = engineCommandManager
   rustContextInThisFile = rustContext
 })
@@ -282,14 +282,14 @@ extrude001 = extrude([region001, region002], length = 1)`
     async function runAddTranslateTest(
       code: string,
       instance: ModuleType,
-      kclManager: KclManager,
+      executingEditor: ExecutingEditor,
       rustContext: RustContext
     ) {
       const {
         artifactGraph,
         ast,
         sketches: objects,
-      } = await getAstAndSketchSelections(code, instance, kclManager)
+      } = await getAstAndSketchSelections(code, instance, executingEditor)
       const result = addTranslate({
         ast,
         artifactGraph,
@@ -319,7 +319,7 @@ extrude001 = extrude(profile001, length = 1)`
       const newCode = await runAddTranslateTest(
         code,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         rustContextInThisFile
       )
       expect(newCode).toContain(code + '\n' + expectedNewLine)
@@ -338,7 +338,7 @@ extrude001 = extrude(profile001, length = 1)`
       const newCode = await runAddTranslateTest(
         code,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         rustContextInThisFile
       )
       expect(newCode).toContain(code + '\n' + expectedNewLine)
@@ -377,7 +377,7 @@ split001 = split(extrude001, tools = extrude002)`
       const { artifactGraph, ast } = await getAstAndArtifactGraph(
         code,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const splitOutput = [...artifactGraph.values()].find(
         (artifact) =>
@@ -417,14 +417,14 @@ split001 = split(extrude001, tools = extrude002)`
       code: string,
       nodeToEdit: PathToNode,
       instance: ModuleType,
-      kclManager: KclManager,
+      executingEditor: ExecutingEditor,
       rustContext: RustContext
     ) {
       const {
         artifactGraph,
         ast,
         sketches: objects,
-      } = await getAstAndSketchSelections(code, instance, kclManager)
+      } = await getAstAndSketchSelections(code, instance, executingEditor)
       const result = addTranslate({
         ast,
         artifactGraph,
@@ -471,7 +471,7 @@ translate(
         code,
         nodeToEdit,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         rustContextInThisFile
       )
       expect(newCode).toContain(expectedNewCode)
@@ -508,7 +508,7 @@ translate(
         code,
         nodeToEdit,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         rustContextInThisFile
       )
       expect(newCode).toContain(expectedNewCode)
@@ -519,14 +519,14 @@ translate(
     async function runAddScaleTest(
       code: string,
       instance: ModuleType,
-      kclManager: KclManager,
+      executingEditor: ExecutingEditor,
       rustContext: RustContext
     ) {
       const {
         artifactGraph,
         ast,
         sketches: objects,
-      } = await getAstAndSketchSelections(code, instance, kclManager)
+      } = await getAstAndSketchSelections(code, instance, executingEditor)
       const result = addScale({
         ast,
         artifactGraph,
@@ -556,7 +556,7 @@ extrude001 = extrude(profile001, length = 1)`
       const newCode = await runAddScaleTest(
         code,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         rustContextInThisFile
       )
       expect(newCode).toContain(code + '\n' + expectedNewLine)
@@ -575,7 +575,7 @@ extrude001 = extrude(profile001, length = 1)`
       const newCode = await runAddScaleTest(
         code,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         rustContextInThisFile
       )
       expect(newCode).toContain(code + '\n' + expectedNewLine)
@@ -595,7 +595,7 @@ scale(extrude001, factor = 2)`
       } = await getAstAndSketchSelections(
         cylinderCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const result = addScale({
         ast,
@@ -622,7 +622,7 @@ scale(extrude001, factor = 2)`
       } = await getAstAndSketchSelections(
         scaledCylinderCode,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const nodeToEdit: PathToNode = [
         ['body', ''],
@@ -654,14 +654,14 @@ scale(extrude001, factor = 2)`
       code: string,
       nodeToEdit: PathToNode,
       instance: ModuleType,
-      kclManager: KclManager,
+      executingEditor: ExecutingEditor,
       rustContext: RustContext
     ) {
       const {
         artifactGraph,
         ast,
         sketches: objects,
-      } = await getAstAndSketchSelections(code, instance, kclManager)
+      } = await getAstAndSketchSelections(code, instance, executingEditor)
       const result = addScale({
         ast,
         artifactGraph,
@@ -708,7 +708,7 @@ scale(
         code,
         nodeToEdit,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         rustContextInThisFile
       )
       expect(newCode).toContain(expectedNewCode)
@@ -745,7 +745,7 @@ scale(
         code,
         nodeToEdit,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         rustContextInThisFile
       )
       expect(newCode).toContain(expectedNewCode)
@@ -758,14 +758,14 @@ scale(
     async function runAddRotateTest(
       code: string,
       instance: ModuleType,
-      kclManager: KclManager,
+      executingEditor: ExecutingEditor,
       rustContext: RustContext
     ) {
       const {
         artifactGraph,
         ast,
         sketches: objects,
-      } = await getAstAndSketchSelections(code, instance, kclManager)
+      } = await getAstAndSketchSelections(code, instance, executingEditor)
       const result = addRotate({
         ast,
         artifactGraph,
@@ -795,7 +795,7 @@ extrude001 = extrude(profile001, length = 1)`
       const newCode = await runAddRotateTest(
         code,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         rustContextInThisFile
       )
       expect(newCode).toContain(code + '\n' + expectedNewLine)
@@ -814,7 +814,7 @@ extrude001 = extrude(profile001, length = 1)`
       const newCode = await runAddRotateTest(
         code,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         rustContextInThisFile
       )
       expect(newCode).toContain(code + '\n' + expectedNewLine)
@@ -824,14 +824,14 @@ extrude001 = extrude(profile001, length = 1)`
       code: string,
       nodeToEdit: PathToNode,
       instance: ModuleType,
-      kclManager: KclManager,
+      executingEditor: ExecutingEditor,
       rustContext: RustContext
     ) {
       const {
         artifactGraph,
         ast,
         sketches: objects,
-      } = await getAstAndSketchSelections(code, instance, kclManager)
+      } = await getAstAndSketchSelections(code, instance, executingEditor)
       const result = addRotate({
         ast,
         artifactGraph,
@@ -878,7 +878,7 @@ rotate(
         code,
         nodeToEdit,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         rustContextInThisFile
       )
       expect(newCode).toContain(expectedNewCode)
@@ -915,7 +915,7 @@ rotate(
         code,
         nodeToEdit,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         rustContextInThisFile
       )
       expect(newCode).toContain(expectedNewCode)
@@ -928,14 +928,14 @@ rotate(
     async function runAddCloneTest(
       code: string,
       instance: ModuleType,
-      kclManager: KclManager,
+      executingEditor: ExecutingEditor,
       rustContext: RustContext
     ) {
       const {
         artifactGraph,
         ast,
         sketches: objects,
-      } = await getAstAndSketchSelections(code, instance, kclManager)
+      } = await getAstAndSketchSelections(code, instance, executingEditor)
       const result = addClone({
         ast,
         artifactGraph,
@@ -956,7 +956,7 @@ extrude001 = extrude(profile001, length = 1)`
       const newCode = await runAddCloneTest(
         code,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         rustContextInThisFile
       )
       expect(newCode).toContain(code + '\n' + expectedNewLine)
@@ -967,14 +967,14 @@ extrude001 = extrude(profile001, length = 1)`
     async function runAddAppearanceTest(
       code: string,
       instance: ModuleType,
-      kclManager: KclManager,
+      executingEditor: ExecutingEditor,
       rustContext: RustContext
     ) {
       const {
         artifactGraph,
         ast,
         sketches: objects,
-      } = await getAstAndSketchSelections(code, instance, kclManager)
+      } = await getAstAndSketchSelections(code, instance, executingEditor)
       const result = addAppearance({
         ast,
         artifactGraph,
@@ -995,7 +995,7 @@ extrude001 = extrude(profile001, length = 1)`
       const newCode = await runAddAppearanceTest(
         box,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         rustContextInThisFile
       )
       expect(newCode).toContain(box + '\n' + expectedNewLine)
@@ -1009,7 +1009,7 @@ extrude001 = extrude(profile001, length = 1)`
       const newCode = await runAddAppearanceTest(
         code,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         rustContextInThisFile
       )
       expect(newCode).toContain(code + '\n' + expectedNewLine)
@@ -1023,7 +1023,7 @@ extrude001 = extrude(profile001, length = 1)`
       } = await getAstAndSketchSelections(
         box,
         instanceInThisFile,
-        kclManagerInThisFile
+        executingEditorInThisFile
       )
       const result = addAppearance({
         ast,
@@ -1064,14 +1064,14 @@ appearance(
       code: string,
       nodeToEdit: PathToNode,
       instance: ModuleType,
-      kclManager: KclManager,
+      executingEditor: ExecutingEditor,
       rustContext: RustContext
     ) {
       const {
         artifactGraph,
         ast,
         sketches: objects,
-      } = await getAstAndSketchSelections(code, instance, kclManager)
+      } = await getAstAndSketchSelections(code, instance, executingEditor)
       const result = addAppearance({
         ast,
         artifactGraph,
@@ -1103,7 +1103,7 @@ appearance(extrude001, color = "#00FF00")`
         code,
         nodeToEdit,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         rustContextInThisFile
       )
       expect(newCode).toContain(expectedNewCode)
@@ -1129,7 +1129,7 @@ appearance(extrude001, color = "#00FF00")`
         code,
         nodeToEdit,
         instanceInThisFile,
-        kclManagerInThisFile,
+        executingEditorInThisFile,
         rustContextInThisFile
       )
       expect(newCode).toContain(expectedNewCode)

--- a/src/lang/queryAst.spec.ts
+++ b/src/lang/queryAst.spec.ts
@@ -47,7 +47,7 @@ import {
 import { err } from '@src/lib/trap'
 import type { Selection, Selections } from '@src/machines/modelingSharedTypes'
 
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import type RustContext from '@src/lib/rustContext'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { ConnectionManager } from '@src/network/connectionManager'
@@ -55,7 +55,7 @@ import { buildTheWorldAndConnectToEngine } from '@src/unitTestUtils'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 
 let instanceInThisFile: ModuleType = null!
-let kclManagerInThisFile: KclManager = null!
+let executingEditorInThisFile: ExecutingEditor = null!
 let engineCommandManagerInThisFile: ConnectionManager = null!
 let rustContextInThisFile: RustContext = null!
 
@@ -70,10 +70,10 @@ beforeEach(async () => {
     return
   }
 
-  const { instance, kclManager, engineCommandManager, rustContext } =
+  const { instance, executingEditor, engineCommandManager, rustContext } =
     await buildTheWorldAndConnectToEngine()
   instanceInThisFile = instance
-  kclManagerInThisFile = kclManager
+  executingEditorInThisFile = executingEditor
   engineCommandManagerInThisFile = engineCommandManager
   rustContextInThisFile = rustContext
 })
@@ -1596,7 +1596,7 @@ extrude002 = extrude(capEnd001, length = 5)
     const { artifactGraph, operations } = await getAstAndArtifactGraph(
       circleProfileInVar,
       instanceInThisFile,
-      kclManagerInThisFile
+      executingEditorInThisFile
     )
     const op = getAllOperations(operations).findLast(
       (o) => o.type === 'StdLibCall' && o.name === 'extrude'
@@ -1698,7 +1698,7 @@ extrude002 = extrude(seg01, length = 5, hideSeams = true)`
     const { artifactGraph, operations } = await getAstAndArtifactGraph(
       code,
       instanceInThisFile,
-      kclManagerInThisFile
+      executingEditorInThisFile
     )
     const op = getAllOperations(operations).findLast(
       (o) => o.type === 'StdLibCall' && o.name === 'extrude'

--- a/src/lang/testHelpers/executingEditorTestHarness.ts
+++ b/src/lang/testHelpers/executingEditorTestHarness.ts
@@ -1,29 +1,29 @@
 import { type Diagnostic, setDiagnosticsEffect } from '@codemirror/lint'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { App } from '@src/lib/app'
 import { isArray } from '@src/lib/utils'
 import { loadWasm } from '@src/unitTestUtils'
 
 const wasmPromise = loadWasm()
 
-export function createKclManagerTestHarness(initialCode = ''): {
+export function createExecutingEditorTestHarness(initialCode = ''): {
   app: App
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
 } {
   const app = App.fromProvided({
     wasmPromise,
   })
-  const { kclManager } = app.singletons
+  const { executingEditor } = app.singletons
 
-  if (kclManager.code !== initialCode) {
-    kclManager.updateCodeEditor(initialCode, {
+  if (executingEditor.code !== initialCode) {
+    executingEditor.updateCodeEditor(initialCode, {
       shouldExecute: false,
       shouldWriteToDisk: false,
       shouldResetCamera: false,
     })
   }
 
-  return { app, kclManager }
+  return { app, executingEditor }
 }
 
 export function getLatestDispatchedDiagnostics(

--- a/src/lang/testHelpers/executingEditorTestHarness.ts
+++ b/src/lang/testHelpers/executingEditorTestHarness.ts
@@ -1,5 +1,9 @@
 import { type Diagnostic, setDiagnosticsEffect } from '@codemirror/lint'
-import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
+import { signal } from '@preact/signals-core'
+import {
+  type ExecutingEditor,
+  ExecutingEditor as ExecutingEditorClass,
+} from '@src/lang/ExecutingEditor'
 import { App } from '@src/lib/app'
 import { isArray } from '@src/lib/utils'
 import { loadWasm } from '@src/unitTestUtils'
@@ -13,7 +17,15 @@ export function createExecutingEditorTestHarness(initialCode = ''): {
   const app = App.fromProvided({
     wasmPromise,
   })
-  const { executingEditor } = app.singletons
+  const executingEditor = new ExecutingEditorClass('some-file', '', {
+    wasmInstancePromise: wasmPromise,
+    settings: app.settings.actor,
+    commandBar: app.commands.actor,
+    engineCommandManager: app.engineCommandManager,
+    rustContext: app.rustContext,
+    projectPath: signal('some-project'),
+  })
+  app.setExecutingEditor(executingEditor)
 
   if (executingEditor.code !== initialCode) {
     executingEditor.updateCodeEditor(initialCode, {

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -149,11 +149,7 @@ describe('project system', () => {
           'publish.open',
         ])
       )
-      expect(
-        app.registry.get(executingEditorService).hasEditsSinceLastExecution
-          .value
-      ).toBe(false)
-      expect(app.registry.get(executingEditorService).code.value).toBe('')
+      expect(app.registry.signal(executingEditorService).value).toBeUndefined()
 
       const textEditorSettings = app.settings.get().textEditor as Record<
         string,

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -1,5 +1,5 @@
 import { pluginsValueSpec } from '@kittycad/registry'
-import { File } from '@src/lang/KclManager'
+import { File } from '@src/lang/ExecutingEditor'
 import { App } from '@src/lib/app'
 import { StorageName, moduleFsViaModuleImport } from '@src/lib/fs-zds'
 import type { Project } from '@src/lib/project'

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -74,7 +74,6 @@ import {
   provideCommand,
 } from '@src/registry/contracts/commands'
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
-import { keymapService } from '@src/registry/contracts/keymap'
 import { layoutContributionsValueSpec } from '@src/registry/contracts/layout'
 import { machineManagerService } from '@src/registry/contracts/machineManager'
 import { settingsValueSpec } from '@src/registry/contracts/settings'
@@ -139,10 +138,11 @@ function createAppRegistryItems({
   ]
 }
 
-// We set some of our singletons on the window for debugging and E2E tests
+// We set some app subsystems on the window for debugging and E2E tests.
 declare global {
   interface Window {
     app: App
+    executingEditor: ExecutingEditor
     engineCommandManager: ConnectionManager
     rustContext: RustContext
     engineDebugger: Debugger
@@ -219,7 +219,6 @@ export class App implements AppSubsystems {
   set project(newProject: ZDSProject | undefined) {
     this.projectSignal.value = newProject
   }
-  singletons: ReturnType<typeof this.buildSingletons>
   /**
    * THE bundle of WASM, a cornerstone of our app. We use this for:
    * - settings parse/unparse
@@ -297,7 +296,6 @@ export class App implements AppSubsystems {
     this.auth.actor.subscribe(this.syncUserFeaturesFromAuth)
     this.syncUserFeaturesFromAuth(this.auth.actor.getSnapshot())
 
-    this.singletons = this.buildSingletons()
     this.lastSettings = getAllCurrentSettings(
       getOnlySettingsFromContext(this.settings.actor.getSnapshot().context)
     )
@@ -551,31 +549,35 @@ export class App implements AppSubsystems {
   }
 
   async openProject(projectIORef: Project) {
+    if (this.project) {
+      this.closeProject()
+    }
+
     const projectIORefSignal = signal(projectIORef)
     this.project = await ZDSProject.open(projectIORefSignal, this)
 
     // This extension makes it possible to mark FS operations as un/redoable
-    effect(() => {
-      if (this.project?.executingEditor.value) {
-        buildFSHistoryExtension(
-          this.systemIOActor,
-          this.project.executingEditor.value
-        )
+    this.unsubscribeFromProjectFsHistory = effect(() => {
+      const executingEditor = this.project?.executingEditor.value
+      if (executingEditor) {
+        return buildFSHistoryExtension(this.systemIOActor, executingEditor)
       }
     })
 
     // TODO: Rework the systemIOActor to fit into the system better,
     // so that the project doesn't need to subscribe to it.
-    this.systemIOActor.subscribe(({ context }) => {
-      const foundProject = (context.folders ?? []).find(
-        (p) =>
-          p.name === projectIORefSignal.value.name &&
-          p.path === projectIORefSignal.value.path
-      )
-      if (foundProject && projectIORefSignal.value !== foundProject) {
-        projectIORefSignal.value = foundProject
+    this.unsubscribeFromSystemIO = this.systemIOActor.subscribe(
+      ({ context }) => {
+        const foundProject = (context.folders ?? []).find(
+          (p) =>
+            p.name === projectIORefSignal.value.name &&
+            p.path === projectIORefSignal.value.path
+        )
+        if (foundProject && projectIORefSignal.value !== foundProject) {
+          projectIORefSignal.value = foundProject
+        }
       }
-    })
+    )
 
     this.unsubscribeFromSettings = this.settings.actor.subscribe(
       this.onSettingsUpdate
@@ -584,10 +586,18 @@ export class App implements AppSubsystems {
     return this.project
   }
   private unsubscribeFromSettings: Subscription | undefined = undefined
+  private unsubscribeFromProjectFsHistory: ReturnType<typeof effect> | undefined
+  private unsubscribeFromSystemIO: Subscription | undefined
   closeProject() {
     this.unsubscribeFromSettings?.unsubscribe()
+    this.unsubscribeFromSettings = undefined
+    this.unsubscribeFromProjectFsHistory?.()
+    this.unsubscribeFromProjectFsHistory = undefined
+    this.unsubscribeFromSystemIO?.unsubscribe()
+    this.unsubscribeFromSystemIO = undefined
     this.project?.close()
     this.project = undefined
+    this.clearExecutingEditor()
   }
 
   syncUserFeaturesFromAuth = (
@@ -651,22 +661,7 @@ export class App implements AppSubsystems {
     }
   }
 
-  /**
-   * Build the world!
-   */
-  buildSingletons() {
-    // TODO: Remove this and make the app handle no executing editor,
-    // so we don't need to stub with empty strings
-    const executingEditor = new ExecutingEditor('', '', {
-      settings: this.settings.actor,
-      wasmInstancePromise: this.wasmPromise,
-      commandBar: this.commands.actor,
-      projectPath: signal(''),
-      engineCommandManager: this.engineCommandManager,
-      rustContext: this.rustContext,
-      keymap: this.registry.get(keymapService),
-    })
-
+  setExecutingEditor(executingEditor: ExecutingEditor) {
     this.registry.reconfigure(appRegistryServicesSlot, [
       defineRegistryItem({
         id: 'executing-editor-services',
@@ -681,8 +676,9 @@ export class App implements AppSubsystems {
 
     if (typeof window !== 'undefined') {
       // Accessible for tests mostly
-      window.engineCommandManager = executingEditor.engineCommandManager
-      window.rustContext = executingEditor.rustContext
+      window.engineCommandManager = this.engineCommandManager
+      window.executingEditor = executingEditor
+      window.rustContext = this.rustContext
       window.engineDebugger = EngineDebugger
       ;(window as any).enableMousePositionLogs = () =>
         document.addEventListener('mousemove', (e) =>
@@ -692,7 +688,7 @@ export class App implements AppSubsystems {
         ;(window as any)._enableFillet = true
       }
       ;(window as any).zoomToFit = () =>
-        executingEditor.engineCommandManager.sendSceneCommand({
+        this.engineCommandManager.sendSceneCommand({
           type: 'modeling_cmd_req',
           cmd_id: uuidv4(),
           cmd: {
@@ -708,9 +704,13 @@ export class App implements AppSubsystems {
       type: 'Set executingEditor',
       data: executingEditor,
     })
+  }
 
-    return {
-      executingEditor,
+  clearExecutingEditor() {
+    this.registry.reconfigure(appRegistryServicesSlot, [])
+    this.commands.actor.send({ type: 'Set executingEditor', data: undefined })
+    if (typeof window !== 'undefined') {
+      delete (window as Partial<Window>).executingEditor
     }
   }
 
@@ -722,10 +722,17 @@ export class App implements AppSubsystems {
     if (!this.project) {
       return // Everything in here only matters inside a project.
     }
+    const executingEditor = this.project.executingEditor.value
+    if (!executingEditor) {
+      this.lastSettings = getAllCurrentSettings(
+        getOnlySettingsFromContext(snapshot.context)
+      )
+      return
+    }
     const { context } = snapshot
 
     // Update line wrapping
-    this.singletons.executingEditor.setEditorLineWrapping(
+    executingEditor.setEditorLineWrapping(
       context.textEditor.textWrapping.current
     )
 
@@ -733,9 +740,9 @@ export class App implements AppSubsystems {
     const newHighlighting = context.modeling.highlightEdges.current
     if (
       newHighlighting !== this.lastSettings.modeling.highlightEdges &&
-      this.singletons.executingEditor.engineCommandManager.connection
+      executingEditor.engineCommandManager.connection
     ) {
-      this.singletons.executingEditor.engineCommandManager
+      executingEditor.engineCommandManager
         .setHighlightEdges(newHighlighting)
         .catch(reportRejection)
     }
@@ -746,17 +753,16 @@ export class App implements AppSubsystems {
       '--cursor-color',
       newBlinking ? 'auto' : 'transparent'
     )
-    this.singletons.executingEditor.setCursorBlinking(newBlinking)
+    executingEditor.setCursorBlinking(newBlinking)
 
     // Update theme
     const newTheme = context.app.theme.current
     const newBackfaceColor = context.modeling.backfaceColor.current
     Promise.all([
-      this.singletons.executingEditor.updateTheme(newTheme),
-      ...(this.singletons.executingEditor.engineCommandManager.connection
-        ?.connected
+      executingEditor.updateTheme(newTheme),
+      ...(executingEditor.engineCommandManager.connection?.connected
         ? [
-            this.singletons.executingEditor.engineCommandManager.setDefaultSystemProperties(
+            executingEditor.engineCommandManager.setDefaultSystemProperties(
               newBackfaceColor
             ),
           ]
@@ -782,29 +788,29 @@ export class App implements AppSubsystems {
       // Relevant settings requiring a cleared scene and re-exec
       if (
         settingsIncludeNewRelevantValues &&
-        this.singletons.executingEditor.engineCommandManager.connection
+        executingEditor.engineCommandManager.connection
       ) {
-        this.singletons.executingEditor.rustContext
+        executingEditor.rustContext
           .clearSceneAndBustCache(
             jsAppSettings(this.settings.actor),
-            this.singletons.executingEditor.path
+            executingEditor.path
           )
-          .then(() => this.singletons.executingEditor.executeCode())
+          .then(() => executingEditor.executeCode())
           .catch(reportRejection)
       }
     } catch (e) {
       console.error('Error executing AST after settings change', e)
     }
 
-    this.singletons.executingEditor.sceneInfra.camControls._setting_allowOrbitInSketchMode =
+    executingEditor.sceneInfra.camControls._setting_allowOrbitInSketchMode =
       context.app.allowOrbitInSketchMode.current
 
     const newCurrentProjection = context.modeling.cameraProjection.current
     if (
-      this.singletons.executingEditor.sceneInfra.camControls &&
-      !this.singletons.executingEditor.modelingState?.matches('Sketch')
+      executingEditor.sceneInfra.camControls &&
+      !executingEditor.modelingState?.matches('Sketch')
     ) {
-      this.singletons.executingEditor.sceneInfra.camControls.engineCameraProjection =
+      executingEditor.sceneInfra.camControls.engineCameraProjection =
         newCurrentProjection
     }
 

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -9,7 +9,7 @@ import {
 } from '@kittycad/registry'
 import { type Signal, effect, signal } from '@preact/signals-core'
 import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
-import { KclManager, ZDSProject } from '@src/lang/KclManager'
+import { ExecutingEditor, ZDSProject } from '@src/lang/ExecutingEditor'
 import { initialiseWasm } from '@src/lang/wasmUtils'
 import { MachineManager } from '@src/lib/MachineManager'
 import { createAuthCommands } from '@src/lib/commandBarConfigs/authCommandConfig'
@@ -225,7 +225,7 @@ export class App implements AppSubsystems {
    * - settings parse/unparse
    * - KCL parsing, execution, linting, and LSP
    *
-   * Access this through `kclManager.wasmInstance`, not directly.
+   * Access this through `executingEditor.wasmInstance`, not directly.
    */
   wasmPromise: Promise<ModuleType>
   /** Auth system. Use `send` method to act with auth. */
@@ -657,7 +657,7 @@ export class App implements AppSubsystems {
   buildSingletons() {
     // TODO: Remove this and make the app handle no executing editor,
     // so we don't need to stub with empty strings
-    const kclManager = new KclManager('', '', {
+    const executingEditor = new ExecutingEditor('', '', {
       settings: this.settings.actor,
       wasmInstancePromise: this.wasmPromise,
       commandBar: this.commands.actor,
@@ -673,7 +673,7 @@ export class App implements AppSubsystems {
         providesServices: [
           provideService(
             executingEditorService,
-            kclManager.executingEditorService
+            executingEditor.executingEditorService
           ),
         ],
       }),
@@ -681,8 +681,8 @@ export class App implements AppSubsystems {
 
     if (typeof window !== 'undefined') {
       // Accessible for tests mostly
-      window.engineCommandManager = kclManager.engineCommandManager
-      window.rustContext = kclManager.rustContext
+      window.engineCommandManager = executingEditor.engineCommandManager
+      window.rustContext = executingEditor.rustContext
       window.engineDebugger = EngineDebugger
       ;(window as any).enableMousePositionLogs = () =>
         document.addEventListener('mousemove', (e) =>
@@ -692,7 +692,7 @@ export class App implements AppSubsystems {
         ;(window as any)._enableFillet = true
       }
       ;(window as any).zoomToFit = () =>
-        kclManager.engineCommandManager.sendSceneCommand({
+        executingEditor.engineCommandManager.sendSceneCommand({
           type: 'modeling_cmd_req',
           cmd_id: uuidv4(),
           cmd: {
@@ -704,10 +704,13 @@ export class App implements AppSubsystems {
         })
     }
 
-    this.commands.actor.send({ type: 'Set kclManager', data: kclManager })
+    this.commands.actor.send({
+      type: 'Set executingEditor',
+      data: executingEditor,
+    })
 
     return {
-      kclManager,
+      executingEditor,
     }
   }
 
@@ -722,7 +725,7 @@ export class App implements AppSubsystems {
     const { context } = snapshot
 
     // Update line wrapping
-    this.singletons.kclManager.setEditorLineWrapping(
+    this.singletons.executingEditor.setEditorLineWrapping(
       context.textEditor.textWrapping.current
     )
 
@@ -730,9 +733,9 @@ export class App implements AppSubsystems {
     const newHighlighting = context.modeling.highlightEdges.current
     if (
       newHighlighting !== this.lastSettings.modeling.highlightEdges &&
-      this.singletons.kclManager.engineCommandManager.connection
+      this.singletons.executingEditor.engineCommandManager.connection
     ) {
-      this.singletons.kclManager.engineCommandManager
+      this.singletons.executingEditor.engineCommandManager
         .setHighlightEdges(newHighlighting)
         .catch(reportRejection)
     }
@@ -743,16 +746,17 @@ export class App implements AppSubsystems {
       '--cursor-color',
       newBlinking ? 'auto' : 'transparent'
     )
-    this.singletons.kclManager.setCursorBlinking(newBlinking)
+    this.singletons.executingEditor.setCursorBlinking(newBlinking)
 
     // Update theme
     const newTheme = context.app.theme.current
     const newBackfaceColor = context.modeling.backfaceColor.current
     Promise.all([
-      this.singletons.kclManager.updateTheme(newTheme),
-      ...(this.singletons.kclManager.engineCommandManager.connection?.connected
+      this.singletons.executingEditor.updateTheme(newTheme),
+      ...(this.singletons.executingEditor.engineCommandManager.connection
+        ?.connected
         ? [
-            this.singletons.kclManager.engineCommandManager.setDefaultSystemProperties(
+            this.singletons.executingEditor.engineCommandManager.setDefaultSystemProperties(
               newBackfaceColor
             ),
           ]
@@ -778,29 +782,29 @@ export class App implements AppSubsystems {
       // Relevant settings requiring a cleared scene and re-exec
       if (
         settingsIncludeNewRelevantValues &&
-        this.singletons.kclManager.engineCommandManager.connection
+        this.singletons.executingEditor.engineCommandManager.connection
       ) {
-        this.singletons.kclManager.rustContext
+        this.singletons.executingEditor.rustContext
           .clearSceneAndBustCache(
             jsAppSettings(this.settings.actor),
-            this.singletons.kclManager.path
+            this.singletons.executingEditor.path
           )
-          .then(() => this.singletons.kclManager.executeCode())
+          .then(() => this.singletons.executingEditor.executeCode())
           .catch(reportRejection)
       }
     } catch (e) {
       console.error('Error executing AST after settings change', e)
     }
 
-    this.singletons.kclManager.sceneInfra.camControls._setting_allowOrbitInSketchMode =
+    this.singletons.executingEditor.sceneInfra.camControls._setting_allowOrbitInSketchMode =
       context.app.allowOrbitInSketchMode.current
 
     const newCurrentProjection = context.modeling.cameraProjection.current
     if (
-      this.singletons.kclManager.sceneInfra.camControls &&
-      !this.singletons.kclManager.modelingState?.matches('Sketch')
+      this.singletons.executingEditor.sceneInfra.camControls &&
+      !this.singletons.executingEditor.modelingState?.matches('Sketch')
     ) {
-      this.singletons.kclManager.sceneInfra.camControls.engineCameraProjection =
+      this.singletons.executingEditor.sceneInfra.camControls.engineCameraProjection =
         newCurrentProjection
     }
 

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -9,7 +9,7 @@ import {
 } from '@kittycad/registry'
 import { type Signal, effect, signal } from '@preact/signals-core'
 import { buildFSHistoryExtension } from '@src/editor/plugins/fs'
-import { ExecutingEditor, ZDSProject } from '@src/lang/ExecutingEditor'
+import { type ExecutingEditor, ZDSProject } from '@src/lang/ExecutingEditor'
 import { initialiseWasm } from '@src/lang/wasmUtils'
 import { MachineManager } from '@src/lib/MachineManager'
 import { createAuthCommands } from '@src/lib/commandBarConfigs/authCommandConfig'

--- a/src/lib/boot.ts
+++ b/src/lib/boot.ts
@@ -1,3 +1,5 @@
+import { useSignals } from '@preact/signals-react/runtime'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { App } from '@src/lib/app'
 import {
   StorageName,
@@ -5,6 +7,7 @@ import {
   moduleFsViaWindow,
 } from '@src/lib/fs-zds'
 import { isPlaywright } from '@src/lib/isPlaywright'
+import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import React from 'react'
 
 // Earliest as possible point to configure the fs layer.
@@ -45,14 +48,14 @@ export const AppContext = React.createContext(app)
 window.app = app
 
 /**
- * Hook to gain access to the global app instance's singletons
- *
- * Alternatively, can use `useApp` and peel needed singletons off.
- * `useSingletons` will eventually be deprecated.
- */
-export const useSingletons = () => React.useContext(AppContext).singletons
-
-/**
  * Hook to get access to the app instance.
  */
 export const useApp = () => React.useContext(AppContext)
+
+export const useExecutingEditorService = () => {
+  useSignals()
+  return useApp().registry.signal(executingEditorService).value
+}
+
+export const useExecutingEditor = () =>
+  useExecutingEditorService()?.executingEditor as ExecutingEditor

--- a/src/lib/codeEditor.ts
+++ b/src/lib/codeEditor.ts
@@ -7,7 +7,7 @@ export const normalizeLineEndings = (str: string, normalized = '\n') => {
  * so that if we discover we're doing it wrong we only need to change this function.
  *
  * We use it right now to verify an OS file system "change" event isn't already known
- * about by our in-memory kclManager.
+ * about by our in-memory executingEditor.
  */
 export function isCodeTheSame(left: string, right: string) {
   const leftBasis = normalizeLineEndings(left)

--- a/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
@@ -31,7 +31,7 @@ gdt::datum(face = capEnd001, name = "A")`
 describe('GDT tolerance defaults', () => {
   it('uses the current file unit for the tolerance input default', () => {
     const modelingContext = {
-      kclManager: {
+      executingEditor: {
         fileSettings: {
           defaultLengthUnit: 'in',
         },

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -647,7 +647,7 @@ export const getDefaultGdtTolerance = (
   modelingContext?: ModelingMachineContext
 ) => {
   const defaultLengthUnit =
-    modelingContext?.kclManager.fileSettings.defaultLengthUnit ||
+    modelingContext?.executingEditor.fileSettings.defaultLengthUnit ||
     DEFAULT_DEFAULT_LENGTH_UNIT
   return `${KCL_DEFAULT_TOLERANCE}${defaultLengthUnit}`
 }
@@ -930,7 +930,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -938,8 +938,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addExtrude({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Extrude']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -1046,7 +1046,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -1054,8 +1054,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addSweep({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Sweep']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -1120,7 +1120,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -1128,8 +1128,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addLoft({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Loft']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -1186,7 +1186,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -1194,8 +1194,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addRevolve({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Revolve']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -1286,7 +1286,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -1294,8 +1294,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addShell({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Shell']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -1333,7 +1333,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -1341,8 +1341,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addHole({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Hole']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -1481,7 +1481,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -1489,9 +1489,9 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addSubtract({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Boolean Subtract']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
-        wasmInstance: await kclManager.wasmInstancePromise,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
+        wasmInstance: await executingEditor.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
       const execRes = await mockExecAstAndReportErrors(
@@ -1526,7 +1526,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -1534,9 +1534,9 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addUnion({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Boolean Union']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
-        wasmInstance: await kclManager.wasmInstancePromise,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
+        wasmInstance: await executingEditor.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
       const execRes = await mockExecAstAndReportErrors(
@@ -1564,7 +1564,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -1572,9 +1572,9 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addIntersect({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Boolean Intersect']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
-        wasmInstance: await kclManager.wasmInstancePromise,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
+        wasmInstance: await executingEditor.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
       const execRes = await mockExecAstAndReportErrors(
@@ -1603,7 +1603,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -1611,9 +1611,9 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addSplit({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Boolean Split']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
-        wasmInstance: await kclManager.wasmInstancePromise,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
+        wasmInstance: await executingEditor.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
       const execRes = await mockExecAstAndReportErrors(
@@ -1659,7 +1659,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -1667,9 +1667,9 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addOffsetPlane({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Offset plane']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
-        variables: kclManager.variables,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
+        variables: executingEditor.variables,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -1713,7 +1713,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -1721,8 +1721,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addHelix({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Helix']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -1820,7 +1820,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -1828,7 +1828,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addHelicalGear({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Helical Gear']),
-        ast: kclManager.ast,
+        ast: executingEditor.ast,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -1878,7 +1878,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -1886,7 +1886,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addHerringboneGear({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Herringbone Gear']),
-        ast: kclManager.ast,
+        ast: executingEditor.ast,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -1936,7 +1936,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -1944,7 +1944,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addSpurGear({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Spur Gear']),
-        ast: kclManager.ast,
+        ast: executingEditor.ast,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -1989,7 +1989,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -1997,7 +1997,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addRingGear({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Ring Gear']),
-        ast: kclManager.ast,
+        ast: executingEditor.ast,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -2046,7 +2046,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -2054,14 +2054,14 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const commandArgs =
         context.argumentsToSubmit as ModelingCommandSchema['Fillet']
-      const wasmInstance = await kclManager.wasmInstancePromise
-      let ast = kclManager.ast
+      const wasmInstance = await executingEditor.wasmInstancePromise
+      let ast = executingEditor.ast
       if (
         commandArgs.version &&
-        kclManager.fileSettings.experimentalFeatures?.type !== 'Allow'
+        executingEditor.fileSettings.experimentalFeatures?.type !== 'Allow'
       ) {
         const astWithNewSetting = setExperimentalFeatures(
-          kclManager.code,
+          executingEditor.code,
           {
             type: 'Allow',
           },
@@ -2073,7 +2073,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       const modRes = addFillet({
         ...commandArgs,
         ast,
-        artifactGraph: kclManager.artifactGraph,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance,
       })
       if (err(modRes)) return modRes
@@ -2128,7 +2128,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -2136,14 +2136,14 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const commandArgs =
         context.argumentsToSubmit as ModelingCommandSchema['Chamfer']
-      const wasmInstance = await kclManager.wasmInstancePromise
-      let ast = kclManager.ast
+      const wasmInstance = await executingEditor.wasmInstancePromise
+      let ast = executingEditor.ast
       if (
         commandArgs.version &&
-        kclManager.fileSettings.experimentalFeatures?.type !== 'Allow'
+        executingEditor.fileSettings.experimentalFeatures?.type !== 'Allow'
       ) {
         const astWithNewSetting = setExperimentalFeatures(
-          kclManager.code,
+          executingEditor.code,
           {
             type: 'Allow',
           },
@@ -2155,7 +2155,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       const modRes = addChamfer({
         ...commandArgs,
         ast,
-        artifactGraph: kclManager.artifactGraph,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance,
       })
       if (err(modRes)) return modRes
@@ -2233,18 +2233,18 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
           const angleLength = angleLengthInfo({
             selectionRanges,
             angleOrLength: 'setLength',
-            kclManager: machineContext.kclManager,
+            executingEditor: machineContext.executingEditor,
             wasmInstance,
           })
           if (err(angleLength) || !wasmInstance) return KCL_DEFAULT_LENGTH
           const { transforms } = angleLength
 
-          // QUESTION: is it okay to reference kclManager here? will its state be up to date?
+          // QUESTION: is it okay to reference executingEditor here? will its state be up to date?
           const sketched = transformAstSketchLines({
-            ast: structuredClone(machineContext.kclManager.ast),
+            ast: structuredClone(machineContext.executingEditor.ast),
             selectionRanges,
             transformInfos: transforms,
-            memVars: machineContext.kclManager.variables,
+            memVars: machineContext.executingEditor.variables,
             referenceSegName: '',
             wasmInstance,
           })
@@ -2306,7 +2306,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -2314,8 +2314,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addAppearance({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Appearance']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -2365,21 +2365,21 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
         return hasConnectionRes
       }
 
-      let ast = kclManager.ast
-      if (kclManager.fileSettings.experimentalFeatures?.type !== 'Allow') {
+      let ast = executingEditor.ast
+      if (executingEditor.fileSettings.experimentalFeatures?.type !== 'Allow') {
         const astWithExperimentalFeatures = setExperimentalFeatures(
-          kclManager.code,
+          executingEditor.code,
           {
             type: 'Allow',
           },
-          await kclManager.wasmInstancePromise
+          await executingEditor.wasmInstancePromise
         )
         if (err(astWithExperimentalFeatures)) {
           return astWithExperimentalFeatures
@@ -2391,7 +2391,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       const modRes = addDelete({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Delete']),
         ast,
-        artifactGraph: kclManager.artifactGraph,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -2418,7 +2418,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -2426,8 +2426,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addTranslate({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Translate']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -2477,7 +2477,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -2485,8 +2485,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addRotate({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Rotate']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -2536,7 +2536,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -2544,8 +2544,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addScale({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Scale']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -2600,7 +2600,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -2608,9 +2608,9 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addClone({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Clone']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
-        wasmInstance: await kclManager.wasmInstancePromise,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
+        wasmInstance: await executingEditor.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
       const execRes = await mockExecAstAndReportErrors(
@@ -2638,7 +2638,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
             return KCL_DEFAULT_CONSTANT_PREFIXES.CLONE
           }
           return findUniqueName(
-            modelingContext.kclManager.ast,
+            modelingContext.executingEditor.ast,
             KCL_DEFAULT_CONSTANT_PREFIXES.CLONE
           )
         },
@@ -2648,8 +2648,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
           }
           // Be conservative and error out if there is an item or module with the same name.
           const variableExists =
-            modelingContext.kclManager.variables[data] ||
-            modelingContext.kclManager.variables['__mod_' + data]
+            modelingContext.executingEditor.variables[data] ||
+            modelingContext.executingEditor.variables['__mod_' + data]
           if (variableExists) {
             return 'This variable name is already in use.'
           }
@@ -2668,7 +2668,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -2676,10 +2676,10 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addMirror3D({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Mirror 3D']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
-        variables: kclManager.variables,
-        wasmInstance: await kclManager.wasmInstancePromise,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
+        variables: executingEditor.variables,
+        wasmInstance: await executingEditor.wasmInstancePromise,
       })
       if (err(modRes)) {
         return modRes
@@ -2725,7 +2725,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -2733,8 +2733,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addPatternCircular3D({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Pattern Circular 3D']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -2798,7 +2798,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -2806,8 +2806,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addPatternLinear3D({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Pattern Linear 3D']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -2863,7 +2863,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -2871,8 +2871,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addFlatnessGdt({
         ...(context.argumentsToSubmit as ModelingCommandSchema['GDT Flatness']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -2933,7 +2933,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -2941,8 +2941,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addStraightnessGdt({
         ...(context.argumentsToSubmit as ModelingCommandSchema['GDT Straightness']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -3003,7 +3003,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -3011,8 +3011,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addCircularityGdt({
         ...(context.argumentsToSubmit as ModelingCommandSchema['GDT Circularity']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -3073,7 +3073,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -3081,8 +3081,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addCylindricityGdt({
         ...(context.argumentsToSubmit as ModelingCommandSchema['GDT Cylindricity']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -3143,7 +3143,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -3151,8 +3151,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addDatumGdt({
         ...(context.argumentsToSubmit as ModelingCommandSchema['GDT Datum']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -3177,7 +3177,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         inputType: 'string',
         defaultValue: (_, modelingContext) =>
           modelingContext
-            ? getNextAvailableDatumName(modelingContext.kclManager.ast)
+            ? getNextAvailableDatumName(modelingContext.executingEditor.ast)
             : 'A',
         required: true,
       },
@@ -3213,7 +3213,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -3221,8 +3221,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addPositionGdt({
         ...(context.argumentsToSubmit as ModelingCommandSchema['GDT Position']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -3286,7 +3286,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -3294,8 +3294,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addProfileGdt({
         ...(context.argumentsToSubmit as ModelingCommandSchema['GDT Profile']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -3359,7 +3359,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -3367,8 +3367,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addDistanceGdt({
         ...(context.argumentsToSubmit as ModelingCommandSchema['GDT Distance']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) {
@@ -3433,7 +3433,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -3441,8 +3441,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addPerpendicularityGdt({
         ...(context.argumentsToSubmit as ModelingCommandSchema['GDT Perpendicularity']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -3506,7 +3506,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -3514,8 +3514,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addParallelismGdt({
         ...(context.argumentsToSubmit as ModelingCommandSchema['GDT Parallelism']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -3578,7 +3578,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -3586,8 +3586,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addAnnotationGdt({
         ...(context.argumentsToSubmit as ModelingCommandSchema['GDT Annotation']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -3645,7 +3645,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -3653,8 +3653,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addFlipSurface({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Flip Surface']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -3681,7 +3681,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -3689,8 +3689,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addJoinSurfaces({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Join Surfaces']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -3718,7 +3718,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -3726,8 +3726,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addDeleteFace({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Delete Face']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes
@@ -3755,7 +3755,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       if (!modelingActor) {
         return new Error('modelingMachine not found')
       }
-      const { engineCommandManager, kclManager, rustContext } =
+      const { engineCommandManager, executingEditor, rustContext } =
         modelingActor.getSnapshot().context
       const hasConnectionRes = hasEngineConnection(engineCommandManager)
       if (err(hasConnectionRes)) {
@@ -3763,8 +3763,8 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       }
       const modRes = addBlend({
         ...(context.argumentsToSubmit as ModelingCommandSchema['Blend']),
-        ast: kclManager.ast,
-        artifactGraph: kclManager.artifactGraph,
+        ast: executingEditor.ast,
+        artifactGraph: executingEditor.artifactGraph,
         wasmInstance: await context.wasmInstancePromise,
       })
       if (err(modRes)) return modRes

--- a/src/lib/commandBarConfigs/standardViewsConfig.ts
+++ b/src/lib/commandBarConfigs/standardViewsConfig.ts
@@ -1,11 +1,11 @@
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import type { Command } from '@src/lib/commandTypes'
 import { AxisNames } from '@src/lib/constants'
 import { reportRejection } from '@src/lib/trap'
 import { engineStreamZoomToFit } from '@src/lib/utils'
 
-export function createStandardViewsCommands(kclManager: KclManager) {
-  const { engineCommandManager, sceneInfra } = kclManager
+export function createStandardViewsCommands(executingEditor: ExecutingEditor) {
+  const { engineCommandManager, sceneInfra } = executingEditor
   const topViewCommand: Command = {
     name: 'Top view',
     displayName: `Top view`,

--- a/src/lib/exceptions.ts
+++ b/src/lib/exceptions.ts
@@ -1,6 +1,6 @@
 import toast from 'react-hot-toast'
 
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { jsAppSettings } from '@src/lib/settings/settingsUtils'
 import { reportRejection } from '@src/lib/trap'
 import { getModule, reloadModule } from '@src/lib/wasm_lib_wrapper'
@@ -13,7 +13,9 @@ let initialized = false
  * the global/DOM level. This will have to interface with whatever controlflow that needs to be picked up
  * within the error branch in the typescript to cover the application state.
  */
-export const initializeWindowExceptionHandler = (kclManager: KclManager) => {
+export const initializeWindowExceptionHandler = (
+  executingEditor: ExecutingEditor
+) => {
   if (window && !initialized) {
     window.addEventListener('error', (event) => {
       void (async () => {
@@ -25,14 +27,14 @@ export const initializeWindowExceptionHandler = (kclManager: KclManager) => {
           matchGenericWasmRuntimeHeuristicErrorCrash(event)
         ) {
           // do global singleton cleanup
-          kclManager.executeAstCleanUp()
+          executingEditor.executeAstCleanUp()
           toast.error(
             'You have hit a KCL execution bug! Put your KCL code in a github issue to help us resolve this bug.'
           )
           try {
             const newModulePromise = reloadModule().then(() => getModule())
-            // Refresh kclManager singleton's reference to the current WASM module.
-            kclManager.wasmInstancePromise = newModulePromise
+            // Refresh executingEditor singleton's reference to the current WASM module.
+            executingEditor.wasmInstancePromise = newModulePromise
             await newModulePromise.then((newModule) => newModule.default())
             /**
              * If I do not cache bust, swapping between files when a rust runtime error happens
@@ -43,8 +45,8 @@ export const initializeWindowExceptionHandler = (kclManager: KclManager) => {
              * }
              * ^-- this is the block of code that returns which prevents it from running a new execute
              */
-            await kclManager.rustContext?.clearSceneAndBustCache(
-              jsAppSettings(kclManager.rustContext.settingsActor),
+            await executingEditor.rustContext?.clearSceneAndBustCache(
+              jsAppSettings(executingEditor.rustContext.settingsActor),
               undefined
             )
           } catch (e) {

--- a/src/lib/exceptions.ts
+++ b/src/lib/exceptions.ts
@@ -14,7 +14,7 @@ let initialized = false
  * within the error branch in the typescript to cover the application state.
  */
 export const initializeWindowExceptionHandler = (
-  executingEditor: ExecutingEditor
+  getExecutingEditor: () => ExecutingEditor | undefined
 ) => {
   if (window && !initialized) {
     window.addEventListener('error', (event) => {
@@ -26,6 +26,10 @@ export const initializeWindowExceptionHandler = (
           matchMemoryAccessOutOfBoundsErrorCrash(event.message) ||
           matchGenericWasmRuntimeHeuristicErrorCrash(event)
         ) {
+          const executingEditor = getExecutingEditor()
+          if (!executingEditor) {
+            return
+          }
           // do global singleton cleanup
           executingEditor.executeAstCleanUp()
           toast.error(

--- a/src/lib/exportDxf.spec.ts
+++ b/src/lib/exportDxf.spec.ts
@@ -77,7 +77,7 @@ const createMockDependencies = (): Parameters<typeof exportSketchToDxf>[1] => ({
     rejectAllModelingCommands: vi.fn(),
     tearDown: vi.fn(),
   } as any,
-  kclManager: {
+  executingEditor: {
     artifactGraph: new Map(),
     ast: {
       body: [],
@@ -171,9 +171,9 @@ describe('DXF Export', () => {
         consumed: false,
       }
 
-      mockDeps.kclManager.artifactGraph.set('plane-id', planeArtifact)
-      mockDeps.kclManager.artifactGraph.set('path-1', pathArtifact1)
-      mockDeps.kclManager.artifactGraph.set('path-2', pathArtifact2)
+      mockDeps.executingEditor.artifactGraph.set('plane-id', planeArtifact)
+      mockDeps.executingEditor.artifactGraph.set('path-1', pathArtifact1)
+      mockDeps.executingEditor.artifactGraph.set('path-2', pathArtifact2)
 
       // Mock successful engine response
       const mockResponse: WebSocketResponse = {
@@ -267,8 +267,8 @@ describe('DXF Export', () => {
         consumed: false,
       }
 
-      mockDeps.kclManager.artifactGraph.set('plane-id', planeArtifact)
-      mockDeps.kclManager.artifactGraph.set('path-1', pathArtifact)
+      mockDeps.executingEditor.artifactGraph.set('plane-id', planeArtifact)
+      mockDeps.executingEditor.artifactGraph.set('path-1', pathArtifact)
 
       // Mock successful engine response
       const mockResponse: WebSocketResponse = {
@@ -328,7 +328,7 @@ describe('DXF Export', () => {
 
     it('should return error when plane artifact is not found', async () => {
       // Setup: empty artifact graph
-      mockDeps.kclManager.artifactGraph.clear()
+      mockDeps.executingEditor.artifactGraph.clear()
 
       const result = await exportSketchToDxf(mockOperation, mockDeps)
 
@@ -353,7 +353,10 @@ describe('DXF Export', () => {
           pathToNode: [],
         },
       }
-      mockDeps.kclManager.artifactGraph.set('plane-id', planeArtifactNoPathIds)
+      mockDeps.executingEditor.artifactGraph.set(
+        'plane-id',
+        planeArtifactNoPathIds
+      )
 
       let result = await exportSketchToDxf(mockOperation, mockDeps)
 
@@ -367,7 +370,7 @@ describe('DXF Export', () => {
 
       // Test case 2: plane artifact with pathIds but no path artifacts in graph
       vi.clearAllMocks()
-      mockDeps.kclManager.artifactGraph.clear()
+      mockDeps.executingEditor.artifactGraph.clear()
 
       const planeArtifactEmptyPaths: Artifact = {
         id: 'plane-id',
@@ -379,7 +382,10 @@ describe('DXF Export', () => {
           pathToNode: [],
         },
       }
-      mockDeps.kclManager.artifactGraph.set('plane-id', planeArtifactEmptyPaths)
+      mockDeps.executingEditor.artifactGraph.set(
+        'plane-id',
+        planeArtifactEmptyPaths
+      )
 
       result = await exportSketchToDxf(mockOperation, mockDeps)
 
@@ -419,8 +425,8 @@ describe('DXF Export', () => {
         consumed: false,
       }
 
-      mockDeps.kclManager.artifactGraph.set('plane-id', planeArtifact)
-      mockDeps.kclManager.artifactGraph.set('path-1', pathArtifact)
+      mockDeps.executingEditor.artifactGraph.set('plane-id', planeArtifact)
+      mockDeps.executingEditor.artifactGraph.set('path-1', pathArtifact)
 
       // Test case 1: Engine command failure
       const mockFailedResponse: WebSocketResponse = {
@@ -489,8 +495,8 @@ describe('DXF Export', () => {
         consumed: false,
       }
 
-      mockDeps.kclManager.artifactGraph.set('plane-id', planeArtifact)
-      mockDeps.kclManager.artifactGraph.set('path-1', pathArtifact)
+      mockDeps.executingEditor.artifactGraph.set('plane-id', planeArtifact)
+      mockDeps.executingEditor.artifactGraph.set('path-1', pathArtifact)
 
       // Mock successful engine response
       const mockResponse: WebSocketResponse = {
@@ -561,8 +567,8 @@ describe('DXF Export', () => {
         consumed: false,
       }
 
-      mockDeps.kclManager.artifactGraph.set('plane-id', planeArtifact)
-      mockDeps.kclManager.artifactGraph.set('path-1', pathArtifact)
+      mockDeps.executingEditor.artifactGraph.set('plane-id', planeArtifact)
+      mockDeps.executingEditor.artifactGraph.set('path-1', pathArtifact)
 
       // Mock engine response with multiple files - DXF should be prioritized
       const mockResponse: WebSocketResponse = {
@@ -610,7 +616,7 @@ describe('DXF Export', () => {
       // but the filename comes from the sketch name, not the selected file name
       expect(mockDeps.base64Decode).toHaveBeenCalledWith(
         'Zmlyc3QtZHhmLWNvbnRlbnQ=',
-        await mockDeps.kclManager.wasmInstancePromise
+        await mockDeps.executingEditor.wasmInstancePromise
       )
       expect(mockElectron.save).toHaveBeenCalledWith({
         defaultPath: 'sketch.dxf',

--- a/src/lib/exportDxf.ts
+++ b/src/lib/exportDxf.ts
@@ -1,6 +1,6 @@
 import type { WebSocketResponse } from '@kittycad/lib'
 import type { OpKclValue } from '@rust/kcl-lib/bindings/Operation'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import {
   type StdLibCallOp,
   findOperationPlaneLikeArtifact,
@@ -29,19 +29,19 @@ function getSketchArtifactId(
 // by resolving the sketch artifact ID from the operation args.
 function findPlaneArtifactForSubtract2d(
   operation: StdLibCallOp,
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
 ): Artifact | null {
   const sketchId = getSketchArtifactId(operation.unlabeledArg?.value)
   if (!sketchId) return null
 
-  const sketchArtifact = kclManager.artifactGraph.get(sketchId)
+  const sketchArtifact = executingEditor.artifactGraph.get(sketchId)
   const planeArtifact = getPlaneFromArtifact(
     sketchArtifact,
-    kclManager.artifactGraph
+    executingEditor.artifactGraph
   )
 
   if (planeArtifact instanceof Error) return null
-  return kclManager.artifactGraph.get(planeArtifact.id) ?? null
+  return executingEditor.artifactGraph.get(planeArtifact.id) ?? null
 }
 
 // Exports a sketch operation to DXF format
@@ -49,7 +49,7 @@ export async function exportSketchToDxf(
   operation: StdLibCallOp,
   dependencies: {
     engineCommandManager: ConnectionManager
-    kclManager: KclManager
+    executingEditor: ExecutingEditor
     toast: {
       error: (message: string, options?: ToastOptions) => void
       loading: (message: string) => string
@@ -70,7 +70,7 @@ export async function exportSketchToDxf(
 ): Promise<boolean | Error> {
   const {
     engineCommandManager,
-    kclManager,
+    executingEditor,
     toast,
     uuidv4,
     base64Decode,
@@ -83,7 +83,7 @@ export async function exportSketchToDxf(
     // For subtract2d operations, find the plane artifact from the same sketch
     let planeArtifact
     if (operation.name === 'subtract2d') {
-      planeArtifact = findPlaneArtifactForSubtract2d(operation, kclManager)
+      planeArtifact = findPlaneArtifactForSubtract2d(operation, executingEditor)
       if (!planeArtifact) {
         toast.error(
           'Could not find sketch to export from subtract2d operation.'
@@ -94,7 +94,7 @@ export async function exportSketchToDxf(
       // Get the plane artifact associated with this sketch operation
       planeArtifact = findOperationPlaneLikeArtifact(
         operation,
-        kclManager.artifactGraph
+        executingEditor.artifactGraph
       )
     }
 
@@ -112,7 +112,7 @@ export async function exportSketchToDxf(
     // Get all entity IDs from the plane's paths
     const entityIds: string[] = []
     for (const pathId of planeArtifact.pathIds) {
-      const pathArtifact = kclManager.artifactGraph.get(pathId)
+      const pathArtifact = executingEditor.artifactGraph.get(pathId)
       if (!pathArtifact) continue
       if ('compositeSolidId' in pathArtifact && pathArtifact.compositeSolidId) {
         // Sketch has been extruded - use the composite solid ID
@@ -217,7 +217,7 @@ export async function exportSketchToDxf(
     try {
       const decoded = base64Decode(
         selectedFile.contents,
-        await kclManager.wasmInstancePromise
+        await executingEditor.wasmInstancePromise
       )
       if (decoded instanceof Error) {
         console.error('Base64 decode failed:', decoded)
@@ -236,8 +236,8 @@ export async function exportSketchToDxf(
     // Generate meaningful filename from sketch name
     const sketchName = getOperationVariableName(
       operation,
-      kclManager.ast,
-      await kclManager.wasmInstancePromise
+      executingEditor.ast,
+      await executingEditor.wasmInstancePromise
     )
     const fileName = `${sketchName || 'sketch'}.dxf`
 

--- a/src/lib/featureTree.ts
+++ b/src/lib/featureTree.ts
@@ -1,6 +1,6 @@
 import type { Operation } from '@rust/kcl-lib/bindings/Operation'
 import type { SceneEntities } from '@src/clientSideScene/sceneEntities'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { sourceRangeToUtf16 } from '@src/lang/errors'
 import {
   deleteSelectionPromise,
@@ -106,7 +106,7 @@ export function sendDeleteCommand(input: {
   artifact: Artifact | undefined
   targetSourceRange: SourceRange | undefined
   systemDeps: {
-    kclManager: KclManager
+    executingEditor: ExecutingEditor
     rustContext: RustContext
     sceneEntitiesManager: SceneEntities
   }
@@ -119,7 +119,7 @@ export function sendDeleteCommand(input: {
     }
 
     const pathToNode = getNodePathFromSourceRange(
-      input.systemDeps.kclManager.ast,
+      input.systemDeps.executingEditor.ast,
       targetSourceRange
     )
     const selection = {
@@ -164,21 +164,23 @@ export function prepareEditCommand(
 export function sendSelectionEvent(
   input: {
     sourceRange: SourceRange
-    kclManager: KclManager
+    executingEditor: ExecutingEditor
     modelingSend: ActorRefFrom<typeof modelingMachine>['send']
   },
   convertRangeToUtf16 = false
 ) {
   const artifact =
-    getArtifactFromRange(input.sourceRange, input.kclManager.artifactGraph) ??
-    undefined
+    getArtifactFromRange(
+      input.sourceRange,
+      input.executingEditor.artifactGraph
+    ) ?? undefined
 
   const selection = {
     codeRef: codeRefFromRange(
       convertRangeToUtf16
-        ? sourceRangeToUtf16(input.sourceRange, input.kclManager.code)
+        ? sourceRangeToUtf16(input.sourceRange, input.executingEditor.code)
         : input.sourceRange,
-      input.kclManager.ast
+      input.executingEditor.ast
     ),
     artifact,
   }

--- a/src/lib/hotkeyWrapper.ts
+++ b/src/lib/hotkeyWrapper.ts
@@ -1,4 +1,4 @@
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { useEffect } from 'react'
 import type { Options } from 'react-hotkeys-hook'
 import { useHotkeys } from 'react-hotkeys-hook'
@@ -16,7 +16,7 @@ import { useHotkeys } from 'react-hotkeys-hook'
 export default function useHotkeyWrapper(
   hotkey: string[],
   callback: () => void,
-  kclManager?: KclManager,
+  executingEditor?: ExecutingEditor,
   additionalOptions?: Options & {
     registerToCodeMirror?: boolean
   }
@@ -30,7 +30,7 @@ export default function useHotkeyWrapper(
     }
     for (const key of hotkey) {
       const keybinding = mapHotkeyToCodeMirrorHotkey(key)
-      kclManager?.registerHotkey(keybinding, callback)
+      executingEditor?.registerHotkey(keybinding, callback)
     }
   })
 }

--- a/src/lib/kclCommands.ts
+++ b/src/lib/kclCommands.ts
@@ -2,7 +2,7 @@ import type { UnitLength } from '@kittycad/lib'
 import toast from 'react-hot-toast'
 
 import type { Node } from '@rust/kcl-lib/bindings/Node'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { updateModelingState } from '@src/lang/modelingWorkflows'
 import {
   addModuleImport,
@@ -45,7 +45,7 @@ interface KclCommandConfig {
   specialPropsForInsertCommand: {
     providedOptions: ReadonlyArray<CommandArgumentOption<string>>
   }
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   systemIOActor: SystemIOActor
   wasmInstance: ModuleType
   projectData: IndexLoaderData
@@ -77,16 +77,17 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
           required: true,
           inputType: 'options',
           defaultValue:
-            commandProps.kclManager.fileSettings.defaultLengthUnit ||
+            commandProps.executingEditor.fileSettings.defaultLengthUnit ||
             DEFAULT_DEFAULT_LENGTH_UNIT,
           options: () =>
             Object.values(baseUnitsUnion).map((v) => {
               return {
                 name: v,
                 value: v,
-                isCurrent: commandProps.kclManager.fileSettings
+                isCurrent: commandProps.executingEditor.fileSettings
                   .defaultLengthUnit
-                  ? v === commandProps.kclManager.fileSettings.defaultLengthUnit
+                  ? v ===
+                    commandProps.executingEditor.fileSettings.defaultLengthUnit
                   : v === DEFAULT_DEFAULT_LENGTH_UNIT,
               }
             }),
@@ -95,14 +96,14 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
       onSubmit: (data) => {
         if (typeof data === 'object' && 'unit' in data) {
           const newCode = changeDefaultUnits(
-            commandProps.kclManager.code,
+            commandProps.executingEditor.code,
             data.unit,
             commandProps.wasmInstance
           )
           if (err(newCode)) {
             toast.error(`Failed to set per-file units: ${newCode.message}`)
           } else {
-            commandProps.kclManager.updateCodeEditor(newCode, {
+            commandProps.executingEditor.updateCodeEditor(newCode, {
               shouldExecute: true,
               shouldResetCamera: true,
             })
@@ -127,18 +128,18 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
           required: true,
           inputType: 'options',
           defaultValue:
-            commandProps.kclManager.fileSettings.experimentalFeatures?.type ||
-            DEFAULT_EXPERIMENTAL_FEATURES.type,
+            commandProps.executingEditor.fileSettings.experimentalFeatures
+              ?.type || DEFAULT_EXPERIMENTAL_FEATURES.type,
           options: () =>
             warningLevels.map((l) => {
               return {
                 name: l.type,
                 value: l.type,
-                isCurrent: commandProps.kclManager.fileSettings
+                isCurrent: commandProps.executingEditor.fileSettings
                   .experimentalFeatures
                   ? l.type ===
-                    commandProps.kclManager.fileSettings.experimentalFeatures
-                      .type
+                    commandProps.executingEditor.fileSettings
+                      .experimentalFeatures.type
                   : l.type === DEFAULT_EXPERIMENTAL_FEATURES.type,
               }
             }),
@@ -150,11 +151,11 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
         async function awaitWasmAndSubmit() {
           if (typeof data === 'object' && 'level' in data) {
             const newAst = setExperimentalFeatures(
-              commandProps.kclManager.code,
+              commandProps.executingEditor.code,
               {
                 type: data.level,
               },
-              await commandProps.kclManager.wasmInstancePromise
+              await commandProps.executingEditor.wasmInstancePromise
             )
             if (err(newAst)) {
               toast.error(
@@ -165,7 +166,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
             updateModelingState(
               newAst,
               EXECUTION_TYPE_REAL,
-              commandProps.kclManager
+              commandProps.executingEditor
             )
               .then((result) => {
                 if (err(result)) {
@@ -196,7 +197,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
       hide: 'web',
       needsReview: true,
       reviewValidation: async () => {
-        if (commandProps.kclManager.isExecuting) {
+        if (commandProps.executingEditor.isExecuting) {
           return new Error(EXECUTING_MESSAGE)
         }
       },
@@ -227,7 +228,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
             return providedOptions
           },
           validation: async ({ data }) => {
-            const importExists = commandProps.kclManager.ast.body.find(
+            const importExists = commandProps.executingEditor.ast.body.find(
               (n) =>
                 n.type === 'ImportStatement' &&
                 ((n.path.type === 'Kcl' && n.path.filename === data.path) ||
@@ -254,7 +255,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
           },
           validation: async ({ data }) => {
             const variableExists =
-              commandProps.kclManager.variables['__mod_' + data.localName]
+              commandProps.executingEditor.variables['__mod_' + data.localName]
             if (variableExists) {
               return 'This variable name is already in use.'
             }
@@ -268,7 +269,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
           return new Error(NO_INPUT_PROVIDED_MESSAGE)
         }
 
-        const ast = commandProps.kclManager.ast
+        const ast = commandProps.executingEditor.ast
         const { path, localName } = data
         const { modifiedAst, pathToNode } = addModuleImport({
           ast,
@@ -278,7 +279,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
         updateModelingState(
           modifiedAst,
           EXECUTION_TYPE_REAL,
-          commandProps.kclManager,
+          commandProps.executingEditor,
           {
             focusPath: [pathToNode],
             skipErrorsOnMockExecution: true,
@@ -294,7 +295,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
       groupId: 'code',
       icon: 'code',
       onSubmit: () => {
-        commandProps.kclManager.format().catch(reportRejection)
+        commandProps.executingEditor.format().catch(reportRejection)
       },
     },
     {
@@ -307,7 +308,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
       onSubmit: (input) => {
         copyFileShareLink({
           token: commandProps.authToken,
-          code: commandProps.kclManager.code,
+          code: commandProps.executingEditor.code,
           name: commandProps.projectData.project?.name || '',
           isRestrictedToOrg: input?.event.data.isRestrictedToOrg ?? false,
           password: input?.event.data.password,
@@ -352,9 +353,9 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
           return new Error('variable declaration is required')
         }
 
-        const freshAst = await commandProps.kclManager.safeParse(
-          commandProps.kclManager.code,
-          commandProps.kclManager.wasmInstancePromise
+        const freshAst = await commandProps.executingEditor.safeParse(
+          commandProps.executingEditor.code,
+          commandProps.executingEditor.wasmInstancePromise
         )
         if (!freshAst) {
           return new Error('Current code could not be parsed')
@@ -365,13 +366,13 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
 
         const newCode = recast(
           modifiedAst,
-          await commandProps.kclManager.wasmInstancePromise
+          await commandProps.executingEditor.wasmInstancePromise
         )
         if (err(newCode)) {
           return new Error(`Failed to create parameter: ${newCode.message}`)
         }
 
-        commandProps.kclManager.updateCodeEditor(newCode, {
+        commandProps.executingEditor.updateCodeEditor(newCode, {
           shouldExecute: true,
           shouldWriteToDisk: true,
           shouldAddToHistory: true,
@@ -391,7 +392,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
           inputType: 'options',
           valueSummary: (nodeToEdit: PathToNode) => {
             const node = getNodeFromPath<VariableDeclarator>(
-              commandProps.kclManager.ast,
+              commandProps.executingEditor.ast,
               nodeToEdit,
               commandProps.wasmInstance,
               'VariableDeclarator',
@@ -404,7 +405,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
           required: true,
           options() {
             return getAllOperations(
-              commandProps.kclManager.execState.operations
+              commandProps.executingEditor.execState.operations
             ).flatMap((op) => {
               if (op.type !== 'VariableDeclaration') return []
               if (op.value.type !== 'Number') return []
@@ -420,7 +421,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
             const nodeToEdit = commandBarContext.argumentsToSubmit.nodeToEdit
             if (!nodeToEdit || !isPathToNode(nodeToEdit)) return '5'
             const node = getNodeFromPath<VariableDeclarator>(
-              commandProps.kclManager.ast,
+              commandProps.executingEditor.ast,
               nodeToEdit,
               commandProps.wasmInstance,
               'VariableDeclarator'
@@ -430,11 +431,11 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
             const variableName = node.node.id.name || ''
             if (typeof variableName !== 'string') return '5'
             const variableNode = getVariableDeclaration(
-              commandProps.kclManager.ast,
+              commandProps.executingEditor.ast,
               variableName
             )
             if (!variableNode) return '5'
-            const code = commandProps.kclManager.code.slice(
+            const code = commandProps.executingEditor.code.slice(
               variableNode.declaration.init.start,
               variableNode.declaration.init.end
             )
@@ -450,7 +451,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
 
         // Get the variable AST node to edit
         const { nodeToEdit, value } = data
-        const newAst = structuredClone(commandProps.kclManager.ast)
+        const newAst = structuredClone(commandProps.executingEditor.ast)
         const variableNode = getNodeFromPath<Node<VariableDeclarator>>(
           newAst,
           nodeToEdit,
@@ -471,7 +472,7 @@ export function kclCommands(commandProps: KclCommandConfig): Command[] {
         updateModelingState(
           newAst,
           EXECUTION_TYPE_REAL,
-          commandProps.kclManager
+          commandProps.executingEditor
         ).catch(reportRejection)
       },
     },

--- a/src/lib/kclVersion.ts
+++ b/src/lib/kclVersion.ts
@@ -1,4 +1,4 @@
-// This value is set by singletons.ts when it initializes kclManager
+// This value is set by singletons.ts when it initializes executingEditor
 let currentKclVersion = ''
 
 export function setKclVersion(version: string): void {

--- a/src/lib/layout/defaultActionLibrary.ts
+++ b/src/lib/layout/defaultActionLibrary.ts
@@ -1,6 +1,6 @@
 import { useSignals } from '@preact/signals-react/runtime'
 import { useReliesOnEngine } from '@src/hooks/useReliesOnEngine'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { sendAddFileToProjectCommandForCurrentProject } from '@src/lib/commandBarConfigs/applicationCommandConfig'
 import { isDesktop } from '@src/lib/isDesktop'
 import { isMobile } from '@src/lib/isMobile'
@@ -10,7 +10,7 @@ import { layoutActionLibraryValueSpec } from '@src/registry/contracts/layout'
 export const useDefaultActionLibrary = () => {
   useSignals()
   const { commands, settings, registry } = useApp()
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const machineApiEnabled = settings.useSettings().app.machineApi.current
   const registeredActionLibrary = registry.signal(
     layoutActionLibraryValueSpec

--- a/src/lib/layout/defaultActionLibrary.ts
+++ b/src/lib/layout/defaultActionLibrary.ts
@@ -10,7 +10,7 @@ import { layoutActionLibraryValueSpec } from '@src/registry/contracts/layout'
 export const useDefaultActionLibrary = () => {
   useSignals()
   const { commands, settings, registry } = useApp()
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const machineApiEnabled = settings.useSettings().app.machineApi.current
   const registeredActionLibrary = registry.signal(
     layoutActionLibraryValueSpec
@@ -21,7 +21,7 @@ export const useDefaultActionLibrary = () => {
       useHidden: () => false,
       useDisabled: () => {
         const engineIsReady = useReliesOnEngine(
-          kclManager.isExecutingSignal.value ?? false
+          executingEditor.isExecutingSignal.value ?? false
         )
         return engineIsReady ? 'Need engine connection to export' : undefined
       },

--- a/src/lib/layout/defaultAreaLibrary.tsx
+++ b/src/lib/layout/defaultAreaLibrary.tsx
@@ -90,7 +90,7 @@ function ModelingArea() {
 export const useDefaultAreaLibrary = () => {
   useSignals()
   const { settings, layout, registry } = useApp()
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const getSettings = settings.get
   const registeredAreaLibrary = registry.signal(
     layoutAreaLibraryValueSpec
@@ -106,9 +106,9 @@ export const useDefaultAreaLibrary = () => {
           shouldExpand: true,
         })
       )
-      kclManager.scrollToFirstErrorDiagnosticIfExists()
+      executingEditor.scrollToFirstErrorDiagnosticIfExists()
     },
-    [kclManager, layout]
+    [executingEditor, layout]
   )
 
   return useMemo(
@@ -141,7 +141,7 @@ export const useDefaultAreaLibrary = () => {
           shortcut: 'Shift + C',
           Component: KclEditorPane,
           useNotifications() {
-            const value = kclManager.diagnosticsSignal.value.filter(
+            const value = executingEditor.diagnosticsSignal.value.filter(
               (diagnostic) => diagnostic.severity === 'error'
             ).length
             return useMemo(() => {
@@ -160,7 +160,9 @@ export const useDefaultAreaLibrary = () => {
           useNotifications() {
             const title = 'Project files have runtime errors'
             // Only compute runtime errors! Compilation errors are not tracked here.
-            const errors = kclErrorsByFilename(kclManager.errorsSignal.value)
+            const errors = kclErrorsByFilename(
+              executingEditor.errorsSignal.value
+            )
             const value = errors.size > 0 ? 'x' : ''
             const onClick: MouseEventHandler = useCallback((e) => {
               e.preventDefault()
@@ -169,7 +171,7 @@ export const useDefaultAreaLibrary = () => {
               // Open the first error in the array of errors
               // Then scroll to error
               // Do you automatically open the project files
-              // kclManager.scrollToFirstErrorDiagnosticIfExists()
+              // executingEditor.scrollToFirstErrorDiagnosticIfExists()
             }, [])
             return useMemo(() => ({ value, onClick, title }), [value, onClick])
           },
@@ -191,7 +193,12 @@ export const useDefaultAreaLibrary = () => {
         },
         ...registeredAreaLibrary,
       } satisfies AreaLibrary),
-    [getSettings, kclManager, onCodeNotificationClick, registeredAreaLibrary]
+    [
+      getSettings,
+      executingEditor,
+      onCodeNotificationClick,
+      registeredAreaLibrary,
+    ]
   )
 }
 

--- a/src/lib/layout/defaultAreaLibrary.tsx
+++ b/src/lib/layout/defaultAreaLibrary.tsx
@@ -14,7 +14,7 @@ import { MlEphantConversationPaneWrapper } from '@src/components/layout/areas/Ml
 import { ProjectExplorerPane } from '@src/components/layout/areas/ProjectExplorerPane'
 import { useModelingContext } from '@src/hooks/useModelingContext'
 import { kclErrorsByFilename } from '@src/lang/errors'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp, useExecutingEditor } from '@src/lib/boot'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
 import type { AreaLibrary, AreaTypeDefinition } from '@src/lib/layout/types'
 import { togglePaneLayoutNode } from '@src/lib/layout/utils'
@@ -90,7 +90,7 @@ function ModelingArea() {
 export const useDefaultAreaLibrary = () => {
   useSignals()
   const { settings, layout, registry } = useApp()
-  const { executingEditor } = useSingletons()
+  const executingEditor = useExecutingEditor()
   const getSettings = settings.get
   const registeredAreaLibrary = registry.signal(
     layoutAreaLibraryValueSpec

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -6,7 +6,7 @@ import type {
   Operation,
 } from '@rust/kcl-lib/bindings/Operation'
 import type { CustomIconName } from '@src/components/CustomIcon'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { toUtf16 } from '@src/lang/errors'
 import { updateModelingState } from '@src/lang/modelingWorkflows'
 import {
@@ -4174,14 +4174,15 @@ export function onDelete(props: {
 export async function onUnhide(props: {
   hideOperation: HideOperation
   targetArtifact: Artifact
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
 }) {
   if (props.hideOperation.unlabeledArg === null) {
     return new Error('Missing unlabeled arg for hide operation')
   }
-  let modifiedAst = structuredClone(props.kclManager.ast)
+  let modifiedAst = structuredClone(props.executingEditor.ast)
   const pathToNode = pathToNodeFromRustNodePath(props.hideOperation.nodePath)
-  const wasmInstance = await props.kclManager.rustContext.wasmInstancePromise
+  const wasmInstance =
+    await props.executingEditor.rustContext.wasmInstancePromise
   const hideCall = getNodeFromPath<Node<CallExpressionKw>>(
     modifiedAst,
     pathToNode,
@@ -4209,7 +4210,7 @@ export async function onUnhide(props: {
     }
 
     const deleteResult = deleteTermFromUnlabeledArgumentArray(
-      props.kclManager.ast,
+      props.executingEditor.ast,
       pathToNode,
       wasmInstance,
       termToDelete
@@ -4229,7 +4230,7 @@ export async function onUnhide(props: {
   return updateModelingState(
     modifiedAst,
     EXECUTION_TYPE_REAL,
-    props.kclManager,
+    props.executingEditor,
     {
       focusPath: [],
     }

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -1,3 +1,4 @@
+import { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { projectSkeletonCreate } from '@src/lang/project'
 import { projectFsManager } from '@src/lang/std/fileSystemManager'
 import type { App } from '@src/lib/app'
@@ -58,8 +59,7 @@ export const baseLoader =
     }
 
     // Web, make a default project and redirect to it.
-    const wasmInstance =
-      await app.singletons.executingEditor.wasmInstancePromise
+    const wasmInstance = await app.wasmPromise
 
     const settings = await loadAndValidateSettings(wasmInstance, undefined)
 
@@ -103,7 +103,6 @@ export const fileLoader =
     const {
       settings: { actor: settingsActor },
     } = app
-    const { executingEditor } = app.singletons
     const { params } = routerData
 
     // Must basically remain for all eternity, until the last person
@@ -118,7 +117,7 @@ export const fileLoader =
       ? params.id.split(fsZds.sep).slice(0, -1).join(fsZds.sep)
       : undefined
 
-    const wasmInstance = await executingEditor.wasmInstancePromise
+    const wasmInstance = await app.wasmPromise
 
     let settings = await loadAndValidateSettings(
       wasmInstance,
@@ -207,14 +206,19 @@ export const fileLoader =
     })
     await waitFor(settingsActor, (state) => state.matches('idle'))
 
-    const projectRef = await app.openProject(project)
+    const existingProjectRef =
+      app.project?.path === project.path ? app.project : undefined
+    if (existingProjectRef) {
+      existingProjectRef.projectIORefSignal.value = project
+    }
+    const projectRef = existingProjectRef ?? (await app.openProject(project))
     const editor = await projectRef.openEditor(
       currentFilePath || PROJECT_ENTRYPOINT,
-      app.singletons.executingEditor,
+      undefined,
       // If persistCode in localStorage is present, it'll persist that code
       // through *anything*. INTENDED FOR TESTS.
       window.electron?.process.env.NODE_ENV === 'test'
-        ? executingEditor.localStoragePersistCode()
+        ? ExecutingEditor.localStoragePersistCode()
         : undefined
     )
 

--- a/src/lib/routeLoaders.ts
+++ b/src/lib/routeLoaders.ts
@@ -58,7 +58,8 @@ export const baseLoader =
     }
 
     // Web, make a default project and redirect to it.
-    const wasmInstance = await app.singletons.kclManager.wasmInstancePromise
+    const wasmInstance =
+      await app.singletons.executingEditor.wasmInstancePromise
 
     const settings = await loadAndValidateSettings(wasmInstance, undefined)
 
@@ -102,7 +103,7 @@ export const fileLoader =
     const {
       settings: { actor: settingsActor },
     } = app
-    const { kclManager } = app.singletons
+    const { executingEditor } = app.singletons
     const { params } = routerData
 
     // Must basically remain for all eternity, until the last person
@@ -117,7 +118,7 @@ export const fileLoader =
       ? params.id.split(fsZds.sep).slice(0, -1).join(fsZds.sep)
       : undefined
 
-    const wasmInstance = await kclManager.wasmInstancePromise
+    const wasmInstance = await executingEditor.wasmInstancePromise
 
     let settings = await loadAndValidateSettings(
       wasmInstance,
@@ -209,11 +210,11 @@ export const fileLoader =
     const projectRef = await app.openProject(project)
     const editor = await projectRef.openEditor(
       currentFilePath || PROJECT_ENTRYPOINT,
-      app.singletons.kclManager,
+      app.singletons.executingEditor,
       // If persistCode in localStorage is present, it'll persist that code
       // through *anything*. INTENDED FOR TESTS.
       window.electron?.process.env.NODE_ENV === 'test'
-        ? kclManager.localStoragePersistCode()
+        ? executingEditor.localStoragePersistCode()
         : undefined
     )
 

--- a/src/lib/selectionFilterUtils.ts
+++ b/src/lib/selectionFilterUtils.ts
@@ -5,7 +5,7 @@
 
 import type { EntityType, ModelingCmdReq } from '@kittycad/lib'
 import type { SceneEntities } from '@src/clientSideScene/sceneEntities'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import type { handleSelectionBatch } from '@src/lib/selections'
 import { uuidv4 } from '@src/lib/utils'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
@@ -24,14 +24,14 @@ export const defaultSelectionFilter: EntityType[] = [
 /** TODO: This function is not synchronous but is currently treated as such */
 export function setSelectionFilterToDefault({
   engineCommandManager,
-  kclManager,
+  executingEditor,
   sceneEntitiesManager,
   selectionsToRestore,
   handleSelectionBatchFn,
   wasmInstance,
 }: {
   engineCommandManager: ConnectionManager
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   sceneEntitiesManager: SceneEntities
   selectionsToRestore?: Selections
   handleSelectionBatchFn?: typeof handleSelectionBatch
@@ -40,7 +40,7 @@ export function setSelectionFilterToDefault({
   setSelectionFilter({
     filter: defaultSelectionFilter,
     engineCommandManager,
-    kclManager,
+    executingEditor,
     sceneEntitiesManager,
     selectionsToRestore,
     handleSelectionBatchFn,
@@ -52,7 +52,7 @@ export function setSelectionFilterToDefault({
 export function setSelectionFilter({
   filter,
   engineCommandManager,
-  kclManager,
+  executingEditor,
   sceneEntitiesManager,
   selectionsToRestore,
   handleSelectionBatchFn,
@@ -60,21 +60,21 @@ export function setSelectionFilter({
 }: {
   filter: EntityType[]
   engineCommandManager: ConnectionManager
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   sceneEntitiesManager: SceneEntities
   selectionsToRestore?: Selections
   handleSelectionBatchFn?: typeof handleSelectionBatch
   wasmInstance: ModuleType
 }) {
-  kclManager.selectionFilter.value = filter
+  executingEditor.selectionFilter.value = filter
 
   const { engineEvents } =
     selectionsToRestore && handleSelectionBatchFn
       ? handleSelectionBatchFn({
           selections: selectionsToRestore,
-          artifactGraph: kclManager.artifactGraph,
-          code: kclManager.code,
-          ast: kclManager.ast,
+          artifactGraph: executingEditor.artifactGraph,
+          code: executingEditor.code,
+          ast: executingEditor.ast,
           systemDeps: {
             sceneEntitiesManager,
             engineCommandManager,

--- a/src/lib/selections.ts
+++ b/src/lib/selections.ts
@@ -37,7 +37,7 @@ import type { SceneEntities } from '@src/clientSideScene/sceneEntities'
 import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
 import { showSketchOnImportToast } from '@src/components/SketchOnImportToast'
 import { showUnsupportedSelectionToast } from '@src/components/ToastUnsupportedSelection'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import {
   getCapCodeRef,
   getCodeRefsByArtifactId,
@@ -232,17 +232,17 @@ export async function getEventForSelectWithPoint(
   { data }: Extract<OkModelingCmdResponse, { type: 'select_with_point' }>,
   {
     engineCommandManager,
-    kclManager,
+    executingEditor,
     rustContext,
     wasmInstance,
   }: {
     engineCommandManager: ConnectionManager
-    kclManager: KclManager
+    executingEditor: ExecutingEditor
     rustContext: RustContext
     wasmInstance: ModuleType
   }
 ): Promise<ModelingMachineEvent | null> {
-  const { ast, artifactGraph } = kclManager
+  const { ast, artifactGraph } = executingEditor
   if (!data?.entity_id) {
     return {
       type: 'Set selection',
@@ -1526,14 +1526,14 @@ export async function selectOffsetSketchPlane(
 export async function selectSketchPlane(
   planeOrFaceId: string | undefined,
   useSketchSolveMode: boolean | undefined,
-  kclManager?: KclManager
+  executingEditor?: ExecutingEditor
 ) {
   try {
-    if (!kclManager) return
+    if (!executingEditor) return
     if (!planeOrFaceId) return
 
     if (useSketchSolveMode) {
-      kclManager.sceneInfra.modelingSend({
+      executingEditor.sceneInfra.modelingSend({
         type: 'Select sketch solve plane',
         data: planeOrFaceId,
       })
@@ -1541,17 +1541,17 @@ export async function selectSketchPlane(
     }
 
     const defaultSketchPlaneSelected = selectDefaultSketchPlane(planeOrFaceId, {
-      sceneInfra: kclManager.sceneInfra,
-      rustContext: kclManager.rustContext,
+      sceneInfra: executingEditor.sceneInfra,
+      rustContext: executingEditor.rustContext,
     })
     if (!err(defaultSketchPlaneSelected) && defaultSketchPlaneSelected) {
       return
     }
 
-    const artifact = kclManager.artifactGraph.get(planeOrFaceId)
+    const artifact = executingEditor.artifactGraph.get(planeOrFaceId)
     const offsetPlaneSelected = await selectOffsetSketchPlane(artifact, {
-      sceneInfra: kclManager.sceneInfra,
-      sceneEntitiesManager: kclManager.sceneEntitiesManager,
+      sceneInfra: executingEditor.sceneInfra,
+      sceneEntitiesManager: executingEditor.sceneEntitiesManager,
     })
     if (!err(offsetPlaneSelected) && offsetPlaneSelected) {
       return
@@ -1559,18 +1559,18 @@ export async function selectSketchPlane(
 
     const sweepFaceSelected = await selectionBodyFace(
       planeOrFaceId,
-      kclManager.artifactGraph,
-      kclManager.ast,
-      kclManager.execState,
+      executingEditor.artifactGraph,
+      executingEditor.ast,
+      executingEditor.execState,
       {
-        rustContext: kclManager.rustContext,
-        sceneInfra: kclManager.sceneInfra,
-        sceneEntitiesManager: kclManager.sceneEntitiesManager,
-        wasmInstance: await kclManager.wasmInstancePromise,
+        rustContext: executingEditor.rustContext,
+        sceneInfra: executingEditor.sceneInfra,
+        sceneEntitiesManager: executingEditor.sceneEntitiesManager,
+        wasmInstance: await executingEditor.wasmInstancePromise,
       }
     )
     if (sweepFaceSelected) {
-      kclManager.sceneInfra.modelingSend({
+      executingEditor.sceneInfra.modelingSend({
         type: 'Select sketch plane',
         data: sweepFaceSelected,
       })

--- a/src/lib/testHelpers.ts
+++ b/src/lib/testHelpers.ts
@@ -1,6 +1,6 @@
 import type { Node } from '@rust/kcl-lib/bindings/Node'
 
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { getCodeRefsByArtifactId } from '@src/lang/std/artifactGraph'
 import {
   type Artifact,
@@ -31,15 +31,15 @@ export async function enginelessExecutor(
 export async function getAstAndArtifactGraph(
   code: string,
   instance: ModuleType,
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
 ) {
   const ast = assertParse(code, instance)
-  await kclManager.executeAst({ ast })
+  await executingEditor.executeAst({ ast })
   const {
     artifactGraph,
     execState: { operations },
     variables,
-  } = kclManager
+  } = executingEditor
   await new Promise((resolve) => setTimeout(resolve, 100))
   return { ast, artifactGraph, operations, variables }
 }
@@ -47,13 +47,13 @@ export async function getAstAndArtifactGraph(
 export async function getAstAndSketchSelections(
   code: string,
   instance: ModuleType,
-  kclManager: KclManager,
+  executingEditor: ExecutingEditor,
   count: number | undefined = undefined
 ) {
   const { ast, artifactGraph } = await getAstAndArtifactGraph(
     code,
     instance,
-    kclManager
+    executingEditor
   )
   const artifacts = [...artifactGraph.values()].filter((a) => a.type === 'path')
   if (artifacts.length === 0) {

--- a/src/lib/toolbar.spec.ts
+++ b/src/lib/toolbar.spec.ts
@@ -254,7 +254,7 @@ describe('toolbar state helpers', () => {
     const sketchItem = findModelingToolbarItem('sketch')
     const modelingState = {
       context: {
-        kclManager: { sceneInfra: { modelingSend } },
+        executingEditor: { sceneInfra: { modelingSend } },
         selectionRanges: {
           graphSelections: [
             {
@@ -299,7 +299,7 @@ describe('toolbar state helpers', () => {
     const sketchItem = findModelingToolbarItem('sketch')
     const modelingState = {
       context: {
-        kclManager: { sceneInfra: { modelingSend } },
+        executingEditor: { sceneInfra: { modelingSend } },
         selectionRanges: {
           graphSelections: [],
           otherSelections: [{ id: 'default-plane-xy', name: 'XY' }],

--- a/src/lib/toolbar.ts
+++ b/src/lib/toolbar.ts
@@ -598,7 +598,7 @@ export function buildToolbarConfig(
               void selectSketchPlane(
                 selectedSketchTarget,
                 modelingState.context.store.useSketchSolveMode?.current,
-                modelingState.context.kclManager
+                modelingState.context.executingEditor
               )
             } else {
               // No sketch context - start new sketch
@@ -1679,13 +1679,13 @@ export function buildToolbarConfig(
                 return (
                   (!isEditingExistingSketch({
                     sketchDetails: state.context.sketchDetails,
-                    kclManager: state.context.kclManager,
+                    executingEditor: state.context.executingEditor,
                     wasmInstance: state.context.wasmInstance,
                   }) &&
                     !state.matches({ Sketch: 'Tangential arc to' })) ||
                   pipeHasCircle({
                     sketchDetails: state.context.sketchDetails,
-                    kclManager: state.context.kclManager,
+                    executingEditor: state.context.executingEditor,
                     wasmInstance: state.context.wasmInstance,
                   })
                 )
@@ -1693,7 +1693,7 @@ export function buildToolbarConfig(
               disabledReason: (state) => {
                 return !isEditingExistingSketch({
                   sketchDetails: state.context.sketchDetails,
-                  kclManager: state.context.kclManager,
+                  executingEditor: state.context.executingEditor,
                   wasmInstance: state.context.wasmInstance,
                 }) && !state.matches({ Sketch: 'Tangential arc to' })
                   ? "Cannot start a tangential arc because there's no previous line to be tangential to.  Try drawing a line first or selecting an existing sketch to edit."

--- a/src/lib/usePreviousVarMentions.ts
+++ b/src/lib/usePreviousVarMentions.ts
@@ -12,8 +12,8 @@ export function usePreviousVarMentions(
   ast: Program,
   variables: VariableMap
 ) {
-  const { kclManager } = useSingletons()
-  const wasmInstance = use(kclManager.wasmInstancePromise)
+  const { executingEditor } = useSingletons()
+  const wasmInstance = use(executingEditor.wasmInstancePromise)
   const previousVariables = usePreviousVariables({
     code: context.view?.state.doc.toString() || '',
     ast,

--- a/src/lib/usePreviousVarMentions.ts
+++ b/src/lib/usePreviousVarMentions.ts
@@ -1,7 +1,7 @@
 import type { CompletionContext } from '@codemirror/autocomplete'
 
 import type { Program, VariableMap } from '@src/lang/wasm'
-import { useSingletons } from '@src/lib/boot'
+import { useApp } from '@src/lib/boot'
 import { usePreviousVariables } from '@src/lib/usePreviousVariables'
 import { use } from 'react'
 
@@ -12,8 +12,8 @@ export function usePreviousVarMentions(
   ast: Program,
   variables: VariableMap
 ) {
-  const { executingEditor } = useSingletons()
-  const wasmInstance = use(executingEditor.wasmInstancePromise)
+  const app = useApp()
+  const wasmInstance = use(app.wasmPromise)
   const previousVariables = usePreviousVariables({
     code: context.view?.state.doc.toString() || '',
     ast,

--- a/src/machines/commandBarMachine.ts
+++ b/src/machines/commandBarMachine.ts
@@ -134,7 +134,7 @@ export type CommandBarMachineEvent =
       type: 'Change current argument'
       data: { [x: string]: CommandArgumentWithName<unknown> }
     }
-  | { type: 'Set executingEditor'; data: ExecutingEditor }
+  | { type: 'Set executingEditor'; data: ExecutingEditor | undefined }
 
 export const commandBarMachine = setup({
   types: {
@@ -210,7 +210,7 @@ export const commandBarMachine = setup({
         const { selectedCommand } = context
         if (!(selectedCommand && selectedCommand.args)) return undefined
         const rejectedArg =
-          'data' in event && 'arg' in event.data && event.data.arg
+          'data' in event && event.data && 'arg' in event.data && event.data.arg
 
         // Find the first argument that is not to be skipped:
         // that is, the first argument that is not already in the argumentsToSubmit

--- a/src/machines/commandBarMachine.ts
+++ b/src/machines/commandBarMachine.ts
@@ -1,4 +1,4 @@
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import type { MachineManager } from '@src/lib/MachineManager'
 import type {
   Command,
@@ -64,7 +64,7 @@ export type CommandBarContext = CommandBarInput & {
   argumentsToSubmit: { [x: string]: unknown }
   reviewValidationError?: string
   machineManager: MachineManager
-  kclManager?: KclManager
+  executingEditor?: ExecutingEditor
   userFeatures?: UserFeaturesService
 }
 
@@ -134,7 +134,7 @@ export type CommandBarMachineEvent =
       type: 'Change current argument'
       data: { [x: string]: CommandArgumentWithName<unknown> }
     }
-  | { type: 'Set kclManager'; data: KclManager }
+  | { type: 'Set executingEditor'; data: ExecutingEditor }
 
 export const commandBarMachine = setup({
   types: {
@@ -155,9 +155,9 @@ export const commandBarMachine = setup({
         }
       },
     }),
-    'Set kclManager': assign({
-      kclManager: ({ event }) => {
-        assertEvent(event, 'Set kclManager')
+    'Set executingEditor': assign({
+      executingEditor: ({ event }) => {
+        assertEvent(event, 'Set executingEditor')
         return event.data
       },
     }),
@@ -757,8 +757,8 @@ export const commandBarMachine = setup({
     },
   },
   on: {
-    'Set kclManager': {
-      actions: 'Set kclManager',
+    'Set executingEditor': {
+      actions: 'Set executingEditor',
     },
     'Set userFeatures': {
       actions: 'Set userFeatures',

--- a/src/machines/modelingMachine.spec.ts
+++ b/src/machines/modelingMachine.spec.ts
@@ -1,5 +1,5 @@
 import type { Node } from '@rust/kcl-lib/bindings/Node'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { ARG_END_ABSOLUTE, ARG_INTERIOR_ABSOLUTE } from '@src/lang/constants'
 import {
   createIdentifier,
@@ -44,7 +44,7 @@ import { type ActorRefFrom, createActor, fromPromise } from 'xstate'
 const GLOBAL_TIMEOUT_FOR_MODELING_MACHINE = 5000
 
 let instanceInThisFile: ModuleType = null!
-let kclManagerInThisFile: KclManager = null!
+let executingEditorInThisFile: ExecutingEditor = null!
 let engineCommandManagerInThisFile: ConnectionManager = null!
 let rustContextInThisFile: RustContext = null!
 let commandBarActorInThisFile: CommandBarActorType = null!
@@ -72,13 +72,13 @@ beforeEach(async () => {
   const {
     instance,
     engineCommandManager,
-    kclManager,
+    executingEditor,
     rustContext,
     commandBarActor,
     machineManager,
   } = await buildTheWorldAndConnectToEngine()
   instanceInThisFile = instance
-  kclManagerInThisFile = kclManager
+  executingEditorInThisFile = executingEditor
   engineCommandManagerInThisFile = engineCommandManager
   rustContextInThisFile = rustContext
   commandBarActorInThisFile = commandBarActor
@@ -176,7 +176,7 @@ describe('modelingMachine.test.ts', () => {
     describe('when initialized', () => {
       it('should start in the idle state', async () => {
         const contextCopied = generateModelingMachineDefaultContext({
-          kclManager: kclManagerInThisFile,
+          executingEditor: executingEditorInThisFile,
           rustContext: rustContextInThisFile,
           wasmInstance: instanceInThisFile,
           engineCommandManager: engineCommandManagerInThisFile,
@@ -946,14 +946,14 @@ p3 = [342.51, 216.38],
           it(name, async () => {
             const indexOfInterest = code.indexOf(searchText)
             // You need to update this!!
-            kclManagerInThisFile.updateCodeEditor(code)
+            executingEditorInThisFile.updateCodeEditor(code)
             const ast = assertParse(code, instanceInThisFile)
-            await kclManagerInThisFile.executeAst({ ast })
+            await executingEditorInThisFile.executeAst({ ast })
 
-            expect(kclManagerInThisFile.errors).toEqual([])
+            expect(executingEditorInThisFile.errors).toEqual([])
 
             // segment artifact with that source range
-            const artifact = [...kclManagerInThisFile.artifactGraph].find(
+            const artifact = [...executingEditorInThisFile.artifactGraph].find(
               ([_, artifact]) =>
                 artifact?.type === 'segment' &&
                 artifact.codeRef.range[0] <= indexOfInterest &&
@@ -966,7 +966,7 @@ p3 = [342.51, 216.38],
             }
 
             const contextCopied = generateModelingMachineDefaultContext({
-              kclManager: kclManagerInThisFile,
+              executingEditor: executingEditorInThisFile,
               rustContext: rustContextInThisFile,
               wasmInstance: instanceInThisFile,
               engineCommandManager: engineCommandManagerInThisFile,
@@ -1012,7 +1012,7 @@ p3 = [342.51, 216.38],
             })
 
             const callExp = getNodeFromPath<Node<CallExpressionKw>>(
-              kclManagerInThisFile.ast,
+              executingEditorInThisFile.ast,
               artifact.codeRef.pathToNode,
               instanceInThisFile,
               'CallExpressionKw'
@@ -1022,7 +1022,7 @@ p3 = [342.51, 216.38],
             }
             const constraintInfo = getConstraintInfoKw(
               callExp.node,
-              kclManagerInThisFile.code,
+              executingEditorInThisFile.code,
               artifact.codeRef.pathToNode,
               filter
             )
@@ -1048,13 +1048,13 @@ p3 = [342.51, 216.38],
 
             const startTime = Date.now()
             while (
-              kclManagerInThisFile.code.includes(searchText) &&
+              executingEditorInThisFile.code.includes(searchText) &&
               Date.now() - startTime < GLOBAL_TIMEOUT_FOR_MODELING_MACHINE
             ) {
               await new Promise((resolve) => setTimeout(resolve, 100))
             }
 
-            expect(kclManagerInThisFile.code).not.toContain(searchText)
+            expect(executingEditorInThisFile.code).not.toContain(searchText)
           }, 10_000)
         }
       )
@@ -1076,15 +1076,15 @@ p3 = [342.51, 216.38],
           it(name, async () => {
             const indexOfInterest = code.indexOf(searchText)
             // You need to update this!!
-            kclManagerInThisFile.updateCodeEditor(code)
+            executingEditorInThisFile.updateCodeEditor(code)
             const ast = assertParse(code, instanceInThisFile)
 
-            await kclManagerInThisFile.executeAst({ ast })
+            await executingEditorInThisFile.executeAst({ ast })
 
-            expect(kclManagerInThisFile.errors).toEqual([])
+            expect(executingEditorInThisFile.errors).toEqual([])
 
             // segment artifact with that source range
-            const artifact = [...kclManagerInThisFile.artifactGraph].find(
+            const artifact = [...executingEditorInThisFile.artifactGraph].find(
               ([_, artifact]) =>
                 artifact?.type === 'segment' &&
                 artifact.codeRef.range[0] <= indexOfInterest &&
@@ -1097,7 +1097,7 @@ p3 = [342.51, 216.38],
             }
 
             const contextCopied = generateModelingMachineDefaultContext({
-              kclManager: kclManagerInThisFile,
+              executingEditor: executingEditorInThisFile,
               rustContext: rustContextInThisFile,
               wasmInstance: instanceInThisFile,
               engineCommandManager: engineCommandManagerInThisFile,
@@ -1143,7 +1143,7 @@ p3 = [342.51, 216.38],
             })
 
             const callExp = getNodeFromPath<Node<CallExpressionKw>>(
-              kclManagerInThisFile.ast,
+              executingEditorInThisFile.ast,
               artifact.codeRef.pathToNode,
               instanceInThisFile,
               'CallExpressionKw'
@@ -1153,7 +1153,7 @@ p3 = [342.51, 216.38],
             }
             const constraintInfo = getConstraintInfoKw(
               callExp.node,
-              kclManagerInThisFile.code,
+              executingEditorInThisFile.code,
               artifact.codeRef.pathToNode,
               filter
             )
@@ -1194,7 +1194,7 @@ p3 = [342.51, 216.38],
               modelingMachineActor: actor,
               stateString: { Sketch: { SketchIdle: 'scene drawn' } },
             })
-            expect(kclManagerInThisFile.code).toContain(expectedResult)
+            expect(executingEditorInThisFile.code).toContain(expectedResult)
           }, 10_000)
         }
       )
@@ -1217,15 +1217,15 @@ p3 = [342.51, 216.38],
           it(name, async () => {
             const indexOfInterest = code.indexOf(searchText)
             // You need to update this!!
-            kclManagerInThisFile.updateCodeEditor(code)
+            executingEditorInThisFile.updateCodeEditor(code)
             const ast = assertParse(code, instanceInThisFile)
 
-            await kclManagerInThisFile.executeAst({ ast })
+            await executingEditorInThisFile.executeAst({ ast })
 
-            expect(kclManagerInThisFile.errors).toEqual([])
+            expect(executingEditorInThisFile.errors).toEqual([])
 
             // segment artifact with that source range
-            const artifact = [...kclManagerInThisFile.artifactGraph].find(
+            const artifact = [...executingEditorInThisFile.artifactGraph].find(
               ([_, artifact]) =>
                 artifact?.type === 'segment' &&
                 artifact.codeRef.range[0] <= indexOfInterest &&
@@ -1238,7 +1238,7 @@ p3 = [342.51, 216.38],
             }
 
             const contextCopied = generateModelingMachineDefaultContext({
-              kclManager: kclManagerInThisFile,
+              executingEditor: executingEditorInThisFile,
               rustContext: rustContextInThisFile,
               wasmInstance: instanceInThisFile,
               engineCommandManager: engineCommandManagerInThisFile,
@@ -1288,7 +1288,7 @@ p3 = [342.51, 216.38],
             })
 
             const callExp = getNodeFromPath<Node<CallExpressionKw>>(
-              kclManagerInThisFile.ast,
+              executingEditorInThisFile.ast,
               artifact.codeRef.pathToNode,
               instanceInThisFile,
               'CallExpressionKw'
@@ -1298,7 +1298,7 @@ p3 = [342.51, 216.38],
             }
             const constraintInfo = getConstraintInfoKw(
               callExp.node,
-              kclManagerInThisFile.code,
+              executingEditorInThisFile.code,
               artifact.codeRef.pathToNode,
               filter
             )
@@ -1313,7 +1313,7 @@ p3 = [342.51, 216.38],
               constraint.pathToNode,
               constraint.argPosition,
               ast,
-              kclManagerInThisFile.variables,
+              executingEditorInThisFile.variables,
               removeSingleConstraint,
               transformAstSketchLines,
               instanceInThisFile
@@ -1345,15 +1345,15 @@ p3 = [342.51, 216.38],
           it(name, async () => {
             const indexOfInterest = code.indexOf(searchText)
             // You need to update this!!
-            kclManagerInThisFile.updateCodeEditor(code)
+            executingEditorInThisFile.updateCodeEditor(code)
             const ast = assertParse(code, instanceInThisFile)
 
-            await kclManagerInThisFile.executeAst({ ast })
+            await executingEditorInThisFile.executeAst({ ast })
 
-            expect(kclManagerInThisFile.errors).toEqual([])
+            expect(executingEditorInThisFile.errors).toEqual([])
 
             // segment artifact with that source range
-            const artifact = [...kclManagerInThisFile.artifactGraph].find(
+            const artifact = [...executingEditorInThisFile.artifactGraph].find(
               ([_, artifact]) =>
                 artifact?.type === 'segment' &&
                 artifact.codeRef.range[0] <= indexOfInterest &&
@@ -1366,7 +1366,7 @@ p3 = [342.51, 216.38],
             }
 
             const contextCopied = generateModelingMachineDefaultContext({
-              kclManager: kclManagerInThisFile,
+              executingEditor: executingEditorInThisFile,
               rustContext: rustContextInThisFile,
               wasmInstance: instanceInThisFile,
               engineCommandManager: engineCommandManagerInThisFile,
@@ -1417,7 +1417,7 @@ p3 = [342.51, 216.38],
             })
 
             const callExp = getNodeFromPath<Node<CallExpressionKw>>(
-              kclManagerInThisFile.ast,
+              executingEditorInThisFile.ast,
               artifact.codeRef.pathToNode,
               instanceInThisFile,
               'CallExpressionKw'
@@ -1454,12 +1454,12 @@ p3 = [342.51, 216.38],
             }, GLOBAL_TIMEOUT_FOR_MODELING_MACHINE)
             const startTime = Date.now()
             while (
-              !kclManagerInThisFile.code.includes(expectedResult) &&
+              !executingEditorInThisFile.code.includes(expectedResult) &&
               Date.now() - startTime < GLOBAL_TIMEOUT_FOR_MODELING_MACHINE
             ) {
               await new Promise((resolve) => setTimeout(resolve, 100))
             }
-            expect(kclManagerInThisFile.code).toContain(expectedResult)
+            expect(executingEditorInThisFile.code).toContain(expectedResult)
           }, 10_000)
         }
       )
@@ -1476,23 +1476,23 @@ sketch001 = sketch(on = YZ) {
       it('keeps invalid code intact when sketch creation is attempted with parse errors', async () => {
         const {
           instance,
-          kclManager,
+          executingEditor,
           rustContext,
           engineCommandManager,
           commandBarActor,
           machineManager,
         } = await buildTheWorldAndNoEngineConnection()
 
-        kclManager.updateCodeEditor(invalidCode)
-        const parseResult = await kclManager.safeParse(invalidCode)
+        executingEditor.updateCodeEditor(invalidCode)
+        const parseResult = await executingEditor.safeParse(invalidCode)
 
         expect(parseResult).toBeNull()
-        expect(kclManager.hasParseErrors()).toBe(true)
+        expect(executingEditor.hasParseErrors()).toBe(true)
 
         const newSketchSpy = vi.spyOn(rustContext, 'newSketch')
 
         const context = generateModelingMachineDefaultContext({
-          kclManager,
+          executingEditor,
           rustContext,
           wasmInstance: instance,
           engineCommandManager,
@@ -1517,7 +1517,7 @@ sketch001 = sketch(on = YZ) {
         )
 
         expect(newSketchSpy).not.toHaveBeenCalled()
-        expect(kclManager.code).toBe(invalidCode)
+        expect(executingEditor.code).toBe(invalidCode)
         expect(actor.getSnapshot().value).toBe('Sketch no face')
         expect(toastErrorSpy).toHaveBeenCalledWith(
           'Unable to enter sketch while KCL has parse errors.'
@@ -1580,7 +1580,7 @@ sketch001 = sketch(on = YZ) {
             ],
             otherSelections: [],
           },
-          kclManager: {
+          executingEditor: {
             artifactGraph,
             hidePlanes: vi.fn(),
             showPlanes: vi.fn(),
@@ -1637,7 +1637,7 @@ sketch001 = sketch(on = YZ) {
     it('restores camera orbit controls when sketch exit errors', async () => {
       const {
         instance,
-        kclManager,
+        executingEditor,
         rustContext,
         engineCommandManager,
         commandBarActor,
@@ -1649,7 +1649,7 @@ sketch001 = sketch(on = YZ) {
         .mockRejectedValue(new Error('sketch exit failed'))
 
       const context = generateModelingMachineDefaultContext({
-        kclManager,
+        executingEditor,
         rustContext,
         wasmInstance: instance,
         engineCommandManager,
@@ -1706,9 +1706,9 @@ sketch001 = sketch(on = YZ) {
       })
 
       expect(sendSceneCommandSpy).toHaveBeenCalled()
-      expect(kclManager.sceneInfra.camControls.enableRotate).toBe(true)
-      expect(kclManager.sceneInfra.camControls.enablePan).toBe(true)
-      expect(kclManager.sceneInfra.camControls.syncDirection).toBe(
+      expect(executingEditor.sceneInfra.camControls.enableRotate).toBe(true)
+      expect(executingEditor.sceneInfra.camControls.enablePan).toBe(true)
+      expect(executingEditor.sceneInfra.camControls.syncDirection).toBe(
         'engineToClient'
       )
     })
@@ -1716,7 +1716,7 @@ sketch001 = sketch(on = YZ) {
     it('disables camera orbit controls in sketch solve mode', async () => {
       const {
         instance,
-        kclManager,
+        executingEditor,
         rustContext,
         engineCommandManager,
         commandBarActor,
@@ -1724,7 +1724,7 @@ sketch001 = sketch(on = YZ) {
       } = await buildTheWorldAndNoEngineConnection()
 
       const context = generateModelingMachineDefaultContext({
-        kclManager,
+        executingEditor,
         rustContext,
         wasmInstance: instance,
         engineCommandManager,
@@ -1769,8 +1769,8 @@ sketch001 = sketch(on = YZ) {
         )
       })
 
-      expect(kclManager.sceneInfra.camControls.enableRotate).toBe(false)
-      expect(kclManager.sceneInfra.camControls.syncDirection).toBe(
+      expect(executingEditor.sceneInfra.camControls.enableRotate).toBe(false)
+      expect(executingEditor.sceneInfra.camControls.syncDirection).toBe(
         'clientToEngine'
       )
     })

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -94,7 +94,7 @@ import {
   applyConstraintAngleLength,
   applyConstraintLength,
 } from '@src/components/Toolbar/setAngleLength'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { updateModelingState } from '@src/lang/modelingWorkflows'
 import {
   insertNamedConstant,
@@ -315,7 +315,7 @@ function getSelectedSketchBlockArtifact({
   artifactGraph,
   selectionRanges,
 }: {
-  artifactGraph: ModelingMachineContext['kclManager']['artifactGraph']
+  artifactGraph: ModelingMachineContext['executingEditor']['artifactGraph']
   selectionRanges: Selections
 }): Extract<Artifact, { type: 'sketchBlock' }> | undefined {
   const selectedArtifact = selectionRanges.graphSelections[0]?.artifact
@@ -349,7 +349,7 @@ function getSelectedSketchBlockArtifact({
 
 async function enterSketchSolveFromSketchBlockArtifact({
   sketchBlockArtifact,
-  kclManager,
+  executingEditor,
   rustContext,
   engineCommandManager,
   defaultUnit,
@@ -357,7 +357,7 @@ async function enterSketchSolveFromSketchBlockArtifact({
   wasmInstance,
 }: {
   sketchBlockArtifact: Extract<Artifact, { type: 'sketchBlock' }>
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   rustContext: RustContext
   engineCommandManager: ConnectionManager
   defaultUnit?: ModelingMachineContext['store']['defaultUnit']
@@ -375,17 +375,17 @@ async function enterSketchSolveFromSketchBlockArtifact({
   }
 
   const systemDeps = {
-    sceneInfra: kclManager.sceneInfra,
+    sceneInfra: executingEditor.sceneInfra,
     rustContext,
-    sceneEntitiesManager: kclManager.sceneEntitiesManager,
-    ast: kclManager.ast,
-    execState: kclManager.execState,
+    sceneEntitiesManager: executingEditor.sceneEntitiesManager,
+    ast: executingEditor.ast,
+    execState: executingEditor.execState,
     wasmInstance,
   }
 
   const planeData = await getPlaneDataFromSketchBlock(
     sketchBlockArtifact,
-    kclManager.artifactGraph,
+    executingEditor.artifactGraph,
     systemDeps
   )
   if (!planeData) {
@@ -397,7 +397,7 @@ async function enterSketchSolveFromSketchBlockArtifact({
   const id =
     planeData.type === 'extrudeFace' ? planeData.faceId : planeData.planeId
   await letEngineAnimateAndSyncCamAfter(engineCommandManager, id)
-  kclManager.sceneInfra.camControls.syncDirection = 'clientToEngine'
+  executingEditor.sceneInfra.camControls.syncDirection = 'clientToEngine'
 
   const project = projectRef?.current
   if (!project) {
@@ -413,7 +413,7 @@ async function enterSketchSolveFromSketchBlockArtifact({
   try {
     await rustContext.clearSketchCheckpoints()
     await rustContext.hackSetProgram(
-      kclManager.ast,
+      executingEditor.ast,
       jsAppSettings(rustContext.settingsActor)
     )
     editSketchResult = await rustContext.editSketch(
@@ -432,8 +432,8 @@ async function enterSketchSolveFromSketchBlockArtifact({
       toast.error(errorMessage)
       return reject(new Error(errorMessage))
     }
-    kclManager.updateCodeEditor(
-      kclManager.code,
+    executingEditor.updateCodeEditor(
+      executingEditor.code,
       {
         shouldAddToHistory: false,
         shouldWriteToDisk: false,
@@ -754,25 +754,25 @@ export const modelingMachine = setup({
       return context.store.useSketchSolveMode?.current === true
     },
     'Selection is sketchBlock': ({
-      context: { selectionRanges, kclManager },
+      context: { selectionRanges, executingEditor },
       event,
     }): boolean => {
       if (event.type !== 'Enter sketch') return false
       if (event.data?.forceNewSketch) return false
       return !!getSelectedSketchBlockArtifact({
-        artifactGraph: kclManager.artifactGraph,
+        artifactGraph: executingEditor.artifactGraph,
         selectionRanges,
       })
     },
     'Selection is on face': ({
-      context: { selectionRanges, kclManager, wasmInstance },
+      context: { selectionRanges, executingEditor, wasmInstance },
       event,
     }): boolean => {
       if (event.type !== 'Enter sketch') return false
       if (event.data?.forceNewSketch) return false
       if (
         getSelectedSketchBlockArtifact({
-          artifactGraph: kclManager.artifactGraph,
+          artifactGraph: executingEditor.artifactGraph,
           selectionRanges,
         })
       ) {
@@ -784,13 +784,13 @@ export const modelingMachine = setup({
         // See if the selection is "close enough" to be coerced to the plane later
         const maybePlane = getPlaneFromArtifact(
           selectionRanges.graphSelections[0].artifact,
-          kclManager.artifactGraph
+          executingEditor.artifactGraph
         )
         return !err(maybePlane)
       }
       if (
         isCursorInFunctionDefinition(
-          kclManager.ast,
+          executingEditor.ast,
           selectionRanges.graphSelections[0],
           wasmInstance
         )
@@ -798,12 +798,12 @@ export const modelingMachine = setup({
         return false
       }
       return !!isCursorInSketchCommandRange(
-        kclManager.artifactGraph,
+        executingEditor.artifactGraph,
         selectionRanges
       )
     },
-    'Has exportable geometry': ({ context: { kclManager } }) =>
-      !kclManager.hasErrors() && kclManager.ast.body.length > 0,
+    'Has exportable geometry': ({ context: { executingEditor } }) =>
+      !executingEditor.hasErrors() && executingEditor.ast.body.length > 0,
     'has valid selection for deletion': ({ context }) => {
       const isCommandBarClosed =
         context.commandBarActor.getSnapshot().matches('Closed') ?? true
@@ -812,15 +812,15 @@ export const modelingMachine = setup({
       return true
     },
     // TODO: figure out if we really need this one, was separate from 'no kcl errors'
-    'is-error-free': ({ context: { kclManager } }): boolean => {
-      return kclManager.errors.length === 0 && !kclManager.hasErrors()
+    'is-error-free': ({ context: { executingEditor } }): boolean => {
+      return executingEditor.errors.length === 0 && !executingEditor.hasErrors()
     },
     'is editing existing sketch': ({
-      context: { sketchDetails, kclManager, wasmInstance },
+      context: { sketchDetails, executingEditor, wasmInstance },
     }) => {
       return isEditingExistingSketch({
         sketchDetails,
-        kclManager,
+        executingEditor,
         wasmInstance,
       })
     },
@@ -828,7 +828,7 @@ export const modelingMachine = setup({
       const info = horzVertInfo(
         context.selectionRanges,
         'horizontal',
-        context.kclManager.ast,
+        context.executingEditor.ast,
         context.wasmInstance
       )
       if (err(info)) return false
@@ -838,7 +838,7 @@ export const modelingMachine = setup({
       const info = horzVertInfo(
         context.selectionRanges,
         'vertical',
-        context.kclManager.ast,
+        context.executingEditor.ast,
         context.wasmInstance
       )
       if (err(info)) return false
@@ -848,7 +848,7 @@ export const modelingMachine = setup({
       const info = horzVertDistanceInfo({
         selectionRanges: context.selectionRanges,
         constraint: 'setHorzDistance',
-        kclManager: context.kclManager,
+        executingEditor: context.executingEditor,
         wasmInstance: context.wasmInstance,
       })
       if (err(info)) return false
@@ -858,7 +858,7 @@ export const modelingMachine = setup({
       const info = horzVertDistanceInfo({
         selectionRanges: context.selectionRanges,
         constraint: 'setVertDistance',
-        kclManager: context.kclManager,
+        executingEditor: context.executingEditor,
         wasmInstance: context.wasmInstance,
       })
       if (err(info)) return false
@@ -868,7 +868,7 @@ export const modelingMachine = setup({
       const info = absDistanceInfo({
         selectionRanges: context.selectionRanges,
         constraint: 'xAbs',
-        kclManager: context.kclManager,
+        executingEditor: context.executingEditor,
         wasmInstance: context.wasmInstance,
       })
       if (err(info)) return false
@@ -878,36 +878,36 @@ export const modelingMachine = setup({
       const info = absDistanceInfo({
         selectionRanges: context.selectionRanges,
         constraint: 'yAbs',
-        kclManager: context.kclManager,
+        executingEditor: context.executingEditor,
         wasmInstance: context.wasmInstance,
       })
       if (err(info)) return false
       return info.enabled
     },
     'Can constrain angle': ({
-      context: { selectionRanges, kclManager, wasmInstance },
+      context: { selectionRanges, executingEditor, wasmInstance },
     }) => {
       const angleBetween = angleBetweenInfo({
         selectionRanges,
-        kclManager,
+        executingEditor,
         wasmInstance,
       })
       if (err(angleBetween)) return false
       const angleLength = angleLengthInfo({
         selectionRanges,
         angleOrLength: 'setAngle',
-        kclManager,
+        executingEditor,
         wasmInstance,
       })
       if (err(angleLength)) return false
       return angleBetween.enabled || angleLength.enabled
     },
     'Can constrain length': ({
-      context: { selectionRanges, kclManager, wasmInstance },
+      context: { selectionRanges, executingEditor, wasmInstance },
     }) => {
       const angleLength = angleLengthInfo({
         selectionRanges,
-        kclManager,
+        executingEditor,
         wasmInstance,
       })
       if (err(angleLength)) return false
@@ -916,7 +916,7 @@ export const modelingMachine = setup({
     'Can constrain perpendicular distance': ({ context }) => {
       const info = intersectInfo({
         selectionRanges: context.selectionRanges,
-        kclManager: context.kclManager,
+        executingEditor: context.executingEditor,
         wasmInstance: context.wasmInstance,
       })
       if (err(info)) return false
@@ -926,7 +926,7 @@ export const modelingMachine = setup({
       const info = horzVertDistanceInfo({
         selectionRanges: context.selectionRanges,
         constraint: 'setHorzDistance',
-        kclManager: context.kclManager,
+        executingEditor: context.executingEditor,
         wasmInstance: context.wasmInstance,
       })
       if (err(info)) return false
@@ -936,7 +936,7 @@ export const modelingMachine = setup({
       const info = horzVertDistanceInfo({
         selectionRanges: context.selectionRanges,
         constraint: 'setHorzDistance',
-        kclManager: context.kclManager,
+        executingEditor: context.executingEditor,
         wasmInstance: context.wasmInstance,
       })
       if (err(info)) return false
@@ -946,7 +946,7 @@ export const modelingMachine = setup({
       const info = absDistanceInfo({
         selectionRanges: context.selectionRanges,
         constraint: 'snapToXAxis',
-        kclManager: context.kclManager,
+        executingEditor: context.executingEditor,
         wasmInstance: context.wasmInstance,
       })
       if (err(info)) return false
@@ -956,7 +956,7 @@ export const modelingMachine = setup({
       const info = absDistanceInfo({
         selectionRanges: context.selectionRanges,
         constraint: 'snapToYAxis',
-        kclManager: context.kclManager,
+        executingEditor: context.executingEditor,
         wasmInstance: context.wasmInstance,
       })
       if (err(info)) return false
@@ -965,7 +965,7 @@ export const modelingMachine = setup({
     'Can constrain equal length': ({ context }) => {
       const info = setEqualLengthInfo({
         selectionRanges: context.selectionRanges,
-        ast: context.kclManager.ast,
+        ast: context.executingEditor.ast,
         wasmInstance: context.wasmInstance,
       })
       if (err(info)) return false
@@ -974,14 +974,14 @@ export const modelingMachine = setup({
     'Can constrain parallel': ({ context }) => {
       const info = equalAngleInfo({
         selectionRanges: context.selectionRanges,
-        kclManager: context.kclManager,
+        executingEditor: context.executingEditor,
         wasmInstance: context.wasmInstance,
       })
       if (err(info)) return false
       return info.enabled
     },
     'Can constrain remove constraints': ({
-      context: { selectionRanges, kclManager, wasmInstance },
+      context: { selectionRanges, executingEditor, wasmInstance },
       event,
     }) => {
       if (event.type !== 'Constrain remove constraints') return false
@@ -993,7 +993,7 @@ export const modelingMachine = setup({
           })
       const info = removeConstrainingValuesInfo(
         pathToNodes,
-        kclManager,
+        executingEditor,
         wasmInstance
       )
       if (err(info)) return false
@@ -1004,7 +1004,7 @@ export const modelingMachine = setup({
       if (!event.data) return false
 
       const ast = parse(
-        recast(context.kclManager.ast, context.wasmInstance),
+        recast(context.executingEditor.ast, context.wasmInstance),
         context.wasmInstance
       )
       if (err(ast) || !ast.program || ast.errors.length > 0) return false
@@ -1017,11 +1017,15 @@ export const modelingMachine = setup({
       return isSafeRetVal.isSafe
     },
     'next is tangential arc': ({
-      context: { sketchDetails, currentTool, kclManager, wasmInstance },
+      context: { sketchDetails, currentTool, executingEditor, wasmInstance },
     }) => {
       return (
         currentTool === 'tangentialArc' &&
-        isEditingExistingSketch({ sketchDetails, kclManager, wasmInstance })
+        isEditingExistingSketch({
+          sketchDetails,
+          executingEditor,
+          wasmInstance,
+        })
       )
     },
     'next is rectangle': ({ context: { currentTool } }) =>
@@ -1057,7 +1061,7 @@ export const modelingMachine = setup({
     toastErrorAndExitSketch: ({
       event,
       context: {
-        kclManager: { sceneEntitiesManager },
+        executingEditor: { sceneEntitiesManager },
       },
     }) => {
       if ('output' in event && event.output instanceof Error) {
@@ -1097,7 +1101,7 @@ export const modelingMachine = setup({
     'hide default planes': assign({
       defaultPlaneVisibility: ({ context }) => {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        context.kclManager.hidePlanes()
+        context.executingEditor.hidePlanes()
         return { xy: false, xz: false, yz: false }
       },
     }),
@@ -1132,12 +1136,12 @@ export const modelingMachine = setup({
       }
     }),
     'set up draft line': assign(
-      ({ context: { sketchDetails, kclManager }, event }) => {
+      ({ context: { sketchDetails, executingEditor }, event }) => {
         if (!sketchDetails) return {}
         if (event.type !== 'Add start point') return {}
 
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        kclManager.sceneEntitiesManager.setupDraftSegment(
+        executingEditor.sceneEntitiesManager.setupDraftSegment(
           event.data.sketchEntryNodePath || sketchDetails.sketchEntryNodePath,
           event.data.sketchNodePaths || sketchDetails.sketchNodePaths,
           sketchDetails.planeNodePath,
@@ -1156,12 +1160,12 @@ export const modelingMachine = setup({
       }
     ),
     'set up draft arc': assign(
-      ({ context: { sketchDetails, kclManager }, event }) => {
+      ({ context: { sketchDetails, executingEditor }, event }) => {
         if (!sketchDetails) return {}
         if (event.type !== 'Continue existing profile') return {}
 
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        kclManager.sceneEntitiesManager.setupDraftSegment(
+        executingEditor.sceneEntitiesManager.setupDraftSegment(
           event.data.sketchEntryNodePath || sketchDetails.sketchEntryNodePath,
           event.data.sketchNodePaths || sketchDetails.sketchNodePaths,
           sketchDetails.planeNodePath,
@@ -1182,7 +1186,7 @@ export const modelingMachine = setup({
     'listen for rectangle origin': ({
       context: {
         sketchDetails,
-        kclManager: { sceneEntitiesManager, sceneInfra },
+        executingEditor: { sceneEntitiesManager, sceneInfra },
         wasmInstance,
       },
     }) => {
@@ -1234,7 +1238,7 @@ export const modelingMachine = setup({
     'listen for center rectangle origin': ({
       context: {
         sketchDetails,
-        kclManager: { sceneEntitiesManager, sceneInfra },
+        executingEditor: { sceneEntitiesManager, sceneInfra },
         wasmInstance,
       },
     }) => {
@@ -1285,7 +1289,7 @@ export const modelingMachine = setup({
     'listen for circle origin': ({
       context: {
         sketchDetails,
-        kclManager: { sceneEntitiesManager, sceneInfra },
+        executingEditor: { sceneEntitiesManager, sceneInfra },
         wasmInstance,
       },
     }) => {
@@ -1337,7 +1341,7 @@ export const modelingMachine = setup({
     'listen for circle first point': ({
       context: {
         sketchDetails,
-        kclManager: { sceneEntitiesManager, sceneInfra },
+        executingEditor: { sceneEntitiesManager, sceneInfra },
         wasmInstance,
       },
     }) => {
@@ -1389,7 +1393,7 @@ export const modelingMachine = setup({
     'listen for circle second point': ({
       context: {
         sketchDetails,
-        kclManager: { sceneEntitiesManager, sceneInfra },
+        executingEditor: { sceneEntitiesManager, sceneInfra },
         wasmInstance,
       },
       event,
@@ -1500,17 +1504,17 @@ export const modelingMachine = setup({
     'show default planes': assign({
       defaultPlaneVisibility: ({ context }) => {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        context.kclManager.showPlanes()
+        context.executingEditor.showPlanes()
         return { xy: true, xz: true, yz: true }
       },
     }),
     'show default planes if no errors': assign({
       defaultPlaneVisibility: ({
-        context: { kclManager, defaultPlaneVisibility },
+        context: { executingEditor, defaultPlaneVisibility },
       }) => {
-        if (!kclManager.hasErrors()) {
+        if (!executingEditor.hasErrors()) {
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
-          kclManager.showPlanes()
+          executingEditor.showPlanes()
           return { xy: true, xz: true, yz: true }
         }
         return { ...defaultPlaneVisibility }
@@ -1522,14 +1526,14 @@ export const modelingMachine = setup({
         // When entering via right-click "Start sketch on selection", show planes only if not requested to keep current visibility
         return {}
       }
-      void context.kclManager.showPlanes()
+      void context.executingEditor.showPlanes()
       return { defaultPlaneVisibility: { xy: true, xz: true, yz: true } }
     }),
     'setup noPoints onClick listener': ({
       context: {
         sketchDetails,
         currentTool,
-        kclManager: { sceneEntitiesManager, sceneInfra },
+        executingEditor: { sceneEntitiesManager, sceneInfra },
       },
     }) => {
       if (!sketchDetails) return
@@ -1544,18 +1548,18 @@ export const modelingMachine = setup({
           ),
       })
     },
-    'add axis n grid': ({ context: { sketchDetails, kclManager } }) => {
+    'add axis n grid': ({ context: { sketchDetails, executingEditor } }) => {
       if (!sketchDetails) return
       if (localStorage.getItem('disableAxis')) return
 
-      kclManager.sceneEntitiesManager.createSketchAxis(
+      executingEditor.sceneEntitiesManager.createSketchAxis(
         sketchDetails.zAxis,
         sketchDetails.yAxis,
         sketchDetails.origin
       )
 
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      kclManager.updateEditorWithAstAndWriteToFile(kclManager.ast, {
+      executingEditor.updateEditorWithAstAndWriteToFile(executingEditor.ast, {
         shouldAddToHistory: false,
         shouldWriteToDisk: false,
       })
@@ -1563,41 +1567,42 @@ export const modelingMachine = setup({
     'reset client scene mouse handlers': ({ context }) => {
       // when not in sketch mode we don't need any mouse listeners
       // Orbit controls are always active though.
-      context.kclManager.sceneInfra.resetMouseListeners()
+      context.executingEditor.sceneInfra.resetMouseListeners()
     },
     'restore modeling camera controls': ({ context }) => {
-      const camControls = context.kclManager.sceneInfra.camControls
+      const camControls = context.executingEditor.sceneInfra.camControls
       camControls.enablePan = true
       camControls.enableRotate = true
       camControls.syncDirection = 'engineToClient'
     },
     'clientToEngine cam sync direction': ({ context }) => {
-      context.kclManager.sceneInfra.camControls.syncDirection = 'clientToEngine'
+      context.executingEditor.sceneInfra.camControls.syncDirection =
+        'clientToEngine'
     },
     'disable rotate for sketch solve mode': ({ context }) => {
       // Sketch solve currently has sync issues with engine and trouble translating world space to sketch space,
       // so block orbit input until those controls are synchronized.
       // When that is the case, the hidden setting "allow orbit in sketch mode" will be shown to users.
-      context.kclManager.sceneInfra.camControls.enableRotate =
-        context.kclManager.sceneInfra.camControls._setting_allowOrbitInSketchMode
+      context.executingEditor.sceneInfra.camControls.enableRotate =
+        context.executingEditor.sceneInfra.camControls._setting_allowOrbitInSketchMode
     },
     /** TODO: this action is hiding unawaited asynchronous code */
     'set selection filter to faces only': ({ context }) => {
-      context.kclManager.setSelectionFilter(
+      context.executingEditor.setSelectionFilter(
         ['face', 'object'],
         context.wasmInstance
       )
     },
     /** TODO: this action is hiding unawaited asynchronous code */
     'set selection filter to defaults': ({ context }) => {
-      context.kclManager.setSelectionFilterToDefault(context.wasmInstance)
+      context.executingEditor.setSelectionFilterToDefault(context.wasmInstance)
     },
     'Delete segments': ({
       context: {
         sketchDetails,
-        kclManager,
+        executingEditor,
         rustContext,
-        kclManager: { sceneEntitiesManager, sceneInfra },
+        executingEditor: { sceneEntitiesManager, sceneInfra },
       },
       event,
     }) => {
@@ -1608,15 +1613,15 @@ export const modelingMachine = setup({
         pathToNodes: event.data,
         sketchDetails,
         dependencies: {
-          kclManager,
+          executingEditor,
           rustContext,
           sceneEntitiesManager,
           sceneInfra,
         },
       })
         .then(() => {
-          return kclManager.updateEditorWithAstAndWriteToFile(
-            kclManager.ast,
+          return executingEditor.updateEditorWithAstAndWriteToFile(
+            executingEditor.ast,
             undefined
           )
         })
@@ -1624,16 +1629,16 @@ export const modelingMachine = setup({
           console.warn('error', e)
         })
     },
-    'remove draft entities': ({ context: { kclManager } }) => {
+    'remove draft entities': ({ context: { executingEditor } }) => {
       const draftPoint =
-        kclManager.sceneInfra.scene.getObjectByName(DRAFT_POINT)
+        executingEditor.sceneInfra.scene.getObjectByName(DRAFT_POINT)
       if (draftPoint) {
-        kclManager.sceneInfra.scene.remove(draftPoint)
+        executingEditor.sceneInfra.scene.remove(draftPoint)
       }
       const draftLine =
-        kclManager.sceneInfra.scene.getObjectByName(DRAFT_DASHED_LINE)
+        executingEditor.sceneInfra.scene.getObjectByName(DRAFT_DASHED_LINE)
       if (draftLine) {
-        kclManager.sceneInfra.scene.remove(draftLine)
+        executingEditor.sceneInfra.scene.remove(draftLine)
       }
     },
     'add draft line': ({ event, context }) => {
@@ -1643,8 +1648,8 @@ export const modelingMachine = setup({
       )
         return
 
-      const sceneEntitiesManager = context.kclManager.sceneEntitiesManager
-      const sceneInfra = context.kclManager.sceneInfra
+      const sceneEntitiesManager = context.executingEditor.sceneEntitiesManager
+      const sceneInfra = context.executingEditor.sceneInfra
       let sketchEntryNodePath: PathToNode | undefined
 
       if (event.type === 'Add start point') {
@@ -1657,7 +1662,7 @@ export const modelingMachine = setup({
       }
       if (!sketchEntryNodePath) return
       const varDec = getNodeFromPath<VariableDeclaration>(
-        context.kclManager.ast,
+        context.executingEditor.ast,
         sketchEntryNodePath,
         context.wasmInstance,
         'VariableDeclaration'
@@ -1665,7 +1670,7 @@ export const modelingMachine = setup({
       if (err(varDec)) return
       const varName = varDec.node.declaration.id.name
       const sg = sketchFromKclValue(
-        context.kclManager.variables[varName],
+        context.executingEditor.variables[varName],
         varName
       )
       if (err(sg)) return
@@ -1713,11 +1718,11 @@ export const modelingMachine = setup({
         },
       }
     }),
-    'enable copilot': ({ context: { kclManager } }) => {
-      kclManager.setCopilotEnabled(true)
+    'enable copilot': ({ context: { executingEditor } }) => {
+      executingEditor.setCopilotEnabled(true)
     },
-    'disable copilot': ({ context: { kclManager } }) => {
-      kclManager.setCopilotEnabled(false)
+    'disable copilot': ({ context: { executingEditor } }) => {
+      executingEditor.setCopilotEnabled(false)
     },
     'Set selection': assign(
       ({
@@ -1725,7 +1730,7 @@ export const modelingMachine = setup({
           selectionRanges,
           sketchDetails,
           engineCommandManager,
-          kclManager,
+          executingEditor,
           wasmInstance,
         },
         event,
@@ -1747,7 +1752,7 @@ export const modelingMachine = setup({
           otherSelections: [],
         }
         if (setSelections.selectionType === 'singleCodeCursor') {
-          if (!setSelections.selection && kclManager.isShiftDown) {
+          if (!setSelections.selection && executingEditor.isShiftDown) {
             // if the user is holding shift, but they didn't select anything
             // don't nuke their other selections (frustrating to have one bad click ruin your
             // whole selection)
@@ -1755,17 +1760,17 @@ export const modelingMachine = setup({
               graphSelections: selectionRanges.graphSelections,
               otherSelections: selectionRanges.otherSelections,
             }
-          } else if (!setSelections.selection && !kclManager.isShiftDown) {
+          } else if (!setSelections.selection && !executingEditor.isShiftDown) {
             selections = {
               graphSelections: [],
               otherSelections: [],
             }
-          } else if (setSelections.selection && !kclManager.isShiftDown) {
+          } else if (setSelections.selection && !executingEditor.isShiftDown) {
             selections = {
               graphSelections: [setSelections.selection],
               otherSelections: [],
             }
-          } else if (setSelections.selection && kclManager.isShiftDown) {
+          } else if (setSelections.selection && executingEditor.isShiftDown) {
             // selecting and deselecting multiple objects
 
             /**
@@ -1841,17 +1846,17 @@ export const modelingMachine = setup({
           const { engineEvents, codeMirrorSelection, updateSceneObjectColors } =
             handleSelectionBatch({
               selections,
-              artifactGraph: kclManager.artifactGraph,
-              code: kclManager.code,
-              ast: kclManager.ast,
+              artifactGraph: executingEditor.artifactGraph,
+              code: executingEditor.code,
+              ast: executingEditor.ast,
               systemDeps: {
                 engineCommandManager,
-                sceneEntitiesManager: kclManager.sceneEntitiesManager,
+                sceneEntitiesManager: executingEditor.sceneEntitiesManager,
                 wasmInstance,
               },
             })
           if (codeMirrorSelection) {
-            kclManager.editorView.dispatch({
+            executingEditor.editorView.dispatch({
               selection: codeMirrorSelection,
               effects: setSelections.scrollIntoView
                 ? [
@@ -1893,7 +1898,7 @@ export const modelingMachine = setup({
               selection.entityId === setSelections.selection.entityId
           )
 
-          const otherSelections = kclManager.isShiftDown
+          const otherSelections = executingEditor.isShiftDown
             ? shouldDeselect
               ? selectionRanges.otherSelections.filter(
                   (selection) =>
@@ -1906,19 +1911,19 @@ export const modelingMachine = setup({
             : [setSelections.selection]
 
           const selections: Selections = {
-            graphSelections: kclManager.isShiftDown
+            graphSelections: executingEditor.isShiftDown
               ? selectionRanges.graphSelections
               : [],
             otherSelections,
           }
           const { engineEvents } = handleSelectionBatch({
             selections,
-            artifactGraph: kclManager.artifactGraph,
-            code: kclManager.code,
-            ast: kclManager.ast,
+            artifactGraph: executingEditor.artifactGraph,
+            code: executingEditor.code,
+            ast: executingEditor.ast,
             systemDeps: {
               engineCommandManager,
-              sceneEntitiesManager: kclManager.sceneEntitiesManager,
+              sceneEntitiesManager: executingEditor.sceneEntitiesManager,
               wasmInstance,
             },
           })
@@ -1942,7 +1947,7 @@ export const modelingMachine = setup({
               selection.id === setSelections.selection.id
           )
 
-          const otherSelections = kclManager.isShiftDown
+          const otherSelections = executingEditor.isShiftDown
             ? shouldDeselect
               ? selectionRanges.otherSelections.filter(
                   (selection) =>
@@ -1955,19 +1960,19 @@ export const modelingMachine = setup({
             : [setSelections.selection]
 
           const selections: Selections = {
-            graphSelections: kclManager.isShiftDown
+            graphSelections: executingEditor.isShiftDown
               ? selectionRanges.graphSelections
               : [],
             otherSelections,
           }
           const { engineEvents } = handleSelectionBatch({
             selections,
-            artifactGraph: kclManager.artifactGraph,
-            code: kclManager.code,
-            ast: kclManager.ast,
+            artifactGraph: executingEditor.artifactGraph,
+            code: executingEditor.code,
+            ast: executingEditor.ast,
             systemDeps: {
               engineCommandManager,
-              sceneEntitiesManager: kclManager.sceneEntitiesManager,
+              sceneEntitiesManager: executingEditor.sceneEntitiesManager,
               wasmInstance,
             },
           })
@@ -1985,7 +1990,7 @@ export const modelingMachine = setup({
           setSelections.selectionType === 'axisSelection' ||
           setSelections.selectionType === 'defaultPlaneSelection'
         ) {
-          if (kclManager.isShiftDown) {
+          if (executingEditor.isShiftDown) {
             selections = {
               graphSelections: selectionRanges.graphSelections,
               otherSelections: [setSelections.selection],
@@ -2000,12 +2005,12 @@ export const modelingMachine = setup({
           if (setSelections.selectionType === 'defaultPlaneSelection') {
             const { engineEvents, codeMirrorSelection } = handleSelectionBatch({
               selections,
-              artifactGraph: kclManager.artifactGraph,
-              code: kclManager.code,
-              ast: kclManager.ast,
+              artifactGraph: executingEditor.artifactGraph,
+              code: executingEditor.code,
+              ast: executingEditor.ast,
               systemDeps: {
                 engineCommandManager,
-                sceneEntitiesManager: kclManager.sceneEntitiesManager,
+                sceneEntitiesManager: executingEditor.sceneEntitiesManager,
                 wasmInstance,
               },
             })
@@ -2013,7 +2018,7 @@ export const modelingMachine = setup({
             if (codeMirrorSelection) {
               // Default planes are non-code selections, so clear any previous
               // graph selection still highlighted in the editor.
-              kclManager.editorView.dispatch({
+              executingEditor.editorView.dispatch({
                 selection: codeMirrorSelection,
               })
             }
@@ -2031,23 +2036,23 @@ export const modelingMachine = setup({
         }
 
         if (setSelections.selectionType === 'completeSelection') {
-          const codeMirrorSelection = kclManager.createEditorSelection(
+          const codeMirrorSelection = executingEditor.createEditorSelection(
             setSelections.selection
           )
 
-          kclManager.editorView.dispatch({
+          executingEditor.editorView.dispatch({
             selection: codeMirrorSelection,
           })
 
           // This turns the selection into blue, needed when selecting with ctrl+A
           const { updateSceneObjectColors } = handleSelectionBatch({
             selections: setSelections.selection,
-            artifactGraph: kclManager.artifactGraph,
-            code: kclManager.code,
-            ast: kclManager.ast,
+            artifactGraph: executingEditor.artifactGraph,
+            code: executingEditor.code,
+            ast: executingEditor.ast,
             systemDeps: {
               engineCommandManager,
-              sceneEntitiesManager: kclManager.sceneEntitiesManager,
+              sceneEntitiesManager: executingEditor.sceneEntitiesManager,
               wasmInstance,
             },
           })
@@ -2111,7 +2116,7 @@ export const modelingMachine = setup({
             mouseOnParent?.userData?.pathToNode
           )
           const timeoutId = setTimeout(() => {
-            context.kclManager.sceneInfra.modelingSend({
+            context.executingEditor.sceneInfra.modelingSend({
               type: 'Set mouse state',
               data: {
                 type: 'timeoutEnd',
@@ -2191,7 +2196,7 @@ export const modelingMachine = setup({
       const currentVisibility = currentVisibilityMap[event.planeKey]
       const newVisibility = !currentVisibility
 
-      context.kclManager.engineCommandManager
+      context.executingEditor.engineCommandManager
         .setPlaneHidden(event.planeId, !newVisibility)
         .catch(reportRejection)
 
@@ -2215,7 +2220,7 @@ export const modelingMachine = setup({
         context.savedDefaultPlaneVisibility
       ) as (keyof PlaneVisibilityMap)[]) {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        context.kclManager.setPlaneVisibilityByKey(
+        context.executingEditor.setPlaneVisibilityByKey(
           planeKey,
           context.savedDefaultPlaneVisibility[planeKey]
         )
@@ -2261,7 +2266,7 @@ export const modelingMachine = setup({
     sketchExit: fromPromise(
       async (args: { input: { context: ModelingMachineContext } }) => {
         const context = args.input.context
-        const { store, engineCommandManager, kclManager } = context
+        const { store, engineCommandManager, executingEditor } = context
         try {
           // When cancelling the sketch mode we should disable sketch mode within the engine.
           await engineCommandManager.sendSceneCommand({
@@ -2270,19 +2275,21 @@ export const modelingMachine = setup({
             cmd: { type: 'sketch_mode_disable' },
           })
 
-          kclManager.sceneInfra.camControls.syncDirection = 'clientToEngine'
+          executingEditor.sceneInfra.camControls.syncDirection =
+            'clientToEngine'
 
           if (store.cameraProjection?.current === 'perspective') {
-            await kclManager.sceneInfra.camControls.snapToPerspectiveBeforeHandingBackControlToEngine()
+            await executingEditor.sceneInfra.camControls.snapToPerspectiveBeforeHandingBackControlToEngine()
           }
 
-          kclManager.sceneInfra.camControls.syncDirection = 'engineToClient'
+          executingEditor.sceneInfra.camControls.syncDirection =
+            'engineToClient'
 
           // TODO: Re-evaluate if this pause/play logic is needed.
           // TODO: Do I need this video element?
           store.videoElement?.pause()
 
-          await kclManager
+          await executingEditor
             .executeCode()
             .then(() => {
               if (
@@ -2298,14 +2305,16 @@ export const modelingMachine = setup({
             })
             .catch(reportRejection)
         } finally {
-          const camControls = kclManager.sceneInfra.camControls
-          kclManager.sceneEntitiesManager.tearDownSketch({ removeAxis: false })
-          kclManager.sceneEntitiesManager.removeSketchGrid()
+          const camControls = executingEditor.sceneInfra.camControls
+          executingEditor.sceneEntitiesManager.tearDownSketch({
+            removeAxis: false,
+          })
+          executingEditor.sceneEntitiesManager.removeSketchGrid()
           camControls.enablePan = true
           camControls.enableRotate = true
           camControls.syncDirection = 'engineToClient'
-          kclManager.sceneEntitiesManager.resetOverlays()
-          kclManager.sceneInfra.stop()
+          executingEditor.sceneEntitiesManager.resetOverlays()
+          executingEditor.sceneInfra.stop()
         }
       }
     ),
@@ -2317,26 +2326,29 @@ export const modelingMachine = setup({
           selectionRanges,
           sketchDetails,
           data,
-          kclManager,
+          executingEditor,
           wasmInstance,
         },
       }: {
         input: Pick<
           ModelingMachineContext,
-          'selectionRanges' | 'sketchDetails' | 'wasmInstance' | 'kclManager'
+          | 'selectionRanges'
+          | 'sketchDetails'
+          | 'wasmInstance'
+          | 'executingEditor'
         > & { data?: PathToNode }
       }) => {
         const constraint = applyRemoveConstrainingValues({
           selectionRanges,
           pathToNodes: data && [data],
-          kclManager,
+          executingEditor,
           wasmInstance,
         })
         if (trap(constraint)) return
         const { pathToNodeMap } = constraint
         if (!sketchDetails) return
         let updatedAst =
-          await kclManager.sceneEntitiesManager.updateAstAndRejigSketch(
+          await executingEditor.sceneEntitiesManager.updateAstAndRejigSketch(
             pathToNodeMap[0],
             sketchDetails.sketchNodePaths,
             sketchDetails.planeNodePath,
@@ -2350,7 +2362,7 @@ export const modelingMachine = setup({
         if (trap(updatedAst, { suppress: true })) return
         if (!updatedAst) return
 
-        await kclManager.updateEditorWithAstAndWriteToFile(
+        await executingEditor.updateEditorWithAstAndWriteToFile(
           updatedAst.newAst,
           undefined
         )
@@ -2361,7 +2373,7 @@ export const modelingMachine = setup({
             pathToNodeMap,
             selectionRanges,
             updatedAst.newAst,
-            kclManager.artifactGraph,
+            executingEditor.artifactGraph,
             wasmInstance
           ),
         }
@@ -2369,25 +2381,33 @@ export const modelingMachine = setup({
     ),
     'do-constrain-horizontally': fromPromise(
       async ({
-        input: { selectionRanges, sketchDetails, kclManager, wasmInstance },
+        input: {
+          selectionRanges,
+          sketchDetails,
+          executingEditor,
+          wasmInstance,
+        },
       }: {
         input: Pick<
           ModelingMachineContext,
-          'selectionRanges' | 'sketchDetails' | 'kclManager' | 'wasmInstance'
+          | 'selectionRanges'
+          | 'sketchDetails'
+          | 'executingEditor'
+          | 'wasmInstance'
         >
       }) => {
         const constraint = applyConstraintHorzVert(
           selectionRanges,
           'horizontal',
-          kclManager.ast,
-          kclManager.variables,
-          await kclManager.wasmInstancePromise
+          executingEditor.ast,
+          executingEditor.variables,
+          await executingEditor.wasmInstancePromise
         )
         if (trap(constraint)) return false
         const { modifiedAst, pathToNodeMap } = constraint
         if (!sketchDetails) return
         const updatedAst =
-          await kclManager.sceneEntitiesManager.updateAstAndRejigSketch(
+          await executingEditor.sceneEntitiesManager.updateAstAndRejigSketch(
             sketchDetails.sketchEntryNodePath,
             sketchDetails.sketchNodePaths,
             sketchDetails.planeNodePath,
@@ -2400,7 +2420,7 @@ export const modelingMachine = setup({
           )
         if (trap(updatedAst, { suppress: true })) return
         if (!updatedAst) return
-        await kclManager.updateEditorWithAstAndWriteToFile(
+        await executingEditor.updateEditorWithAstAndWriteToFile(
           updatedAst.newAst,
           undefined
         )
@@ -2410,7 +2430,7 @@ export const modelingMachine = setup({
             pathToNodeMap,
             selectionRanges,
             updatedAst.newAst,
-            kclManager.artifactGraph,
+            executingEditor.artifactGraph,
             wasmInstance
           ),
         }
@@ -2418,25 +2438,33 @@ export const modelingMachine = setup({
     ),
     'do-constrain-vertically': fromPromise(
       async ({
-        input: { selectionRanges, sketchDetails, kclManager, wasmInstance },
+        input: {
+          selectionRanges,
+          sketchDetails,
+          executingEditor,
+          wasmInstance,
+        },
       }: {
         input: Pick<
           ModelingMachineContext,
-          'selectionRanges' | 'sketchDetails' | 'kclManager' | 'wasmInstance'
+          | 'selectionRanges'
+          | 'sketchDetails'
+          | 'executingEditor'
+          | 'wasmInstance'
         >
       }) => {
         const constraint = applyConstraintHorzVert(
           selectionRanges,
           'vertical',
-          kclManager.ast,
-          kclManager.variables,
-          await kclManager.wasmInstancePromise
+          executingEditor.ast,
+          executingEditor.variables,
+          await executingEditor.wasmInstancePromise
         )
         if (trap(constraint)) return false
         const { modifiedAst, pathToNodeMap } = constraint
         if (!sketchDetails) return
         const updatedAst =
-          await kclManager.sceneEntitiesManager.updateAstAndRejigSketch(
+          await executingEditor.sceneEntitiesManager.updateAstAndRejigSketch(
             sketchDetails.sketchEntryNodePath || [],
             sketchDetails.sketchNodePaths,
             sketchDetails.planeNodePath,
@@ -2449,7 +2477,7 @@ export const modelingMachine = setup({
           )
         if (trap(updatedAst, { suppress: true })) return
         if (!updatedAst) return
-        await kclManager.updateEditorWithAstAndWriteToFile(
+        await executingEditor.updateEditorWithAstAndWriteToFile(
           updatedAst.newAst,
           undefined
         )
@@ -2459,7 +2487,7 @@ export const modelingMachine = setup({
             pathToNodeMap,
             selectionRanges,
             updatedAst.newAst,
-            kclManager.artifactGraph,
+            executingEditor.artifactGraph,
             wasmInstance
           ),
         }
@@ -2467,24 +2495,32 @@ export const modelingMachine = setup({
     ),
     'do-constrain-horizontally-align': fromPromise(
       async ({
-        input: { selectionRanges, sketchDetails, kclManager, wasmInstance },
+        input: {
+          selectionRanges,
+          sketchDetails,
+          executingEditor,
+          wasmInstance,
+        },
       }: {
         input: Pick<
           ModelingMachineContext,
-          'selectionRanges' | 'sketchDetails' | 'kclManager' | 'wasmInstance'
+          | 'selectionRanges'
+          | 'sketchDetails'
+          | 'executingEditor'
+          | 'wasmInstance'
         >
       }) => {
         const constraint = applyConstraintHorzVertAlign({
           selectionRanges,
           constraint: 'setVertDistance',
-          kclManager: kclManager,
-          wasmInstance: await kclManager.wasmInstancePromise,
+          executingEditor: executingEditor,
+          wasmInstance: await executingEditor.wasmInstancePromise,
         })
         if (trap(constraint)) return
         const { modifiedAst, pathToNodeMap } = constraint
         if (!sketchDetails) return
         const updatedAst =
-          await kclManager.sceneEntitiesManager.updateAstAndRejigSketch(
+          await executingEditor.sceneEntitiesManager.updateAstAndRejigSketch(
             sketchDetails?.sketchEntryNodePath || [],
             sketchDetails.sketchNodePaths,
             sketchDetails.planeNodePath,
@@ -2497,7 +2533,7 @@ export const modelingMachine = setup({
           )
         if (trap(updatedAst, { suppress: true })) return
         if (!updatedAst) return
-        await kclManager.updateEditorWithAstAndWriteToFile(
+        await executingEditor.updateEditorWithAstAndWriteToFile(
           updatedAst.newAst,
           undefined
         )
@@ -2505,7 +2541,7 @@ export const modelingMachine = setup({
           pathToNodeMap,
           selectionRanges,
           updatedAst.newAst,
-          kclManager.artifactGraph,
+          executingEditor.artifactGraph,
           wasmInstance
         )
         return {
@@ -2516,24 +2552,32 @@ export const modelingMachine = setup({
     ),
     'do-constrain-vertically-align': fromPromise(
       async ({
-        input: { selectionRanges, sketchDetails, kclManager, wasmInstance },
+        input: {
+          selectionRanges,
+          sketchDetails,
+          executingEditor,
+          wasmInstance,
+        },
       }: {
         input: Pick<
           ModelingMachineContext,
-          'selectionRanges' | 'sketchDetails' | 'kclManager' | 'wasmInstance'
+          | 'selectionRanges'
+          | 'sketchDetails'
+          | 'executingEditor'
+          | 'wasmInstance'
         >
       }) => {
         const constraint = applyConstraintHorzVertAlign({
           selectionRanges,
           constraint: 'setHorzDistance',
-          kclManager: kclManager,
-          wasmInstance: await kclManager.wasmInstancePromise,
+          executingEditor: executingEditor,
+          wasmInstance: await executingEditor.wasmInstancePromise,
         })
         if (trap(constraint)) return
         const { modifiedAst, pathToNodeMap } = constraint
         if (!sketchDetails) return
         const updatedAst =
-          await kclManager.sceneEntitiesManager.updateAstAndRejigSketch(
+          await executingEditor.sceneEntitiesManager.updateAstAndRejigSketch(
             sketchDetails?.sketchEntryNodePath || [],
             sketchDetails.sketchNodePaths,
             sketchDetails.planeNodePath,
@@ -2546,7 +2590,7 @@ export const modelingMachine = setup({
           )
         if (trap(updatedAst, { suppress: true })) return
         if (!updatedAst) return
-        await kclManager.updateEditorWithAstAndWriteToFile(
+        await executingEditor.updateEditorWithAstAndWriteToFile(
           updatedAst.newAst,
           undefined
         )
@@ -2554,7 +2598,7 @@ export const modelingMachine = setup({
           pathToNodeMap,
           selectionRanges,
           updatedAst.newAst,
-          kclManager.artifactGraph,
+          executingEditor.artifactGraph,
           wasmInstance
         )
         return {
@@ -2565,24 +2609,32 @@ export const modelingMachine = setup({
     ),
     'do-constrain-snap-to-x': fromPromise(
       async ({
-        input: { selectionRanges, sketchDetails, kclManager, wasmInstance },
+        input: {
+          selectionRanges,
+          sketchDetails,
+          executingEditor,
+          wasmInstance,
+        },
       }: {
         input: Pick<
           ModelingMachineContext,
-          'selectionRanges' | 'sketchDetails' | 'kclManager' | 'wasmInstance'
+          | 'selectionRanges'
+          | 'sketchDetails'
+          | 'executingEditor'
+          | 'wasmInstance'
         >
       }) => {
         const constraint = applyConstraintAxisAlign({
           selectionRanges,
           constraint: 'snapToXAxis',
-          kclManager: kclManager,
-          wasmInstance: await kclManager.wasmInstancePromise,
+          executingEditor: executingEditor,
+          wasmInstance: await executingEditor.wasmInstancePromise,
         })
         if (err(constraint)) return false
         const { modifiedAst, pathToNodeMap } = constraint
         if (!sketchDetails) return
         const updatedAst =
-          await kclManager.sceneEntitiesManager.updateAstAndRejigSketch(
+          await executingEditor.sceneEntitiesManager.updateAstAndRejigSketch(
             sketchDetails?.sketchEntryNodePath || [],
             sketchDetails.sketchNodePaths,
             sketchDetails.planeNodePath,
@@ -2595,7 +2647,7 @@ export const modelingMachine = setup({
           )
         if (trap(updatedAst, { suppress: true })) return
         if (!updatedAst) return
-        await kclManager.updateEditorWithAstAndWriteToFile(
+        await executingEditor.updateEditorWithAstAndWriteToFile(
           updatedAst.newAst,
           undefined
         )
@@ -2603,7 +2655,7 @@ export const modelingMachine = setup({
           pathToNodeMap,
           selectionRanges,
           updatedAst.newAst,
-          kclManager.artifactGraph,
+          executingEditor.artifactGraph,
           wasmInstance
         )
         return {
@@ -2614,24 +2666,32 @@ export const modelingMachine = setup({
     ),
     'do-constrain-snap-to-y': fromPromise(
       async ({
-        input: { selectionRanges, sketchDetails, kclManager, wasmInstance },
+        input: {
+          selectionRanges,
+          sketchDetails,
+          executingEditor,
+          wasmInstance,
+        },
       }: {
         input: Pick<
           ModelingMachineContext,
-          'selectionRanges' | 'sketchDetails' | 'kclManager' | 'wasmInstance'
+          | 'selectionRanges'
+          | 'sketchDetails'
+          | 'executingEditor'
+          | 'wasmInstance'
         >
       }) => {
         const constraint = applyConstraintAxisAlign({
           selectionRanges,
           constraint: 'snapToYAxis',
-          kclManager: kclManager,
-          wasmInstance: await kclManager.wasmInstancePromise,
+          executingEditor: executingEditor,
+          wasmInstance: await executingEditor.wasmInstancePromise,
         })
         if (trap(constraint)) return false
         const { modifiedAst, pathToNodeMap } = constraint
         if (!sketchDetails) return
         const updatedAst =
-          await kclManager.sceneEntitiesManager.updateAstAndRejigSketch(
+          await executingEditor.sceneEntitiesManager.updateAstAndRejigSketch(
             sketchDetails?.sketchEntryNodePath || [],
             sketchDetails.sketchNodePaths,
             sketchDetails.planeNodePath,
@@ -2644,7 +2704,7 @@ export const modelingMachine = setup({
           )
         if (trap(updatedAst, { suppress: true })) return
         if (!updatedAst) return
-        await kclManager.updateEditorWithAstAndWriteToFile(
+        await executingEditor.updateEditorWithAstAndWriteToFile(
           updatedAst.newAst,
           undefined
         )
@@ -2652,7 +2712,7 @@ export const modelingMachine = setup({
           pathToNodeMap,
           selectionRanges,
           updatedAst.newAst,
-          kclManager.artifactGraph,
+          executingEditor.artifactGraph,
           wasmInstance
         )
         return {
@@ -2663,17 +2723,25 @@ export const modelingMachine = setup({
     ),
     'do-constrain-parallel': fromPromise(
       async ({
-        input: { selectionRanges, sketchDetails, kclManager, wasmInstance },
+        input: {
+          selectionRanges,
+          sketchDetails,
+          executingEditor,
+          wasmInstance,
+        },
       }: {
         input: Pick<
           ModelingMachineContext,
-          'selectionRanges' | 'sketchDetails' | 'kclManager' | 'wasmInstance'
+          | 'selectionRanges'
+          | 'sketchDetails'
+          | 'executingEditor'
+          | 'wasmInstance'
         >
       }) => {
         const constraint = applyConstraintEqualAngle({
           selectionRanges,
-          kclManager,
-          wasmInstance: await kclManager.wasmInstancePromise,
+          executingEditor,
+          wasmInstance: await executingEditor.wasmInstancePromise,
         })
         if (trap(constraint)) return false
         const { modifiedAst, pathToNodeMap } = constraint
@@ -2686,7 +2754,7 @@ export const modelingMachine = setup({
         if (err(recastAst) || !resultIsOk(recastAst)) return
 
         const updatedAst =
-          await kclManager.sceneEntitiesManager.updateAstAndRejigSketch(
+          await executingEditor.sceneEntitiesManager.updateAstAndRejigSketch(
             sketchDetails?.sketchEntryNodePath || [],
             sketchDetails.sketchNodePaths,
             sketchDetails.planeNodePath,
@@ -2699,7 +2767,7 @@ export const modelingMachine = setup({
           )
         if (trap(updatedAst, { suppress: true })) return
         if (!updatedAst) return
-        await kclManager.updateEditorWithAstAndWriteToFile(
+        await executingEditor.updateEditorWithAstAndWriteToFile(
           updatedAst.newAst,
           undefined
         )
@@ -2708,7 +2776,7 @@ export const modelingMachine = setup({
           pathToNodeMap,
           selectionRanges,
           updatedAst.newAst,
-          kclManager.artifactGraph,
+          executingEditor.artifactGraph,
           wasmInstance
         )
         return {
@@ -2719,24 +2787,32 @@ export const modelingMachine = setup({
     ),
     'do-constrain-equal-length': fromPromise(
       async ({
-        input: { selectionRanges, sketchDetails, kclManager, wasmInstance },
+        input: {
+          selectionRanges,
+          sketchDetails,
+          executingEditor,
+          wasmInstance,
+        },
       }: {
         input: Pick<
           ModelingMachineContext,
-          'selectionRanges' | 'sketchDetails' | 'kclManager' | 'wasmInstance'
+          | 'selectionRanges'
+          | 'sketchDetails'
+          | 'executingEditor'
+          | 'wasmInstance'
         >
       }) => {
         const constraint = applyConstraintEqualLength({
           selectionRanges,
-          ast: kclManager.ast,
-          variables: kclManager.variables,
-          wasmInstance: await kclManager.wasmInstancePromise,
+          ast: executingEditor.ast,
+          variables: executingEditor.variables,
+          wasmInstance: await executingEditor.wasmInstancePromise,
         })
         if (trap(constraint)) return false
         const { modifiedAst, pathToNodeMap } = constraint
         if (!sketchDetails) return
         const updatedAst =
-          await kclManager.sceneEntitiesManager.updateAstAndRejigSketch(
+          await executingEditor.sceneEntitiesManager.updateAstAndRejigSketch(
             sketchDetails?.sketchEntryNodePath || [],
             sketchDetails.sketchNodePaths,
             sketchDetails.planeNodePath,
@@ -2749,7 +2825,7 @@ export const modelingMachine = setup({
           )
         if (trap(updatedAst, { suppress: true })) return
         if (!updatedAst) return
-        await kclManager.updateEditorWithAstAndWriteToFile(
+        await executingEditor.updateEditorWithAstAndWriteToFile(
           updatedAst.newAst,
           undefined
         )
@@ -2757,7 +2833,7 @@ export const modelingMachine = setup({
           pathToNodeMap,
           selectionRanges,
           updatedAst.newAst,
-          kclManager.artifactGraph,
+          executingEditor.artifactGraph,
           wasmInstance
         )
         return {
@@ -2770,19 +2846,19 @@ export const modelingMachine = setup({
     /* Below are actors which aren't using updateModelingState and don't have the 'no kcl errors' guard yet */
     'Get vertical info': fromPromise(
       async ({
-        input: { selectionRanges, sketchDetails, kclManager },
+        input: { selectionRanges, sketchDetails, executingEditor },
       }: {
         input: Pick<
           ModelingMachineContext,
-          'selectionRanges' | 'sketchDetails' | 'kclManager'
+          'selectionRanges' | 'sketchDetails' | 'executingEditor'
         >
       }) => {
-        const wasmInstance = await kclManager.wasmInstancePromise
+        const wasmInstance = await executingEditor.wasmInstancePromise
         const { modifiedAst, pathToNodeMap, exprInsertIndex } =
           await applyConstraintHorzVertDistance({
             constraint: 'setVertDistance',
             selectionRanges,
-            kclManager,
+            executingEditor,
           })
         const pResult = parse(recast(modifiedAst, wasmInstance), wasmInstance)
         if (trap(pResult) || !resultIsOk(pResult))
@@ -2803,7 +2879,7 @@ export const modelingMachine = setup({
         })
 
         const updatedAst =
-          await kclManager.sceneEntitiesManager.updateAstAndRejigSketch(
+          await executingEditor.sceneEntitiesManager.updateAstAndRejigSketch(
             updatedSketchEntryNodePath,
             updatedSketchNodePaths,
             updatedPlaneNodePath,
@@ -2816,13 +2892,15 @@ export const modelingMachine = setup({
           )
         if (err(updatedAst)) return Promise.reject(updatedAst)
 
-        await kclManager.updateEditorWithAstAndWriteToFile(updatedAst.newAst)
+        await executingEditor.updateEditorWithAstAndWriteToFile(
+          updatedAst.newAst
+        )
 
         const selection = updateSelections(
           pathToNodeMap,
           selectionRanges,
           updatedAst.newAst,
-          kclManager.artifactGraph,
+          executingEditor.artifactGraph,
           wasmInstance
         )
         if (err(selection)) return Promise.reject(selection)
@@ -2837,19 +2915,19 @@ export const modelingMachine = setup({
     ),
     'Get ABS X info': fromPromise(
       async ({
-        input: { selectionRanges, sketchDetails, kclManager },
+        input: { selectionRanges, sketchDetails, executingEditor },
       }: {
         input: Pick<
           ModelingMachineContext,
-          'selectionRanges' | 'sketchDetails' | 'kclManager'
+          'selectionRanges' | 'sketchDetails' | 'executingEditor'
         >
       }) => {
-        const wasmInstance = await kclManager.wasmInstancePromise
+        const wasmInstance = await executingEditor.wasmInstancePromise
         const { modifiedAst, pathToNodeMap, exprInsertIndex } =
           await applyConstraintAbsDistance({
             constraint: 'xAbs',
             selectionRanges,
-            kclManager,
+            executingEditor,
           })
         const pResult = parse(recast(modifiedAst, wasmInstance), wasmInstance)
         if (trap(pResult) || !resultIsOk(pResult))
@@ -2869,7 +2947,7 @@ export const modelingMachine = setup({
           exprInsertIndex,
         })
         const updatedAst =
-          await kclManager.sceneEntitiesManager.updateAstAndRejigSketch(
+          await executingEditor.sceneEntitiesManager.updateAstAndRejigSketch(
             updatedSketchEntryNodePath,
             updatedSketchNodePaths,
             updatedPlaneNodePath,
@@ -2882,13 +2960,15 @@ export const modelingMachine = setup({
           )
         if (err(updatedAst)) return Promise.reject(updatedAst)
 
-        await kclManager.updateEditorWithAstAndWriteToFile(updatedAst.newAst)
+        await executingEditor.updateEditorWithAstAndWriteToFile(
+          updatedAst.newAst
+        )
 
         const selection = updateSelections(
           pathToNodeMap,
           selectionRanges,
           updatedAst.newAst,
-          kclManager.artifactGraph,
+          executingEditor.artifactGraph,
           wasmInstance
         )
         if (err(selection)) return Promise.reject(selection)
@@ -2903,19 +2983,19 @@ export const modelingMachine = setup({
     ),
     'Get ABS Y info': fromPromise(
       async ({
-        input: { selectionRanges, sketchDetails, kclManager },
+        input: { selectionRanges, sketchDetails, executingEditor },
       }: {
         input: Pick<
           ModelingMachineContext,
-          'selectionRanges' | 'sketchDetails' | 'kclManager'
+          'selectionRanges' | 'sketchDetails' | 'executingEditor'
         >
       }) => {
-        const wasmInstance = await kclManager.wasmInstancePromise
+        const wasmInstance = await executingEditor.wasmInstancePromise
         const { modifiedAst, pathToNodeMap, exprInsertIndex } =
           await applyConstraintAbsDistance({
             constraint: 'yAbs',
             selectionRanges,
-            kclManager,
+            executingEditor,
           })
         const pResult = parse(recast(modifiedAst, wasmInstance), wasmInstance)
         if (trap(pResult) || !resultIsOk(pResult))
@@ -2935,7 +3015,7 @@ export const modelingMachine = setup({
           exprInsertIndex,
         })
         const updatedAst =
-          await kclManager.sceneEntitiesManager.updateAstAndRejigSketch(
+          await executingEditor.sceneEntitiesManager.updateAstAndRejigSketch(
             updatedSketchEntryNodePath,
             updatedSketchNodePaths,
             updatedPlaneNodePath,
@@ -2948,13 +3028,15 @@ export const modelingMachine = setup({
           )
         if (err(updatedAst)) return Promise.reject(updatedAst)
 
-        await kclManager.updateEditorWithAstAndWriteToFile(updatedAst.newAst)
+        await executingEditor.updateEditorWithAstAndWriteToFile(
+          updatedAst.newAst
+        )
 
         const selection = updateSelections(
           pathToNodeMap,
           selectionRanges,
           updatedAst.newAst,
-          kclManager.artifactGraph,
+          executingEditor.artifactGraph,
           wasmInstance
         )
         if (err(selection)) return Promise.reject(selection)
@@ -2969,17 +3051,17 @@ export const modelingMachine = setup({
     ),
     'Get angle info': fromPromise(
       async ({
-        input: { selectionRanges, sketchDetails, kclManager },
+        input: { selectionRanges, sketchDetails, executingEditor },
       }: {
         input: Pick<
           ModelingMachineContext,
-          'selectionRanges' | 'sketchDetails' | 'kclManager'
+          'selectionRanges' | 'sketchDetails' | 'executingEditor'
         >
       }) => {
-        const wasmInstance = await kclManager.wasmInstancePromise
+        const wasmInstance = await executingEditor.wasmInstancePromise
         const info = angleBetweenInfo({
           selectionRanges,
-          kclManager,
+          executingEditor,
           wasmInstance,
         })
         if (err(info)) return Promise.reject(info)
@@ -2987,12 +3069,12 @@ export const modelingMachine = setup({
           await (info.enabled
             ? applyConstraintAngleBetween({
                 selectionRanges,
-                kclManager,
+                executingEditor,
               })
             : applyConstraintAngleLength({
                 selectionRanges,
                 angleOrLength: 'setAngle',
-                kclManager,
+                executingEditor,
               }))
         const pResult = parse(recast(modifiedAst, wasmInstance), wasmInstance)
         if (trap(pResult) || !resultIsOk(pResult))
@@ -3015,7 +3097,7 @@ export const modelingMachine = setup({
         })
 
         const updatedAst =
-          await kclManager.sceneEntitiesManager.updateAstAndRejigSketch(
+          await executingEditor.sceneEntitiesManager.updateAstAndRejigSketch(
             updatedSketchEntryNodePath,
             updatedSketchNodePaths,
             updatedPlaneNodePath,
@@ -3028,13 +3110,15 @@ export const modelingMachine = setup({
           )
         if (err(updatedAst)) return Promise.reject(updatedAst)
 
-        await kclManager.updateEditorWithAstAndWriteToFile(updatedAst.newAst)
+        await executingEditor.updateEditorWithAstAndWriteToFile(
+          updatedAst.newAst
+        )
 
         const selection = updateSelections(
           pathToNodeMap,
           selectionRanges,
           updatedAst.newAst,
-          kclManager.artifactGraph,
+          executingEditor.artifactGraph,
           wasmInstance
         )
         if (err(selection)) return Promise.reject(selection)
@@ -3049,18 +3133,18 @@ export const modelingMachine = setup({
     ),
     'Get perpendicular distance info': fromPromise(
       async ({
-        input: { selectionRanges, sketchDetails, kclManager },
+        input: { selectionRanges, sketchDetails, executingEditor },
       }: {
         input: Pick<
           ModelingMachineContext,
-          'selectionRanges' | 'sketchDetails' | 'kclManager'
+          'selectionRanges' | 'sketchDetails' | 'executingEditor'
         >
       }) => {
-        const wasmInstance = await kclManager.wasmInstancePromise
+        const wasmInstance = await executingEditor.wasmInstancePromise
         const { modifiedAst, pathToNodeMap, exprInsertIndex } =
           await applyConstraintIntersect({
             selectionRanges,
-            kclManager,
+            executingEditor,
           })
         const pResult = parse(recast(modifiedAst, wasmInstance), wasmInstance)
         if (trap(pResult) || !resultIsOk(pResult))
@@ -3081,7 +3165,7 @@ export const modelingMachine = setup({
         })
 
         const updatedAst =
-          await kclManager.sceneEntitiesManager.updateAstAndRejigSketch(
+          await executingEditor.sceneEntitiesManager.updateAstAndRejigSketch(
             updatedSketchEntryNodePath,
             updatedSketchNodePaths,
             updatedPlaneNodePath,
@@ -3094,13 +3178,15 @@ export const modelingMachine = setup({
           )
         if (err(updatedAst)) return Promise.reject(updatedAst)
 
-        await kclManager.updateEditorWithAstAndWriteToFile(updatedAst.newAst)
+        await executingEditor.updateEditorWithAstAndWriteToFile(
+          updatedAst.newAst
+        )
 
         const selection = updateSelections(
           pathToNodeMap,
           selectionRanges,
           updatedAst.newAst,
-          kclManager.artifactGraph,
+          executingEditor.artifactGraph,
           wasmInstance
         )
         if (err(selection)) return Promise.reject(selection)
@@ -3115,19 +3201,19 @@ export const modelingMachine = setup({
     ),
     'AST-undo-startSketchOn': fromPromise(
       async ({
-        input: { sketchDetails, kclManager },
+        input: { sketchDetails, executingEditor },
       }: {
-        input: Pick<ModelingMachineContext, 'sketchDetails' | 'kclManager'>
+        input: Pick<ModelingMachineContext, 'sketchDetails' | 'executingEditor'>
       }) => {
         if (!sketchDetails) return
-        if (kclManager.ast.body.length) {
-          const newAst = structuredClone(kclManager.ast)
+        if (executingEditor.ast.body.length) {
+          const newAst = structuredClone(executingEditor.ast)
           const varDecIndex = sketchDetails.planeNodePath[1][0]
 
           const varDec = getNodeFromPath<VariableDeclaration>(
             newAst,
             sketchDetails.planeNodePath,
-            await kclManager.wasmInstancePromise,
+            await executingEditor.wasmInstancePromise,
             'VariableDeclaration'
           )
           if (err(varDec)) return reject(new Error('No varDec'))
@@ -3150,13 +3236,13 @@ export const modelingMachine = setup({
 
           // remove body item at varDecIndex
           newAst.body = newAst.body.filter((_, i) => i !== varDecIndex)
-          const didReParse = await kclManager.executeAstMock(newAst)
+          const didReParse = await executingEditor.executeAstMock(newAst)
           if (err(didReParse)) return reject(didReParse)
-          await kclManager.updateEditorWithAstAndWriteToFile(newAst, {
+          await executingEditor.updateEditorWithAstAndWriteToFile(newAst, {
             shouldAddToHistory: false,
           })
         }
-        kclManager.sceneInfra.setCallbacks({
+        executingEditor.sceneInfra.setCallbacks({
           onClick: () => {},
           onDrag: () => {},
         })
@@ -3169,33 +3255,34 @@ export const modelingMachine = setup({
       }: {
         input?: {
           plane: ExtrudeFacePlane | DefaultPlane | OffsetPlane
-          kclManager: KclManager
+          executingEditor: ExecutingEditor
           engineCommandManager: ConnectionManager
           wasmInstance: ModuleType
         }
       }) => {
         if (!input) return null
-        const { plane, kclManager, engineCommandManager, wasmInstance } = input
-        if (kclManager.hasParseErrors()) {
+        const { plane, executingEditor, engineCommandManager, wasmInstance } =
+          input
+        if (executingEditor.hasParseErrors()) {
           const errorMessage =
             'Unable to enter sketch while KCL has parse errors.'
           toast.error(errorMessage)
           return reject(new Error(errorMessage))
         }
         if (plane.type === 'extrudeFace' || plane.type === 'offsetPlane') {
-          const originalCode = kclManager.code
+          const originalCode = executingEditor.code
           const sketched =
             plane.type === 'extrudeFace'
               ? sketchOnExtrudedFace(
-                  kclManager.ast,
+                  executingEditor.ast,
                   plane.sketchPathToNode,
                   plane.extrudePathToNode,
                   addTagForSketchOnFace,
-                  await kclManager.wasmInstancePromise,
+                  await executingEditor.wasmInstancePromise,
                   plane.faceInfo
                 )
               : sketchOnOffsetPlane(
-                  kclManager.ast,
+                  executingEditor.ast,
                   plane.pathToNode,
                   plane.negated,
                   wasmInstance
@@ -3209,10 +3296,10 @@ export const modelingMachine = setup({
           }
           const { modifiedAst, pathToNode: pathToNewSketchNode } = sketched
 
-          const didReParse = await kclManager.executeAstMock(modifiedAst)
+          const didReParse = await executingEditor.executeAstMock(modifiedAst)
           if (err(didReParse)) {
             // there was a problem, restore the original code
-            kclManager.updateCodeEditor(originalCode, {
+            executingEditor.updateCodeEditor(originalCode, {
               shouldAddToHistory: false,
             })
             return reject(didReParse)
@@ -3220,7 +3307,8 @@ export const modelingMachine = setup({
 
           const id = plane.type === 'extrudeFace' ? plane.faceId : plane.planeId
           await letEngineAnimateAndSyncCamAfter(engineCommandManager, id)
-          kclManager.sceneInfra.camControls.syncDirection = 'clientToEngine'
+          executingEditor.sceneInfra.camControls.syncDirection =
+            'clientToEngine'
           return {
             sketchEntryNodePath: [],
             planeNodePath: pathToNewSketchNode,
@@ -3231,14 +3319,14 @@ export const modelingMachine = setup({
           }
         }
         const { modifiedAst, pathToNode } = startSketchOnDefault(
-          kclManager.ast,
+          executingEditor.ast,
           plane.plane,
-          await kclManager.wasmInstancePromise
+          await executingEditor.wasmInstancePromise
         )
-        await kclManager.updateAst(modifiedAst, false)
-        kclManager.sceneInfra.camControls.enableRotate =
-          kclManager.sceneInfra.camControls._setting_allowOrbitInSketchMode
-        kclManager.sceneInfra.camControls.syncDirection = 'clientToEngine'
+        await executingEditor.updateAst(modifiedAst, false)
+        executingEditor.sceneInfra.camControls.enableRotate =
+          executingEditor.sceneInfra.camControls._setting_allowOrbitInSketchMode
+        executingEditor.sceneInfra.camControls.syncDirection = 'clientToEngine'
 
         await letEngineAnimateAndSyncCamAfter(
           engineCommandManager,
@@ -3263,7 +3351,7 @@ export const modelingMachine = setup({
         input:
           | {
               artifactOrPlaneId: ArtifactId | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
               engineCommandManager: ConnectionManager
               wasmInstance: ModuleType
@@ -3281,14 +3369,14 @@ export const modelingMachine = setup({
         }
         const {
           artifactOrPlaneId,
-          kclManager,
+          executingEditor,
           rustContext,
           engineCommandManager,
           wasmInstance,
           defaultUnit,
           projectRef,
         } = input
-        if (kclManager.hasParseErrors()) {
+        if (executingEditor.hasParseErrors()) {
           return reject(
             new Error('Unable to enter sketch while KCL has parse errors.')
           )
@@ -3296,7 +3384,7 @@ export const modelingMachine = setup({
         let result: DefaultPlane | OffsetPlane | ExtrudeFacePlane | null = null
 
         const defaultResult = getDefaultSketchPlaneData(artifactOrPlaneId, {
-          sceneInfra: kclManager.sceneInfra,
+          sceneInfra: executingEditor.sceneInfra,
           rustContext,
         })
         if (!err(defaultResult) && defaultResult) {
@@ -3305,10 +3393,10 @@ export const modelingMachine = setup({
 
         // Look up the artifact from the artifact graph for getOffsetSketchPlaneData
         if (!result) {
-          const artifact = kclManager.artifactGraph.get(artifactOrPlaneId)
+          const artifact = executingEditor.artifactGraph.get(artifactOrPlaneId)
           const offsetResult = await getOffsetSketchPlaneData(artifact, {
-            sceneEntitiesManager: kclManager.sceneEntitiesManager,
-            sceneInfra: kclManager.sceneInfra,
+            sceneEntitiesManager: executingEditor.sceneEntitiesManager,
+            sceneInfra: executingEditor.sceneInfra,
           })
           if (!isErr(offsetResult) && offsetResult) {
             result = offsetResult
@@ -3317,14 +3405,14 @@ export const modelingMachine = setup({
         if (!result) {
           const sweepFaceSelected = await selectionBodyFace(
             artifactOrPlaneId,
-            kclManager.artifactGraph,
-            kclManager.astSignal.value,
-            kclManager.execState,
+            executingEditor.artifactGraph,
+            executingEditor.astSignal.value,
+            executingEditor.execState,
             {
               wasmInstance,
               rustContext,
-              sceneInfra: kclManager.sceneInfra,
-              sceneEntitiesManager: kclManager.sceneEntitiesManager,
+              sceneInfra: executingEditor.sceneInfra,
+              sceneEntitiesManager: executingEditor.sceneEntitiesManager,
             }
           )
           if (sweepFaceSelected) {
@@ -3338,7 +3426,7 @@ export const modelingMachine = setup({
         const legacyExtrudeFaceTemporaryCompat: ExtrudeFacePlane | null =
           result.type === 'extrudeFace' &&
           result.faceInfo.type === 'wall' &&
-          isFaceFromLegacySketch(result.faceId, kclManager.artifactGraph)
+          isFaceFromLegacySketch(result.faceId, executingEditor.artifactGraph)
             ? result
             : null
 
@@ -3346,7 +3434,7 @@ export const modelingMachine = setup({
           // Temporary compatibility branch for legacy sketch V1.
           // Remove this once sketch-on-face always originates from sketch
           // blocks and no longer needs a JS-side code mod before sketch solve.
-          const legacyFaceArtifact = kclManager.artifactGraph.get(
+          const legacyFaceArtifact = executingEditor.artifactGraph.get(
             legacyExtrudeFaceTemporaryCompat.faceId
           )
           const legacyFaceCodeRef = legacyFaceArtifact
@@ -3359,14 +3447,14 @@ export const modelingMachine = setup({
           }
 
           const legacySketchBlock = sketchBlockOnExtrudedFace(
-            kclManager.ast,
+            executingEditor.ast,
             {
               artifact: legacyFaceArtifact,
               codeRef: legacyFaceCodeRef,
             },
             legacyExtrudeFaceTemporaryCompat.sketchPathToNode,
             legacyExtrudeFaceTemporaryCompat.extrudePathToNode,
-            kclManager.artifactGraph,
+            executingEditor.artifactGraph,
             wasmInstance
           )
           if (err(legacySketchBlock)) {
@@ -3376,7 +3464,7 @@ export const modelingMachine = setup({
           await updateModelingState(
             legacySketchBlock.modifiedAst,
             EXECUTION_TYPE_REAL,
-            kclManager,
+            executingEditor,
             {
               focusPath: [legacySketchBlock.pathToNode],
             }
@@ -3384,7 +3472,7 @@ export const modelingMachine = setup({
 
           const sketchBlockArtifact = getSketchBlockArtifactForPathToNode(
             legacySketchBlock.pathToNode,
-            kclManager.artifactGraph
+            executingEditor.artifactGraph
           )
           if (!sketchBlockArtifact) {
             return reject(
@@ -3394,7 +3482,7 @@ export const modelingMachine = setup({
 
           return enterSketchSolveFromSketchBlockArtifact({
             sketchBlockArtifact,
-            kclManager,
+            executingEditor,
             rustContext,
             engineCommandManager,
             defaultUnit,
@@ -3412,7 +3500,7 @@ export const modelingMachine = setup({
         // Construct SketchCtor based on the result
         let sketchArgs: SketchCtor
         const setProgramOutcome = await rustContext.hackSetProgram(
-          kclManager.ast,
+          executingEditor.ast,
           jsAppSettings(rustContext.settingsActor)
         )
         if (result.type === 'defaultPlane') {
@@ -3429,7 +3517,7 @@ export const modelingMachine = setup({
           const selectedSceneObject = findSceneObjectForPlaneSelection(
             setProgramOutcome.sceneGraph.objects,
             result,
-            kclManager.ast,
+            executingEditor.ast,
             wasmInstance
           )
 
@@ -3464,7 +3552,7 @@ export const modelingMachine = setup({
           )
         } catch (error) {
           await rustContext.hackSetProgram(
-            kclManager.ast,
+            executingEditor.ast,
             jsAppSettings(rustContext.settingsActor)
           )
           return reject(
@@ -3478,8 +3566,8 @@ export const modelingMachine = setup({
           result.type === 'extrudeFace' ? result.faceId : result.planeId
         await letEngineAnimateAndSyncCamAfter(engineCommandManager, id)
 
-        kclManager.sceneInfra.camControls.syncDirection = 'clientToEngine'
-        kclManager.updateCodeEditor(
+        executingEditor.sceneInfra.camControls.syncDirection = 'clientToEngine'
+        executingEditor.updateCodeEditor(
           newSketchResult.kclSource.text,
           {
             shouldAddToHistory: true,
@@ -3503,7 +3591,7 @@ export const modelingMachine = setup({
         input:
           | {
               artifactId: ArtifactId | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
               engineCommandManager: ConnectionManager
               defaultUnit?: ModelingMachineContext['store']['defaultUnit']
@@ -3522,16 +3610,16 @@ export const modelingMachine = setup({
         }
         const {
           artifactId,
-          kclManager,
+          executingEditor,
           rustContext,
           engineCommandManager,
           defaultUnit,
           projectRef,
         } = input
-        const wasmInstance = await kclManager.wasmInstancePromise
+        const wasmInstance = await executingEditor.wasmInstancePromise
 
         // Get the sketchBlock artifact from the artifact graph
-        const artifact = kclManager.artifactGraph.get(artifactId)
+        const artifact = executingEditor.artifactGraph.get(artifactId)
         if (!artifact || artifact.type !== 'sketchBlock') {
           const errorMessage = 'Invalid sketchBlock artifact'
           toast.error(errorMessage)
@@ -3540,7 +3628,7 @@ export const modelingMachine = setup({
 
         return enterSketchSolveFromSketchBlockArtifact({
           sketchBlockArtifact: artifact,
-          kclManager,
+          executingEditor,
           rustContext,
           engineCommandManager,
           defaultUnit,
@@ -3551,19 +3639,19 @@ export const modelingMachine = setup({
     ),
     'Get horizontal info': fromPromise(
       async ({
-        input: { selectionRanges, sketchDetails, kclManager },
+        input: { selectionRanges, sketchDetails, executingEditor },
       }: {
         input: Pick<
           ModelingMachineContext,
-          'sketchDetails' | 'selectionRanges' | 'kclManager'
+          'sketchDetails' | 'selectionRanges' | 'executingEditor'
         >
       }) => {
-        const wasmInstance = await kclManager.wasmInstancePromise
+        const wasmInstance = await executingEditor.wasmInstancePromise
         const { modifiedAst, pathToNodeMap, exprInsertIndex } =
           await applyConstraintHorzVertDistance({
             constraint: 'setHorzDistance',
             selectionRanges,
-            kclManager,
+            executingEditor,
           })
         const pResult = parse(recast(modifiedAst, wasmInstance), wasmInstance)
         if (trap(pResult) || !resultIsOk(pResult))
@@ -3585,7 +3673,7 @@ export const modelingMachine = setup({
         })
 
         const updatedAst =
-          await kclManager.sceneEntitiesManager.updateAstAndRejigSketch(
+          await executingEditor.sceneEntitiesManager.updateAstAndRejigSketch(
             updatedSketchEntryNodePath,
             updatedSketchNodePaths,
             updatedPlaneNodePath,
@@ -3598,13 +3686,15 @@ export const modelingMachine = setup({
           )
         if (err(updatedAst)) return Promise.reject(updatedAst)
 
-        await kclManager.updateEditorWithAstAndWriteToFile(updatedAst.newAst)
+        await executingEditor.updateEditorWithAstAndWriteToFile(
+          updatedAst.newAst
+        )
 
         const selection = updateSelections(
           pathToNodeMap,
           selectionRanges,
           updatedAst.newAst,
-          kclManager.artifactGraph,
+          executingEditor.artifactGraph,
           wasmInstance
         )
         if (err(selection)) return Promise.reject(selection)
@@ -3619,21 +3709,21 @@ export const modelingMachine = setup({
     ),
     astConstrainLength: fromPromise(
       async ({
-        input: { selectionRanges, sketchDetails, lengthValue, kclManager },
+        input: { selectionRanges, sketchDetails, lengthValue, executingEditor },
       }: {
         input: Pick<
           ModelingMachineContext,
-          'sketchDetails' | 'selectionRanges' | 'kclManager'
+          'sketchDetails' | 'selectionRanges' | 'executingEditor'
         > & {
           lengthValue?: KclCommandValue
         }
       }) => {
-        const wasmInstance = await kclManager.wasmInstancePromise
+        const wasmInstance = await executingEditor.wasmInstancePromise
         if (!lengthValue) return Promise.reject(new Error('No length value'))
         const constraintResult = await applyConstraintLength({
           selectionRanges,
           length: lengthValue,
-          kclManager,
+          executingEditor,
         })
         if (err(constraintResult)) return Promise.reject(constraintResult)
         const { modifiedAst, pathToNodeMap, exprInsertIndex } = constraintResult
@@ -3655,7 +3745,7 @@ export const modelingMachine = setup({
           exprInsertIndex,
         })
         const updatedAst =
-          await kclManager.sceneEntitiesManager.updateAstAndRejigSketch(
+          await executingEditor.sceneEntitiesManager.updateAstAndRejigSketch(
             updatedSketchEntryNodePath,
             updatedSketchNodePaths,
             updatedPlaneNodePath,
@@ -3668,13 +3758,15 @@ export const modelingMachine = setup({
           )
         if (err(updatedAst)) return Promise.reject(updatedAst)
 
-        await kclManager.updateEditorWithAstAndWriteToFile(updatedAst.newAst)
+        await executingEditor.updateEditorWithAstAndWriteToFile(
+          updatedAst.newAst
+        )
 
         const selection = updateSelections(
           pathToNodeMap,
           selectionRanges,
           updatedAst.newAst,
-          kclManager.artifactGraph,
+          executingEditor.artifactGraph,
           wasmInstance
         )
         if (err(selection)) return Promise.reject(selection)
@@ -3689,12 +3781,12 @@ export const modelingMachine = setup({
     ),
     'setup-client-side-sketch-segments': fromPromise(
       async ({
-        input: { sketchDetails, selectionRanges, kclManager },
+        input: { sketchDetails, selectionRanges, executingEditor },
       }: {
         input: {
           sketchDetails: SketchDetails | null
           selectionRanges: Selections
-          kclManager: KclManager
+          executingEditor: ExecutingEditor
         }
       }) => {
         if (!sketchDetails) {
@@ -3703,23 +3795,25 @@ export const modelingMachine = setup({
         if (!sketchDetails.sketchEntryNodePath?.length) {
           // When unequipping eg. the three-point arc tool during placement of the 3rd point, sketchEntryNodePath is
           // empty if its the first profile in a sketch, but we still need to tear down and cancel the current tool properly.
-          kclManager.sceneInfra.resetMouseListeners()
-          kclManager.sceneEntitiesManager.tearDownSketch({ removeAxis: false })
+          executingEditor.sceneInfra.resetMouseListeners()
+          executingEditor.sceneEntitiesManager.tearDownSketch({
+            removeAxis: false,
+          })
           return
         }
-        kclManager.sceneInfra.resetMouseListeners()
-        await kclManager.sceneEntitiesManager.setupSketch({
+        executingEditor.sceneInfra.resetMouseListeners()
+        await executingEditor.sceneEntitiesManager.setupSketch({
           sketchEntryNodePath: sketchDetails.sketchEntryNodePath,
           sketchNodePaths: sketchDetails.sketchNodePaths,
           forward: sketchDetails.zAxis,
           up: sketchDetails.yAxis,
           position: sketchDetails.origin,
-          maybeModdedAst: kclManager.ast,
+          maybeModdedAst: executingEditor.ast,
           selectionRanges,
         })
-        kclManager.sceneInfra.resetMouseListeners()
+        executingEditor.sceneInfra.resetMouseListeners()
 
-        kclManager.sceneEntitiesManager.setupSketchIdleCallbacks({
+        executingEditor.sceneEntitiesManager.setupSketchIdleCallbacks({
           sketchEntryNodePath: sketchDetails.sketchEntryNodePath,
           forward: sketchDetails.zAxis,
           up: sketchDetails.yAxis,
@@ -3739,16 +3833,19 @@ export const modelingMachine = setup({
     ),
     'animate-to-sketch': fromPromise(
       async ({
-        input: { selectionRanges, kclManager, engineCommandManager },
+        input: { selectionRanges, executingEditor, engineCommandManager },
       }: {
         input: {
           selectionRanges: Selections
-          kclManager: KclManager
+          executingEditor: ExecutingEditor
           engineCommandManager: ConnectionManager
         }
       }): Promise<ModelingMachineContext['sketchDetails']> => {
         const artifact = selectionRanges.graphSelections[0].artifact
-        const plane = getPlaneFromArtifact(artifact, kclManager.artifactGraph)
+        const plane = getPlaneFromArtifact(
+          artifact,
+          executingEditor.artifactGraph
+        )
         if (err(plane)) return Promise.reject(plane)
         // if the user selected a segment, make sure we enter the right sketch as there can be multiple on a plane
         // but still works if the user selected a plane/face by defaulting to the first path
@@ -3759,7 +3856,9 @@ export const modelingMachine = setup({
         let sketch: KclValue | null = null
         let planeVar: Plane | null = null
 
-        for (const variable of Object.values(kclManager.execState.variables)) {
+        for (const variable of Object.values(
+          executingEditor.execState.variables
+        )) {
           // find programMemory that matches path artifact
           // This is similar to sketchFromKclValueOptional(), could be combined.
           if (
@@ -3806,7 +3905,7 @@ export const modelingMachine = setup({
               point.z,
             ]
             const planPath = getNodePathFromSourceRange(
-              kclManager.ast,
+              executingEditor.ast,
               planeCodeRef.range
             )
             await letEngineAnimateAndSyncCamAfter(
@@ -3826,7 +3925,7 @@ export const modelingMachine = setup({
           return Promise.reject(new Error('No sketch'))
         }
         const info =
-          await kclManager.sceneEntitiesManager.getSketchOrientationDetails(
+          await executingEditor.sceneEntitiesManager.getSketchOrientationDetails(
             sketch.value
           )
         await letEngineAnimateAndSyncCamAfter(
@@ -3834,22 +3933,22 @@ export const modelingMachine = setup({
           info?.sketchDetails?.faceId || ''
         )
 
-        const sketchArtifact = kclManager.artifactGraph.get(mainPath)
+        const sketchArtifact = executingEditor.artifactGraph.get(mainPath)
         if (sketchArtifact?.type !== 'path') {
           return Promise.reject(new Error('No sketch artifact'))
         }
         const sketchPaths = getPathsFromArtifact({
-          artifact: kclManager.artifactGraph.get(plane.id),
+          artifact: executingEditor.artifactGraph.get(plane.id),
           sketchPathToNode: sketchArtifact?.codeRef?.pathToNode,
-          artifactGraph: kclManager.artifactGraph,
-          ast: kclManager.ast,
+          artifactGraph: executingEditor.artifactGraph,
+          ast: executingEditor.ast,
         })
         if (err(sketchPaths)) return Promise.reject(sketchPaths)
         let codeRef = getFaceCodeRef(plane)
         if (!codeRef) return Promise.reject(new Error('No plane codeRef'))
         // codeRef.pathToNode is not always populated correctly
         const planeNodePath = getNodePathFromSourceRange(
-          kclManager.ast,
+          executingEditor.ast,
           codeRef.range
         )
         return {
@@ -3859,7 +3958,7 @@ export const modelingMachine = setup({
           zAxis: info.sketchDetails.zAxis || null,
           yAxis: info.sketchDetails.yAxis || null,
           origin: info.sketchDetails.origin.map(
-            (a) => a / kclManager.sceneInfra.baseUnitMultiplier
+            (a) => a / executingEditor.sceneInfra.baseUnitMultiplier
           ) as [number, number, number],
           animateTargetId: info?.sketchDetails?.faceId || '',
         }
@@ -3871,7 +3970,10 @@ export const modelingMachine = setup({
       }: {
         input: Pick<
           ModelingMachineContext,
-          'sketchDetails' | 'selectionRanges' | 'kclManager' | 'wasmInstance'
+          | 'sketchDetails'
+          | 'selectionRanges'
+          | 'executingEditor'
+          | 'wasmInstance'
         > & {
           data?: ModelingCommandSchema['Constrain with named value']
         }
@@ -3885,7 +3987,7 @@ export const modelingMachine = setup({
         }
         const wasmInstance = input.wasmInstance
         let pResult = parse(
-          recast(input.kclManager.ast, wasmInstance),
+          recast(input.executingEditor.ast, wasmInstance),
           wasmInstance
         )
         if (trap(pResult) || !resultIsOk(pResult))
@@ -3978,7 +4080,7 @@ export const modelingMachine = setup({
         })
 
         const updatedAst =
-          await input.kclManager.sceneEntitiesManager.updateAstAndRejigSketch(
+          await input.executingEditor.sceneEntitiesManager.updateAstAndRejigSketch(
             updatedSketchEntryNodePath,
             updatedSketchNodePaths,
             updatedPlaneNodePath,
@@ -3991,7 +4093,7 @@ export const modelingMachine = setup({
           )
         if (err(updatedAst)) return Promise.reject(updatedAst)
 
-        await input.kclManager.updateEditorWithAstAndWriteToFile(
+        await input.executingEditor.updateEditorWithAstAndWriteToFile(
           updatedAst.newAst,
           undefined
         )
@@ -4000,7 +4102,7 @@ export const modelingMachine = setup({
           { 0: result.pathToReplaced },
           selectionRanges,
           updatedAst.newAst,
-          input.kclManager.artifactGraph,
+          input.executingEditor.artifactGraph,
           wasmInstance
         )
         if (err(selection)) return Promise.reject(selection)
@@ -4015,22 +4117,26 @@ export const modelingMachine = setup({
     ),
     'set-up-draft-circle': fromPromise(
       async ({
-        input: { sketchDetails, data, kclManager },
+        input: { sketchDetails, data, executingEditor },
       }: {
-        input: Pick<ModelingMachineContext, 'sketchDetails' | 'kclManager'> & {
+        input: Pick<
+          ModelingMachineContext,
+          'sketchDetails' | 'executingEditor'
+        > & {
           data: [x: number, y: number]
         }
       }) => {
         if (!sketchDetails || !data) return reject('No sketch details or data')
 
-        const result = await kclManager.sceneEntitiesManager.setupDraftCircle(
-          sketchDetails.sketchNodePaths,
-          sketchDetails.planeNodePath,
-          sketchDetails.zAxis,
-          sketchDetails.yAxis,
-          sketchDetails.origin,
-          data
-        )
+        const result =
+          await executingEditor.sceneEntitiesManager.setupDraftCircle(
+            sketchDetails.sketchNodePaths,
+            sketchDetails.planeNodePath,
+            sketchDetails.zAxis,
+            sketchDetails.yAxis,
+            sketchDetails.origin,
+            data
+          )
         if (err(result)) return reject(result)
 
         return result
@@ -4038,16 +4144,19 @@ export const modelingMachine = setup({
     ),
     'set-up-draft-circle-three-point': fromPromise(
       async ({
-        input: { sketchDetails, data, kclManager },
+        input: { sketchDetails, data, executingEditor },
       }: {
-        input: Pick<ModelingMachineContext, 'sketchDetails' | 'kclManager'> & {
+        input: Pick<
+          ModelingMachineContext,
+          'sketchDetails' | 'executingEditor'
+        > & {
           data: { p1: [x: number, y: number]; p2: [x: number, y: number] }
         }
       }) => {
         if (!sketchDetails || !data) return reject('No sketch details or data')
 
         const result =
-          await kclManager.sceneEntitiesManager.setupDraftCircleThreePoint(
+          await executingEditor.sceneEntitiesManager.setupDraftCircleThreePoint(
             sketchDetails.sketchNodePaths,
             sketchDetails.planeNodePath,
             sketchDetails.zAxis,
@@ -4063,16 +4172,19 @@ export const modelingMachine = setup({
     ),
     'set-up-draft-rectangle': fromPromise(
       async ({
-        input: { sketchDetails, data, kclManager },
+        input: { sketchDetails, data, executingEditor },
       }: {
-        input: Pick<ModelingMachineContext, 'sketchDetails' | 'kclManager'> & {
+        input: Pick<
+          ModelingMachineContext,
+          'sketchDetails' | 'executingEditor'
+        > & {
           data: [x: number, y: number]
         }
       }) => {
         if (!sketchDetails || !data) return reject('No sketch details or data')
 
         const result =
-          await kclManager.sceneEntitiesManager.setupDraftRectangle(
+          await executingEditor.sceneEntitiesManager.setupDraftRectangle(
             sketchDetails.sketchNodePaths,
             sketchDetails.planeNodePath,
             sketchDetails.zAxis,
@@ -4087,15 +4199,18 @@ export const modelingMachine = setup({
     ),
     'set-up-draft-center-rectangle': fromPromise(
       async ({
-        input: { sketchDetails, data, kclManager },
+        input: { sketchDetails, data, executingEditor },
       }: {
-        input: Pick<ModelingMachineContext, 'sketchDetails' | 'kclManager'> & {
+        input: Pick<
+          ModelingMachineContext,
+          'sketchDetails' | 'executingEditor'
+        > & {
           data: [x: number, y: number]
         }
       }) => {
         if (!sketchDetails || !data) return reject('No sketch details or data')
         const result =
-          await kclManager.sceneEntitiesManager.setupDraftCenterRectangle(
+          await executingEditor.sceneEntitiesManager.setupDraftCenterRectangle(
             sketchDetails.sketchNodePaths,
             sketchDetails.planeNodePath,
             sketchDetails.zAxis,
@@ -4110,14 +4225,17 @@ export const modelingMachine = setup({
     ),
     'set-up-draft-arc': fromPromise(
       async ({
-        input: { sketchDetails, data, kclManager },
+        input: { sketchDetails, data, executingEditor },
       }: {
-        input: Pick<ModelingMachineContext, 'sketchDetails' | 'kclManager'> & {
+        input: Pick<
+          ModelingMachineContext,
+          'sketchDetails' | 'executingEditor'
+        > & {
           data: [x: number, y: number]
         }
       }) => {
         if (!sketchDetails || !data) return reject('No sketch details or data')
-        const result = await kclManager.sceneEntitiesManager.setupDraftArc(
+        const result = await executingEditor.sceneEntitiesManager.setupDraftArc(
           sketchDetails.sketchEntryNodePath,
           sketchDetails.sketchNodePaths,
           sketchDetails.zAxis,
@@ -4132,15 +4250,18 @@ export const modelingMachine = setup({
     ),
     'set-up-draft-arc-three-point': fromPromise(
       async ({
-        input: { sketchDetails, data, kclManager },
+        input: { sketchDetails, data, executingEditor },
       }: {
-        input: Pick<ModelingMachineContext, 'sketchDetails' | 'kclManager'> & {
+        input: Pick<
+          ModelingMachineContext,
+          'sketchDetails' | 'executingEditor'
+        > & {
           data: [x: number, y: number]
         }
       }) => {
         if (!sketchDetails || !data) return reject('No sketch details or data')
         const result =
-          await kclManager.sceneEntitiesManager.setupDraftArcThreePoint(
+          await executingEditor.sceneEntitiesManager.setupDraftArcThreePoint(
             sketchDetails.sketchEntryNodePath,
             sketchDetails.sketchNodePaths,
             sketchDetails.zAxis,
@@ -4157,11 +4278,11 @@ export const modelingMachine = setup({
       SketchDetailsUpdate,
       {
         sketchDetails: SketchDetails
-        kclManager: KclManager
+        executingEditor: ExecutingEditor
         wasmInstance: ModuleType
         rustContext: RustContext
       }
-    >(async ({ input: { sketchDetails, kclManager, wasmInstance } }) => {
+    >(async ({ input: { sketchDetails, executingEditor, wasmInstance } }) => {
       if (!sketchDetails) {
         return reject(new Error('No sketch details'))
       }
@@ -4182,14 +4303,14 @@ export const modelingMachine = setup({
         return existingSketchInfoNoOp
       }
       const doesNeedSplitting = doesSketchPipeNeedSplitting(
-        kclManager.ast,
+        executingEditor.ast,
         sketchDetails.sketchEntryNodePath,
         wasmInstance
       )
       if (err(doesNeedSplitting)) {
         return reject(doesNeedSplitting)
       }
-      let moddedAst: Node<Program> = structuredClone(kclManager.ast)
+      let moddedAst: Node<Program> = structuredClone(executingEditor.ast)
       let pathToProfile = sketchDetails.sketchEntryNodePath
       let updatedSketchNodePaths = sketchDetails.sketchNodePaths
       if (doesNeedSplitting) {
@@ -4216,7 +4337,7 @@ export const modelingMachine = setup({
         const pipe = getNodeFromPath<PipeExpression>(
           moddedAst,
           pathToProfile,
-          await kclManager.wasmInstancePromise,
+          await executingEditor.wasmInstancePromise,
           'PipeExpression'
         )
         if (err(pipe)) {
@@ -4255,7 +4376,11 @@ export const modelingMachine = setup({
         indexToDelete >= 0 ||
         isLastInPipeThreePointArc
       ) {
-        await updateModelingState(moddedAst, EXECUTION_TYPE_MOCK, kclManager)
+        await updateModelingState(
+          moddedAst,
+          EXECUTION_TYPE_MOCK,
+          executingEditor
+        )
       }
       return {
         updatedEntryNodePath: pathToProfile,
@@ -4279,7 +4404,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Extrude'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -4288,15 +4413,16 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const { artifactGraph } = input.kclManager
-        const wasmInstance = await input.kclManager.wasmInstancePromise
-        let ast = input.kclManager.ast
+        const { artifactGraph } = input.executingEditor
+        const wasmInstance = await input.executingEditor.wasmInstancePromise
+        let ast = input.executingEditor.ast
         if (
           input.data.draftAngle &&
-          input.kclManager.fileSettings.experimentalFeatures?.type !== 'Allow'
+          input.executingEditor.fileSettings.experimentalFeatures?.type !==
+            'Allow'
         ) {
           const astWithNewSetting = setExperimentalFeatures(
-            input.kclManager.code,
+            input.executingEditor.code,
             {
               type: 'Allow',
             },
@@ -4323,7 +4449,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [pathToNode],
           }
@@ -4337,7 +4463,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Sweep'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -4346,12 +4472,12 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const { ast, artifactGraph } = input.kclManager
+        const { ast, artifactGraph } = input.executingEditor
         const astResult = addSweep({
           ...input.data,
           ast,
           artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          wasmInstance: await input.executingEditor.wasmInstancePromise,
         })
         if (err(astResult)) {
           return Promise.reject(astResult)
@@ -4361,7 +4487,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [pathToNode],
           }
@@ -4375,7 +4501,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Loft'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -4383,11 +4509,11 @@ export const modelingMachine = setup({
         if (!input || !input.data) {
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
-        const { ast, artifactGraph } = input.kclManager
+        const { ast, artifactGraph } = input.executingEditor
         const astResult = addLoft({
           ast,
           artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          wasmInstance: await input.executingEditor.wasmInstancePromise,
           ...input.data,
         })
         if (err(astResult)) {
@@ -4398,7 +4524,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [pathToNode],
           }
@@ -4412,7 +4538,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Revolve'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -4421,11 +4547,11 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const { ast, artifactGraph } = input.kclManager
+        const { ast, artifactGraph } = input.executingEditor
         const astResult = addRevolve({
           ast,
           artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          wasmInstance: await input.executingEditor.wasmInstancePromise,
           ...input.data,
         })
         if (err(astResult)) {
@@ -4436,7 +4562,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [pathToNode],
           }
@@ -4450,7 +4576,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Offset plane'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -4459,13 +4585,13 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const { ast, artifactGraph, variables } = input.kclManager
+        const { ast, artifactGraph, variables } = input.executingEditor
         const astResult = addOffsetPlane({
           ...input.data,
           ast,
           artifactGraph,
           variables,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          wasmInstance: await input.executingEditor.wasmInstancePromise,
         })
         if (err(astResult)) {
           return Promise.reject(astResult)
@@ -4475,7 +4601,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [pathToNode],
           }
@@ -4489,7 +4615,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Helix'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -4498,12 +4624,12 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const { ast, artifactGraph } = input.kclManager
+        const { ast, artifactGraph } = input.executingEditor
         const astResult = addHelix({
           ...input.data,
           ast,
           artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          wasmInstance: await input.executingEditor.wasmInstancePromise,
         })
         if (err(astResult)) {
           return Promise.reject(astResult)
@@ -4513,7 +4639,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [pathToNode],
           }
@@ -4527,7 +4653,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Helical Gear'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -4538,14 +4664,15 @@ export const modelingMachine = setup({
 
         let astWithNewSetting: Node<Program> | undefined
         if (
-          input.kclManager.fileSettings.experimentalFeatures?.type !== 'Allow'
+          input.executingEditor.fileSettings.experimentalFeatures?.type !==
+          'Allow'
         ) {
           const ast = setExperimentalFeatures(
-            input.kclManager.code,
+            input.executingEditor.code,
             {
               type: 'Allow',
             },
-            await input.kclManager.wasmInstancePromise
+            await input.executingEditor.wasmInstancePromise
           )
           if (err(ast)) {
             return Promise.reject(ast)
@@ -4556,8 +4683,8 @@ export const modelingMachine = setup({
 
         const astResult = addHelicalGear({
           ...input.data,
-          ast: astWithNewSetting ?? input.kclManager.ast,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          ast: astWithNewSetting ?? input.executingEditor.ast,
+          wasmInstance: await input.executingEditor.wasmInstancePromise,
         })
         if (err(astResult)) {
           return Promise.reject(astResult)
@@ -4567,7 +4694,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [pathToNode],
           }
@@ -4581,7 +4708,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Herringbone Gear'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -4592,14 +4719,15 @@ export const modelingMachine = setup({
 
         let astWithNewSetting: Node<Program> | undefined
         if (
-          input.kclManager.fileSettings.experimentalFeatures?.type !== 'Allow'
+          input.executingEditor.fileSettings.experimentalFeatures?.type !==
+          'Allow'
         ) {
           const ast = setExperimentalFeatures(
-            input.kclManager.code,
+            input.executingEditor.code,
             {
               type: 'Allow',
             },
-            await input.kclManager.wasmInstancePromise
+            await input.executingEditor.wasmInstancePromise
           )
           if (err(ast)) {
             return Promise.reject(ast)
@@ -4610,8 +4738,8 @@ export const modelingMachine = setup({
 
         const astResult = addHerringboneGear({
           ...input.data,
-          ast: astWithNewSetting ?? input.kclManager.ast,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          ast: astWithNewSetting ?? input.executingEditor.ast,
+          wasmInstance: await input.executingEditor.wasmInstancePromise,
         })
         if (err(astResult)) {
           return Promise.reject(astResult)
@@ -4621,7 +4749,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [pathToNode],
           }
@@ -4635,7 +4763,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Spur Gear'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -4646,14 +4774,15 @@ export const modelingMachine = setup({
 
         let astWithNewSetting: Node<Program> | undefined
         if (
-          input.kclManager.fileSettings.experimentalFeatures?.type !== 'Allow'
+          input.executingEditor.fileSettings.experimentalFeatures?.type !==
+          'Allow'
         ) {
           const ast = setExperimentalFeatures(
-            input.kclManager.code,
+            input.executingEditor.code,
             {
               type: 'Allow',
             },
-            await input.kclManager.wasmInstancePromise
+            await input.executingEditor.wasmInstancePromise
           )
           if (err(ast)) {
             return Promise.reject(ast)
@@ -4664,8 +4793,8 @@ export const modelingMachine = setup({
 
         const astResult = addSpurGear({
           ...input.data,
-          ast: astWithNewSetting ?? input.kclManager.ast,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          ast: astWithNewSetting ?? input.executingEditor.ast,
+          wasmInstance: await input.executingEditor.wasmInstancePromise,
         })
         if (err(astResult)) {
           return Promise.reject(astResult)
@@ -4675,7 +4804,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [pathToNode],
           }
@@ -4689,7 +4818,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Ring Gear'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -4700,14 +4829,15 @@ export const modelingMachine = setup({
 
         let astWithNewSetting: Node<Program> | undefined
         if (
-          input.kclManager.fileSettings.experimentalFeatures?.type !== 'Allow'
+          input.executingEditor.fileSettings.experimentalFeatures?.type !==
+          'Allow'
         ) {
           const ast = setExperimentalFeatures(
-            input.kclManager.code,
+            input.executingEditor.code,
             {
               type: 'Allow',
             },
-            await input.kclManager.wasmInstancePromise
+            await input.executingEditor.wasmInstancePromise
           )
           if (err(ast)) {
             return Promise.reject(ast)
@@ -4718,8 +4848,8 @@ export const modelingMachine = setup({
 
         const astResult = addRingGear({
           ...input.data,
-          ast: astWithNewSetting ?? input.kclManager.ast,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          ast: astWithNewSetting ?? input.executingEditor.ast,
+          wasmInstance: await input.executingEditor.wasmInstancePromise,
         })
         if (err(astResult)) {
           return Promise.reject(astResult)
@@ -4729,7 +4859,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [pathToNode],
           }
@@ -4743,7 +4873,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Shell'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -4752,12 +4882,12 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const { ast, artifactGraph } = input.kclManager
+        const { ast, artifactGraph } = input.executingEditor
         const astResult = addShell({
           ...input.data,
           ast,
           artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          wasmInstance: await input.executingEditor.wasmInstancePromise,
         })
         if (err(astResult)) {
           return Promise.reject(astResult)
@@ -4767,7 +4897,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [pathToNode],
           }
@@ -4781,7 +4911,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Delete Face'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -4792,9 +4922,9 @@ export const modelingMachine = setup({
 
         const astResult = addDeleteFace({
           ...input.data,
-          ast: input.kclManager.ast,
-          artifactGraph: input.kclManager.artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          ast: input.executingEditor.ast,
+          artifactGraph: input.executingEditor.artifactGraph,
+          wasmInstance: await input.executingEditor.wasmInstancePromise,
         })
         if (err(astResult)) {
           return Promise.reject(astResult)
@@ -4804,7 +4934,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [pathToNode],
           }
@@ -4818,7 +4948,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Hole'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -4829,9 +4959,9 @@ export const modelingMachine = setup({
 
         const astResult = addHole({
           ...input.data,
-          ast: input.kclManager.ast,
-          artifactGraph: input.kclManager.artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          ast: input.executingEditor.ast,
+          artifactGraph: input.executingEditor.artifactGraph,
+          wasmInstance: await input.executingEditor.wasmInstancePromise,
         })
         if (err(astResult)) {
           return Promise.reject(astResult)
@@ -4841,7 +4971,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [pathToNode],
           }
@@ -4855,7 +4985,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Fillet'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
               engineCommandManager: ConnectionManager
               wasmInstance: ModuleType
@@ -4866,14 +4996,15 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const { artifactGraph } = input.kclManager
-        let ast = input.kclManager.ast
+        const { artifactGraph } = input.executingEditor
+        let ast = input.executingEditor.ast
         if (
           input.data.version &&
-          input.kclManager.fileSettings.experimentalFeatures?.type !== 'Allow'
+          input.executingEditor.fileSettings.experimentalFeatures?.type !==
+            'Allow'
         ) {
           const astWithNewSetting = setExperimentalFeatures(
-            input.kclManager.code,
+            input.executingEditor.code,
             {
               type: 'Allow',
             },
@@ -4900,7 +5031,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: pathToNode,
           }
@@ -4914,7 +5045,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Chamfer'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
               engineCommandManager: ConnectionManager
               wasmInstance: ModuleType
@@ -4925,14 +5056,15 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const { artifactGraph } = input.kclManager
-        let ast = input.kclManager.ast
+        const { artifactGraph } = input.executingEditor
+        let ast = input.executingEditor.ast
         if (
           input.data.version &&
-          input.kclManager.fileSettings.experimentalFeatures?.type !== 'Allow'
+          input.executingEditor.fileSettings.experimentalFeatures?.type !==
+            'Allow'
         ) {
           const astWithNewSetting = setExperimentalFeatures(
-            input.kclManager.code,
+            input.executingEditor.code,
             {
               type: 'Allow',
             },
@@ -4959,7 +5091,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: pathToNode,
           }
@@ -4973,7 +5105,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Blend'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
               wasmInstance: ModuleType
             }
@@ -4983,7 +5115,7 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const { ast, artifactGraph } = input.kclManager
+        const { ast, artifactGraph } = input.executingEditor
         const astResult = addBlend({
           ...input.data,
           ast,
@@ -4999,7 +5131,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [pathToNode],
           }
@@ -5013,7 +5145,7 @@ export const modelingMachine = setup({
         input: {
           selectionRanges: Selections
           systemDeps: {
-            kclManager: KclManager
+            executingEditor: ExecutingEditor
             rustContext: RustContext
           }
         }
@@ -5047,7 +5179,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Appearance'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -5055,13 +5187,13 @@ export const modelingMachine = setup({
         if (!input || !input.data) {
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
-        const ast = input.kclManager.ast
-        const artifactGraph = input.kclManager.artifactGraph
+        const ast = input.executingEditor.ast
+        const artifactGraph = input.executingEditor.artifactGraph
         const result = addAppearance({
           ...input.data,
           ast,
           artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          wasmInstance: await input.executingEditor.wasmInstancePromise,
         })
         if (err(result)) {
           return Promise.reject(result)
@@ -5069,7 +5201,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -5083,7 +5215,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Translate'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -5092,13 +5224,13 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const ast = input.kclManager.ast
-        const artifactGraph = input.kclManager.artifactGraph
+        const ast = input.executingEditor.ast
+        const artifactGraph = input.executingEditor.artifactGraph
         const result = addTranslate({
           ...input.data,
           ast,
           artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          wasmInstance: await input.executingEditor.wasmInstancePromise,
         })
         if (err(result)) {
           return Promise.reject(result)
@@ -5106,7 +5238,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -5120,7 +5252,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Rotate'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -5128,13 +5260,13 @@ export const modelingMachine = setup({
         if (!input || !input.data) {
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
-        const ast = input.kclManager.ast
-        const artifactGraph = input.kclManager.artifactGraph
+        const ast = input.executingEditor.ast
+        const artifactGraph = input.executingEditor.artifactGraph
         const result = addRotate({
           ...input.data,
           ast,
           artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          wasmInstance: await input.executingEditor.wasmInstancePromise,
         })
         if (err(result)) {
           return Promise.reject(result)
@@ -5143,7 +5275,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -5157,7 +5289,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Scale'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -5166,13 +5298,13 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const ast = input.kclManager.ast
-        const artifactGraph = input.kclManager.artifactGraph
+        const ast = input.executingEditor.ast
+        const artifactGraph = input.executingEditor.artifactGraph
         const result = addScale({
           ...input.data,
           ast,
           artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          wasmInstance: await input.executingEditor.wasmInstancePromise,
         })
         if (err(result)) {
           return Promise.reject(result)
@@ -5181,7 +5313,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -5195,7 +5327,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Clone'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
               wasmInstance: ModuleType
             }
@@ -5204,8 +5336,8 @@ export const modelingMachine = setup({
         if (!input || !input.data) {
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
-        const ast = input.kclManager.ast
-        const artifactGraph = input.kclManager.artifactGraph
+        const ast = input.executingEditor.ast
+        const artifactGraph = input.executingEditor.artifactGraph
         const result = addClone({
           ...input.data,
           ast,
@@ -5218,7 +5350,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -5232,7 +5364,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Mirror 3D'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
               wasmInstance: ModuleType
             }
@@ -5242,7 +5374,7 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const { ast, artifactGraph, variables } = input.kclManager
+        const { ast, artifactGraph, variables } = input.executingEditor
         const result = addMirror3D({
           ...input.data,
           ast,
@@ -5256,7 +5388,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -5274,7 +5406,7 @@ export const modelingMachine = setup({
                     objects: Selections
                   }
                 | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
               wasmInstance: ModuleType
             }
@@ -5283,8 +5415,8 @@ export const modelingMachine = setup({
         if (!input || !input.data) {
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
-        const ast = input.kclManager.ast
-        const artifactGraph = input.kclManager.artifactGraph
+        const ast = input.executingEditor.ast
+        const artifactGraph = input.executingEditor.artifactGraph
         const result = addHide({
           ...input.data,
           ast,
@@ -5297,7 +5429,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager
+          input.executingEditor
         )
       }
     ),
@@ -5312,7 +5444,7 @@ export const modelingMachine = setup({
                     objects: Selections
                   }
                 | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
               wasmInstance: ModuleType
             }
@@ -5322,16 +5454,17 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        let ast: Node<Program> = input.kclManager.ast
+        let ast: Node<Program> = input.executingEditor.ast
         if (
-          input.kclManager.fileSettings.experimentalFeatures?.type !== 'Allow'
+          input.executingEditor.fileSettings.experimentalFeatures?.type !==
+          'Allow'
         ) {
           const astWithExperimentalFeatures = setExperimentalFeatures(
-            input.kclManager.code,
+            input.executingEditor.code,
             {
               type: 'Allow',
             },
-            await input.kclManager.wasmInstancePromise
+            await input.executingEditor.wasmInstancePromise
           )
           if (err(astWithExperimentalFeatures)) {
             return Promise.reject(astWithExperimentalFeatures)
@@ -5340,7 +5473,7 @@ export const modelingMachine = setup({
           ast = astWithExperimentalFeatures
         }
 
-        const artifactGraph = input.kclManager.artifactGraph
+        const artifactGraph = input.executingEditor.artifactGraph
         const result = addDelete({
           ...input.data,
           ast,
@@ -5353,7 +5486,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager
+          input.executingEditor
         )
       }
     ),
@@ -5364,7 +5497,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['GDT Flatness'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -5373,21 +5506,21 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const wasmInstance = await input.kclManager.wasmInstancePromise
+        const wasmInstance = await input.executingEditor.wasmInstancePromise
 
         const data = await withDefaultGdtFrameDefaults({
           data: input.data,
-          engineCommandManager: input.kclManager.engineCommandManager,
-          ast: input.kclManager.ast,
-          sourceCode: input.kclManager.code,
-          outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
+          engineCommandManager: input.executingEditor.engineCommandManager,
+          ast: input.executingEditor.ast,
+          sourceCode: input.executingEditor.code,
+          outputUnit: input.executingEditor.fileSettings.defaultLengthUnit,
           wasmInstance,
         })
 
         const result = addFlatnessGdt({
           ...data,
-          ast: input.kclManager.ast,
-          artifactGraph: input.kclManager.artifactGraph,
+          ast: input.executingEditor.ast,
+          artifactGraph: input.executingEditor.artifactGraph,
           wasmInstance,
         })
         if (err(result)) {
@@ -5397,7 +5530,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -5411,7 +5544,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['GDT Straightness'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -5420,21 +5553,21 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const wasmInstance = await input.kclManager.wasmInstancePromise
+        const wasmInstance = await input.executingEditor.wasmInstancePromise
 
         const data = await withDefaultGdtFrameDefaults({
           data: input.data,
-          engineCommandManager: input.kclManager.engineCommandManager,
-          ast: input.kclManager.ast,
-          sourceCode: input.kclManager.code,
-          outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
+          engineCommandManager: input.executingEditor.engineCommandManager,
+          ast: input.executingEditor.ast,
+          sourceCode: input.executingEditor.code,
+          outputUnit: input.executingEditor.fileSettings.defaultLengthUnit,
           wasmInstance,
         })
 
         const result = addStraightnessGdt({
           ...data,
-          ast: input.kclManager.ast,
-          artifactGraph: input.kclManager.artifactGraph,
+          ast: input.executingEditor.ast,
+          artifactGraph: input.executingEditor.artifactGraph,
           wasmInstance,
         })
         if (err(result)) {
@@ -5444,7 +5577,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -5458,7 +5591,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['GDT Circularity'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -5467,21 +5600,21 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const wasmInstance = await input.kclManager.wasmInstancePromise
+        const wasmInstance = await input.executingEditor.wasmInstancePromise
 
         const data = await withDefaultGdtFrameDefaults({
           data: input.data,
-          engineCommandManager: input.kclManager.engineCommandManager,
-          ast: input.kclManager.ast,
-          sourceCode: input.kclManager.code,
-          outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
+          engineCommandManager: input.executingEditor.engineCommandManager,
+          ast: input.executingEditor.ast,
+          sourceCode: input.executingEditor.code,
+          outputUnit: input.executingEditor.fileSettings.defaultLengthUnit,
           wasmInstance,
         })
 
         const result = addCircularityGdt({
           ...data,
-          ast: input.kclManager.ast,
-          artifactGraph: input.kclManager.artifactGraph,
+          ast: input.executingEditor.ast,
+          artifactGraph: input.executingEditor.artifactGraph,
           wasmInstance,
         })
         if (err(result)) {
@@ -5491,7 +5624,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -5505,7 +5638,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['GDT Cylindricity'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -5514,21 +5647,21 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const wasmInstance = await input.kclManager.wasmInstancePromise
+        const wasmInstance = await input.executingEditor.wasmInstancePromise
 
         const data = await withDefaultGdtFrameDefaults({
           data: input.data,
-          engineCommandManager: input.kclManager.engineCommandManager,
-          ast: input.kclManager.ast,
-          sourceCode: input.kclManager.code,
-          outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
+          engineCommandManager: input.executingEditor.engineCommandManager,
+          ast: input.executingEditor.ast,
+          sourceCode: input.executingEditor.code,
+          outputUnit: input.executingEditor.fileSettings.defaultLengthUnit,
           wasmInstance,
         })
 
         const result = addCylindricityGdt({
           ...data,
-          ast: input.kclManager.ast,
-          artifactGraph: input.kclManager.artifactGraph,
+          ast: input.executingEditor.ast,
+          artifactGraph: input.executingEditor.artifactGraph,
           wasmInstance,
         })
         if (err(result)) {
@@ -5538,7 +5671,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -5552,7 +5685,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['GDT Datum'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -5561,21 +5694,21 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const wasmInstance = await input.kclManager.wasmInstancePromise
+        const wasmInstance = await input.executingEditor.wasmInstancePromise
 
         const data = await withDefaultGdtFrameDefaults({
           data: input.data,
-          engineCommandManager: input.kclManager.engineCommandManager,
-          ast: input.kclManager.ast,
-          sourceCode: input.kclManager.code,
-          outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
+          engineCommandManager: input.executingEditor.engineCommandManager,
+          ast: input.executingEditor.ast,
+          sourceCode: input.executingEditor.code,
+          outputUnit: input.executingEditor.fileSettings.defaultLengthUnit,
           wasmInstance,
         })
 
         const result = addDatumGdt({
           ...data,
-          ast: input.kclManager.ast,
-          artifactGraph: input.kclManager.artifactGraph,
+          ast: input.executingEditor.ast,
+          artifactGraph: input.executingEditor.artifactGraph,
           wasmInstance,
         })
         if (err(result)) {
@@ -5585,7 +5718,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -5599,7 +5732,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['GDT Profile'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -5608,21 +5741,21 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const wasmInstance = await input.kclManager.wasmInstancePromise
+        const wasmInstance = await input.executingEditor.wasmInstancePromise
 
         const data = await withDefaultGdtFrameDefaults({
           data: input.data,
-          engineCommandManager: input.kclManager.engineCommandManager,
-          ast: input.kclManager.ast,
-          sourceCode: input.kclManager.code,
-          outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
+          engineCommandManager: input.executingEditor.engineCommandManager,
+          ast: input.executingEditor.ast,
+          sourceCode: input.executingEditor.code,
+          outputUnit: input.executingEditor.fileSettings.defaultLengthUnit,
           wasmInstance,
         })
 
         const result = addProfileGdt({
           ...data,
-          ast: input.kclManager.ast,
-          artifactGraph: input.kclManager.artifactGraph,
+          ast: input.executingEditor.ast,
+          artifactGraph: input.executingEditor.artifactGraph,
           wasmInstance,
         })
         if (err(result)) {
@@ -5632,7 +5765,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -5646,7 +5779,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['GDT Position'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -5655,21 +5788,21 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const wasmInstance = await input.kclManager.wasmInstancePromise
+        const wasmInstance = await input.executingEditor.wasmInstancePromise
 
         const data = await withDefaultGdtFrameDefaults({
           data: input.data,
-          engineCommandManager: input.kclManager.engineCommandManager,
-          ast: input.kclManager.ast,
-          sourceCode: input.kclManager.code,
-          outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
+          engineCommandManager: input.executingEditor.engineCommandManager,
+          ast: input.executingEditor.ast,
+          sourceCode: input.executingEditor.code,
+          outputUnit: input.executingEditor.fileSettings.defaultLengthUnit,
           wasmInstance,
         })
 
         const result = addPositionGdt({
           ...data,
-          ast: input.kclManager.ast,
-          artifactGraph: input.kclManager.artifactGraph,
+          ast: input.executingEditor.ast,
+          artifactGraph: input.executingEditor.artifactGraph,
           wasmInstance,
         })
         if (err(result)) {
@@ -5679,7 +5812,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -5693,7 +5826,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['GDT Distance'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -5702,21 +5835,21 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const wasmInstance = await input.kclManager.wasmInstancePromise
+        const wasmInstance = await input.executingEditor.wasmInstancePromise
 
         const data = await withDefaultGdtFrameDefaults({
           data: input.data,
-          engineCommandManager: input.kclManager.engineCommandManager,
-          ast: input.kclManager.ast,
-          sourceCode: input.kclManager.code,
-          outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
+          engineCommandManager: input.executingEditor.engineCommandManager,
+          ast: input.executingEditor.ast,
+          sourceCode: input.executingEditor.code,
+          outputUnit: input.executingEditor.fileSettings.defaultLengthUnit,
           wasmInstance,
         })
 
         const result = addDistanceGdt({
           ...data,
-          ast: input.kclManager.ast,
-          artifactGraph: input.kclManager.artifactGraph,
+          ast: input.executingEditor.ast,
+          artifactGraph: input.executingEditor.artifactGraph,
           wasmInstance,
         })
         if (err(result)) {
@@ -5726,7 +5859,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -5740,7 +5873,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['GDT Perpendicularity'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -5749,21 +5882,21 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const wasmInstance = await input.kclManager.wasmInstancePromise
+        const wasmInstance = await input.executingEditor.wasmInstancePromise
 
         const data = await withDefaultGdtFrameDefaults({
           data: input.data,
-          engineCommandManager: input.kclManager.engineCommandManager,
-          ast: input.kclManager.ast,
-          sourceCode: input.kclManager.code,
-          outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
+          engineCommandManager: input.executingEditor.engineCommandManager,
+          ast: input.executingEditor.ast,
+          sourceCode: input.executingEditor.code,
+          outputUnit: input.executingEditor.fileSettings.defaultLengthUnit,
           wasmInstance,
         })
 
         const result = addPerpendicularityGdt({
           ...data,
-          ast: input.kclManager.ast,
-          artifactGraph: input.kclManager.artifactGraph,
+          ast: input.executingEditor.ast,
+          artifactGraph: input.executingEditor.artifactGraph,
           wasmInstance,
         })
         if (err(result)) {
@@ -5773,7 +5906,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -5787,7 +5920,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['GDT Parallelism'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -5796,21 +5929,21 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const wasmInstance = await input.kclManager.wasmInstancePromise
+        const wasmInstance = await input.executingEditor.wasmInstancePromise
 
         const data = await withDefaultGdtFrameDefaults({
           data: input.data,
-          engineCommandManager: input.kclManager.engineCommandManager,
-          ast: input.kclManager.ast,
-          sourceCode: input.kclManager.code,
-          outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
+          engineCommandManager: input.executingEditor.engineCommandManager,
+          ast: input.executingEditor.ast,
+          sourceCode: input.executingEditor.code,
+          outputUnit: input.executingEditor.fileSettings.defaultLengthUnit,
           wasmInstance,
         })
 
         const result = addParallelismGdt({
           ...data,
-          ast: input.kclManager.ast,
-          artifactGraph: input.kclManager.artifactGraph,
+          ast: input.executingEditor.ast,
+          artifactGraph: input.executingEditor.artifactGraph,
           wasmInstance,
         })
         if (err(result)) {
@@ -5820,7 +5953,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -5834,7 +5967,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['GDT Annotation'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -5843,21 +5976,21 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const wasmInstance = await input.kclManager.wasmInstancePromise
+        const wasmInstance = await input.executingEditor.wasmInstancePromise
 
         const data = await withDefaultGdtFrameDefaults({
           data: input.data,
-          engineCommandManager: input.kclManager.engineCommandManager,
-          ast: input.kclManager.ast,
-          sourceCode: input.kclManager.code,
-          outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
+          engineCommandManager: input.executingEditor.engineCommandManager,
+          ast: input.executingEditor.ast,
+          sourceCode: input.executingEditor.code,
+          outputUnit: input.executingEditor.fileSettings.defaultLengthUnit,
           wasmInstance,
         })
 
         const result = addAnnotationGdt({
           ...data,
-          ast: input.kclManager.ast,
-          artifactGraph: input.kclManager.artifactGraph,
+          ast: input.executingEditor.ast,
+          artifactGraph: input.executingEditor.artifactGraph,
           wasmInstance,
         })
         if (err(result)) {
@@ -5867,7 +6000,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -5881,7 +6014,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Flip Surface'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -5892,9 +6025,9 @@ export const modelingMachine = setup({
 
         const result = addFlipSurface({
           ...input.data,
-          ast: input.kclManager.ast,
-          artifactGraph: input.kclManager.artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          ast: input.executingEditor.ast,
+          artifactGraph: input.executingEditor.artifactGraph,
+          wasmInstance: await input.executingEditor.wasmInstancePromise,
         })
         if (err(result)) {
           return Promise.reject(result)
@@ -5903,7 +6036,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -5917,7 +6050,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Join Surfaces'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -5928,9 +6061,9 @@ export const modelingMachine = setup({
 
         const result = addJoinSurfaces({
           ...input.data,
-          ast: input.kclManager.ast,
-          artifactGraph: input.kclManager.artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          ast: input.executingEditor.ast,
+          artifactGraph: input.executingEditor.artifactGraph,
+          wasmInstance: await input.executingEditor.wasmInstancePromise,
         })
         if (err(result)) {
           return Promise.reject(result)
@@ -5939,7 +6072,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -5953,7 +6086,7 @@ export const modelingMachine = setup({
         input?:
           | {
               data: ModelingCommandSchema['Export'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
               defaultUnit?: ModelingMachineContext['store']['defaultUnit']
             }
@@ -5962,13 +6095,16 @@ export const modelingMachine = setup({
         if (!input || !input.data) {
           return new Error(NO_INPUT_PROVIDED_MESSAGE)
         }
-        const { data, kclManager, rustContext, defaultUnit } = input
+        const { data, executingEditor, rustContext, defaultUnit } = input
 
-        if (kclManager.hasErrors() || kclManager.ast.body.length === 0) {
+        if (
+          executingEditor.hasErrors() ||
+          executingEditor.ast.body.length === 0
+        ) {
           let errorMessage = 'Unable to Export '
-          if (kclManager.hasErrors()) {
+          if (executingEditor.hasErrors()) {
             errorMessage += 'due to KCL Errors'
-          } else if (kclManager.ast.body.length === 0) {
+          } else if (executingEditor.ast.body.length === 0) {
             errorMessage += 'due to Empty Scene'
           }
           console.error(errorMessage)
@@ -5976,10 +6112,9 @@ export const modelingMachine = setup({
           return new Error(errorMessage)
         }
 
-        let fileName = (kclManager.currentFileName ?? 'output.kcl')?.replace(
-          '.kcl',
-          `.${data.type}`
-        )
+        let fileName = (
+          executingEditor.currentFileName ?? 'output.kcl'
+        )?.replace('.kcl', `.${data.type}`)
         // Ensure the file has an extension.
         if (!fileName.includes('.')) {
           fileName += `.${data.type}`
@@ -6140,7 +6275,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Boolean Subtract'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
               wasmInstance: ModuleType
             }
@@ -6149,8 +6284,8 @@ export const modelingMachine = setup({
         if (!input || !input.data) {
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
-        const ast = input.kclManager.ast
-        const artifactGraph = input.kclManager.artifactGraph
+        const ast = input.executingEditor.ast
+        const artifactGraph = input.executingEditor.artifactGraph
         const result = addSubtract({
           ...input.data,
           ast,
@@ -6163,7 +6298,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -6177,7 +6312,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Boolean Union'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
               wasmInstance: ModuleType
             }
@@ -6186,8 +6321,8 @@ export const modelingMachine = setup({
         if (!input || !input.data) {
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
-        const ast = input.kclManager.ast
-        const artifactGraph = input.kclManager.artifactGraph
+        const ast = input.executingEditor.ast
+        const artifactGraph = input.executingEditor.artifactGraph
         const result = addUnion({
           ...input.data,
           ast,
@@ -6200,7 +6335,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -6214,7 +6349,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Boolean Intersect'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
               wasmInstance: ModuleType
             }
@@ -6224,8 +6359,8 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const ast = input.kclManager.ast
-        const artifactGraph = input.kclManager.artifactGraph
+        const ast = input.executingEditor.ast
+        const artifactGraph = input.executingEditor.artifactGraph
         const result = addIntersect({
           ...input.data,
           ast,
@@ -6238,7 +6373,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -6252,7 +6387,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Boolean Split'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
               wasmInstance: ModuleType
             }
@@ -6262,8 +6397,8 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const ast = input.kclManager.ast
-        const artifactGraph = input.kclManager.artifactGraph
+        const ast = input.executingEditor.ast
+        const artifactGraph = input.executingEditor.artifactGraph
         const result = addSplit({
           ...input.data,
           ast,
@@ -6276,7 +6411,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -6291,7 +6426,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Pattern Circular 3D'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -6299,13 +6434,13 @@ export const modelingMachine = setup({
         if (!input || !input.data) {
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
-        const ast = input.kclManager.ast
-        const artifactGraph = input.kclManager.artifactGraph
+        const ast = input.executingEditor.ast
+        const artifactGraph = input.executingEditor.artifactGraph
         const result = addPatternCircular3D({
           ...input.data,
           ast,
           artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          wasmInstance: await input.executingEditor.wasmInstancePromise,
         })
         if (err(result)) {
           return Promise.reject(result)
@@ -6313,7 +6448,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -6328,7 +6463,7 @@ export const modelingMachine = setup({
         input:
           | {
               data: ModelingCommandSchema['Pattern Linear 3D'] | undefined
-              kclManager: KclManager
+              executingEditor: ExecutingEditor
               rustContext: RustContext
             }
           | undefined
@@ -6337,13 +6472,13 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
-        const ast = input.kclManager.ast
-        const artifactGraph = input.kclManager.artifactGraph
+        const ast = input.executingEditor.ast
+        const artifactGraph = input.executingEditor.artifactGraph
         const result = addPatternLinear3D({
           ...input.data,
           ast,
           artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          wasmInstance: await input.executingEditor.wasmInstancePromise,
         })
         if (err(result)) {
           return Promise.reject(result)
@@ -6351,7 +6486,7 @@ export const modelingMachine = setup({
         await updateModelingState(
           result.modifiedAst,
           EXECUTION_TYPE_REAL,
-          input.kclManager,
+          input.executingEditor,
           {
             focusPath: [result.pathToNode],
           }
@@ -6362,11 +6497,11 @@ export const modelingMachine = setup({
     /* Pierre: looks like somewhat of a one-off */
     'reeval-node-paths': fromPromise(
       async ({
-        input: { sketchDetails, kclManager, wasmInstance },
+        input: { sketchDetails, executingEditor, wasmInstance },
       }: {
         input: Pick<
           ModelingMachineContext,
-          'sketchDetails' | 'kclManager' | 'wasmInstance'
+          'sketchDetails' | 'executingEditor' | 'wasmInstance'
         >
       }) => {
         const errorMessage =
@@ -6376,7 +6511,7 @@ export const modelingMachine = setup({
         }
 
         // hasErrors is for parse errors, errors is for runtime errors
-        if (kclManager.errors.length > 0 || kclManager.hasErrors()) {
+        if (executingEditor.errors.length > 0 || executingEditor.hasErrors()) {
           // if there's an error in the execution, we don't actually want to disable sketch mode
           // instead we'll give the user the chance to fix their error
           return {
@@ -6387,8 +6522,8 @@ export const modelingMachine = setup({
         }
 
         const updatedPlaneNodePath = updatePathToNodesAfterEdit(
-          kclManager._lastAst,
-          kclManager.ast,
+          executingEditor._lastAst,
+          executingEditor.ast,
           sketchDetails.planeNodePath,
           wasmInstance
         )
@@ -6396,17 +6531,17 @@ export const modelingMachine = setup({
         if (err(updatedPlaneNodePath)) {
           return Promise.reject(new Error(errorMessage))
         }
-        const maybePlaneArtifact = [...kclManager.artifactGraph.values()].find(
-          (artifact) => {
-            const codeRef = getFaceCodeRef(artifact)
-            if (!codeRef) return false
+        const maybePlaneArtifact = [
+          ...executingEditor.artifactGraph.values(),
+        ].find((artifact) => {
+          const codeRef = getFaceCodeRef(artifact)
+          if (!codeRef) return false
 
-            return (
-              stringifyPathToNode(codeRef.pathToNode) ===
-              stringifyPathToNode(updatedPlaneNodePath)
-            )
-          }
-        )
+          return (
+            stringifyPathToNode(codeRef.pathToNode) ===
+            stringifyPathToNode(updatedPlaneNodePath)
+          )
+        })
         if (
           !maybePlaneArtifact ||
           (maybePlaneArtifact.type !== 'plane' &&
@@ -6418,7 +6553,9 @@ export const modelingMachine = setup({
         if (maybePlaneArtifact.type === 'plane') {
           planeArtifact = maybePlaneArtifact
         } else {
-          const face = kclManager.artifactGraph.get(maybePlaneArtifact.faceId)
+          const face = executingEditor.artifactGraph.get(
+            maybePlaneArtifact.faceId
+          )
           if (face) {
             planeArtifact = face
           }
@@ -6434,8 +6571,8 @@ export const modelingMachine = setup({
 
         const newPaths = getPathsFromPlaneArtifact(
           planeArtifact,
-          kclManager.artifactGraph,
-          kclManager.ast
+          executingEditor.artifactGraph,
+          executingEditor.ast
         )
 
         return {
@@ -6467,7 +6604,7 @@ export const modelingMachine = setup({
           target: 'animating to existing sketch solve',
           actions: [
             ({ context }) => {
-              context.kclManager.sceneInfra.animate()
+              context.executingEditor.sceneInfra.animate()
             },
           ],
         },
@@ -6476,7 +6613,7 @@ export const modelingMachine = setup({
             target: 'animating to existing sketch solve',
             actions: [
               ({ context }) => {
-                context.kclManager.sceneInfra.animate()
+                context.executingEditor.sceneInfra.animate()
               },
             ],
             guard: 'Selection is sketchBlock',
@@ -6485,7 +6622,7 @@ export const modelingMachine = setup({
             target: 'animating to existing sketch',
             actions: [
               ({ context }) => {
-                context.kclManager.sceneInfra.animate()
+                context.executingEditor.sceneInfra.animate()
               },
             ],
             guard: 'Selection is on face',
@@ -6494,7 +6631,7 @@ export const modelingMachine = setup({
             target: 'Sketch no face',
             actions: [
               ({ context }) => {
-                context.kclManager.sceneInfra.animate()
+                context.executingEditor.sceneInfra.animate()
               },
             ],
           },
@@ -6826,12 +6963,12 @@ export const modelingMachine = setup({
                   context: {
                     sketchDetails,
                     selectionRanges,
-                    kclManager: providedKclManager,
+                    executingEditor: providedExecutingEditor,
                   },
                 }) => ({
                   sketchDetails,
                   selectionRanges,
-                  kclManager: providedKclManager,
+                  executingEditor: providedExecutingEditor,
                 }),
                 onDone: [
                   {
@@ -6866,11 +7003,11 @@ export const modelingMachine = setup({
             src: 'Get horizontal info',
             id: 'get-horizontal-info',
             input: ({
-              context: { selectionRanges, sketchDetails, kclManager },
+              context: { selectionRanges, sketchDetails, executingEditor },
             }) => ({
               selectionRanges,
               sketchDetails,
-              kclManager,
+              executingEditor,
             }),
             onDone: {
               target: 'SketchIdle',
@@ -6885,11 +7022,11 @@ export const modelingMachine = setup({
             src: 'Get vertical info',
             id: 'get-vertical-info',
             input: ({
-              context: { selectionRanges, sketchDetails, kclManager },
+              context: { selectionRanges, sketchDetails, executingEditor },
             }) => ({
               selectionRanges,
               sketchDetails,
-              kclManager,
+              executingEditor,
             }),
             onDone: {
               target: 'SketchIdle',
@@ -6904,11 +7041,11 @@ export const modelingMachine = setup({
             src: 'Get ABS X info',
             id: 'get-abs-x-info',
             input: ({
-              context: { selectionRanges, sketchDetails, kclManager },
+              context: { selectionRanges, sketchDetails, executingEditor },
             }) => ({
               selectionRanges,
               sketchDetails,
-              kclManager,
+              executingEditor,
             }),
             onDone: {
               target: 'SketchIdle',
@@ -6923,11 +7060,11 @@ export const modelingMachine = setup({
             src: 'Get ABS Y info',
             id: 'get-abs-y-info',
             input: ({
-              context: { selectionRanges, sketchDetails, kclManager },
+              context: { selectionRanges, sketchDetails, executingEditor },
             }) => ({
               selectionRanges,
               sketchDetails,
-              kclManager,
+              executingEditor,
             }),
             onDone: {
               target: 'SketchIdle',
@@ -6942,11 +7079,11 @@ export const modelingMachine = setup({
             src: 'Get angle info',
             id: 'get-angle-info',
             input: ({
-              context: { selectionRanges, sketchDetails, kclManager },
+              context: { selectionRanges, sketchDetails, executingEditor },
             }) => ({
               selectionRanges,
               sketchDetails,
-              kclManager,
+              executingEditor,
             }),
             onDone: {
               target: 'SketchIdle',
@@ -6961,7 +7098,7 @@ export const modelingMachine = setup({
             src: 'astConstrainLength',
             id: 'AST-constrain-length',
             input: ({
-              context: { selectionRanges, sketchDetails, kclManager },
+              context: { selectionRanges, sketchDetails, executingEditor },
               event,
             }) => {
               const data =
@@ -6969,7 +7106,7 @@ export const modelingMachine = setup({
               return {
                 selectionRanges,
                 sketchDetails,
-                kclManager,
+                executingEditor,
                 lengthValue: data?.length,
               }
             },
@@ -6986,11 +7123,11 @@ export const modelingMachine = setup({
             src: 'Get perpendicular distance info',
             id: 'get-perpendicular-distance-info',
             input: ({
-              context: { selectionRanges, sketchDetails, kclManager },
+              context: { selectionRanges, sketchDetails, executingEditor },
             }) => ({
               selectionRanges,
               sketchDetails,
-              kclManager,
+              executingEditor,
             }),
             onDone: {
               target: 'SketchIdle',
@@ -7036,13 +7173,13 @@ export const modelingMachine = setup({
                   context: {
                     sketchDetails,
                     selectionRanges,
-                    kclManager: providedKclManager,
+                    executingEditor: providedExecutingEditor,
                     wasmInstance,
                   },
                 }) => ({
                   sketchDetails,
                   selectionRanges,
-                  kclManager: providedKclManager,
+                  executingEditor: providedExecutingEditor,
                   wasmInstance,
                 }),
               },
@@ -7109,13 +7246,13 @@ export const modelingMachine = setup({
                   context: {
                     sketchDetails,
                     selectionRanges,
-                    kclManager: providedKclManager,
+                    executingEditor: providedExecutingEditor,
                     wasmInstance,
                   },
                 }) => ({
                   sketchDetails,
                   selectionRanges,
-                  kclManager: providedKclManager,
+                  executingEditor: providedExecutingEditor,
                   wasmInstance,
                 }),
               },
@@ -7135,9 +7272,9 @@ export const modelingMachine = setup({
             {
               src: 'AST-undo-startSketchOn',
               id: 'AST-undo-startSketchOn',
-              input: ({ context: { sketchDetails, kclManager } }) => ({
+              input: ({ context: { sketchDetails, executingEditor } }) => ({
                 sketchDetails,
-                kclManager,
+                executingEditor,
               }),
 
               onDone: {
@@ -7184,13 +7321,13 @@ export const modelingMachine = setup({
                   context: {
                     sketchDetails,
                     selectionRanges,
-                    kclManager: providedKclManager,
+                    executingEditor: providedExecutingEditor,
                     wasmInstance,
                   },
                 }) => ({
                   sketchDetails,
                   selectionRanges,
-                  kclManager: providedKclManager,
+                  executingEditor: providedExecutingEditor,
                   wasmInstance,
                 }),
               },
@@ -7205,17 +7342,20 @@ export const modelingMachine = setup({
                   actions: 'update sketchDetails',
                 },
                 onError: 'Awaiting origin',
-                input: ({ context: { sketchDetails, kclManager }, event }) => {
+                input: ({
+                  context: { sketchDetails, executingEditor },
+                  event,
+                }) => {
                   if (event.type !== 'click in scene')
                     return {
                       sketchDetails,
                       data: [0, 0],
-                      kclManager,
+                      executingEditor,
                     }
                   return {
                     sketchDetails,
                     data: event.data,
-                    kclManager,
+                    executingEditor,
                   }
                 },
               },
@@ -7263,13 +7403,13 @@ export const modelingMachine = setup({
                   context: {
                     sketchDetails,
                     selectionRanges,
-                    kclManager: providedKclManager,
+                    executingEditor: providedExecutingEditor,
                     wasmInstance,
                   },
                 }) => ({
                   sketchDetails,
                   selectionRanges,
-                  kclManager: providedKclManager,
+                  executingEditor: providedExecutingEditor,
                   wasmInstance,
                 }),
               },
@@ -7284,17 +7424,20 @@ export const modelingMachine = setup({
                   actions: 'update sketchDetails',
                 },
                 onError: 'Awaiting origin',
-                input: ({ context: { sketchDetails, kclManager }, event }) => {
+                input: ({
+                  context: { sketchDetails, executingEditor },
+                  event,
+                }) => {
                   if (event.type !== 'Add center rectangle origin')
                     return {
                       sketchDetails,
                       data: [0, 0],
-                      kclManager,
+                      executingEditor,
                     }
                   return {
                     sketchDetails,
                     data: event.data,
-                    kclManager,
+                    executingEditor,
                   }
                 },
               },
@@ -7316,10 +7459,10 @@ export const modelingMachine = setup({
             src: 'reeval-node-paths',
             id: 'reeval-node-paths',
             input: ({
-              context: { sketchDetails, kclManager, wasmInstance },
+              context: { sketchDetails, executingEditor, wasmInstance },
             }) => ({
               sketchDetails,
-              kclManager,
+              executingEditor,
               wasmInstance,
             }),
 
@@ -7344,7 +7487,7 @@ export const modelingMachine = setup({
                 selectionRanges,
                 sketchDetails,
                 wasmInstance,
-                kclManager,
+                executingEditor,
               },
               event,
             }) => {
@@ -7354,7 +7497,7 @@ export const modelingMachine = setup({
                 sketchDetails,
                 data: event.data,
                 wasmInstance,
-                kclManager,
+                executingEditor,
               }
             },
             onError: 'SketchIdle',
@@ -7374,7 +7517,7 @@ export const modelingMachine = setup({
                 selectionRanges,
                 sketchDetails,
                 wasmInstance,
-                kclManager: providedKclManager,
+                executingEditor: providedExecutingEditor,
               },
               event,
             }) => {
@@ -7386,7 +7529,7 @@ export const modelingMachine = setup({
                     ? event.data
                     : undefined,
                 wasmInstance,
-                kclManager: providedKclManager,
+                executingEditor: providedExecutingEditor,
               }
             },
             onDone: {
@@ -7404,13 +7547,13 @@ export const modelingMachine = setup({
               context: {
                 selectionRanges,
                 sketchDetails,
-                kclManager: providedKclManager,
+                executingEditor: providedExecutingEditor,
                 wasmInstance,
               },
             }) => ({
               selectionRanges,
               sketchDetails,
-              kclManager: providedKclManager,
+              executingEditor: providedExecutingEditor,
               wasmInstance,
             }),
             onDone: {
@@ -7428,13 +7571,13 @@ export const modelingMachine = setup({
               context: {
                 selectionRanges,
                 sketchDetails,
-                kclManager: providedKclManager,
+                executingEditor: providedExecutingEditor,
                 wasmInstance,
               },
             }) => ({
               selectionRanges,
               sketchDetails,
-              kclManager: providedKclManager,
+              executingEditor: providedExecutingEditor,
               wasmInstance,
             }),
             onDone: {
@@ -7451,7 +7594,7 @@ export const modelingMachine = setup({
             input: ({ context }) => ({
               selectionRanges: context.selectionRanges,
               sketchDetails: context.sketchDetails,
-              kclManager: context.kclManager,
+              executingEditor: context.executingEditor,
               wasmInstance: context.wasmInstance,
             }),
             onDone: {
@@ -7468,7 +7611,7 @@ export const modelingMachine = setup({
             input: ({ context }) => ({
               selectionRanges: context.selectionRanges,
               sketchDetails: context.sketchDetails,
-              kclManager: context.kclManager,
+              executingEditor: context.executingEditor,
               wasmInstance: context.wasmInstance,
             }),
             onDone: {
@@ -7485,7 +7628,7 @@ export const modelingMachine = setup({
             input: ({ context }) => ({
               selectionRanges: context.selectionRanges,
               sketchDetails: context.sketchDetails,
-              kclManager: context.kclManager,
+              executingEditor: context.executingEditor,
               wasmInstance: context.wasmInstance,
             }),
             onDone: {
@@ -7502,7 +7645,7 @@ export const modelingMachine = setup({
             input: ({ context }) => ({
               selectionRanges: context.selectionRanges,
               sketchDetails: context.sketchDetails,
-              kclManager: context.kclManager,
+              executingEditor: context.executingEditor,
               wasmInstance: context.wasmInstance,
             }),
             onDone: {
@@ -7519,7 +7662,7 @@ export const modelingMachine = setup({
             input: ({ context }) => ({
               selectionRanges: context.selectionRanges,
               sketchDetails: context.sketchDetails,
-              kclManager: context.kclManager,
+              executingEditor: context.executingEditor,
               wasmInstance: context.wasmInstance,
             }),
             onDone: {
@@ -7536,7 +7679,7 @@ export const modelingMachine = setup({
             input: ({ context }) => ({
               selectionRanges: context.selectionRanges,
               sketchDetails: context.sketchDetails,
-              kclManager: context.kclManager,
+              executingEditor: context.executingEditor,
               wasmInstance: context.wasmInstance,
             }),
             onDone: {
@@ -7628,13 +7771,13 @@ export const modelingMachine = setup({
                   context: {
                     sketchDetails,
                     selectionRanges,
-                    kclManager: providedKclManager,
+                    executingEditor: providedExecutingEditor,
                     wasmInstance,
                   },
                 }) => ({
                   sketchDetails,
                   selectionRanges,
-                  kclManager: providedKclManager,
+                  executingEditor: providedExecutingEditor,
                   wasmInstance,
                 }),
               },
@@ -7649,17 +7792,20 @@ export const modelingMachine = setup({
                   actions: 'update sketchDetails',
                 },
                 onError: 'Awaiting origin',
-                input: ({ context: { sketchDetails, kclManager }, event }) => {
+                input: ({
+                  context: { sketchDetails, executingEditor },
+                  event,
+                }) => {
                   if (event.type !== 'Add circle origin')
                     return {
                       sketchDetails,
                       data: [0, 0],
-                      kclManager,
+                      executingEditor,
                     }
                   return {
                     sketchDetails,
                     data: event.data,
-                    kclManager,
+                    executingEditor,
                   }
                 },
               },
@@ -7682,7 +7828,7 @@ export const modelingMachine = setup({
                 onError: '#Modeling.Sketch.SketchIdle',
                 input: ({ context }) => ({
                   sketchDetails: context.sketchDetails!,
-                  kclManager: context.kclManager,
+                  executingEditor: context.executingEditor,
                   wasmInstance: context.wasmInstance,
                   rustContext: context.rustContext,
                 }),
@@ -7699,13 +7845,13 @@ export const modelingMachine = setup({
                   context: {
                     sketchDetails,
                     selectionRanges,
-                    kclManager: providedKclManager,
+                    executingEditor: providedExecutingEditor,
                     wasmInstance,
                   },
                 }) => ({
                   sketchDetails,
                   selectionRanges,
-                  kclManager: providedKclManager,
+                  executingEditor: providedExecutingEditor,
                   wasmInstance,
                 }),
               },
@@ -7744,17 +7890,20 @@ export const modelingMachine = setup({
                   target: 'Awaiting third point',
                   actions: 'update sketchDetails',
                 },
-                input: ({ context: { sketchDetails, kclManager }, event }) => {
+                input: ({
+                  context: { sketchDetails, executingEditor },
+                  event,
+                }) => {
                   if (event.type !== 'Add second point')
                     return {
                       sketchDetails,
                       data: { p1: [0, 0], p2: [0, 0] },
-                      kclManager,
+                      executingEditor,
                     }
                   return {
                     sketchDetails,
                     data: event.data,
-                    kclManager,
+                    executingEditor,
                   }
                 },
               },
@@ -7778,13 +7927,13 @@ export const modelingMachine = setup({
                   context: {
                     sketchDetails,
                     selectionRanges,
-                    kclManager: providedKclManager,
+                    executingEditor: providedExecutingEditor,
                     wasmInstance,
                   },
                 }) => ({
                   sketchDetails,
                   selectionRanges,
-                  kclManager: providedKclManager,
+                  executingEditor: providedExecutingEditor,
                   wasmInstance,
                 }),
               },
@@ -7829,17 +7978,20 @@ export const modelingMachine = setup({
                   target: 'Awaiting endAngle',
                   actions: 'update sketchDetails',
                 },
-                input: ({ context: { sketchDetails, kclManager }, event }) => {
+                input: ({
+                  context: { sketchDetails, executingEditor },
+                  event,
+                }) => {
                   if (event.type !== 'click in scene')
                     return {
                       sketchDetails,
                       data: [0, 0],
-                      kclManager,
+                      executingEditor,
                     }
                   return {
                     sketchDetails,
                     data: event.data,
-                    kclManager,
+                    executingEditor,
                   }
                 },
               },
@@ -7860,13 +8012,13 @@ export const modelingMachine = setup({
                   context: {
                     sketchDetails,
                     selectionRanges,
-                    kclManager: providedKclManager,
+                    executingEditor: providedExecutingEditor,
                     wasmInstance,
                   },
                 }) => ({
                   sketchDetails,
                   selectionRanges,
-                  kclManager: providedKclManager,
+                  executingEditor: providedExecutingEditor,
                   wasmInstance,
                 }),
               },
@@ -7916,17 +8068,20 @@ export const modelingMachine = setup({
                   target: 'Awaiting third point',
                   actions: 'update sketchDetails',
                 },
-                input: ({ context: { sketchDetails, kclManager }, event }) => {
+                input: ({
+                  context: { sketchDetails, executingEditor },
+                  event,
+                }) => {
                   if (event.type !== 'click in scene')
                     return {
                       sketchDetails,
                       data: [0, 0],
-                      kclManager,
+                      executingEditor,
                     }
                   return {
                     sketchDetails,
                     data: event.data,
-                    kclManager,
+                    executingEditor,
                   }
                 },
               },
@@ -7958,13 +8113,13 @@ export const modelingMachine = setup({
                   context: {
                     sketchDetails,
                     selectionRanges,
-                    kclManager: providedKclManager,
+                    executingEditor: providedExecutingEditor,
                     wasmInstance,
                   },
                 }) => ({
                   sketchDetails,
                   selectionRanges,
-                  kclManager: providedKclManager,
+                  executingEditor: providedExecutingEditor,
                   wasmInstance,
                 }),
               },
@@ -7979,13 +8134,13 @@ export const modelingMachine = setup({
                   context: {
                     sketchDetails,
                     selectionRanges,
-                    kclManager: providedKclManager,
+                    executingEditor: providedExecutingEditor,
                     wasmInstance,
                   },
                 }) => ({
                   sketchDetails,
                   selectionRanges,
-                  kclManager: providedKclManager,
+                  executingEditor: providedExecutingEditor,
                   wasmInstance,
                 }),
               },
@@ -8050,7 +8205,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Select sketch plane') return undefined
           return {
             plane: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             engineCommandManager: context.engineCommandManager,
             wasmInstance: context.wasmInstance,
           }
@@ -8072,7 +8227,7 @@ export const modelingMachine = setup({
 
         input: ({ context }) => ({
           selectionRanges: context.selectionRanges,
-          kclManager: context.kclManager,
+          executingEditor: context.executingEditor,
           engineCommandManager: context.engineCommandManager,
         }),
 
@@ -8141,7 +8296,7 @@ export const modelingMachine = setup({
               initialSketchSolvePlane: context.sketchSolveInit,
               sketchId: context.sketchSolveId || 0,
               initialSceneGraphDelta: context.initialSceneGraphDelta,
-              kclManager: context.kclManager,
+              executingEditor: context.executingEditor,
             }),
             onDone: {
               target: '#sketchSolveMode.exiting',
@@ -8178,7 +8333,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Extrude') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8198,7 +8353,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Sweep') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8218,7 +8373,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Loft') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8238,7 +8393,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Revolve') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8258,7 +8413,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Offset plane') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8278,7 +8433,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Helix') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8298,7 +8453,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Helical Gear') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8318,7 +8473,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Herringbone Gear') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8338,7 +8493,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Spur Gear') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8358,7 +8513,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Ring Gear') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8378,7 +8533,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Shell') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8398,7 +8553,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Delete Face') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8418,7 +8573,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Hole') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8438,7 +8593,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Fillet') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             engineCommandManager: context.engineCommandManager,
             rustContext: context.rustContext,
             wasmInstance: context.wasmInstance,
@@ -8460,7 +8615,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Chamfer') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             engineCommandManager: context.engineCommandManager,
             rustContext: context.rustContext,
             wasmInstance: context.wasmInstance,
@@ -8482,7 +8637,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Blend') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
             wasmInstance: context.wasmInstance,
           }
@@ -8524,7 +8679,7 @@ export const modelingMachine = setup({
           return {
             selectionRanges: context.selectionRanges,
             systemDeps: {
-              kclManager: context.kclManager,
+              executingEditor: context.executingEditor,
               rustContext: context.rustContext,
             },
           }
@@ -8551,7 +8706,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Appearance') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8571,7 +8726,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Translate') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8591,7 +8746,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Rotate') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8611,7 +8766,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Scale') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8631,7 +8786,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Clone') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
             wasmInstance: context.wasmInstance,
           }
@@ -8652,7 +8807,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Mirror 3D') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
             wasmInstance: context.wasmInstance,
           }
@@ -8673,7 +8828,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Hide') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
             wasmInstance: context.wasmInstance,
           }
@@ -8694,7 +8849,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Delete') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
             wasmInstance: context.wasmInstance,
           }
@@ -8715,7 +8870,7 @@ export const modelingMachine = setup({
           if (event.type !== 'GDT Flatness') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8735,7 +8890,7 @@ export const modelingMachine = setup({
           if (event.type !== 'GDT Straightness') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8755,7 +8910,7 @@ export const modelingMachine = setup({
           if (event.type !== 'GDT Circularity') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8775,7 +8930,7 @@ export const modelingMachine = setup({
           if (event.type !== 'GDT Cylindricity') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8795,7 +8950,7 @@ export const modelingMachine = setup({
           if (event.type !== 'GDT Datum') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8815,7 +8970,7 @@ export const modelingMachine = setup({
           if (event.type !== 'GDT Profile') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8835,7 +8990,7 @@ export const modelingMachine = setup({
           if (event.type !== 'GDT Position') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8855,7 +9010,7 @@ export const modelingMachine = setup({
           if (event.type !== 'GDT Distance') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8875,7 +9030,7 @@ export const modelingMachine = setup({
           if (event.type !== 'GDT Perpendicularity') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8895,7 +9050,7 @@ export const modelingMachine = setup({
           if (event.type !== 'GDT Parallelism') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8915,7 +9070,7 @@ export const modelingMachine = setup({
           if (event.type !== 'GDT Annotation') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -8935,7 +9090,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Flip Surface') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
             wasmInstance: context.wasmInstance,
           }
@@ -8956,7 +9111,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Join Surfaces') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
             wasmInstance: context.wasmInstance,
           }
@@ -8977,7 +9132,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Export') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
             defaultUnit: context.store.defaultUnit,
             fileName: context.fileName,
@@ -9013,7 +9168,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Boolean Subtract') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
             wasmInstance: context.wasmInstance,
           }
@@ -9034,7 +9189,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Boolean Union') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
             wasmInstance: context.wasmInstance,
           }
@@ -9055,7 +9210,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Boolean Intersect') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
             wasmInstance: context.wasmInstance,
           }
@@ -9076,7 +9231,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Boolean Split') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
             wasmInstance: context.wasmInstance,
           }
@@ -9097,7 +9252,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Pattern Circular 3D') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -9117,7 +9272,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Pattern Linear 3D') return undefined
           return {
             data: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
           }
         },
@@ -9154,7 +9309,7 @@ export const modelingMachine = setup({
           if (event.type !== 'Select sketch solve plane') return undefined
           return {
             artifactOrPlaneId: event.data,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             rustContext: context.rustContext,
             engineCommandManager: context.engineCommandManager,
             wasmInstance: context.wasmInstance,
@@ -9172,7 +9327,7 @@ export const modelingMachine = setup({
           if (event.type === 'Edit sketch solve') {
             return {
               artifactId: event.data.artifactId,
-              kclManager: context.kclManager,
+              executingEditor: context.executingEditor,
               rustContext: context.rustContext,
               engineCommandManager: context.engineCommandManager,
               defaultUnit: context.store.defaultUnit,
@@ -9181,13 +9336,13 @@ export const modelingMachine = setup({
           }
           if (event.type === 'Enter sketch') {
             const sketchBlockArtifact = getSelectedSketchBlockArtifact({
-              artifactGraph: context.kclManager.artifactGraph,
+              artifactGraph: context.executingEditor.artifactGraph,
               selectionRanges: context.selectionRanges,
             })
             if (sketchBlockArtifact?.id) {
               return {
                 artifactId: sketchBlockArtifact.id,
-                kclManager: context.kclManager,
+                executingEditor: context.executingEditor,
                 rustContext: context.rustContext,
                 engineCommandManager: context.engineCommandManager,
                 defaultUnit: context.store.defaultUnit,
@@ -9226,7 +9381,7 @@ export const modelingMachine = setup({
         'reset sketch metadata',
         'enable copilot',
         ({ context }) => {
-          context.kclManager.sceneInfra.stop()
+          context.executingEditor.sceneInfra.stop()
         },
       ],
     },
@@ -9310,18 +9465,18 @@ function listenForOriginMove(
 
 export function isEditingExistingSketch({
   sketchDetails,
-  kclManager,
+  executingEditor,
   wasmInstance,
 }: {
   sketchDetails: SketchDetails | null
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   wasmInstance: ModuleType
 }): boolean {
   // should check that the variable declaration is a pipeExpression
   // and that the pipeExpression contains a "startProfile" callExpression
   if (!sketchDetails?.sketchEntryNodePath) return false
   const variableDeclaration = getNodeFromPath<VariableDeclarator>(
-    kclManager.ast,
+    executingEditor.ast,
     sketchDetails.sketchEntryNodePath,
     wasmInstance,
     'VariableDeclarator',
@@ -9360,16 +9515,16 @@ export function isEditingExistingSketch({
 
 export function pipeHasCircle({
   sketchDetails,
-  kclManager,
+  executingEditor,
   wasmInstance,
 }: {
   sketchDetails: SketchDetails | null
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   wasmInstance: ModuleType
 }): boolean {
   if (!sketchDetails?.sketchEntryNodePath) return false
   const variableDeclaration = getNodeFromPath<VariableDeclarator>(
-    kclManager.ast,
+    executingEditor.ast,
     sketchDetails.sketchEntryNodePath,
     wasmInstance,
     'VariableDeclarator'

--- a/src/machines/modelingSharedContext.ts
+++ b/src/machines/modelingSharedContext.ts
@@ -1,5 +1,5 @@
 import type { SceneGraphDelta } from '@rust/kcl-lib/bindings/FrontendApi'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { emptyOperationsByModule } from '@src/lang/wasm'
 import type { MachineManager } from '@src/lib/MachineManager'
 import type RustContext from '@src/lib/rustContext'
@@ -76,7 +76,7 @@ export const modelingMachineInitialInternalContext: ModelingMachineInternalConte
   }
 
 export function generateModelingMachineDefaultContext(systemDeps: {
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   rustContext: RustContext
   wasmInstance: ModuleType
   engineCommandManager: ConnectionManager

--- a/src/machines/modelingSharedTypes.ts
+++ b/src/machines/modelingSharedTypes.ts
@@ -1,7 +1,7 @@
 import type { EntityType, Point2d } from '@kittycad/lib'
 import type { CameraProjectionType } from '@rust/kcl-lib/bindings/CameraProjectionType'
 import type { SceneGraphDelta } from '@rust/kcl-lib/bindings/FrontendApi'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import type { Artifact, ArtifactId, CodeRef } from '@src/lang/std/artifactGraph'
 import type { Coords2d } from '@src/lang/util'
 import type { PathToNode } from '@src/lang/wasm'
@@ -229,7 +229,7 @@ export type MoveDesc = { line: number; snippet: string }
 
 /** Input into the Modeling machine consists of its external dependencies */
 export type ModelingMachineInput = {
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   engineCommandManager: ConnectionManager
   rustContext: RustContext
   machineManager: MachineManager

--- a/src/machines/sketchSolve/sketchSolveDiagram.ts
+++ b/src/machines/sketchSolve/sketchSolveDiagram.ts
@@ -4,7 +4,7 @@ import type {
   SegmentCtor,
 } from '@rust/kcl-lib/bindings/FrontendApi'
 import { toggleSketchExtension } from '@src/editor/plugins/sketch'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import {
   baseUnitToNumericSuffix,
   distanceBetweenPoint2DExpr,
@@ -71,7 +71,7 @@ const DEFAULT_DISTANCE_FALLBACK = 5
 const constraintToolNameSet = new Set<string>(constraintToolNames)
 
 type SketchSolveInput = {
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   initialSketchSolvePlane?: DefaultPlane | OffsetPlane | ExtrudeFacePlane | null
   sketchId: number
   initialSceneGraphDelta: SceneGraphDelta
@@ -307,7 +307,7 @@ async function addAxisDistanceConstraint(
       ? providedDistance
       : DEFAULT_DISTANCE_FALLBACK
   const units = baseUnitToNumericSuffix(
-    context.kclManager.fileSettings.defaultLengthUnit
+    context.executingEditor.fileSettings.defaultLengthUnit
   )
   // Calculate distance between two points if both are point segments
   if (currentSelections.length === 2 && providedDistance === undefined) {
@@ -343,7 +343,7 @@ async function addAxisDistanceConstraint(
         is_literal: true,
       },
     },
-    jsAppSettings(context.kclManager.systemDeps.settings),
+    jsAppSettings(context.executingEditor.systemDeps.settings),
     true
   )
   sendToolbarConstraintOutcome(self, result, keepSelection)
@@ -362,7 +362,7 @@ function getPreparedApplyForConstraintTool(
     objects,
     {
       defaultLengthUnit: baseUnitToNumericSuffix(
-        context.kclManager.fileSettings.defaultLengthUnit ?? 'mm'
+        context.executingEditor.fileSettings.defaultLengthUnit ?? 'mm'
       ),
     }
   )
@@ -429,11 +429,11 @@ export const sketchSolveMachine = setup({
           objects:
             context.sketchExecOutcome?.sceneGraphDelta.new_graph.objects || [],
           defaultLengthUnit: baseUnitToNumericSuffix(
-            context.kclManager.fileSettings.defaultLengthUnit ?? 'mm'
+            context.executingEditor.fileSettings.defaultLengthUnit ?? 'mm'
           ),
           rustContext: context.rustContext,
           sketchId: context.sketchId,
-          settings: jsAppSettings(context.kclManager.systemDeps.settings),
+          settings: jsAppSettings(context.executingEditor.systemDeps.settings),
           equipConstraintTool: (nextToolName) => {
             sendToActorIfActive(self, {
               type: 'equip tool',
@@ -513,15 +513,15 @@ export const sketchSolveMachine = setup({
       initialPlane: input?.initialSketchSolvePlane ?? undefined,
       sketchExecOutcome: {
         sourceDelta: {
-          text: input.kclManager.code,
+          text: input.executingEditor.code,
         },
         sceneGraphDelta: input.initialSceneGraphDelta,
       },
       sketchId: input?.sketchId || 0,
-      sceneInfra: input.kclManager.sceneInfra,
-      sceneEntitiesManager: input.kclManager.sceneEntitiesManager,
-      rustContext: input.kclManager.rustContext,
-      kclManager: input.kclManager,
+      sceneInfra: input.executingEditor.sceneInfra,
+      sceneEntitiesManager: input.executingEditor.sceneEntitiesManager,
+      rustContext: input.executingEditor.rustContext,
+      executingEditor: input.executingEditor,
       showNonVisualConstraints: false,
     }
   },
@@ -588,7 +588,7 @@ export const sketchSolveMachine = setup({
               .filter(Boolean)
             let distance = DEFAULT_DISTANCE_FALLBACK
             const units = baseUnitToNumericSuffix(
-              context.kclManager.fileSettings.defaultLengthUnit
+              context.executingEditor.fileSettings.defaultLengthUnit
             )
 
             if (currentSelections.length === 2) {
@@ -617,7 +617,7 @@ export const sketchSolveMachine = setup({
                     0,
                     context.sketchId,
                     angleConstraint,
-                    jsAppSettings(context.kclManager.systemDeps.settings),
+                    jsAppSettings(context.executingEditor.systemDeps.settings),
                     true
                   )
                   sendToolbarConstraintOutcome(self, result, keepSelection)
@@ -640,7 +640,7 @@ export const sketchSolveMachine = setup({
                 const distanceResult = distanceBetweenPoint2DExpr(
                   point1,
                   point2,
-                  await context.kclManager.wasmInstancePromise
+                  await context.executingEditor.wasmInstancePromise
                 )
                 if (!(distanceResult instanceof Error)) {
                   distance = roundOff(distanceResult.distance)
@@ -679,7 +679,7 @@ export const sketchSolveMachine = setup({
                   const distanceResult = distanceBetweenPoint2DExpr(
                     point1,
                     point2,
-                    await context.kclManager.wasmInstancePromise
+                    await context.executingEditor.wasmInstancePromise
                   )
                   if (!(distanceResult instanceof Error)) {
                     distance = roundOff(distanceResult.distance)
@@ -697,7 +697,7 @@ export const sketchSolveMachine = setup({
                   0,
                   context.sketchId,
                   constraint,
-                  jsAppSettings(context.kclManager.systemDeps.settings),
+                  jsAppSettings(context.executingEditor.systemDeps.settings),
                   true
                 )
                 sendToolbarConstraintOutcome(self, result, keepSelection)
@@ -724,7 +724,7 @@ export const sketchSolveMachine = setup({
                   const distanceResult = distanceBetweenPoint2DExpr(
                     point1,
                     point2,
-                    await context.kclManager.wasmInstancePromise
+                    await context.executingEditor.wasmInstancePromise
                   )
                   if (!(distanceResult instanceof Error)) {
                     distance = roundOff(distanceResult.distance)
@@ -760,7 +760,7 @@ export const sketchSolveMachine = setup({
                   is_literal: true,
                 },
               },
-              jsAppSettings(context.kclManager.systemDeps.settings),
+              jsAppSettings(context.executingEditor.systemDeps.settings),
               true
             )
             sendToolbarConstraintOutcome(self, result, keepSelection)
@@ -897,7 +897,7 @@ export const sketchSolveMachine = setup({
                 0,
                 context.sketchId,
                 segmentsToEdit,
-                jsAppSettings(context.kclManager.systemDeps.settings),
+                jsAppSettings(context.executingEditor.systemDeps.settings),
                 true,
                 []
               )
@@ -971,7 +971,7 @@ export const sketchSolveMachine = setup({
               context.sketchId,
               constraintIds,
               segmentIds,
-              jsAppSettings(context.kclManager.systemDeps.settings),
+              jsAppSettings(context.executingEditor.systemDeps.settings),
               true
             )
             .catch((err) => {
@@ -1140,7 +1140,9 @@ export const sketchSolveMachine = setup({
             ({ event, context, self }) => {
               // Update code editor if new source was returned
               if (event.output?.kclSource) {
-                context.kclManager.updateCodeEditor(event.output.kclSource.text)
+                context.executingEditor.updateCodeEditor(
+                  event.output.kclSource.text
+                )
               }
 
               // Scene cleanup will run on entry of final exiting state
@@ -1191,16 +1193,20 @@ export const sketchSolveMachine = setup({
     'initialize initial scene graph',
     'setUpOnDragAndSelectionClickCallbacks',
     ({ context, self }) =>
-      toggleSketchExtension(context.kclManager.editorView, true, (ranges) => {
-        sendToActorIfActive(self, {
-          type: 'update selected ids from code selection',
-          data: { ranges },
-        })
-      }),
+      toggleSketchExtension(
+        context.executingEditor.editorView,
+        true,
+        (ranges) => {
+          sendToActorIfActive(self, {
+            type: 'update selected ids from code selection',
+            data: { ranges },
+          })
+        }
+      ),
   ],
 
   exit: [
     ({ context }) =>
-      toggleSketchExtension(context.kclManager.editorView, false),
+      toggleSketchExtension(context.executingEditor.editorView, false),
   ],
 })

--- a/src/machines/sketchSolve/sketchSolveImpl.spec.ts
+++ b/src/machines/sketchSolve/sketchSolveImpl.spec.ts
@@ -153,7 +153,7 @@ describe('updateSelectedCodeHighlight', () => {
         sketchExecOutcome: {
           sceneGraphDelta: createSceneGraphDelta([firstLine, secondLine]),
         },
-        kclManager: {
+        executingEditor: {
           code: 'x'.repeat(200),
           editorView: { dispatch },
         },
@@ -196,7 +196,7 @@ describe('updateSelectedCodeHighlight', () => {
         sketchExecOutcome: {
           sceneGraphDelta: createSceneGraphDelta([point, ownerLine]),
         },
-        kclManager: {
+        executingEditor: {
           code: 'x'.repeat(200),
           editorView: { dispatch },
         },
@@ -250,7 +250,7 @@ describe('updateHoveredId', () => {
         sketchExecOutcome: {
           sceneGraphDelta: createSceneGraphDelta([line]),
         },
-        kclManager: {
+        executingEditor: {
           setHighlightRange,
         },
       },
@@ -280,7 +280,7 @@ describe('updateHoveredId', () => {
         sketchExecOutcome: {
           sceneGraphDelta: createSceneGraphDelta([line]),
         },
-        kclManager: {
+        executingEditor: {
           setHighlightRange,
         },
       },
@@ -312,7 +312,7 @@ describe('updateHoveredId', () => {
         sketchExecOutcome: {
           sceneGraphDelta: createSceneGraphDelta([point, ownerLine]),
         },
-        kclManager: {
+        executingEditor: {
           setHighlightRange,
         },
       },
@@ -333,7 +333,7 @@ describe('updateHoveredId', () => {
         sketchExecOutcome: {
           sceneGraphDelta: createSceneGraphDelta([]),
         },
-        kclManager: {
+        executingEditor: {
           setHighlightRange,
         },
       },
@@ -349,7 +349,7 @@ describe('updateHoveredId', () => {
 })
 
 describe('updateSketchOutcome', () => {
-  test('syncs sketch solve operations into KclManager after an immediate editor update', () => {
+  test('syncs sketch solve operations into ExecutingEditor after an immediate editor update', () => {
     const setSketchSolveDiagnostics = vi.fn()
     const dispatch = vi.fn()
     const updateCodeEditor = vi.fn()
@@ -358,7 +358,7 @@ describe('updateSketchOutcome', () => {
 
     updateSketchOutcome({
       context: {
-        kclManager: {
+        executingEditor: {
           code: 'old code',
           dispatch,
           setSketchSolveDiagnostics,
@@ -404,7 +404,7 @@ describe('updateSketchOutcome', () => {
 
     updateSketchOutcome({
       context: {
-        kclManager: {
+        executingEditor: {
           code: 'newer editor code',
           dispatch,
           setSketchSolveDiagnostics,
@@ -445,7 +445,7 @@ describe('updateSketchOutcome', () => {
 
       updateSketchOutcome({
         context: {
-          kclManager: {
+          executingEditor: {
             code: 'old code',
             dispatch,
             setSketchSolveDiagnostics,
@@ -489,7 +489,7 @@ describe('updateSketchOutcome', () => {
 
     updateSketchOutcome({
       context: {
-        kclManager: {
+        executingEditor: {
           code: 'last good preview',
           dispatch,
           setSketchSolveDiagnostics,
@@ -546,7 +546,7 @@ describe('updateSketchOutcome', () => {
 
       const result = updateSketchOutcome({
         context: {
-          kclManager: {
+          executingEditor: {
             code: 'old code',
             dispatch,
             setSketchSolveDiagnostics,

--- a/src/machines/sketchSolve/sketchSolveImpl.ts
+++ b/src/machines/sketchSolve/sketchSolveImpl.ts
@@ -8,7 +8,7 @@ import type {
 import type { SourceRange } from '@rust/kcl-lib/bindings/SourceRange'
 import type { SceneEntities } from '@src/clientSideScene/sceneEntities'
 import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import type RustContext from '@src/lib/rustContext'
 import type { Themes } from '@src/lib/theme'
 import type {
@@ -246,7 +246,7 @@ export type SketchSolveContext = {
   sceneInfra: SceneInfra
   sceneEntitiesManager: SceneEntities
   rustContext: RustContext
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
 }
 
 export type SolveActionArgs = ActionArgs<
@@ -861,17 +861,17 @@ export function updateSelectedCodeHighlight({ context }: SolveActionArgs) {
     range[1]
       ? [
           EditorSelection.cursor(
-            Math.min(range[1], context.kclManager.code.length)
+            Math.min(range[1], context.executingEditor.code.length)
           ),
         ]
       : []
   )
 
-  context.kclManager.editorView.dispatch({
+  context.executingEditor.editorView.dispatch({
     selection: EditorSelection.create(
       codeMirrorSelections.length
         ? codeMirrorSelections
-        : [EditorSelection.cursor(context.kclManager.code.length)],
+        : [EditorSelection.cursor(context.executingEditor.code.length)],
       Math.max(codeMirrorSelections.length - 1, 0)
     ),
     annotations: selectionDispatchedBySketchSolveEvent,
@@ -986,7 +986,7 @@ export function updateHoveredId({
     }
   }
 
-  context.kclManager.setHighlightRange(highlightRanges)
+  context.executingEditor.setHighlightRange(highlightRanges)
 
   return {
     hoveredId,
@@ -995,7 +995,7 @@ export function updateHoveredId({
 }
 
 export function clearHoveredCodeHighlight({ context }: SolveActionArgs) {
-  context.kclManager.setHighlightRange([])
+  context.executingEditor.setHighlightRange([])
 }
 
 function getSourceRangesForObjectId(
@@ -1071,7 +1071,7 @@ export function initializeInitialSceneGraph({
     // Set sketchExecOutcome in context so drag callbacks can access it
     // Use current code from editorManager since editSketch doesn't return kclSource
     const kclSource: SourceDelta = {
-      text: context.kclManager.code,
+      text: context.executingEditor.code,
     }
 
     return {
@@ -1254,24 +1254,24 @@ function getSketchSolveScaleFactor(context: SketchSolveContext): number {
 // Debounced editor update function - persists across calls
 // This allows us to cancel editor updates if a double-click is detected
 // The debounce delay is short (100ms) to minimize perceived lag while still allowing cancellation
-// We store the latest kclManager reference so the debounced function can access it
+// We store the latest executingEditor reference so the debounced function can access it
 const debouncedEditorUpdate = deferredCallback(
   ({
     text,
-    kclManager,
+    executingEditor,
     sceneGraphDelta,
     shouldWriteToDisk,
     shouldAddToHistory,
     spec,
   }: {
     text: string
-    kclManager: KclManager
+    executingEditor: ExecutingEditor
     sceneGraphDelta: SceneGraphDelta
     shouldWriteToDisk: boolean
     shouldAddToHistory: boolean
     spec: { effects: StateEffect<unknown>[] }
   }) => {
-    kclManager.updateCodeEditor(
+    executingEditor.updateCodeEditor(
       text,
       {
         shouldWriteToDisk,
@@ -1280,7 +1280,7 @@ const debouncedEditorUpdate = deferredCallback(
       },
       spec
     )
-    kclManager.syncSketchSolveOutcome(text, sceneGraphDelta)
+    executingEditor.syncSketchSolveOutcome(text, sceneGraphDelta)
   },
   200
 )
@@ -1303,7 +1303,7 @@ export function updateSketchOutcome({ event, context }: SolveAssignArgs) {
     getSketchSolveExecOutcomeIssues(sceneGraphDelta),
     event.data.sourceDelta.text
   )
-  context.kclManager.setSketchSolveDiagnostics(sketchSolveDiagnostics)
+  context.executingEditor.setSketchSolveDiagnostics(sketchSolveDiagnostics)
   if (!event.data.suppressExecOutcomeIssues) {
     toastSketchSolveExecOutcomeErrors(
       sceneGraphDelta,
@@ -1339,14 +1339,14 @@ export function updateSketchOutcome({ event, context }: SolveAssignArgs) {
   const isCheckpointOnlyCommit =
     shouldAddToHistory &&
     event.data.checkpointId != null &&
-    context.kclManager.code === event.data.sourceDelta.text
+    context.executingEditor.code === event.data.sourceDelta.text
   const shouldDispatchSceneImmediately =
     !shouldUpdateEditor ||
-    context.kclManager.code !== event.data.sourceDelta.text ||
+    context.executingEditor.code !== event.data.sourceDelta.text ||
     isCheckpointOnlyCommit
 
   if (shouldDispatchSceneImmediately) {
-    context.kclManager.dispatch({
+    context.executingEditor.dispatch({
       annotations: Transaction.addToHistory.of(false),
       effects: additionalSpec.effects,
     })
@@ -1365,13 +1365,13 @@ export function updateSketchOutcome({ event, context }: SolveAssignArgs) {
   if (!shouldUpdateEditor) {
     /*
      * This is the direct CodeMirror edit path. The editor is already the source
-     * of truth, and KclManager has already checked that this async execution is
+     * of truth, and ExecutingEditor has already checked that this async execution is
      * still fresh before sending the event. Keep the derived scene/diagnostic
      * state in sync, but do not write source text back through CodeMirror or
      * disk. A source write here turns an old execution snapshot into an editor
      * command, which is the exact stale overwrite bug this path prevents.
      */
-    context.kclManager.syncSketchSolveOutcome(
+    context.executingEditor.syncSketchSolveOutcome(
       event.data.sourceDelta.text,
       sceneGraphDelta
     )
@@ -1395,7 +1395,7 @@ export function updateSketchOutcome({ event, context }: SolveAssignArgs) {
     // If a new update comes in within 200ms, the previous one is cancelled
     debouncedEditorUpdate({
       text: event.data.sourceDelta.text,
-      kclManager: context.kclManager,
+      executingEditor: context.executingEditor,
       sceneGraphDelta,
       shouldWriteToDisk,
       shouldAddToHistory,
@@ -1403,7 +1403,7 @@ export function updateSketchOutcome({ event, context }: SolveAssignArgs) {
     })
   } else {
     // Update editor immediately - no debounce for frequent updates like onMove
-    context.kclManager.updateCodeEditor(
+    context.executingEditor.updateCodeEditor(
       event.data.sourceDelta.text,
       {
         shouldExecute: false,
@@ -1412,7 +1412,7 @@ export function updateSketchOutcome({ event, context }: SolveAssignArgs) {
       },
       editorAdditionalSpec
     )
-    context.kclManager.syncSketchSolveOutcome(
+    context.executingEditor.syncSketchSolveOutcome(
       event.data.sourceDelta.text,
       sceneGraphDelta
     )
@@ -1554,7 +1554,7 @@ export function spawnTool(
     input: {
       sceneInfra: context.sceneInfra,
       rustContext: context.rustContext,
-      kclManager: context.kclManager,
+      executingEditor: context.executingEditor,
       sketchId: context.sketchId,
       initialSelectionIds: context.selectedIds,
       initialObjects:
@@ -1594,7 +1594,7 @@ export const tearDownSketchSolve = fromPromise(
 export type ToolInput = {
   sceneInfra: SceneInfra
   rustContext: RustContext
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   sketchId: number
   initialSelectionIds?: SketchSolveSelectionId[]
   initialObjects?: ApiObject[]

--- a/src/machines/sketchSolve/tools/centerArcToolDiagram.spec.ts
+++ b/src/machines/sketchSolve/tools/centerArcToolDiagram.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '@src/machines/sketchSolve/tools/centerArcToolDiagram'
 import {
   createArcApiObject,
-  createMockKclManager,
+  createMockExecutingEditor,
   createMockRustContext,
   createMockSceneInfra,
   createPointApiObject,
@@ -36,7 +36,7 @@ function createTestMachine(mockActors?: {
 }) {
   const sceneInfra = createMockSceneInfra()
   const rustContext = createMockRustContext()
-  const kclManager = createMockKclManager()
+  const executingEditor = createMockExecutingEditor()
 
   // Create a machine with mocked actors
   const testMachine = machine.provide({
@@ -62,20 +62,20 @@ function createTestMachine(mockActors?: {
     machine: testMachine,
     sceneInfra,
     rustContext,
-    kclManager,
+    executingEditor,
   }
 }
 
 describe('centerArcTool - XState', () => {
   describe('when initialized', () => {
     it('should have default context values', () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -91,13 +91,13 @@ describe('centerArcTool - XState', () => {
     })
 
     it('should call setCallbacks on entry to ready for center click', () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -109,13 +109,13 @@ describe('centerArcTool - XState', () => {
 
   describe('escape key handling', () => {
     it('should transition to unequipping when escape is pressed in ready for center click', async () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -129,13 +129,13 @@ describe('centerArcTool - XState', () => {
 
   describe('unequip handling', () => {
     it('should transition to unequipping when unequip event is sent', async () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -149,13 +149,13 @@ describe('centerArcTool - XState', () => {
 
   describe('three-click workflow', () => {
     it('should store center point on first click and transition to Showing radius preview', () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -169,13 +169,13 @@ describe('centerArcTool - XState', () => {
     })
 
     it('should transition to Creating arc on second click', async () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -197,7 +197,7 @@ describe('centerArcTool - XState', () => {
       const endPoint = createPointApiObject({ id: 3, x: 30, y: 40 })
       const arcObj = createArcApiObject({ id: 4, center: 1, start: 2, end: 3 })
 
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine({
           createArc: async () => ({
             kclSource: { text: 'test' },
@@ -212,7 +212,7 @@ describe('centerArcTool - XState', () => {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -239,7 +239,7 @@ describe('centerArcTool - XState', () => {
       const endPoint = createPointApiObject({ id: 3, x: 30, y: 40 })
       const arcObj = createArcApiObject({ id: 4, center: 1, start: 2, end: 3 })
 
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine({
           createArc: async () => ({
             kclSource: { text: 'test' },
@@ -254,7 +254,7 @@ describe('centerArcTool - XState', () => {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -280,7 +280,7 @@ describe('centerArcTool - XState', () => {
       const endPoint = createPointApiObject({ id: 3, x: 30, y: 40 })
       const arcObj = createArcApiObject({ id: 4, center: 1, start: 2, end: 3 })
 
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine({
           createArc: async () => ({
             kclSource: { text: 'test' },
@@ -302,7 +302,7 @@ describe('centerArcTool - XState', () => {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -327,13 +327,13 @@ describe('centerArcTool - XState', () => {
 
   describe('escape during workflow', () => {
     it('should transition to unequipping when escape is pressed in Showing radius preview', async () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -355,7 +355,7 @@ describe('centerArcTool - XState', () => {
       const endPoint = createPointApiObject({ id: 3, x: 30, y: 40 })
       const arcObj = createArcApiObject({ id: 4, center: 1, start: 2, end: 3 })
 
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine({
           createArc: async () => ({
             kclSource: { text: 'test' },
@@ -370,7 +370,7 @@ describe('centerArcTool - XState', () => {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()

--- a/src/machines/sketchSolve/tools/centerArcToolDiagram.ts
+++ b/src/machines/sketchSolve/tools/centerArcToolDiagram.ts
@@ -72,7 +72,7 @@ export const machine = setup({
     sceneGraphDelta: {} as SceneGraphDelta,
     sceneInfra: input.sceneInfra,
     rustContext: input.rustContext,
-    kclManager: input.kclManager,
+    executingEditor: input.executingEditor,
     sketchId: input.sketchId || 0,
   }),
   id: toolId,
@@ -152,7 +152,7 @@ export const machine = setup({
             startPoint: event.data,
             centerSnapTarget: context.centerSnapTarget,
             rustContext: context.rustContext,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             sketchId: context.sketchId,
           }
         },
@@ -236,7 +236,7 @@ export const machine = setup({
             startSnapTarget: context.startSnapTarget,
             endSnapTarget: event.snapTarget,
             rustContext: context.rustContext,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             sketchId: context.sketchId,
             arcIsSwapped: context.arcIsSwapped,
           }

--- a/src/machines/sketchSolve/tools/centerArcToolImpl.spec.ts
+++ b/src/machines/sketchSolve/tools/centerArcToolImpl.spec.ts
@@ -13,7 +13,7 @@ import {
   storeCreatedArcResult,
 } from '@src/machines/sketchSolve/tools/centerArcToolImpl'
 import {
-  createMockKclManager,
+  createMockExecutingEditor,
   createMockRustContext,
 } from '@src/machines/sketchSolve/tools/sketchToolTestUtils'
 import { describe, expect, it, vi } from 'vitest'
@@ -495,7 +495,7 @@ describe('centerArcToolImpl', () => {
   describe('snap constraints', () => {
     it('creates a coincident constraint for the snapped center point only during draft creation', async () => {
       const rustContext = createMockRustContext()
-      const kclManager = createMockKclManager()
+      const executingEditor = createMockExecutingEditor()
       const addConstraintSpy = vi.spyOn(rustContext, 'addConstraint')
       const centerPoint = createPointApiObject({ id: 1, x: 0, y: 0 })
       const startPoint = createPointApiObject({ id: 2, x: 10, y: 0 })
@@ -524,7 +524,7 @@ describe('centerArcToolImpl', () => {
           startPoint: [10, 0],
           centerSnapTarget: { type: 'origin' },
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 7,
         },
       })
@@ -555,7 +555,7 @@ describe('centerArcToolImpl', () => {
       'anchors the center and radius-defining endpoint when finalizing a %s arc without snaps',
       async (_name, arcIsSwapped, expectedAnchorIds) => {
         const rustContext = createMockRustContext()
-        const kclManager = createMockKclManager()
+        const executingEditor = createMockExecutingEditor()
         const editSegmentsSpy = vi.spyOn(rustContext, 'editSegments')
         const currentArc = createArcApiObject({
           id: 4,
@@ -595,7 +595,7 @@ describe('centerArcToolImpl', () => {
             endPoint: [0, 10],
             sceneGraphDelta: inputSceneGraphDelta,
             rustContext,
-            kclManager,
+            executingEditor,
             sketchId: 7,
             arcIsSwapped,
           },
@@ -620,7 +620,7 @@ describe('centerArcToolImpl', () => {
 
     it('adds coincident constraints to the fixed and clicked endpoints when finalizing a swapped arc', async () => {
       const rustContext = createMockRustContext()
-      const kclManager = createMockKclManager()
+      const executingEditor = createMockExecutingEditor()
       const addConstraintSpy = vi.spyOn(rustContext, 'addConstraint')
       const currentArc = createArcApiObject({
         id: 4,
@@ -678,7 +678,7 @@ describe('centerArcToolImpl', () => {
           startSnapTarget: { type: 'point', id: 77 },
           endSnapTarget: { type: 'point', id: 99 },
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 7,
           arcIsSwapped: true,
         },
@@ -717,7 +717,7 @@ describe('centerArcToolImpl', () => {
 
     it('adds the deferred second-click snap to the start endpoint when the arc stays unswapped', async () => {
       const rustContext = createMockRustContext()
-      const kclManager = createMockKclManager()
+      const executingEditor = createMockExecutingEditor()
       const addConstraintSpy = vi.spyOn(rustContext, 'addConstraint')
       const currentArc = createArcApiObject({
         id: 4,
@@ -761,7 +761,7 @@ describe('centerArcToolImpl', () => {
           sceneGraphDelta: inputSceneGraphDelta,
           startSnapTarget: { type: 'point', id: 77 },
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 7,
           arcIsSwapped: false,
         },

--- a/src/machines/sketchSolve/tools/centerArcToolImpl.ts
+++ b/src/machines/sketchSolve/tools/centerArcToolImpl.ts
@@ -5,7 +5,7 @@ import type {
   SourceDelta,
 } from '@rust/kcl-lib/bindings/FrontendApi'
 import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import type { Coords2d } from '@src/lang/util'
 import { baseUnitToNumericSuffix } from '@src/lang/wasm'
 import type RustContext from '@src/lib/rustContext'
@@ -75,7 +75,7 @@ export type ToolContext = {
   sceneGraphDelta: SceneGraphDelta
   sceneInfra: SceneInfra
   rustContext: RustContext
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   sketchId: number
 }
 
@@ -268,7 +268,7 @@ export function animateArcEndPointListener({ self, context }: ToolActionArgs) {
         })
 
         const units = baseUnitToNumericSuffix(
-          context.kclManager.fileSettings.defaultLengthUnit
+          context.executingEditor.fileSettings.defaultLengthUnit
         )
         try {
           isEditInProgress = true
@@ -658,7 +658,7 @@ export async function createArcActor({
         startPoint: [number, number]
         centerSnapTarget?: SnapTarget
         rustContext: RustContext
-        kclManager: KclManager
+        executingEditor: ExecutingEditor
         sketchId: number
       }
     | {
@@ -682,11 +682,11 @@ export async function createArcActor({
     startPoint,
     centerSnapTarget,
     rustContext,
-    kclManager,
+    executingEditor,
     sketchId,
   } = input
   const units = baseUnitToNumericSuffix(
-    kclManager.fileSettings.defaultLengthUnit
+    executingEditor.fileSettings.defaultLengthUnit
   )
 
   try {
@@ -800,7 +800,7 @@ export async function finalizeArcActor({
         startSnapTarget?: SnapTarget
         endSnapTarget?: SnapTarget
         rustContext: RustContext
-        kclManager: KclManager
+        executingEditor: ExecutingEditor
         sketchId: number
         arcIsSwapped?: boolean
       }
@@ -828,12 +828,12 @@ export async function finalizeArcActor({
     startSnapTarget,
     endSnapTarget,
     rustContext,
-    kclManager,
+    executingEditor,
     sketchId,
     arcIsSwapped: contextIsSwapped,
   } = input
   const units = baseUnitToNumericSuffix(
-    kclManager.fileSettings.defaultLengthUnit
+    executingEditor.fileSettings.defaultLengthUnit
   )
 
   try {

--- a/src/machines/sketchSolve/tools/circleToolDiagram.spec.ts
+++ b/src/machines/sketchSolve/tools/circleToolDiagram.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '@src/machines/sketchSolve/tools/circleToolDiagram'
 import {
   createCircleApiObject,
-  createMockKclManager,
+  createMockExecutingEditor,
   createMockRustContext,
   createMockSceneInfra,
   createPointApiObject,
@@ -27,7 +27,7 @@ function createTestMachine(mockActors?: {
 }) {
   const sceneInfra = createMockSceneInfra()
   const rustContext = createMockRustContext()
-  const kclManager = createMockKclManager()
+  const executingEditor = createMockExecutingEditor()
 
   const testMachine = machine.provide({
     actors: {
@@ -45,20 +45,20 @@ function createTestMachine(mockActors?: {
     machine: testMachine,
     sceneInfra,
     rustContext,
-    kclManager,
+    executingEditor,
   }
 }
 
 describe('circleTool - XState', () => {
   describe('when initialized', () => {
     it('should have default context values', () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -72,13 +72,13 @@ describe('circleTool - XState', () => {
     })
 
     it('should call setCallbacks on entry to ready for center click', async () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -91,13 +91,13 @@ describe('circleTool - XState', () => {
 
   describe('escape key handling', () => {
     it('should transition to unequipping when escape is pressed in ready for center click', async () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -111,13 +111,13 @@ describe('circleTool - XState', () => {
 
   describe('unequip handling', () => {
     it('should transition to unequipping when unequip event is sent', async () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -131,13 +131,13 @@ describe('circleTool - XState', () => {
 
   describe('two-click workflow', () => {
     it('should store center point on first click and transition to Showing radius preview', () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -151,13 +151,13 @@ describe('circleTool - XState', () => {
     })
 
     it('should transition to Creating circle on second click', async () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -176,7 +176,7 @@ describe('circleTool - XState', () => {
       const startPoint = createPointApiObject({ id: 2, x: 30, y: 40 })
       const circleObj = createCircleApiObject({ id: 3, center: 1, start: 2 })
 
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine({
           createCircle: async () => ({
             kclSource: { text: 'test' },
@@ -191,7 +191,7 @@ describe('circleTool - XState', () => {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -213,13 +213,13 @@ describe('circleTool - XState', () => {
 
   describe('escape during workflow', () => {
     it('should transition to unequipping when escape is pressed in Showing radius preview', async () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()

--- a/src/machines/sketchSolve/tools/circleToolDiagram.ts
+++ b/src/machines/sketchSolve/tools/circleToolDiagram.ts
@@ -54,7 +54,7 @@ export const machine = setup({
     sceneGraphDelta: {} as SceneGraphDelta,
     sceneInfra: input.sceneInfra,
     rustContext: input.rustContext,
-    kclManager: input.kclManager,
+    executingEditor: input.executingEditor,
     sketchId: input.sketchId || 0,
   }),
   id: toolId,
@@ -126,7 +126,7 @@ export const machine = setup({
             centerSnapTarget: context.centerSnapTarget,
             startSnapTarget: event.snapTarget,
             rustContext: context.rustContext,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             sketchId: context.sketchId,
           }
         },

--- a/src/machines/sketchSolve/tools/circleToolImpl.spec.ts
+++ b/src/machines/sketchSolve/tools/circleToolImpl.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '@src/machines/sketchSolve/tools/circleToolImpl'
 import {
   createCircleApiObject,
-  createMockKclManager,
+  createMockExecutingEditor,
   createMockRustContext,
   createPointApiObject,
   createSceneGraphDelta,
@@ -30,7 +30,7 @@ describe('circleToolImpl', () => {
     it('creates a circle segment using the circle label', async () => {
       const rustContext = createMockRustContext()
       const spiedFn = vi.spyOn(rustContext, 'addSegment')
-      const kclManager = createMockKclManager()
+      const executingEditor = createMockExecutingEditor()
       const sceneGraphDelta = createSceneGraphDelta([], [])
       ;(rustContext.addSegment as any).mockResolvedValue({
         kclSource: { text: 'circle' },
@@ -42,7 +42,7 @@ describe('circleToolImpl', () => {
           centerPoint: [10, 20],
           startPoint: [30, 40],
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 7,
         },
       })
@@ -73,7 +73,7 @@ describe('circleToolImpl', () => {
 
     it('adds coincident constraints for snapped center and radius points', async () => {
       const rustContext = createMockRustContext()
-      const kclManager = createMockKclManager()
+      const executingEditor = createMockExecutingEditor()
       const addConstraintSpy = vi.spyOn(rustContext, 'addConstraint')
       const centerPoint = createPointApiObject({ id: 1, x: 10, y: 20 })
       const startPoint = createPointApiObject({ id: 2, x: 30, y: 40 })
@@ -105,7 +105,7 @@ describe('circleToolImpl', () => {
           centerSnapTarget: { type: 'origin' },
           startSnapTarget: { type: 'point', id: 99 },
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 7,
         },
       })

--- a/src/machines/sketchSolve/tools/circleToolImpl.ts
+++ b/src/machines/sketchSolve/tools/circleToolImpl.ts
@@ -4,7 +4,7 @@ import type {
   SourceDelta,
 } from '@rust/kcl-lib/bindings/FrontendApi'
 import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import type { Coords2d } from '@src/lang/util'
 import { baseUnitToNumericSuffix } from '@src/lang/wasm'
 import type RustContext from '@src/lib/rustContext'
@@ -58,7 +58,7 @@ export type ToolContext = {
   sceneGraphDelta: SceneGraphDelta
   sceneInfra: SceneInfra
   rustContext: RustContext
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   sketchId: number
 }
 
@@ -271,7 +271,7 @@ export async function createCircleActor({
         centerSnapTarget?: SnapTarget
         startSnapTarget?: SnapTarget
         rustContext: RustContext
-        kclManager: KclManager
+        executingEditor: ExecutingEditor
         sketchId: number
       }
     | {
@@ -297,11 +297,11 @@ export async function createCircleActor({
     centerSnapTarget,
     startSnapTarget,
     rustContext,
-    kclManager,
+    executingEditor,
     sketchId,
   } = input
   const units = baseUnitToNumericSuffix(
-    kclManager.fileSettings.defaultLengthUnit
+    executingEditor.fileSettings.defaultLengthUnit
   )
 
   try {

--- a/src/machines/sketchSolve/tools/constraintToolMachine.spec.ts
+++ b/src/machines/sketchSolve/tools/constraintToolMachine.spec.ts
@@ -10,7 +10,7 @@ import {
 import {
   createArcApiObject,
   createLineApiObject,
-  createMockKclManager,
+  createMockExecutingEditor,
   createMockRustContext,
   createMockSceneInfra,
   createPointApiObject,
@@ -64,7 +64,7 @@ function createHarness({
 }) {
   const sceneInfra = createMockSceneInfra()
   const rustContext = createMockRustContext()
-  const kclManager = createMockKclManager()
+  const executingEditor = createMockExecutingEditor()
   const events: Array<{ type: string; data?: Record<string, unknown> }> = []
   const sceneGraphDelta = createSceneGraphDelta(objects)
 
@@ -132,7 +132,7 @@ function createHarness({
           input: {
             sceneInfra,
             rustContext,
-            kclManager,
+            executingEditor,
             sketchId: 0,
             initialSelectionIds: selectedIds,
             initialObjects: sceneGraphDelta.new_graph.objects,

--- a/src/machines/sketchSolve/tools/constraintToolMachine.ts
+++ b/src/machines/sketchSolve/tools/constraintToolMachine.ts
@@ -6,7 +6,7 @@ import type {
 import type { NumericSuffix } from '@rust/kcl-lib/bindings/NumericSuffix'
 import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
 import { SKETCH_SOLVE_GROUP } from '@src/clientSideScene/sceneUtils'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { baseUnitToNumericSuffix } from '@src/lang/wasm'
 import type RustContext from '@src/lib/rustContext'
 import { jsAppSettings } from '@src/lib/settings/settingsUtils'
@@ -49,7 +49,7 @@ import { assertEvent, assign, fromPromise, setup } from 'xstate'
 type ConstraintToolContext = {
   sceneInfra: SceneInfra
   rustContext: RustContext
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   sketchId: number
   toolName: ConstraintToolName
   initialSelectionIds: SketchSolveSelectionId[]
@@ -65,7 +65,7 @@ type ConstraintToolContext = {
 type ConstraintToolInput = {
   sceneInfra: SceneInfra
   rustContext: RustContext
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   sketchId: number
   initialSelectionIds: SketchSolveSelectionId[]
   initialObjects: ApiObject[]
@@ -78,9 +78,9 @@ type ConstraintToolApplyResult = {
   checkpointId?: number | null
 }
 
-function getDefaultLengthUnit(kclManager: KclManager): NumericSuffix {
+function getDefaultLengthUnit(executingEditor: ExecutingEditor): NumericSuffix {
   return baseUnitToNumericSuffix(
-    kclManager.fileSettings.defaultLengthUnit ?? 'mm'
+    executingEditor.fileSettings.defaultLengthUnit ?? 'mm'
   )
 }
 
@@ -731,7 +731,7 @@ export function createConstraintToolMachine({
             normalized.selectionIds,
             event.objects,
             {
-              defaultLengthUnit: getDefaultLengthUnit(context.kclManager),
+              defaultLengthUnit: getDefaultLengthUnit(context.executingEditor),
             }
           ) !== null
         )
@@ -744,7 +744,7 @@ export function createConstraintToolMachine({
             currentSelectionIds: event.currentSelectionIds,
             clickedSelectionId: event.clickedSelectionId,
             objects: event.objects,
-            defaultLengthUnit: getDefaultLengthUnit(context.kclManager),
+            defaultLengthUnit: getDefaultLengthUnit(context.executingEditor),
           }).type === 'apply'
         )
       },
@@ -787,7 +787,7 @@ export function createConstraintToolMachine({
           currentSelectionIds: event.currentSelectionIds,
           clickedSelectionId: event.clickedSelectionId,
           objects: event.objects,
-          defaultLengthUnit: getDefaultLengthUnit(context.kclManager),
+          defaultLengthUnit: getDefaultLengthUnit(context.executingEditor),
         })
 
         if (clickAction.type === 'clear') {
@@ -814,7 +814,9 @@ export function createConstraintToolMachine({
                 normalized.selectionIds,
                 event.objects,
                 {
-                  defaultLengthUnit: getDefaultLengthUnit(context.kclManager),
+                  defaultLengthUnit: getDefaultLengthUnit(
+                    context.executingEditor
+                  ),
                 }
               ) ?? undefined,
           }
@@ -828,7 +830,7 @@ export function createConstraintToolMachine({
             currentSelectionIds: event.currentSelectionIds,
             clickedSelectionId: event.clickedSelectionId,
             objects: event.objects,
-            defaultLengthUnit: getDefaultLengthUnit(context.kclManager),
+            defaultLengthUnit: getDefaultLengthUnit(context.executingEditor),
           })
 
           return {
@@ -851,7 +853,7 @@ export function createConstraintToolMachine({
           currentSelectionIds: event.currentSelectionIds,
           candidateSelectionIds: event.candidateSelectionIds,
           objects: event.objects,
-          defaultLengthUnit: getDefaultLengthUnit(context.kclManager),
+          defaultLengthUnit: getDefaultLengthUnit(context.executingEditor),
         })
         const previewSelectionIds = getPreviewSelectionIds(selectionAction)
         const previewIds = previewSelectionIds
@@ -876,7 +878,7 @@ export function createConstraintToolMachine({
           currentSelectionIds: event.currentSelectionIds,
           candidateSelectionIds: event.candidateSelectionIds,
           objects: event.objects,
-          defaultLengthUnit: getDefaultLengthUnit(context.kclManager),
+          defaultLengthUnit: getDefaultLengthUnit(context.executingEditor),
         })
 
         sendDuringAreaSelectionToParent(self, [])
@@ -898,7 +900,7 @@ export function createConstraintToolMachine({
             currentSelectionIds: event.currentSelectionIds,
             candidateSelectionIds: event.candidateSelectionIds,
             objects: event.objects,
-            defaultLengthUnit: getDefaultLengthUnit(context.kclManager),
+            defaultLengthUnit: getDefaultLengthUnit(context.executingEditor),
           })
 
           return {
@@ -978,7 +980,7 @@ export function createConstraintToolMachine({
     context: ({ input }): ConstraintToolContext => ({
       sceneInfra: input.sceneInfra,
       rustContext: input.rustContext,
-      kclManager: input.kclManager,
+      executingEditor: input.executingEditor,
       sketchId: input.sketchId,
       toolName,
       initialSelectionIds: input.initialSelectionIds,
@@ -1050,7 +1052,9 @@ export function createConstraintToolMachine({
                     currentSelectionIds: event.currentSelectionIds,
                     candidateSelectionIds: event.candidateSelectionIds,
                     objects: event.objects,
-                    defaultLengthUnit: getDefaultLengthUnit(context.kclManager),
+                    defaultLengthUnit: getDefaultLengthUnit(
+                      context.executingEditor
+                    ),
                   }).type === 'apply'
                 )
               },

--- a/src/machines/sketchSolve/tools/dimensionTool.ts
+++ b/src/machines/sketchSolve/tools/dimensionTool.ts
@@ -1,6 +1,6 @@
 import type { SceneGraphDelta } from '@rust/kcl-lib/bindings/FrontendApi'
 import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import type RustContext from '@src/lib/rustContext'
 import { toastSketchSolveError } from '@src/machines/sketchSolve/sketchSolveErrors'
 import type { BaseToolEvent } from '@src/machines/sketchSolve/tools/sharedToolTypes'
@@ -15,7 +15,7 @@ export const machine = setup({
     input: {} as {
       sceneInfra: SceneInfra
       rustContext: RustContext
-      kclManager: KclManager
+      executingEditor: ExecutingEditor
       sketchId: number
       sceneGraphDelta?: SceneGraphDelta
     },

--- a/src/machines/sketchSolve/tools/lineToolDiagram.spec.ts
+++ b/src/machines/sketchSolve/tools/lineToolDiagram.spec.ts
@@ -10,7 +10,7 @@ import {
 } from '@src/machines/sketchSolve/tools/lineToolDiagram'
 import {
   createLineApiObject,
-  createMockKclManager,
+  createMockExecutingEditor,
   createMockRustContext,
   createMockSceneInfra,
   createPointApiObject,
@@ -48,7 +48,7 @@ function createTestMachine(mockActors?: {
 }) {
   const sceneInfra = createMockSceneInfra()
   const rustContext = createMockRustContext()
-  const kclManager = createMockKclManager()
+  const executingEditor = createMockExecutingEditor()
 
   // Create a machine with mocked actors
   const testMachine = machine.provide({
@@ -84,20 +84,20 @@ function createTestMachine(mockActors?: {
     machine: testMachine,
     sceneInfra,
     rustContext,
-    kclManager,
+    executingEditor,
   }
 }
 
 describe('lineTool - XState', () => {
   describe('when initialized', () => {
     it('should have default context values', () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -110,13 +110,13 @@ describe('lineTool - XState', () => {
     })
 
     it('should call setCallbacks on entry to ready for user click', () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -128,13 +128,13 @@ describe('lineTool - XState', () => {
 
   describe('escape key handling', () => {
     it('should transition to unequipping when escape is pressed in ready for user click', () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -148,13 +148,13 @@ describe('lineTool - XState', () => {
 
   describe('unequip handling', () => {
     it('should transition to unequipping when unequip event is sent', () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -168,13 +168,13 @@ describe('lineTool - XState', () => {
 
   describe('adding points', () => {
     it('should transition to Adding point when add point event is sent', () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -189,7 +189,7 @@ describe('lineTool - XState', () => {
       const pointObj = createPointApiObject({ id: 1, x: 10, y: 20 })
       const lineObj = createLineApiObject({ id: 2, start: 1, end: 1 })
 
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine({
           modAndSolveFirstClick: async () => ({
             kclSource: { text: 'test' },
@@ -201,7 +201,7 @@ describe('lineTool - XState', () => {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -220,7 +220,7 @@ describe('lineTool - XState', () => {
       const pointObj = createPointApiObject({ id: 1, x: 10, y: 20 })
       const lineObj = createLineApiObject({ id: 2, start: 1, end: 1 })
 
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine({
           modAndSolveFirstClick: async () => ({
             kclSource: { text: 'test' },
@@ -232,7 +232,7 @@ describe('lineTool - XState', () => {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -255,7 +255,7 @@ describe('lineTool - XState', () => {
       const pointObj2 = createPointApiObject({ id: 3, x: 30, y: 40 })
       const lineObj2 = createLineApiObject({ id: 4, start: 1, end: 3 })
 
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine({
           modAndSolveFirstClick: async () => ({
             kclSource: { text: 'test' },
@@ -287,7 +287,7 @@ describe('lineTool - XState', () => {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -380,7 +380,7 @@ describe('lineTool - XState', () => {
 
         const sceneInfra = createMockSceneInfra()
         const rustContext = createMockRustContext()
-        const kclManager = createMockKclManager()
+        const executingEditor = createMockExecutingEditor()
         // eslint-disable-next-line @typescript-eslint/unbound-method
         const addSegmentMock = vi.mocked(rustContext.addSegment)
         // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -414,7 +414,7 @@ describe('lineTool - XState', () => {
           input: {
             sceneInfra,
             rustContext,
-            kclManager,
+            executingEditor,
             sketchId: 0,
           },
         }).start()

--- a/src/machines/sketchSolve/tools/lineToolDiagram.ts
+++ b/src/machines/sketchSolve/tools/lineToolDiagram.ts
@@ -5,7 +5,7 @@ import type {
   SegmentCtor,
   SourceDelta,
 } from '@rust/kcl-lib/bindings/FrontendApi'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { baseUnitToNumericSuffix } from '@src/lang/wasm'
 import type RustContext from '@src/lib/rustContext'
 import { jsAppSettings } from '@src/lib/settings/settingsUtils'
@@ -80,7 +80,7 @@ export const machine = setup({
           pointData: [number, number]
           snapTarget?: SnapTarget
           rustContext: RustContext
-          kclManager: KclManager
+          executingEditor: ExecutingEditor
           sketchId: number
         }
       }): Promise<
@@ -97,12 +97,17 @@ export const machine = setup({
             error: string
           }
       > => {
-        const { pointData, snapTarget, rustContext, kclManager, sketchId } =
-          input
+        const {
+          pointData,
+          snapTarget,
+          rustContext,
+          executingEditor,
+          sketchId,
+        } = input
         const [x, y] = pointData
 
         const units = baseUnitToNumericSuffix(
-          kclManager.fileSettings.defaultLengthUnit
+          executingEditor.fileSettings.defaultLengthUnit
         )
 
         try {
@@ -200,7 +205,7 @@ export const machine = setup({
           snapTarget?: SnapTarget
           isDoubleClick?: boolean
           rustContext: RustContext
-          kclManager: KclManager
+          executingEditor: ExecutingEditor
           sketchId: number
         }
       }): Promise<
@@ -220,12 +225,12 @@ export const machine = setup({
           snapTarget,
           isDoubleClick,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId,
         } = input
         const [x, y] = pointData
         const units = baseUnitToNumericSuffix(
-          kclManager.fileSettings.defaultLengthUnit
+          executingEditor.fileSettings.defaultLengthUnit
         )
         const settings = jsAppSettings(rustContext.settingsActor)
 
@@ -347,7 +352,7 @@ export const machine = setup({
           sceneGraphDelta?: SceneGraphDelta
           draftPointData: [number, number]
           rustContext: RustContext
-          kclManager: KclManager
+          executingEditor: ExecutingEditor
           sketchId: number
         }
       }): Promise<
@@ -369,7 +374,7 @@ export const machine = setup({
           sceneGraphDelta,
           draftPointData,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId,
         } = input
 
@@ -391,7 +396,7 @@ export const machine = setup({
         const [startX, startY] = pointToCoords2d(graphPoint)
         const [endX, endY] = draftPointData
         const units = baseUnitToNumericSuffix(
-          kclManager.fileSettings.defaultLengthUnit
+          executingEditor.fileSettings.defaultLengthUnit
         )
         const settings = jsAppSettings(rustContext.settingsActor)
 
@@ -478,7 +483,7 @@ export const machine = setup({
     deleteFromEscape: undefined,
     sceneInfra: input.sceneInfra,
     rustContext: input.rustContext,
-    kclManager: input.kclManager,
+    executingEditor: input.executingEditor,
     sketchId: input.sketchId || 0,
   }),
   id: toolId,
@@ -515,7 +520,7 @@ export const machine = setup({
             snapTarget: event.snapTarget,
             isDoubleClick: event.isDoubleClick,
             rustContext: context.rustContext,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             sketchId: context.sketchId,
           }
         },
@@ -596,7 +601,7 @@ export const machine = setup({
             sceneGraphDelta: context.pendingSketchOutcome?.sceneGraphDelta,
             draftPointData: event.data,
             rustContext: context.rustContext,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             sketchId: context.sketchId,
           }
         },
@@ -656,7 +661,7 @@ export const machine = setup({
             pointData: event.data,
             snapTarget: event.snapTarget,
             rustContext: context.rustContext,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             sketchId: context.sketchId,
           }
         },

--- a/src/machines/sketchSolve/tools/lineToolImpl.ts
+++ b/src/machines/sketchSolve/tools/lineToolImpl.ts
@@ -4,7 +4,7 @@ import type {
   SourceDelta,
 } from '@rust/kcl-lib/bindings/FrontendApi'
 import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import type { Coords2d } from '@src/lang/util'
 import { baseUnitToNumericSuffix } from '@src/lang/wasm'
 import type RustContext from '@src/lib/rustContext'
@@ -62,7 +62,7 @@ export type ToolContext = {
   deleteFromEscape?: boolean // Track if deletion was triggered by escape (vs unequip)
   sceneInfra: SceneInfra
   rustContext: RustContext
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   sketchId: number
 }
 
@@ -137,7 +137,7 @@ export function animateDraftSegmentListener({ self, context }: ToolActionArgs) {
         })
 
         const units = baseUnitToNumericSuffix(
-          context.kclManager.fileSettings.defaultLengthUnit
+          context.executingEditor.fileSettings.defaultLengthUnit
         )
         try {
           isEditInProgress = true

--- a/src/machines/sketchSolve/tools/moveTool/moveTool.spec.ts
+++ b/src/machines/sketchSolve/tools/moveTool/moveTool.spec.ts
@@ -292,7 +292,7 @@ function setUpMoveToolCallbacks({
         })),
       },
     },
-    kclManager: {
+    executingEditor: {
       fileSettings: {
         defaultLengthUnit: 'mm' as UnitLength,
       },

--- a/src/machines/sketchSolve/tools/moveTool/moveTool.ts
+++ b/src/machines/sketchSolve/tools/moveTool/moveTool.ts
@@ -1837,7 +1837,7 @@ export function setUpOnDragAndSelectionClickCallbacks({
         }
       },
       getCurrentCommittedCheckpointId: () =>
-        context.kclManager.currentSketchCheckpointId,
+        context.executingEditor.currentSketchCheckpointId,
       dismissConstraintHoverPopup: dismissConstraintHoverPopupOnDragStart,
     }),
     onDragEnd: createOnDragEndCallback({
@@ -1875,7 +1875,7 @@ export function setUpOnDragAndSelectionClickCallbacks({
             const labelPosition = buildConstraintLabelPosition(
               intersectionPoint.twoD,
               baseUnitToNumericSuffix(
-                context.kclManager.fileSettings.defaultLengthUnit
+                context.executingEditor.fileSettings.defaultLengthUnit
               )
             )
             const result =
@@ -1919,7 +1919,7 @@ export function setUpOnDragAndSelectionClickCallbacks({
               : null
 
           const units = baseUnitToNumericSuffix(
-            context.kclManager.fileSettings.defaultLengthUnit
+            context.executingEditor.fileSettings.defaultLengthUnit
           )
           const snapConstraints =
             snappingCandidate && draggedEntityId !== null
@@ -2328,7 +2328,7 @@ export function setUpOnDragAndSelectionClickCallbacks({
         })
       },
       getDefaultLengthUnit: () =>
-        context.kclManager.fileSettings.defaultLengthUnit,
+        context.executingEditor.fileSettings.defaultLengthUnit,
       getJsAppSettings: async () =>
         jsAppSettings(context.rustContext.settingsActor),
       sceneInfra: context.sceneInfra,

--- a/src/machines/sketchSolve/tools/pointTool.spec.ts
+++ b/src/machines/sketchSolve/tools/pointTool.spec.ts
@@ -3,7 +3,7 @@ import { createActor } from 'xstate'
 
 import { machine } from '@src/machines/sketchSolve/tools/pointTool'
 import {
-  createMockKclManager,
+  createMockExecutingEditor,
   createMockRustContext,
   createMockSceneInfra,
   createPointApiObject,
@@ -28,13 +28,13 @@ function createTestActor() {
   const setCallbacksMock = vi.fn()
   sceneInfra.setCallbacks = setCallbacksMock
   const rustContext = createMockRustContext()
-  const kclManager = createMockKclManager()
+  const executingEditor = createMockExecutingEditor()
 
   const actor = createActor(machine, {
     input: {
       sceneInfra,
       rustContext,
-      kclManager,
+      executingEditor,
       sketchId: 7,
     },
   }).start()

--- a/src/machines/sketchSolve/tools/pointTool.ts
+++ b/src/machines/sketchSolve/tools/pointTool.ts
@@ -6,7 +6,7 @@ import type {
   SourceDelta,
 } from '@rust/kcl-lib/bindings/FrontendApi'
 import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import type { Coords2d } from '@src/lang/util'
 import { baseUnitToNumericSuffix } from '@src/lang/wasm'
 import type RustContext from '@src/lib/rustContext'
@@ -77,7 +77,7 @@ export const machine = setup({
     context: {} as {
       sceneInfra: SceneInfra
       rustContext: RustContext
-      kclManager: KclManager
+      executingEditor: ExecutingEditor
       sketchId: number
     },
     events: {} as ToolEvents,
@@ -178,18 +178,23 @@ export const machine = setup({
           pointData: [number, number]
           snapTarget?: SnapTarget
           rustContext: RustContext
-          kclManager: KclManager
+          executingEditor: ExecutingEditor
           sketchId: number
         }
       }) => {
-        const { pointData, snapTarget, rustContext, kclManager, sketchId } =
-          input
+        const {
+          pointData,
+          snapTarget,
+          rustContext,
+          executingEditor,
+          sketchId,
+        } = input
         const [x, y] = pointData
 
         try {
           // Get the current unit from file settings, defaulting to mm if not set
           const units = baseUnitToNumericSuffix(
-            kclManager.fileSettings.defaultLengthUnit
+            executingEditor.fileSettings.defaultLengthUnit
           )
           const settings = jsAppSettings(rustContext.settingsActor)
 
@@ -263,7 +268,7 @@ export const machine = setup({
   context: ({ input }) => ({
     sceneInfra: input.sceneInfra,
     rustContext: input.rustContext,
-    kclManager: input.kclManager,
+    executingEditor: input.executingEditor,
     sketchId: input.sketchId,
   }),
   id: TOOL_ID,
@@ -298,7 +303,7 @@ export const machine = setup({
             pointData: event.data,
             snapTarget: event.snapTarget,
             rustContext: context.rustContext,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             sketchId: context.sketchId,
           }
         },

--- a/src/machines/sketchSolve/tools/rectTool.spec.ts
+++ b/src/machines/sketchSolve/tools/rectTool.spec.ts
@@ -6,7 +6,7 @@ import { MIN_DRAFT_GEOMETRY_DELTA_MM } from '@src/machines/sketchSolve/tools/dra
 import { machine } from '@src/machines/sketchSolve/tools/rectTool'
 import type { RectDraftIds } from '@src/machines/sketchSolve/tools/rectUtils'
 import {
-  createMockKclManager,
+  createMockExecutingEditor,
   createMockRustContext,
   createMockSceneInfra,
   createSceneGraphDelta,
@@ -41,7 +41,7 @@ function createTestMachine(mockActors?: {
   const setCallbacksMock = vi.fn()
   sceneInfra.setCallbacks = setCallbacksMock
   const rustContext = createMockRustContext()
-  const kclManager = createMockKclManager()
+  const executingEditor = createMockExecutingEditor()
 
   const testMachine = machine.provide({
     actors: {
@@ -66,7 +66,7 @@ function createTestMachine(mockActors?: {
     sceneInfra,
     setCallbacksMock,
     rustContext,
-    kclManager,
+    executingEditor,
   }
 }
 
@@ -78,13 +78,13 @@ describe('rectTool - XState', () => {
 
   describe('when initialized', () => {
     it('should have default context values', () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -97,13 +97,13 @@ describe('rectTool - XState', () => {
     })
 
     it('should use center origin mode when toolVariant is center', () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
           toolVariant: 'center',
         },
@@ -115,13 +115,18 @@ describe('rectTool - XState', () => {
     })
 
     it('should call setCallbacks on entry to awaiting first point', () => {
-      const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
-        createTestMachine()
+      const {
+        machine,
+        sceneInfra,
+        setCallbacksMock,
+        rustContext,
+        executingEditor,
+      } = createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -139,13 +144,18 @@ describe('rectTool - XState', () => {
         distance: 0,
       })
 
-      const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
-        createTestMachine()
+      const {
+        machine,
+        sceneInfra,
+        setCallbacksMock,
+        rustContext,
+        executingEditor,
+      } = createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -179,15 +189,20 @@ describe('rectTool - XState', () => {
         distance: 0,
       })
 
-      const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
-        createTestMachine({
-          modAndSolveFirstClick,
-        })
+      const {
+        machine,
+        sceneInfra,
+        setCallbacksMock,
+        rustContext,
+        executingEditor,
+      } = createTestMachine({
+        modAndSolveFirstClick,
+      })
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -211,13 +226,13 @@ describe('rectTool - XState', () => {
     })
 
     it('should transition to awaiting second point after first click', async () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -230,13 +245,13 @@ describe('rectTool - XState', () => {
     })
 
     it('should transition to awaiting third point in angled mode after setting second point', async () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
           toolVariant: 'angled',
         },
@@ -259,13 +274,18 @@ describe('rectTool - XState', () => {
         distance: 0,
       })
 
-      const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
-        createTestMachine()
+      const {
+        machine,
+        sceneInfra,
+        setCallbacksMock,
+        rustContext,
+        executingEditor,
+      } = createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
           toolVariant: 'angled',
         },
@@ -287,13 +307,13 @@ describe('rectTool - XState', () => {
     })
 
     it('should remain in awaiting second point in angled mode when second point equals first point', async () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
           toolVariant: 'angled',
         },
@@ -312,13 +332,18 @@ describe('rectTool - XState', () => {
     })
 
     it('should ignore an aligned finalize click until the rectangle crosses the preview threshold', async () => {
-      const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
-        createTestMachine()
+      const {
+        machine,
+        sceneInfra,
+        setCallbacksMock,
+        rustContext,
+        executingEditor,
+      } = createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -348,13 +373,18 @@ describe('rectTool - XState', () => {
         distance: 0,
       })
 
-      const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
-        createTestMachine()
+      const {
+        machine,
+        sceneInfra,
+        setCallbacksMock,
+        rustContext,
+        executingEditor,
+      } = createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
           toolVariant: 'center',
         },
@@ -379,13 +409,18 @@ describe('rectTool - XState', () => {
     })
 
     it('should ignore an angled second click until the first side crosses the preview threshold', async () => {
-      const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
-        createTestMachine()
+      const {
+        machine,
+        sceneInfra,
+        setCallbacksMock,
+        rustContext,
+        executingEditor,
+      } = createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
           toolVariant: 'angled',
         },
@@ -412,13 +447,18 @@ describe('rectTool - XState', () => {
     })
 
     it('should remain in awaiting third point in angled mode when third click equals second point', async () => {
-      const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
-        createTestMachine()
+      const {
+        machine,
+        sceneInfra,
+        setCallbacksMock,
+        rustContext,
+        executingEditor,
+      } = createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
           toolVariant: 'angled',
         },
@@ -446,13 +486,18 @@ describe('rectTool - XState', () => {
     })
 
     it('should ignore an angled third click until the rectangle has non-zero width', async () => {
-      const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
-        createTestMachine()
+      const {
+        machine,
+        sceneInfra,
+        setCallbacksMock,
+        rustContext,
+        executingEditor,
+      } = createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
           toolVariant: 'angled',
         },
@@ -485,13 +530,13 @@ describe('rectTool - XState', () => {
 
   describe('escape handling', () => {
     it('should return to awaiting first point on escape after first click', async () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -511,13 +556,13 @@ describe('rectTool - XState', () => {
 
   describe('finalize handling', () => {
     it('should clear draft and return to awaiting first point', async () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -535,13 +580,13 @@ describe('rectTool - XState', () => {
     })
 
     it('should clear draft and second point when finalizing angled mode from third point state', async () => {
-      const { machine, sceneInfra, rustContext, kclManager } =
+      const { machine, sceneInfra, rustContext, executingEditor } =
         createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
           toolVariant: 'angled',
         },
@@ -573,13 +618,18 @@ describe('rectTool - XState', () => {
       }
       vi.mocked(getBestSnappingCandidate).mockReturnValue(snappingCandidate)
 
-      const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
-        createTestMachine()
+      const {
+        machine,
+        sceneInfra,
+        setCallbacksMock,
+        rustContext,
+        executingEditor,
+      } = createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -603,13 +653,18 @@ describe('rectTool - XState', () => {
     })
 
     it('clears snapping preview when pointer leaves the sketch plane', () => {
-      const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
-        createTestMachine()
+      const {
+        machine,
+        sceneInfra,
+        setCallbacksMock,
+        rustContext,
+        executingEditor,
+      } = createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()
@@ -626,13 +681,18 @@ describe('rectTool - XState', () => {
     })
 
     it('skips aligned draft edits until the preview threshold is crossed', async () => {
-      const { machine, sceneInfra, setCallbacksMock, rustContext, kclManager } =
-        createTestMachine()
+      const {
+        machine,
+        sceneInfra,
+        setCallbacksMock,
+        rustContext,
+        executingEditor,
+      } = createTestMachine()
       const actor = createActor(machine, {
         input: {
           sceneInfra,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 0,
         },
       }).start()

--- a/src/machines/sketchSolve/tools/rectTool.ts
+++ b/src/machines/sketchSolve/tools/rectTool.ts
@@ -4,7 +4,7 @@ import type {
   SourceDelta,
 } from '@rust/kcl-lib/bindings/FrontendApi'
 import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import type RustContext from '@src/lib/rustContext'
 import {
   isSketchSolveErrorOutput,
@@ -62,7 +62,7 @@ export type RectToolEvent =
 type RectToolContext = {
   sceneInfra: SceneInfra
   rustContext: RustContext
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   sketchId: number
   firstPointId?: number
   draft?: RectDraftIds
@@ -248,7 +248,7 @@ export const machine = setup({
                   isEditInProgress = true
                   result = await updateDraftRectangleAngled({
                     rustContext: context.rustContext,
-                    kclManager: context.kclManager,
+                    executingEditor: context.executingEditor,
                     sketchId: context.sketchId,
                     draft: context.draft,
                     p1: context.origin,
@@ -291,7 +291,7 @@ export const machine = setup({
 
                   result = await updateDraftRectangleAligned({
                     rustContext: context.rustContext,
-                    kclManager: context.kclManager,
+                    executingEditor: context.executingEditor,
                     sketchId: context.sketchId,
                     draft: context.draft,
                     mode: context.rectOriginMode,
@@ -423,7 +423,7 @@ export const machine = setup({
               isEditInProgress = true
               const result = await updateDraftRectangleAngled({
                 rustContext: context.rustContext,
-                kclManager: context.kclManager,
+                executingEditor: context.executingEditor,
                 sketchId: context.sketchId,
                 draft: context.draft,
                 p1: context.origin,
@@ -548,7 +548,7 @@ export const machine = setup({
         input: {
           pointData: [number, number]
           rustContext: RustContext
-          kclManager: KclManager
+          executingEditor: ExecutingEditor
           sketchId: number
           origin: [number, number]
           snapTarget?: SnapTarget
@@ -557,7 +557,7 @@ export const machine = setup({
       }) => {
         const {
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId,
           rectOriginMode,
           snapTarget,
@@ -566,7 +566,7 @@ export const machine = setup({
         try {
           const result = await createDraftRectangle({
             rustContext,
-            kclManager,
+            executingEditor,
             sketchId,
             mode: rectOriginMode,
             origin: input.origin,
@@ -590,7 +590,7 @@ export const machine = setup({
   context: ({ input }) => ({
     sceneInfra: input.sceneInfra,
     rustContext: input.rustContext,
-    kclManager: input.kclManager,
+    executingEditor: input.executingEditor,
     sketchId: input.sketchId,
     origin: [0, 0],
     originSnapTarget: undefined,
@@ -637,7 +637,7 @@ export const machine = setup({
             snapTarget: context.originSnapTarget,
             rectOriginMode: context.rectOriginMode,
             rustContext: context.rustContext,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             sketchId: context.sketchId,
           }
         },

--- a/src/machines/sketchSolve/tools/rectUtils.spec.ts
+++ b/src/machines/sketchSolve/tools/rectUtils.spec.ts
@@ -13,7 +13,7 @@ import {
 } from '@src/machines/sketchSolve/tools/rectUtils'
 import {
   createLineApiObject,
-  createMockKclManager,
+  createMockExecutingEditor,
   createMockRustContext,
   createPointApiObject,
   createSceneGraphDelta,
@@ -100,7 +100,7 @@ describe('rectUtils.getAngledRectangleCorners', () => {
 describe('rectUtils.createDraftRectangle', () => {
   it('adds center rectangle construction geometry and constraints in center mode', async () => {
     const rustContext = createMockRustContext()
-    const kclManager = createMockKclManager()
+    const executingEditor = createMockExecutingEditor()
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const addSegmentMock = vi.mocked(rustContext.addSegment)
     // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -171,7 +171,7 @@ describe('rectUtils.createDraftRectangle', () => {
 
     const result = await createDraftRectangle({
       rustContext,
-      kclManager,
+      executingEditor,
       sketchId: 7,
       mode: 'center',
       origin: [12, 8],
@@ -238,7 +238,7 @@ describe('rectUtils.createDraftRectangle', () => {
 
   it('adds a snap constraint for the rectangle origin point when the first click snaps', async () => {
     const rustContext = createMockRustContext()
-    const kclManager = createMockKclManager()
+    const executingEditor = createMockExecutingEditor()
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const addSegmentMock = vi.mocked(rustContext.addSegment)
     // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -294,7 +294,7 @@ describe('rectUtils.createDraftRectangle', () => {
 
     const result = await createDraftRectangle({
       rustContext,
-      kclManager,
+      executingEditor,
       sketchId: 4,
       mode: 'corner',
       origin: [1, 2],
@@ -312,7 +312,7 @@ describe('rectUtils.createDraftRectangle', () => {
 
   it('seeds corner rectangles at the clicked origin with a non-degenerate draft size', async () => {
     const rustContext = createMockRustContext()
-    const kclManager = createMockKclManager()
+    const executingEditor = createMockExecutingEditor()
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const addSegmentMock = vi.mocked(rustContext.addSegment)
     // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -353,7 +353,7 @@ describe('rectUtils.createDraftRectangle', () => {
 
     await createDraftRectangle({
       rustContext,
-      kclManager,
+      executingEditor,
       sketchId: 12,
       mode: 'corner',
       origin: [12, 8],
@@ -380,7 +380,7 @@ describe('rectUtils.createDraftRectangle', () => {
 describe('rectUtils.updateDraftRectangleAligned', () => {
   it('updates center rectangle diagonals and center point alongside the outer lines', async () => {
     const rustContext = createMockRustContext()
-    const kclManager = createMockKclManager()
+    const executingEditor = createMockExecutingEditor()
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const editSegmentsMock = vi.mocked(rustContext.editSegments)
 
@@ -391,7 +391,7 @@ describe('rectUtils.updateDraftRectangleAligned', () => {
 
     await updateDraftRectangleAligned({
       rustContext,
-      kclManager,
+      executingEditor,
       sketchId: 9,
       draft: {
         lineIds: [1, 2, 3, 4],
@@ -455,7 +455,7 @@ describe('rectUtils.updateDraftRectangleAligned', () => {
 
   it('keeps the first corner pinned when dragging into the negative quadrant', async () => {
     const rustContext = createMockRustContext()
-    const kclManager = createMockKclManager()
+    const executingEditor = createMockExecutingEditor()
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const editSegmentsMock = vi.mocked(rustContext.editSegments)
 
@@ -466,7 +466,7 @@ describe('rectUtils.updateDraftRectangleAligned', () => {
 
     await updateDraftRectangleAligned({
       rustContext,
-      kclManager,
+      executingEditor,
       sketchId: 9,
       draft: {
         lineIds: [1, 2, 3, 4],

--- a/src/machines/sketchSolve/tools/rectUtils.ts
+++ b/src/machines/sketchSolve/tools/rectUtils.ts
@@ -3,7 +3,7 @@ import type {
   SegmentCtor,
   SourceDelta,
 } from '@rust/kcl-lib/bindings/FrontendApi'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import type { Coords2d } from '@src/lang/util'
 import { baseUnitToNumericSuffix } from '@src/lang/wasm'
 import type RustContext from '@src/lib/rustContext'
@@ -105,14 +105,14 @@ function getPointFromDelta(
 
 export async function createDraftRectangle({
   rustContext,
-  kclManager,
+  executingEditor,
   sketchId,
   mode,
   origin = [0, 0],
   snapTarget,
 }: {
   rustContext: RustContext
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   sketchId: number
   mode: RectOriginMode
   origin?: Coords2d
@@ -123,7 +123,7 @@ export async function createDraftRectangle({
   draft: RectDraftIds
 }> {
   const units = baseUnitToNumericSuffix(
-    kclManager.fileSettings.defaultLengthUnit
+    executingEditor.fileSettings.defaultLengthUnit
   )
   const settings = jsAppSettings(rustContext.settingsActor)
   const draftCorners = getInitialDraftRectangleCorners(origin, mode)
@@ -455,7 +455,7 @@ export async function createDraftRectangle({
 // Updates draft rectangle for center and corner rectangles.
 export async function updateDraftRectangleAligned({
   rustContext,
-  kclManager,
+  executingEditor,
   sketchId,
   draft,
   mode,
@@ -463,7 +463,7 @@ export async function updateDraftRectangleAligned({
   currentPoint,
 }: {
   rustContext: RustContext
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   sketchId: number
   draft: RectDraftIds
   mode: Extract<RectOriginMode, 'corner' | 'center'>
@@ -474,7 +474,7 @@ export async function updateDraftRectangleAligned({
   sceneGraphDelta: SceneGraphDelta
 }> {
   const units = baseUnitToNumericSuffix(
-    kclManager.fileSettings.defaultLengthUnit
+    executingEditor.fileSettings.defaultLengthUnit
   )
   const settings = jsAppSettings(rustContext.settingsActor)
 
@@ -584,7 +584,7 @@ function getInitialDraftRectangleCorners(
 // Updates draft rectangle for angled (rotated) rectangle
 export async function updateDraftRectangleAngled({
   rustContext,
-  kclManager,
+  executingEditor,
   sketchId,
   draft,
   p1,
@@ -592,7 +592,7 @@ export async function updateDraftRectangleAngled({
   p3,
 }: {
   rustContext: RustContext
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   sketchId: number
   draft: RectDraftIds
   p1: Coords2d
@@ -603,7 +603,7 @@ export async function updateDraftRectangleAngled({
   sceneGraphDelta: SceneGraphDelta
 }> {
   const units = baseUnitToNumericSuffix(
-    kclManager.fileSettings.defaultLengthUnit
+    executingEditor.fileSettings.defaultLengthUnit
   )
   const settings = jsAppSettings(rustContext.settingsActor)
 

--- a/src/machines/sketchSolve/tools/sketchToolTestUtils.ts
+++ b/src/machines/sketchSolve/tools/sketchToolTestUtils.ts
@@ -3,7 +3,7 @@ import type {
   SceneGraphDelta,
 } from '@rust/kcl-lib/bindings/FrontendApi'
 import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { emptyOperationsByModule } from '@src/lang/wasm'
 import type RustContext from '@src/lib/rustContext'
 import { Themes } from '@src/lib/theme'
@@ -265,7 +265,7 @@ export function createControlPointSplineApiObject({
 /**
  * Mock dependencies
  * Note: SceneInfra only needs setCallbacks, but we mock it for simplicity
- * RustContext and KclManager MUST be mocked as they have WASM bindings and complex dependencies
+ * RustContext and ExecutingEditor MUST be mocked as they have WASM bindings and complex dependencies
  */
 export function createMockSceneInfra(): SceneInfra {
   return {
@@ -297,10 +297,10 @@ export function createMockRustContext(): RustContext {
   } as unknown as RustContext
 }
 
-export function createMockKclManager(): KclManager {
+export function createMockExecutingEditor(): ExecutingEditor {
   return {
     fileSettings: {
       defaultLengthUnit: 'Mm',
     },
-  } as unknown as KclManager
+  } as unknown as ExecutingEditor
 }

--- a/src/machines/sketchSolve/tools/splineTool.spec.ts
+++ b/src/machines/sketchSolve/tools/splineTool.spec.ts
@@ -2,7 +2,7 @@ import { SKETCH_SOLVE_GROUP } from '@src/clientSideScene/sceneUtils'
 import { Themes } from '@src/lib/theme'
 import {
   createControlPointSplineApiObject,
-  createMockKclManager,
+  createMockExecutingEditor,
   createMockRustContext,
   createPointApiObject,
   createSceneGraphDelta,
@@ -94,7 +94,7 @@ function createToolHarness(
       input: {
         sceneInfra,
         rustContext: options?.rustContext ?? createMockRustContext(),
-        kclManager: createMockKclManager(),
+        executingEditor: createMockExecutingEditor(),
         sketchId: 0,
       },
     },

--- a/src/machines/sketchSolve/tools/splineTool.ts
+++ b/src/machines/sketchSolve/tools/splineTool.ts
@@ -7,7 +7,7 @@ import type {
 } from '@rust/kcl-lib/bindings/FrontendApi'
 import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
 import { SKETCH_SOLVE_GROUP } from '@src/clientSideScene/sceneUtils'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import type { Coords2d } from '@src/lang/util'
 import { baseUnitToNumericSuffix } from '@src/lang/wasm'
 import type RustContext from '@src/lib/rustContext'
@@ -95,7 +95,7 @@ type ToolContext = {
   committedControlCount: number
   sceneInfra: SceneInfra
   rustContext: RustContext
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   sketchId: number
   cancelTarget: 'ready' | 'unequip'
   shouldFinishClosedSpline: boolean
@@ -795,7 +795,7 @@ function animateDraftPointListener({
 
       const [x, y] = snappingCandidate?.position ?? mousePosition
       const units = baseUnitToNumericSuffix(
-        context.kclManager.fileSettings.defaultLengthUnit
+        context.executingEditor.fileSettings.defaultLengthUnit
       )
 
       try {
@@ -1026,14 +1026,15 @@ export const machine = setup({
           points: [Coords2d, Coords2d, Coords2d]
           snapTargets: [SnapTarget | undefined, SnapTarget | undefined]
           rustContext: RustContext
-          kclManager: KclManager
+          executingEditor: ExecutingEditor
           sketchId: number
         }
       }): Promise<ToolDoneOutput | ErrorOutput> => {
-        const { points, snapTargets, rustContext, kclManager, sketchId } = input
+        const { points, snapTargets, rustContext, executingEditor, sketchId } =
+          input
         const settings = jsAppSettings(rustContext.settingsActor)
         const units = baseUnitToNumericSuffix(
-          kclManager.fileSettings.defaultLengthUnit
+          executingEditor.fileSettings.defaultLengthUnit
         )
 
         try {
@@ -1123,7 +1124,7 @@ export const machine = setup({
           draftPointId: number
           snapTarget?: SnapTarget
           rustContext: RustContext
-          kclManager: KclManager
+          executingEditor: ExecutingEditor
           sketchId: number
         }
       }): Promise<ToolDoneOutput | ErrorOutput> => {
@@ -1132,11 +1133,11 @@ export const machine = setup({
           draftPointId,
           snapTarget,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId,
         } = input
         const units = baseUnitToNumericSuffix(
-          kclManager.fileSettings.defaultLengthUnit
+          executingEditor.fileSettings.defaultLengthUnit
         )
         const settings = jsAppSettings(rustContext.settingsActor)
 
@@ -1195,7 +1196,7 @@ export const machine = setup({
           construction: boolean
           draftPoint: Coords2d
           rustContext: RustContext
-          kclManager: KclManager
+          executingEditor: ExecutingEditor
           sketchId: number
         }
       }): Promise<ToolDoneOutput | ErrorOutput> => {
@@ -1205,11 +1206,11 @@ export const machine = setup({
           construction,
           draftPoint,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId,
         } = input
         const units = baseUnitToNumericSuffix(
-          kclManager.fileSettings.defaultLengthUnit
+          executingEditor.fileSettings.defaultLengthUnit
         )
         const settings = jsAppSettings(rustContext.settingsActor)
         try {
@@ -1283,7 +1284,7 @@ export const machine = setup({
           points: Coords2d[]
           construction: boolean
           rustContext: RustContext
-          kclManager: KclManager
+          executingEditor: ExecutingEditor
           sketchId: number
         }
       }): Promise<ToolDoneOutput | ErrorOutput> => {
@@ -1292,7 +1293,7 @@ export const machine = setup({
           points,
           construction,
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId,
         } = input
         const settings = jsAppSettings(rustContext.settingsActor)
@@ -1314,7 +1315,7 @@ export const machine = setup({
           }
 
           const units = baseUnitToNumericSuffix(
-            kclManager.fileSettings.defaultLengthUnit
+            executingEditor.fileSettings.defaultLengthUnit
           )
           const result = await rustContext.editSegments(
             0,
@@ -1358,7 +1359,7 @@ export const machine = setup({
     committedControlCount: 0,
     sceneInfra: input.sceneInfra,
     rustContext: input.rustContext,
-    kclManager: input.kclManager,
+    executingEditor: input.executingEditor,
     sketchId: input.sketchId,
     cancelTarget: 'ready',
     shouldFinishClosedSpline: false,
@@ -1434,7 +1435,7 @@ export const machine = setup({
               context.secondSnapTarget,
             ] as const,
             rustContext: context.rustContext,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             sketchId: context.sketchId,
           }
         },
@@ -1487,7 +1488,7 @@ export const machine = setup({
             draftPointId: context.draftPointId!,
             snapTarget: event.snapTarget,
             rustContext: context.rustContext,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             sketchId: context.sketchId,
           }
         },
@@ -1568,7 +1569,7 @@ export const machine = setup({
             construction: state?.splineObj.kind.segment.construction ?? false,
             draftPoint: event.data,
             rustContext: context.rustContext,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             sketchId: context.sketchId,
           }
         },
@@ -1622,7 +1623,7 @@ export const machine = setup({
             points: state?.points ?? [],
             construction: state?.splineObj.kind.segment.construction ?? false,
             rustContext: context.rustContext,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             sketchId: context.sketchId,
           }
         },

--- a/src/machines/sketchSolve/tools/tangentialArcToolDiagram.spec.ts
+++ b/src/machines/sketchSolve/tools/tangentialArcToolDiagram.spec.ts
@@ -4,7 +4,7 @@ import type {
 } from '@rust/kcl-lib/bindings/FrontendApi'
 import {
   createArcApiObject,
-  createMockKclManager,
+  createMockExecutingEditor,
   createMockRustContext,
   createMockSceneInfra,
   createPointApiObject,
@@ -30,7 +30,7 @@ function createTestMachine(mockActors?: {
 }) {
   const sceneInfra = createMockSceneInfra()
   const rustContext = createMockRustContext()
-  const kclManager = createMockKclManager()
+  const executingEditor = createMockExecutingEditor()
 
   const testMachine = machine.provide({
     actors: {
@@ -55,18 +55,19 @@ function createTestMachine(mockActors?: {
     machine: testMachine,
     sceneInfra,
     rustContext,
-    kclManager,
+    executingEditor,
   }
 }
 
 describe('tangentialArcTool - XState', () => {
   it('should start in ready-for-info state', () => {
-    const { machine, sceneInfra, rustContext, kclManager } = createTestMachine()
+    const { machine, sceneInfra, rustContext, executingEditor } =
+      createTestMachine()
     const actor = createActor(machine, {
       input: {
         sceneInfra,
         rustContext,
-        kclManager,
+        executingEditor,
         sketchId: 0,
       },
     }).start()
@@ -85,18 +86,19 @@ describe('tangentialArcTool - XState', () => {
       [1, 2, 3, 4]
     )
 
-    const { machine, sceneInfra, rustContext, kclManager } = createTestMachine({
-      createArc: async () => ({
-        kclSource: { text: 'create' },
-        sceneGraphDelta: createResult,
-      }),
-    })
+    const { machine, sceneInfra, rustContext, executingEditor } =
+      createTestMachine({
+        createArc: async () => ({
+          kclSource: { text: 'create' },
+          sceneGraphDelta: createResult,
+        }),
+      })
 
     const actor = createActor(machine, {
       input: {
         sceneInfra,
         rustContext,
-        kclManager,
+        executingEditor,
         sketchId: 0,
       },
     }).start()
@@ -124,22 +126,23 @@ describe('tangentialArcTool - XState', () => {
       [1, 2, 3, 4]
     )
 
-    const { machine, sceneInfra, rustContext, kclManager } = createTestMachine({
-      createArc: async () => ({
-        kclSource: { text: 'create' },
-        sceneGraphDelta: createResult,
-      }),
-      finalizeArc: async () => ({
-        kclSource: { text: 'finalize' },
-        sceneGraphDelta: createResult,
-      }),
-    })
+    const { machine, sceneInfra, rustContext, executingEditor } =
+      createTestMachine({
+        createArc: async () => ({
+          kclSource: { text: 'create' },
+          sceneGraphDelta: createResult,
+        }),
+        finalizeArc: async () => ({
+          kclSource: { text: 'finalize' },
+          sceneGraphDelta: createResult,
+        }),
+      })
 
     const actor = createActor(machine, {
       input: {
         sceneInfra,
         rustContext,
-        kclManager,
+        executingEditor,
         sketchId: 0,
       },
     }).start()

--- a/src/machines/sketchSolve/tools/tangentialArcToolDiagram.ts
+++ b/src/machines/sketchSolve/tools/tangentialArcToolDiagram.ts
@@ -55,7 +55,7 @@ export const machine = setup({
     arcEndPointId: undefined,
     sceneInfra: input.sceneInfra,
     rustContext: input.rustContext,
-    kclManager: input.kclManager,
+    executingEditor: input.executingEditor,
     sketchId: input.sketchId || 0,
   }),
   id: toolId,
@@ -101,7 +101,7 @@ export const machine = setup({
           return {
             tangentInfo: context.tangentInfo,
             rustContext: context.rustContext,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             sketchId: context.sketchId,
           }
         },
@@ -171,7 +171,7 @@ export const machine = setup({
             endSnapTarget: event.snapTarget,
             tangentInfo: context.tangentInfo,
             rustContext: context.rustContext,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             sketchId: context.sketchId,
           }
         },

--- a/src/machines/sketchSolve/tools/tangentialArcToolImpl.spec.ts
+++ b/src/machines/sketchSolve/tools/tangentialArcToolImpl.spec.ts
@@ -4,7 +4,7 @@ import { SKETCH_SOLVE_SNAPPING_PREVIEW_SPRITE } from '@src/machines/sketchSolve/
 import {
   createArcApiObject,
   createLineApiObject,
-  createMockKclManager,
+  createMockExecutingEditor,
   createMockRustContext,
   createMockSceneInfra,
   createPointApiObject,
@@ -324,7 +324,7 @@ describe('tangentialArcToolImpl', () => {
   describe('finalizeArcActor', () => {
     it('adds a coincident constraint for a snapped free endpoint before tangent constraints', async () => {
       const rustContext = createMockRustContext()
-      const kclManager = createMockKclManager()
+      const executingEditor = createMockExecutingEditor()
       const addConstraintSpy = vi.spyOn(rustContext, 'addConstraint')
       const center = createPointApiObject({ id: 1, x: 0, y: 1 })
       const start = createPointApiObject({ id: 2, x: 0, y: 0 })
@@ -362,7 +362,7 @@ describe('tangentialArcToolImpl', () => {
             tangentDirection: [1, 0],
           },
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 7,
         },
       })

--- a/src/machines/sketchSolve/tools/tangentialArcToolImpl.ts
+++ b/src/machines/sketchSolve/tools/tangentialArcToolImpl.ts
@@ -8,7 +8,7 @@ import type {
   OnMoveCallbackArgs,
   SceneInfra,
 } from '@src/clientSideScene/sceneInfra'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import type { Coords2d } from '@src/lang/util'
 import { baseUnitToNumericSuffix } from '@src/lang/wasm'
 import type RustContext from '@src/lib/rustContext'
@@ -93,7 +93,7 @@ export type ToolContext = {
   arcEndPointId?: number
   sceneInfra: SceneInfra
   rustContext: RustContext
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   sketchId: number
 }
 
@@ -508,7 +508,7 @@ export function animateArcEndPointListener({ self, context }: ToolActionArgs) {
       )
 
       const units = baseUnitToNumericSuffix(
-        context.kclManager.fileSettings.defaultLengthUnit
+        context.executingEditor.fileSettings.defaultLengthUnit
       )
 
       try {
@@ -730,7 +730,7 @@ export async function createArcActor({
     | {
         tangentInfo: TangentInfo
         rustContext: RustContext
-        kclManager: KclManager
+        executingEditor: ExecutingEditor
         sketchId: number
       }
     | {
@@ -749,7 +749,7 @@ export async function createArcActor({
     return { error: input.error }
   }
 
-  const { tangentInfo, rustContext, kclManager, sketchId } = input
+  const { tangentInfo, rustContext, executingEditor, sketchId } = input
   const startPoint = tangentInfo.tangentStart.position
   const tangentDirection = tangentInfo.tangentDirection
   const tangentUnit = normalizeVec(tangentDirection)
@@ -760,7 +760,7 @@ export async function createArcActor({
   const normal = perpendicular(tangentUnit)
   const centerPoint = addVec(startPoint, normal)
   const units = baseUnitToNumericSuffix(
-    kclManager.fileSettings.defaultLengthUnit
+    executingEditor.fileSettings.defaultLengthUnit
   )
 
   try {
@@ -805,7 +805,7 @@ export async function finalizeArcActor({
         endSnapTarget?: SnapTarget
         tangentInfo: TangentInfo
         rustContext: RustContext
-        kclManager: KclManager
+        executingEditor: ExecutingEditor
         sketchId: number
       }
     | {
@@ -831,7 +831,7 @@ export async function finalizeArcActor({
     endSnapTarget,
     tangentInfo,
     rustContext,
-    kclManager,
+    executingEditor,
     sketchId,
   } = input
   const startPoint = tangentInfo.tangentStart.position
@@ -856,7 +856,7 @@ export async function finalizeArcActor({
   )
 
   const units = baseUnitToNumericSuffix(
-    kclManager.fileSettings.defaultLengthUnit
+    executingEditor.fileSettings.defaultLengthUnit
   )
 
   try {

--- a/src/machines/sketchSolve/tools/threePointArcToolDiagram.ts
+++ b/src/machines/sketchSolve/tools/threePointArcToolDiagram.ts
@@ -66,7 +66,7 @@ export const machine = setup({
     arcEndPointId: undefined,
     sceneInfra: input.sceneInfra,
     rustContext: input.rustContext,
-    kclManager: input.kclManager,
+    executingEditor: input.executingEditor,
     sketchId: input.sketchId || 0,
   }),
   id: toolId,
@@ -105,7 +105,7 @@ export const machine = setup({
             point: event.data,
             snapTarget: event.snapTarget,
             rustContext: context.rustContext,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             sketchId: context.sketchId,
           }
         },
@@ -152,7 +152,7 @@ export const machine = setup({
             point: event.data,
             snapTarget: event.snapTarget,
             rustContext: context.rustContext,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             sketchId: context.sketchId,
           }
         },
@@ -185,7 +185,7 @@ export const machine = setup({
             startPoint: context.startPoint,
             throughPoint: context.throughPoint,
             rustContext: context.rustContext,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             sketchId: context.sketchId,
           }
         },
@@ -252,7 +252,7 @@ export const machine = setup({
             endPoint: event.data,
             endSnapTarget: event.snapTarget,
             rustContext: context.rustContext,
-            kclManager: context.kclManager,
+            executingEditor: context.executingEditor,
             sketchId: context.sketchId,
           }
         },

--- a/src/machines/sketchSolve/tools/threePointArcToolImpl.spec.ts
+++ b/src/machines/sketchSolve/tools/threePointArcToolImpl.spec.ts
@@ -10,7 +10,7 @@ vi.mock('@rust/kcl-wasm-lib/pkg/kcl_wasm_lib', () => ({
 
 import {
   createArcApiObject,
-  createMockKclManager,
+  createMockExecutingEditor,
   createMockRustContext,
   createPointApiObject,
   createSceneGraphDelta,
@@ -24,7 +24,7 @@ describe('threePointArcToolImpl', () => {
   describe('addDraftPointActor', () => {
     it('adds a coincident constraint when the draft point is snapped', async () => {
       const rustContext = createMockRustContext()
-      const kclManager = createMockKclManager()
+      const executingEditor = createMockExecutingEditor()
       const addConstraintSpy = vi.spyOn(rustContext, 'addConstraint')
       ;(rustContext.addSegment as any).mockResolvedValue({
         kclSource: { text: 'point' },
@@ -43,7 +43,7 @@ describe('threePointArcToolImpl', () => {
           point: [10, 20],
           snapTarget: { type: 'origin' },
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 7,
         },
       })
@@ -72,7 +72,7 @@ describe('threePointArcToolImpl', () => {
   describe('finalizeArcActor', () => {
     it('adds a coincident constraint for the snapped end point before cleanup', async () => {
       const rustContext = createMockRustContext()
-      const kclManager = createMockKclManager()
+      const executingEditor = createMockExecutingEditor()
       const addConstraintSpy = vi.spyOn(rustContext, 'addConstraint')
       const deleteObjectsSpy = vi.spyOn(rustContext, 'deleteObjects')
       const center = createPointApiObject({ id: 4, x: 1, y: 0 })
@@ -110,7 +110,7 @@ describe('threePointArcToolImpl', () => {
           endPoint: [2, 0],
           endSnapTarget: { type: 'point', id: 99 },
           rustContext,
-          kclManager,
+          executingEditor,
           sketchId: 7,
         },
       })

--- a/src/machines/sketchSolve/tools/threePointArcToolImpl.ts
+++ b/src/machines/sketchSolve/tools/threePointArcToolImpl.ts
@@ -5,7 +5,7 @@ import type {
 } from '@rust/kcl-lib/bindings/FrontendApi'
 import { calculate_circle_from_3_points } from '@rust/kcl-wasm-lib/pkg/kcl_wasm_lib'
 import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import type { Coords2d } from '@src/lang/util'
 import { baseUnitToNumericSuffix } from '@src/lang/wasm'
 import type RustContext from '@src/lib/rustContext'
@@ -93,7 +93,7 @@ export type ToolContext = {
   arcEndPointId?: number
   sceneInfra: SceneInfra
   rustContext: RustContext
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   sketchId: number
 }
 
@@ -202,7 +202,7 @@ async function editArcWithThreePoints({
   endPoint,
   throughPoint,
   rustContext,
-  kclManager,
+  executingEditor,
   sketchId,
   settings,
   commitSolverResults = true,
@@ -212,7 +212,7 @@ async function editArcWithThreePoints({
   endPoint: Coords2d
   throughPoint: Coords2d
   rustContext: RustContext
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   sketchId: number
   settings: Awaited<ReturnType<typeof jsAppSettings>>
   commitSolverResults?: boolean
@@ -241,7 +241,7 @@ async function editArcWithThreePoints({
   })
 
   const units = baseUnitToNumericSuffix(
-    kclManager.fileSettings.defaultLengthUnit
+    executingEditor.fileSettings.defaultLengthUnit
   )
 
   return rustContext.editSegments(
@@ -424,7 +424,7 @@ export function animateArcEndPointListener({ self, context }: ToolActionArgs) {
           endPoint: [twoD.x, twoD.y],
           throughPoint,
           rustContext: context.rustContext,
-          kclManager: context.kclManager,
+          executingEditor: context.executingEditor,
           sketchId: context.sketchId,
           settings: cachedSettings,
           commitSolverResults: false,
@@ -587,7 +587,7 @@ export async function addDraftPointActor({
         point: Coords2d
         snapTarget?: SnapTarget
         rustContext: RustContext
-        kclManager: KclManager
+        executingEditor: ExecutingEditor
         sketchId: number
       }
     | {
@@ -598,9 +598,9 @@ export async function addDraftPointActor({
     return { error: input.error }
   }
 
-  const { point, snapTarget, rustContext, kclManager, sketchId } = input
+  const { point, snapTarget, rustContext, executingEditor, sketchId } = input
   const units = baseUnitToNumericSuffix(
-    kclManager.fileSettings.defaultLengthUnit
+    executingEditor.fileSettings.defaultLengthUnit
   )
   const settings = jsAppSettings(rustContext.settingsActor)
 
@@ -663,7 +663,7 @@ export async function createArcActor({
         startPoint: Coords2d
         throughPoint: Coords2d
         rustContext: RustContext
-        kclManager: KclManager
+        executingEditor: ExecutingEditor
         sketchId: number
       }
     | {
@@ -674,9 +674,10 @@ export async function createArcActor({
     return { error: input.error }
   }
 
-  const { startPoint, throughPoint, rustContext, kclManager, sketchId } = input
+  const { startPoint, throughPoint, rustContext, executingEditor, sketchId } =
+    input
   const units = baseUnitToNumericSuffix(
-    kclManager.fileSettings.defaultLengthUnit
+    executingEditor.fileSettings.defaultLengthUnit
   )
   const settings = jsAppSettings(rustContext.settingsActor)
 
@@ -732,7 +733,7 @@ export async function finalizeArcActor({
         endPoint: Coords2d
         endSnapTarget?: SnapTarget
         rustContext: RustContext
-        kclManager: KclManager
+        executingEditor: ExecutingEditor
         sketchId: number
       }
     | {
@@ -759,7 +760,7 @@ export async function finalizeArcActor({
     endPoint,
     endSnapTarget,
     rustContext,
-    kclManager,
+    executingEditor,
     sketchId,
   } = input
 
@@ -770,7 +771,7 @@ export async function finalizeArcActor({
     endPoint,
     throughPoint,
     rustContext,
-    kclManager,
+    executingEditor,
     sketchId,
     settings,
   })

--- a/src/machines/sketchSolve/tools/trimToolDiagram.ts
+++ b/src/machines/sketchSolve/tools/trimToolDiagram.ts
@@ -6,7 +6,7 @@ import type {
 } from '@rust/kcl-lib/bindings/FrontendApi'
 import type { SceneInfra } from '@src/clientSideScene/sceneInfra'
 import { SKETCH_SOLVE_GROUP } from '@src/clientSideScene/sceneUtils'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { TRIM_PREVIEW_LINE_COLOR_HEX } from '@src/lib/constants'
 import { getTrimPreviewLineWidth } from '@src/lib/freehandLineDrawing'
 import type RustContext from '@src/lib/rustContext'
@@ -34,7 +34,7 @@ export const machine = setup({
     context: {} as {
       sceneInfra: SceneInfra
       rustContext: RustContext
-      kclManager: KclManager
+      executingEditor: ExecutingEditor
       sketchId: number
       sceneGraphDelta?: SceneGraphDelta
       trimPoints: Vector3[]
@@ -46,7 +46,7 @@ export const machine = setup({
     input: {} as {
       sceneInfra: SceneInfra
       rustContext: RustContext
-      kclManager: KclManager
+      executingEditor: ExecutingEditor
       sketchId: number
       sceneGraphDelta?: SceneGraphDelta
     },
@@ -387,7 +387,7 @@ export const machine = setup({
   context: ({ input }) => ({
     sceneInfra: input.sceneInfra,
     rustContext: input.rustContext,
-    kclManager: input.kclManager,
+    executingEditor: input.executingEditor,
     sketchId: input.sketchId,
     sceneGraphDelta: input.sceneGraphDelta,
     trimPoints: [],

--- a/src/menu/register.ts
+++ b/src/menu/register.ts
@@ -1,4 +1,4 @@
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { AxisNames } from '@src/lib/constants'
 import { PATHS } from '@src/lib/paths'
 import type { SettingsType } from '@src/lib/settings/initialSettings'
@@ -17,7 +17,7 @@ export function modelingMenuCallbackMostActions({
   filePath,
   authActor,
   commandBarActor,
-  kclManager,
+  executingEditor,
   settingsActor,
 }: {
   settings: SettingsType
@@ -25,7 +25,7 @@ export function modelingMenuCallbackMostActions({
   filePath: string | undefined
   authActor: ActorRefFrom<typeof authMachine>
   commandBarActor: ActorRefFrom<typeof commandBarMachine>
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   settingsActor: SettingsActorType
 }) {
   // Menu listeners
@@ -158,13 +158,13 @@ export function modelingMenuCallbackMostActions({
         // Cleaner, but can't import 'electron' to this file:
         // webContents.getFocusedWebContents()?.undo()
       } else {
-        kclManager.undo()
+        executingEditor.undo()
       }
     } else if (data.menuLabel === 'Edit.Redo') {
       if (activeFocusIsInput()) {
         document.execCommand('redo')
       } else {
-        kclManager.redo()
+        executingEditor.redo()
       }
     } else if (data.menuLabel === 'View.Orthographic view') {
       settingsActor.send({
@@ -183,38 +183,38 @@ export function modelingMenuCallbackMostActions({
         },
       })
     } else if (data.menuLabel === 'View.Standard views.Right view') {
-      kclManager.sceneInfra.camControls
+      executingEditor.sceneInfra.camControls
         .updateCameraToAxis(AxisNames.X)
         .catch(reportRejection)
     } else if (data.menuLabel === 'View.Standard views.Back view') {
-      kclManager.sceneInfra.camControls
+      executingEditor.sceneInfra.camControls
         .updateCameraToAxis(AxisNames.Y)
         .catch(reportRejection)
     } else if (data.menuLabel === 'View.Standard views.Top view') {
-      kclManager.sceneInfra.camControls
+      executingEditor.sceneInfra.camControls
         .updateCameraToAxis(AxisNames.Z)
         .catch(reportRejection)
     } else if (data.menuLabel === 'View.Standard views.Left view') {
-      kclManager.sceneInfra.camControls
+      executingEditor.sceneInfra.camControls
         .updateCameraToAxis(AxisNames.NEG_X)
         .catch(reportRejection)
     } else if (data.menuLabel === 'View.Standard views.Front view') {
-      kclManager.sceneInfra.camControls
+      executingEditor.sceneInfra.camControls
         .updateCameraToAxis(AxisNames.NEG_Y)
         .catch(reportRejection)
     } else if (data.menuLabel === 'View.Standard views.Bottom view') {
-      kclManager.sceneInfra.camControls
+      executingEditor.sceneInfra.camControls
         .updateCameraToAxis(AxisNames.NEG_Z)
         .catch(reportRejection)
     } else if (data.menuLabel === 'View.Standard views.Reset view') {
-      kclManager.sceneInfra.camControls
+      executingEditor.sceneInfra.camControls
         .resetCameraPosition()
         .catch(reportRejection)
     } else if (
       data.menuLabel === 'View.Standard views.Center view on selection'
     ) {
       // Gotcha: out of band from modelingMachineProvider, has no state or extra workflows. I am taking the function's logic and porting it here.
-      kclManager.engineCommandManager
+      executingEditor.engineCommandManager
         .sendSceneCommand({
           type: 'modeling_cmd_req',
           cmd_id: uuidv4(),

--- a/src/registry/contracts/executingEditor.ts
+++ b/src/registry/contracts/executingEditor.ts
@@ -1,5 +1,6 @@
 import { defineContract, defineService } from '@kittycad/registry'
 import type { ReadonlySignal } from '@preact/signals-core'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 
 export interface ExecutingEditorUpdateOptions {
   shouldExecute?: boolean
@@ -10,6 +11,7 @@ export interface ExecutingEditorUpdateOptions {
 }
 
 export interface ExecutingEditorService {
+  readonly executingEditor: ExecutingEditor
   readonly code: ReadonlySignal<string>
   readonly hasEditsSinceLastExecution: ReadonlySignal<boolean>
   readonly isExecuting: ReadonlySignal<boolean>

--- a/src/registry/extensions/commands/index.spec.ts
+++ b/src/registry/extensions/commands/index.spec.ts
@@ -4,7 +4,7 @@ import {
   defineRegistryItem,
   provideService,
 } from '@kittycad/registry'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { MachineManager } from '@src/lib/MachineManager'
 import type { Command } from '@src/lib/commandTypes'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
@@ -20,10 +20,10 @@ import { commandsExtension } from '.'
 import { TOOLBAR_COMMAND_IDS, toolbarCommands } from './toolbarCommands'
 
 function createCommandBarContext({
-  kclManager,
+  executingEditor,
   userFeatures,
 }: {
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   userFeatures?: NonNullable<CommandBarContext['userFeatures']>
 }): CommandBarContext {
   const context: CommandBarContext = {
@@ -31,7 +31,7 @@ function createCommandBarContext({
     wasmInstancePromise: Promise.resolve({} as ModuleType),
     machineManager: new MachineManager(),
     argumentsToSubmit: {},
-    kclManager,
+    executingEditor,
   }
 
   if (userFeatures) {
@@ -89,9 +89,9 @@ describe('commands extension', () => {
     )
   })
 
-  it('runs toolbar commands against the KclManager from command input', () => {
+  it('runs toolbar commands against the ExecutingEditor from command input', () => {
     const sentEvents: unknown[] = []
-    const kclManager = {
+    const executingEditor = {
       modelingState: {
         matches: (state: unknown) => state === 'sketchSolveMode',
         context: { sketchSolveToolName: null },
@@ -100,7 +100,7 @@ describe('commands extension', () => {
         sentEvents.push(event)
         return true
       },
-    } as unknown as KclManager
+    } as unknown as ExecutingEditor
 
     const command = toolbarCommands.find(
       (candidate) => candidate.id === TOOLBAR_COMMAND_IDS.sketchSolve.line
@@ -108,7 +108,7 @@ describe('commands extension', () => {
 
     expect(
       command?.onSubmit({
-        context: { kclManager } as CommandBarContext,
+        context: { executingEditor } as CommandBarContext,
       })
     ).toBe(true)
     expect(sentEvents).toEqual([
@@ -118,7 +118,7 @@ describe('commands extension', () => {
 
   it('does not run experimental toolbar commands without the user feature flag', () => {
     const sentEvents: unknown[] = []
-    const kclManager = {
+    const executingEditor = {
       modelingState: {
         matches: (state: unknown) => state === 'sketchSolveMode',
         context: { sketchSolveToolName: null },
@@ -127,7 +127,7 @@ describe('commands extension', () => {
         sentEvents.push(event)
         return true
       },
-    } as unknown as KclManager
+    } as unknown as ExecutingEditor
 
     const command = toolbarCommands.find(
       (candidate) => candidate.id === TOOLBAR_COMMAND_IDS.sketchSolve.spline
@@ -136,7 +136,7 @@ describe('commands extension', () => {
     expect(command).toBeDefined()
     expect(
       command?.onSubmit({
-        context: createCommandBarContext({ kclManager }),
+        context: createCommandBarContext({ executingEditor }),
       })
     ).toBeUndefined()
     expect(sentEvents).toEqual([])
@@ -144,7 +144,7 @@ describe('commands extension', () => {
 
   it('runs experimental toolbar commands with the user feature flag', () => {
     const sentEvents: unknown[] = []
-    const kclManager = {
+    const executingEditor = {
       modelingState: {
         matches: (state: unknown) => state === 'sketchSolveMode',
         context: { sketchSolveToolName: null },
@@ -153,7 +153,7 @@ describe('commands extension', () => {
         sentEvents.push(event)
         return true
       },
-    } as unknown as KclManager
+    } as unknown as ExecutingEditor
     const userFeatures = {
       has: vi.fn(() => true),
     } satisfies NonNullable<CommandBarContext['userFeatures']>
@@ -165,7 +165,7 @@ describe('commands extension', () => {
     expect(command).toBeDefined()
     expect(
       command?.onSubmit({
-        context: createCommandBarContext({ kclManager, userFeatures }),
+        context: createCommandBarContext({ executingEditor, userFeatures }),
       })
     ).toBe(true)
     expect(sentEvents).toEqual([
@@ -175,7 +175,7 @@ describe('commands extension', () => {
 
   it('exits sketch solve mode while a sketch solve tool is equipped', () => {
     const sentEvents: unknown[] = []
-    const kclManager = {
+    const executingEditor = {
       modelingState: {
         matches: (state: unknown) => state === 'sketchSolveMode',
         context: { sketchSolveToolName: 'lineTool' },
@@ -184,7 +184,7 @@ describe('commands extension', () => {
         sentEvents.push(event)
         return true
       },
-    } as unknown as KclManager
+    } as unknown as ExecutingEditor
 
     const command = toolbarCommands.find(
       (candidate) => candidate.id === TOOLBAR_COMMAND_IDS.sketchSolve.exit
@@ -192,15 +192,15 @@ describe('commands extension', () => {
 
     expect(
       command?.onSubmit({
-        context: { kclManager } as CommandBarContext,
+        context: { executingEditor } as CommandBarContext,
       })
     ).toBe(true)
     expect(sentEvents).toEqual([{ type: 'Exit sketch' }])
   })
 
-  it('runs toolbar commands selected by keymaps against the command bar KclManager', () => {
+  it('runs toolbar commands selected by keymaps against the command bar ExecutingEditor', () => {
     const sentEvents: unknown[] = []
-    const kclManager = {
+    const executingEditor = {
       modelingState: {
         matches: (state: unknown) => state === 'sketchSolveMode',
         context: { sketchSolveToolName: null },
@@ -209,7 +209,7 @@ describe('commands extension', () => {
         sentEvents.push(event)
         return true
       },
-    } as unknown as KclManager
+    } as unknown as ExecutingEditor
     const command = toolbarCommands.find(
       (candidate) => candidate.id === TOOLBAR_COMMAND_IDS.sketchSolve.line
     )
@@ -237,9 +237,12 @@ describe('commands extension', () => {
     ])
 
     const commandSystem = registry.get(commandSystemService)
-    commandSystem.actor.send({ type: 'Set kclManager', data: kclManager })
-    expect(commandSystem.actor.getSnapshot().context.kclManager).toBe(
-      kclManager
+    commandSystem.actor.send({
+      type: 'Set executingEditor',
+      data: executingEditor,
+    })
+    expect(commandSystem.actor.getSnapshot().context.executingEditor).toBe(
+      executingEditor
     )
     commandSystem.send({
       type: 'Find and select command',

--- a/src/registry/extensions/commands/toolbarCommands.ts
+++ b/src/registry/extensions/commands/toolbarCommands.ts
@@ -1,4 +1,4 @@
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import {
   getSelectedSketchTarget,
   isCursorInFunctionDefinition,
@@ -134,7 +134,7 @@ const createToolbarCommand = ({
 
 // Temporary adapter between registry commands and the pre-registry modeling
 // runtime. Command submissions carry command bar context in `input`, including
-// the active KclManager while we wait for KclManager/modelingMachine to become
+// the active ExecutingEditor while we wait for ExecutingEditor/modelingMachine to become
 // registry services. Once those services exist, toolbar commands should consume
 // them directly and this helper layer can go away.
 function getCommandBarContext(input: unknown): CommandBarContext | undefined {
@@ -147,8 +147,8 @@ function getCommandBarContext(input: unknown): CommandBarContext | undefined {
     : undefined
 }
 
-function getKclManager(input: unknown): KclManager | undefined {
-  return getCommandBarContext(input)?.kclManager
+function getExecutingEditor(input: unknown): ExecutingEditor | undefined {
+  return getCommandBarContext(input)?.executingEditor
 }
 
 function getUserFeatures(input: unknown): CommandBarContext['userFeatures'] {
@@ -163,20 +163,20 @@ function hasSketchExperimentalFeatures(input: unknown): boolean {
 }
 
 function getModelingState(input: unknown): ModelingState | undefined {
-  return getKclManager(input)?.modelingState ?? undefined
+  return getExecutingEditor(input)?.modelingState ?? undefined
 }
 
 function sendModelingEvent(
   input: unknown,
   event: ModelingMachineEvent
 ): true | Error {
-  const kclManager = getKclManager(input)
+  const executingEditor = getExecutingEditor(input)
 
-  if (!kclManager?.modelingState) {
+  if (!executingEditor?.modelingState) {
     return new Error('No active modeling context')
   }
 
-  kclManager.sendModelingEvent(event)
+  executingEditor.sendModelingEvent(event)
   return true
 }
 
@@ -261,22 +261,22 @@ function createSketchSolveActionCommand({
 }
 
 async function enterSketch(input: unknown) {
-  const kclManager = getKclManager(input)
-  const state = kclManager?.modelingState
-  if (!kclManager || !state) {
+  const executingEditor = getExecutingEditor(input)
+  const state = executingEditor?.modelingState
+  if (!executingEditor || !state) {
     return new Error('No active modeling context')
   }
 
-  const wasmInstance = await kclManager.wasmInstancePromise
+  const wasmInstance = await executingEditor.wasmInstancePromise
   const cursorSelection = state.context.selectionRanges.graphSelections[0]
   const sketchPathId = isCursorInFunctionDefinition(
-    kclManager.ast,
+    executingEditor.ast,
     cursorSelection,
     wasmInstance
   )
     ? false
     : isCursorInSketchCommandRange(
-        kclManager.artifactGraph,
+        executingEditor.artifactGraph,
         state.context.selectionRanges
       )
   const isSketchBlock = isSketchBlockSelected(state.context.selectionRanges)
@@ -284,7 +284,7 @@ async function enterSketch(input: unknown) {
     state.context.selectionRanges
   )
 
-  if ((kclManager.editorView.hasFocus && sketchPathId) || isSketchBlock) {
+  if ((executingEditor.editorView.hasFocus && sketchPathId) || isSketchBlock) {
     return sendModelingEvent(input, { type: 'Enter sketch' })
   }
 
@@ -310,7 +310,7 @@ async function enterSketch(input: unknown) {
   void selectSketchPlane(
     selectedSketchTarget,
     state.context.store.useSketchSolveMode?.current,
-    kclManager
+    executingEditor
   )
 
   return result

--- a/src/registry/extensions/engineScene/SelectionFilterControls.tsx
+++ b/src/registry/extensions/engineScene/SelectionFilterControls.tsx
@@ -66,9 +66,9 @@ function getActiveSelectionFilterOption(filter: EntityType[]) {
 export function SelectionFilterControls() {
   useSignals()
   const { state } = useModelingContext()
-  const { kclManager, wasmInstance } = state.context
+  const { executingEditor, wasmInstance } = state.context
   const activeOption = getActiveSelectionFilterOption(
-    kclManager.selectionFilter.value
+    executingEditor.selectionFilter.value
   )
   const activeLabel = activeOption?.label ?? 'Custom'
 
@@ -80,13 +80,13 @@ export function SelectionFilterControls() {
       }
 
       if (option.filter) {
-        kclManager.setSelectionFilter(option.filter, wasmInstance)
+        executingEditor.setSelectionFilter(option.filter, wasmInstance)
       } else {
-        kclManager.setSelectionFilterToDefault(wasmInstance)
+        executingEditor.setSelectionFilterToDefault(wasmInstance)
       }
-      kclManager.clearSelection().catch(reportRejection)
+      executingEditor.clearSelection().catch(reportRejection)
     },
-    [kclManager, wasmInstance]
+    [executingEditor, wasmInstance]
   )
 
   return (

--- a/src/registry/extensions/engineScene/executionIndicator/index.test.ts
+++ b/src/registry/extensions/engineScene/executionIndicator/index.test.ts
@@ -17,6 +17,7 @@ function createExecutingEditorService(
   isExecuting = signal(false)
 ): ExecutingEditorService {
   return {
+    executingEditor: {} as ExecutingEditorService['executingEditor'],
     code: signal(''),
     hasEditsSinceLastExecution: signal(false),
     isExecuting,

--- a/src/registry/extensions/engineScene/index.spec.ts
+++ b/src/registry/extensions/engineScene/index.spec.ts
@@ -17,6 +17,7 @@ function createExecutingEditorService(
   showExperimentalFeaturesStatusBarItem = signal(true)
 ): ExecutingEditorService {
   return {
+    executingEditor: {} as ExecutingEditorService['executingEditor'],
     code: signal(''),
     hasEditsSinceLastExecution: signal(false),
     isExecuting,

--- a/src/registry/extensions/keymap/index.ts
+++ b/src/registry/extensions/keymap/index.ts
@@ -284,17 +284,17 @@ const keymapExtension = defineRegistryItemFactory((ctx) => {
   }
 
   const resetView = () => {
-    const kclManager = ctx.services
+    const executingEditor = ctx.services
       .optional(commandSystemService)
-      ?.actor.getSnapshot().context.kclManager
-    if (!kclManager) {
+      ?.actor.getSnapshot().context.executingEditor
+    if (!executingEditor) {
       return
     }
 
     resetCameraPosition({
-      sceneInfra: kclManager.sceneInfra,
-      engineCommandManager: kclManager.engineCommandManager,
-      settingsActor: kclManager.systemDeps.settings,
+      sceneInfra: executingEditor.sceneInfra,
+      engineCommandManager: executingEditor.engineCommandManager,
+      settingsActor: executingEditor.systemDeps.settings,
     }).catch(reportRejection)
   }
 

--- a/src/registry/plugins/codeEditor/index.ts
+++ b/src/registry/plugins/codeEditor/index.ts
@@ -45,7 +45,7 @@ function RenderHeaderItem({ app }: AppHeaderItemProps) {
 
       toast.success('Your work is auto-saved in real-time.')
     },
-    app.singletons.kclManager,
+    app.singletons.executingEditor,
     {
       enabled: !!currentProject,
       registerToCodeMirror: !!currentProject,

--- a/src/registry/plugins/codeEditor/index.ts
+++ b/src/registry/plugins/codeEditor/index.ts
@@ -45,7 +45,7 @@ function RenderHeaderItem({ app }: AppHeaderItemProps) {
 
       toast.success('Your work is auto-saved in real-time.')
     },
-    app.singletons.executingEditor,
+    executionService?.executingEditor,
     {
       enabled: !!currentProject,
       registerToCodeMirror: !!currentProject,

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -34,7 +34,7 @@ import {
   autoUpdateDownloadProgressSignal,
   autoUpdateReadySignal,
 } from '@src/lib/autoUpdate'
-import { useApp, useSingletons } from '@src/lib/boot'
+import { useApp } from '@src/lib/boot'
 import { isDesktop } from '@src/lib/isDesktop'
 import { openExternalBrowserIfDesktop } from '@src/lib/openWindow'
 import { PATHS } from '@src/lib/paths'
@@ -83,10 +83,9 @@ const Home = () => {
   useSignals()
   const { auth, billing, commands, settings, systemIOActor, registry } =
     useApp()
-  const { executingEditor } = useSingletons()
   const executingPath = useAbsoluteFilePath()
   const settingsActor = settings.actor
-  useQueryParamEffects(executingEditor)
+  useQueryParamEffects()
   const navigate = useNavigate()
   const readWriteProjectDir = useCanReadWriteProjectDirectory()
   const [nativeFileMenuCreated, setNativeFileMenuCreated] = useState(false)
@@ -213,11 +212,9 @@ const Home = () => {
   }
   useMenuListener(cb)
 
-  // Cancel all KCL executions while on the home page
   useEffect(() => {
     markOnce('code/didLoadHome')
-    executingEditor.cancelAllExecutions()
-  }, [executingEditor])
+  }, [])
 
   useHotkeys('backspace', (e) => {
     e.preventDefault()
@@ -257,7 +254,6 @@ const Home = () => {
                     acceptOnboarding({
                       onboardingStatus,
                       navigate,
-                      executingEditor,
                       systemIOActor,
                       settingsActor,
                       executingPath,

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -83,10 +83,10 @@ const Home = () => {
   useSignals()
   const { auth, billing, commands, settings, systemIOActor, registry } =
     useApp()
-  const { kclManager } = useSingletons()
+  const { executingEditor } = useSingletons()
   const executingPath = useAbsoluteFilePath()
   const settingsActor = settings.actor
-  useQueryParamEffects(kclManager)
+  useQueryParamEffects(executingEditor)
   const navigate = useNavigate()
   const readWriteProjectDir = useCanReadWriteProjectDirectory()
   const [nativeFileMenuCreated, setNativeFileMenuCreated] = useState(false)
@@ -216,8 +216,8 @@ const Home = () => {
   // Cancel all KCL executions while on the home page
   useEffect(() => {
     markOnce('code/didLoadHome')
-    kclManager.cancelAllExecutions()
-  }, [kclManager])
+    executingEditor.cancelAllExecutions()
+  }, [executingEditor])
 
   useHotkeys('backspace', (e) => {
     e.preventDefault()
@@ -257,7 +257,7 @@ const Home = () => {
                     acceptOnboarding({
                       onboardingStatus,
                       navigate,
-                      kclManager,
+                      executingEditor,
                       systemIOActor,
                       settingsActor,
                       executingPath,

--- a/src/routes/Onboarding/utils.tsx
+++ b/src/routes/Onboarding/utils.tsx
@@ -13,7 +13,6 @@ import { CustomIcon, type CustomIconName } from '@src/components/CustomIcon'
 import { Logo } from '@src/components/Logo'
 import Tooltip from '@src/components/Tooltip'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
-import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { useApp } from '@src/lib/boot'
 import {
   ONBOARDING_DATA_ATTRIBUTE,
@@ -321,7 +320,6 @@ export function OnboardingButtons({
 
 export interface OnboardingUtilDeps {
   onboardingStatus: OnboardingStatus
-  executingEditor: ExecutingEditor
   systemIOActor: SystemIOActor
   settingsActor: SettingsActorType
   navigate: NavigateFunction

--- a/src/routes/Onboarding/utils.tsx
+++ b/src/routes/Onboarding/utils.tsx
@@ -13,7 +13,7 @@ import { CustomIcon, type CustomIconName } from '@src/components/CustomIcon'
 import { Logo } from '@src/components/Logo'
 import Tooltip from '@src/components/Tooltip'
 import { useAbsoluteFilePath } from '@src/hooks/useAbsoluteFilePath'
-import type { KclManager } from '@src/lang/KclManager'
+import type { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import { useApp } from '@src/lib/boot'
 import {
   ONBOARDING_DATA_ATTRIBUTE,
@@ -321,7 +321,7 @@ export function OnboardingButtons({
 
 export interface OnboardingUtilDeps {
   onboardingStatus: OnboardingStatus
-  kclManager: KclManager
+  executingEditor: ExecutingEditor
   systemIOActor: SystemIOActor
   settingsActor: SettingsActorType
   navigate: NavigateFunction

--- a/src/unitTestUtils.ts
+++ b/src/unitTestUtils.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import { signal } from '@preact/signals-core'
 import env from '@src/env'
-import { KclManager } from '@src/lang/KclManager'
+import { ExecutingEditor } from '@src/lang/ExecutingEditor'
 import {
   ARG_ANGLE,
   ARG_END_ABSOLUTE_X,
@@ -85,7 +85,7 @@ export async function buildTheWorldAndConnectToEngine() {
     engineCommandManager,
     settingsActor
   )
-  const kclManager = new KclManager('some-file', '', {
+  const executingEditor = new ExecutingEditor('some-file', '', {
     wasmInstancePromise: instancePromise,
     settings: settingsActor,
     commandBar: commandBarActor,
@@ -95,7 +95,7 @@ export async function buildTheWorldAndConnectToEngine() {
   })
 
   await new Promise((resolve, reject) => {
-    kclManager.engineCommandManager
+    executingEditor.engineCommandManager
       .start({
         token: env().VITE_ZOO_API_TOKEN || '',
         width: 256,
@@ -115,15 +115,15 @@ export async function buildTheWorldAndConnectToEngine() {
             console.log('unit test connected!')
           }
         },
-        rustContext: kclManager.rustContext,
+        rustContext: executingEditor.rustContext,
       })
       .catch(reportRejection)
   })
   return {
     instance: await instancePromise,
-    engineCommandManager: kclManager.engineCommandManager,
-    rustContext: kclManager.rustContext,
-    kclManager,
+    engineCommandManager: executingEditor.engineCommandManager,
+    rustContext: executingEditor.rustContext,
+    executingEditor,
     commandBarActor,
     settingsActor,
     machineManager,
@@ -144,7 +144,7 @@ export async function loadWasm() {
  * "Building the world" in Node consists of only the WASM module.
  *
  * Must use for Node integration tests, because some non-Node systems
- * like `kclManager.editorView` rely on browser window APIs that break in Node
+ * like `executingEditor.editorView` rely on browser window APIs that break in Node
  * testing environments.
  */
 export async function buildTheWorldNode() {
@@ -181,7 +181,7 @@ export async function buildTheWorldAndNoEngineConnection(mockWasm = false) {
     engineCommandManager,
     settingsActor
   )
-  const kclManager = new KclManager('some-file', '', {
+  const executingEditor = new ExecutingEditor('some-file', '', {
     wasmInstancePromise: instancePromise,
     settings: settingsActor,
     commandBar: commandBarActor,
@@ -194,11 +194,11 @@ export async function buildTheWorldAndNoEngineConnection(mockWasm = false) {
 
   return {
     instance: await instancePromise,
-    engineCommandManager: kclManager.engineCommandManager,
-    rustContext: kclManager.rustContext,
-    sceneInfra: kclManager.sceneInfra,
-    kclManager,
-    sceneEntitiesManager: kclManager.sceneEntitiesManager,
+    engineCommandManager: executingEditor.engineCommandManager,
+    rustContext: executingEditor.rustContext,
+    sceneInfra: executingEditor.sceneInfra,
+    executingEditor,
+    sceneEntitiesManager: executingEditor.sceneEntitiesManager,
     commandBarActor,
     settingsActor,
     machineManager,


### PR DESCRIPTION
This refactors the old `KclManager` singleton path into an optional `executingEditorService`, with `KclManager` renamed to `ExecutingEditor` to match its current role. Codex assisted. Closes #9956, towards #6836. This should be a pure refactor, and introduce no new behavior.

Key changes:
- Removes app-level `singletons` usage and migrates consumers to the optional executing editor service.
- Defers executing editor creation until a project/file route is opened.
- Reuses an already-open project when navigating between files in the same project.
- Ensures file navigation replaces the active executing editor, closes stale editors, and executes the newly active file when the engine is connected.
- Cleans up project subscriptions, editor DOM mounting, and executing editor teardown.
- Guards cube gizmo WebGL initialization so renderer failures do not become full-page route errors.