### PR TITLE
Scale GD&T font size defaults

### DIFF
--- a/src/lib/gdtFramePosition.test.ts
+++ b/src/lib/gdtFramePosition.test.ts
@@ -12,18 +12,9 @@ import type { Selections } from '@src/machines/modelingSharedTypes'
 import type { ConnectionManager } from '@src/network/connectionManager'
 import { describe, expect, it, vi } from 'vitest'
 
+const formatNumberLiteral = vi.fn().mockReturnValue('1.2cm')
 const wasmInstance = {
-  format_number_literal: (value: number, suffix: string) => {
-    const unitBySuffix: Record<string, string> = {
-      Cm: 'cm',
-      Ft: 'ft',
-      Inch: 'in',
-      M: 'm',
-      Mm: 'mm',
-      Yd: 'yd',
-    }
-    return `${value}${unitBySuffix[JSON.parse(suffix)] ?? ''}`
-  },
+  format_number_literal: formatNumberLiteral,
 } as unknown as ModuleType
 
 const artifact = (value: object) =>
@@ -168,6 +159,11 @@ describe('GD&T bounding box frame position defaults', () => {
     )
     expect(result.framePosition?.valueText).toBe('[6, 6]')
     expect(result.fontSize?.valueText).toBe('1.2cm')
+    expect(result.fontSize?.valueAst).toMatchObject({
+      type: 'Literal',
+      raw: '1.2cm',
+    })
+    expect(formatNumberLiteral).toHaveBeenCalledWith(1.2, '"Cm"', 4)
     expect(GDT_FONT_SIZE_TO_BOUNDING_BOX_AVERAGE_RATIO).toBe(0.2)
   })
 

--- a/src/lib/gdtFramePosition.test.ts
+++ b/src/lib/gdtFramePosition.test.ts
@@ -1,13 +1,83 @@
-import type { ConnectionManager } from '@src/network/connectionManager'
-import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+import type { ModelingCommandSchema } from '@src/lib/commandBarConfigs/modelingCommandConfig'
+import type { KclCommandValue } from '@src/lib/commandTypes'
 import {
+  GDT_FONT_SIZE_TO_BOUNDING_BOX_AVERAGE_RATIO,
   getAverageBoundingBoxDimension,
   getEngineEntityIdsForGdtSelections,
+  getExistingGdtFontSize,
   withDefaultGdtFramePosition,
 } from '@src/lib/gdtFramePosition'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { Selections } from '@src/machines/modelingSharedTypes'
-import type { ModelingCommandSchema } from '@src/lib/commandBarConfigs/modelingCommandConfig'
+import type { ConnectionManager } from '@src/network/connectionManager'
 import { describe, expect, it, vi } from 'vitest'
