### PR TITLE
Fix GDT annotation autofill casing

### DIFF
--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -3192,7 +3192,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
       },
       annotation: {
         inputType: 'text',
-        defaultValue: 'Break all sharp edges',
+        defaultValue: 'BREAK ALL SHARP EDGES',
         required: true,
       },
       framePosition: {


### PR DESCRIPTION
Change the GDT Annotation default note to all caps: BREAK ALL SHARP EDGES

Closes #11619