### PR TITLE
Preserve KCL datum expressions for GDT edit flows

### DIFF
--- a/src/lang/modifyAst/gdt.spec.ts
+++ b/src/lang/modifyAst/gdt.spec.ts
@@ -84,7 +84,10 @@ async function getKclCommandValue(
   instance: ModuleType,
   rustContext: RustContext
 ) {
-  const result = await stringToKclExpression(value, rustContext)
+  const result = await stringToKclExpression(value, rustContext, {
+    allowArrays: true,
+    allowStringArrays: true,
+  })
   if (err(result) || 'errors' in result) {
     throw new Error('Failed to create KCL expression')
   }
@@ -585,11 +588,16 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
         instanceInThisFile,
         rustContextInThisFile
       )
+      const datums = await getKclCommandValue(
+        '["A", "B"]',
+        instanceInThisFile,
+        rustContextInThisFile
+      )
       const result = addProfileGdt({
         ast,
         artifactGraph,
         edges: createSelectionFromArtifacts([edge], artifactGraph),
-        datums: 'A, B',
+        datums,
         tolerance,
         wasmInstance: instanceInThisFile,
       })
@@ -909,11 +917,16 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
         instanceInThisFile,
         rustContextInThisFile
       )
+      const datums = await getKclCommandValue(
+        '["A", "B"]',
+        instanceInThisFile,
+        rustContextInThisFile
+      )
       const result = addPerpendicularityGdt({
         ast,
         artifactGraph,
         objects: createSelectionFromArtifacts([face, edge], artifactGraph),
-        datums: 'A, B',
+        datums,
         tolerance,
         wasmInstance: instanceInThisFile,
       })
@@ -957,13 +970,18 @@ extrude001 = extrude(profile001, length = 10, tagEnd = $capEnd001)
         instanceInThisFile,
         rustContextInThisFile
       )
