### PR TITLE
Move zookeeper area definition into its own plugin, add setting to toggle on timing debugging

### DIFF
--- a/src/components/ExchangeCard.tsx
+++ b/src/components/ExchangeCard.tsx
@@ -1,22 +1,24 @@
 import type { MlCopilotServerMessage } from '@kittycad/lib'
 import { CustomIcon } from '@src/components/CustomIcon'
+import { MarkdownText } from '@src/components/MarkdownText'
+import { PlaceholderLine } from '@src/components/PlaceholderLine'
 import { Thinking } from '@src/components/Thinking'
+import Tooltip from '@src/components/Tooltip'
 import {
   type Exchange,
+  type ZookeeperDebugTimingSpan,
+  formatZookeeperDebugTimingSpan,
   isMlCopilotUserRequest,
 } from '@src/machines/mlEphantManagerMachine'
 import ms from 'ms'
 import {
-  useEffect,
-  useState,
-  type ReactNode,
   type ComponentProps,
+  type ReactNode,
+  useEffect,
   useMemo,
+  useState,
 } from 'react'
-import Tooltip from '@src/components/Tooltip'
 import toast from 'react-hot-toast'
-import { PlaceholderLine } from '@src/components/PlaceholderLine'
-import { MarkdownText } from '@src/components/MarkdownText'
 
 export type ExchangeCardProps = Exchange & {
   userAvatar?: string
@@ -168,6 +170,34 @@ export const ExchangeCardStatus = (props: {
           ) : null}
         </div>
       )}
+    </div>
+  )
+}
+
+const ZookeeperDebugTimings = (props: {
+  timings?: ZookeeperDebugTimingSpan[]
+}) => {
+  if (!props.timings || props.timings.length === 0) {
+    return null
+  }
+
+  return (
+    <div
+      className="ml-9 mt-2 rounded-sm border border-chalkboard-20 dark:border-chalkboard-80 bg-chalkboard-10/50 dark:bg-chalkboard-90/50 p-2 text-[11px] leading-4 text-chalkboard-70 dark:text-chalkboard-40"
+      data-testid="zookeeper-debug-timings"
+    >
+      <div className="font-medium text-chalkboard-80 dark:text-chalkboard-30">
+        Client debug timings
+      </div>
+      <ul className="m-0 list-none p-0">
+        {props.timings.map((timing) => (
+          <li
+            key={`${timing.startedAt}-${timing.endedAt}-${timing.from}-${timing.to}`}
+          >
+            {formatZookeeperDebugTimingSpan(timing)}
+          </li>
+        ))}
+      </ul>
     </div>
   )
 }
