### PR TITLE
Fix GDT edit path cloning when inserting variables

### DIFF
--- a/src/lang/modifyAst/gdt.ts
+++ b/src/lang/modifyAst/gdt.ts
@@ -77,6 +77,7 @@ export function addFlatnessGdt({
 }): Error | { modifiedAst: Node<Program>; pathToNode: PathToNode } {
   // Clone the AST to avoid mutating the original
   let modifiedAst = structuredClone(ast)
+  const mNodeToEdit = structuredClone(nodeToEdit)
 
   // Filter to only include face selections
   const faceSelections = faces.graphSelections.filter((selection) =>
@@ -127,16 +128,16 @@ export function addFlatnessGdt({
 
   // Insert variables for tolerance and precision parameters
   if ('variableName' in tolerance && tolerance.variableName) {
-    insertVariableAndOffsetPathToNode(tolerance, modifiedAst, nodeToEdit)
+    insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
   }
   if (precision && 'variableName' in precision && precision.variableName) {
-    insertVariableAndOffsetPathToNode(precision, modifiedAst, nodeToEdit)
+    insertVariableAndOffsetPathToNode(precision, modifiedAst, mNodeToEdit)
   }
 
   // Process common GDT style parameters
   const styleResult = processGdtStyleParameters({
     modifiedAst,
-    nodeToEdit,
+    nodeToEdit: mNodeToEdit,
     wasmInstance,
     framePosition,
     framePlane,
@@ -188,7 +189,7 @@ export function addFlatnessGdt({
     const pathToNode = setCallInAst({
       ast: modifiedAst,
       call,
-      pathToEdit: nodeToEdit,
+      pathToEdit: mNodeToEdit,
       pathIfNewPipe: undefined, // GDT annotations don't pipe
       variableIfNewDecl: undefined, // Creates expression statement at the end
       wasmInstance,
@@ -322,7 +323,9 @@ export function addPositionGdt({
     fontPointSize,
     fontScale,
   })
-  if (err(styleResult)) return styleResult
+  if (err(styleResult)) {
+    return styleResult
+  }
 
   let lastPathToNode: PathToNode | undefined
   const createPositionCall = (
@@ -425,6 +428,7 @@ export function addProfileGdt({
   nodeToEdit?: PathToNode
 }): Error | { modifiedAst: Node<Program>; pathToNode: PathToNode } {
   let modifiedAst = structuredClone(ast)
+  const mNodeToEdit = structuredClone(nodeToEdit)
 
   const edgeSelections = edges.graphSelections.filter((selection) =>
     isProfileEdgeArtifact(selection.artifact)
@@ -467,15 +471,15 @@ export function addProfileGdt({
   }
 
   if ('variableName' in tolerance && tolerance.variableName) {
-    insertVariableAndOffsetPathToNode(tolerance, modifiedAst, nodeToEdit)
+    insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
   }
   if (precision && 'variableName' in precision && precision.variableName) {
-    insertVariableAndOffsetPathToNode(precision, modifiedAst, nodeToEdit)
+    insertVariableAndOffsetPathToNode(precision, modifiedAst, mNodeToEdit)
   }
 
   const styleResult = processGdtStyleParameters({
     modifiedAst,
-    nodeToEdit,
+    nodeToEdit: mNodeToEdit,
     wasmInstance,
     framePosition,
     framePlane,
@@ -526,7 +530,7 @@ export function addProfileGdt({
     const pathToNode = setCallInAst({
       ast: modifiedAst,
       call,
-      pathToEdit: nodeToEdit,
+      pathToEdit: mNodeToEdit,
       pathIfNewPipe: undefined,
       variableIfNewDecl: undefined,
       wasmInstance,
@@ -577,6 +581,7 @@ export function addDistanceGdt({
   nodeToEdit?: PathToNode
 }): Error | { modifiedAst: Node<Program>; pathToNode: PathToNode } {
   let modifiedAst = structuredClone(ast)
+  const mNodeToEdit = structuredClone(nodeToEdit)
   const selections = objects ?? edges
 
   if (!selections) {
@@ -650,15 +655,15 @@ export function addDistanceGdt({
   }
 
   if ('variableName' in tolerance && tolerance.variableName) {
-    insertVariableAndOffsetPathToNode(tolerance, modifiedAst, nodeToEdit)
+    insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
   }
   if (precision && 'variableName' in precision && precision.variableName) {
-    insertVariableAndOffsetPathToNode(precision, modifiedAst, nodeToEdit)
+    insertVariableAndOffsetPathToNode(precision, modifiedAst, mNodeToEdit)
   }
 
   const styleResult = processGdtStyleParameters({
     modifiedAst,
-    nodeToEdit,
+    nodeToEdit: mNodeToEdit,
     wasmInstance,
     framePosition,
     framePlane,
@@ -711,7 +716,7 @@ export function addDistanceGdt({
   const pathToNode = setCallInAst({
     ast: modifiedAst,
     call,
-    pathToEdit: nodeToEdit,
+    pathToEdit: mNodeToEdit,
     pathIfNewPipe: undefined,
     variableIfNewDecl: undefined,
     wasmInstance,
@@ -756,6 +761,7 @@ export function addPerpendicularityGdt({
   nodeToEdit?: PathToNode
 }): Error | { modifiedAst: Node<Program>; pathToNode: PathToNode } {
   let modifiedAst = structuredClone(ast)
+  const mNodeToEdit = structuredClone(nodeToEdit)
 
   const faceSelections = objects.graphSelections.filter((selection) =>
     isFaceArtifact(selection.artifact)
@@ -818,15 +824,15 @@ export function addPerpendicularityGdt({
   }
 
   if ('variableName' in tolerance && tolerance.variableName) {
-    insertVariableAndOffsetPathToNode(tolerance, modifiedAst, nodeToEdit)
+    insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
   }
   if (precision && 'variableName' in precision && precision.variableName) {
-    insertVariableAndOffsetPathToNode(precision, modifiedAst, nodeToEdit)
+    insertVariableAndOffsetPathToNode(precision, modifiedAst, mNodeToEdit)
   }
 
   const styleResult = processGdtStyleParameters({
     modifiedAst,
-    nodeToEdit,
+    nodeToEdit: mNodeToEdit,
     wasmInstance,
     framePosition,
     framePlane,
@@ -882,7 +888,7 @@ export function addPerpendicularityGdt({
     const pathToNode = setCallInAst({
       ast: modifiedAst,
       call: createPerpendicularityCall('faces', faceExpr),
-      pathToEdit: nodeToEdit,
+      pathToEdit: mNodeToEdit,
       pathIfNewPipe: undefined,
       variableIfNewDecl: undefined,
       wasmInstance,
@@ -897,7 +903,7 @@ export function addPerpendicularityGdt({
     const pathToNode = setCallInAst({
       ast: modifiedAst,
       call: createPerpendicularityCall('edges', edgeExpr),
-      pathToEdit: nodeToEdit,
+      pathToEdit: mNodeToEdit,
       pathIfNewPipe: undefined,
       variableIfNewDecl: undefined,
       wasmInstance,
@@ -948,6 +954,7 @@ export function addParallelismGdt({
   nodeToEdit?: PathToNode
 }): Error | { modifiedAst: Node<Program>; pathToNode: PathToNode } {
   let modifiedAst = structuredClone(ast)
+  const mNodeToEdit = structuredClone(nodeToEdit)
 
   const faceSelections = objects.graphSelections.filter((selection) =>
     isFaceArtifact(selection.artifact)
@@ -1010,15 +1017,15 @@ export function addParallelismGdt({
   }
 
   if ('variableName' in tolerance && tolerance.variableName) {
-    insertVariableAndOffsetPathToNode(tolerance, modifiedAst, nodeToEdit)
+    insertVariableAndOffsetPathToNode(tolerance, modifiedAst, mNodeToEdit)
   }
   if (precision && 'variableName' in precision && precision.variableName) {
-    insertVariableAndOffsetPathToNode(precision, modifiedAst, nodeToEdit)
+    insertVariableAndOffsetPathToNode(precision, modifiedAst, mNodeToEdit)
   }
 
   const styleResult = processGdtStyleParameters({
     modifiedAst,
-    nodeToEdit,
+    nodeToEdit: mNodeToEdit,
     wasmInstance,
     framePosition,
     framePlane,
@@ -1074,7 +1081,7 @@ export function addParallelismGdt({
     const pathToNode = setCallInAst({
       ast: modifiedAst,
       call: createParallelismCall('faces', faceExpr),
-      pathToEdit: nodeToEdit,
+      pathToEdit: mNodeToEdit,
       pathIfNewPipe: undefined,
       variableIfNewDecl: undefined,
       wasmInstance,
@@ -1089,7 +1096,7 @@ export function addParallelismGdt({
     const pathToNode = setCallInAst({
       ast: modifiedAst,
       call: createParallelismCall('edges', edgeExpr),
-      pathToEdit: nodeToEdit,
+      pathToEdit: mNodeToEdit,
       pathIfNewPipe: undefined,
       variableIfNewDecl: undefined,
       wasmInstance,
@@ -1136,6 +1143,7 @@ export function addAnnotationGdt({
   nodeToEdit?: PathToNode
 }): Error | { modifiedAst: Node<Program>; pathToNode: PathToNode } {
   let modifiedAst = structuredClone(ast)
+  const mNodeToEdit = structuredClone(nodeToEdit)
 
   const faceSelections = objects.graphSelections.filter((selection) =>
     isFaceArtifact(selection.artifact)
@@ -1199,7 +1207,7 @@ export function addAnnotationGdt({
 
   const styleResult = processGdtStyleParameters({
     modifiedAst,
-    nodeToEdit,
+    nodeToEdit: mNodeToEdit,
     wasmInstance,
     framePosition,
     framePlane,
@@ -1232,7 +1240,7 @@ export function addAnnotationGdt({
     const pathToNode = setCallInAst({
       ast: modifiedAst,
       call: createAnnotationCall('faces', faceExpr),
-      pathToEdit: nodeToEdit,
+      pathToEdit: mNodeToEdit,
       pathIfNewPipe: undefined,
       variableIfNewDecl: undefined,
       wasmInstance,
@@ -1247,7 +1255,7 @@ export function addAnnotationGdt({
     const pathToNode = setCallInAst({
       ast: modifiedAst,
       call: createAnnotationCall('edges', edgeExpr),
-      pathToEdit: nodeToEdit,
+      pathToEdit: mNodeToEdit,
       pathIfNewPipe: undefined,
       variableIfNewDecl: undefined,
       wasmInstance,


### PR DESCRIPTION
related to: https://github.com/KittyCAD/modeling-app/pull/11512#discussion_r3207930560
ai assisted

## Summary

Fixes GDT edit flows that create new variables while editing an existing annotation.

`insertVariableAndOffsetPathToNode` mutates the edit path it receives so the path still points to the edited call after a variable declaration is inserted. That is fine for the local AST update, but the original `nodeToEdit` should not be mutated across command bar review/submit passes.

This applies the existing `Position`/`Datum` pattern across the remaining GDT modifiers by cloning `nodeToEdit` before passing it into variable insertion, style parameter handling, and `setCallInAst`.

Covered GDT commands:

- Flatness
- Position
- Profile
- Distance
- Perpendicularity
- Parallelism
- Annotation
- Datum