+      const datums = await getKclCommandValue(
+        '["A", "B"]',
+        instanceInThisFile,
+        rustContextInThisFile
+      )
 
       const result = addParallelismGdt({
         ast,
         artifactGraph,
         objects,
         tolerance,
-        datums: 'A, B',
+        datums,
         wasmInstance: instanceInThisFile,
       })
       if (err(result)) {

--- a/src/lang/modifyAst/gdt.ts
+++ b/src/lang/modifyAst/gdt.ts
@@ -413,7 +413,7 @@ export function addProfileGdt({
   ast: Node<Program>
   artifactGraph: ArtifactGraph
   edges: Selections
-  datums?: string
+  datums?: KclCommandValue
   tolerance: KclCommandValue
   wasmInstance: ModuleType
   precision?: KclCommandValue
@@ -469,6 +469,9 @@ export function addProfileGdt({
   if ('variableName' in tolerance && tolerance.variableName) {
     insertVariableAndOffsetPathToNode(tolerance, modifiedAst, nodeToEdit)
   }
+  if (datums && 'variableName' in datums && datums.variableName) {
+    insertVariableAndOffsetPathToNode(datums, modifiedAst, nodeToEdit)
+  }
   if (precision && 'variableName' in precision && precision.variableName) {
     insertVariableAndOffsetPathToNode(precision, modifiedAst, nodeToEdit)
   }
@@ -495,16 +498,8 @@ export function addProfileGdt({
 
     labeledArgs.push(createLabeledArg('tolerance', valueOrVariable(tolerance)))
 
-    const datumNames = parseDatumNames(datums)
-    if (datumNames.length > 0) {
-      labeledArgs.push(
-        createLabeledArg(
-          'datums',
-          createArrayExpression(
-            datumNames.map((datum) => createLiteral(datum, wasmInstance))
-          )
-        )
-      )
+    if (datums) {
+      labeledArgs.push(createLabeledArg('datums', valueOrVariable(datums)))
     }
 
     if (precision !== undefined) {
@@ -744,7 +739,7 @@ export function addPerpendicularityGdt({
   ast: Node<Program>
   artifactGraph: ArtifactGraph
   objects: Selections
-  datums?: string
+  datums?: KclCommandValue
   tolerance: KclCommandValue
   wasmInstance: ModuleType
   precision?: KclCommandValue
@@ -820,6 +815,9 @@ export function addPerpendicularityGdt({
   if ('variableName' in tolerance && tolerance.variableName) {
     insertVariableAndOffsetPathToNode(tolerance, modifiedAst, nodeToEdit)
   }
+  if (datums && 'variableName' in datums && datums.variableName) {
+    insertVariableAndOffsetPathToNode(datums, modifiedAst, nodeToEdit)
+  }
   if (precision && 'variableName' in precision && precision.variableName) {
     insertVariableAndOffsetPathToNode(precision, modifiedAst, nodeToEdit)
   }
@@ -838,7 +836,6 @@ export function addPerpendicularityGdt({
     return styleResult
   }
 
-  const datumNames = parseDatumNames(datums)
   let lastPathToNode: PathToNode | undefined
 
   const createPerpendicularityCall = (
@@ -850,15 +847,8 @@ export function addPerpendicularityGdt({
       createLabeledArg('tolerance', valueOrVariable(tolerance)),
     ]
 
-    if (datumNames.length > 0) {
-      labeledArgs.push(
-        createLabeledArg(
-          'datums',
-          createArrayExpression(
-            datumNames.map((datum) => createLiteral(datum, wasmInstance))
-          )
-        )
-      )
+    if (datums) {
+      labeledArgs.push(createLabeledArg('datums', valueOrVariable(datums)))
     }
 
     if (precision !== undefined) {
@@ -936,7 +926,7 @@ export function addParallelismGdt({
   ast: Node<Program>
   artifactGraph: ArtifactGraph
   objects: Selections
-  datums?: string
+  datums?: KclCommandValue
   tolerance: KclCommandValue
   wasmInstance: ModuleType
   precision?: KclCommandValue
@@ -1012,6 +1002,9 @@ export function addParallelismGdt({
   if ('variableName' in tolerance && tolerance.variableName) {
     insertVariableAndOffsetPathToNode(tolerance, modifiedAst, nodeToEdit)
   }
+  if (datums && 'variableName' in datums && datums.variableName) {
+    insertVariableAndOffsetPathToNode(datums, modifiedAst, nodeToEdit)
+  }
   if (precision && 'variableName' in precision && precision.variableName) {
     insertVariableAndOffsetPathToNode(precision, modifiedAst, nodeToEdit)
   }
@@ -1030,7 +1023,6 @@ export function addParallelismGdt({
     return styleResult
   }
 
-  const datumNames = parseDatumNames(datums)
   let lastPathToNode: PathToNode | undefined
 
   const createParallelismCall = (
@@ -1042,15 +1034,8 @@ export function addParallelismGdt({
       createLabeledArg('tolerance', valueOrVariable(tolerance)),
     ]
 
-    if (datumNames.length > 0) {
-      labeledArgs.push(
-        createLabeledArg(
-          'datums',
-          createArrayExpression(
-            datumNames.map((datum) => createLiteral(datum, wasmInstance))
-          )
-        )
-      )
+    if (datums) {
+      labeledArgs.push(createLabeledArg('datums', valueOrVariable(datums)))
     }
 
     if (precision !== undefined) {
@@ -1472,13 +1457,6 @@ export function getNextAvailableDatumName(ast?: Node<Program>): string {
   }
 
   return fallback
-}
-
-function parseDatumNames(datums?: string): string[] {
-  return (datums ?? '')
-    .split(',')
-    .map((datum) => datum.trim())
-    .filter(Boolean)
 }
 
 /**

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -458,7 +458,7 @@ export type ModelingCommandSchema = {
   'GDT Profile': {
     nodeToEdit?: PathToNode
     edges: Selections
-    datums?: string
+    datums?: KclCommandValue
     tolerance: KclCommandValue
     precision?: KclCommandValue
     framePosition?: KclCommandValue
@@ -481,7 +481,7 @@ export type ModelingCommandSchema = {
   'GDT Perpendicularity': {
     nodeToEdit?: PathToNode
     objects: Selections
-    datums?: string
+    datums?: KclCommandValue
     tolerance: KclCommandValue
     precision?: KclCommandValue
     framePosition?: KclCommandValue
@@ -493,7 +493,7 @@ export type ModelingCommandSchema = {
   'GDT Parallelism': {
     nodeToEdit?: PathToNode
     objects: Selections
-    datums?: string
+    datums?: KclCommandValue
     tolerance: KclCommandValue
     precision?: KclCommandValue
     framePosition?: KclCommandValue
@@ -2899,7 +2899,14 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         hidden: (context) => Boolean(context.argumentsToSubmit.nodeToEdit),
       },
       datums: {
-        inputType: 'string',
+        inputType: 'kcl',
+        defaultValue: KCL_DEFAULT_DATUM_REFS,
+        allowArrays: true,
+        allowStringArrays: true,
+        allowUncalculated: true,
+        inputToKclValue: datumInputToKclArray,
+        kclValueToInput: kclDatumArrayToInput,
+        valueSummary: summarizeDatumKclValue,
         required: false,
       },
       tolerance: {
@@ -3071,7 +3078,14 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         hidden: (context) => Boolean(context.argumentsToSubmit.nodeToEdit),
       },
       datums: {
-        inputType: 'string',
+        inputType: 'kcl',
+        defaultValue: KCL_DEFAULT_DATUM_REFS,
+        allowArrays: true,
+        allowStringArrays: true,
+        allowUncalculated: true,
+        inputToKclValue: datumInputToKclArray,
+        kclValueToInput: kclDatumArrayToInput,
+        valueSummary: summarizeDatumKclValue,
         required: false,
       },
       tolerance: {
@@ -3157,7 +3171,14 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         hidden: (context) => Boolean(context.argumentsToSubmit.nodeToEdit),
       },
       datums: {
-        inputType: 'string',
+        inputType: 'kcl',
+        defaultValue: KCL_DEFAULT_DATUM_REFS,
+        allowArrays: true,
+        allowStringArrays: true,
+        allowUncalculated: true,
+        inputToKclValue: datumInputToKclArray,
+        kclValueToInput: kclDatumArrayToInput,
+        valueSummary: summarizeDatumKclValue,
         required: false,
       },
       tolerance: {

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -599,6 +599,18 @@ const summarizeDatumKclValue = (value?: KclCommandValue) =>
       )
     : ''
 
+const datumsProps = {
+  inputType: 'kcl',
+  defaultValue: KCL_DEFAULT_DATUM_REFS,
+  allowArrays: true,
+  allowStringArrays: true,
+  allowUncalculated: true,
+  inputToKclValue: datumInputToKclArray,
+  kclValueToInput: kclDatumArrayToInput,
+  valueSummary: summarizeDatumKclValue,
+  required: false,
+} satisfies CommandArgumentConfig<KclCommandValue, ModelingMachineContext>
+
 export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
   typeof modelingMachine,
   ModelingCommandSchema
@@ -2806,15 +2818,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         hidden: (context) => Boolean(context.argumentsToSubmit.nodeToEdit),
       },
       datums: {
-        inputType: 'kcl',
-        defaultValue: KCL_DEFAULT_DATUM_REFS,
-        allowArrays: true,
-        allowStringArrays: true,
-        allowUncalculated: true,
-        inputToKclValue: datumInputToKclArray,
-        kclValueToInput: kclDatumArrayToInput,
-        valueSummary: summarizeDatumKclValue,
-        required: false,
+        ...datumsProps,
       },
       tolerance: {
         inputType: 'kcl',
@@ -2899,15 +2903,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         hidden: (context) => Boolean(context.argumentsToSubmit.nodeToEdit),
       },
       datums: {
-        inputType: 'kcl',
-        defaultValue: KCL_DEFAULT_DATUM_REFS,
-        allowArrays: true,
-        allowStringArrays: true,
-        allowUncalculated: true,
-        inputToKclValue: datumInputToKclArray,
-        kclValueToInput: kclDatumArrayToInput,
-        valueSummary: summarizeDatumKclValue,
-        required: false,
+        ...datumsProps,
       },
       tolerance: {
         inputType: 'kcl',
@@ -3078,15 +3074,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         hidden: (context) => Boolean(context.argumentsToSubmit.nodeToEdit),
       },
       datums: {
-        inputType: 'kcl',
-        defaultValue: KCL_DEFAULT_DATUM_REFS,
-        allowArrays: true,
-        allowStringArrays: true,
-        allowUncalculated: true,
-        inputToKclValue: datumInputToKclArray,
-        kclValueToInput: kclDatumArrayToInput,
-        valueSummary: summarizeDatumKclValue,
-        required: false,
+        ...datumsProps,
       },
       tolerance: {
         inputType: 'kcl',
@@ -3171,15 +3159,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         hidden: (context) => Boolean(context.argumentsToSubmit.nodeToEdit),
       },
       datums: {
-        inputType: 'kcl',
-        defaultValue: KCL_DEFAULT_DATUM_REFS,
-        allowArrays: true,
-        allowStringArrays: true,
-        allowUncalculated: true,
-        inputToKclValue: datumInputToKclArray,
-        kclValueToInput: kclDatumArrayToInput,
-        valueSummary: summarizeDatumKclValue,
-        required: false,
+        ...datumsProps,
       },
       tolerance: {
         inputType: 'kcl',

--- a/src/lib/operations.spec.ts
+++ b/src/lib/operations.spec.ts
@@ -1,10 +1,11 @@
+import { join } from 'path'
 import type { NodePath } from '@rust/kcl-lib/bindings/NodePath'
+import type { OpKclValue } from '@rust/kcl-lib/bindings/Operation'
 import type { Operation } from '@rust/kcl-lib/bindings/Operation'
 import { defaultSourceRange } from '@src/lang/sourceRange'
 import { topLevelRange } from '@src/lang/util'
-import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import { loadAndInitialiseWasmInstance } from '@src/lang/wasmUtilsNode'
-import { join } from 'path'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 const WASM_PATH = join(process.cwd(), 'public/kcl_wasm_lib_bg.wasm')
 
 import {
@@ -13,15 +14,17 @@ import {
   defaultNodePath,
   nodePathFromRange,
 } from '@src/lang/wasm'
+import type { Artifact, ArtifactGraph } from '@src/lang/wasm'
 import {
+  enterEditFlow,
   filterOperations,
   getHideOpForArtifact,
   getOperationVariableName,
-  groupSketchBlockOperations,
   groupOperationTypeStreaks,
+  groupSketchBlockOperations,
 } from '@src/lib/operations'
-import { expect, describe, it } from 'vitest'
-import type { Artifact, ArtifactGraph } from '@src/lang/wasm'
+import { buildTheWorldAndNoEngineConnection } from '@src/unitTestUtils'
+import { describe, expect, it } from 'vitest'
 
 function stdlib(name: string): Operation {
   return {
@@ -70,6 +73,21 @@ function compositeSolidArtifact(
       nodePath,
       pathToNode: [],
     },
+  }
+}
+
+function segmentArtifact(id: string): Artifact {
+  return {
+    type: 'segment',
+    id,
+    pathId: 'path-id',
+    edgeIds: [],
+    codeRef: {
+      range: defaultSourceRange(),
+      nodePath: defaultNodePath(),
+      pathToNode: [],
+    },
+    commonSurfaceIds: [],
   }
 }
 
@@ -332,6 +350,111 @@ describe('operations.test.ts', () => {
       defaultNodePath()
     )
   }
+
+  describe('GDT edit flow', () => {
+    it.each([
+      {
+        operationName: 'gdt::profile',
+        commandName: 'GDT Profile',
+        targetLabel: 'edges',
+        targetExpression: '[edge001]',
+        targetValue: {
+          type: 'Array',
+          value: [{ type: 'Uuid', value: 'segment-id' }],
+        } satisfies OpKclValue,
+      },
+      {
+        operationName: 'gdt::perpendicularity',
+        commandName: 'GDT Perpendicularity',
+        targetLabel: 'faces',
+        targetExpression: '[side]',
+        targetValue: {
+          type: 'Array',
+          value: [
+            {
+              type: 'TagIdentifier',
+              value: 'side',
+              artifact_id: 'segment-id',
+            },
+          ],
+        } satisfies OpKclValue,
+      },
+      {
+        operationName: 'gdt::parallelism',
+        commandName: 'GDT Parallelism',
+        targetLabel: 'faces',
+        targetExpression: '[side]',
+        targetValue: {
+          type: 'Array',
+          value: [
+            {
+              type: 'TagIdentifier',
+              value: 'side',
+              artifact_id: 'segment-id',
+            },
+          ],
+        } satisfies OpKclValue,
+      },
+    ])(
+      'preserves variable-backed datums for $operationName',
+      async ({
+        operationName,
+        commandName,
+        targetLabel,
+        targetExpression,
+        targetValue,
+      }) => {
+        const { rustContext } = await buildTheWorldAndNoEngineConnection()
+        const code = `datumRefs = ["A"]
+edge001 = getCommonEdge(faces = [side, top])
+${operationName}(${targetLabel} = ${targetExpression}, tolerance = 0.1mm, datums = datumRefs)`
+        const datumRefsArgStart = code.lastIndexOf('datumRefs')
+        const operation = stdlib(operationName)
+        if (operation.type !== 'StdLibCall') {
+          throw new Error('Expected operation to be a StdLibCall')
+        }
+        operation.labeledArgs = {
+          [targetLabel]: {
+            value: targetValue,
+            sourceRange: rangeOfText(code, targetExpression),
+          },
+          tolerance: {
+            value: { type: 'Number', value: 0.1, ty: { type: 'Any' } },
+            sourceRange: rangeOfText(code, '0.1mm'),
+          },
+          datums: {
+            value: {
+              type: 'Array',
+              value: [{ type: 'String', value: 'A' }],
+            },
+            sourceRange: topLevelRange(
+              datumRefsArgStart,
+              datumRefsArgStart + 'datumRefs'.length
+            ),
+          },
+        }
+
+        const result = await enterEditFlow({
+          operation,
+          code,
+          artifactGraph: toArtifactGraph([segmentArtifact('segment-id')]),
+          rustContext,
+        })
+        if (result instanceof Error) {
+          throw result
+        }
+        if (result.type !== 'Find and select command') {
+          throw new Error(`Expected edit flow event, got ${result.type}`)
+        }
+
+        const argDefaultValues = result.data.argDefaultValues as {
+          datums?: { valueText: string }
+        }
+        expect(result.data.name).toBe(commandName)
+        expect(argDefaultValues.datums?.valueText).toBe('datumRefs')
+      }
+    )
+  })
 
   describe('variable name of operations', () => {
     it('finds the variable name with simple assignment', async () => {

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -101,7 +101,8 @@ async function extractKclArgument(
   operation: StdLibCallOp,
   argName: string,
   rustContext: RustContext,
-  isArray?: boolean
+  isArray?: boolean,
+  allowStringArrays?: boolean
 ): Promise<KclCommandValue | { error: string }> {
   const arg = operation.labeledArgs?.[argName]
   if (!arg?.sourceRange) {
@@ -111,7 +112,7 @@ async function extractKclArgument(
   const result = await stringToKclExpression(
     code.slice(...arg.sourceRange.map((r) => toUtf16(r, code))),
     rustContext,
-    { allowArrays: isArray }
+    { allowArrays: isArray, allowStringArrays }
   )
 
   if (err(result) || 'errors' in result) {
@@ -243,21 +244,17 @@ function extractStringArgument(
     : undefined
 }
 
-function extractStringArrayArgument(
+async function extractOptionalKclArrayArgument(
   code: string,
   operation: StdLibCallOp,
-  argName: string
-): string | undefined {
-  const raw = extractStringArgument(code, operation, argName)
-  if (!raw) return undefined
+  argName: string,
+  rustContext: RustContext
+): Promise<KclCommandValue | undefined | { error: string }> {
+  if (!operation.labeledArgs?.[argName]?.sourceRange) {
+    return undefined
+  }
 
-  return raw
-    .replace(/^\s*\[/, '')
-    .replace(/\]\s*$/, '')
-    .split(',')
-    .map((value) => stripQuotes(value.trim()))
-    .filter(Boolean)
-    .join(', ')
+  return extractKclArgument(code, operation, argName, rustContext, true, true)
 }
 
 /**
@@ -2036,19 +2033,14 @@ const prepareToEditGdtPosition: PrepareToEditCallback = async ({
     optionalArgs.map((arg) => ('error' in arg ? undefined : arg))
 
   const framePlane = extractStringArgument(code, operation, 'framePlane')
-  let datums: ModelingCommandSchema['GDT Position']['datums']
-  if (operation.labeledArgs?.['datums']?.sourceRange) {
-    const datumsResult = await extractKclArgument(
-      code,
-      operation,
-      'datums',
-      rustContext,
-      true
-    )
-    if ('error' in datumsResult) {
-      return { reason: datumsResult.error }
-    }
-    datums = datumsResult
+  const datums = await extractOptionalKclArrayArgument(
+    code,
+    operation,
+    'datums',
+    rustContext
+  )
+  if (datums && 'error' in datums) {
+    return { reason: datums.error }
   }
 
   const argDefaultValues: ModelingCommandSchema['GDT Position'] = {
@@ -2112,7 +2104,15 @@ const prepareToEditGdtProfile: PrepareToEditCallback = async ({
     optionalArgs.map((arg) => ('error' in arg ? undefined : arg))
 
   const framePlane = extractStringArgument(code, operation, 'framePlane')
-  const datums = extractStringArrayArgument(code, operation, 'datums')
+  const datums = await extractOptionalKclArrayArgument(
+    code,
+    operation,
+    'datums',
+    rustContext
+  )
+  if (datums && 'error' in datums) {
+    return { reason: datums.error }
+  }
 
   const argDefaultValues: ModelingCommandSchema['GDT Profile'] = {
     edges,
@@ -2282,7 +2282,15 @@ const prepareToEditGdtPerpendicularity: PrepareToEditCallback = async ({
     optionalArgs.map((arg) => ('error' in arg ? undefined : arg))
 
   const framePlane = extractStringArgument(code, operation, 'framePlane')
-  const datums = extractStringArrayArgument(code, operation, 'datums')
+  const datums = await extractOptionalKclArrayArgument(
+    code,
+    operation,
+    'datums',
+    rustContext
+  )
+  if (datums && 'error' in datums) {
+    return { reason: datums.error }
+  }
 
   const argDefaultValues: ModelingCommandSchema['GDT Perpendicularity'] = {
     objects: { graphSelections, otherSelections: [] },
@@ -2361,7 +2369,15 @@ const prepareToEditGdtParallelism: PrepareToEditCallback = async ({
     optionalArgs.map((arg) => ('error' in arg ? undefined : arg))
 
   const framePlane = extractStringArgument(code, operation, 'framePlane')
-  const datums = extractStringArrayArgument(code, operation, 'datums')
+  const datums = await extractOptionalKclArrayArgument(
+    code,
+    operation,
+    'datums',
+    rustContext
+  )
+  if (datums && 'error' in datums) {
+    return { reason: datums.error }
+  }
 
   const argDefaultValues: ModelingCommandSchema['GDT Parallelism'] = {
     objects: { graphSelections, otherSelections: [] },


### PR DESCRIPTION
ai assisted

## Summary
- Treat GDT Profile, Perpendicularity, and Parallelism datums as KCL command values, matching Position.
- Preserve datum array expressions and variable references during edit-flow extraction and AST updates.
- Add regression coverage for variable-backed datums like datumRefs across the remaining GDT edit flows.

Fixes #11583