### PR TITLE
Infer GDT framePlane defaults from selected geometry

### DIFF
--- a/src/lib/gdtFramePosition.test.ts
+++ b/src/lib/gdtFramePosition.test.ts
@@ -1,6 +1,6 @@
+import type { ConnectionManager } from '@src/network/connectionManager'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { Artifact, Expr } from '@src/lang/wasm'
-import type { ModelingCommandSchema } from '@src/lib/commandBarConfigs/modelingCommandConfig'
-import type { KclCommandValue } from '@src/lib/commandTypes'
 import {
   getAverageBoundingBoxDimension,
   getDefaultGdtFramePlaneFromBoundingBox,
@@ -10,9 +10,9 @@ import {
   getPlanarFaceEntityIdsForGdtSelections,
   withDefaultGdtFrameDefaults,
 } from '@src/lib/gdtFramePosition'
-import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { Selections } from '@src/machines/modelingSharedTypes'
-import type { ConnectionManager } from '@src/network/connectionManager'
+import type { ModelingCommandSchema } from '@src/lib/commandBarConfigs/modelingCommandConfig'
+import type { KclCommandValue } from '@src/lib/commandTypes'
 import { describe, expect, it, vi } from 'vitest'
 
 function testArtifact<T extends Artifact['type']>(

--- a/src/lib/gdtFramePosition.test.ts
+++ b/src/lib/gdtFramePosition.test.ts
@@ -5,6 +5,7 @@ import {
   getAverageBoundingBoxDimension,
   getDefaultGdtFramePlaneFromBoundingBox,
   getDefaultGdtFramePlaneFromNormal,
+  getDefaultGdtFramePositionSignsFromNormal,
   getEngineEntityIdsForGdtSelections,
   getPlanarFaceEntityIdsForGdtSelections,
   withDefaultGdtFrameDefaults,
@@ -41,6 +42,30 @@ describe('GD&T frame defaults', () => {
     expect(getDefaultGdtFramePlaneFromNormal({ x: 1, y: 0, z: 0 })).toBe('XY')
     expect(
       getDefaultGdtFramePlaneFromNormal({ x: 1, y: 1, z: 0 })
+    ).toBeUndefined()
+  })
+
+  it('infers framePosition signs from face normals', () => {
+    expect(
+      getDefaultGdtFramePositionSignsFromNormal({ x: 0, y: 0, z: 1 })
+    ).toEqual([1, 1])
+    expect(
+      getDefaultGdtFramePositionSignsFromNormal({ x: 0, y: 0, z: -1 })
+    ).toEqual([1, -1])
+    expect(
+      getDefaultGdtFramePositionSignsFromNormal({ x: 1, y: 0, z: 0 })
+    ).toEqual([1, 1])
+    expect(
+      getDefaultGdtFramePositionSignsFromNormal({ x: -1, y: 0, z: 0 })
+    ).toEqual([-1, 1])
+    expect(
+      getDefaultGdtFramePositionSignsFromNormal({ x: 0, y: 1, z: 0 })
+    ).toEqual([1, 1])
+    expect(
+      getDefaultGdtFramePositionSignsFromNormal({ x: 0, y: -1, z: 0 })
+    ).toEqual([1, -1])
+    expect(
+      getDefaultGdtFramePositionSignsFromNormal({ x: 1, y: 1, z: 0 })
     ).toBeUndefined()
   })
 
@@ -197,6 +222,129 @@ describe('GD&T frame defaults', () => {
       })
     )
     expect(result.framePosition?.valueText).toBe('[6, 6]')
+  })
+
+  it('signs omitted framePosition from the selected face normal', async () => {
+    const sendSceneCommand = vi
+      .fn()
+      .mockResolvedValueOnce({
+        success: true,
+        resp: {
+          type: 'modeling',
+          data: {
+            modeling_response: {
+              type: 'face_is_planar',
+              data: {
+                origin: { x: 0, y: 0, z: 0 },
+                x_axis: { x: 1, y: 0, z: 0 },
+                y_axis: { x: 0, y: 1, z: 0 },
+                z_axis: { x: 0, y: 0, z: -1 },
+              },
+            },
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        resp: {
+          type: 'modeling',
+          data: {
+            modeling_response: {
+              type: 'bounding_box',
+              data: {
+                center: { x: 0, y: 0, z: 0 },
+                dimensions: { x: 4, y: 0, z: 8 },
+              },
+            },
+          },
+        },
+      })
+
+    const data = {
+      name: 'A',
+      faces: {
+        graphSelections: [
+          {
+            codeRef: { range: [0, 1, 0], pathToNode: [] },
+            artifact: testArtifact({ type: 'cap', id: 'cap-1' }),
+          },
+        ],
+        otherSelections: [],
+      },
+    } as ModelingCommandSchema['GDT Datum']
+
+    const result = await withDefaultGdtFrameDefaults({
+      data,
+      engineCommandManager: {
+        sendSceneCommand,
+      } as unknown as ConnectionManager,
+      wasmInstance: {} as ModuleType,
+    })
+
+    expect(result.framePlane).toBe('XZ')
+    expect(result.framePosition?.valueText).toBe('[6, -6]')
+  })
+
+  it('uses normal framePosition signs even when framePlane is explicit', async () => {
+    const sendSceneCommand = vi
+      .fn()
+      .mockResolvedValueOnce({
+        success: true,
+        resp: {
+          type: 'modeling',
+          data: {
+            modeling_response: {
+              type: 'face_is_planar',
+              data: {
+                origin: { x: 0, y: 0, z: 0 },
+                x_axis: { x: 0, y: 1, z: 0 },
+                y_axis: { x: 0, y: 0, z: 1 },
+                z_axis: { x: -1, y: 0, z: 0 },
+              },
+            },
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        resp: {
+          type: 'modeling',
+          data: {
+            modeling_response: {
+              type: 'bounding_box',
+              data: {
+                center: { x: 0, y: 0, z: 0 },
+                dimensions: { x: 4, y: 0, z: 8 },
+              },
+            },
+          },
+        },
+      })
+
+    const data = {
+      name: 'A',
+      framePlane: 'YZ',
+      faces: {
+        graphSelections: [
+          {
+            codeRef: { range: [0, 1, 0], pathToNode: [] },
+            artifact: testArtifact({ type: 'cap', id: 'cap-1' }),
+          },
+        ],
+        otherSelections: [],
+      },
+    } as ModelingCommandSchema['GDT Datum']
+
+    const result = await withDefaultGdtFrameDefaults({
+      data,
+      engineCommandManager: {
+        sendSceneCommand,
+      } as unknown as ConnectionManager,
+      wasmInstance: {} as ModuleType,
+    })
+
+    expect(result.framePlane).toBe('YZ')
+    expect(result.framePosition?.valueText).toBe('[-6, 6]')
   })
 
   it('fills omitted framePlane from a planar face normal', async () => {

--- a/src/lib/gdtFramePosition.test.ts
+++ b/src/lib/gdtFramePosition.test.ts
@@ -1,19 +1,62 @@
-import type { ConnectionManager } from '@src/network/connectionManager'
-import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+import type { Artifact, Expr } from '@src/lang/wasm'
+import type { ModelingCommandSchema } from '@src/lib/commandBarConfigs/modelingCommandConfig'
+import type { KclCommandValue } from '@src/lib/commandTypes'
 import {
   getAverageBoundingBoxDimension,
+  getDefaultGdtFramePlaneFromBoundingBox,
+  getDefaultGdtFramePlaneFromNormal,
   getEngineEntityIdsForGdtSelections,
-  withDefaultGdtFramePosition,
+  getPlanarFaceEntityIdsForGdtSelections,
+  withDefaultGdtFrameDefaults,
 } from '@src/lib/gdtFramePosition'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 import type { Selections } from '@src/machines/modelingSharedTypes'
-import type { ModelingCommandSchema } from '@src/lib/commandBarConfigs/modelingCommandConfig'
+import type { ConnectionManager } from '@src/network/connectionManager'
 import { describe, expect, it, vi } from 'vitest'
 
-describe('GD&T bounding box frame position defaults', () => {
+function testArtifact<T extends Artifact['type']>(
+  artifact: { type: T } & Record<string, unknown>
+): Extract<Artifact, { type: T }> {
+  return artifact as Extract<Artifact, { type: T }>
+}
+
+function testFramePosition(): KclCommandValue {
+  return {
+    valueAst: {} as Expr,
+    valueCalculated: '[1, 2]',
+    valueText: '[1, 2]',
+  }
+}
+
+describe('GD&T frame defaults', () => {
   it('averages non-zero bounding box dimensions', () => {
     expect(getAverageBoundingBoxDimension({ x: 4, y: 0, z: 8 })).toBe(6)
     expect(getAverageBoundingBoxDimension({ x: 4, y: 4, z: 4 })).toBe(4)
     expect(getAverageBoundingBoxDimension({ x: 0, y: 0, z: 0 })).toBeUndefined()
+  })
+
+  it('infers perpendicular frame planes from face normals', () => {
+    expect(getDefaultGdtFramePlaneFromNormal({ x: 0, y: 0, z: 1 })).toBe('XZ')
+    expect(getDefaultGdtFramePlaneFromNormal({ x: 0, y: -1, z: 0 })).toBe('XY')
+    expect(getDefaultGdtFramePlaneFromNormal({ x: 1, y: 0, z: 0 })).toBe('XY')
+    expect(
+      getDefaultGdtFramePlaneFromNormal({ x: 1, y: 1, z: 0 })
+    ).toBeUndefined()
+  })
+
+  it('infers perpendicular frame planes from bounding box thin axes', () => {
+    expect(getDefaultGdtFramePlaneFromBoundingBox({ x: 8, y: 4, z: 0 })).toBe(
+      'XZ'
+    )
+    expect(getDefaultGdtFramePlaneFromBoundingBox({ x: 8, y: 0, z: 4 })).toBe(
+      'XY'
+    )
+    expect(getDefaultGdtFramePlaneFromBoundingBox({ x: 0, y: 8, z: 4 })).toBe(
+      'XY'
+    )
+    expect(
+      getDefaultGdtFramePlaneFromBoundingBox({ x: 4, y: 4, z: 4 })
+    ).toBeUndefined()
   })
 
   it('gets engine entity ids from GD&T selections', () => {
@@ -21,20 +64,20 @@ describe('GD&T bounding box frame position defaults', () => {
       graphSelections: [
         {
           codeRef: { range: [0, 1, 0], pathToNode: [] },
-          artifact: {
+          artifact: testArtifact({
             type: 'cap',
             id: 'cap-1',
-          } as any,
+          }),
         },
         {
           codeRef: { range: [1, 2, 0], pathToNode: [] },
-          artifact: {
+          artifact: testArtifact({
             type: 'pattern',
             id: 'pattern-1',
             copyIds: ['copy-1'],
             copyFaceIds: ['copy-face-1'],
             copyEdgeIds: ['copy-edge-1', 'copy-face-1'],
-          } as any,
+          }),
         },
       ],
       otherSelections: [],
@@ -48,22 +91,79 @@ describe('GD&T bounding box frame position defaults', () => {
     ])
   })
 
+  it('gets planar face ids from GD&T selections', () => {
+    const selections: Selections = {
+      graphSelections: [
+        {
+          codeRef: { range: [0, 1, 0], pathToNode: [] },
+          artifact: testArtifact({ type: 'cap', id: 'cap-1' }),
+        },
+        {
+          codeRef: { range: [1, 2, 0], pathToNode: [] },
+          engineEntityId: 'selected-wall-face',
+          artifact: testArtifact({ type: 'wall', id: 'wall-1' }),
+        },
+        {
+          codeRef: { range: [2, 3, 0], pathToNode: [] },
+          artifact: testArtifact({
+            type: 'edgeCut',
+            id: 'edge-cut-1',
+            surfaceId: 'edge-cut-surface-1',
+          }),
+        },
+        {
+          codeRef: { range: [3, 4, 0], pathToNode: [] },
+          artifact: testArtifact({
+            type: 'pattern',
+            id: 'pattern-1',
+            copyIds: ['copy-1'],
+            copyFaceIds: ['copy-face-1'],
+            copyEdgeIds: ['copy-edge-1'],
+          }),
+        },
+      ],
+      otherSelections: [],
+    }
+
+    expect(getPlanarFaceEntityIdsForGdtSelections(selections)).toEqual([
+      'cap-1',
+      'selected-wall-face',
+      'edge-cut-surface-1',
+      'edge-cut-1',
+      'copy-face-1',
+    ])
+  })
+
   it('fills omitted framePosition from the selected bounding box', async () => {
-    const sendSceneCommand = vi.fn().mockResolvedValue({
-      success: true,
-      resp: {
-        type: 'modeling',
-        data: {
-          modeling_response: {
-            type: 'bounding_box',
-            data: {
-              center: { x: 0, y: 0, z: 0 },
-              dimensions: { x: 4, y: 0, z: 8 },
+    const sendSceneCommand = vi
+      .fn()
+      .mockResolvedValueOnce({
+        success: true,
+        resp: {
+          type: 'modeling',
+          data: {
+            modeling_response: {
+              type: 'face_is_planar',
+              data: {},
             },
           },
         },
-      },
-    })
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        resp: {
+          type: 'modeling',
+          data: {
+            modeling_response: {
+              type: 'bounding_box',
+              data: {
+                center: { x: 0, y: 0, z: 0 },
+                dimensions: { x: 4, y: 0, z: 8 },
+              },
+            },
+          },
+        },
+      })
 
     const data = {
       name: 'A',
@@ -71,14 +171,14 @@ describe('GD&T bounding box frame position defaults', () => {
         graphSelections: [
           {
             codeRef: { range: [0, 1, 0], pathToNode: [] },
-            artifact: { type: 'cap', id: 'cap-1' } as any,
+            artifact: testArtifact({ type: 'cap', id: 'cap-1' }),
           },
         ],
         otherSelections: [],
       },
     } as ModelingCommandSchema['GDT Datum']
 
-    const result = await withDefaultGdtFramePosition({
+    const result = await withDefaultGdtFrameDefaults({
       data,
       engineCommandManager: {
         sendSceneCommand,
@@ -99,20 +199,125 @@ describe('GD&T bounding box frame position defaults', () => {
     expect(result.framePosition?.valueText).toBe('[6, 6]')
   })
 
-  it('preserves an explicit framePosition', async () => {
+  it('fills omitted framePlane from a planar face normal', async () => {
+    const sendSceneCommand = vi.fn().mockResolvedValue({
+      success: true,
+      resp: {
+        type: 'modeling',
+        data: {
+          modeling_response: {
+            type: 'face_is_planar',
+            data: {
+              origin: { x: 0, y: 0, z: 0 },
+              x_axis: { x: 1, y: 0, z: 0 },
+              y_axis: { x: 0, y: 1, z: 0 },
+              z_axis: { x: 0, y: 0, z: 1 },
+            },
+          },
+        },
+      },
+    })
+
+    const data = {
+      name: 'A',
+      framePosition: testFramePosition(),
+      faces: {
+        graphSelections: [
+          {
+            codeRef: { range: [0, 1, 0], pathToNode: [] },
+            artifact: testArtifact({ type: 'cap', id: 'cap-1' }),
+          },
+        ],
+        otherSelections: [],
+      },
+    } as ModelingCommandSchema['GDT Datum']
+
+    const result = await withDefaultGdtFrameDefaults({
+      data,
+      engineCommandManager: {
+        sendSceneCommand,
+      } as unknown as ConnectionManager,
+      wasmInstance: {} as ModuleType,
+    })
+
+    expect(sendSceneCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cmd: expect.objectContaining({
+          type: 'face_is_planar',
+          object_id: 'cap-1',
+        }),
+      })
+    )
+    expect(result.framePlane).toBe('XZ')
+  })
+
+  it('falls back to bounding box framePlane inference when normals are unavailable', async () => {
+    const sendSceneCommand = vi
+      .fn()
+      .mockResolvedValueOnce({
+        success: true,
+        resp: {
+          type: 'modeling',
+          data: {
+            modeling_response: {
+              type: 'face_is_planar',
+              data: {},
+            },
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        resp: {
+          type: 'modeling',
+          data: {
+            modeling_response: {
+              type: 'bounding_box',
+              data: {
+                center: { x: 0, y: 0, z: 0 },
+                dimensions: { x: 8, y: 4, z: 0 },
+              },
+            },
+          },
+        },
+      })
+
+    const data = {
+      name: 'A',
+      framePosition: testFramePosition(),
+      faces: {
+        graphSelections: [
+          {
+            codeRef: { range: [0, 1, 0], pathToNode: [] },
+            artifact: testArtifact({ type: 'cap', id: 'cap-1' }),
+          },
+        ],
+        otherSelections: [],
+      },
+    } as ModelingCommandSchema['GDT Datum']
+
+    const result = await withDefaultGdtFrameDefaults({
+      data,
+      engineCommandManager: {
+        sendSceneCommand,
+      } as unknown as ConnectionManager,
+      wasmInstance: {} as ModuleType,
+    })
+
+    expect(result.framePlane).toBe('XZ')
+  })
+
+  it('preserves explicit frame defaults', async () => {
     const sendSceneCommand = vi.fn()
-    const framePosition = {
-      valueAst: {} as any,
-      valueCalculated: '[1, 2]',
-      valueText: '[1, 2]',
-    }
+    const framePosition = testFramePosition()
     const data = {
       name: 'A',
       framePosition,
+      framePlane: 'YZ',
       faces: { graphSelections: [], otherSelections: [] },
     } as ModelingCommandSchema['GDT Datum']
 
-    const result = await withDefaultGdtFramePosition({
+    const result = await withDefaultGdtFrameDefaults({
       data,
       engineCommandManager: {
         sendSceneCommand,
@@ -122,5 +327,6 @@ describe('GD&T bounding box frame position defaults', () => {
 
     expect(sendSceneCommand).not.toHaveBeenCalled()
     expect(result.framePosition).toBe(framePosition)
+    expect(result.framePlane).toBe('YZ')
   })
 })

--- a/src/lib/gdtFramePosition.ts
+++ b/src/lib/gdtFramePosition.ts
@@ -1,16 +1,30 @@
-import type { BoundingBox } from '@kittycad/lib'
+import type { BoundingBox, FaceIsPlanar, Point3d } from '@kittycad/lib'
 
+import type { UnitLength } from '@rust/kcl-lib/bindings/ModelingCmd'
 import { createArrayExpression, createLiteral } from '@src/lang/create'
 import type { ArtifactId } from '@src/lang/wasm'
-import type { UnitLength } from '@rust/kcl-lib/bindings/ModelingCmd'
 import type { ModelingCommandSchema } from '@src/lib/commandBarConfigs/modelingCommandConfig'
 import type { KclCommandValue } from '@src/lib/commandTypes'
-import { DEFAULT_DEFAULT_LENGTH_UNIT } from '@src/lib/constants'
+import {
+  DEFAULT_DEFAULT_LENGTH_UNIT,
+  KCL_PLANE_XY,
+  KCL_PLANE_XZ,
+  KCL_PLANE_YZ,
+} from '@src/lib/constants'
 import { isModelingResponse } from '@src/lib/kcSdkGuards'
 import { roundOff, uuidv4 } from '@src/lib/utils'
-import type { ConnectionManager } from '@src/network/connectionManager'
-import type { Selections } from '@src/machines/modelingSharedTypes'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+import type { Selections } from '@src/machines/modelingSharedTypes'
+import type { ConnectionManager } from '@src/network/connectionManager'
+
+type Axis = 'x' | 'y' | 'z'
+type GdtFramePlane =
+  | typeof KCL_PLANE_XY
+  | typeof KCL_PLANE_XZ
+  | typeof KCL_PLANE_YZ
+
+const AXIS_INFERENCE_TOLERANCE = 0.05
+const AXES: Axis[] = ['x', 'y', 'z']
 
 type GdtCommandData =
   | ModelingCommandSchema['GDT Flatness']
@@ -25,24 +39,42 @@ type GdtCommandData =
 function getSelectionsFromGdtData(
   data: GdtCommandData
 ): Selections | undefined {
-  if ('objects' in data) return data.objects
-  if ('faces' in data) return data.faces
-  if ('edges' in data) return data.edges
+  if ('objects' in data) {
+    return data.objects
+  }
+  if ('faces' in data) {
+    return data.faces
+  }
+  if ('edges' in data) {
+    return data.edges
+  }
   return undefined
+}
+
+function deduplicateArtifactIds(entityIds: ArtifactId[]): ArtifactId[] {
+  return [...new Set(entityIds)]
 }
 
 export function getEngineEntityIdsForGdtSelections(
   selections: Selections | undefined
 ): ArtifactId[] {
-  if (!selections) return []
+  if (!selections) {
+    return []
+  }
 
   const entityIds = selections.graphSelections.flatMap((selection) => {
-    if (selection.engineEntityId) return [selection.engineEntityId]
+    if (selection.engineEntityId) {
+      return [selection.engineEntityId]
+    }
 
     const artifact = selection.artifact
-    if (!artifact?.id) return []
+    if (!artifact?.id) {
+      return []
+    }
 
-    if (artifact.type !== 'pattern') return [artifact.id]
+    if (artifact.type !== 'pattern') {
+      return [artifact.id]
+    }
 
     return [
       ...artifact.copyIds,
@@ -51,7 +83,123 @@ export function getEngineEntityIdsForGdtSelections(
     ]
   })
 
-  return [...new Set(entityIds)]
+  return deduplicateArtifactIds(entityIds)
+}
+
+export function getPlanarFaceEntityIdsForGdtSelections(
+  selections: Selections | undefined
+): ArtifactId[] {
+  if (!selections) {
+    return []
+  }
+
+  const entityIds = selections.graphSelections.flatMap((selection) => {
+    const artifact = selection.artifact
+
+    if (artifact?.type === 'pattern') {
+      return artifact.copyFaceIds
+    }
+
+    if (
+      artifact?.type === 'cap' ||
+      artifact?.type === 'wall' ||
+      artifact?.type === 'primitiveFace'
+    ) {
+      return [selection.engineEntityId ?? artifact.id]
+    }
+
+    if (artifact?.type === 'edgeCut') {
+      return [artifact.surfaceId, selection.engineEntityId, artifact.id].filter(
+        (id): id is ArtifactId => Boolean(id)
+      )
+    }
+
+    return []
+  })
+
+  return deduplicateArtifactIds(entityIds)
+}
+
+function getDecisiveAxis(
+  values: Record<Axis, number>,
+  compare: (left: number, right: number) => number
+): Axis | undefined {
+  const sortedAxes = [...AXES].sort((left, right) =>
+    compare(values[left], values[right])
+  )
+  const bestAxis = sortedAxes[0]
+  const nextAxis = sortedAxes[1]
+  if (!bestAxis || !nextAxis) {
+    return undefined
+  }
+
+  const bestValue = values[bestAxis]
+  const nextValue = values[nextAxis]
+  if (!Number.isFinite(bestValue) || !Number.isFinite(nextValue)) {
+    return undefined
+  }
+
+  const scale = Math.max(...Object.values(values).map(Math.abs), 1)
+  if (Math.abs(bestValue - nextValue) <= scale * AXIS_INFERENCE_TOLERANCE) {
+    return undefined
+  }
+
+  return bestAxis
+}
+
+function getFeaturePlaneForNormalAxis(axis: Axis): GdtFramePlane {
+  if (axis === 'x') {
+    return KCL_PLANE_YZ
+  }
+  if (axis === 'y') {
+    return KCL_PLANE_XZ
+  }
+  return KCL_PLANE_XY
+}
+
+function getFramePlaneForFeaturePlane(
+  featurePlane: GdtFramePlane
+): GdtFramePlane {
+  if (featurePlane === KCL_PLANE_XY) {
+    return KCL_PLANE_XZ
+  }
+  return KCL_PLANE_XY
+}
+
+export function getDefaultGdtFramePlaneFromNormal(
+  normal: Point3d
+): GdtFramePlane | undefined {
+  const axis = getDecisiveAxis(
+    {
+      x: Math.abs(normal.x),
+      y: Math.abs(normal.y),
+      z: Math.abs(normal.z),
+    },
+    (left, right) => right - left
+  )
+  if (!axis) {
+    return undefined
+  }
+
+  return getFramePlaneForFeaturePlane(getFeaturePlaneForNormalAxis(axis))
+}
+
+export function getDefaultGdtFramePlaneFromBoundingBox(
+  dimensions: BoundingBox['dimensions']
+): GdtFramePlane | undefined {
+  const axis = getDecisiveAxis(
+    {
+      x: dimensions.x,
+      y: dimensions.y,
+      z: dimensions.z,
+    },
+    (left, right) => left - right
+  )
+  if (!axis) {
+    return undefined
+  }
+
+  return getFramePlaneForFeaturePlane(getFeaturePlaneForNormalAxis(axis))
 }
 
 export function getAverageBoundingBoxDimension(
@@ -61,7 +209,9 @@ export function getAverageBoundingBoxDimension(
     (dimension) => Number.isFinite(dimension) && dimension > 0
   )
 
-  if (nonZeroDimensions.length === 0) return undefined
+  if (nonZeroDimensions.length === 0) {
+    return undefined
+  }
 
   return roundOff(
     nonZeroDimensions.reduce((sum, dimension) => sum + dimension, 0) /
@@ -85,21 +235,86 @@ function createFramePositionCommandValue(
   }
 }
 
-export async function withDefaultGdtFramePosition<T extends GdtCommandData>({
-  data,
-  engineCommandManager,
-  outputUnit = DEFAULT_DEFAULT_LENGTH_UNIT,
-  wasmInstance,
-}: {
-  data: T
-  engineCommandManager: ConnectionManager
-  outputUnit?: UnitLength
-  wasmInstance: ModuleType
-}): Promise<T> {
-  if (data.framePosition) return data
+function getNormalFromPlanarFace(face: FaceIsPlanar): Point3d | undefined {
+  const normal = face.z_axis
+  if (
+    !normal ||
+    !Number.isFinite(normal.x) ||
+    !Number.isFinite(normal.y) ||
+    !Number.isFinite(normal.z) ||
+    (normal.x === 0 && normal.y === 0 && normal.z === 0)
+  ) {
+    return undefined
+  }
 
-  const selections = getSelectionsFromGdtData(data)
-  const entityIds = getEngineEntityIdsForGdtSelections(selections)
+  return normal
+}
+
+async function getPlanarFaceNormal(
+  engineCommandManager: ConnectionManager,
+  entityId: ArtifactId
+): Promise<Point3d | undefined> {
+  try {
+    const response = await engineCommandManager.sendSceneCommand({
+      type: 'modeling_cmd_req',
+      cmd_id: uuidv4(),
+      cmd: {
+        type: 'face_is_planar',
+        object_id: entityId,
+      },
+    })
+
+    if (!isModelingResponse(response)) {
+      return undefined
+    }
+
+    const modelingResponse = response.resp.data.modeling_response
+    if (modelingResponse.type !== 'face_is_planar') {
+      return undefined
+    }
+
+    return getNormalFromPlanarFace(modelingResponse.data)
+  } catch {
+    return undefined
+  }
+}
+
+async function getDefaultGdtFramePlaneFromSelectionNormals({
+  engineCommandManager,
+  selections,
+}: {
+  engineCommandManager: ConnectionManager
+  selections: Selections | undefined
+}): Promise<GdtFramePlane | undefined> {
+  const faceEntityIds = getPlanarFaceEntityIdsForGdtSelections(selections)
+
+  for (const entityId of faceEntityIds) {
+    const normal = await getPlanarFaceNormal(engineCommandManager, entityId)
+    if (!normal) {
+      continue
+    }
+
+    const framePlane = getDefaultGdtFramePlaneFromNormal(normal)
+    if (framePlane) {
+      return framePlane
+    }
+  }
+
+  return undefined
+}
+
+async function getBoundingBoxForGdtSelections({
+  engineCommandManager,
+  entityIds,
+  outputUnit,
+}: {
+  engineCommandManager: ConnectionManager
+  entityIds: ArtifactId[]
+  outputUnit: UnitLength
+}): Promise<BoundingBox | undefined> {
+  if (entityIds.length === 0) {
+    return undefined
+  }
 
   try {
     const response = await engineCommandManager.sendSceneCommand({
@@ -112,24 +327,101 @@ export async function withDefaultGdtFramePosition<T extends GdtCommandData>({
       },
     })
 
-    if (!isModelingResponse(response)) return data
+    if (!isModelingResponse(response)) {
+      return undefined
+    }
 
     const modelingResponse = response.resp.data.modeling_response
-    if (modelingResponse.type !== 'bounding_box') return data
+    if (modelingResponse.type !== 'bounding_box') {
+      return undefined
+    }
 
-    const averageDimension = getAverageBoundingBoxDimension(
-      modelingResponse.data.dimensions
+    return modelingResponse.data
+  } catch {
+    return undefined
+  }
+}
+
+export async function withDefaultGdtFrameDefaults<T extends GdtCommandData>({
+  data,
+  engineCommandManager,
+  outputUnit = DEFAULT_DEFAULT_LENGTH_UNIT,
+  wasmInstance,
+}: {
+  data: T
+  engineCommandManager: ConnectionManager
+  outputUnit?: UnitLength
+  wasmInstance: ModuleType
+}): Promise<T> {
+  const selections = getSelectionsFromGdtData(data)
+  const entityIds = getEngineEntityIdsForGdtSelections(selections)
+  let nextData = data
+  let hasResolvedFramePlane = Boolean(data.framePlane)
+
+  if (!data.framePlane) {
+    const framePlaneFromNormal =
+      await getDefaultGdtFramePlaneFromSelectionNormals({
+        engineCommandManager,
+        selections,
+      })
+
+    if (framePlaneFromNormal) {
+      hasResolvedFramePlane = true
+      if (framePlaneFromNormal !== KCL_PLANE_XY) {
+        nextData = {
+          ...nextData,
+          framePlane: framePlaneFromNormal,
+        }
+      }
+    }
+  }
+
+  if (nextData.framePosition && hasResolvedFramePlane) {
+    return nextData
+  }
+
+  const boundingBox = await getBoundingBoxForGdtSelections({
+    engineCommandManager,
+    entityIds,
+    outputUnit,
+  })
+
+  if (!boundingBox) {
+    return nextData
+  }
+
+  if (!hasResolvedFramePlane) {
+    const framePlaneFromBoundingBox = getDefaultGdtFramePlaneFromBoundingBox(
+      boundingBox.dimensions
     )
-    if (averageDimension === undefined) return data
 
-    return {
-      ...data,
+    if (framePlaneFromBoundingBox) {
+      hasResolvedFramePlane = true
+      if (framePlaneFromBoundingBox !== KCL_PLANE_XY) {
+        nextData = {
+          ...nextData,
+          framePlane: framePlaneFromBoundingBox,
+        }
+      }
+    }
+  }
+
+  if (!nextData.framePosition) {
+    const averageDimension = getAverageBoundingBoxDimension(
+      boundingBox.dimensions
+    )
+    if (averageDimension === undefined) {
+      return nextData
+    }
+
+    nextData = {
+      ...nextData,
       framePosition: createFramePositionCommandValue(
         averageDimension,
         wasmInstance
       ),
     }
-  } catch {
-    return data
   }
+
+  return nextData
 }

--- a/src/lib/gdtFramePosition.ts
+++ b/src/lib/gdtFramePosition.ts
@@ -1,8 +1,8 @@
 import type { BoundingBox, FaceIsPlanar, Point3d } from '@kittycad/lib'
 
-import type { UnitLength } from '@rust/kcl-lib/bindings/ModelingCmd'
 import { createArrayExpression, createLiteral } from '@src/lang/create'
 import type { ArtifactId } from '@src/lang/wasm'
+import type { UnitLength } from '@rust/kcl-lib/bindings/ModelingCmd'
 import type { ModelingCommandSchema } from '@src/lib/commandBarConfigs/modelingCommandConfig'
 import type { KclCommandValue } from '@src/lib/commandTypes'
 import {
@@ -13,9 +13,9 @@ import {
 } from '@src/lib/constants'
 import { isModelingResponse } from '@src/lib/kcSdkGuards'
 import { roundOff, uuidv4 } from '@src/lib/utils'
-import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
-import type { Selections } from '@src/machines/modelingSharedTypes'
 import type { ConnectionManager } from '@src/network/connectionManager'
+import type { Selections } from '@src/machines/modelingSharedTypes'
+import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
 
 type Axis = 'x' | 'y' | 'z'
 type GdtFramePlane =

--- a/src/lib/gdtFramePosition.ts
+++ b/src/lib/gdtFramePosition.ts
@@ -22,6 +22,11 @@ type GdtFramePlane =
   | typeof KCL_PLANE_XY
   | typeof KCL_PLANE_XZ
   | typeof KCL_PLANE_YZ
+type GdtFramePositionSigns = readonly [number, number]
+type GdtFrameDefaultsFromNormal = {
+  framePlane: GdtFramePlane
+  framePositionSigns: GdtFramePositionSigns
+}
 
 const AXIS_INFERENCE_TOLERANCE = 0.05
 const AXES: Axis[] = ['x', 'y', 'z']
@@ -166,10 +171,8 @@ function getFramePlaneForFeaturePlane(
   return KCL_PLANE_XY
 }
 
-export function getDefaultGdtFramePlaneFromNormal(
-  normal: Point3d
-): GdtFramePlane | undefined {
-  const axis = getDecisiveAxis(
+function getDominantNormalAxis(normal: Point3d): Axis | undefined {
+  return getDecisiveAxis(
     {
       x: Math.abs(normal.x),
       y: Math.abs(normal.y),
@@ -177,11 +180,51 @@ export function getDefaultGdtFramePlaneFromNormal(
     },
     (left, right) => right - left
   )
+}
+
+export function getDefaultGdtFramePlaneFromNormal(
+  normal: Point3d
+): GdtFramePlane | undefined {
+  const axis = getDominantNormalAxis(normal)
   if (!axis) {
     return undefined
   }
 
   return getFramePlaneForFeaturePlane(getFeaturePlaneForNormalAxis(axis))
+}
+
+export function getDefaultGdtFramePositionSignsFromNormal(
+  normal: Point3d
+): GdtFramePositionSigns | undefined {
+  const axis = getDominantNormalAxis(normal)
+  if (!axis) {
+    return undefined
+  }
+
+  if (axis === 'x') {
+    return [normal.x >= 0 ? 1 : -1, 1]
+  }
+  if (axis === 'y') {
+    return [1, normal.y >= 0 ? 1 : -1]
+  }
+
+  return [1, normal.z >= 0 ? 1 : -1]
+}
+
+function getDefaultGdtFrameDefaultsFromNormal(
+  normal: Point3d
+): GdtFrameDefaultsFromNormal | undefined {
+  const framePlane = getDefaultGdtFramePlaneFromNormal(normal)
+  const framePositionSigns = getDefaultGdtFramePositionSignsFromNormal(normal)
+
+  if (!framePlane || !framePositionSigns) {
+    return undefined
+  }
+
+  return {
+    framePlane,
+    framePositionSigns,
+  }
 }
 
 export function getDefaultGdtFramePlaneFromBoundingBox(
@@ -221,14 +264,15 @@ export function getAverageBoundingBoxDimension(
 }
 
 function createFramePositionCommandValue(
-  value: number,
+  xValue: number,
+  yValue: number,
   wasmInstance: ModuleType
 ): KclCommandValue {
-  const valueText = `[${value}, ${value}]`
+  const valueText = `[${xValue}, ${yValue}]`
   return {
     valueAst: createArrayExpression([
-      createLiteral(value, wasmInstance),
-      createLiteral(value, wasmInstance),
+      createLiteral(xValue, wasmInstance),
+      createLiteral(yValue, wasmInstance),
     ]),
     valueCalculated: valueText,
     valueText,
@@ -279,13 +323,13 @@ async function getPlanarFaceNormal(
   }
 }
 
-async function getDefaultGdtFramePlaneFromSelectionNormals({
+async function getDefaultGdtFrameDefaultsFromSelectionNormals({
   engineCommandManager,
   selections,
 }: {
   engineCommandManager: ConnectionManager
   selections: Selections | undefined
-}): Promise<GdtFramePlane | undefined> {
+}): Promise<GdtFrameDefaultsFromNormal | undefined> {
   const faceEntityIds = getPlanarFaceEntityIdsForGdtSelections(selections)
 
   for (const entityId of faceEntityIds) {
@@ -294,9 +338,9 @@ async function getDefaultGdtFramePlaneFromSelectionNormals({
       continue
     }
 
-    const framePlane = getDefaultGdtFramePlaneFromNormal(normal)
-    if (framePlane) {
-      return framePlane
+    const defaults = getDefaultGdtFrameDefaultsFromNormal(normal)
+    if (defaults) {
+      return defaults
     }
   }
 
@@ -357,20 +401,23 @@ export async function withDefaultGdtFrameDefaults<T extends GdtCommandData>({
   const entityIds = getEngineEntityIdsForGdtSelections(selections)
   let nextData = data
   let hasResolvedFramePlane = Boolean(data.framePlane)
+  let framePositionSigns: GdtFramePositionSigns | undefined
+  const shouldQueryNormalDefaults = !data.framePlane || !data.framePosition
 
-  if (!data.framePlane) {
-    const framePlaneFromNormal =
-      await getDefaultGdtFramePlaneFromSelectionNormals({
+  if (shouldQueryNormalDefaults) {
+    const defaultsFromNormal =
+      await getDefaultGdtFrameDefaultsFromSelectionNormals({
         engineCommandManager,
         selections,
       })
 
-    if (framePlaneFromNormal) {
+    if (defaultsFromNormal) {
+      framePositionSigns = defaultsFromNormal.framePositionSigns
       hasResolvedFramePlane = true
-      if (framePlaneFromNormal !== KCL_PLANE_XY) {
+      if (!data.framePlane && defaultsFromNormal.framePlane !== KCL_PLANE_XY) {
         nextData = {
           ...nextData,
-          framePlane: framePlaneFromNormal,
+          framePlane: defaultsFromNormal.framePlane,
         }
       }
     }
@@ -413,11 +460,13 @@ export async function withDefaultGdtFrameDefaults<T extends GdtCommandData>({
     if (averageDimension === undefined) {
       return nextData
     }
+    const [xSign, ySign] = framePositionSigns ?? [1, 1]
 
     nextData = {
       ...nextData,
       framePosition: createFramePositionCommandValue(
-        averageDimension,
+        averageDimension * xSign,
+        averageDimension * ySign,
         wasmInstance
       ),
     }

--- a/src/machines/modelingMachine.ts
+++ b/src/machines/modelingMachine.ts
@@ -235,7 +235,7 @@ import { addFlipSurface, addJoinSurfaces } from '@src/lang/modifyAst/surfaces'
 import { jsAppSettings } from '@src/lib/settings/settingsUtils'
 import { addTagForSketchOnFace } from '@src/lang/std/sketch'
 import { toPlaneName } from '@src/lib/planes'
-import { withDefaultGdtFramePosition } from '@src/lib/gdtFramePosition'
+import { withDefaultGdtFrameDefaults } from '@src/lib/gdtFramePosition'
 
 function sourceRangesEqual(
   a: [number, number, number],
@@ -5122,7 +5122,7 @@ export const modelingMachine = setup({
 
         const wasmInstance = await input.kclManager.wasmInstancePromise
 
-        const data = await withDefaultGdtFramePosition({
+        const data = await withDefaultGdtFrameDefaults({
           data: input.data,
           engineCommandManager: input.kclManager.engineCommandManager,
           outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
@@ -5167,7 +5167,7 @@ export const modelingMachine = setup({
 
         const wasmInstance = await input.kclManager.wasmInstancePromise
 
-        const data = await withDefaultGdtFramePosition({
+        const data = await withDefaultGdtFrameDefaults({
           data: input.data,
           engineCommandManager: input.kclManager.engineCommandManager,
           outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
@@ -5212,7 +5212,7 @@ export const modelingMachine = setup({
 
         const wasmInstance = await input.kclManager.wasmInstancePromise
 
-        const data = await withDefaultGdtFramePosition({
+        const data = await withDefaultGdtFrameDefaults({
           data: input.data,
           engineCommandManager: input.kclManager.engineCommandManager,
           outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
@@ -5257,7 +5257,7 @@ export const modelingMachine = setup({
 
         const wasmInstance = await input.kclManager.wasmInstancePromise
 
-        const data = await withDefaultGdtFramePosition({
+        const data = await withDefaultGdtFrameDefaults({
           data: input.data,
           engineCommandManager: input.kclManager.engineCommandManager,
           outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
@@ -5302,7 +5302,7 @@ export const modelingMachine = setup({
 
         const wasmInstance = await input.kclManager.wasmInstancePromise
 
-        const data = await withDefaultGdtFramePosition({
+        const data = await withDefaultGdtFrameDefaults({
           data: input.data,
           engineCommandManager: input.kclManager.engineCommandManager,
           outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
@@ -5347,7 +5347,7 @@ export const modelingMachine = setup({
 
         const wasmInstance = await input.kclManager.wasmInstancePromise
 
-        const data = await withDefaultGdtFramePosition({
+        const data = await withDefaultGdtFrameDefaults({
           data: input.data,
           engineCommandManager: input.kclManager.engineCommandManager,
           outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
@@ -5392,7 +5392,7 @@ export const modelingMachine = setup({
 
         const wasmInstance = await input.kclManager.wasmInstancePromise
 
-        const data = await withDefaultGdtFramePosition({
+        const data = await withDefaultGdtFrameDefaults({
           data: input.data,
           engineCommandManager: input.kclManager.engineCommandManager,
           outputUnit: input.kclManager.fileSettings.defaultLengthUnit,
@@ -5437,7 +5437,7 @@ export const modelingMachine = setup({
 
         const wasmInstance = await input.kclManager.wasmInstancePromise
 
-        const data = await withDefaultGdtFramePosition({
+        const data = await withDefaultGdtFrameDefaults({
           data: input.data,
           engineCommandManager: input.kclManager.engineCommandManager,
           outputUnit: input.kclManager.fileSettings.defaultLengthUnit,


### PR DESCRIPTION
ai assisted

https://github.com/user-attachments/assets/ce757db3-1fbe-4720-8fcb-d2647d58e1fa

## Problem
GD&T commands currently place their annotation frames with generic defaults, so users selecting a face or feature can get a frame plane and position that do not reflect the selected geometry orientation.

## Solution
Use selected face normals when available to infer the GD&T frame plane and choose framePosition signs that place the frame in the direction that matches the face orientation. When normals are unavailable, fall back to the selection bounding box to infer the frame plane and keep the existing positive framePosition behavior. Explicit user-provided framePlane and framePosition values are preserved.

Fixes #11610