+
+const wasmInstance = {
+  format_number_literal: (value: number, suffix: string) => {
+    const unitBySuffix: Record<string, string> = {
+      Cm: 'cm',
+      Ft: 'ft',
+      Inch: 'in',
+      M: 'm',
+      Mm: 'mm',
+      Yd: 'yd',
+    }
+    return `${value}${unitBySuffix[JSON.parse(suffix)] ?? ''}`
+  },
+} as unknown as ModuleType
+
+const artifact = (value: object) =>
+  value as unknown as NonNullable<
+    Selections['graphSelections'][number]['artifact']
+  >
+
+const kclValue = (valueText: string): KclCommandValue => ({
+  valueAst: {} as unknown as KclCommandValue['valueAst'],
+  valueCalculated: valueText,
+  valueText,
+})
+
+function gdtProgramWithFontSizes(fontSizes: string[]) {
+  let sourceCode = ''
+  const body = fontSizes.map((fontSize) => {
+    const expressionPrefix = `gdt::datum(face = capEnd001, name = "A", fontSize = `
+    const expressionSuffix = ')'
+    const expressionStart = sourceCode.length
+    const fontSizeStart = expressionStart + expressionPrefix.length
+    const fontSizeEnd = fontSizeStart + fontSize.length
+    sourceCode += `${expressionPrefix}${fontSize}${expressionSuffix}\n`
+
+    return {
+      type: 'ExpressionStatement',
+      expression: {
+        type: 'CallExpressionKw',
+        callee: {
+          type: 'Name',
+          path: [{ name: 'gdt' }],
+          name: { name: 'datum' },
+        },
+        unlabeled: null,
+        arguments: [
+          {
+            label: { name: 'fontSize' },
+            arg: {
+              type: 'Literal',
+              value: { value: Number.parseFloat(fontSize), suffix: 'Mm' },
+              raw: fontSize,
+              start: fontSizeStart,
+              end: fontSizeEnd,
+            },
+          },
+        ],
+      },
+    }
+  })
+
+  return {
+    ast: { body } as unknown as Parameters<typeof getExistingGdtFontSize>[0],
+    sourceCode,
+  }
+}
 
 describe('GD&T bounding box frame position defaults', () => {
   it('averages non-zero bounding box dimensions', () => {
@@ -21,20 +91,20 @@ describe('GD&T bounding box frame position defaults', () => {
       graphSelections: [
         {
           codeRef: { range: [0, 1, 0], pathToNode: [] },
-          artifact: {
+          artifact: artifact({
             type: 'cap',
             id: 'cap-1',
-          } as any,
+          }),
         },
         {
           codeRef: { range: [1, 2, 0], pathToNode: [] },
-          artifact: {
+          artifact: artifact({
             type: 'pattern',
             id: 'pattern-1',
             copyIds: ['copy-1'],
             copyFaceIds: ['copy-face-1'],
             copyEdgeIds: ['copy-edge-1', 'copy-face-1'],
-          } as any,
+          }),
         },
       ],
       otherSelections: [],
@@ -71,7 +141,7 @@ describe('GD&T bounding box frame position defaults', () => {
         graphSelections: [
           {
             codeRef: { range: [0, 1, 0], pathToNode: [] },
-            artifact: { type: 'cap', id: 'cap-1' } as any,
+            artifact: artifact({ type: 'cap', id: 'cap-1' }),
           },
         ],
         otherSelections: [],
@@ -84,7 +154,7 @@ describe('GD&T bounding box frame position defaults', () => {
         sendSceneCommand,
       } as unknown as ConnectionManager,
       outputUnit: 'cm',
-      wasmInstance: {} as ModuleType,
+      wasmInstance,
     })
 
     expect(sendSceneCommand).toHaveBeenCalledWith(
@@ -97,18 +167,18 @@ describe('GD&T bounding box frame position defaults', () => {
       })
     )
     expect(result.framePosition?.valueText).toBe('[6, 6]')
+    expect(result.fontSize?.valueText).toBe('1.2cm')
+    expect(GDT_FONT_SIZE_TO_BOUNDING_BOX_AVERAGE_RATIO).toBe(0.2)
   })
 
-  it('preserves an explicit framePosition', async () => {
+  it('preserves explicit framePosition and fontSize', async () => {
     const sendSceneCommand = vi.fn()
-    const framePosition = {
-      valueAst: {} as any,
-      valueCalculated: '[1, 2]',
-      valueText: '[1, 2]',
-    }
+    const framePosition = kclValue('[1, 2]')
+    const fontSize = kclValue('2mm')
     const data = {
       name: 'A',
       framePosition,
+      fontSize,
       faces: { graphSelections: [], otherSelections: [] },
     } as ModelingCommandSchema['GDT Datum']
 
@@ -122,5 +192,35 @@ describe('GD&T bounding box frame position defaults', () => {
 
     expect(sendSceneCommand).not.toHaveBeenCalled()
     expect(result.framePosition).toBe(framePosition)
+    expect(result.fontSize).toBe(fontSize)
+  })
+
+  it('uses the last explicit GD&T fontSize already in the file', async () => {
+    const sendSceneCommand = vi.fn()
+    const { ast, sourceCode } = gdtProgramWithFontSizes(['2mm', '3mm'])
+    const data = {
+      name: 'B',
+      framePosition: kclValue('[1, 2]'),
+      faces: { graphSelections: [], otherSelections: [] },
+    } as ModelingCommandSchema['GDT Datum']
+
+    const result = await withDefaultGdtFramePosition({
+      data,
+      engineCommandManager: {
+        sendSceneCommand,
+      } as unknown as ConnectionManager,
+      ast,
+      sourceCode,
+      wasmInstance: {} as ModuleType,
+    })
+
+    expect(sendSceneCommand).not.toHaveBeenCalled()
+    expect(result.fontSize?.valueText).toBe('3mm')
+  })
+
+  it('finds existing GD&T fontSize values in source order', () => {
+    const { ast, sourceCode } = gdtProgramWithFontSizes(['2mm', '4mm'])
+
+    expect(getExistingGdtFontSize(ast, sourceCode)?.valueText).toBe('4mm')
   })
 })

--- a/src/lib/gdtFramePosition.ts
+++ b/src/lib/gdtFramePosition.ts
@@ -16,7 +16,7 @@ import type { ModelingCommandSchema } from '@src/lib/commandBarConfigs/modelingC
 import type { KclCommandValue } from '@src/lib/commandTypes'
 import { DEFAULT_DEFAULT_LENGTH_UNIT } from '@src/lib/constants'
 import { isModelingResponse } from '@src/lib/kcSdkGuards'
-import { roundOff, uuidv4 } from '@src/lib/utils'
+import { isArray, roundOff, uuidv4 } from '@src/lib/utils'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { Selections } from '@src/machines/modelingSharedTypes'
 import type { ConnectionManager } from '@src/network/connectionManager'
@@ -49,20 +49,38 @@ function getSelectionsFromGdtData(
 }
 
 function isGdtCall(node: unknown): node is Node<CallExpressionKw> {
+  if (
+    typeof node !== 'object' ||
+    node === null ||
+    !('type' in node) ||
+    node.type !== 'CallExpressionKw' ||
+    !('callee' in node)
+  ) {
+    return false
+  }
+
+  const callee = node.callee
+  if (
+    typeof callee !== 'object' ||
+    callee === null ||
+    !('type' in callee) ||
+    callee.type !== 'Name' ||
+    !('path' in callee)
+  ) {
+    return false
+  }
+
+  const path = callee.path
+  if (!isArray(path) || path.length !== 1) {
+    return false
+  }
+
+  const firstPathEntry = path[0]
   return (
-    typeof node === 'object' &&
-    node !== null &&
-    'type' in node &&
-    node.type === 'CallExpressionKw' &&
-    'callee' in node &&
-    typeof node.callee === 'object' &&
-    node.callee !== null &&
-    'type' in node.callee &&
-    node.callee.type === 'Name' &&
-    'path' in node.callee &&
-    Array.isArray(node.callee.path) &&
-    node.callee.path.length === 1 &&
-    node.callee.path[0]?.name === 'gdt'
+    typeof firstPathEntry === 'object' &&
+    firstPathEntry !== null &&
+    'name' in firstPathEntry &&
+    firstPathEntry.name === 'gdt'
   )
 }
 

--- a/src/lib/gdtFramePosition.ts
+++ b/src/lib/gdtFramePosition.ts
@@ -234,15 +234,16 @@ function createFontSizeCommandValue(
     averageDimension * GDT_FONT_SIZE_TO_BOUNDING_BOX_AVERAGE_RATIO,
     4
   )
-  const valueText = `${value}${outputUnit}`
+  const valueAst = createLiteral(
+    value,
+    wasmInstance,
+    baseUnitToNumericSuffix(outputUnit),
+    4
+  )
+  const valueText = valueAst.raw
 
   return {
-    valueAst: createLiteral(
-      value,
-      wasmInstance,
-      baseUnitToNumericSuffix(outputUnit),
-      4
-    ),
+    valueAst,
     valueCalculated: valueText,
     valueText,
   }

--- a/src/lib/gdtFramePosition.ts
+++ b/src/lib/gdtFramePosition.ts
@@ -4,7 +4,6 @@ import type { UnitLength } from '@rust/kcl-lib/bindings/ModelingCmd'
 import type { Node } from '@rust/kcl-lib/bindings/Node'
 import { createArrayExpression, createLiteral } from '@src/lang/create'
 import { toUtf16 } from '@src/lang/errors'
-import { traverse } from '@src/lang/queryAst'
 import type {
   ArtifactId,
   CallExpressionKw,
@@ -46,6 +45,21 @@ function getSelectionsFromGdtData(
     return data.edges
   }
   return undefined
+}
+
+function visitAstNodes(value: unknown, onNode: (node: unknown) => void): void {
+  if (typeof value !== 'object' || value === null) {
+    return
+  }
+
+  onNode(value)
+
+  if (isArray(value)) {
+    value.forEach((item) => visitAstNodes(item, onNode))
+    return
+  }
+
+  Object.values(value).forEach((item) => visitAstNodes(item, onNode))
 }
 
 function isGdtCall(node: unknown): node is Node<CallExpressionKw> {
@@ -120,30 +134,28 @@ export function getExistingGdtFontSize(
 
   let fontSize: KclCommandValue | undefined
 
-  traverse(ast, {
-    enter: (node) => {
-      if (!isGdtCall(node)) {
-        return
-      }
+  visitAstNodes(ast, (node) => {
+    if (!isGdtCall(node)) {
+      return
+    }
 
-      const fontSizeArg = node.arguments?.find(
-        (arg) => arg.label?.name === 'fontSize'
-      )
-      if (!fontSizeArg) {
-        return
-      }
+    const fontSizeArg = node.arguments?.find(
+      (arg) => arg.label?.name === 'fontSize'
+    )
+    if (!fontSizeArg) {
+      return
+    }
 
-      const valueText = getSourceTextForExpr(fontSizeArg.arg, sourceCode)
-      if (!valueText) {
-        return
-      }
+    const valueText = getSourceTextForExpr(fontSizeArg.arg, sourceCode)
+    if (!valueText) {
+      return
+    }
 
-      fontSize = {
-        valueAst: structuredClone(fontSizeArg.arg),
-        valueCalculated: valueText,
-        valueText,
-      }
-    },
+    fontSize = {
+      valueAst: structuredClone(fontSizeArg.arg),
+      valueCalculated: valueText,
+      valueText,
+    }
   })
 
   return fontSize

--- a/src/lib/gdtFramePosition.ts
+++ b/src/lib/gdtFramePosition.ts
@@ -1,16 +1,25 @@
 import type { BoundingBox } from '@kittycad/lib'
 
-import { createArrayExpression, createLiteral } from '@src/lang/create'
-import type { ArtifactId } from '@src/lang/wasm'
 import type { UnitLength } from '@rust/kcl-lib/bindings/ModelingCmd'
+import type { Node } from '@rust/kcl-lib/bindings/Node'
+import { createArrayExpression, createLiteral } from '@src/lang/create'
+import { toUtf16 } from '@src/lang/errors'
+import { traverse } from '@src/lang/queryAst'
+import type {
+  ArtifactId,
+  CallExpressionKw,
+  Expr,
+  Program,
+} from '@src/lang/wasm'
+import { baseUnitToNumericSuffix } from '@src/lang/wasm'
 import type { ModelingCommandSchema } from '@src/lib/commandBarConfigs/modelingCommandConfig'
 import type { KclCommandValue } from '@src/lib/commandTypes'
 import { DEFAULT_DEFAULT_LENGTH_UNIT } from '@src/lib/constants'
 import { isModelingResponse } from '@src/lib/kcSdkGuards'
 import { roundOff, uuidv4 } from '@src/lib/utils'
-import type { ConnectionManager } from '@src/network/connectionManager'
-import type { Selections } from '@src/machines/modelingSharedTypes'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+import type { Selections } from '@src/machines/modelingSharedTypes'
+import type { ConnectionManager } from '@src/network/connectionManager'
 
 type GdtCommandData =
   | ModelingCommandSchema['GDT Flatness']
@@ -22,27 +31,126 @@ type GdtCommandData =
   | ModelingCommandSchema['GDT Parallelism']
   | ModelingCommandSchema['GDT Annotation']
 
+export const GDT_FONT_SIZE_TO_BOUNDING_BOX_AVERAGE_RATIO = 0.2
+
 function getSelectionsFromGdtData(
   data: GdtCommandData
 ): Selections | undefined {
-  if ('objects' in data) return data.objects
-  if ('faces' in data) return data.faces
-  if ('edges' in data) return data.edges
+  if ('objects' in data) {
+    return data.objects
+  }
+  if ('faces' in data) {
+    return data.faces
+  }
+  if ('edges' in data) {
+    return data.edges
+  }
   return undefined
+}
+
+function isGdtCall(node: unknown): node is Node<CallExpressionKw> {
+  return (
+    typeof node === 'object' &&
+    node !== null &&
+    'type' in node &&
+    node.type === 'CallExpressionKw' &&
+    'callee' in node &&
+    typeof node.callee === 'object' &&
+    node.callee !== null &&
+    'type' in node.callee &&
+    node.callee.type === 'Name' &&
+    'path' in node.callee &&
+    Array.isArray(node.callee.path) &&
+    node.callee.path.length === 1 &&
+    node.callee.path[0]?.name === 'gdt'
+  )
+}
+
+function getSourceTextForExpr(
+  expr: Expr,
+  sourceCode: string | undefined
+): string | undefined {
+  if (
+    sourceCode &&
+    Number.isFinite(expr.start) &&
+    Number.isFinite(expr.end) &&
+    expr.end > expr.start
+  ) {
+    return sourceCode
+      .slice(toUtf16(expr.start, sourceCode), toUtf16(expr.end, sourceCode))
+      .trim()
+  }
+
+  if (expr.type === 'Literal') {
+    return expr.raw
+  }
+
+  if (expr.type === 'Name') {
+    return [...expr.path.map(({ name }) => name), expr.name.name].join('::')
+  }
+
+  return undefined
+}
+
+export function getExistingGdtFontSize(
+  ast: Node<Program> | undefined,
+  sourceCode?: string
+): KclCommandValue | undefined {
+  if (!ast) {
+    return undefined
+  }
+
+  let fontSize: KclCommandValue | undefined
+
+  traverse(ast, {
+    enter: (node) => {
+      if (!isGdtCall(node)) {
+        return
+      }
+
+      const fontSizeArg = node.arguments?.find(
+        (arg) => arg.label?.name === 'fontSize'
+      )
+      if (!fontSizeArg) {
+        return
+      }
+
+      const valueText = getSourceTextForExpr(fontSizeArg.arg, sourceCode)
+      if (!valueText) {
+        return
+      }
+
+      fontSize = {
+        valueAst: structuredClone(fontSizeArg.arg),
+        valueCalculated: valueText,
+        valueText,
+      }
+    },
+  })
+
+  return fontSize
 }
 
 export function getEngineEntityIdsForGdtSelections(
   selections: Selections | undefined
 ): ArtifactId[] {
-  if (!selections) return []
+  if (!selections) {
+    return []
+  }
 
   const entityIds = selections.graphSelections.flatMap((selection) => {
-    if (selection.engineEntityId) return [selection.engineEntityId]
+    if (selection.engineEntityId) {
+      return [selection.engineEntityId]
+    }
 
     const artifact = selection.artifact
-    if (!artifact?.id) return []
+    if (!artifact?.id) {
+      return []
+    }
 
-    if (artifact.type !== 'pattern') return [artifact.id]
+    if (artifact.type !== 'pattern') {
+      return [artifact.id]
+    }
 
     return [
       ...artifact.copyIds,
@@ -61,7 +169,9 @@ export function getAverageBoundingBoxDimension(
     (dimension) => Number.isFinite(dimension) && dimension > 0
   )
 
-  if (nonZeroDimensions.length === 0) return undefined
+  if (nonZeroDimensions.length === 0) {
+    return undefined
+  }
 
   return roundOff(
     nonZeroDimensions.reduce((sum, dimension) => sum + dimension, 0) /
@@ -85,18 +195,61 @@ function createFramePositionCommandValue(
   }
 }
 
+function createFontSizeCommandValue(
+  averageDimension: number,
+  outputUnit: UnitLength,
+  wasmInstance: ModuleType
+): KclCommandValue {
+  const value = roundOff(
+    averageDimension * GDT_FONT_SIZE_TO_BOUNDING_BOX_AVERAGE_RATIO,
+    4
+  )
+  const valueText = `${value}${outputUnit}`
+
+  return {
+    valueAst: createLiteral(
+      value,
+      wasmInstance,
+      baseUnitToNumericSuffix(outputUnit),
+      4
+    ),
+    valueCalculated: valueText,
+    valueText,
+  }
+}
+
 export async function withDefaultGdtFramePosition<T extends GdtCommandData>({
   data,
   engineCommandManager,
+  ast,
+  sourceCode,
   outputUnit = DEFAULT_DEFAULT_LENGTH_UNIT,
   wasmInstance,
 }: {
   data: T
   engineCommandManager: ConnectionManager
+  ast?: Node<Program>
+  sourceCode?: string
   outputUnit?: UnitLength
   wasmInstance: ModuleType
 }): Promise<T> {
-  if (data.framePosition) return data
+  const existingFontSize = data.fontSize
+    ? undefined
+    : getExistingGdtFontSize(ast, sourceCode)
+  const dataWithExistingFontSize =
+    existingFontSize === undefined
+      ? data
+      : {
+          ...data,
+          fontSize: existingFontSize,
+        }
+
+  if (
+    dataWithExistingFontSize.framePosition &&
+    dataWithExistingFontSize.fontSize
+  ) {
+    return dataWithExistingFontSize
+  }
 
   const selections = getSelectionsFromGdtData(data)
   const entityIds = getEngineEntityIdsForGdtSelections(selections)
@@ -112,24 +265,43 @@ export async function withDefaultGdtFramePosition<T extends GdtCommandData>({
       },
     })
 
-    if (!isModelingResponse(response)) return data
+    if (!isModelingResponse(response)) {
+      return dataWithExistingFontSize
+    }
 
     const modelingResponse = response.resp.data.modeling_response
-    if (modelingResponse.type !== 'bounding_box') return data
+    if (modelingResponse.type !== 'bounding_box') {
+      return dataWithExistingFontSize
+    }
 
     const averageDimension = getAverageBoundingBoxDimension(
       modelingResponse.data.dimensions
     )
-    if (averageDimension === undefined) return data
+    if (averageDimension === undefined) {
+      return dataWithExistingFontSize
+    }
 
     return {
-      ...data,
-      framePosition: createFramePositionCommandValue(
-        averageDimension,
-        wasmInstance
-      ),
+      ...dataWithExistingFontSize,
+      ...(dataWithExistingFontSize.framePosition
+        ? {}
+        : {
+            framePosition: createFramePositionCommandValue(
+              averageDimension,
+              wasmInstance
+            ),
+          }),
+      ...(dataWithExistingFontSize.fontSize
+        ? {}
+        : {
+            fontSize: createFontSizeCommandValue(
+              averageDimension,
+              outputUnit,
+              wasmInstance
+            ),
+          }),
     }
   } catch {
-    return data
+    return dataWithExistingFontSize
   }
 }

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -5125,6 +5125,8 @@ export const modelingMachine = setup({
         const data = await withDefaultGdtFramePosition({
           data: input.data,
           engineCommandManager: input.kclManager.engineCommandManager,
+          ast: input.kclManager.ast,
+          sourceCode: input.kclManager.code,
           outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
           wasmInstance,
         })
@@ -5170,6 +5172,8 @@ export const modelingMachine = setup({
         const data = await withDefaultGdtFramePosition({
           data: input.data,
           engineCommandManager: input.kclManager.engineCommandManager,
+          ast: input.kclManager.ast,
+          sourceCode: input.kclManager.code,
           outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
           wasmInstance,
         })
@@ -5215,6 +5219,8 @@ export const modelingMachine = setup({
         const data = await withDefaultGdtFramePosition({
           data: input.data,
           engineCommandManager: input.kclManager.engineCommandManager,
+          ast: input.kclManager.ast,
+          sourceCode: input.kclManager.code,
           outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
           wasmInstance,
         })
@@ -5260,6 +5266,8 @@ export const modelingMachine = setup({
         const data = await withDefaultGdtFramePosition({
           data: input.data,
           engineCommandManager: input.kclManager.engineCommandManager,
+          ast: input.kclManager.ast,
+          sourceCode: input.kclManager.code,
           outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
           wasmInstance,
         })
@@ -5305,6 +5313,8 @@ export const modelingMachine = setup({
         const data = await withDefaultGdtFramePosition({
           data: input.data,
           engineCommandManager: input.kclManager.engineCommandManager,
+          ast: input.kclManager.ast,
+          sourceCode: input.kclManager.code,
           outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
           wasmInstance,
         })
@@ -5350,6 +5360,8 @@ export const modelingMachine = setup({
         const data = await withDefaultGdtFramePosition({
           data: input.data,
           engineCommandManager: input.kclManager.engineCommandManager,
+          ast: input.kclManager.ast,
+          sourceCode: input.kclManager.code,
           outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
           wasmInstance,
         })
@@ -5395,6 +5407,8 @@ export const modelingMachine = setup({
         const data = await withDefaultGdtFramePosition({
           data: input.data,
           engineCommandManager: input.kclManager.engineCommandManager,
+          ast: input.kclManager.ast,
+          sourceCode: input.kclManager.code,
           outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
           wasmInstance,
         })
@@ -5440,6 +5454,8 @@ export const modelingMachine = setup({
         const data = await withDefaultGdtFramePosition({
           data: input.data,
           engineCommandManager: input.kclManager.engineCommandManager,
+          ast: input.kclManager.ast,
+          sourceCode: input.kclManager.code,
           outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
           wasmInstance,
         })


### PR DESCRIPTION
ai assisted

https://github.com/user-attachments/assets/1a617294-adec-47ca-b5f2-889b4d75febb

## Problem
Small parts can get GD&T labels that are visually oversized because the app falls back to a fixed model-space font size. That makes annotations hard to use across models with very different scales and forces users to manually correct the same setting repeatedly.

Closes #11608

## Solution
Default new GD&T font size from the selected geometry scale when no font size exists yet, using 20% of the same average bounding-box dimension used for frame placement. When the file already has an explicit GD&T fontSize, reuse the latest one so added annotations stay visually consistent across nearby faces and later edits.