### PR TITLE
Scale GD&T frame position defaults to bounding box

### DIFF
--- a/src/lib/gdtFramePosition.test.ts
+++ b/src/lib/gdtFramePosition.test.ts
@@ -1,0 +1,126 @@
+import type { ConnectionManager } from '@src/network/connectionManager'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+import {
+  getAverageBoundingBoxDimension,
+  getEngineEntityIdsForGdtSelections,
+  withDefaultGdtFramePosition,
+} from '@src/lib/gdtFramePosition'
+import type { Selections } from '@src/machines/modelingSharedTypes'
+import type { ModelingCommandSchema } from '@src/lib/commandBarConfigs/modelingCommandConfig'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('GD&T bounding box frame position defaults', () => {
+  it('averages non-zero bounding box dimensions', () => {
+    expect(getAverageBoundingBoxDimension({ x: 4, y: 0, z: 8 })).toBe(6)
+    expect(getAverageBoundingBoxDimension({ x: 4, y: 4, z: 4 })).toBe(4)
+    expect(getAverageBoundingBoxDimension({ x: 0, y: 0, z: 0 })).toBeUndefined()
+  })
+
+  it('gets engine entity ids from GD&T selections', () => {
+    const selections: Selections = {
+      graphSelections: [
+        {
+          codeRef: { range: [0, 1, 0], pathToNode: [] },
+          artifact: {
+            type: 'cap',
+            id: 'cap-1',
+          } as any,
+        },
+        {
+          codeRef: { range: [1, 2, 0], pathToNode: [] },
+          artifact: {
+            type: 'pattern',
+            id: 'pattern-1',
+            copyIds: ['copy-1'],
+            copyFaceIds: ['copy-face-1'],
+            copyEdgeIds: ['copy-edge-1', 'copy-face-1'],
+          } as any,
+        },
+      ],
+      otherSelections: [],
+    }
+
+    expect(getEngineEntityIdsForGdtSelections(selections)).toEqual([
+      'cap-1',
+      'copy-1',
+      'copy-face-1',
+      'copy-edge-1',
+    ])
+  })
+
+  it('fills omitted framePosition from the selected bounding box', async () => {
+    const sendSceneCommand = vi.fn().mockResolvedValue({
+      success: true,
+      resp: {
+        type: 'modeling',
+        data: {
+          modeling_response: {
+            type: 'bounding_box',
+            data: {
+              center: { x: 0, y: 0, z: 0 },
+              dimensions: { x: 4, y: 0, z: 8 },
+            },
+          },
+        },
+      },
+    })
+
+    const data = {
+      name: 'A',
+      faces: {
+        graphSelections: [
+          {
+            codeRef: { range: [0, 1, 0], pathToNode: [] },
+            artifact: { type: 'cap', id: 'cap-1' } as any,
+          },
+        ],
+        otherSelections: [],
+      },
+    } as ModelingCommandSchema['GDT Datum']
+
+    const result = await withDefaultGdtFramePosition({
+      data,
+      engineCommandManager: {
+        sendSceneCommand,
+      } as unknown as ConnectionManager,
+      outputUnit: 'cm',
+      wasmInstance: {} as ModuleType,
+    })
+
+    expect(sendSceneCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cmd: expect.objectContaining({
+          type: 'bounding_box',
+          entity_ids: ['cap-1'],
+          output_unit: 'cm',
+        }),
+      })
+    )
+    expect(result.framePosition?.valueText).toBe('[6, 6]')
+  })
+
+  it('preserves an explicit framePosition', async () => {
+    const sendSceneCommand = vi.fn()
+    const framePosition = {
+      valueAst: {} as any,
+      valueCalculated: '[1, 2]',
+      valueText: '[1, 2]',
+    }
+    const data = {
+      name: 'A',
+      framePosition,
+      faces: { graphSelections: [], otherSelections: [] },
+    } as ModelingCommandSchema['GDT Datum']
+
+    const result = await withDefaultGdtFramePosition({
+      data,
+      engineCommandManager: {
+        sendSceneCommand,
+      } as unknown as ConnectionManager,
+      wasmInstance: {} as ModuleType,
+    })
+
+    expect(sendSceneCommand).not.toHaveBeenCalled()
+    expect(result.framePosition).toBe(framePosition)
+  })
+})