@@ -449,6 +479,7 @@ export const ExchangeCard = (props: ExchangeCardProps) => {
             startedAt={startedAt}
             updatedAt={updatedAt}
           />
+          <ZookeeperDebugTimings timings={props.debugTimings} />
         </div>
       )}
       {reasoningThoughts.length > 0 && (

--- a/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
+++ b/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
@@ -7,14 +7,29 @@ import { useModelingContext } from '@src/hooks/useModelingContext'
 import { useApp, useSingletons } from '@src/lib/boot'
 import { browserSaveFile } from '@src/lib/browserSaveFile'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
+import type { Setting, SettingsType } from '@src/lib/settings/initialSettings'
 import { BillingTransition } from '@src/machines/billingMachine'
 import {
   MlEphantConversationToMarkdown,
   MlEphantManagerReactContext,
+  MlEphantManagerTransitions,
 } from '@src/machines/mlEphantManagerMachine'
+import { useEffect } from 'react'
 // Yea, feels bad, but literally every other pane is doing this.
 // TODO: Don't use CSS module for this? More generic module?
 import styles from './KclEditorMenu.module.css'
+
+type ZookeeperSettings = SettingsType & {
+  zookeeper?: {
+    debugTiming?: Setting<boolean>
+  }
+}
+
+function getZookeeperDebugTimingSetting(settings: SettingsType) {
+  return Boolean(
+    (settings as ZookeeperSettings).zookeeper?.debugTiming?.current
+  )
+}
 
 export function MlEphantConversationPaneWrapper(props: AreaTypeComponentProps) {
   useSignals()
@@ -30,6 +45,14 @@ export function MlEphantConversationPaneWrapper(props: AreaTypeComponentProps) {
   } = useModelingContext()
   const loaderFile = project?.executingFileEntry.value
   const mlEphantManagerActor = MlEphantManagerReactContext.useActorRef()
+  const zookeeperDebugTiming = getZookeeperDebugTimingSetting(settingsValues)
+
+  useEffect(() => {
+    mlEphantManagerActor.send({
+      type: MlEphantManagerTransitions.DebugTimingSet,
+      enabled: zookeeperDebugTiming,
+    })
+  }, [mlEphantManagerActor, zookeeperDebugTiming])
 
   const sendBillingUpdate = () => {
     billing.send({

--- a/src/lib/layout/configs/default.ts
+++ b/src/lib/layout/configs/default.ts
@@ -1,12 +1,11 @@
 import { isDesktop } from '@src/lib/isDesktop'
 import { isMobile } from '@src/lib/isMobile'
 import {
+  type Action,
   ActionType,
   AreaType,
-  LayoutType,
-  type Action,
-  type PaneChild,
   type Layout,
+  LayoutType,
   type PaneLayout,
 } from '@src/lib/layout/types'
 
@@ -50,17 +49,6 @@ const primaryPane: Layout = {
   sizes: isDesktop() ? [50, 50] : [100],
   splitOrientation: 'block',
   children: [
-    ...(isMobile()
-      ? [
-          {
-            id: DefaultLayoutPaneID.TTC,
-            label: 'Zookeeper',
-            type: LayoutType.Simple,
-            areaType: AreaType.TTC,
-            icon: 'sparkles',
-          } satisfies PaneChild,
-        ]
-      : []),
     {
       id: DefaultLayoutPaneID.FeatureTree,
       label: 'Feature Tree',
@@ -147,24 +135,6 @@ const modelingPane: Layout = {
   type: LayoutType.Simple,
   areaType: AreaType.ModelingScene,
 }
-const secondaryPane: Layout = {
-  id: DefaultLayoutToolbarID.Right,
-  label: DefaultLayoutToolbarID.Right,
-  type: LayoutType.Panes,
-  side: 'inline-end',
-  activeIndices: [0],
-  sizes: [100],
-  splitOrientation: 'block',
-  children: [
-    {
-      id: DefaultLayoutPaneID.TTC,
-      label: 'Zookeeper',
-      type: LayoutType.Simple,
-      areaType: AreaType.TTC,
-      icon: 'sparkles',
-    },
-  ],
-}
 
 /**
  * The default layout has:
@@ -173,16 +143,14 @@ const secondaryPane: Layout = {
  *   - code
  *   - variables
  * - the modeling view
- * - a right (in LTR languages) sidebar with:
- *   - Zookeeper
  */
 export const defaultLayoutConfig: Layout = {
   id: 'default',
   label: 'root',
   type: LayoutType.Splits,
   orientation: isMobile() ? 'block' : 'inline',
-  sizes: isMobile() ? [50, 50] : [20, 50, 30],
+  sizes: isMobile() ? [50, 50] : [20, 80],
   children: isMobile()
     ? [modelingPane, primaryPane]
-    : [primaryPane, modelingPane, secondaryPane],
+    : [primaryPane, modelingPane],
 }

--- a/src/lib/layout/defaultAreaLibrary.tsx
+++ b/src/lib/layout/defaultAreaLibrary.tsx
@@ -1,26 +1,25 @@
-import { useApp, useSingletons } from '@src/lib/boot'
-import { ConnectionStream } from '@src/components/ConnectionStream'
-import Gizmo from '@src/components/gizmo/Gizmo'
+import { useSignals } from '@preact/signals-react/runtime'
 import { Toolbar } from '@src/Toolbar'
-import type { AreaLibrary, AreaTypeDefinition } from '@src/lib/layout/types'
+import { DEFAULT_SKETCH_SOLVE_STREAM_DIMMING } from '@src/clientSideScene/ClientSideSceneComp'
+import { ConnectionStream } from '@src/components/ConnectionStream'
+import { CustomIcon } from '@src/components/CustomIcon'
+import Gizmo from '@src/components/gizmo/Gizmo'
+import { BodiesPane } from '@src/components/layout/areas/BodiesPane'
+import { DebugPane } from '@src/components/layout/areas/DebugPane'
+import { FeatureTreePane } from '@src/components/layout/areas/FeatureTreePane'
+import { KclEditorPane } from '@src/components/layout/areas/KclEditorPane'
+import { LogsPane } from '@src/components/layout/areas/LoggingPanes'
+import { MemoryPane } from '@src/components/layout/areas/MemoryPane'
+import { ProjectExplorerPane } from '@src/components/layout/areas/ProjectExplorerPane'
+import { useModelingContext } from '@src/hooks/useModelingContext'
 import { kclErrorsByFilename } from '@src/lang/errors'
+import { useApp, useSingletons } from '@src/lib/boot'
+import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
+import type { AreaLibrary, AreaTypeDefinition } from '@src/lib/layout/types'
+import { togglePaneLayoutNode } from '@src/lib/layout/utils'
+import { layoutAreaLibraryValueSpec } from '@src/registry/contracts/layout'
 import type { MouseEventHandler } from 'react'
 import { useCallback, useMemo, useState } from 'react'
-import { togglePaneLayoutNode } from '@src/lib/layout/utils'
-import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
-import { ProjectExplorerPane } from '@src/components/layout/areas/ProjectExplorerPane'
-import { KclEditorPane } from '@src/components/layout/areas/KclEditorPane'
-import { MlEphantConversationPaneWrapper } from '@src/components/layout/areas/MlEphantConversationPaneWrapper'
-import { FeatureTreePane } from '@src/components/layout/areas/FeatureTreePane'
-import { MemoryPane } from '@src/components/layout/areas/MemoryPane'
-import { LogsPane } from '@src/components/layout/areas/LoggingPanes'
-import { DebugPane } from '@src/components/layout/areas/DebugPane'
-import { BodiesPane } from '@src/components/layout/areas/BodiesPane'
-import { useSignals } from '@preact/signals-react/runtime'
-import { useModelingContext } from '@src/hooks/useModelingContext'
-import { DEFAULT_SKETCH_SOLVE_STREAM_DIMMING } from '@src/clientSideScene/ClientSideSceneComp'
-import { CustomIcon } from '@src/components/CustomIcon'
-import { layoutAreaLibraryValueSpec } from '@src/registry/contracts/layout'
 
 function ModelingArea() {
   const { auth } = useApp()
@@ -127,15 +126,6 @@ export const useDefaultAreaLibrary = () => {
           hide: () => false,
           Component: ModelingArea,
         },
-        ttc: {
-          hide: () => false,
-          shortcut: 'Ctrl + T',
-          cssClassOverrides: {
-            button:
-              'bg-ml-green pressed:bg-transparent dark:!text-chalkboard-100 hover:dark:!text-inherit dark:pressed:!text-inherit',
-          },
-          Component: MlEphantConversationPaneWrapper,
-        },
         codeEditor: {
           hide: () => false,
           shortcut: 'Shift + C',
@@ -162,7 +152,7 @@ export const useDefaultAreaLibrary = () => {
             // Only compute runtime errors! Compilation errors are not tracked here.
             const errors = kclErrorsByFilename(kclManager.errorsSignal.value)
             const value = errors.size > 0 ? 'x' : ''
-            const onClick: MouseEventHandler = (e) => {
+            const onClick: MouseEventHandler = useCallback((e) => {
               e.preventDefault()
               // TODO: When we have generic file open
               // If badge is pressed
@@ -170,8 +160,8 @@ export const useDefaultAreaLibrary = () => {
               // Then scroll to error
               // Do you automatically open the project files
               // kclManager.scrollToFirstErrorDiagnosticIfExists()
-            }
-            return useMemo(() => ({ value, onClick, title }), [value, title])
+            }, [])
+            return useMemo(() => ({ value, onClick, title }), [value, onClick])
           },
         },
         variables: {

--- a/src/lib/layout/service.ts
+++ b/src/lib/layout/service.ts
@@ -1,3 +1,8 @@
+import {
+  type RegistryItemDefinition,
+  defineRegistryItem,
+  provideService,
+} from '@kittycad/registry'
 import type { Signal } from '@preact/signals-core'
 import type {
   Layout,
@@ -6,16 +11,22 @@ import type {
   LayoutService,
 } from '@src/lib/layout/types'
 import { applyLayoutContribution } from '@src/lib/layout/utils'
-import {
-  defineRegistryItem,
-  provideService,
-  type RegistryItemDefinition,
-} from '@kittycad/registry'
 import { layoutService as layoutServiceToken } from '@src/registry/contracts/layout'
 
 export function createLayoutService(
   layoutSignal: Signal<Layout>
 ): LayoutService {
+  function update(transform: (rootLayout: Layout) => boolean) {
+    const rootLayout = structuredClone(layoutSignal.peek())
+    const applied = transform(rootLayout)
+
+    if (applied) {
+      layoutSignal.value = rootLayout
+    }
+
+    return applied
+  }
+
   function applyContributions(contributions: readonly LayoutContribution[]) {
     const rootLayout = structuredClone(layoutSignal.peek())
     const results: LayoutContributionResult[] = []
@@ -32,6 +43,8 @@ export function createLayoutService(
   }
 
   return {
+    signal: layoutSignal,
+    update,
     applyContribution(contribution) {
       return applyContributions([contribution])[0]
     },

--- a/src/lib/layout/types.ts
+++ b/src/lib/layout/types.ts
@@ -1,3 +1,4 @@
+import type { ReadonlySignal } from '@preact/signals-core'
 import type { CustomIconName } from '@src/components/CustomIcon'
 import type { MouseEventHandler, useMemo } from 'react'
 
@@ -162,6 +163,8 @@ export type LayoutContributionResult = {
 }
 
 export type LayoutService = {
+  readonly signal: ReadonlySignal<Layout>
+  update: (transform: (rootLayout: Layout) => boolean) => boolean
   applyContribution: (
     contribution: LayoutContribution
   ) => LayoutContributionResult

--- a/src/machines/mlEphantManagerMachine.test.ts
+++ b/src/machines/mlEphantManagerMachine.test.ts
@@ -240,6 +240,110 @@ describe('mlEphantManagerMachine', () => {
     })
   })
 
+  describe('ResponseReceive debug timings', () => {
+    it('records reasoning-to-tool-response spans when debug timing is enabled', async () => {
+      const originalPerformance = globalThis.performance
+      vi.stubGlobal('performance', {
+        now: vi.fn().mockReturnValueOnce(100).mockReturnValueOnce(175),
+        mark: vi.fn(),
+        measure: vi.fn(),
+        getEntriesByName: vi.fn(() => [{ duration: 75 }]),
+      })
+
+      const ws: TestWebSocket = new TestSocket() as TestWebSocket
+      const machine = mlEphantManagerMachine.provide({
+        actors: {
+          [MlEphantManagerStates.Setup]: fromPromise<
+            Partial<MlEphantManagerContext>,
+            SetupActorInput
+          >(async () => ({
+            ws,
+            conversation: {
+              exchanges: [
+                {
+                  deltasAggregated: '',
+                  request: {
+                    type: 'user',
+                    content: 'make me a sandwich',
+                  },
+                  responses: [],
+                },
+              ],
+            },
+          })),
+        },
+      })
+      const actor = createActor(machine, {
+        input: {
+          apiToken: '',
+        },
+      }).start()
+
+      try {
+        actor.send({
+          type: MlEphantManagerTransitions.CacheSetupAndConnect,
+          refParentSend: vi.fn(),
+        })
+
+        await waitFor(actor, (state) =>
+          state.matches(MlEphantManagerStates.WaitForContinueCheck)
+        )
+
+        actor.send({
+          type: MlEphantManagerStates.ContinueCheck,
+          projectName: 'zoo-project',
+          projectFiles: [],
+        })
+
+        await waitFor(actor, (state) =>
+          state.matches(MlEphantManagerStates.Ready)
+        )
+
+        actor.send({
+          type: MlEphantManagerTransitions.DebugTimingSet,
+          enabled: true,
+        })
+        actor.send({
+          type: MlEphantManagerTransitions.ResponseReceive,
+          response: {
+            reasoning: {
+              type: 'text',
+              content: 'thinking',
+            },
+          },
+        })
+        actor.send({
+          type: MlEphantManagerTransitions.ResponseReceive,
+          response: {
+            tool_output: {
+              result: {},
+            },
+          } as never,
+        })
+
+        await waitFor(actor, (state) => {
+          const exchange = state.context.conversation?.exchanges[0]
+          return Boolean(exchange?.debugTimings?.length)
+        })
+
+        expect(
+          actor.getSnapshot().context.conversation?.exchanges[0].debugTimings
+        ).toStrictEqual([
+          {
+            from: 'reasoning',
+            to: 'tool_output',
+            durationMs: 75,
+            startedAt: 100,
+            endedAt: 175,
+          },
+        ])
+      } finally {
+        actor.stop()
+        vi.stubGlobal('performance', originalPerformance)
+      }
+    })
+  })
+
   describe('ConversationClose', () => {
     it('clears conversation state on an intentional close', async () => {
       const ws: TestWebSocket = new TestSocket() as TestWebSocket
@@ -410,6 +514,15 @@ describe('mlEphantManagerMachine', () => {
                 },
               },
             ],
+            debugTimings: [
+              {
+                from: 'reasoning',
+                to: 'tool_output',
+                durationMs: 12.5,
+                startedAt: 100,
+                endedAt: 112.5,
+              },
+            ],
           },
         ],
       }
@@ -419,6 +532,7 @@ describe('mlEphantManagerMachine', () => {
       // All we can check is _some_ content made it through to the other side,
       // and that all code paths have been taken via the test.
       expect(output.length).toBeGreaterThan(0)
+      expect(output).toContain('reasoning -> tool call response: 12.5 ms')
     })
 
     // Motivated by https://github.com/KittyCAD/modeling-app/issues/9912

--- a/src/machines/mlEphantManagerMachine.ts
+++ b/src/machines/mlEphantManagerMachine.ts
@@ -1,26 +1,26 @@
-import ms from 'ms'
-import { decode as msgpackDecode } from '@msgpack/msgpack'
-import { withMlephantWebSocketURL } from '@src/lib/withBaseURL'
 import type {
   MlCopilotClientMessage,
-  MlCopilotServerMessage,
   MlCopilotFile,
+  MlCopilotServerMessage,
 } from '@kittycad/lib'
-import { assertEvent, assign, setup, fromPromise } from 'xstate'
-import { createActorContext } from '@xstate/react'
-import type { ActorRefFrom } from 'xstate'
+import { decode as msgpackDecode } from '@msgpack/msgpack'
 import type { KittyCadLibFile } from '@src/lib/promptToEditTypes'
 import type { KclFileMetaMap } from '@src/lib/promptToEditTypes'
+import { withMlephantWebSocketURL } from '@src/lib/withBaseURL'
+import { createActorContext } from '@xstate/react'
+import ms from 'ms'
+import { assertEvent, assign, fromPromise, setup } from 'xstate'
+import type { ActorRefFrom } from 'xstate'
 
 import {
-  isCustomIconName,
   type CustomIconName,
+  isCustomIconName,
 } from '@src/components/CustomIcon'
 
 import { isArray } from '@src/lib/utils'
 
-import { S, transitions } from '@src/machines/utils'
 import { getKclVersion } from '@src/lib/kclVersion'
+import { S, transitions } from '@src/machines/utils'
 
 import { Socket } from '@src/lib/socket'
 
@@ -28,9 +28,9 @@ import { Socket } from '@src/lib/socket'
 // import { MockSocket } from '@src/mocks/copilot'
 
 import type { ArtifactGraph } from '@src/lang/wasm'
-import type { Selections } from '@src/machines/modelingSharedTypes'
 import type { FileEntry, Project } from '@src/lib/project'
 import type { FileMeta } from '@src/lib/types'
+import type { Selections } from '@src/machines/modelingSharedTypes'
 
 import { constructMultiFileIterationRequestWithPromptHelpers } from '@src/lib/promptToEdit'
 
@@ -167,6 +167,7 @@ export enum MlEphantManagerTransitions {
   MessageSend = 'message-send',
   ResponseReceive = 'response-receive',
   ModesReceive = 'modes-receive',
+  DebugTimingSet = 'debug-timing-set',
   ConversationClose = 'conversation-close',
   Cancel = 'cancel',
   Interrupt = 'interrupt',
@@ -223,6 +224,10 @@ export type MlEphantManagerEvents =
       modeOptions: MlCopilotModeOption[]
     }
   | {
+      type: MlEphantManagerTransitions.DebugTimingSet
+      enabled: boolean
+    }
+  | {
       type: MlEphantManagerTransitions.ConversationClose
     }
   | {
@@ -254,10 +259,29 @@ export interface Exchange {
   // BELOW:
   // An optimization. `delta` messages will be appended here.
   deltasAggregated: string
+
+  debugTimings?: ZookeeperDebugTimingSpan[]
 }
 
 export type Conversation = {
   exchanges: Exchange[]
+}
+
+export type ZookeeperDebugTimingResponseType = 'reasoning' | 'tool_output'
+
+export type ZookeeperDebugTimingSpan = {
+  from: ZookeeperDebugTimingResponseType
+  to: ZookeeperDebugTimingResponseType
+  durationMs: number
+  startedAt: number
+  endedAt: number
+}
+
+type ZookeeperDebugTimingPoint = {
+  exchangeIndex: number
+  responseType: ZookeeperDebugTimingResponseType
+  timestamp: number
+  markName?: string
 }
 
 export interface MlEphantManagerContext {
@@ -275,6 +299,8 @@ export interface MlEphantManagerContext {
   pendingBackendShutdown: boolean
   defaultMode?: MlCopilotModeId
   modeOptions?: MlCopilotModeOption[]
+  debugTimingEnabled: boolean
+  lastDebugTimingPoint?: ZookeeperDebugTimingPoint
   cachedSetup?: {
     refParentSend?: (event: MlEphantManagerEvents) => void
     conversationId?: string
@@ -300,6 +326,8 @@ export const mlEphantDefaultContext = (args: {
   pendingBackendShutdown: false,
   defaultMode: undefined,
   modeOptions: undefined,
+  debugTimingEnabled: false,
+  lastDebugTimingPoint: undefined,
 })
 
 const ZOOKEEPER_DISCONNECT_LOG_PREFIX = '[zookeeper-disconnect]'
@@ -356,6 +384,132 @@ function isBackendShutdownMessage(
 
 function isResponseComplete(response: MlCopilotServerMessage): boolean {
   return 'end_of_stream' in response || 'error' in response
+}
+
+function getZookeeperDebugTimingResponseType(
+  response: MlCopilotServerMessage
+): ZookeeperDebugTimingResponseType | undefined {
+  if ('reasoning' in response) {
+    return 'reasoning'
+  }
+  if ('tool_output' in response) {
+    return 'tool_output'
+  }
+  return undefined
+}
+
+let debugTimingMarkCounter = 0
+
+function createZookeeperDebugTimingPoint({
+  responseType,
+  exchangeIndex,
+}: {
+  responseType: ZookeeperDebugTimingResponseType
+  exchangeIndex: number
+}): ZookeeperDebugTimingPoint {
+  const timestamp = globalThis.performance?.now?.() ?? Date.now()
+  const markName = `zookeeper.debugTiming.${responseType}.${debugTimingMarkCounter++}`
+
+  try {
+    globalThis.performance?.mark?.(markName)
+  } catch {
+    return { exchangeIndex, responseType, timestamp }
+  }
+
+  return { exchangeIndex, responseType, timestamp, markName }
+}
+
+function createZookeeperDebugTimingSpan({
+  previous,
+  current,
+}: {
+  previous: ZookeeperDebugTimingPoint
+  current: ZookeeperDebugTimingPoint
+}): ZookeeperDebugTimingSpan {
+  let durationMs = current.timestamp - previous.timestamp
+
+  if (previous.markName && current.markName) {
+    const measureName = `zookeeper.debugTiming.${previous.responseType}-to-${current.responseType}.${debugTimingMarkCounter++}`
+    try {
+      globalThis.performance?.measure?.(
+        measureName,
+        previous.markName,
+        current.markName
+      )
+      const measuredDuration = globalThis.performance
+        ?.getEntriesByName?.(measureName)
+        .at(-1)?.duration
+      if (typeof measuredDuration === 'number') {
+        durationMs = measuredDuration
+      }
+    } catch {
+      durationMs = current.timestamp - previous.timestamp
+    }
+  }
+
+  return {
+    from: previous.responseType,
+    to: current.responseType,
+    durationMs: Math.max(0, durationMs),
+    startedAt: previous.timestamp,
+    endedAt: current.timestamp,
+  }
+}
+
+function formatZookeeperDebugTimingResponseType(
+  responseType: ZookeeperDebugTimingResponseType
+) {
+  return responseType === 'reasoning' ? 'reasoning' : 'tool call response'
+}
+
+export function formatZookeeperDebugTimingSpan(span: ZookeeperDebugTimingSpan) {
+  const duration =
+    span.durationMs < 1000
+      ? `${span.durationMs.toFixed(1)} ms`
+      : ms(span.durationMs, { long: true })
+
+  return `${formatZookeeperDebugTimingResponseType(span.from)} -> ${formatZookeeperDebugTimingResponseType(span.to)}: ${duration}`
+}
+
+function applyZookeeperDebugTiming({
+  context,
+  exchange,
+  exchangeIndex,
+  response,
+}: {
+  context: MlEphantManagerContext
+  exchange: Exchange
+  exchangeIndex: number
+  response: MlCopilotServerMessage
+}): ZookeeperDebugTimingPoint | undefined {
+  if (!context.debugTimingEnabled) {
+    return undefined
+  }
+
+  const responseType = getZookeeperDebugTimingResponseType(response)
+  if (!responseType) {
+    return isResponseComplete(response)
+      ? undefined
+      : context.lastDebugTimingPoint
+  }
+
+  const current = createZookeeperDebugTimingPoint({
+    responseType,
+    exchangeIndex,
+  })
+  const previous = context.lastDebugTimingPoint
+  if (
+    previous &&
+    previous.exchangeIndex === exchangeIndex &&
+    previous.responseType !== current.responseType
+  ) {
+    exchange.debugTimings = [
+      ...(exchange.debugTimings ?? []),
+      createZookeeperDebugTimingSpan({ previous, current }),
+    ]
+  }
+
+  return current
 }
 
 async function toMlCopilotFile(file: File): Promise<MlCopilotFile> {
@@ -418,6 +572,14 @@ export const MlEphantConversationToMarkdown = (
 
       // An error signals end of stream as well.
       if ('error' in response || 'end_of_stream' in response) {
+        if (exchange.debugTimings && exchange.debugTimings.length > 0) {
+          reason += '**Client debug timings:**\n\n'
+          for (const timing of exchange.debugTimings) {
+            reason += `* ${formatZookeeperDebugTimingSpan(timing)}\n`
+          }
+          reason += '\n'
+        }
+
         let time = 0
         if ('end_of_stream' in response) {
           time =
@@ -543,6 +705,13 @@ export const mlEphantManagerMachine = setup({
       return {
         defaultMode: event.defaultMode ?? context.defaultMode,
         modeOptions: event.modeOptions,
+      }
+    }),
+    assignDebugTimingEnabled: assign(({ event }) => {
+      assertEvent(event, MlEphantManagerTransitions.DebugTimingSet)
+      return {
+        debugTimingEnabled: event.enabled,
+        lastDebugTimingPoint: undefined,
       }
     }),
     disconnectIfIdle: ({ context }) => {
@@ -1061,6 +1230,9 @@ export const mlEphantManagerMachine = setup({
     [MlEphantManagerTransitions.ModesReceive]: {
       actions: ['assignModeOptions'],
     },
+    [MlEphantManagerTransitions.DebugTimingSet]: {
+      actions: ['assignDebugTimingEnabled'],
+    },
   },
   states: {
     [S.Await]: {
@@ -1076,6 +1248,7 @@ export const mlEphantManagerMachine = setup({
               conversationId: undefined,
               defaultMode: undefined,
               modeOptions: undefined,
+              lastDebugTimingPoint: undefined,
               awaitingResponse: false,
               pendingBackendShutdown: false,
             }),
@@ -1112,6 +1285,7 @@ export const mlEphantManagerMachine = setup({
               ...event.output,
               defaultMode: event.output.defaultMode ?? context.defaultMode,
               modeOptions: event.output.modeOptions ?? context.modeOptions,
+              lastDebugTimingPoint: undefined,
               awaitingResponse: false,
               pendingBackendShutdown: false,
             })),
@@ -1184,6 +1358,7 @@ export const mlEphantManagerMachine = setup({
               awaitingResponse({ event }) {
                 return event.output.awaitingResponse ?? false
               },
+              lastDebugTimingPoint: undefined,
             }),
           ],
         },
@@ -1251,6 +1426,7 @@ export const mlEphantManagerMachine = setup({
                       return {
                         conversation,
                         lastMessageId,
+                        lastDebugTimingPoint: undefined,
                         awaitingResponse: false,
                         pendingBackendShutdown: responseComplete
                           ? false
@@ -1276,6 +1452,13 @@ export const mlEphantManagerMachine = setup({
                     } else {
                       lastExchange.responses.push(event.response)
                     }
+                    const lastExchangeIndex = conversation.exchanges.length - 1
+                    const lastDebugTimingPoint = applyZookeeperDebugTiming({
+                      context,
+                      exchange: lastExchange,
+                      exchangeIndex: lastExchangeIndex,
+                      response: event.response,
+                    })
 
                     // This sucks but must be done because we can't
                     // enumerate the message types.
@@ -1305,6 +1488,7 @@ export const mlEphantManagerMachine = setup({
                       conversation,
                       lastMessageId,
                       lastMessageType,
+                      lastDebugTimingPoint,
                       awaitingResponse: responseComplete
                         ? false
                         : context.awaitingResponse,
@@ -1354,6 +1538,7 @@ export const mlEphantManagerMachine = setup({
                     assign(({ event, context }) => ({
                       ...event.output,
                       awaitingResponse: true,
+                      lastDebugTimingPoint: undefined,
                       pendingBackendShutdown: context.pendingBackendShutdown,
                     })),
                   ],
@@ -1427,6 +1612,7 @@ export const mlEphantManagerMachine = setup({
               lastMessageType: undefined,
               awaitingResponse: false,
               pendingBackendShutdown: false,
+              lastDebugTimingPoint: undefined,
               closeReason: undefined,
               ws: undefined,
             }

--- a/src/machines/modelingMachine.test.ts
+++ b/src/machines/modelingMachine.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createActor, fromPromise } from 'xstate'
+
+import type { Artifact, ArtifactGraph } from '@src/lang/wasm'
+import { modelingMachine } from '@src/machines/modelingMachine'
+import { modelingMachineInitialInternalContext } from '@src/machines/modelingSharedContext'
+
+function timeout(ms: number): Promise<never> {
+  return new Promise((_, reject) => {
+    setTimeout(() => reject(new Error('Timed out waiting for actor')), ms)
+  })
+}
+
+describe('modelingMachine sketch entry', () => {
+  it('routes a cursor inside a sketch block segment to sketch solve edit', async () => {
+    const pathToNode = [['body', '']] as any
+    const sketchBlockCodeRef = {
+      range: [0, 100, 0] as [number, number, number],
+      pathToNode,
+      nodePath: { steps: [] },
+    } as any
+    const segmentCodeRef = {
+      range: [35, 85, 0] as [number, number, number],
+      pathToNode,
+      nodePath: { steps: [] },
+    } as any
+    const sketchBlock: Extract<Artifact, { type: 'sketchBlock' }> = {
+      type: 'sketchBlock',
+      id: 'sketch-block-1',
+      codeRef: sketchBlockCodeRef,
+      planeId: 'plane-1',
+      sketchId: 7,
+    }
+    const path: Artifact = {
+      type: 'path',
+      subType: 'sketch',
+      id: 'path-1',
+      codeRef: sketchBlockCodeRef,
+      planeId: 'plane-1',
+      segIds: ['segment-1'],
+      trajectorySweepId: null,
+      consumed: false,
+      sketchBlockId: sketchBlock.id,
+    }
+    const segment: Artifact = {
+      type: 'segment',
+      id: 'segment-1',
+      pathId: path.id,
+      edgeIds: [],
+      commonSurfaceIds: [],
+      codeRef: segmentCodeRef,
+    }
+    const artifactGraph: ArtifactGraph = new Map()
+    artifactGraph.set(sketchBlock.id, sketchBlock)
+    artifactGraph.set(path.id, path)
+    artifactGraph.set(segment.id, segment)
+
+    const context = {
+      ...modelingMachineInitialInternalContext,
+      selectionRanges: {
+        graphSelections: [
+          {
+            codeRef: {
+              range: [45, 45, 0],
+              pathToNode,
+            },
+          },
+        ],
+        otherSelections: [],
+      },
+      kclManager: {
+        artifactGraph,
+        hidePlanes: vi.fn(),
+        showPlanes: vi.fn(),
+        sceneInfra: {
+          animate: vi.fn(),
+          resetMouseListeners: vi.fn(),
+          camControls: {
+            enablePan: true,
+            enableRotate: true,
+            syncDirection: 'engineToClient',
+          },
+        },
+      },
+      rustContext: {},
+      engineCommandManager: {},
+      wasmInstance: {},
+      commandBarActor: {},
+      machineManager: {},
+    } as any
+
+    let receivedInput: any
+    let markActorStarted: () => void = () => {}
+    const actorStarted = new Promise<void>((resolve) => {
+      markActorStarted = resolve
+    })
+    const machine = modelingMachine.provide({
+      actors: {
+        'animate-to-existing-sketch-solve': fromPromise(async ({ input }) => {
+          receivedInput = input
+          markActorStarted()
+          return await new Promise<any>(() => {})
+        }),
+      },
+    })
+
+    const actor = createActor(machine, { input: context }).start()
+
+    actor.send({ type: 'Enter sketch' })
+
+    await Promise.race([actorStarted, timeout(1_000)])
+
+    expect(actor.getSnapshot().value).toBe('animating to existing sketch solve')
+    expect(receivedInput).toEqual(
+      expect.objectContaining({
+        artifactId: sketchBlock.id,
+      })
+    )
+
+    actor.stop()
+  })
+})

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -171,6 +171,7 @@ import {
   getPlaneFromArtifact,
   isFaceFromLegacySketch,
   getSketchBlockArtifactForPathToNode,
+  getSketchBlockForArtifact,
 } from '@src/lang/std/artifactGraph'
 import {
   crossProduct,
@@ -212,7 +213,6 @@ import {
   updateExtraSegments,
   updateSelections,
 } from '@src/lib/selections'
-import { isSketchBlockSelected } from '@src/machines/sketchSolve/sketchSolveImpl'
 import { err, isErr, reject, reportRejection, trap } from '@src/lib/trap'
 import { uuidv4 } from '@src/lib/utils'
 import { sketchSolveMachine } from '@src/machines/sketchSolve/sketchSolveDiagram'
@@ -301,6 +301,42 @@ function findSceneObjectForPlaneSelection(
       sourceRangesEqual(object.source.ranges[0][0], sweepRange) &&
       sourceRangesEqual(object.source.ranges[1][0], segmentRange)
   )
+}
+
+function getSelectedSketchBlockArtifact({
+  artifactGraph,
+  selectionRanges,
+}: {
+  artifactGraph: ModelingMachineContext['kclManager']['artifactGraph']
+  selectionRanges: Selections
+}): Extract<Artifact, { type: 'sketchBlock' }> | undefined {
+  const selectedArtifact = selectionRanges.graphSelections[0]?.artifact
+  const selectedSketchBlock = getSketchBlockForArtifact(
+    selectedArtifact,
+    artifactGraph
+  )
+  if (typeof selectedSketchBlock?.sketchId === 'number') {
+    return selectedSketchBlock
+  }
+
+  const sketchPathId = isCursorInSketchCommandRange(
+    artifactGraph,
+    selectionRanges
+  )
+  if (!sketchPathId) {
+    return undefined
+  }
+
+  const sketchPathArtifact = artifactGraph.get(sketchPathId)
+  const sketchBlockFromCursor = getSketchBlockForArtifact(
+    sketchPathArtifact,
+    artifactGraph
+  )
+  if (typeof sketchBlockFromCursor?.sketchId !== 'number') {
+    return undefined
+  }
+
+  return sketchBlockFromCursor
 }
 
 async function enterSketchSolveFromSketchBlockArtifact({
@@ -686,12 +722,15 @@ export const modelingMachine = setup({
       return context.store.useSketchSolveMode?.current === true
     },
     'Selection is sketchBlock': ({
-      context: { selectionRanges },
+      context: { selectionRanges, kclManager },
       event,
     }): boolean => {
       if (event.type !== 'Enter sketch') return false
       if (event.data?.forceNewSketch) return false
-      return isSketchBlockSelected(selectionRanges)
+      return !!getSelectedSketchBlockArtifact({
+        artifactGraph: kclManager.artifactGraph,
+        selectionRanges,
+      })
     },
     'Selection is on face': ({
       context: { selectionRanges, kclManager, wasmInstance },
@@ -699,6 +738,14 @@ export const modelingMachine = setup({
     }): boolean => {
       if (event.type !== 'Enter sketch') return false
       if (event.data?.forceNewSketch) return false
+      if (
+        getSelectedSketchBlockArtifact({
+          artifactGraph: kclManager.artifactGraph,
+          selectionRanges,
+        })
+      ) {
+        return false
+      }
       if (artifactIsPlaneWithPaths(selectionRanges)) {
         return true
       } else if (selectionRanges.graphSelections[0]?.artifact) {
@@ -8561,12 +8608,13 @@ export const modelingMachine = setup({
             }
           }
           if (event.type === 'Enter sketch') {
-            // Get artifact ID from selection
-            const artifact =
-              context.selectionRanges.graphSelections[0]?.artifact
-            if (artifact?.type === 'sketchBlock' && artifact.id) {
+            const sketchBlockArtifact = getSelectedSketchBlockArtifact({
+              artifactGraph: context.kclManager.artifactGraph,
+              selectionRanges: context.selectionRanges,
+            })
+            if (sketchBlockArtifact?.id) {
               return {
-                artifactId: artifact.id,
+                artifactId: sketchBlockArtifact.id,
                 kclManager: context.kclManager,
                 rustContext: context.rustContext,
                 engineCommandManager: context.engineCommandManager,

--- a/src/registry/plugins/zookeeper/index.ts
+++ b/src/registry/plugins/zookeeper/index.ts
@@ -6,10 +6,31 @@ import {
 } from '@kittycad/registry'
 import { effect } from '@preact/signals-core'
 import { MlEphantConversationPaneWrapper } from '@src/components/layout/areas/MlEphantConversationPaneWrapper'
+import { defineBooleanExtensionSetting } from '@src/lib/settings/extensionSettings'
 import { layoutService as layoutServiceToken } from '@src/registry/contracts/layout'
 import { layoutAreaLibraryValueSpec } from '@src/registry/contracts/layout'
+import { settingsValueSpec } from '@src/registry/contracts/settings'
 import { createZdsPlugin } from '@src/registry/createZdsPlugin'
 import { ensureZookeeperLayout, removeZookeeperLayout } from './layout'
+
+const zookeeperSettingsItem = defineRegistryItem({
+  provides: [
+    provide(settingsValueSpec, {
+      zookeeper: {
+        debugTiming: defineBooleanExtensionSetting({
+          defaultValue: false,
+          description:
+            'Whether Zookeeper records client-side reasoning and tool-call response timings.',
+          hideOnLevel: 'project',
+          userToml: {
+            sectionKey: 'zookeeper',
+            tomlKey: 'debug_timing',
+          },
+        }),
+      },
+    }),
+  ],
+})
 
 const zookeeperAreaItem = defineRegistryItem({
   provides: [
@@ -49,7 +70,7 @@ const zookeeper = createZdsPlugin({
   title: 'Zookeeper',
   description:
     'Adds the in-app LLM agent pane and keeps it in the right sidebar.',
-  items: [zookeeperAreaItem, zookeeperLayoutItem],
+  items: [zookeeperSettingsItem, zookeeperAreaItem, zookeeperLayoutItem],
   defaultSetting: 'core',
 })
 

--- a/src/registry/plugins/zookeeper/index.ts
+++ b/src/registry/plugins/zookeeper/index.ts
@@ -1,0 +1,56 @@
+import {
+  defineRegistryItem,
+  defineRegistryItemFactory,
+  defineRuntimeRegistryItem,
+  provide,
+} from '@kittycad/registry'
+import { effect } from '@preact/signals-core'
+import { MlEphantConversationPaneWrapper } from '@src/components/layout/areas/MlEphantConversationPaneWrapper'
+import { layoutService as layoutServiceToken } from '@src/registry/contracts/layout'
+import { layoutAreaLibraryValueSpec } from '@src/registry/contracts/layout'
+import { createZdsPlugin } from '@src/registry/createZdsPlugin'
+import { ensureZookeeperLayout, removeZookeeperLayout } from './layout'
+
+const zookeeperAreaItem = defineRegistryItem({
+  provides: [
+    provide(layoutAreaLibraryValueSpec, {
+      ttc: {
+        hide: () => false,
+        shortcut: 'Ctrl + T',
+        cssClassOverrides: {
+          button:
+            'bg-ml-green pressed:bg-transparent dark:!text-chalkboard-100 hover:dark:!text-inherit dark:pressed:!text-inherit',
+        },
+        Component: MlEphantConversationPaneWrapper,
+      },
+    }),
+  ],
+})
+
+const zookeeperLayoutItem = defineRegistryItemFactory((ctx) => {
+  const layoutService = ctx.container.get(layoutServiceToken)
+  const disposeEffect = effect(() => {
+    layoutService.signal.value
+    layoutService.update(ensureZookeeperLayout)
+  })
+
+  return {
+    item: defineRuntimeRegistryItem({
+      dispose: () => {
+        disposeEffect()
+        layoutService.update(removeZookeeperLayout)
+      },
+    }),
+  }
+}, 'zookeeper-layout')
+
+const zookeeper = createZdsPlugin({
+  id: 'zookeeper',
+  title: 'Zookeeper',
+  description:
+    'Adds the in-app LLM agent pane and keeps it in the right sidebar.',
+  items: [zookeeperAreaItem, zookeeperLayoutItem],
+  defaultSetting: 'core',
+})
+
+export default zookeeper

--- a/src/registry/plugins/zookeeper/layout.test.ts
+++ b/src/registry/plugins/zookeeper/layout.test.ts
@@ -1,0 +1,148 @@
+import {
+  DefaultLayoutPaneID,
+  DefaultLayoutToolbarID,
+} from '@src/lib/layout/configs/default'
+import { AreaType, type Layout, LayoutType } from '@src/lib/layout/types'
+import { describe, expect, it } from 'vitest'
+import { ensureZookeeperLayout, removeZookeeperLayout } from './layout'
+
+const featureTreePane = {
+  id: DefaultLayoutPaneID.FeatureTree,
+  label: 'Feature Tree',
+  type: LayoutType.Simple,
+  areaType: AreaType.FeatureTree,
+  icon: 'model',
+} as const
+
+const codePane = {
+  id: DefaultLayoutPaneID.Code,
+  label: 'Code Editor',
+  type: LayoutType.Simple,
+  areaType: AreaType.Code,
+  icon: 'code',
+} as const
+
+const modelingPane = {
+  id: 'modeling-scene',
+  label: 'Modeling scene',
+  type: LayoutType.Simple,
+  areaType: AreaType.ModelingScene,
+} as const
+
+function createLayoutWithoutRightSidebar(): Layout {
+  return {
+    id: 'default',
+    label: 'root',
+    type: LayoutType.Splits,
+    orientation: 'inline',
+    sizes: [20, 80],
+    children: [
+      {
+        id: DefaultLayoutToolbarID.Left,
+        label: 'left-toolbar',
+        type: LayoutType.Panes,
+        side: 'inline-start',
+        activeIndices: [0],
+        sizes: [100],
+        splitOrientation: 'block',
+        children: [structuredClone(featureTreePane)],
+      },
+      structuredClone(modelingPane),
+    ],
+  }
+}
+
+describe('Zookeeper plugin layout reconciliation', () => {
+  it('adds the right sidebar and opens Zookeeper when the sidebar is missing', () => {
+    const layout = createLayoutWithoutRightSidebar()
+
+    expect(ensureZookeeperLayout(layout)).toBe(true)
+
+    expect(layout).toHaveProperty(
+      'children[2].id',
+      DefaultLayoutToolbarID.Right
+    )
+    expect(layout).toHaveProperty(
+      'children[2].children[0].id',
+      DefaultLayoutPaneID.TTC
+    )
+    expect(layout).toHaveProperty('children[2].activeIndices', [0])
+    expect(layout).toHaveProperty('children[2].sizes', [100])
+  })
+
+  it('moves a legacy Zookeeper pane into the right sidebar', () => {
+    const layout = createLayoutWithoutRightSidebar()
+
+    if (
+      layout.type !== LayoutType.Splits ||
+      layout.children[0].type !== LayoutType.Panes
+    ) {
+      throw new Error('Unexpected test layout shape')
+    }
+
+    layout.children[0].children.push({
+      id: DefaultLayoutPaneID.TTC,
+      label: 'Zookeeper',
+      type: LayoutType.Simple,
+      areaType: AreaType.TTC,
+      icon: 'sparkles',
+    })
+    layout.children.push({
+      id: DefaultLayoutToolbarID.Right,
+      label: DefaultLayoutToolbarID.Right,
+      type: LayoutType.Panes,
+      side: 'inline-end',
+      activeIndices: [],
+      sizes: [],
+      splitOrientation: 'block',
+      children: [],
+    })
+    layout.sizes = [20, 70, 10]
+
+    expect(ensureZookeeperLayout(layout)).toBe(true)
+
+    expect(layout).toHaveProperty('children[0].children', [featureTreePane])
+    expect(layout).toHaveProperty(
+      'children[2].children[0].id',
+      DefaultLayoutPaneID.TTC
+    )
+    expect(layout).toHaveProperty('children[2].activeIndices', [0])
+  })
+
+  it('removes the right sidebar when disabled and Zookeeper is the only pane', () => {
+    const layout = createLayoutWithoutRightSidebar()
+    ensureZookeeperLayout(layout)
+
+    expect(removeZookeeperLayout(layout)).toBe(true)
+
+    expect(layout).toHaveProperty('children.length', 2)
+    expect(layout).not.toHaveProperty('children[2]')
+  })
+
+  it('removes only Zookeeper when disabled and the right sidebar has other panes', () => {
+    const layout = createLayoutWithoutRightSidebar()
+
+    if (layout.type !== LayoutType.Splits) {
+      throw new Error('Unexpected test layout shape')
+    }
+
+    layout.children.push({
+      id: DefaultLayoutToolbarID.Right,
+      label: DefaultLayoutToolbarID.Right,
+      type: LayoutType.Panes,
+      side: 'inline-end',
+      activeIndices: [0],
+      sizes: [100],
+      splitOrientation: 'block',
+      children: [structuredClone(codePane)],
+    })
+    layout.sizes = [20, 50, 30]
+    ensureZookeeperLayout(layout)
+
+    expect(removeZookeeperLayout(layout)).toBe(true)
+
+    expect(layout).toHaveProperty('children.length', 3)
+    expect(layout).toHaveProperty('children[2].children', [codePane])
+    expect(layout).toHaveProperty('children[2].activeIndices', [0])
+  })
+})

--- a/src/registry/plugins/zookeeper/layout.ts
+++ b/src/registry/plugins/zookeeper/layout.ts
@@ -1,0 +1,242 @@
+import {
+  DefaultLayoutPaneID,
+  DefaultLayoutToolbarID,
+} from '@src/lib/layout/configs/default'
+import {
+  AreaType,
+  type Layout,
+  LayoutType,
+  type PaneChild,
+  type PaneLayout,
+  type SplitLayout,
+} from '@src/lib/layout/types'
+import {
+  findLayoutChildNode,
+  findLayoutParentNode,
+} from '@src/lib/layout/utils'
+
+const ZOOKEEPER_SPLIT_SIZE = 30
+
+export const zookeeperPane = Object.freeze({
+  id: DefaultLayoutPaneID.TTC,
+  label: 'Zookeeper',
+  type: LayoutType.Simple,
+  areaType: AreaType.TTC,
+  icon: 'sparkles',
+} satisfies PaneChild)
+
+function createRightSidebar(): PaneLayout {
+  return {
+    id: DefaultLayoutToolbarID.Right,
+    label: DefaultLayoutToolbarID.Right,
+    type: LayoutType.Panes,
+    side: 'inline-end',
+    activeIndices: [0],
+    sizes: [100],
+    splitOrientation: 'block',
+    children: [structuredClone(zookeeperPane)],
+  }
+}
+
+function getActivePaneState(paneLayout: PaneLayout) {
+  const activePaneIds = paneLayout.activeIndices
+    .map((activeIndex) => paneLayout.children[activeIndex]?.id)
+    .filter((id) => id !== undefined)
+  const sizeByPaneId = new Map(
+    paneLayout.activeIndices
+      .map((activeIndex, sizeIndex) => [
+        paneLayout.children[activeIndex]?.id,
+        paneLayout.sizes[sizeIndex],
+      ])
+      .filter(
+        (entry): entry is [string, number] =>
+          entry[0] !== undefined && entry[1] !== undefined
+      )
+  )
+
+  return { activePaneIds, sizeByPaneId }
+}
+
+function setActivePaneState({
+  paneLayout,
+  activePaneIds,
+  sizeByPaneId,
+}: {
+  paneLayout: PaneLayout
+  activePaneIds: readonly string[]
+  sizeByPaneId: Map<string, number>
+}) {
+  paneLayout.activeIndices = activePaneIds
+    .map((id) => paneLayout.children.findIndex((child) => child.id === id))
+    .filter((index) => index >= 0)
+    .sort((a, b) => a - b)
+  paneLayout.sizes = paneLayout.activeIndices.map((activeIndex) => {
+    const paneId = paneLayout.children[activeIndex]?.id
+    return paneId ? (sizeByPaneId.get(paneId) ?? 0) : 0
+  })
+}
+
+function appendSplitSize(
+  sizes: readonly number[],
+  existingChildCount: number
+): number[] {
+  const nextChildCount = existingChildCount + 1
+  const total = sizes.reduce((sum, size) => sum + size, 0)
+
+  if (sizes.length !== existingChildCount || total <= 0) {
+    return new Array(nextChildCount).fill(100 / nextChildCount)
+  }
+
+  const remainingSize = 100 - ZOOKEEPER_SPLIT_SIZE
+  const scale = remainingSize / total
+  return [...sizes.map((size) => size * scale), ZOOKEEPER_SPLIT_SIZE]
+}
+
+function removeSplitChild(rootLayout: Layout, childId: string) {
+  const parent = findLayoutParentNode({ rootLayout, targetNodeId: childId })
+  if (!parent || parent.type !== LayoutType.Splits) {
+    return false
+  }
+
+  const childIndex = parent.children.findIndex((child) => child.id === childId)
+  if (childIndex < 0) {
+    return false
+  }
+
+  const removedSize = parent.sizes[childIndex] ?? 0
+  parent.children.splice(childIndex, 1)
+  parent.sizes.splice(childIndex, 1)
+
+  if (parent.sizes.length > 0) {
+    const recipientIndex = childIndex === 0 ? 0 : childIndex - 1
+    parent.sizes[recipientIndex] += removedSize
+  }
+
+  return true
+}
+
+function removePaneChild(paneLayout: PaneLayout, childId: string) {
+  const childIndex = paneLayout.children.findIndex(
+    (child) => child.id === childId
+  )
+  if (childIndex < 0) {
+    return false
+  }
+
+  const { activePaneIds, sizeByPaneId } = getActivePaneState(paneLayout)
+  paneLayout.children.splice(childIndex, 1)
+  setActivePaneState({
+    paneLayout,
+    activePaneIds: activePaneIds.filter((id) => id !== childId),
+    sizeByPaneId,
+  })
+
+  return true
+}
+
+function removeZookeeperFromNonRightPaneLayouts(
+  rootLayout: Layout,
+  rightSidebar: PaneLayout
+) {
+  const parent = findLayoutParentNode({
+    rootLayout,
+    targetNodeId: zookeeperPane.id,
+  })
+
+  if (
+    !parent ||
+    parent.id === rightSidebar.id ||
+    parent.type !== LayoutType.Panes
+  ) {
+    return false
+  }
+
+  return removePaneChild(parent, zookeeperPane.id)
+}
+
+function addZookeeperToRightSidebar(rightSidebar: PaneLayout) {
+  const { activePaneIds } = getActivePaneState(rightSidebar)
+  rightSidebar.children.push(structuredClone(zookeeperPane))
+  rightSidebar.activeIndices = rightSidebar.children
+    .map((child, index) =>
+      activePaneIds.includes(child.id) || child.id === zookeeperPane.id
+        ? index
+        : -1
+    )
+    .filter((index) => index >= 0)
+  rightSidebar.sizes =
+    rightSidebar.activeIndices.length > 0
+      ? new Array(rightSidebar.activeIndices.length).fill(
+          100 / rightSidebar.activeIndices.length
+        )
+      : []
+}
+
+function addRightSidebar(rootLayout: Layout): PaneLayout | undefined {
+  if (rootLayout.type !== LayoutType.Splits) {
+    return undefined
+  }
+
+  const splitLayout = rootLayout as SplitLayout
+  const sidebar = createRightSidebar()
+  splitLayout.sizes = appendSplitSize(
+    splitLayout.sizes,
+    splitLayout.children.length
+  )
+  splitLayout.children.push(sidebar)
+  return sidebar
+}
+
+export function ensureZookeeperLayout(rootLayout: Layout) {
+  const existingRightSidebar = findLayoutChildNode({
+    rootLayout,
+    targetNodeId: DefaultLayoutToolbarID.Right,
+  })
+
+  if (existingRightSidebar && existingRightSidebar.type !== LayoutType.Panes) {
+    return false
+  }
+
+  const rightSidebar = existingRightSidebar ?? addRightSidebar(rootLayout)
+  if (!rightSidebar) {
+    return false
+  }
+  const addedRightSidebar = !existingRightSidebar
+
+  const movedFromAnotherPane = removeZookeeperFromNonRightPaneLayouts(
+    rootLayout,
+    rightSidebar
+  )
+  const alreadyInRightSidebar = rightSidebar.children.some(
+    (child) => child.id === zookeeperPane.id
+  )
+
+  if (alreadyInRightSidebar) {
+    return addedRightSidebar || movedFromAnotherPane
+  }
+
+  addZookeeperToRightSidebar(rightSidebar)
+  return true
+}
+
+export function removeZookeeperLayout(rootLayout: Layout) {
+  const rightSidebar = findLayoutChildNode({
+    rootLayout,
+    targetNodeId: DefaultLayoutToolbarID.Right,
+  })
+
+  if (!rightSidebar || rightSidebar.type !== LayoutType.Panes) {
+    return false
+  }
+
+  const removedZookeeper = removePaneChild(rightSidebar, zookeeperPane.id)
+  if (!removedZookeeper) {
+    return false
+  }
+
+  if (rightSidebar.children.length === 0) {
+    removeSplitChild(rootLayout, rightSidebar.id)
+  }
+
+  return true
+}


### PR DESCRIPTION
Starts off a proper plugin definition to hold the Zookeeper system eventually, in service of having a good place to put a little debug setting behavior that adds (client-measured) timing messages to Zookeeper's reasoning stream and exported conversations. This might help us investigate any disagreement between the server-side timings of Zookeeper and the experience in ZDS.