### PR TITLE
Franknoirot/adhoc/fix sketch regression

### DIFF
--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1762,7 +1762,7 @@ impl Node<SketchBlock> {
                     return Err(internal_err(message, self));
                 };
                 let initial_guess = exec_state
-                    .sketch_var_initial_guess_override(sketch_var.id)
+                    .sketch_var_initial_guess_override(sketch_var)
                     .unwrap_or(initial_guess);
                 Ok((constraint_id, initial_guess))
             })

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -3,6 +3,7 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use ahash::AHashMap;
 use anyhow::Result;
 pub use artifact::Artifact;
 pub use artifact::ArtifactCommand;
@@ -486,9 +487,10 @@ pub struct MockConfig {
     pub freedom_analysis: bool,
     /// The segments that were edited that triggered this execution.
     pub segment_ids_edited: AhashIndexSet<ObjectId>,
-    /// Per-sketch-variable initial guess overrides, keyed by sketch variable
-    /// order. These are transient warm-start values for interactive solves.
-    pub sketch_var_initial_guess_overrides: Vec<f64>,
+    /// Per-sketch-variable initial guess overrides, keyed by the source range
+    /// of the `var` initial value. This is the stable form used by sketch
+    /// interaction because some constraints introduce hidden solver variables.
+    pub sketch_var_initial_guess_overrides_by_source: AHashMap<SourceRange, f64>,
 }
 
 impl Default for MockConfig {
@@ -499,7 +501,7 @@ impl Default for MockConfig {
             sketch_block_id: None,
             freedom_analysis: true,
             segment_ids_edited: AhashIndexSet::default(),
-            sketch_var_initial_guess_overrides: Vec::new(),
+            sketch_var_initial_guess_overrides_by_source: AHashMap::new(),
         }
     }
 }
@@ -520,8 +522,11 @@ impl MockConfig {
     }
 
     #[must_use]