--- a/src/lib/gdtFramePosition.ts
+++ b/src/lib/gdtFramePosition.ts
@@ -1,0 +1,135 @@
+import type { BoundingBox } from '@kittycad/lib'
+
+import { createArrayExpression, createLiteral } from '@src/lang/create'
+import type { ArtifactId } from '@src/lang/wasm'
+import type { UnitLength } from '@rust/kcl-lib/bindings/ModelingCmd'
+import type { ModelingCommandSchema } from '@src/lib/commandBarConfigs/modelingCommandConfig'
+import type { KclCommandValue } from '@src/lib/commandTypes'
+import { DEFAULT_DEFAULT_LENGTH_UNIT } from '@src/lib/constants'
+import { isModelingResponse } from '@src/lib/kcSdkGuards'
+import { roundOff, uuidv4 } from '@src/lib/utils'
+import type { ConnectionManager } from '@src/network/connectionManager'
+import type { Selections } from '@src/machines/modelingSharedTypes'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+
+type GdtCommandData =
+  | ModelingCommandSchema['GDT Flatness']
+  | ModelingCommandSchema['GDT Datum']
+  | ModelingCommandSchema['GDT Position']
+  | ModelingCommandSchema['GDT Profile']
+  | ModelingCommandSchema['GDT Distance']
+  | ModelingCommandSchema['GDT Perpendicularity']
+  | ModelingCommandSchema['GDT Parallelism']
+  | ModelingCommandSchema['GDT Annotation']
+
+function getSelectionsFromGdtData(
+  data: GdtCommandData
+): Selections | undefined {
+  if ('objects' in data) return data.objects
+  if ('faces' in data) return data.faces
+  if ('edges' in data) return data.edges
+  return undefined
+}
+
+export function getEngineEntityIdsForGdtSelections(
+  selections: Selections | undefined
+): ArtifactId[] {
+  if (!selections) return []
+
+  const entityIds = selections.graphSelections.flatMap((selection) => {
+    if (selection.engineEntityId) return [selection.engineEntityId]
+
+    const artifact = selection.artifact
+    if (!artifact?.id) return []
+
+    if (artifact.type !== 'pattern') return [artifact.id]
+
+    return [
+      ...artifact.copyIds,
+      ...artifact.copyFaceIds,
+      ...artifact.copyEdgeIds,
+    ]
+  })
+
+  return [...new Set(entityIds)]
+}
+
+export function getAverageBoundingBoxDimension(
+  dimensions: BoundingBox['dimensions']
+): number | undefined {
+  const nonZeroDimensions = [dimensions.x, dimensions.y, dimensions.z].filter(
+    (dimension) => Number.isFinite(dimension) && dimension > 0
+  )
+
+  if (nonZeroDimensions.length === 0) return undefined
+
+  return roundOff(
+    nonZeroDimensions.reduce((sum, dimension) => sum + dimension, 0) /
+      nonZeroDimensions.length,
+    4
+  )
+}
+
+function createFramePositionCommandValue(
+  value: number,
+  wasmInstance: ModuleType
+): KclCommandValue {
+  const valueText = `[${value}, ${value}]`
+  return {
+    valueAst: createArrayExpression([
+      createLiteral(value, wasmInstance),
+      createLiteral(value, wasmInstance),
+    ]),
+    valueCalculated: valueText,
+    valueText,
+  }
+}
+
+export async function withDefaultGdtFramePosition<T extends GdtCommandData>({
+  data,
+  engineCommandManager,
+  outputUnit = DEFAULT_DEFAULT_LENGTH_UNIT,
+  wasmInstance,
+}: {
+  data: T
+  engineCommandManager: ConnectionManager
+  outputUnit?: UnitLength
+  wasmInstance: ModuleType
+}): Promise<T> {
+  if (data.framePosition) return data
+
+  const selections = getSelectionsFromGdtData(data)
+  const entityIds = getEngineEntityIdsForGdtSelections(selections)
+
+  try {
+    const response = await engineCommandManager.sendSceneCommand({
+      type: 'modeling_cmd_req',
+      cmd_id: uuidv4(),
+      cmd: {
+        type: 'bounding_box',
+        entity_ids: entityIds,
+        output_unit: outputUnit,
+      },
+    })
+
+    if (!isModelingResponse(response)) return data
+
+    const modelingResponse = response.resp.data.modeling_response
+    if (modelingResponse.type !== 'bounding_box') return data
+
+    const averageDimension = getAverageBoundingBoxDimension(
+      modelingResponse.data.dimensions
+    )
+    if (averageDimension === undefined) return data
+
+    return {
+      ...data,
+      framePosition: createFramePositionCommandValue(
+        averageDimension,
+        wasmInstance
+      ),
+    }
+  } catch {
+    return data
+  }
+}

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -235,6 +235,7 @@ import { addFlipSurface, addJoinSurfaces } from '@src/lang/modifyAst/surfaces'
 import { jsAppSettings } from '@src/lib/settings/settingsUtils'
 import { addTagForSketchOnFace } from '@src/lang/std/sketch'
 import { toPlaneName } from '@src/lib/planes'
