### PR TITLE
Stabilize GdtAnnotation type docs

### DIFF
--- a/docs/kcl-std-legacy/types/std-types-GdtAnnotation.md
+++ b/docs/kcl-std-legacy/types/std-types-GdtAnnotation.md
@@ -5,8 +5,6 @@ excerpt: "A GD&T annotation created by one of the `gdt` functions."
 layout: manual
 ---
 
-**WARNING:** This type is experimental and may change or be removed.
-
 A GD&T annotation created by one of the `gdt` functions.
 
 

--- a/docs/kcl-std-sketch-solve/types/std-types-GdtAnnotation.md
+++ b/docs/kcl-std-sketch-solve/types/std-types-GdtAnnotation.md
@@ -5,8 +5,6 @@ excerpt: "A GD&T annotation created by one of the `gdt` functions."
 layout: manual
 ---
 
-**WARNING:** This type is experimental and may change or be removed.
-
 A GD&T annotation created by one of the `gdt` functions.
 
 

--- a/docs/kcl-std/types/std-types-GdtAnnotation.md
+++ b/docs/kcl-std/types/std-types-GdtAnnotation.md
@@ -5,8 +5,6 @@ excerpt: "A GD&T annotation created by one of the [`gdt` functions](/docs/kcl-st
 layout: manual
 ---
 
-**WARNING:** This type is experimental and may change or be removed.
-
 A GD&T annotation created by one of the [`gdt` functions](/docs/kcl-std/modules/std-gdt).
 
 

--- a/rust/kcl-lib/std/types.kcl
+++ b/rust/kcl-lib/std/types.kcl
@@ -386,7 +386,7 @@ export type Axis2d
 export type Axis3d
 
 /// A GD&T annotation created by one of the [`gdt` functions](/docs/kcl-std/modules/std-gdt).
-@(impl = std_rust, experimental = true)
+@(impl = std_rust)
 export type GdtAnnotation
 
 export type mm = number(mm)


### PR DESCRIPTION
## Summary
- remove the experimental marker from std::types::GdtAnnotation
- regenerate the GdtAnnotation type docs so the warning is gone from canonical and split docs