-    pub(crate) fn with_sketch_var_initial_guess_overrides(mut self, overrides: Vec<f64>) -> Self {
-        self.sketch_var_initial_guess_overrides = overrides;
+    pub(crate) fn with_sketch_var_initial_guess_overrides_by_source(
+        mut self,
+        overrides: AHashMap<SourceRange, f64>,
+    ) -> Self {
+        self.sketch_var_initial_guess_overrides_by_source = overrides;
         self
     }
 }

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -82,9 +82,9 @@ pub(super) struct GlobalState {
     pub root_module_artifacts: ModuleArtifactState,
     /// The segments that were edited that triggered this execution.
     pub segment_ids_edited: AhashIndexSet<ObjectId>,
-    /// Transient warm-start values for sketch variables, keyed by the solver
-    /// variable order in the current sketch block.
-    pub sketch_var_initial_guess_overrides: Vec<f64>,
+    /// Transient warm-start values for sketch variables, keyed by the source
+    /// range of the `var` initial value.
+    pub sketch_var_initial_guess_overrides_by_source: AHashMap<SourceRange, f64>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -308,7 +308,7 @@ pub(crate) struct SketchBlockState {
 impl ExecState {
     pub fn new(exec_context: &super::ExecutorContext) -> Self {
         ExecState {
-            global: GlobalState::new(&exec_context.settings, Default::default(), Vec::new()),
+            global: GlobalState::new(&exec_context.settings, Default::default(), Default::default()),
             mod_local: ModuleState::new(ModulePath::Main, ProgramMemory::new(), Default::default(), false, true),
         }
     }
@@ -319,7 +319,7 @@ impl ExecState {
             global: GlobalState::new(
                 &exec_context.settings,
                 segment_ids_edited,
-                mock_config.sketch_var_initial_guess_overrides.clone(),
+                mock_config.sketch_var_initial_guess_overrides_by_source.clone(),
             ),
             mod_local: ModuleState::new(
                 ModulePath::Main,
@@ -332,7 +332,7 @@ impl ExecState {
     }
 
     pub(super) fn reset(&mut self, exec_context: &super::ExecutorContext) {
-        let global = GlobalState::new(&exec_context.settings, Default::default(), Vec::new());
+        let global = GlobalState::new(&exec_context.settings, Default::default(), Default::default());
 
         *self = ExecState {
             global,
@@ -553,8 +553,16 @@ impl ExecState {
         self.global.segment_ids_edited.contains(object_id)
     }
 
-    pub(crate) fn sketch_var_initial_guess_override(&self, var_id: SketchVarId) -> Option<f64> {
-        self.global.sketch_var_initial_guess_overrides.get(var_id.0).copied()
+    pub(crate) fn sketch_var_initial_guess_override(&self, sketch_var: &crate::execution::SketchVar) -> Option<f64> {
+        sketch_var
+            .meta
+            .first()
+            .and_then(|meta| {
+                self.global
+                    .sketch_var_initial_guess_overrides_by_source
+                    .get(&meta.source_range)
+            })
+            .copied()
     }
 
     pub(super) fn is_in_sketch_block(&self) -> bool {
@@ -889,7 +897,7 @@ impl GlobalState {
     fn new(
         settings: &ExecutorSettings,
         segment_ids_edited: AhashIndexSet<ObjectId>,
-        sketch_var_initial_guess_overrides: Vec<f64>,
+        sketch_var_initial_guess_overrides_by_source: AHashMap<SourceRange, f64>,
     ) -> Self {
         let mut global = GlobalState {
             path_to_source_id: Default::default(),
@@ -900,7 +908,7 @@ impl GlobalState {
             issues: Default::default(),
             id_to_source: Default::default(),
             segment_ids_edited,
-            sketch_var_initial_guess_overrides,
+            sketch_var_initial_guess_overrides_by_source,
         };
 
         let root_id = ModuleId::default();

--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::ops::ControlFlow;
 
+use ahash::AHashMap;
 use indexmap::IndexMap;
 use kcl_error::CompilationIssue;
 use kcl_error::SourceRange;
@@ -237,7 +238,9 @@ pub struct FrontendState {
     /// Transient solver continuity state. During previews we warm-start from
     /// the previous solution without treating those solved guesses as committed
     /// source text.
-    sketch_var_warm_start_overrides: HashMap<ObjectId, Vec<f64>>,
+    /// Same continuity state keyed by source range, which remains valid when
+    /// constraints insert hidden solver variables into the sketch var order.
+    sketch_var_warm_start_overrides_by_source: HashMap<ObjectId, AHashMap<SourceRange, f64>>,
     next_sketch_var_update_mode: Option<SketchVarUpdateMode>,
     sketch_checkpoints: VecDeque<SketchCheckpoint>,
     sketch_checkpoint_id_gen: IncIdGenerator<u64>,
@@ -262,7 +265,7 @@ impl FrontendState {
                 sketch_mode: Default::default(),
             },
             point_freedom_cache: HashMap::new(),
-            sketch_var_warm_start_overrides: HashMap::new(),
+            sketch_var_warm_start_overrides_by_source: HashMap::new(),
             next_sketch_var_update_mode: None,
             sketch_checkpoints: VecDeque::new(),
             sketch_checkpoint_id_gen: IncIdGenerator::new(1),
@@ -346,7 +349,7 @@ impl FrontendState {
     }
 
     pub(crate) fn clear_sketch_var_warm_starts(&mut self) {
-        self.sketch_var_warm_start_overrides.clear();
+        self.sketch_var_warm_start_overrides_by_source.clear();
     }
 
     pub async fn edit_segments_for_preview(
@@ -398,9 +401,13 @@ impl FrontendState {
             ..Default::default()
         };
 
-        match (use_warm_starts, self.sketch_var_warm_start_overrides.get(&sketch)) {
-            (true, Some(overrides)) => config.with_sketch_var_initial_guess_overrides(overrides.clone()),
-            _ => config,
+        if !use_warm_starts {
+            return config;
+        }
+
+        match self.sketch_var_warm_start_overrides_by_source.get(&sketch) {
+            Some(overrides) => config.with_sketch_var_initial_guess_overrides_by_source(overrides.clone()),
+            None => config,
         }
     }
 
@@ -436,19 +443,38 @@ impl FrontendState {
     fn replace_sketch_var_warm_starts(&mut self, sketch: ObjectId, outcome: &ExecOutcome) {
         #[cfg(feature = "artifact-graph")]
         {
-            let solution_by_range = outcome
-                .var_solutions
-                .iter()
-                .map(|(range, value)| (*range, value.value))
-                .collect::<HashMap<_, _>>();
-            let values = self
-                .sketch_var_initial_guesses_from_program(sketch, &solution_by_range)
-                .unwrap_or_else(|| outcome.var_solutions.iter().map(|(_, value)| value.value).collect());
-            self.sketch_var_warm_start_overrides.insert(sketch, values);
+            self.sketch_var_warm_start_overrides_by_source.insert(
+                sketch,
+                outcome
+                    .var_solutions
+                    .iter()
+                    .map(|(range, value)| (*range, value.value))
+                    .collect::<AHashMap<_, _>>(),
+            );
         }
         #[cfg(not(feature = "artifact-graph"))]
         {
             let _ = (sketch, outcome);
+        }
+    }
+
+    fn replace_sketch_var_warm_starts_from_ordered_values(&mut self, sketch: ObjectId, values: &[f64]) {
+        #[cfg(feature = "artifact-graph")]
+        {
+            if let Some(source_values) = self.sketch_var_source_values_from_program(sketch) {
+                self.sketch_var_warm_start_overrides_by_source.insert(
+                    sketch,
+                    source_values
+                        .into_iter()
+                        .zip(values.iter().copied())
+                        .map(|((range, _), value)| (range, value))
+                        .collect::<AHashMap<_, _>>(),
+                );
+            }
+        }
+        #[cfg(not(feature = "artifact-graph"))]
+        {
+            let _ = (sketch, values);
         }
     }
 
@@ -457,7 +483,8 @@ impl FrontendState {
         sketch: ObjectId,
         outcome: &ExecOutcome,
         segment_ids_edited: &AhashIndexSet<ObjectId>,
-    ) {
+        previous_ordered_values: Option<Vec<f64>>,
+    ) -> Option<Vec<f64>> {
         #[cfg(feature = "artifact-graph")]
         {
             let solution_by_range = outcome
@@ -465,32 +492,62 @@ impl FrontendState {
                 .iter()
                 .map(|(range, value)| (*range, value.value))
                 .collect::<HashMap<_, _>>();
-            let previous = self.sketch_var_warm_start_overrides.get(&sketch).cloned();
+            let previous_by_source = self.sketch_var_warm_start_overrides_by_source.get(&sketch).cloned();
             let Some(source_values) = self.sketch_var_source_values_from_program(sketch) else {
                 self.replace_sketch_var_warm_starts(sketch, outcome);
-                return;
+                return Some(outcome.var_solutions.iter().map(|(_, value)| value.value).collect());
             };
             let edited_var_indices = self.edited_sketch_var_indices(&source_values, segment_ids_edited);
-            let values = source_values
+            let merged_values = source_values
                 .into_iter()
                 .enumerate()
                 .map(|(index, (range, source_value))| {
-                    if edited_var_indices.contains(&index) || !solution_by_range.contains_key(&range) {
+                    let value = if edited_var_indices.contains(&index) || !solution_by_range.contains_key(&range) {
                         source_value
                     } else {
-                        previous
+                        previous_by_source
                             .as_ref()
-                            .and_then(|values| values.get(index))
+                            .and_then(|values| values.get(&range))
                             .copied()
+                            .or_else(|| {
+                                previous_ordered_values
+                                    .as_ref()
+                                    .and_then(|values| values.get(index))
+                                    .copied()
+                            })
                             .unwrap_or(source_value)
-                    }
+                    };
+                    (range, value)
                 })
-                .collect();
-            self.sketch_var_warm_start_overrides.insert(sketch, values);
+                .collect::<Vec<_>>();
+            let ordered_values = merged_values.iter().map(|(_, value)| *value).collect::<Vec<_>>();
+            self.sketch_var_warm_start_overrides_by_source
+                .insert(sketch, merged_values.into_iter().collect());
+            Some(ordered_values)
         }
         #[cfg(not(feature = "artifact-graph"))]
         {
-            let _ = (sketch, outcome, segment_ids_edited);
+            let _ = (sketch, outcome, segment_ids_edited, previous_ordered_values);
+            None
+        }
+    }
+
+    fn ordered_sketch_var_warm_starts(&self, sketch: ObjectId) -> Option<Vec<f64>> {
+        #[cfg(feature = "artifact-graph")]
+        {
+            let warm_starts = self.sketch_var_warm_start_overrides_by_source.get(&sketch)?;
+            let source_values = self.sketch_var_source_values_from_program(sketch)?;
+            Some(
+                source_values
+                    .iter()
+                    .map(|(range, source_value)| warm_starts.get(range).copied().unwrap_or(*source_value))
+                    .collect(),
+            )
+        }
+        #[cfg(not(feature = "artifact-graph"))]
+        {
+            let _ = sketch;
+            None
         }
     }
 
@@ -519,22 +576,9 @@ impl FrontendState {
     }
 
     #[cfg(feature = "artifact-graph")]
-    fn sketch_var_initial_guesses_from_program(
-        &self,
-        sketch: ObjectId,
-        solution_by_range: &HashMap<SourceRange, f64>,
-    ) -> Option<Vec<f64>> {
-        self.sketch_var_source_values_from_program(sketch).map(|source_values| {
-            source_values
-                .into_iter()
-                .map(|(range, source_value)| solution_by_range.get(&range).copied().unwrap_or(source_value))
-                .collect()
-        })
-    }
-
-    #[cfg(feature = "artifact-graph")]
     fn sketch_var_source_values_from_program(&self, sketch: ObjectId) -> Option<Vec<(SourceRange, f64)>> {
-        let sketch_range = source_ref_primary_range(&self.scene_graph.objects.get(sketch.0)?.source)?;
+        let sketch_ref = expect_single_node_ref(self.scene_graph.objects.get(sketch.0)?).ok()?;
+        let sketch_range = current_sketch_block_range(&self.program.ast, &sketch_ref).unwrap_or(sketch_ref.range);
         let values = RefCell::new(Vec::new());
         crate::walk::walk(&self.program.ast, |node| -> anyhow::Result<bool> {
             let Node::SketchVar(sketch_var) = node else {
@@ -595,9 +639,26 @@ impl FrontendState {
     fn commit_var_solutions_to_program(&mut self, outcome: &ExecOutcome) -> ExecResult<String> {
         #[cfg(feature = "artifact-graph")]
         {
-            let (new_ast, source) = self.source_with_committed_var_solutions(outcome)?;
+            let (_new_ast, source) = self.source_with_committed_var_solutions(outcome)?;
+            let (new_program, errors) = Program::parse(&source).map_err(|err| {
+                KclErrorWithOutputs::from_error_outcome(KclError::refactor(err.to_string()), outcome.clone())
+            })?;
+            if !errors.is_empty() {
+                return Err(KclErrorWithOutputs::from_error_outcome(
+                    KclError::refactor(format!(
+                        "Error parsing KCL source after committing sketch vars: {errors:?}"
+                    )),
+                    outcome.clone(),
+                ));
+            }
+            let Some(new_program) = new_program else {
+                return Err(KclErrorWithOutputs::from_error_outcome(
+                    KclError::refactor("No AST produced after committing sketch vars".to_owned()),
+                    outcome.clone(),
+                ));
+            };
             self.program = Program {
-                ast: new_ast,
+                ast: new_program.ast,
                 original_file_contents: source.clone(),
             };
             Ok(source)
@@ -3086,6 +3147,8 @@ impl FrontendState {
             )));
         };
 
+        let previous_warm_start_values = self.ordered_sketch_var_warm_starts(sketch);
+
         // TODO: sketch-api: make sure to only set this if there are no errors.
         self.program = new_program.clone();
 
@@ -3114,19 +3177,27 @@ impl FrontendState {
 
         // Uses freedom_analysis: is_delete
         let outcome = self.update_state_after_exec(outcome, is_delete);
-        match options.sketch_var_update_mode {
-            SketchVarUpdateMode::CommitSolvedVars => {
-                self.merge_committed_edit_sketch_var_warm_starts(sketch, &outcome, &options.segment_ids_edited);
-            }
+        let warm_start_values_after_commit = match options.sketch_var_update_mode {
+            SketchVarUpdateMode::CommitSolvedVars => self.merge_committed_edit_sketch_var_warm_starts(
+                sketch,
+                &outcome,
+                &options.segment_ids_edited,
+                previous_warm_start_values,
+            ),
             SketchVarUpdateMode::WarmStartOnly | SketchVarUpdateMode::CommitSolvedVarsFromWarmStart => {
                 self.replace_sketch_var_warm_starts(sketch, &outcome);
+                Some(outcome.var_solutions.iter().map(|(_, value)| value.value).collect())
             }
-        }
+        };
 
         let new_source = match options.sketch_var_update_mode {
             SketchVarUpdateMode::WarmStartOnly => new_source,
             SketchVarUpdateMode::CommitSolvedVars | SketchVarUpdateMode::CommitSolvedVarsFromWarmStart => {
-                self.commit_var_solutions_to_program(&outcome)?
+                let source = self.commit_var_solutions_to_program(&outcome)?;
+                if let Some(values) = warm_start_values_after_commit {
+                    self.replace_sketch_var_warm_starts_from_ordered_values(sketch, &values);
+                }
+                source
             }
         };
 
@@ -5799,6 +5870,51 @@ impl<'a> crate::walk::Visitor<'a> for &FindSketchBlockByNodePath {
 
         Ok(true)
     }
+}
+
+struct FindSketchBlockRangeByNodePath {
+    target_node_path: ast::NodePath,
+    found: Cell<Option<SourceRange>>,
+}
+
+impl<'a> crate::walk::Visitor<'a> for &FindSketchBlockRangeByNodePath {
+    type Error = crate::front::Error;
+
+    fn visit_node(&self, node: crate::walk::Node<'a>) -> anyhow::Result<bool, Self::Error> {
+        let Ok(node_path) = <Option<ast::NodePath>>::try_from(&node) else {
+            return Ok(true);
+        };
+
+        if let crate::walk::Node::SketchBlock(sketch_block) = node {
+            if let Some(node_path) = node_path
+                && node_path == self.target_node_path
+            {
+                self.found.set(Some(SourceRange::from(sketch_block)));
+                return Ok(false);
+            }
+
+            return Ok(true);
+        }
+
+        for child in node.children().iter() {
+            if !child.visit(*self)? {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+}
+
+fn current_sketch_block_range(ast: &ast::Node<ast::Program>, sketch_ref: &AstNodeRef) -> Option<SourceRange> {
+    let node_path = sketch_ref.node_path.as_ref()?;
+    let find = FindSketchBlockRangeByNodePath {
+        target_node_path: node_path.clone(),
+        found: Cell::new(None),
+    };
+    let node = crate::walk::Node::from(ast);
+    node.visit(&find).ok()?;
+    find.found.into_inner()
 }
 
 /// After adding an item to a sketch block, find the sketch block, and get the
@@ -12418,12 +12534,18 @@ sketch(on = XY) {
 
         frontend.program = program.clone();
         let outcome = mock_ctx.run_mock(&program, &MockConfig::default()).await.unwrap();
-        frontend.update_state_after_exec(outcome, true);
+        let outcome = frontend.update_state_after_exec(outcome, true);
         let sketch_object = find_first_sketch_object(&frontend.scene_graph).unwrap();
         let sketch_id = sketch_object.id;
-        frontend
-            .sketch_var_warm_start_overrides
-            .insert(sketch_id, vec![5.0, 6.0]);
+        frontend.sketch_var_warm_start_overrides_by_source.insert(
+            sketch_id,
+            outcome
+                .var_solutions
+                .iter()
+                .zip([5.0, 6.0])
+                .map(|((range, _), value)| (*range, value))
+                .collect(),
+        );
 
         let mut cold_frontend = frontend.clone();
         let (warm_src_delta, _) = frontend
@@ -12450,6 +12572,54 @@ sketch(on = XY) {
   point(at = [var 1mm, var 2mm])
 }
 "
+        );
+
+        mock_ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_execute_mock_from_preview_warm_starts_after_tangent_hidden_vars() {
+        let initial_source = "\
+sketch(on = XY) {
+  line1 = line(start = [var -10mm, var 0mm], end = [var 10mm, var 0mm])
+  circle1 = circle(start = [var 0mm, var 7mm], center = [var 0mm, var 4mm])
+  tangent([line1, circle1])
+  point1 = point(at = [var 40mm, var 50mm])
+}
+";
+
+        let program = Program::parse(initial_source).unwrap().0.unwrap();
+
+        let mut frontend = FrontendState::new();
+        let mock_ctx = ExecutorContext::new_mock(None).await;
+        let version = Version(0);
+
+        frontend.program = program.clone();
+        let outcome = mock_ctx.run_mock(&program, &MockConfig::default()).await.unwrap();
+        frontend.update_state_after_exec(outcome, true);
+        let sketch_object = find_first_sketch_object(&frontend.scene_graph).unwrap();
+        let sketch_id = sketch_object.id;
+        let source_values = frontend
+            .sketch_var_source_values_from_program(sketch_id)
+            .expect("Expected source sketch vars");
+        let mut warm_starts = source_values.iter().copied().collect::<AHashMap<_, _>>();
+        let point_x = source_values[source_values.len() - 2].0;
+        let point_y = source_values[source_values.len() - 1].0;
+        warm_starts.insert(point_x, 41.0);
+        warm_starts.insert(point_y, 52.0);
+        frontend
+            .sketch_var_warm_start_overrides_by_source
+            .insert(sketch_id, warm_starts);
+
+        let (src_delta, _) = frontend
+            .execute_mock_from_preview(&mock_ctx, version, sketch_id)
+            .await
+            .unwrap();
+
+        assert!(
+            src_delta.text.contains("point1 = point(at = [var 41mm, var 52mm])"),
+            "source was:\n{}",
+            src_delta.text
         );
 
         mock_ctx.close().await;
@@ -12485,11 +12655,18 @@ sketch(on = XY) {
         let sketch = expect_sketch(sketch_object);
         let point_id = *sketch.segments.first().unwrap();
         frontend.replace_sketch_var_warm_starts(sketch_id, &outcome);
+        let source_values = frontend
+            .sketch_var_source_values_from_program(sketch_id)
+            .expect("Expected source sketch vars");
         let previous_warm_starts = frontend
-            .sketch_var_warm_start_overrides
+            .sketch_var_warm_start_overrides_by_source
             .get(&sketch_id)
             .expect("Expected initial warm starts")
             .clone();
+        let previous_values = source_values
+            .iter()
+            .map(|(range, _)| previous_warm_starts.get(range).copied().expect("Expected warm start"))
+            .collect::<Vec<_>>();
 
         let segments = vec![ExistingSegmentCtor {
             id: point_id,
@@ -12511,12 +12688,19 @@ sketch(on = XY) {
             .await
             .unwrap();
         let warm_starts = frontend
-            .sketch_var_warm_start_overrides
+            .sketch_var_warm_start_overrides_by_source
             .get(&sketch_id)
             .expect("Expected warm starts for edited sketch");
 
-        assert_eq!(&warm_starts[0..4], &[1.0, 2.0, 1.28, -0.78]);
-        assert_eq!(&warm_starts[4..], &previous_warm_starts[4..]);
+        let source_values_after_edit = frontend
+            .sketch_var_source_values_from_program(sketch_id)
+            .expect("Expected source sketch vars after edit");
+        let current_values = source_values_after_edit
+            .iter()
+            .map(|(range, _)| warm_starts.get(range).copied().expect("Expected warm start"))
+            .collect::<Vec<_>>();
+        assert_eq!(&current_values[0..4], &[1.0, 2.0, 1.28, -0.78]);
+        assert_eq!(&current_values[4..], &previous_values[4..]);
 
         mock_ctx.close().await;
     }

--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -12626,6 +12626,101 @@ sketch(on = XY) {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_preview_drag_coincident_line_arc_tangent_endpoint() {
+        let initial_source = "\
+sketch001 = sketch(on = XY) {
+  line1 = line(start = [var -3.52mm, var -3.44mm], end = [var -5.78mm, var 1.75mm])
+  arc1 = arc(start = [var -2.7mm, var 4.41mm], end = [var -5.78mm, var 1.75mm], center = [var -3.83mm, var 2.6mm])
+  coincident([line1.end, arc1.end])
+  tangent([line1, arc1])
+  line2 = line(start = [var -2.7mm, var 4.41mm], end = [var 2.02mm, var 1.89mm])
+  coincident([line2.start, arc1.start])
+}
+";
+
+        let program = Program::parse(initial_source).unwrap().0.unwrap();
+
+        let mut frontend = FrontendState::new();
+        let mock_ctx = ExecutorContext::new_mock(None).await;
+        let version = Version(0);
+
+        frontend.program = program.clone();
+        let outcome = mock_ctx.run_mock(&program, &MockConfig::default()).await.unwrap();
+        let outcome = frontend.update_state_after_exec(outcome, true);
+        let sketch_object = find_first_sketch_object(&frontend.scene_graph).unwrap();
+        let sketch_id = sketch_object.id;
+        let sketch = expect_sketch(sketch_object);
+        let line_end_id = sketch
+            .segments
+            .iter()
+            .find_map(|segment_id| match &frontend.scene_graph.objects[segment_id.0].kind {
+                ObjectKind::Segment {
+                    segment: Segment::Line(line),
+                } => Some(line.end),
+                _ => None,
+            })
+            .expect("Expected line segment");
+        let arc_end_id = sketch
+            .segments
+            .iter()
+            .find_map(|segment_id| match &frontend.scene_graph.objects[segment_id.0].kind {
+                ObjectKind::Segment {
+                    segment: Segment::Arc(arc),
+                } => Some(arc.end),
+                _ => None,
+            })
+            .expect("Expected arc segment");
+
+        frontend.replace_sketch_var_warm_starts(sketch_id, &outcome);
+        let target = Point2d {
+            x: Expr::Var(Number {
+                value: -5.2,
+                units: NumericSuffix::Mm,
+            }),
+            y: Expr::Var(Number {
+                value: 2.1,
+                units: NumericSuffix::Mm,
+            }),
+        };
+        let segments = vec![
+            ExistingSegmentCtor {
+                id: line_end_id,
+                ctor: SegmentCtor::Point(PointCtor {
+                    position: target.clone(),
+                }),
+            },
+            ExistingSegmentCtor {
+                id: arc_end_id,
+                ctor: SegmentCtor::Point(PointCtor { position: target }),
+            },
+        ];
+
+        let (_, scene_delta) = frontend
+            .edit_segments_for_preview(&mock_ctx, version, sketch_id, segments)
+            .await
+            .unwrap();
+
+        let line_end_position = point_position(&scene_delta.new_graph, line_end_id);
+        let arc_end_position = point_position(&scene_delta.new_graph, arc_end_id);
+        assert_point_position_close(line_end_position.clone(), arc_end_position);
+        assert_point_position_close(
+            line_end_position,
+            Point2d {
+                x: Number {
+                    value: -5.2,
+                    units: NumericSuffix::Mm,
+                },
+                y: Number {
+                    value: 2.1,
+                    units: NumericSuffix::Mm,
+                },
+            },
+        );
+
+        mock_ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_committed_edit_merges_edited_vars_into_existing_warm_starts() {
         let initial_source = "\
 sketch(on = XY) {

--- a/rust/kcl-lib/src/std/constraints.rs
+++ b/rust/kcl-lib/src/std/constraints.rs
@@ -90,6 +90,9 @@ struct ArcVars {
     end: Option<[SketchVarId; 2]>,
 }
 
+type SketchPointVars = [SketchVarId; 2];
+type CircularTangentPoints = (SketchPointVars, SketchPointVars);
+
 fn make_line_arc_tangency_key(line: LineVars, arc: ArcVars) -> ConstraintKey {
     let [a0, a1, a2, a3] = flatten_line_vars(line);
     let [b0, b1, b2, b3, b4, b5] = flatten_arc_vars(arc);
@@ -201,6 +204,116 @@ fn arc_initial_radius(
     range: crate::SourceRange,
 ) -> Result<f64, KclError> {
     points_initial_distance(sketch_vars, arc.center, arc.start, exec_state, range)
+}
+
+fn datum_point_matches_vars(
+    point: DatumPoint,
+    vars: SketchPointVars,
+    range: crate::SourceRange,
+) -> Result<bool, KclError> {
+    Ok(point.id_x() == vars[0].to_constraint_id(range)? && point.id_y() == vars[1].to_constraint_id(range)?)
+}
+
+fn constraint_connects_points(
+    constraint: &SolverConstraint,
+    point_a: SketchPointVars,
+    point_b: SketchPointVars,
+    range: crate::SourceRange,
+) -> Result<bool, KclError> {
+    let SolverConstraint::PointsCoincident(lhs, rhs) = constraint else {
+        return Ok(false);
+    };
+    Ok(
+        (datum_point_matches_vars(*lhs, point_a, range)? && datum_point_matches_vars(*rhs, point_b, range)?)
+            || (datum_point_matches_vars(*lhs, point_b, range)? && datum_point_matches_vars(*rhs, point_a, range)?),
+    )
+}
+
+fn points_are_coincident_in_constraints(
+    constraints: &[SolverConstraint],
+    point_a: SketchPointVars,
+    point_b: SketchPointVars,
+    range: crate::SourceRange,
+) -> Result<bool, KclError> {
+    if point_a == point_b {
+        return Ok(true);
+    }
+
+    // Coincident constraints may be chained, especially for multi-point
+    // coincident groups. Walk the existing coincidence graph rather than only
+    // checking the direct pair.
+    let mut seen = vec![point_a];
+    let mut pending = vec![point_a];
+    while let Some(current) = pending.pop() {
+        for constraint in constraints {
+            let SolverConstraint::PointsCoincident(lhs, rhs) = constraint else {
+                continue;
+            };
+
+            let next = if datum_point_matches_vars(*lhs, current, range)? {
+                Some([SketchVarId(rhs.id_x() as usize), SketchVarId(rhs.id_y() as usize)])
+            } else if datum_point_matches_vars(*rhs, current, range)? {
+                Some([SketchVarId(lhs.id_x() as usize), SketchVarId(lhs.id_y() as usize)])
+            } else {
+                None
+            };
+
+            let Some(next) = next else {
+                continue;
+            };
+            if next == point_b {
+                return Ok(true);
+            }
+            if !seen.contains(&next) {
+                seen.push(next);
+                pending.push(next);
+            }
+        }
+    }
+
+    // Direct check kept separate for clarity and for any future non-graph
+    // coincident representation.
+    for constraint in constraints {
+        if constraint_connects_points(constraint, point_a, point_b, range)? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn line_circular_shared_tangent_point(
+    constraints: &[SolverConstraint],
+    line: LineVars,
+    circular: ArcVars,
+    range: crate::SourceRange,
+) -> Result<Option<SketchPointVars>, KclError> {
+    let circular_points = [Some(circular.start), circular.end];
+    for line_point in [line.start, line.end] {
+        for circular_point in circular_points.into_iter().flatten() {
+            if points_are_coincident_in_constraints(constraints, line_point, circular_point, range)? {
+                return Ok(Some(circular_point));
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn circular_circular_shared_tangent_points(
+    constraints: &[SolverConstraint],
+    circular0: ArcVars,
+    circular1: ArcVars,
+    range: crate::SourceRange,
+) -> Result<Option<CircularTangentPoints>, KclError> {
+    let circular0_points = [Some(circular0.start), circular0.end];
+    let circular1_points = [Some(circular1.start), circular1.end];
+    for point0 in circular0_points.into_iter().flatten() {
+        for point1 in circular1_points.into_iter().flatten() {
+            if points_are_coincident_in_constraints(constraints, point0, point1, range)? {
+                return Ok(Some((point0, point1)));
+            }
+        }
+    }
+    Ok(None)
 }
 
 fn constrainable_point_from_unsolved_segment(
@@ -3550,148 +3663,195 @@ pub async fn tangent(exec_state: &mut ExecState, args: Args) -> Result<KclValue,
         };
         sketch_state.sketch_vars.clone()
     };
+    let existing_solver_constraints = exec_state
+        .sketch_block()
+        .map(|sketch_state| sketch_state.solver_constraints.clone())
+        .unwrap_or_default();
 
-    // Hidden radius vars. Empty metadata keeps them out of source write-back.
+    // Tangency without a known shared contact point still uses hidden radius
+    // vars. Empty metadata keeps those vars out of source write-back.
     match tangent_case {
         TangentCase::LineCircular(line, circular) => {
-            let tangency_key = make_line_arc_tangency_key(line, circular);
-            let tangency_side = match exec_state.constraint_state(sketch_id, &tangency_key) {
-                Some(ConstraintState::Tangency(TangencyMode::LineCircle(side))) => side,
-                _ => {
-                    let side = infer_line_tangent_side(&sketch_vars, line, circular.center, exec_state, range)?;
-                    exec_state.set_constraint_state(
-                        sketch_id,
-                        tangency_key,
-                        ConstraintState::Tangency(TangencyMode::LineCircle(side)),
-                    );
-                    side
-                }
-            };
-            let line_p0 = datum_point(line.start, range)?;
-            let line_p1 = datum_point(line.end, range)?;
-            let line_datum = DatumLineSegment::new(line_p0, line_p1);
+            if let Some(tangent_point) =
+                line_circular_shared_tangent_point(&existing_solver_constraints, line, circular, range)?
+            {
+                let line_p0 = datum_point(line.start, range)?;
+                let line_p1 = datum_point(line.end, range)?;
+                let line_datum = DatumLineSegment::new(line_p0, line_p1);
+                let radius_line =
+                    DatumLineSegment::new(datum_point(circular.center, range)?, datum_point(tangent_point, range)?);
+                let Some(sketch_state) = exec_state.sketch_block_mut() else {
+                    return Err(KclError::new_semantic(KclErrorDetails::new(
+                        "tangent() can only be used inside a sketch block".to_owned(),
+                        vec![range],
+                    )));
+                };
+                sketch_state.solver_constraints.push(SolverConstraint::LinesAtAngle(
+                    line_datum,
+                    radius_line,
+                    AngleKind::Perpendicular,
+                ));
+            } else {
+                let tangency_key = make_line_arc_tangency_key(line, circular);
+                let tangency_side = match exec_state.constraint_state(sketch_id, &tangency_key) {
+                    Some(ConstraintState::Tangency(TangencyMode::LineCircle(side))) => side,
+                    _ => {
+                        let side = infer_line_tangent_side(&sketch_vars, line, circular.center, exec_state, range)?;
+                        exec_state.set_constraint_state(
+                            sketch_id,
+                            tangency_key,
+                            ConstraintState::Tangency(TangencyMode::LineCircle(side)),
+                        );
+                        side
+                    }
+                };
+                let line_p0 = datum_point(line.start, range)?;
+                let line_p1 = datum_point(line.end, range)?;
+                let line_datum = DatumLineSegment::new(line_p0, line_p1);
 
-            let center = datum_point(circular.center, range)?;
-            let circular_start = datum_point(circular.start, range)?;
-            let circular_end = circular.end.map(|end| datum_point(end, range)).transpose()?;
-            let radius_initial_value = radius_guess(&sketch_vars, circular.center, circular.start, exec_state, range)?;
-            let Some(sketch_state) = exec_state.sketch_block_mut() else {
-                return Err(KclError::new_semantic(KclErrorDetails::new(
-                    "tangent() can only be used inside a sketch block".to_owned(),
-                    vec![range],
-                )));
-            };
-            let radius_id = sketch_state.next_sketch_var_id();
-            sketch_state.sketch_vars.push(KclValue::SketchVar {
-                value: Box::new(crate::execution::SketchVar {
-                    id: radius_id,
-                    initial_value: radius_initial_value,
-                    ty: sketch_var_ty,
-                    meta: vec![],
-                }),
-            });
-            let radius = DatumDistance::new(radius_id.to_constraint_id(range)?);
-            let circle = DatumCircle { center, radius };
+                let center = datum_point(circular.center, range)?;
+                let circular_start = datum_point(circular.start, range)?;
+                let circular_end = circular.end.map(|end| datum_point(end, range)).transpose()?;
+                let radius_initial_value =
+                    radius_guess(&sketch_vars, circular.center, circular.start, exec_state, range)?;
+                let Some(sketch_state) = exec_state.sketch_block_mut() else {
+                    return Err(KclError::new_semantic(KclErrorDetails::new(
+                        "tangent() can only be used inside a sketch block".to_owned(),
+                        vec![range],
+                    )));
+                };
+                let radius_id = sketch_state.next_sketch_var_id();
+                sketch_state.sketch_vars.push(KclValue::SketchVar {
+                    value: Box::new(crate::execution::SketchVar {
+                        id: radius_id,
+                        initial_value: radius_initial_value,
+                        ty: sketch_var_ty,
+                        meta: vec![],
+                    }),
+                });
+                let radius = DatumDistance::new(radius_id.to_constraint_id(range)?);
+                let circle = DatumCircle { center, radius };
 
-            // Tangency decomposition for Line/circular segment:
-            // 1) Introduce a hidden radius variable r for the segment's underlying circle.
-            // 2) Keep the segment's defining points on that circle with DistanceVar(point, center, r).
-            // 3) Apply the native LineTangentToCircle solver constraint.
-            sketch_state
-                .solver_constraints
-                .push(SolverConstraint::DistanceVar(circular_start, center, radius));
-            if let Some(circular_end) = circular_end {
+                // Tangency decomposition for Line/circular segment:
+                // 1) Introduce a hidden radius variable r for the segment's underlying circle.
+                // 2) Keep the segment's defining points on that circle with DistanceVar(point, center, r).
+                // 3) Apply the native LineTangentToCircle solver constraint.
                 sketch_state
                     .solver_constraints
-                    .push(SolverConstraint::DistanceVar(circular_end, center, radius));
+                    .push(SolverConstraint::DistanceVar(circular_start, center, radius));
+                if let Some(circular_end) = circular_end {
+                    sketch_state
+                        .solver_constraints
+                        .push(SolverConstraint::DistanceVar(circular_end, center, radius));
+                }
+                sketch_state
+                    .solver_constraints
+                    .push(SolverConstraint::LineTangentToCircle(line_datum, circle, tangency_side));
             }
-            sketch_state
-                .solver_constraints
-                .push(SolverConstraint::LineTangentToCircle(line_datum, circle, tangency_side));
         }
         TangentCase::CircularCircular(circular0, circular1) => {
-            let tangency_key = make_arc_arc_tangency_key(circular0, circular1);
-            let tangency_side = match exec_state.constraint_state(sketch_id, &tangency_key) {
-                Some(ConstraintState::Tangency(TangencyMode::CircleCircle(side))) => side,
-                _ => {
-                    let side = infer_arc_tangent_side(&sketch_vars, circular0, circular1, exec_state, range)?;
-                    exec_state.set_constraint_state(
-                        sketch_id,
-                        tangency_key,
-                        ConstraintState::Tangency(TangencyMode::CircleCircle(side)),
-                    );
-                    side
+            if let Some((point0, point1)) =
+                circular_circular_shared_tangent_points(&existing_solver_constraints, circular0, circular1, range)?
+            {
+                let radius0_line =
+                    DatumLineSegment::new(datum_point(circular0.center, range)?, datum_point(point0, range)?);
+                let radius1_line =
+                    DatumLineSegment::new(datum_point(circular1.center, range)?, datum_point(point1, range)?);
+                let Some(sketch_state) = exec_state.sketch_block_mut() else {
+                    return Err(KclError::new_semantic(KclErrorDetails::new(
+                        "tangent() can only be used inside a sketch block".to_owned(),
+                        vec![range],
+                    )));
+                };
+                sketch_state.solver_constraints.push(SolverConstraint::LinesAtAngle(
+                    radius0_line,
+                    radius1_line,
+                    AngleKind::Parallel,
+                ));
+            } else {
+                let tangency_key = make_arc_arc_tangency_key(circular0, circular1);
+                let tangency_side = match exec_state.constraint_state(sketch_id, &tangency_key) {
+                    Some(ConstraintState::Tangency(TangencyMode::CircleCircle(side))) => side,
+                    _ => {
+                        let side = infer_arc_tangent_side(&sketch_vars, circular0, circular1, exec_state, range)?;
+                        exec_state.set_constraint_state(
+                            sketch_id,
+                            tangency_key,
+                            ConstraintState::Tangency(TangencyMode::CircleCircle(side)),
+                        );
+                        side
+                    }
+                };
+                let center0 = datum_point(circular0.center, range)?;
+                let start0 = datum_point(circular0.start, range)?;
+                let end0 = circular0.end.map(|end| datum_point(end, range)).transpose()?;
+                let radius0_initial_value =
+                    radius_guess(&sketch_vars, circular0.center, circular0.start, exec_state, range)?;
+                let center1 = datum_point(circular1.center, range)?;
+                let start1 = datum_point(circular1.start, range)?;
+                let end1 = circular1.end.map(|end| datum_point(end, range)).transpose()?;
+                let radius1_initial_value =
+                    radius_guess(&sketch_vars, circular1.center, circular1.start, exec_state, range)?;
+                let Some(sketch_state) = exec_state.sketch_block_mut() else {
+                    return Err(KclError::new_semantic(KclErrorDetails::new(
+                        "tangent() can only be used inside a sketch block".to_owned(),
+                        vec![range],
+                    )));
+                };
+                let radius0_id = sketch_state.next_sketch_var_id();
+                sketch_state.sketch_vars.push(KclValue::SketchVar {
+                    value: Box::new(crate::execution::SketchVar {
+                        id: radius0_id,
+                        initial_value: radius0_initial_value,
+                        ty: sketch_var_ty,
+                        meta: vec![],
+                    }),
+                });
+                let radius0 = DatumDistance::new(radius0_id.to_constraint_id(range)?);
+                let circle0 = DatumCircle {
+                    center: center0,
+                    radius: radius0,
+                };
+
+                let radius1_id = sketch_state.next_sketch_var_id();
+                sketch_state.sketch_vars.push(KclValue::SketchVar {
+                    value: Box::new(crate::execution::SketchVar {
+                        id: radius1_id,
+                        initial_value: radius1_initial_value,
+                        ty: sketch_var_ty,
+                        meta: vec![],
+                    }),
+                });
+                let radius1 = DatumDistance::new(radius1_id.to_constraint_id(range)?);
+                let circle1 = DatumCircle {
+                    center: center1,
+                    radius: radius1,
+                };
+
+                // Tangency decomposition for circular segment/circular segment:
+                // 1) Introduce one hidden radius variable per arc.
+                // 2) Keep each segment's defining points on its corresponding circle.
+                // 3) Apply the native CircleTangentToCircle solver constraint.
+                sketch_state
+                    .solver_constraints
+                    .push(SolverConstraint::DistanceVar(start0, center0, radius0));
+                if let Some(end0) = end0 {
+                    sketch_state
+                        .solver_constraints
+                        .push(SolverConstraint::DistanceVar(end0, center0, radius0));
                 }
-            };
-            let center0 = datum_point(circular0.center, range)?;
-            let start0 = datum_point(circular0.start, range)?;
-            let end0 = circular0.end.map(|end| datum_point(end, range)).transpose()?;
-            let radius0_initial_value =
-                radius_guess(&sketch_vars, circular0.center, circular0.start, exec_state, range)?;
-            let center1 = datum_point(circular1.center, range)?;
-            let start1 = datum_point(circular1.start, range)?;
-            let end1 = circular1.end.map(|end| datum_point(end, range)).transpose()?;
-            let radius1_initial_value =
-                radius_guess(&sketch_vars, circular1.center, circular1.start, exec_state, range)?;
-            let Some(sketch_state) = exec_state.sketch_block_mut() else {
-                return Err(KclError::new_semantic(KclErrorDetails::new(
-                    "tangent() can only be used inside a sketch block".to_owned(),
-                    vec![range],
-                )));
-            };
-            let radius0_id = sketch_state.next_sketch_var_id();
-            sketch_state.sketch_vars.push(KclValue::SketchVar {
-                value: Box::new(crate::execution::SketchVar {
-                    id: radius0_id,
-                    initial_value: radius0_initial_value,
-                    ty: sketch_var_ty,
-                    meta: vec![],
-                }),
-            });
-            let radius0 = DatumDistance::new(radius0_id.to_constraint_id(range)?);
-            let circle0 = DatumCircle {
-                center: center0,
-                radius: radius0,
-            };
-
-            let radius1_id = sketch_state.next_sketch_var_id();
-            sketch_state.sketch_vars.push(KclValue::SketchVar {
-                value: Box::new(crate::execution::SketchVar {
-                    id: radius1_id,
-                    initial_value: radius1_initial_value,
-                    ty: sketch_var_ty,
-                    meta: vec![],
-                }),
-            });
-            let radius1 = DatumDistance::new(radius1_id.to_constraint_id(range)?);
-            let circle1 = DatumCircle {
-                center: center1,
-                radius: radius1,
-            };
-
-            // Tangency decomposition for circular segment/circular segment:
-            // 1) Introduce one hidden radius variable per arc.
-            // 2) Keep each segment's defining points on its corresponding circle.
-            // 3) Apply the native CircleTangentToCircle solver constraint.
-            sketch_state
-                .solver_constraints
-                .push(SolverConstraint::DistanceVar(start0, center0, radius0));
-            if let Some(end0) = end0 {
                 sketch_state
                     .solver_constraints
-                    .push(SolverConstraint::DistanceVar(end0, center0, radius0));
-            }
-            sketch_state
-                .solver_constraints
-                .push(SolverConstraint::DistanceVar(start1, center1, radius1));
-            if let Some(end1) = end1 {
+                    .push(SolverConstraint::DistanceVar(start1, center1, radius1));
+                if let Some(end1) = end1 {
+                    sketch_state
+                        .solver_constraints
+                        .push(SolverConstraint::DistanceVar(end1, center1, radius1));
+                }
                 sketch_state
                     .solver_constraints
-                    .push(SolverConstraint::DistanceVar(end1, center1, radius1));
+                    .push(SolverConstraint::CircleTangentToCircle(circle0, circle1, tangency_side));
             }
-            sketch_state
-                .solver_constraints
-                .push(SolverConstraint::CircleTangentToCircle(circle0, circle1, tangency_side));
         }
     }
 


### PR DESCRIPTION
This PR stabilizes sketch dragging by changing how preview solves are warm-started and how tangency constraints are represented.

Main points:

- Replaces the old drag-vector warm-start path with source-range-based sketch var warm starts, so preview solves reuse the latest solved var values without hidden solver vars drifting into KCL write-back.
- Keeps committed drag edits and preview edits separate: preview warms the solver, commit writes solved source guesses back.
- Fixes tangent-related drag instability by lowering shared-contact tangent constraints locally:
line + arc/circle tangent becomes line perpendicular to the contact radius. arc/circle + arc/circle tangent becomes parallel contact radii. non-contact tangent still uses the native hidden-radius tangent path.
- Adds regression coverage for hidden tangent vars, warm-start consumption, committed edit merging, and dragging coincident line/arc tangent endpoints.