### PR TITLE
Fix intermittent Electron dev startup failures

### DIFF
--- a/vite.base.config.ts
+++ b/vite.base.config.ts
@@ -17,6 +17,22 @@ export const external = [
   'node:fs/promises',
 ]
 
+export const ignoredWatchPathGlobs = [
+  '**/target/**',
+  '**/dist/**',
+  '**/build/**',
+  '**/test-results/**',
+  '**/playwright-report/**',
+]
+
+export function isIgnoredWatchPath(filePath: string) {
+  const normalizedPath = filePath.replace(/\\/g, '/')
+  const pathParts = normalizedPath.split('/')
+  return ['target', 'dist', 'build', 'test-results', 'playwright-report'].some(
+    (ignoredPath) => pathParts.includes(ignoredPath)
+  )
+}
+
 export function getBuildConfig(env: ConfigEnv<'build'>): UserConfig {
   const { root, mode, command } = env
 
@@ -28,7 +44,15 @@ export function getBuildConfig(env: ConfigEnv<'build'>): UserConfig {
       emptyOutDir: false,
       // 🚧 Multiple builds may conflict.
       outDir: '.vite/build',
-      watch: command === 'serve' ? {} : null,
+      watch:
+        command === 'serve'
+          ? {
+              exclude: ignoredWatchPathGlobs,
+              chokidar: {
+                ignored: isIgnoredWatchPath,
+              },
+            }
+          : null,
       minify: command === 'build',
     },
     clearScreen: false,

--- a/vite.base.config.ts
+++ b/vite.base.config.ts
@@ -17,19 +17,23 @@ export const external = [
   'node:fs/promises',
 ]
 
-export const ignoredWatchPathGlobs = [
-  '**/target/**',
-  '**/dist/**',
-  '**/build/**',
-  '**/test-results/**',
-  '**/playwright-report/**',
+const ignoredWatchPathNames = [
+  'target',
+  'dist',
+  'build',
+  'test-results',
+  'playwright-report',
 ]
+
+export const ignoredWatchPathGlobs = ignoredWatchPathNames.map(
+  (pathName) => `**/${pathName}/**`
+)
 
 export function isIgnoredWatchPath(filePath: string) {
   const normalizedPath = filePath.replace(/\\/g, '/')
   const pathParts = normalizedPath.split('/')
-  return ['target', 'dist', 'build', 'test-results', 'playwright-report'].some(
-    (ignoredPath) => pathParts.includes(ignoredPath)
+  return ignoredWatchPathNames.some((ignoredPath) =>
+    pathParts.includes(ignoredPath)
   )
 }
 

--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -13,6 +13,7 @@ import {
   external,
   getBuildConfig,
   getBuildDefine,
+  ignoredWatchPathGlobs,
   pluginHotRestart,
 } from './vite.base.config'
 
@@ -26,13 +27,7 @@ export default defineConfig((env) => {
       open: true,
       port: 3000,
       watch: {
-        ignored: [
-          '**/target/**',
-          '**/dist/**',
-          '**/build/**',
-          '**/test-results/**',
-          '**/playwright-report/**',
-        ],
+        ignored: ignoredWatchPathGlobs,
       },
     },
     test: {

--- a/vite.renderer.config.ts
+++ b/vite.renderer.config.ts
@@ -6,7 +6,11 @@ import topLevelAwait from 'vite-plugin-top-level-await'
 import viteTsconfigPaths from 'vite-tsconfig-paths'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 
-import { indexHtmlCsp, pluginExposeRenderer } from './vite.base.config'
+import {
+  indexHtmlCsp,
+  isIgnoredWatchPath,
+  pluginExposeRenderer,
+} from './vite.base.config'
 
 // https://vitejs.dev/config
 export default defineConfig((env) => {
@@ -18,6 +22,11 @@ export default defineConfig((env) => {
     root,
     mode,
     base: './',
+    server: {
+      watch: {
+        ignored: isIgnoredWatchPath,
+      },
+    },
     build: {
       outDir: `.vite/renderer/${name}`,
     },


### PR DESCRIPTION
DISCLAIMER: I have no idea if these changes make sense (they were generated by Codex, but fixed a real issue I was having). Please feel free to close this if it's not generally useful or correct.

Sometimes when I ran `make run-desktop` it would just fail without any error messages. I used Codex to track down the problem and this is what it came up with:

1. `make run-desktop` starts Electron Forge.
2. Electron Forge starts Vite in dev/watch mode for the renderer, main process, and preload bundle.
3. Vite/Chokidar creates filesystem watchers so it can hot-reload when files change.
4. After Rust builds, rust/target/ contains a very large tree of generated Cargo artifacts.
5. The Vite watcher was walking into that generated tree and trying to watch thousands of files/directories that are irrelevant to the desktop app source.
6. Linux has a per-user inotify watcher limit. When Vite tried to allocate more watchers than allowed, Node threw:
```
ENOSPC: System limit for number of file watchers reached
```
8. Forge’s terminal UI hid the useful part in the normal output, so it looked like a silent `Error 1`.

The fix was to tell Vite/Chokidar not to watch generated output directories, especially:

```
rust/target
dist
build
test-results
playwright-report
```

So Electron dev mode still watches real app source files and hot reloads, but it does not waste watcher handles on Cargo output, build artifacts, or test output.

The intermittent part makes sense too: if `rust/target/` was small, cleaned, or the system had enough watcher headroom, startup might work. If Rust builds had recently produced a large enough artifact tree, run-desktop could fail during Vite startup.