### PR TITLE
Honor lowered sketch geometry in warm starts and stabilize sketch drag previews

### DIFF
--- a/e2e/playwright/sketch-solve-edit.spec.ts
+++ b/e2e/playwright/sketch-solve-edit.spec.ts
@@ -46,6 +46,37 @@ function normaliseCode(code: string): string {
   return code.replaceAll(/\s+/g, ' ').trim()
 }
 
+const getSketchCodeCounts = (code: string) => ({
+  arcs: (code.match(/arc\(/g) ?? []).length,
+  circles: (code.match(/circle\(/g) ?? []).length,
+  lines: (code.match(/line\(/g) ?? []).length,
+  coincidents: (code.match(/coincident\(/g) ?? []).length,
+  tangents: (code.match(/tangent\(/g) ?? []).length,
+})
+
+async function waitForCodeWithCounts(
+  page: Page,
+  previousCode: string,
+  expectedCounts: Partial<ReturnType<typeof getSketchCodeCounts>>
+): Promise<string> {
+  const editor = page.locator('.cm-content')
+  await expect
+    .poll(async () => {
+      const code = await editor.innerText()
+      if (normaliseCode(code) === normaliseCode(previousCode)) {
+        return false
+      }
+
+      const counts = getSketchCodeCounts(code)
+      return Object.entries(expectedCounts).every(([key, value]) => {
+        return counts[key as keyof typeof counts] === value
+      })
+    })
+    .toBe(true)
+
+  return await editor.innerText()
+}
+
 /**
  * Get the midpoint coordinates between two segment IDs.
  * Returns an object with x and y coordinates.
@@ -246,11 +277,13 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
     cmdBar,
     editor,
     toolbar,
+    tronApp,
   }) => {
     const INITIAL_CODE = ''
     const pointHandles = page.locator('[data-handle="sketch-point-handle"]')
 
     await test.step('Set up the app with initial code and enable sketch solve mode', async () => {
+      await tronApp?.cleanProjectDir({ modeling: { base_unit: 'mm' } })
       await context.addInitScript(
         async ({ code }) => {
           localStorage.setItem('persistCode', code)
@@ -1046,9 +1079,10 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
     tronApp,
   }) => {
     const pointHandles = page.locator('[data-handle="sketch-point-handle"]')
-    const INITIAL_CODE = ''
+    const INITIAL_CODE = '@settings(defaultLengthUnit = mm)'
 
     await test.step('Set up app with sketch solve mode enabled', async () => {
+      await tronApp?.cleanProjectDir({ modeling: { base_unit: 'mm' } })
       await context.addInitScript(
         async ({ code }) => {
           localStorage.setItem('persistCode', code)
@@ -1107,13 +1141,7 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
       await page.keyboard.up('Control')
     }
 
-    const getCodeCounts = (code: string) => ({
-      arcs: (code.match(/arc\(/g) ?? []).length,
-      circles: (code.match(/circle\(/g) ?? []).length,
-      lines: (code.match(/line\(/g) ?? []).length,
-      coincidents: (code.match(/coincident\(/g) ?? []).length,
-      tangents: (code.match(/tangent\(/g) ?? []).length,
-    })
+    const getCodeCounts = getSketchCodeCounts
 
     let previousCode = await editor.getCurrentCode()
     const codeAfterSketchStart = previousCode
@@ -1224,7 +1252,11 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
       )
 
       await line1End()
-      previousCode = await waitForCodeChange(page, previousCode)
+      previousCode = await waitForCodeWithCounts(page, previousCode, {
+        arcs: 1,
+        lines: 1,
+        coincidents: 0,
+      })
       let counts = getCodeCounts(previousCode)
       expect(counts.arcs).toBe(1)
       expect(counts.lines).toBe(1)
@@ -1232,14 +1264,20 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
       await expect(pointHandles).toHaveCount(5)
 
       await line2End()
-      previousCode = await waitForCodeChange(page, previousCode)
+      previousCode = await waitForCodeWithCounts(page, previousCode, {
+        lines: 2,
+        coincidents: 1,
+      })
       counts = getCodeCounts(previousCode)
       expect(counts.lines).toBe(2)
       expect(counts.coincidents).toBe(1)
       await expect(pointHandles).toHaveCount(7)
 
       await line3End()
-      previousCode = await waitForCodeChange(page, previousCode)
+      previousCode = await waitForCodeWithCounts(page, previousCode, {
+        lines: 3,
+        coincidents: 2,
+      })
       const codeAfterThreeLines = previousCode
       counts = getCodeCounts(codeAfterThreeLines)
       expect(counts.lines).toBe(3)
@@ -1286,7 +1324,10 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
       previousCode = await waitForCodeChange(page, codeAfterSecondLineUndo)
 
       await newLineEnd()
-      previousCode = await waitForCodeChange(page, previousCode)
+      previousCode = await waitForCodeWithCounts(page, previousCode, {
+        lines: 2,
+        coincidents: 1,
+      })
 
       await toolbar.lineBtn.click()
       await expect(toolbar.lineBtn).toHaveAttribute('aria-pressed', 'false')

--- a/e2e/playwright/sketch-solve-edit.spec.ts
+++ b/e2e/playwright/sketch-solve-edit.spec.ts
@@ -27,6 +27,18 @@ async function waitForCodeChange(
   return await page.locator('.cm-content').innerText()
 }
 
+async function waitForNormalisedCodeChange(
+  page: Page,
+  previousCode: string
+): Promise<string> {
+  await expect
+    .poll(async () =>
+      normaliseCode(await page.locator('.cm-content').innerText())
+    )
+    .not.toBe(normaliseCode(previousCode))
+  return await page.locator('.cm-content').innerText()
+}
+
 /**
  * Normalize code by collapsing whitespace for stable equality checks.
  */
@@ -70,7 +82,7 @@ async function clickSegmentById(
   const box = await scene.getBoundingBoxOrThrow(
     `[data-segment_id="${segmentId}"]`
   )
-  await page.mouse.click(box.x, box.y) // box size is 1x1 px so we can ignore width, height
+  await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2)
 }
 
 async function selectSketchSolveConstraintFromDropdown(
@@ -1312,7 +1324,7 @@ test.describe('Sketch solve edit tests', { tag: '@desktop' }, () => {
       await page.mouse.up()
       await page.waitForTimeout(300)
 
-      const codeAfterPointDrag = await waitForCodeChange(
+      const codeAfterPointDrag = await waitForNormalisedCodeChange(
         page,
         codeBeforePointDrag
       )

--- a/rust/kcl-lib/src/execution/cache.rs
+++ b/rust/kcl-lib/src/execution/cache.rs
@@ -123,6 +123,7 @@ impl GlobalState {
             scene_objects: self.exec_state.root_module_artifacts.scene_objects,
             source_range_to_object: self.exec_state.root_module_artifacts.source_range_to_object,
             var_solutions: self.exec_state.root_module_artifacts.var_solutions,
+            ordered_sketch_var_solutions: self.exec_state.root_module_artifacts.ordered_sketch_var_solutions,
             issues: self.exec_state.issues,
             default_planes: ctx.engine.get_default_planes().read().await.clone(),
         }

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1726,13 +1726,14 @@ impl Node<SketchBlock> {
             .cloned()
             .map(ezpz::ConstraintRequest::highest_priority)
             .chain(
-                // TODO: Assuming interaction-related constraints are the only optional ones atm.
-                // Will need to revisit this if there are others in the mix.
+                // Interaction constraints are only drag preferences. Keep authored
+                // constraints at higher priority so an impossible drag cannot
+                // deform or invalidate the required sketch solution.
                 sketch_block_state
                     .solver_optional_constraints
                     .iter()
                     .cloned()
-                    .map(ezpz::ConstraintRequest::highest_priority),
+                    .map(|constraint| ezpz::ConstraintRequest::new(constraint, 1)),
             )
             .collect::<Vec<_>>();
         let initial_guesses = sketch_block_state

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -198,6 +198,10 @@ fn sketch_var_initial_value(
     range: SourceRange,
     description: &str,
 ) -> Result<f64, KclError> {
+    if let Some(value) = exec_state.sketch_var_initial_guess_override(sketch_vars, id) {
+        return Ok(value);
+    }
+
     sketch_vars
         .get(id.0)
         .and_then(KclValue::as_sketch_var)
@@ -1762,7 +1766,7 @@ impl Node<SketchBlock> {
                     return Err(internal_err(message, self));
                 };
                 let initial_guess = exec_state
-                    .sketch_var_initial_guess_override(sketch_var.id)
+                    .sketch_var_initial_guess_override(&sketch_block_state.sketch_vars, sketch_var.id)
                     .unwrap_or(initial_guess);
                 Ok((constraint_id, initial_guess))
             })
@@ -1874,6 +1878,8 @@ impl Node<SketchBlock> {
         // solutions.
         exec_state.mod_local.artifacts.var_solutions =
             sketch_block_state.var_solutions(&solve_outcome, solution_ty, SourceRange::from(self))?;
+        exec_state.mod_local.artifacts.ordered_sketch_var_solutions =
+            sketch_block_state.ordered_sketch_var_solutions(&solve_outcome, SourceRange::from(self))?;
 
         // Create scene objects after unknowns are solved.
         let scene_objects = create_segment_scene_objects(&solved_segments, range, exec_state)?;
@@ -4332,6 +4338,10 @@ impl Node<BinaryExpression> {
                                 exec_state: &mut ExecState,
                                 range: SourceRange,
                             ) -> Result<f64, KclError> {
+                                if let Some(value) = exec_state.sketch_var_initial_guess_override(sketch_vars, id) {
+                                    return Ok(value);
+                                }
+
                                 sketch_vars
                                     .get(id.0)
                                     .and_then(KclValue::as_sketch_var)

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -500,8 +500,9 @@ pub struct MockConfig {
     /// Per-source-sketch-variable warm starts keyed by source variable order,
     /// excluding hidden lowered variables.
     pub sketch_var_source_initial_guess_overrides: Vec<f64>,
-    /// Whether hidden lowered variables may reuse solver-order warm starts.
-    pub preserve_hidden_sketch_var_initial_guess_overrides: bool,
+    /// Source ranges for the solver-order warm starts. Hidden lowered
+    /// variables have no source range.
+    pub sketch_var_initial_guess_source_ranges: Vec<Option<SourceRange>>,
 }
 
 impl Default for MockConfig {
@@ -514,7 +515,7 @@ impl Default for MockConfig {
             segment_ids_edited: AhashIndexSet::default(),
             sketch_var_initial_guess_overrides: Vec::new(),
             sketch_var_source_initial_guess_overrides: Vec::new(),
-            preserve_hidden_sketch_var_initial_guess_overrides: true,
+            sketch_var_initial_guess_source_ranges: Vec::new(),
         }
     }
 }
@@ -529,21 +530,15 @@ impl MockConfig {
     }
 
     #[must_use]
-    pub(crate) fn no_freedom_analysis(mut self) -> Self {
-        self.freedom_analysis = false;
-        self
-    }
-
-    #[must_use]
     pub(crate) fn with_ordered_sketch_var_initial_guess_overrides(
         mut self,
         solver_overrides: Vec<f64>,
         source_overrides: Vec<f64>,
-        preserve_hidden_by_id: bool,
+        solver_source_ranges: Vec<Option<SourceRange>>,
     ) -> Self {
         self.sketch_var_initial_guess_overrides = solver_overrides;
         self.sketch_var_source_initial_guess_overrides = source_overrides;
-        self.preserve_hidden_sketch_var_initial_guess_overrides = preserve_hidden_by_id;
+        self.sketch_var_initial_guess_source_ranges = solver_source_ranges;
         self
     }
 }

--- a/rust/kcl-lib/src/execution/mod.rs
+++ b/rust/kcl-lib/src/execution/mod.rs
@@ -265,12 +265,20 @@ pub struct ExecOutcome {
     pub source_range_to_object: BTreeMap<SourceRange, ObjectId>,
     #[serde(skip)]
     pub var_solutions: Vec<(SourceRange, Number)>,
+    #[serde(skip)]
+    pub ordered_sketch_var_solutions: Vec<SketchVarSolution>,
     /// Non-fatal errors and warnings.
     pub issues: Vec<CompilationIssue>,
     /// File Names in module Id array index order
     pub filenames: IndexMap<ModuleId, ModulePath>,
     /// The default planes.
     pub default_planes: Option<DefaultPlanes>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SketchVarSolution {
+    pub source_range: Option<SourceRange>,
+    pub value: f64,
 }
 
 /// Per-segment freedom used by the constraint report. Mirrors
@@ -489,6 +497,11 @@ pub struct MockConfig {
     /// Per-sketch-variable initial guess overrides, keyed by sketch variable
     /// order. These are transient warm-start values for interactive solves.
     pub sketch_var_initial_guess_overrides: Vec<f64>,
+    /// Per-source-sketch-variable warm starts keyed by source variable order,
+    /// excluding hidden lowered variables.
+    pub sketch_var_source_initial_guess_overrides: Vec<f64>,
+    /// Whether hidden lowered variables may reuse solver-order warm starts.
+    pub preserve_hidden_sketch_var_initial_guess_overrides: bool,
 }
 
 impl Default for MockConfig {
@@ -500,6 +513,8 @@ impl Default for MockConfig {
             freedom_analysis: true,
             segment_ids_edited: AhashIndexSet::default(),
             sketch_var_initial_guess_overrides: Vec::new(),
+            sketch_var_source_initial_guess_overrides: Vec::new(),
+            preserve_hidden_sketch_var_initial_guess_overrides: true,
         }
     }
 }
@@ -520,8 +535,15 @@ impl MockConfig {
     }
 
     #[must_use]
-    pub(crate) fn with_sketch_var_initial_guess_overrides(mut self, overrides: Vec<f64>) -> Self {
-        self.sketch_var_initial_guess_overrides = overrides;
+    pub(crate) fn with_ordered_sketch_var_initial_guess_overrides(
+        mut self,
+        solver_overrides: Vec<f64>,
+        source_overrides: Vec<f64>,
+        preserve_hidden_by_id: bool,
+    ) -> Self {
+        self.sketch_var_initial_guess_overrides = solver_overrides;
+        self.sketch_var_source_initial_guess_overrides = source_overrides;
+        self.preserve_hidden_sketch_var_initial_guess_overrides = preserve_hidden_by_id;
         self
     }
 }

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -89,8 +89,9 @@ pub(super) struct GlobalState {
     /// Transient warm-start values for source sketch variables, keyed by source
     /// variable order and excluding hidden lowered variables.
     pub sketch_var_source_initial_guess_overrides: Vec<f64>,
-    /// Whether hidden lowered variables may reuse solver-order warm starts.
-    pub preserve_hidden_sketch_var_initial_guess_overrides: bool,
+    /// Source ranges for the solver-order warm starts. Hidden lowered
+    /// variables have no source range.
+    pub sketch_var_initial_guess_source_ranges: Vec<Option<SourceRange>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -318,7 +319,13 @@ pub(crate) struct SketchBlockState {
 impl ExecState {
     pub fn new(exec_context: &super::ExecutorContext) -> Self {
         ExecState {
-            global: GlobalState::new(&exec_context.settings, Default::default(), Vec::new(), Vec::new(), true),
+            global: GlobalState::new(
+                &exec_context.settings,
+                Default::default(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+            ),
             mod_local: ModuleState::new(ModulePath::Main, ProgramMemory::new(), Default::default(), false, true),
         }
     }
@@ -331,7 +338,7 @@ impl ExecState {
                 segment_ids_edited,
                 mock_config.sketch_var_initial_guess_overrides.clone(),
                 mock_config.sketch_var_source_initial_guess_overrides.clone(),
-                mock_config.preserve_hidden_sketch_var_initial_guess_overrides,
+                mock_config.sketch_var_initial_guess_source_ranges.clone(),
             ),
             mod_local: ModuleState::new(
                 ModulePath::Main,
@@ -344,7 +351,13 @@ impl ExecState {
     }
 
     pub(super) fn reset(&mut self, exec_context: &super::ExecutorContext) {
-        let global = GlobalState::new(&exec_context.settings, Default::default(), Vec::new(), Vec::new(), true);
+        let global = GlobalState::new(
+            &exec_context.settings,
+            Default::default(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
 
         *self = ExecState {
             global,
@@ -577,15 +590,21 @@ impl ExecState {
             }
 
             if self.global.sketch_var_source_initial_guess_overrides.is_empty() {
+                if !self.global.sketch_var_initial_guess_source_ranges.is_empty() {
+                    return None;
+                }
                 return self.global.sketch_var_initial_guess_overrides.get(var_id.0).copied();
             }
 
             return None;
         }
 
-        if self.global.preserve_hidden_sketch_var_initial_guess_overrides
-            || self.global.sketch_var_source_initial_guess_overrides.is_empty()
-        {
+        let can_use_solver_slot = self.global.sketch_var_initial_guess_source_ranges.is_empty()
+            || matches!(
+                self.global.sketch_var_initial_guess_source_ranges.get(var_id.0),
+                Some(None)
+            );
+        if can_use_solver_slot {
             self.global.sketch_var_initial_guess_overrides.get(var_id.0).copied()
         } else {
             None
@@ -926,7 +945,7 @@ impl GlobalState {
         segment_ids_edited: AhashIndexSet<ObjectId>,
         sketch_var_initial_guess_overrides: Vec<f64>,
         sketch_var_source_initial_guess_overrides: Vec<f64>,
-        preserve_hidden_sketch_var_initial_guess_overrides: bool,
+        sketch_var_initial_guess_source_ranges: Vec<Option<SourceRange>>,
     ) -> Self {
         let mut global = GlobalState {
             path_to_source_id: Default::default(),
@@ -939,7 +958,7 @@ impl GlobalState {
             segment_ids_edited,
             sketch_var_initial_guess_overrides,
             sketch_var_source_initial_guess_overrides,
-            preserve_hidden_sketch_var_initial_guess_overrides,
+            sketch_var_initial_guess_source_ranges,
         };
 
         let root_id = ModuleId::default();

--- a/rust/kcl-lib/src/execution/state.rs
+++ b/rust/kcl-lib/src/execution/state.rs
@@ -33,6 +33,7 @@ use crate::execution::ExecutorSettings;
 use crate::execution::KclValue;
 use crate::execution::ProgramLookup;
 use crate::execution::SketchVarId;
+use crate::execution::SketchVarSolution;
 use crate::execution::UnsolvedSegment;
 use crate::execution::annotations;
 use crate::execution::cad_op::Operation;
@@ -85,6 +86,11 @@ pub(super) struct GlobalState {
     /// Transient warm-start values for sketch variables, keyed by the solver
     /// variable order in the current sketch block.
     pub sketch_var_initial_guess_overrides: Vec<f64>,
+    /// Transient warm-start values for source sketch variables, keyed by source
+    /// variable order and excluding hidden lowered variables.
+    pub sketch_var_source_initial_guess_overrides: Vec<f64>,
+    /// Whether hidden lowered variables may reuse solver-order warm starts.
+    pub preserve_hidden_sketch_var_initial_guess_overrides: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -141,6 +147,10 @@ pub struct ModuleArtifactState {
     pub artifact_id_to_scene_object: IndexMap<ArtifactId, ObjectId>,
     /// Solutions for sketch variables.
     pub var_solutions: Vec<(SourceRange, Number)>,
+    /// Solutions for every sketch variable in solver order, including hidden
+    /// variables introduced while lowering constraints.
+    #[serde(skip)]
+    pub ordered_sketch_var_solutions: Vec<SketchVarSolution>,
 }
 
 #[derive(Debug, Clone)]
@@ -308,7 +318,7 @@ pub(crate) struct SketchBlockState {
 impl ExecState {
     pub fn new(exec_context: &super::ExecutorContext) -> Self {
         ExecState {
-            global: GlobalState::new(&exec_context.settings, Default::default(), Vec::new()),
+            global: GlobalState::new(&exec_context.settings, Default::default(), Vec::new(), Vec::new(), true),
             mod_local: ModuleState::new(ModulePath::Main, ProgramMemory::new(), Default::default(), false, true),
         }
     }
@@ -320,6 +330,8 @@ impl ExecState {
                 &exec_context.settings,
                 segment_ids_edited,
                 mock_config.sketch_var_initial_guess_overrides.clone(),
+                mock_config.sketch_var_source_initial_guess_overrides.clone(),
+                mock_config.preserve_hidden_sketch_var_initial_guess_overrides,
             ),
             mod_local: ModuleState::new(
                 ModulePath::Main,
@@ -332,7 +344,7 @@ impl ExecState {
     }
 
     pub(super) fn reset(&mut self, exec_context: &super::ExecutorContext) {
-        let global = GlobalState::new(&exec_context.settings, Default::default(), Vec::new());
+        let global = GlobalState::new(&exec_context.settings, Default::default(), Vec::new(), Vec::new(), true);
 
         *self = ExecState {
             global,
@@ -412,6 +424,7 @@ impl ExecState {
             scene_objects: self.global.root_module_artifacts.scene_objects,
             source_range_to_object: self.global.root_module_artifacts.source_range_to_object,
             var_solutions: self.global.root_module_artifacts.var_solutions,
+            ordered_sketch_var_solutions: self.global.root_module_artifacts.ordered_sketch_var_solutions,
             issues: self.global.issues,
             default_planes: ctx.engine.get_default_planes().read().await.clone(),
         }
@@ -553,8 +566,30 @@ impl ExecState {
         self.global.segment_ids_edited.contains(object_id)
     }
 
-    pub(crate) fn sketch_var_initial_guess_override(&self, var_id: SketchVarId) -> Option<f64> {
-        self.global.sketch_var_initial_guess_overrides.get(var_id.0).copied()
+    pub(crate) fn sketch_var_initial_guess_override(
+        &self,
+        sketch_vars: &[KclValue],
+        var_id: SketchVarId,
+    ) -> Option<f64> {
+        if let Some(source_index) = sketch_var_source_index(sketch_vars, var_id) {
+            if let Some(value) = self.global.sketch_var_source_initial_guess_overrides.get(source_index) {
+                return Some(*value);
+            }
+
+            if self.global.sketch_var_source_initial_guess_overrides.is_empty() {
+                return self.global.sketch_var_initial_guess_overrides.get(var_id.0).copied();
+            }
+
+            return None;
+        }
+
+        if self.global.preserve_hidden_sketch_var_initial_guess_overrides
+            || self.global.sketch_var_source_initial_guess_overrides.is_empty()
+        {
+            self.global.sketch_var_initial_guess_overrides.get(var_id.0).copied()
+        } else {
+            None
+        }
     }
 
     pub(super) fn is_in_sketch_block(&self) -> bool {
@@ -890,6 +925,8 @@ impl GlobalState {
         settings: &ExecutorSettings,
         segment_ids_edited: AhashIndexSet<ObjectId>,
         sketch_var_initial_guess_overrides: Vec<f64>,
+        sketch_var_source_initial_guess_overrides: Vec<f64>,
+        preserve_hidden_sketch_var_initial_guess_overrides: bool,
     ) -> Self {
         let mut global = GlobalState {
             path_to_source_id: Default::default(),
@@ -901,6 +938,8 @@ impl GlobalState {
             id_to_source: Default::default(),
             segment_ids_edited,
             sketch_var_initial_guess_overrides,
+            sketch_var_source_initial_guess_overrides,
+            preserve_hidden_sketch_var_initial_guess_overrides,
         };
 
         let root_id = ModuleId::default();
@@ -1001,6 +1040,8 @@ impl ModuleArtifactState {
         self.artifact_id_to_scene_object
             .extend(other.artifact_id_to_scene_object);
         self.var_solutions.extend(other.var_solutions);
+        self.ordered_sketch_var_solutions
+            .extend(other.ordered_sketch_var_solutions);
     }
 
     // Move unprocessed artifact commands so that we don't try to process them
@@ -1074,6 +1115,22 @@ impl ModuleState {
     }
 }
 
+fn sketch_var_source_index(sketch_vars: &[KclValue], var_id: SketchVarId) -> Option<usize> {
+    let mut source_index = 0;
+    for (index, value) in sketch_vars.iter().enumerate() {
+        let Some(sketch_var) = value.as_sketch_var() else {
+            continue;
+        };
+        if index == var_id.0 {
+            return (!sketch_var.meta.is_empty()).then_some(source_index);
+        }
+        if !sketch_var.meta.is_empty() {
+            source_index += 1;
+        }
+    }
+    None
+}
+
 impl SketchBlockState {
     pub(crate) fn next_sketch_var_id(&self) -> SketchVarId {
         SketchVarId(self.sketch_vars.len())
@@ -1121,6 +1178,37 @@ impl SketchBlockState {
             })
             .filter_map(Result::transpose)
             .collect::<Result<Vec<_>, KclError>>()
+    }
+
+    pub(crate) fn ordered_sketch_var_solutions(
+        &self,
+        solve_outcome: &Solved,
+        range: SourceRange,
+    ) -> Result<Vec<SketchVarSolution>, KclError> {
+        self.sketch_vars
+            .iter()
+            .map(|v| {
+                let Some(sketch_var) = v.as_sketch_var() else {
+                    return Err(KclError::new_internal(KclErrorDetails::new(
+                        "Expected sketch variable".to_owned(),
+                        vec![range],
+                    )));
+                };
+                let var_index = sketch_var.id.0;
+                let solved_n = solve_outcome.final_values.get(var_index).ok_or_else(|| {
+                    let message = format!("No solution for sketch variable with id {}", var_index);
+                    debug_assert!(false, "{}", &message);
+                    KclError::new_internal(KclErrorDetails::new(
+                        message,
+                        sketch_var.meta.iter().map(|m| m.source_range).collect(),
+                    ))
+                })?;
+                Ok(SketchVarSolution {
+                    source_range: sketch_var.meta.first().map(|m| m.source_range),
+                    value: *solved_n,
+                })
+            })
+            .collect()
     }
 }
 

--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -6496,6 +6496,201 @@ not_sweep001 = shell(extrude001, faces = [], thickness = 1)
         assert!((actual.y.value - expected.y.value).abs() < 1e-6);
     }
 
+    fn assert_close(label: &str, actual: f64, expected: f64) {
+        const SKETCH_SETUP_TOLERANCE: f64 = 1e-2;
+        assert!(
+            (actual - expected).abs() < SKETCH_SETUP_TOLERANCE,
+            "{label}: expected {expected}, got {actual}"
+        );
+    }
+
+    fn assert_no_solver_failure(label: &str, scene_delta: &SceneGraphDelta) {
+        assert!(
+            !scene_delta
+                .exec_outcome
+                .issues
+                .iter()
+                .any(|issue| issue.message.contains(CONSTRAINT_SOLVER_FAILED_MESSAGE)),
+            "{label}: unexpected solver failure: {:?}",
+            scene_delta.exec_outcome.issues
+        );
+    }
+
+    fn expr_var_number(value: f64, units: NumericSuffix) -> Expr {
+        Expr::Var(Number { value, units })
+    }
+
+    fn point_expr_mm(x: f64, y: f64) -> Point2d<Expr> {
+        Point2d {
+            x: expr_var_number(x, NumericSuffix::Mm),
+            y: expr_var_number(y, NumericSuffix::Mm),
+        }
+    }
+
+    fn translated_point_expr(scene_graph: &SceneGraph, point_id: ObjectId, dx: f64, dy: f64) -> Point2d<Expr> {
+        let position = point_position(scene_graph, point_id);
+        Point2d {
+            x: expr_var_number(position.x.value + dx, position.x.units),
+            y: expr_var_number(position.y.value + dy, position.y.units),
+        }
+    }
+
+    fn point_edit(scene_graph: &SceneGraph, point_id: ObjectId, dx: f64, dy: f64) -> ExistingSegmentCtor {
+        ExistingSegmentCtor {
+            id: point_id,
+            ctor: SegmentCtor::Point(PointCtor {
+                position: translated_point_expr(scene_graph, point_id, dx, dy),
+            }),
+        }
+    }
+
+    fn line_edit_from_points(
+        scene_graph: &SceneGraph,
+        line_id: ObjectId,
+        start_id: ObjectId,
+        end_id: ObjectId,
+        dx: f64,
+        dy: f64,
+    ) -> ExistingSegmentCtor {
+        ExistingSegmentCtor {
+            id: line_id,
+            ctor: SegmentCtor::Line(LineCtor {
+                start: translated_point_expr(scene_graph, start_id, dx, dy),
+                end: translated_point_expr(scene_graph, end_id, dx, dy),
+                construction: None,
+            }),
+        }
+    }
+
+    fn arc_edit_from_points(
+        scene_graph: &SceneGraph,
+        arc_id: ObjectId,
+        start_id: ObjectId,
+        end_id: ObjectId,
+        center_id: ObjectId,
+        dx: f64,
+        dy: f64,
+    ) -> ExistingSegmentCtor {
+        ExistingSegmentCtor {
+            id: arc_id,
+            ctor: SegmentCtor::Arc(ArcCtor {
+                start: translated_point_expr(scene_graph, start_id, dx, dy),
+                end: translated_point_expr(scene_graph, end_id, dx, dy),
+                center: translated_point_expr(scene_graph, center_id, dx, dy),
+                construction: None,
+            }),
+        }
+    }
+
+    fn assert_points_coincident(scene_graph: &SceneGraph, a: ObjectId, b: ObjectId, label: &str) {
+        let a_pos = point_position(scene_graph, a);
+        let b_pos = point_position(scene_graph, b);
+        assert_close(&format!("{label} x"), a_pos.x.value, b_pos.x.value);
+        assert_close(&format!("{label} y"), a_pos.y.value, b_pos.y.value);
+    }
+
+    fn assert_point_translated(
+        before: &SceneGraph,
+        after: &SceneGraph,
+        point_id: ObjectId,
+        dx: f64,
+        dy: f64,
+        label: &str,
+    ) {
+        let before_pos = point_position(before, point_id);
+        let after_pos = point_position(after, point_id);
+        assert_close(&format!("{label} x"), after_pos.x.value, before_pos.x.value + dx);
+        assert_close(&format!("{label} y"), after_pos.y.value, before_pos.y.value + dy);
+    }
+
+    fn line_arc_tangent_all_segment_edits(
+        scene_graph: &SceneGraph,
+        sketch_segments: &[ObjectId],
+        dx: f64,
+        dy: f64,
+    ) -> Vec<ExistingSegmentCtor> {
+        vec![
+            line_edit_from_points(
+                scene_graph,
+                sketch_segments[2],
+                sketch_segments[0],
+                sketch_segments[1],
+                dx,
+                dy,
+            ),
+            arc_edit_from_points(
+                scene_graph,
+                sketch_segments[6],
+                sketch_segments[3],
+                sketch_segments[4],
+                sketch_segments[5],
+                dx,
+                dy,
+            ),
+            line_edit_from_points(
+                scene_graph,
+                sketch_segments[9],
+                sketch_segments[7],
+                sketch_segments[8],
+                dx,
+                dy,
+            ),
+        ]
+    }
+
+    fn lowered_warm_start_slots(frontend: &FrontendState, sketch_id: ObjectId) -> Vec<usize> {
+        frontend
+            .sketch_var_warm_start_overrides
+            .get(&sketch_id)
+            .expect("Expected warm starts for sketch")
+            .solver_source_ranges
+            .iter()
+            .enumerate()
+            .filter_map(|(index, range)| range.is_none().then_some(index))
+            .collect()
+    }
+
+    async fn setup_sketch_with_warm_starts(source: &str) -> (FrontendState, ExecutorContext, ObjectId, Vec<ObjectId>) {
+        let program = Program::parse(source).unwrap().0.unwrap();
+
+        let mut frontend = FrontendState::new();
+        let mock_ctx = ExecutorContext::new_mock(None).await;
+
+        frontend.program = program.clone();
+        let outcome = mock_ctx.run_mock(&program, &MockConfig::default()).await.unwrap();
+        let outcome = frontend.update_state_after_exec(outcome, true);
+        let sketch_object = find_first_sketch_object(&frontend.scene_graph).unwrap();
+        let sketch_id = sketch_object.id;
+        let sketch_segments = expect_sketch(sketch_object).segments.clone();
+        frontend.replace_sketch_var_warm_starts(sketch_id, &outcome);
+
+        (frontend, mock_ctx, sketch_id, sketch_segments)
+    }
+
+    const LINE_ARC_TANGENT_DRAG_SOURCE: &str = "\
+sketch001 = sketch(on = XZ) {
+  line1 = line(start = [var 5.87mm, var -5.86mm], end = [var -7.22mm, var -4.4mm])
+  arc1 = arc(start = [var 0.35mm, var 6.72mm], end = [var -7.22mm, var -4.4mm], center = [var -5.77mm, var 2.75mm])
+  coincident([line1.end, arc1.end])
+  tangent([line1, arc1])
+  line2 = line(start = [var 0.35mm, var 6.72mm], end = [var 0mm, var -5.86mm])
+  coincident([line2.start, arc1.start])
+  coincident([line2.end, line1.start])
+  vertical([line2.end, ORIGIN])
+}
+";
+
+    const CIRCLE_CIRCLE_DISTANCE_SOURCE: &str = "\
+sketch001 = sketch(on = XZ) {
+  circle1 = circle(start = [var -6.97mm, var 0mm], center = [var -1.85mm, var 0.13mm])
+  horizontal([circle1.start, ORIGIN])
+  circle2 = circle(start = [var -14.46mm, var 0mm], center = [var -15.66mm, var 4.19mm])
+  horizontal([circle2.start, ORIGIN])
+  distance([circle1, circle2]) == 4.91mm
+  line1 = line(start = [var -11.38mm, var -5.02mm], end = [var -7.81mm, var 8.69mm])
+}
+";
+
     fn make_line_ctor(start_x: f64, start_y: f64, end_x: f64, end_y: f64, units: NumericSuffix) -> LineCtor {
         LineCtor {
             start: Point2d {
@@ -12648,6 +12843,87 @@ sketch(on = XY) {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_sketch_setup_warm_start_metadata_separates_visible_and_lowered_tangent_vars() {
+        let (mut frontend, mock_ctx, sketch_id, _sketch_segments) =
+            setup_sketch_with_warm_starts(LINE_ARC_TANGENT_DRAG_SOURCE).await;
+        let warm_starts = frontend
+            .sketch_var_warm_start_overrides
+            .get(&sketch_id)
+            .expect("Expected warm starts for sketch");
+
+        assert_eq!(warm_starts.solver_values.len(), warm_starts.solver_source_ranges.len());
+        assert_eq!(warm_starts.source_values.len(), 14);
+        assert!(
+            warm_starts.solver_values.len() > warm_starts.source_values.len(),
+            "tangent should add lowered support variables to solver order"
+        );
+        assert!(
+            !lowered_warm_start_slots(&frontend, sketch_id).is_empty(),
+            "lowered support variables should have no source range"
+        );
+        assert!(
+            warm_starts
+                .solver_source_ranges
+                .iter()
+                .filter_map(|range| *range)
+                .all(|range| warm_starts
+                    .source_values
+                    .iter()
+                    .any(|(source_range, _)| *source_range == range)),
+            "every visible solver slot should point back to a source sketch var"
+        );
+
+        let (_src_delta, scene_delta) = frontend
+            .execute_mock_from_preview(&mock_ctx, Version(0), sketch_id)
+            .await
+            .unwrap();
+        assert_no_solver_failure("line-arc tangent warm-start replay", &scene_delta);
+
+        mock_ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_sketch_setup_warm_start_metadata_handles_circle_circle_distance_lowering() {
+        let (mut frontend, mock_ctx, sketch_id, sketch_segments) =
+            setup_sketch_with_warm_starts(CIRCLE_CIRCLE_DISTANCE_SOURCE).await;
+        let warm_starts = frontend
+            .sketch_var_warm_start_overrides
+            .get(&sketch_id)
+            .expect("Expected warm starts for sketch");
+        let lowered_slots = lowered_warm_start_slots(&frontend, sketch_id);
+
+        assert_eq!(warm_starts.solver_values.len(), warm_starts.solver_source_ranges.len());
+        assert_eq!(warm_starts.source_values.len(), 12);
+        assert!(
+            lowered_slots.len() >= 2,
+            "circle-circle distance should lower through support tangent variables"
+        );
+
+        let line_id = sketch_segments[8];
+        let line_start_id = sketch_segments[6];
+        let line_end_id = sketch_segments[7];
+        let (_src_delta, scene_delta) = frontend
+            .edit_segments_for_preview(
+                &mock_ctx,
+                Version(0),
+                sketch_id,
+                vec![line_edit_from_points(
+                    &frontend.scene_graph,
+                    line_id,
+                    line_start_id,
+                    line_end_id,
+                    1.25,
+                    -0.75,
+                )],
+            )
+            .await
+            .unwrap();
+        assert_no_solver_failure("circle-circle distance lowered warm-start preview", &scene_delta);
+
+        mock_ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_add_arc_uses_warm_starts_for_lowered_constraints() {
         let initial_source = "\
 sketch001 = sketch(on = XZ) {
@@ -12942,6 +13218,172 @@ sketch001 = sketch(on = XZ) {
         );
 
         mock_ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_sketch_setup_select_all_vertical_drag_translates_without_deformation() {
+        let (mut frontend, mock_ctx, sketch_id, sketch_segments) =
+            setup_sketch_with_warm_starts(LINE_ARC_TANGENT_DRAG_SOURCE).await;
+        let baseline_graph = frontend.scene_graph.clone();
+        let dy = 3.25;
+        let edits = line_arc_tangent_all_segment_edits(&baseline_graph, &sketch_segments, 0.0, dy);
+
+        let (_src_delta, scene_delta) = frontend
+            .edit_segments_for_preview(&mock_ctx, Version(0), sketch_id, edits)
+            .await
+            .unwrap();
+        assert_no_solver_failure("select-all vertical drag", &scene_delta);
+
+        for (label, point_id) in [
+            ("line1.start", sketch_segments[0]),
+            ("line1.end", sketch_segments[1]),
+            ("arc1.start", sketch_segments[3]),
+            ("arc1.end", sketch_segments[4]),
+            ("arc1.center", sketch_segments[5]),
+            ("line2.start", sketch_segments[7]),
+            ("line2.end", sketch_segments[8]),
+        ] {
+            assert_point_translated(&baseline_graph, &scene_delta.new_graph, point_id, 0.0, dy, label);
+        }
+
+        assert_points_coincident(
+            &scene_delta.new_graph,
+            sketch_segments[1],
+            sketch_segments[4],
+            "line1.end/arc1.end",
+        );
+        assert_points_coincident(
+            &scene_delta.new_graph,
+            sketch_segments[7],
+            sketch_segments[3],
+            "line2.start/arc1.start",
+        );
+        assert_points_coincident(
+            &scene_delta.new_graph,
+            sketch_segments[8],
+            sketch_segments[0],
+            "line2.end/line1.start",
+        );
+
+        mock_ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_sketch_setup_select_all_impossible_drag_keeps_required_constraints_authoritative() {
+        let (mut frontend, mock_ctx, sketch_id, sketch_segments) =
+            setup_sketch_with_warm_starts(LINE_ARC_TANGENT_DRAG_SOURCE).await;
+        let edits = line_arc_tangent_all_segment_edits(&frontend.scene_graph, &sketch_segments, -5.0, 3.0);
+
+        let (_src_delta, scene_delta) = frontend
+            .edit_segments_for_preview(&mock_ctx, Version(0), sketch_id, edits)
+            .await
+            .unwrap();
+        assert_no_solver_failure("select-all impossible drag", &scene_delta);
+
+        let line2_end = point_position(&scene_delta.new_graph, sketch_segments[8]);
+        assert_close("vertical line2.end x", line2_end.x.value, 0.0);
+        assert_points_coincident(
+            &scene_delta.new_graph,
+            sketch_segments[1],
+            sketch_segments[4],
+            "line1.end/arc1.end",
+        );
+        assert_points_coincident(
+            &scene_delta.new_graph,
+            sketch_segments[7],
+            sketch_segments[3],
+            "line2.start/arc1.start",
+        );
+        assert_points_coincident(
+            &scene_delta.new_graph,
+            sketch_segments[8],
+            sketch_segments[0],
+            "line2.end/line1.start",
+        );
+
+        mock_ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_sketch_setup_repeated_select_all_previews_do_not_accumulate_drift() {
+        let (mut frontend, mock_ctx, sketch_id, sketch_segments) =
+            setup_sketch_with_warm_starts(LINE_ARC_TANGENT_DRAG_SOURCE).await;
+        let baseline_graph = frontend.scene_graph.clone();
+
+        for dy in [0.5, 1.25, 2.5, 4.0] {
+            let edits = line_arc_tangent_all_segment_edits(&baseline_graph, &sketch_segments, 0.0, dy);
+            let (_src_delta, scene_delta) = frontend
+                .edit_segments_for_preview(&mock_ctx, Version(0), sketch_id, edits)
+                .await
+                .unwrap();
+            assert_no_solver_failure(&format!("select-all preview dy={dy}"), &scene_delta);
+
+            for (label, point_id) in [
+                ("line1.start", sketch_segments[0]),
+                ("line1.end", sketch_segments[1]),
+                ("arc1.start", sketch_segments[3]),
+                ("arc1.end", sketch_segments[4]),
+                ("arc1.center", sketch_segments[5]),
+                ("line2.start", sketch_segments[7]),
+                ("line2.end", sketch_segments[8]),
+            ] {
+                assert_point_translated(
+                    &baseline_graph,
+                    &scene_delta.new_graph,
+                    point_id,
+                    0.0,
+                    dy,
+                    &format!("{label} dy={dy}"),
+                );
+            }
+        }
+
+        mock_ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_sketch_setup_dragging_each_coincident_pair_keeps_clusters_stable() {
+        for (label, point_a_index, point_b_index, dx, dy, expect_x_from_vertical) in [
+            ("line1.end/arc1.end", 1, 4, -1.2, 0.8, false),
+            ("line2.start/arc1.start", 7, 3, -0.7, 1.1, false),
+            ("line2.end/line1.start", 8, 0, 1.4, 1.3, true),
+        ] {
+            let (mut frontend, mock_ctx, sketch_id, sketch_segments) =
+                setup_sketch_with_warm_starts(LINE_ARC_TANGENT_DRAG_SOURCE).await;
+            let point_a = sketch_segments[point_a_index];
+            let point_b = sketch_segments[point_b_index];
+            let before = point_position(&frontend.scene_graph, point_a);
+            let edits = vec![
+                point_edit(&frontend.scene_graph, point_a, dx, dy),
+                ExistingSegmentCtor {
+                    id: point_b,
+                    ctor: SegmentCtor::Point(PointCtor {
+                        position: point_expr_mm(before.x.value + dx, before.y.value + dy),
+                    }),
+                },
+            ];
+
+            let (_src_delta, scene_delta) = frontend
+                .edit_segments_for_preview(&mock_ctx, Version(0), sketch_id, edits)
+                .await
+                .unwrap();
+            assert_no_solver_failure(label, &scene_delta);
+            assert_points_coincident(&scene_delta.new_graph, point_a, point_b, label);
+
+            let after = point_position(&scene_delta.new_graph, point_a);
+            if expect_x_from_vertical {
+                assert_close(&format!("{label} vertical x"), after.x.value, 0.0);
+                assert!(
+                    (after.y.value - before.y.value).abs() > dy.abs() * 0.5,
+                    "{label}: expected vertical pair to move with the drag, before={before:?}, after={after:?}"
+                );
+            } else {
+                assert_close(&format!("{label} dragged x"), after.x.value, before.x.value + dx);
+                assert_close(&format!("{label} dragged y"), after.y.value, before.y.value + dy);
+            }
+
+            mock_ctx.close().await;
+        }
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -542,7 +542,7 @@ impl FrontendState {
                 .iter()
                 .enumerate()
                 .map(|(index, (range, source_value))| {
-                    if edited_var_indices.contains(&index) || !solution_by_range.contains_key(&range) {
+                    if edited_var_indices.contains(&index) || !solution_by_range.contains_key(range) {
                         (*range, *source_value)
                     } else {
                         let value = previous

--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -12841,6 +12841,110 @@ sketch001 = sketch(on = XZ) {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_drag_optional_constraints_do_not_compete_with_required_constraints() {
+        let initial_source = "\
+sketch001 = sketch(on = XZ) {
+  line1 = line(start = [var 5.87mm, var -5.86mm], end = [var -7.22mm, var -4.4mm])
+  arc1 = arc(start = [var 0.35mm, var 6.72mm], end = [var -7.22mm, var -4.4mm], center = [var -5.77mm, var 2.75mm])
+  coincident([line1.end, arc1.end])
+  tangent([line1, arc1])
+  line2 = line(start = [var 0.35mm, var 6.72mm], end = [var 0mm, var -5.86mm])
+  coincident([line2.start, arc1.start])
+  coincident([line2.end, line1.start])
+  vertical([line2.end, ORIGIN])
+}
+";
+
+        fn translated_point(scene_graph: &SceneGraph, point_id: ObjectId, dx: f64, dy: f64) -> Point2d<Expr> {
+            let position = point_position(scene_graph, point_id);
+            Point2d {
+                x: Expr::Var(Number {
+                    value: position.x.value + dx,
+                    units: position.x.units,
+                }),
+                y: Expr::Var(Number {
+                    value: position.y.value + dy,
+                    units: position.y.units,
+                }),
+            }
+        }
+
+        let program = Program::parse(initial_source).unwrap().0.unwrap();
+
+        let mut frontend = FrontendState::new();
+        let mock_ctx = ExecutorContext::new_mock(None).await;
+        let version = Version(0);
+
+        frontend.program = program.clone();
+        let outcome = mock_ctx.run_mock(&program, &MockConfig::default()).await.unwrap();
+        let outcome = frontend.update_state_after_exec(outcome, true);
+        let sketch_object = find_first_sketch_object(&frontend.scene_graph).unwrap();
+        let sketch_id = sketch_object.id;
+        let sketch = expect_sketch(sketch_object);
+        let sketch_segments = sketch.segments.clone();
+
+        let line1_id = sketch_segments[2];
+        let arc1_id = sketch_segments[6];
+        let line2_id = sketch_segments[9];
+        let line2_end_id = sketch_segments[8];
+
+        frontend.replace_sketch_var_warm_starts(sketch_id, &outcome);
+
+        let dx = -5.0;
+        let dy = 3.0;
+        let segments = vec![
+            ExistingSegmentCtor {
+                id: line1_id,
+                ctor: SegmentCtor::Line(LineCtor {
+                    start: translated_point(&frontend.scene_graph, sketch_segments[0], dx, dy),
+                    end: translated_point(&frontend.scene_graph, sketch_segments[1], dx, dy),
+                    construction: None,
+                }),
+            },
+            ExistingSegmentCtor {
+                id: arc1_id,
+                ctor: SegmentCtor::Arc(ArcCtor {
+                    start: translated_point(&frontend.scene_graph, sketch_segments[3], dx, dy),
+                    end: translated_point(&frontend.scene_graph, sketch_segments[4], dx, dy),
+                    center: translated_point(&frontend.scene_graph, sketch_segments[5], dx, dy),
+                    construction: None,
+                }),
+            },
+            ExistingSegmentCtor {
+                id: line2_id,
+                ctor: SegmentCtor::Line(LineCtor {
+                    start: translated_point(&frontend.scene_graph, sketch_segments[7], dx, dy),
+                    end: translated_point(&frontend.scene_graph, sketch_segments[8], dx, dy),
+                    construction: None,
+                }),
+            },
+        ];
+
+        let (_src_delta, scene_delta) = frontend
+            .edit_segments_for_preview(&mock_ctx, version, sketch_id, segments)
+            .await
+            .unwrap();
+
+        assert!(
+            !scene_delta
+                .exec_outcome
+                .issues
+                .iter()
+                .any(|issue| issue.message.contains(CONSTRAINT_SOLVER_FAILED_MESSAGE)),
+            "select-all drag preview should not fail solving: {:?}",
+            scene_delta.exec_outcome.issues
+        );
+
+        let line2_end = point_position(&scene_delta.new_graph, line2_end_id);
+        assert!(
+            line2_end.x.value.abs() < 1e-6,
+            "required vertical constraint should not be compromised by drag-only fixed constraints: {line2_end:?}"
+        );
+
+        mock_ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_committed_edit_merges_edited_vars_into_existing_warm_starts() {
         let initial_source = "\
 sketch(on = XY) {

--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -122,6 +122,7 @@ enum SketchVarUpdateMode {
 #[derive(Debug, Clone)]
 struct SketchVarWarmStarts {
     solver_values: Vec<f64>,
+    solver_source_ranges: Vec<Option<SourceRange>>,
     source_values: Vec<(SourceRange, f64)>,
 }
 
@@ -153,6 +154,7 @@ const CIRCLE_VARIABLE: &str = "circle";
 const CIRCLE_START_PARAM: &str = "start";
 const CIRCLE_CENTER_PARAM: &str = "center";
 const LABEL_POSITION_PARAM: &str = "labelPosition";
+const CONSTRAINT_SOLVER_FAILED_MESSAGE: &str = "Constraint solver failed to find a solution";
 
 const COINCIDENT_FN: &str = "coincident";
 const DIAMETER_FN: &str = "diameter";
@@ -401,23 +403,45 @@ impl FrontendState {
             sketch_block_id: Some(sketch),
             freedom_analysis,
             #[cfg(feature = "artifact-graph")]
-            segment_ids_edited,
+            segment_ids_edited: segment_ids_edited.clone(),
             ..Default::default()
         };
 
         match (use_warm_starts, self.sketch_var_warm_start_overrides.get(&sketch)) {
             (true, Some(overrides)) => {
                 #[cfg(feature = "artifact-graph")]
-                let source_var_count = self
-                    .sketch_var_source_values_from_program(sketch)
-                    .map(|values| values.len())
-                    .unwrap_or(overrides.source_values.len());
+                let source_overrides =
+                    if overrides.source_values.is_empty() && overrides.solver_source_ranges.is_empty() {
+                        Vec::new()
+                    } else {
+                        self.sketch_var_source_values_from_program(sketch)
+                            .map(|current_source_values| {
+                                let edited_var_indices =
+                                    self.edited_sketch_var_indices(&current_source_values, &segment_ids_edited);
+                                current_source_values
+                                    .iter()
+                                    .enumerate()
+                                    .map(|(index, (_, source_value))| {
+                                        if edited_var_indices.contains(&index) {
+                                            *source_value
+                                        } else {
+                                            overrides
+                                                .source_values
+                                                .get(index)
+                                                .map(|(_, value)| *value)
+                                                .unwrap_or(*source_value)
+                                        }
+                                    })
+                                    .collect()
+                            })
+                            .unwrap_or_else(|| overrides.source_values.iter().map(|(_, value)| *value).collect())
+                    };
                 #[cfg(not(feature = "artifact-graph"))]
-                let source_var_count = overrides.source_values.len();
+                let source_overrides = overrides.source_values.iter().map(|(_, value)| *value).collect();
                 config.with_ordered_sketch_var_initial_guess_overrides(
                     overrides.solver_values.clone(),
-                    overrides.source_values.iter().map(|(_, value)| *value).collect(),
-                    source_var_count == overrides.source_values.len(),
+                    source_overrides,
+                    overrides.solver_source_ranges.clone(),
                 )
             }
             _ => config,
@@ -456,14 +480,24 @@ impl FrontendState {
     fn replace_sketch_var_warm_starts(&mut self, sketch: ObjectId, outcome: &ExecOutcome) {
         #[cfg(feature = "artifact-graph")]
         {
-            let solver_values = if outcome.ordered_sketch_var_solutions.is_empty() {
-                outcome.var_solutions.iter().map(|(_, value)| value.value).collect()
+            let (solver_values, solver_source_ranges) = if outcome.ordered_sketch_var_solutions.is_empty() {
+                (
+                    outcome.var_solutions.iter().map(|(_, value)| value.value).collect(),
+                    outcome.var_solutions.iter().map(|(range, _)| Some(*range)).collect(),
+                )
             } else {
-                outcome
-                    .ordered_sketch_var_solutions
-                    .iter()
-                    .map(|solution| solution.value)
-                    .collect()
+                (
+                    outcome
+                        .ordered_sketch_var_solutions
+                        .iter()
+                        .map(|solution| solution.value)
+                        .collect(),
+                    outcome
+                        .ordered_sketch_var_solutions
+                        .iter()
+                        .map(|solution| solution.source_range)
+                        .collect(),
+                )
             };
             let source_values = outcome
                 .var_solutions
@@ -474,6 +508,7 @@ impl FrontendState {
                 sketch,
                 SketchVarWarmStarts {
                     solver_values,
+                    solver_source_ranges,
                     source_values,
                 },
             );
@@ -520,22 +555,23 @@ impl FrontendState {
                 })
                 .collect::<Vec<_>>();
 
-            let preserve_previous_hidden = !segment_ids_edited.is_empty()
-                && previous
-                    .as_ref()
-                    .is_some_and(|p| p.source_values.len() == source_values.len());
-            let solver_values = merged_solver_warm_start_values(
-                outcome,
-                previous.as_ref(),
-                &source_values,
-                &edited_var_indices,
-                preserve_previous_hidden,
-            );
+            let solver_values =
+                merged_solver_warm_start_values(outcome, previous.as_ref(), &source_values, &edited_var_indices);
+            let solver_source_ranges = if outcome.ordered_sketch_var_solutions.is_empty() {
+                source_values.iter().map(|(range, _)| Some(*range)).collect()
+            } else {
+                outcome
+                    .ordered_sketch_var_solutions
+                    .iter()
+                    .map(|solution| solution.source_range)
+                    .collect()
+            };
 
             self.sketch_var_warm_start_overrides.insert(
                 sketch,
                 SketchVarWarmStarts {
                     solver_values,
+                    solver_source_ranges,
                     source_values,
                 },
             );
@@ -2051,12 +2087,8 @@ impl FrontendState {
             .map_err(KclErrorWithOutputs::no_outputs)?;
 
         // Execute.
-        let outcome = ctx
-            .run_mock(
-                &truncated_program,
-                &MockConfig::new_sketch_mode(sketch).no_freedom_analysis(),
-            )
-            .await?;
+        let mock_config = self.sketch_mock_config(sketch, false, Default::default(), true);
+        let outcome = ctx.run_mock(&truncated_program, &mock_config).await?;
 
         let new_object_ids = {
             let make_err =
@@ -2085,8 +2117,9 @@ impl FrontendState {
             vec![segment_id]
         };
         let src_delta = SourceDelta { text: new_source };
-        // Uses .no_freedom_analysis() so freedom_analysis: false
+        // Uses freedom_analysis: false
         let outcome = self.update_state_after_exec(outcome, false);
+        self.replace_sketch_var_warm_starts(sketch, &outcome);
         let scene_graph_delta = SceneGraphDelta {
             new_graph: self.scene_graph.clone(),
             invalidates_ids: false,
@@ -2187,12 +2220,8 @@ impl FrontendState {
             .map_err(KclErrorWithOutputs::no_outputs)?;
 
         // Execute.
-        let outcome = ctx
-            .run_mock(
-                &truncated_program,
-                &MockConfig::new_sketch_mode(sketch).no_freedom_analysis(),
-            )
-            .await?;
+        let mock_config = self.sketch_mock_config(sketch, false, Default::default(), true);
+        let outcome = ctx.run_mock(&truncated_program, &mock_config).await?;
 
         let new_object_ids = {
             let make_err =
@@ -2220,8 +2249,9 @@ impl FrontendState {
             vec![line.start, line.end, segment_id]
         };
         let src_delta = SourceDelta { text: new_source };
-        // Uses .no_freedom_analysis() so freedom_analysis: false
+        // Uses freedom_analysis: false
         let outcome = self.update_state_after_exec(outcome, false);
+        self.replace_sketch_var_warm_starts(sketch, &outcome);
         let scene_graph_delta = SceneGraphDelta {
             new_graph: self.scene_graph.clone(),
             invalidates_ids: false,
@@ -2328,12 +2358,8 @@ impl FrontendState {
             .map_err(KclErrorWithOutputs::no_outputs)?;
 
         // Execute.
-        let outcome = ctx
-            .run_mock(
-                &truncated_program,
-                &MockConfig::new_sketch_mode(sketch).no_freedom_analysis(),
-            )
-            .await?;
+        let mock_config = self.sketch_mock_config(sketch, false, Default::default(), true);
+        let outcome = ctx.run_mock(&truncated_program, &mock_config).await?;
 
         let new_object_ids = {
             let make_err =
@@ -2362,8 +2388,9 @@ impl FrontendState {
             vec![arc.start, arc.end, arc.center, segment_id]
         };
         let src_delta = SourceDelta { text: new_source };
-        // Uses .no_freedom_analysis() so freedom_analysis: false
+        // Uses freedom_analysis: false
         let outcome = self.update_state_after_exec(outcome, false);
+        self.replace_sketch_var_warm_starts(sketch, &outcome);
         let scene_graph_delta = SceneGraphDelta {
             new_graph: self.scene_graph.clone(),
             invalidates_ids: false,
@@ -2467,12 +2494,8 @@ impl FrontendState {
             .map_err(KclErrorWithOutputs::no_outputs)?;
 
         // Execute.
-        let outcome = ctx
-            .run_mock(
-                &truncated_program,
-                &MockConfig::new_sketch_mode(sketch).no_freedom_analysis(),
-            )
-            .await?;
+        let mock_config = self.sketch_mock_config(sketch, false, Default::default(), true);
+        let outcome = ctx.run_mock(&truncated_program, &mock_config).await?;
 
         let new_object_ids = {
             let make_err =
@@ -2501,8 +2524,9 @@ impl FrontendState {
             vec![circle.start, circle.center, segment_id]
         };
         let src_delta = SourceDelta { text: new_source };
-        // Uses .no_freedom_analysis() so freedom_analysis: false
+        // Uses freedom_analysis: false
         let outcome = self.update_state_after_exec(outcome, false);
+        self.replace_sketch_var_warm_starts(sketch, &outcome);
         let scene_graph_delta = SceneGraphDelta {
             new_graph: self.scene_graph.clone(),
             invalidates_ids: false,
@@ -3125,6 +3149,12 @@ impl FrontendState {
             )));
         };
 
+        let previous_program = self.program.clone();
+        let previous_source = source_from_ast(&previous_program.ast);
+        let previous_scene_graph = self.scene_graph.clone();
+        let previous_warm_start_overrides = self.sketch_var_warm_start_overrides.clone();
+        let previous_mock_memory = read_old_memory().await;
+
         // TODO: sketch-api: make sure to only set this if there are no errors.
         self.program = new_program.clone();
 
@@ -3150,6 +3180,34 @@ impl FrontendState {
         let mock_config =
             self.sketch_mock_config(sketch, is_delete, options.segment_ids_edited.clone(), use_warm_starts);
         let outcome = ctx.run_mock(&truncated_program, &mock_config).await?;
+        if matches!(options.sketch_var_update_mode, SketchVarUpdateMode::WarmStartOnly)
+            && has_constraint_solver_failed_issue(&outcome)
+        {
+            // Mouse-move previews can hit transient solver branches while an
+            // arc is moving away from a degenerate draft. Keep the last good
+            // sketch state instead of surfacing a red, toast-producing frame.
+            self.program = previous_program;
+            self.scene_graph = previous_scene_graph.clone();
+            self.sketch_var_warm_start_overrides = previous_warm_start_overrides;
+            if let Some(previous_mock_memory) = previous_mock_memory {
+                write_old_memory(previous_mock_memory).await;
+            } else {
+                clear_mem_cache().await;
+            }
+
+            let mut outcome = outcome;
+            outcome.issues.clear();
+            outcome.scene_objects = previous_scene_graph.objects.clone();
+            return Ok((
+                SourceDelta { text: previous_source },
+                SceneGraphDelta {
+                    new_graph: previous_scene_graph,
+                    invalidates_ids: false,
+                    new_objects: Vec::new(),
+                    exec_outcome: outcome,
+                },
+            ));
+        }
 
         // Uses freedom_analysis: is_delete
         let outcome = self.update_state_after_exec(outcome, is_delete);
@@ -5969,7 +6027,6 @@ fn merged_solver_warm_start_values(
     previous: Option<&SketchVarWarmStarts>,
     source_values: &[(SourceRange, f64)],
     edited_var_indices: &HashSet<usize>,
-    preserve_previous_hidden: bool,
 ) -> Vec<f64> {
     if outcome.ordered_sketch_var_solutions.is_empty() {
         return source_values.iter().map(|(_, value)| *value).collect();
@@ -5990,7 +6047,10 @@ fn merged_solver_warm_start_values(
                 return value;
             }
 
-            if preserve_previous_hidden && !edited_var_indices.is_empty() {
+            let previous_slot_was_hidden = previous
+                .is_some_and(|warm_starts| matches!(warm_starts.solver_source_ranges.get(solver_index), Some(None)));
+
+            if previous_slot_was_hidden && !edited_var_indices.is_empty() {
                 previous
                     .and_then(|warm_starts| warm_starts.solver_values.get(solver_index))
                     .copied()
@@ -6000,6 +6060,13 @@ fn merged_solver_warm_start_values(
             }
         })
         .collect()
+}
+
+fn has_constraint_solver_failed_issue(outcome: &ExecOutcome) -> bool {
+    outcome
+        .issues
+        .iter()
+        .any(|issue| issue.message.contains(CONSTRAINT_SOLVER_FAILED_MESSAGE))
 }
 
 #[cfg(feature = "artifact-graph")]
@@ -12503,6 +12570,7 @@ sketch(on = XY) {
             sketch_id,
             SketchVarWarmStarts {
                 solver_values: vec![5.0, 6.0],
+                solver_source_ranges: Vec::new(),
                 source_values: Vec::new(),
             },
         );
@@ -12575,6 +12643,199 @@ sketch(on = XY) {
                 .text
                 .contains("line2 = line(start = [var 10mm, var 20mm], end = [var 30mm, var 40mm])")
         );
+
+        mock_ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_add_arc_uses_warm_starts_for_lowered_constraints() {
+        let initial_source = "\
+sketch001 = sketch(on = XZ) {
+  circle1 = circle(start = [var -6.97mm, var 0mm], center = [var -1.85mm, var 0.13mm])
+  horizontal([circle1.start, ORIGIN])
+  circle2 = circle(start = [var -14.46mm, var 0mm], center = [var -15.66mm, var 4.19mm])
+  horizontal([circle2.start, ORIGIN])
+  line1 = line(start = [var -11.38mm, var -5.02mm], end = [var -7.81mm, var 8.69mm])
+  line2 = line(start = [var -11.38mm, var -5.02mm], end = [var -20.15mm, var -2.97mm])
+  coincident([line2.start, line1.start])
+  line3 = line(start = [var -11.38mm, var -5.02mm], end = [var 0.77mm, var -7.39mm])
+  coincident([line3.start, line2.start])
+  line4 = line(start = [var -11.38mm, var -5.02mm], end = [var -21.87mm, var -13.4mm])
+  coincident([line4.start, line3.start])
+  distance([circle1, circle2]) == 4.91mm
+  arc1 = arc(start = [var -20.15mm, var -2.97mm], end = [var -25.04mm, var -9.89mm], center = [var -21.19mm, var -7.42mm])
+  coincident([line2.end, arc1.start])
+  tangent([line2, arc1])
+  line(start = [var -12.02mm, var -15.45mm], end = [var 4.83mm, var -8.9mm])
+}
+";
+
+        fn var_mm(value: f64) -> Expr {
+            Expr::Var(Number {
+                value,
+                units: NumericSuffix::Mm,
+            })
+        }
+
+        let program = Program::parse(initial_source).unwrap().0.unwrap();
+
+        let mut frontend = FrontendState::new();
+        let mock_ctx = ExecutorContext::new_mock(None).await;
+
+        frontend.program = program.clone();
+        let outcome = mock_ctx.run_mock(&program, &MockConfig::default()).await.unwrap();
+        let outcome = frontend.update_state_after_exec(outcome, true);
+        let sketch_id = find_first_sketch_object(&frontend.scene_graph).unwrap().id;
+        frontend.replace_sketch_var_warm_starts(sketch_id, &outcome);
+
+        let (_src_delta, scene_delta) = frontend
+            .add_arc(
+                &mock_ctx,
+                sketch_id,
+                ArcCtor {
+                    start: Point2d {
+                        x: var_mm(-32.07),
+                        y: var_mm(-2.53),
+                    },
+                    end: Point2d {
+                        x: var_mm(-18.96),
+                        y: var_mm(7.04),
+                    },
+                    center: Point2d {
+                        x: var_mm(-29.12),
+                        y: var_mm(7.19),
+                    },
+                    construction: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !scene_delta
+                .exec_outcome
+                .issues
+                .iter()
+                .any(|issue| issue.message.contains(CONSTRAINT_SOLVER_FAILED_MESSAGE)),
+            "add-arc preview should not drop lowered-constraint warm starts: {:?}",
+            scene_delta.exec_outcome.issues
+        );
+
+        mock_ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_arc_preview_edits_use_warm_starts_for_lowered_constraints() {
+        let initial_source = "\
+sketch001 = sketch(on = XZ) {
+  circle1 = circle(start = [var -6.97mm, var 0mm], center = [var -1.85mm, var 0.13mm])
+  horizontal([circle1.start, ORIGIN])
+  circle2 = circle(start = [var -14.46mm, var 0mm], center = [var -15.66mm, var 4.19mm])
+  horizontal([circle2.start, ORIGIN])
+  line1 = line(start = [var -11.38mm, var -5.02mm], end = [var -7.81mm, var 8.69mm])
+  line2 = line(start = [var -11.38mm, var -5.02mm], end = [var -20.15mm, var -2.97mm])
+  coincident([line2.start, line1.start])
+  line3 = line(start = [var -11.38mm, var -5.02mm], end = [var 0.77mm, var -7.39mm])
+  coincident([line3.start, line2.start])
+  line4 = line(start = [var -11.38mm, var -5.02mm], end = [var -21.87mm, var -13.4mm])
+  coincident([line4.start, line3.start])
+  distance([circle1, circle2]) == 4.91mm
+  arc1 = arc(start = [var -20.15mm, var -2.97mm], end = [var -25.04mm, var -9.89mm], center = [var -21.19mm, var -7.42mm])
+  coincident([line2.end, arc1.start])
+  tangent([line2, arc1])
+  line(start = [var -12.02mm, var -15.45mm], end = [var 4.83mm, var -8.9mm])
+}
+";
+
+        fn var_mm(value: f64) -> Expr {
+            Expr::Var(Number {
+                value,
+                units: NumericSuffix::Mm,
+            })
+        }
+
+        fn point(x: f64, y: f64) -> Point2d<Expr> {
+            Point2d {
+                x: var_mm(x),
+                y: var_mm(y),
+            }
+        }
+
+        fn assert_no_solver_failure(label: &str, scene_delta: &SceneGraphDelta) {
+            assert!(
+                !scene_delta
+                    .exec_outcome
+                    .issues
+                    .iter()
+                    .any(|issue| issue.message.contains(CONSTRAINT_SOLVER_FAILED_MESSAGE)),
+                "{label}: arc preview should not drop lowered-constraint warm starts: {:?}",
+                scene_delta.exec_outcome.issues
+            );
+        }
+
+        let program = Program::parse(initial_source).unwrap().0.unwrap();
+
+        let mut frontend = FrontendState::new();
+        let mock_ctx = ExecutorContext::new_mock(None).await;
+        let version = Version(0);
+
+        frontend.program = program.clone();
+        let outcome = mock_ctx.run_mock(&program, &MockConfig::default()).await.unwrap();
+        let outcome = frontend.update_state_after_exec(outcome, true);
+        let sketch_id = find_first_sketch_object(&frontend.scene_graph).unwrap().id;
+        frontend.replace_sketch_var_warm_starts(sketch_id, &outcome);
+
+        let center = point(-29.12, 7.19);
+        let initial_start = point(-32.07, -2.53);
+        let (_src_delta, scene_delta) = frontend
+            .add_arc(
+                &mock_ctx,
+                sketch_id,
+                ArcCtor {
+                    start: initial_start.clone(),
+                    end: initial_start,
+                    center: center.clone(),
+                    construction: None,
+                },
+            )
+            .await
+            .unwrap();
+        assert_no_solver_failure("add draft arc", &scene_delta);
+
+        let arc_id = scene_delta
+            .new_objects
+            .last()
+            .copied()
+            .expect("Expected added arc object id");
+
+        for (index, (start, end)) in [
+            (point(-32.07, -2.53), point(-32.07, -2.53)),
+            (point(-34.199, -1.607), point(-38.665, 3.716)),
+            (point(-38.665, 3.716), point(-38.665, 10.664)),
+            (point(-38.665, 10.664), point(-34.199, 15.987)),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let (_src_delta, scene_delta) = frontend
+                .edit_segments_for_preview(
+                    &mock_ctx,
+                    version,
+                    sketch_id,
+                    vec![ExistingSegmentCtor {
+                        id: arc_id,
+                        ctor: SegmentCtor::Arc(ArcCtor {
+                            start,
+                            end,
+                            center: center.clone(),
+                            construction: None,
+                        }),
+                    }],
+                )
+                .await
+                .unwrap();
+            assert_no_solver_failure(&format!("preview edit {index}"), &scene_delta);
+        }
 
         mock_ctx.close().await;
     }

--- a/rust/kcl-lib/src/frontend.rs
+++ b/rust/kcl-lib/src/frontend.rs
@@ -118,6 +118,13 @@ enum SketchVarUpdateMode {
     /// warm-start state. Used at drag boundaries after preview edits.
     CommitSolvedVarsFromWarmStart,
 }
+
+#[derive(Debug, Clone)]
+struct SketchVarWarmStarts {
+    solver_values: Vec<f64>,
+    source_values: Vec<(SourceRange, f64)>,
+}
+
 mod traverse;
 pub(crate) mod trim;
 
@@ -237,7 +244,7 @@ pub struct FrontendState {
     /// Transient solver continuity state. During previews we warm-start from
     /// the previous solution without treating those solved guesses as committed
     /// source text.
-    sketch_var_warm_start_overrides: HashMap<ObjectId, Vec<f64>>,
+    sketch_var_warm_start_overrides: HashMap<ObjectId, SketchVarWarmStarts>,
     next_sketch_var_update_mode: Option<SketchVarUpdateMode>,
     sketch_checkpoints: VecDeque<SketchCheckpoint>,
     sketch_checkpoint_id_gen: IncIdGenerator<u64>,
@@ -399,7 +406,20 @@ impl FrontendState {
         };
 
         match (use_warm_starts, self.sketch_var_warm_start_overrides.get(&sketch)) {
-            (true, Some(overrides)) => config.with_sketch_var_initial_guess_overrides(overrides.clone()),
+            (true, Some(overrides)) => {
+                #[cfg(feature = "artifact-graph")]
+                let source_var_count = self
+                    .sketch_var_source_values_from_program(sketch)
+                    .map(|values| values.len())
+                    .unwrap_or(overrides.source_values.len());
+                #[cfg(not(feature = "artifact-graph"))]
+                let source_var_count = overrides.source_values.len();
+                config.with_ordered_sketch_var_initial_guess_overrides(
+                    overrides.solver_values.clone(),
+                    overrides.source_values.iter().map(|(_, value)| *value).collect(),
+                    source_var_count == overrides.source_values.len(),
+                )
+            }
             _ => config,
         }
     }
@@ -436,15 +456,27 @@ impl FrontendState {
     fn replace_sketch_var_warm_starts(&mut self, sketch: ObjectId, outcome: &ExecOutcome) {
         #[cfg(feature = "artifact-graph")]
         {
-            let solution_by_range = outcome
+            let solver_values = if outcome.ordered_sketch_var_solutions.is_empty() {
+                outcome.var_solutions.iter().map(|(_, value)| value.value).collect()
+            } else {
+                outcome
+                    .ordered_sketch_var_solutions
+                    .iter()
+                    .map(|solution| solution.value)
+                    .collect()
+            };
+            let source_values = outcome
                 .var_solutions
                 .iter()
                 .map(|(range, value)| (*range, value.value))
-                .collect::<HashMap<_, _>>();
-            let values = self
-                .sketch_var_initial_guesses_from_program(sketch, &solution_by_range)
-                .unwrap_or_else(|| outcome.var_solutions.iter().map(|(_, value)| value.value).collect());
-            self.sketch_var_warm_start_overrides.insert(sketch, values);
+                .collect();
+            self.sketch_var_warm_start_overrides.insert(
+                sketch,
+                SketchVarWarmStarts {
+                    solver_values,
+                    source_values,
+                },
+            );
         }
         #[cfg(not(feature = "artifact-graph"))]
         {
@@ -471,22 +503,42 @@ impl FrontendState {
                 return;
             };
             let edited_var_indices = self.edited_sketch_var_indices(&source_values, segment_ids_edited);
-            let values = source_values
-                .into_iter()
+            let source_values = source_values
+                .iter()
                 .enumerate()
                 .map(|(index, (range, source_value))| {
                     if edited_var_indices.contains(&index) || !solution_by_range.contains_key(&range) {
-                        source_value
+                        (*range, *source_value)
                     } else {
-                        previous
+                        let value = previous
                             .as_ref()
-                            .and_then(|values| values.get(index))
-                            .copied()
-                            .unwrap_or(source_value)
+                            .and_then(|warm_starts| warm_starts.source_values.get(index))
+                            .map(|(_, value)| *value)
+                            .unwrap_or(*source_value);
+                        (*range, value)
                     }
                 })
-                .collect();
-            self.sketch_var_warm_start_overrides.insert(sketch, values);
+                .collect::<Vec<_>>();
+
+            let preserve_previous_hidden = !segment_ids_edited.is_empty()
+                && previous
+                    .as_ref()
+                    .is_some_and(|p| p.source_values.len() == source_values.len());
+            let solver_values = merged_solver_warm_start_values(
+                outcome,
+                previous.as_ref(),
+                &source_values,
+                &edited_var_indices,
+                preserve_previous_hidden,
+            );
+
+            self.sketch_var_warm_start_overrides.insert(
+                sketch,
+                SketchVarWarmStarts {
+                    solver_values,
+                    source_values,
+                },
+            );
         }
         #[cfg(not(feature = "artifact-graph"))]
         {
@@ -516,20 +568,6 @@ impl FrontendState {
                     .then_some(index)
             })
             .collect()
-    }
-
-    #[cfg(feature = "artifact-graph")]
-    fn sketch_var_initial_guesses_from_program(
-        &self,
-        sketch: ObjectId,
-        solution_by_range: &HashMap<SourceRange, f64>,
-    ) -> Option<Vec<f64>> {
-        self.sketch_var_source_values_from_program(sketch).map(|source_values| {
-            source_values
-                .into_iter()
-                .map(|(range, source_value)| solution_by_range.get(&range).copied().unwrap_or(source_value))
-                .collect()
-        })
     }
 
     #[cfg(feature = "artifact-graph")]
@@ -1928,6 +1966,7 @@ impl FrontendState {
             scene_objects,
             source_range_to_object,
             var_solutions,
+            ordered_sketch_var_solutions: Default::default(),
             issues: non_fatal,
             default_planes,
         })
@@ -5922,6 +5961,45 @@ fn to_source_number(number: Number) -> anyhow::Result<ast::NumericLiteral> {
         raw: format_number_literal(number.value, number.units, None)?,
         digest: None,
     })
+}
+
+#[cfg(feature = "artifact-graph")]
+fn merged_solver_warm_start_values(
+    outcome: &ExecOutcome,
+    previous: Option<&SketchVarWarmStarts>,
+    source_values: &[(SourceRange, f64)],
+    edited_var_indices: &HashSet<usize>,
+    preserve_previous_hidden: bool,
+) -> Vec<f64> {
+    if outcome.ordered_sketch_var_solutions.is_empty() {
+        return source_values.iter().map(|(_, value)| *value).collect();
+    }
+
+    let mut source_index = 0;
+    outcome
+        .ordered_sketch_var_solutions
+        .iter()
+        .enumerate()
+        .map(|(solver_index, solution)| {
+            if solution.source_range.is_some() {
+                let value = source_values
+                    .get(source_index)
+                    .map(|(_, value)| *value)
+                    .unwrap_or(solution.value);
+                source_index += 1;
+                return value;
+            }
+
+            if preserve_previous_hidden && !edited_var_indices.is_empty() {
+                previous
+                    .and_then(|warm_starts| warm_starts.solver_values.get(solver_index))
+                    .copied()
+                    .unwrap_or(solution.value)
+            } else {
+                solution.value
+            }
+        })
+        .collect()
 }
 
 #[cfg(feature = "artifact-graph")]
@@ -12421,9 +12499,13 @@ sketch(on = XY) {
         frontend.update_state_after_exec(outcome, true);
         let sketch_object = find_first_sketch_object(&frontend.scene_graph).unwrap();
         let sketch_id = sketch_object.id;
-        frontend
-            .sketch_var_warm_start_overrides
-            .insert(sketch_id, vec![5.0, 6.0]);
+        frontend.sketch_var_warm_start_overrides.insert(
+            sketch_id,
+            SketchVarWarmStarts {
+                solver_values: vec![5.0, 6.0],
+                source_values: Vec::new(),
+            },
+        );
 
         let mut cold_frontend = frontend.clone();
         let (warm_src_delta, _) = frontend
@@ -12450,6 +12532,48 @@ sketch(on = XY) {
   point(at = [var 1mm, var 2mm])
 }
 "
+        );
+
+        mock_ctx.close().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_warm_starts_keep_lowered_tangent_vars_in_solver_order() {
+        let initial_source = "\
+sketch(on = XY) {
+  line1 = line(start = [var -2mm, var 0mm], end = [var 2mm, var 0mm])
+  circle1 = circle(start = [var 1mm, var 1mm], center = [var 0mm, var 1mm])
+  tangent([line1, circle1])
+  line2 = line(start = [var 10mm, var 20mm], end = [var 30mm, var 40mm])
+}
+";
+
+        let program = Program::parse(initial_source).unwrap().0.unwrap();
+
+        let mut frontend = FrontendState::new();
+        let mock_ctx = ExecutorContext::new_mock(None).await;
+        let version = Version(0);
+
+        frontend.program = program.clone();
+        let outcome = mock_ctx.run_mock(&program, &MockConfig::default()).await.unwrap();
+        let outcome = frontend.update_state_after_exec(outcome, true);
+        let sketch_id = find_first_sketch_object(&frontend.scene_graph).unwrap().id;
+        frontend.replace_sketch_var_warm_starts(sketch_id, &outcome);
+
+        let warm_starts = frontend
+            .sketch_var_warm_start_overrides
+            .get(&sketch_id)
+            .expect("Expected warm starts for sketch");
+        assert!(warm_starts.solver_values.len() > warm_starts.source_values.len());
+
+        let (src_delta, _) = frontend
+            .execute_mock_from_preview(&mock_ctx, version, sketch_id)
+            .await
+            .unwrap();
+        assert!(
+            src_delta
+                .text
+                .contains("line2 = line(start = [var 10mm, var 20mm], end = [var 30mm, var 40mm])")
         );
 
         mock_ctx.close().await;
@@ -12515,8 +12639,18 @@ sketch(on = XY) {
             .get(&sketch_id)
             .expect("Expected warm starts for edited sketch");
 
-        assert_eq!(&warm_starts[0..4], &[1.0, 2.0, 1.28, -0.78]);
-        assert_eq!(&warm_starts[4..], &previous_warm_starts[4..]);
+        let warm_start_source_values = warm_starts
+            .source_values
+            .iter()
+            .map(|(_, value)| *value)
+            .collect::<Vec<_>>();
+        let previous_warm_start_source_values = previous_warm_starts
+            .source_values
+            .iter()
+            .map(|(_, value)| *value)
+            .collect::<Vec<_>>();
+        assert_eq!(&warm_start_source_values[0..4], &[1.0, 2.0, 1.28, -0.78]);
+        assert_eq!(&warm_start_source_values[4..], &previous_warm_start_source_values[4..]);
 
         mock_ctx.close().await;
     }

--- a/rust/kcl-lib/src/frontend/trim/tests.rs
+++ b/rust/kcl-lib/src/frontend/trim/tests.rs
@@ -1764,10 +1764,10 @@ async fn test_trim_line_with_midpoint_coincident_arc_endpoint() {
     let trim_points = vec![Coords2d { x: 0.19, y: 3.25 }, Coords2d { x: 0.41, y: 3.32 }];
 
     let expected_code = r#"sketch001 = sketch(on = YZ) {
-  line6 = line(start = [var 0.32mm, var 3.42mm], end = [var 1.87mm, var 3.41mm])
-  line7 = line(start = [var 1.87mm, var 3.4mm], end = [var 1.87mm, var 2.22mm])
-  line8 = line(start = [var 1.87mm, var 2.22mm], end = [var 0.32mm, var 2.22mm])
-  line9 = line(start = [var 0.32mm, var 2.22mm], end = [var 0.33mm, var 2.95mm])
+  line6 = line(start = [var 0.32mm, var 3.43mm], end = [var 1.87mm, var 3.43mm])
+  line7 = line(start = [var 1.87mm, var 3.43mm], end = [var 1.87mm, var 2.22mm])
+  line8 = line(start = [var 1.87mm, var 2.22mm], end = [var 0.33mm, var 2.22mm])
+  line9 = line(start = [var 0.33mm, var 2.22mm], end = [var 0.33mm, var 2.91mm])
   coincident([line6.end, line7.start])
   coincident([line7.end, line8.start])
   coincident([line8.end, line9.start])
@@ -1775,7 +1775,7 @@ async fn test_trim_line_with_midpoint_coincident_arc_endpoint() {
   parallel([line8, line6])
   perpendicular([line6, line7])
   horizontal(line8)
-  arc2 = arc(start = [var 0.88mm, var 3.47mm], end = [var 0.33mm, var 2.81mm], center = [var 0.89mm, var 2.92mm])
+  arc2 = arc(start = [var 0.88mm, var 3.43mm], end = [var 0.33mm, var 2.86mm], center = [var 0.87mm, var 2.89mm])
   coincident([arc2.end, line9])
   coincident([arc2.start, line6])
   coincident([line9.end, arc2])
@@ -1820,7 +1820,7 @@ async fn test_trim_arc_start_coincident_with_line_segment() {
   parallel([line8, line6])
   perpendicular([line6, line7])
   horizontal(line8)
-  arc2 = arc(start = [var 0.88mm, var 3.43mm], end = [var 0.33mm, var 2.86mm], center = [var 0.87mm, var 2.89mm])
+  arc2 = arc(start = [var 0.88mm, var 3.43mm], end = [var 0.33mm, var 2.87mm], center = [var 0.87mm, var 2.89mm])
   coincident([arc2.end, line9])
   coincident([line9.end, arc2])
   coincident([line6.start, arc2.start])

--- a/rust/kcl-lib/src/std/constraints.rs
+++ b/rust/kcl-lib/src/std/constraints.rs
@@ -3118,6 +3118,10 @@ fn sketch_var_initial_value(
     exec_state: &mut ExecState,
     range: crate::SourceRange,
 ) -> Result<f64, KclError> {
+    if let Some(value) = exec_state.sketch_var_initial_guess_override(sketch_vars, id) {
+        return Ok(value);
+    }
+
     sketch_vars
         .get(id.0)
         .and_then(KclValue::as_sketch_var)

--- a/src/machines/sketchSolve/tools/moveTool/moveTool.spec.ts
+++ b/src/machines/sketchSolve/tools/moveTool/moveTool.spec.ts
@@ -403,6 +403,7 @@ function createPointSegmentGroup({
 describe('createOnDragStartCallback', () => {
   it('should track the drag start position and dismiss constraint hover popup', () => {
     const setLastSuccessfulDragFromPoint = vi.fn()
+    const setDragStartPoint = vi.fn()
     const setLastGoodPreview = vi.fn()
     const setDragStartOutcome = vi.fn()
     const setPreDragCheckpointId = vi.fn()
@@ -416,6 +417,7 @@ describe('createOnDragStartCallback', () => {
 
     const callback = createOnDragStartCallback({
       setLastSuccessfulDragFromPoint,
+      setDragStartPoint,
       setLastGoodPreview,
       setDragStartOutcome,
       setPreDragCheckpointId,
@@ -448,6 +450,10 @@ describe('createOnDragStartCallback', () => {
     expect(callArg).not.toBe(intersectionPoint.twoD)
     expect(callArg.x).toBe(10)
     expect(callArg.y).toBe(20)
+    expect(setDragStartPoint).toHaveBeenCalledWith(
+      expect.objectContaining({ x: 10, y: 20 })
+    )
+    expect(setDragStartPoint.mock.calls[0][0]).not.toBe(intersectionPoint.twoD)
     expect(setLastGoodPreview).toHaveBeenCalledWith(null)
     expect(setDragStartOutcome).toHaveBeenCalledWith({
       kclSource: { text: 'baseline' },
@@ -2150,6 +2156,120 @@ describe('createOnDragCallback', () => {
     if (callArg && callArg.length > 0) {
       expect(callArg[0]).not.toBe(new Vector2(15, 25))
     }
+  })
+
+  it('should build drag previews from the drag-start geometry instead of the previous preview', async () => {
+    const getIsSolveInProgress = vi.fn(() => false)
+    const setIsSolveInProgress = vi.fn()
+    const getLastSuccessfulDragFromPoint = vi.fn(() => new Vector2(5, 1))
+    const setLastSuccessfulDragFromPoint = vi.fn()
+    const getDraggedEntityId = createDraggedEntityIdGetter(3)
+
+    const baselineStart = createPointApiObject({
+      id: 1,
+      x: 0,
+      y: 0,
+      owner: 3,
+    })
+    const baselineEnd = createPointApiObject({
+      id: 2,
+      x: 10,
+      y: 0,
+      owner: 3,
+    })
+    const baselineLine = createLineApiObject({ id: 3, start: 1, end: 2 })
+    const baselineDelta = createSceneGraphDelta([
+      baselineStart,
+      baselineEnd,
+      baselineLine,
+    ])
+
+    const previousPreviewStart = createPointApiObject({
+      id: 1,
+      x: 5,
+      y: 1,
+      owner: 3,
+    })
+    const previousPreviewEnd = createPointApiObject({
+      id: 2,
+      x: 20,
+      y: 4,
+      owner: 3,
+    })
+    const previousPreviewLine = createLineApiObject({
+      id: 3,
+      start: 1,
+      end: 2,
+    })
+    const previousPreviewDelta = createSceneGraphDelta([
+      previousPreviewStart,
+      previousPreviewEnd,
+      previousPreviewLine,
+    ])
+
+    const getContextData = vi.fn(() => ({
+      selectedIds: [3],
+      sketchId: 0,
+      sketchExecOutcome: { sceneGraphDelta: previousPreviewDelta },
+    }))
+    const editSegments = vi.fn(() =>
+      Promise.resolve({
+        kclSource: { text: '' },
+        sceneGraphDelta: baselineDelta,
+      })
+    )
+    const onNewSketchOutcome = vi.fn()
+
+    const callback = createOnDragCallback({
+      getIsSolveInProgress,
+      setIsSolveInProgress,
+      getLastSuccessfulDragFromPoint,
+      setLastSuccessfulDragFromPoint,
+      getDraggedEntityId,
+      getContextData,
+      editSegments,
+      onNewSketchOutcome,
+      getDefaultLengthUnit: vi.fn((): UnitLength => 'mm'),
+      getJsAppSettings: vi.fn(() => Promise.resolve({})),
+      ...createDragSnappingDeps(),
+      getDragStartOutcome: vi.fn(() => ({
+        kclSource: { text: 'baseline' },
+        sceneGraphDelta: baselineDelta,
+      })),
+      getDragStartPoint: vi.fn(() => new Vector2(0, 0)),
+    })
+
+    await callback({
+      intersectionPoint: {
+        twoD: new Vector2(7, 2),
+        threeD: new Vector3(7, 2, 0),
+      },
+      selected: undefined,
+      mouseEvent: createTestMouseEvent(),
+      intersects: [],
+    })
+
+    expect(editSegments).toHaveBeenCalledWith(
+      0,
+      0,
+      [
+        {
+          id: 3,
+          ctor: {
+            type: 'Line',
+            start: {
+              x: { type: 'Var', value: 7, units: 'Mm' },
+              y: { type: 'Var', value: 2, units: 'Mm' },
+            },
+            end: {
+              x: { type: 'Var', value: 17, units: 'Mm' },
+              y: { type: 'Var', value: 2, units: 'Mm' },
+            },
+          },
+        },
+      ],
+      {}
+    )
   })
 
   it('should drag the entity under cursor when no other segments are selected', async () => {

--- a/src/machines/sketchSolve/tools/moveTool/moveTool.ts
+++ b/src/machines/sketchSolve/tools/moveTool/moveTool.ts
@@ -764,6 +764,8 @@ function buildPreviewOutcomeWithPreservedGeometry({
 type CreateOnDragStartCallbackArgs = {
   // Seeds the drag anchor used to compute relative drag vectors.
   setLastSuccessfulDragFromPoint: (point: Vector2) => void
+  // Keeps the fixed drag-start anchor for frame-independent previews.
+  setDragStartPoint: (point: Vector2) => void
   // Clears any previously cached valid preview from an earlier drag session.
   setLastGoodPreview: (preview: DragCommitCandidate | null) => void
   // Stores the frontend sketch outcome at drag start for preview fallback.
@@ -789,6 +791,7 @@ type CreateOnDragStartCallbackArgs = {
  */
 export function createOnDragStartCallback({
   setLastSuccessfulDragFromPoint,
+  setDragStartPoint,
   setLastGoodPreview,
   setDragStartOutcome,
   setPreDragCheckpointId,
@@ -805,7 +808,9 @@ export function createOnDragStartCallback({
   return ({ intersectionPoint }) => {
     dismissConstraintHoverPopup()
     beginDragSession()
-    setLastSuccessfulDragFromPoint(intersectionPoint.twoD.clone())
+    const dragStartPoint = intersectionPoint.twoD.clone()
+    setLastSuccessfulDragFromPoint(dragStartPoint.clone())
+    setDragStartPoint(dragStartPoint)
     setLastGoodPreview(null)
     setDragStartOutcome(getCurrentSketchOutcome())
     setPreDragCheckpointId(getCurrentCommittedCheckpointId())
@@ -1114,6 +1119,7 @@ export function createOnDragCallback({
   getLastGoodPreview,
   setLastGoodPreview,
   getDragStartOutcome,
+  getDragStartPoint,
   getContextData,
   editSegments,
   editDistanceConstraintLabelPosition = async () => null,
@@ -1135,6 +1141,7 @@ export function createOnDragCallback({
   getLastGoodPreview: () => DragCommitCandidate | null
   setLastGoodPreview: (preview: DragCommitCandidate | null) => void
   getDragStartOutcome: () => DragSketchOutcome | null
+  getDragStartPoint?: () => Vector2
   getContextData: () => {
     selectedIds: Array<number>
     sketchId: number
@@ -1254,12 +1261,14 @@ export function createOnDragCallback({
       return
     }
 
+    const dragStartOutcome = getDragStartOutcome()
+    const editSceneGraphDelta =
+      dragStartOutcome?.sceneGraphDelta ?? sceneGraphDelta
+    const editObjects = editSceneGraphDelta.new_graph.objects
+
     const coincidentClusterPointIds =
       entityUnderCursorId !== null
-        ? getCoincidentCluster(
-            entityUnderCursorId,
-            sceneGraphDelta.new_graph.objects
-          )
+        ? getCoincidentCluster(entityUnderCursorId, editObjects)
         : []
 
     // If no entity under cursor and no selectedIds, nothing to do
@@ -1287,10 +1296,14 @@ export function createOnDragCallback({
           })
       onUpdateDragSnapping(snappingCandidate)
 
-      // Calculate drag vector from last successful drag point to current position
-      const dragVec = twoD.clone().sub(getLastSuccessfulDragFromPoint())
+      // Build every preview from the drag-start geometry. Solver output can
+      // legitimately adjust unconstrained geometry, and applying the next drag
+      // increment to that adjusted result compounds small deviations.
+      const dragAnchorPoint =
+        getDragStartPoint?.() ?? getLastSuccessfulDragFromPoint()
+      const dragVec = twoD.clone().sub(dragAnchorPoint)
 
-      const objects = sceneGraphDelta.new_graph.objects
+      const objects = editObjects
       const segmentsToEdit: ExistingSegmentCtor[] = []
 
       // Collect all IDs to edit (entity under cursor + coincident points + selectedIds)
@@ -1461,6 +1474,9 @@ export function setUpOnDragAndSelectionClickCallbacks({
   const [getIsDragActive, setIsDragActive] = createGetSet(false)
   const [getLastSuccessfulDragFromPoint, setLastSuccessfulDragFromPoint] =
     createGetSet<Vector2>(new Vector2())
+  const [getDragStartPoint, setDragStartPoint] = createGetSet<Vector2>(
+    new Vector2()
+  )
   const [getDraggedEntityId, setDraggedEntityId] = createGetSet<number | null>(
     null
   )
@@ -1685,6 +1701,7 @@ export function setUpOnDragAndSelectionClickCallbacks({
   context.sceneInfra.setCallbacks({
     onDragStart: createOnDragStartCallback({
       setLastSuccessfulDragFromPoint,
+      setDragStartPoint,
       setLastGoodPreview,
       setDragStartOutcome,
       setPreDragCheckpointId,
@@ -2135,6 +2152,7 @@ export function setUpOnDragAndSelectionClickCallbacks({
       getLastGoodPreview,
       setLastGoodPreview,
       getDragStartOutcome,
+      getDragStartPoint,
       getContextData: () => {
         const snapshot = self.getSnapshot()
         return {


### PR DESCRIPTION
Fixes regression introduced in #11382, which had major stability issues when tangency, circular-circular distance, and any other constraints that use "lowering" to generate hidden (to the AST, to the user) geometry or constraints.