### PR TITLE
Wire up the error page to client error reporting

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -138,15 +138,6 @@ export const Router = () => {
             ...(IS_STAGING_OR_DEBUG
               ? [
                   {
-                    path: '/error-page-test',
-                    errorElement: <ErrorPage />,
-                    loader: () => {
-                      // eslint-disable-next-line suggest-no-throw/suggest-no-throw
-                      throw new Error('Manual ErrorPage test')
-                    },
-                    element: <></>,
-                  },
-                  {
                     path: '/layout',
                     errorElement: <ErrorPage />,
                     element: <TestLayout />,

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -138,6 +138,15 @@ export const Router = () => {
             ...(IS_STAGING_OR_DEBUG
               ? [
                   {
+                    path: '/error-page-test',
+                    errorElement: <ErrorPage />,
+                    loader: () => {
+                      // eslint-disable-next-line suggest-no-throw/suggest-no-throw
+                      throw new Error('Manual ErrorPage test')
+                    },
+                    element: <></>,
+                  },
+                  {
                     path: '/layout',
                     errorElement: <ErrorPage />,
                     element: <TestLayout />,

--- a/src/components/ErrorPage.tsx
+++ b/src/components/ErrorPage.tsx
@@ -4,38 +4,29 @@ import { isRouteErrorResponse, useRouteError } from 'react-router-dom'
 import { ActionButton } from '@src/components/ActionButton'
 import { reportClientError } from '@src/lib/clientErrors'
 import { isDesktop } from '@src/lib/isDesktop'
-import { reportRejection } from '@src/lib/trap'
 import { refreshPage } from '@src/lib/utils'
+import { reportRejection } from '@src/lib/trap'
 
 /** Type narrowing function of unknown error to a string */
 function errorMessage(error: unknown): string {
   if (isRouteErrorResponse(error)) {
     return `${error.status} ${error.statusText}`
-  }
-  if (error !== undefined && error instanceof Error) {
+  } else if (error != undefined && error instanceof Error) {
     return error.message
-  }
-  if (error && typeof error === 'object') {
-    try {
-      return JSON.stringify(error)
-    } catch {
-      return 'Unknown route error'
-    }
-  }
-  if (typeof error === 'string') {
+  } else if (error && typeof error === 'object') {
+    return JSON.stringify(error)
+  } else if (typeof error === 'string') {
     return error
+  } else {
+    return 'Unknown error'
   }
-  return 'Unknown error'
 }
 
-function errorName(error: unknown): string {
-  if (error instanceof Error) {
-    return error.name
+function stackTraceMessage(error: unknown): string {
+  if (error !== undefined && error instanceof Error) {
+    return error.stack || ''
   }
-  if (isRouteErrorResponse(error)) {
-    return 'RouteErrorResponse'
-  }
-  return 'RouteError'
+  return ''
 }
 
 export const ErrorPage = () => {
@@ -44,17 +35,23 @@ export const ErrorPage = () => {
   console.error('error', error)
 
   useEffect(() => {
+    const isRouteError = isRouteErrorResponse(error)
+    const message = errorMessage(error)
+    const name = error instanceof Error ? error.name : 'RouteError'
+    const stackTrace = stackTraceMessage(error)
+
     void reportClientError({
-      code: isRouteErrorResponse(error)
+      code: isRouteError
         ? `route_error_${error.status}`
         : 'route_error_boundary',
-      message: errorMessage(error),
+      message,
       error: error instanceof Error ? error : undefined,
-      errorName: errorName(error),
-      dedupeKey: `ErrorPage:${errorName(error)}:${errorMessage(error)}`,
+      errorName: isRouteError ? 'RouteErrorResponse' : name,
+      dedupeKey: `ErrorPage:${name}:${message}`,
       extra: {
         source: 'ErrorPage',
-        ...(isRouteErrorResponse(error)
+        ...(stackTrace ? { stackTrace } : {}),
+        ...(isRouteError
           ? {
               status: error.status,
               statusText: error.statusText,

--- a/src/components/ErrorPage.tsx
+++ b/src/components/ErrorPage.tsx
@@ -5,7 +5,7 @@ import { ActionButton } from '@src/components/ActionButton'
 import { reportClientError } from '@src/lib/clientErrors'
 import { isDesktop } from '@src/lib/isDesktop'
 import { refreshPage } from '@src/lib/utils'
-import { reportRejection } from '@src/lib/trap'
+import { isErr, reportRejection } from '@src/lib/trap'
 
 /** Type narrowing function of unknown error to a string */
 function errorMessage(error: unknown): string {
@@ -37,7 +37,7 @@ export const ErrorPage = () => {
   useEffect(() => {
     const isRouteError = isRouteErrorResponse(error)
     const message = errorMessage(error)
-    const name = error instanceof Error ? error.name : 'RouteError'
+    const name = isErr(error) ? error.name : 'RouteError'
     const stackTrace = stackTraceMessage(error)
 
     void reportClientError({
@@ -45,7 +45,7 @@ export const ErrorPage = () => {
         ? `route_error_${error.status}`
         : 'route_error_boundary',
       message,
-      error: error instanceof Error ? error : undefined,
+      error: isErr(error) ? error : undefined,
       errorName: isRouteError ? 'RouteErrorResponse' : name,
       dedupeKey: `ErrorPage:${name}:${message}`,
       extra: {

--- a/src/components/ErrorPage.tsx
+++ b/src/components/ErrorPage.tsx
@@ -1,47 +1,68 @@
+import { useEffect } from 'react'
 import { isRouteErrorResponse, useRouteError } from 'react-router-dom'
 
 import { ActionButton } from '@src/components/ActionButton'
+import { reportClientError } from '@src/lib/clientErrors'
 import { isDesktop } from '@src/lib/isDesktop'
-import { refreshPage } from '@src/lib/utils'
 import { reportRejection } from '@src/lib/trap'
+import { refreshPage } from '@src/lib/utils'
 
 /** Type narrowing function of unknown error to a string */
 function errorMessage(error: unknown): string {
   if (isRouteErrorResponse(error)) {
     return `${error.status} ${error.statusText}`
-  } else if (error != undefined && error instanceof Error) {
-    return error.message
-  } else if (error && typeof error === 'object') {
-    return JSON.stringify(error)
-  } else if (typeof error === 'string') {
-    return error
-  } else {
-    return 'Unknown error'
   }
-}
-
-function stackTraceMessage(error: unknown): string {
   if (error !== undefined && error instanceof Error) {
-    return error.stack || ''
+    return error.message
   }
-  return ''
+  if (error && typeof error === 'object') {
+    try {
+      return JSON.stringify(error)
+    } catch {
+      return 'Unknown route error'
+    }
+  }
+  if (typeof error === 'string') {
+    return error
+  }
+  return 'Unknown error'
 }
 
-/** Generate a GitHub issue URL from the error */
-export function generateToUrl(
-  error: unknown,
-  title: string = 'An unexpected error occurred'
-) {
-  const newLine = '%0A'
-  const body = `${errorMessage(error)} ${newLine} >${stackTraceMessage(error)} ${newLine}`
-  const result = `https://github.com/KittyCAD/modeling-app/issues/new?title=${title}&body=${body}`
-  return result
+function errorName(error: unknown): string {
+  if (error instanceof Error) {
+    return error.name
+  }
+  if (isRouteErrorResponse(error)) {
+    return 'RouteErrorResponse'
+  }
+  return 'RouteError'
 }
 
 export const ErrorPage = () => {
-  let error = useRouteError()
+  const error = useRouteError()
   // We log the error to the console no matter what
   console.error('error', error)
+
+  useEffect(() => {
+    void reportClientError({
+      code: isRouteErrorResponse(error)
+        ? `route_error_${error.status}`
+        : 'route_error_boundary',
+      message: errorMessage(error),
+      error: error instanceof Error ? error : undefined,
+      errorName: errorName(error),
+      dedupeKey: `ErrorPage:${errorName(error)}:${errorMessage(error)}`,
+      extra: {
+        source: 'ErrorPage',
+        ...(isRouteErrorResponse(error)
+          ? {
+              status: error.status,
+              statusText: error.statusText,
+            }
+          : {}),
+      },
+    })
+  }, [error])
 
   return (
     <div className="flex flex-col items-center justify-center h-screen">
@@ -50,10 +71,8 @@ export const ErrorPage = () => {
           An unexpected error occurred
         </h1>
         <p className="mb-8 w-full overflow-auto">
-          <>{errorMessage(error)}</>
-        </p>
-        <p className="mb-8 w-full overflow-auto">
-          <>{stackTraceMessage(error)}</>
+          We're sorry, something went wrong. The error has been reported to our
+          team.
         </p>
         <div className="flex justify-between gap-2 mt-6">
           {isDesktop() && (
@@ -83,13 +102,6 @@ export const ErrorPage = () => {
             }}
           >
             Clear Storage
-          </ActionButton>
-          <ActionButton
-            Element="externalLink"
-            iconStart={{ icon: 'bug' }}
-            to={generateToUrl(error)}
-          >
-            Report Bug
           </ActionButton>
         </div>
       </section>


### PR DESCRIPTION
Closes #11620

### How to test?

1. Navigate to https://modeling-app-git-pierremtb-issue11620-wire-up-the-error-bdebc9.vercel.dev.zoo.dev/error-page-test
2. Expect an error page to show up
3. Check the [Axiom logs](https://kittycadworkspace.slack.com/archives/C07A80B83FS/p1778690037542849?thread_ts=1778613863.995139&cid=C07A80B83FS) for _Error: Manual ErrorPage test_