### PR TITLE
Increase influence of coincident and fixed constraints

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -83,7 +83,7 @@ insta = { opt-level = 3 }
 debug = "line-tables-only"
 
 #Example: how to point modeling-app at a different repo (e.g. a branch or a local clone)
-# [patch.crates-io]
-# ezpz = { git = "https://github.com/KittyCAD/ezpz.git", branch = "david/circle-circle-tangent" }
+[patch.crates-io]
+ezpz = { git = "https://github.com/KittyCAD/ezpz.git", branch = "david/constraint-weights" }
 # kittycad-modeling-cmds = { git = "https://github.com/KittyCAD/modeling-api.git", branch = "main" }
 # kittycad-modeling-cmds = { path = "../../modeling-api/modeling-cmds" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -84,6 +84,6 @@ debug = "line-tables-only"
 
 #Example: how to point modeling-app at a different repo (e.g. a branch or a local clone)
 [patch.crates-io]
-ezpz = { git = "https://github.com/KittyCAD/ezpz.git", branch = "david/constraint-weights" }
+ezpz = { git = "https://github.com/KittyCAD/ezpz.git", branch = "main" }
 # kittycad-modeling-cmds = { git = "https://github.com/KittyCAD/modeling-api.git", branch = "main" }
 # kittycad-modeling-cmds = { path = "../../modeling-api/modeling-cmds" }

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1718,12 +1718,14 @@ impl Node<SketchBlock> {
 
         // Translate sketch variables and constraints to solver input.
         //
-        // Coincident and transient fixed constraints get a heavier weight so they hold up under
-        // stress — e.g. when the user drags a sketch into a configuration that can't be fully
-        // satisfied, we'd rather see other constraints absorb the error than have shared points
-        // come apart.
+        // Coincident constraints get a heavier weight so they hold up under stress — e.g. when the
+        // user drags a sketch into a configuration that can't be fully satisfied, we'd rather see
+        // other constraints absorb the error than have shared points come apart.
+        //
+        // The same should be applied to any transient constraints associated with mouse
+        // interactions once drag improvements are ready.
+        //
         const COINCIDENT_WEIGHT: f64 = 100.0;
-        const DRAG_FIXED_WEIGHT: f64 = 100.0;
         let constraints = sketch_block_state
             .solver_constraints
             .iter()

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1726,6 +1726,7 @@ impl Node<SketchBlock> {
         // interactions once drag improvements are ready.
         //
         const COINCIDENT_WEIGHT: f64 = 100.0;
+        const FIXED_WEIGHT: f64 = 100.0;
         let constraints = sketch_block_state
             .solver_constraints
             .iter()
@@ -1734,6 +1735,7 @@ impl Node<SketchBlock> {
                 let req = ezpz::ConstraintRequest::highest_priority(c);
                 match c {
                     ezpz::Constraint::PointsCoincident(..) => req.with_weight(COINCIDENT_WEIGHT),
+                    ezpz::Constraint::Fixed(..) => req.with_weight(FIXED_WEIGHT),
                     _ => req,
                 }
             })
@@ -1743,7 +1745,14 @@ impl Node<SketchBlock> {
                     .solver_optional_constraints
                     .iter()
                     .cloned()
-                    .map(|c| ezpz::ConstraintRequest::new(c, 1)),
+                    .map(|c| {
+                        let req = ezpz::ConstraintRequest::new(c, 1);
+                        match c {
+                            ezpz::Constraint::PointsCoincident(..) => req.with_weight(COINCIDENT_WEIGHT),
+                            ezpz::Constraint::Fixed(..) => req.with_weight(FIXED_WEIGHT),
+                            _ => req,
+                        }
+                    }),
             )
             .collect::<Vec<_>>();
         let initial_guesses = sketch_block_state

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1717,11 +1717,24 @@ impl Node<SketchBlock> {
         let mut sketch_block_state = sketch_block_state;
 
         // Translate sketch variables and constraints to solver input.
+        //
+        // Coincident and transient fixed constraints get a heavier weight so they hold up under
+        // stress — e.g. when the user drags a sketch into a configuration that can't be fully
+        // satisfied, we'd rather see other constraints absorb the error than have shared points
+        // come apart.
+        const COINCIDENT_WEIGHT: f64 = 100.0;
+        const DRAG_FIXED_WEIGHT: f64 = 100.0;
         let constraints = sketch_block_state
             .solver_constraints
             .iter()
             .cloned()
-            .map(ezpz::ConstraintRequest::highest_priority)
+            .map(|c| {
+                let req = ezpz::ConstraintRequest::highest_priority(c);
+                match c {
+                    ezpz::Constraint::PointsCoincident(..) => req.with_weight(COINCIDENT_WEIGHT),
+                    _ => req,
+                }
+            })
             .chain(
                 // Optional constraints have a lower priority.
                 sketch_block_state


### PR DESCRIPTION
Following up on [this comment](https://github.com/KittyCAD/modeling-app/pull/11382#issuecomment-4366692689) from #11382, this increases the influence of coincident and fixed constraints to mitigate the issue where sketches with unshared vertices visibly come apart during interaction. 

Here's an example showing the difference between weighted and unweighted coincidence constraints during interaction.

[sketch-interaction-weighting-1.webm](https://github.com/user-attachments/assets/56e92f14-2c93-4427-9710-a70761e0c321)

Relies on changes from: kittycad/ezpz#260