+import { withDefaultGdtFramePosition } from '@src/lib/gdtFramePosition'
 
 function sourceRangesEqual(
   a: [number, number, number],
@@ -5119,11 +5120,20 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
+        const wasmInstance = await input.kclManager.wasmInstancePromise
+
+        const data = await withDefaultGdtFramePosition({
+          data: input.data,
+          engineCommandManager: input.kclManager.engineCommandManager,
+          outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
+          wasmInstance,
+        })
+
         const result = addFlatnessGdt({
-          ...input.data,
+          ...data,
           ast: input.kclManager.ast,
           artifactGraph: input.kclManager.artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          wasmInstance,
         })
         if (err(result)) {
           return Promise.reject(result)
@@ -5155,11 +5165,20 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
+        const wasmInstance = await input.kclManager.wasmInstancePromise
+
+        const data = await withDefaultGdtFramePosition({
+          data: input.data,
+          engineCommandManager: input.kclManager.engineCommandManager,
+          outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
+          wasmInstance,
+        })
+
         const result = addDatumGdt({
-          ...input.data,
+          ...data,
           ast: input.kclManager.ast,
           artifactGraph: input.kclManager.artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          wasmInstance,
         })
         if (err(result)) {
           return Promise.reject(result)
@@ -5191,11 +5210,20 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
+        const wasmInstance = await input.kclManager.wasmInstancePromise
+
+        const data = await withDefaultGdtFramePosition({
+          data: input.data,
+          engineCommandManager: input.kclManager.engineCommandManager,
+          outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
+          wasmInstance,
+        })
+
         const result = addProfileGdt({
-          ...input.data,
+          ...data,
           ast: input.kclManager.ast,
           artifactGraph: input.kclManager.artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          wasmInstance,
         })
         if (err(result)) {
           return Promise.reject(result)
@@ -5227,11 +5255,20 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
+        const wasmInstance = await input.kclManager.wasmInstancePromise
+
+        const data = await withDefaultGdtFramePosition({
+          data: input.data,
+          engineCommandManager: input.kclManager.engineCommandManager,
+          outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
+          wasmInstance,
+        })
+
         const result = addPositionGdt({
-          ...input.data,
+          ...data,
           ast: input.kclManager.ast,
           artifactGraph: input.kclManager.artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          wasmInstance,
         })
         if (err(result)) {
           return Promise.reject(result)
@@ -5263,11 +5300,20 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
+        const wasmInstance = await input.kclManager.wasmInstancePromise
+
+        const data = await withDefaultGdtFramePosition({
+          data: input.data,
+          engineCommandManager: input.kclManager.engineCommandManager,
+          outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
+          wasmInstance,
+        })
+
         const result = addDistanceGdt({
-          ...input.data,
+          ...data,
           ast: input.kclManager.ast,
           artifactGraph: input.kclManager.artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          wasmInstance,
         })
         if (err(result)) {
           return Promise.reject(result)
@@ -5299,11 +5345,20 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
+        const wasmInstance = await input.kclManager.wasmInstancePromise
+
+        const data = await withDefaultGdtFramePosition({
+          data: input.data,
+          engineCommandManager: input.kclManager.engineCommandManager,
+          outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
+          wasmInstance,
+        })
+
         const result = addPerpendicularityGdt({
-          ...input.data,
+          ...data,
           ast: input.kclManager.ast,
           artifactGraph: input.kclManager.artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          wasmInstance,
         })
         if (err(result)) {
           return Promise.reject(result)
@@ -5335,11 +5390,20 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
+        const wasmInstance = await input.kclManager.wasmInstancePromise
+
+        const data = await withDefaultGdtFramePosition({
+          data: input.data,
+          engineCommandManager: input.kclManager.engineCommandManager,
+          outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
+          wasmInstance,
+        })
+
         const result = addParallelismGdt({
-          ...input.data,
+          ...data,
           ast: input.kclManager.ast,
           artifactGraph: input.kclManager.artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          wasmInstance,
         })
         if (err(result)) {
           return Promise.reject(result)
@@ -5371,11 +5435,20 @@ export const modelingMachine = setup({
           return Promise.reject(new Error(NO_INPUT_PROVIDED_MESSAGE))
         }
 
+        const wasmInstance = await input.kclManager.wasmInstancePromise
+
+        const data = await withDefaultGdtFramePosition({
+          data: input.data,
+          engineCommandManager: input.kclManager.engineCommandManager,
+          outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
+          wasmInstance,
+        })
+
         const result = addAnnotationGdt({
-          ...input.data,
+          ...data,
           ast: input.kclManager.ast,
           artifactGraph: input.kclManager.artifactGraph,
-          wasmInstance: await input.kclManager.wasmInstancePromise,
+          wasmInstance,
         })
         if (err(result)) {
           return Promise.reject(result)


### PR DESCRIPTION
ai assisted


https://github.com/user-attachments/assets/7bd7477d-4342-4c18-8390-ec738b1c11e7



## Summary
- Add a GD&T framePosition default helper that requests the engine bounding_box for selected entities when framePosition is omitted.
- Use the average of finite positive bounding-box dimensions and inject [avg, avg] in the current file length unit; explicit framePosition values are preserved.
- Apply the computed default across the GD&T command actors, with fallback to the existing stdlib default if the bounding box is unavailable.

## Research notes
- rust/kcl-lib/std/gdt.kcl defaults optional framePosition to [100mm, 100mm].
- The engine modeling command supports bounding_box with entity_ids and output_unit, so the app can query selected geometry before mutating the AST.
- Command data leaves optional framePosition undefined unless the user supplies it, which gives us a clean place to inject the computed value.
