### PR TITLE
Stabilize sketch drag warm starts for coincident point clusters

### DIFF
--- a/src/machines/sketchSolve/tools/moveTool/moveTool.spec.ts
+++ b/src/machines/sketchSolve/tools/moveTool/moveTool.spec.ts
@@ -2411,6 +2411,162 @@ describe('createOnDragCallback', () => {
     }
   })
 
+  it('should pin every point in a dragged coincident cluster to the cursor after selected owner edits', async () => {
+    const getIsSolveInProgress = vi.fn(() => false)
+    const setIsSolveInProgress = vi.fn()
+    const getLastSuccessfulDragFromPoint = vi.fn(() => new Vector2(15, -5.5))
+    const setLastSuccessfulDragFromPoint = vi.fn()
+    const getDraggedEntityId = createDraggedEntityIdGetter(10)
+    const line4Start = createPointApiObject({
+      id: 1,
+      x: 12.6,
+      y: -8.05,
+      owner: 30,
+    })
+    const line5End = createPointApiObject({
+      id: 2,
+      x: 14.48,
+      y: 0,
+      owner: 31,
+    })
+    const line7Start = createPointApiObject({
+      id: 3,
+      x: 1.88,
+      y: -3.33,
+      owner: 32,
+    })
+    const point1 = createPointApiObject({
+      id: 10,
+      x: 14.64,
+      y: -5.7,
+      owner: 30,
+    })
+    const point2 = createPointApiObject({
+      id: 11,
+      x: 14.64,
+      y: -5.7,
+      owner: 31,
+    })
+    const point3 = createPointApiObject({
+      id: 12,
+      x: 14.64,
+      y: -5.7,
+      owner: 32,
+    })
+    const line4 = createLineApiObject({ id: 30, start: 1, end: 10 })
+    const line5 = createLineApiObject({ id: 31, start: 11, end: 2 })
+    const line7 = createLineApiObject({ id: 32, start: 3, end: 12 })
+    const coincidentConstraint1 = {
+      id: 20,
+      kind: {
+        type: 'Constraint',
+        constraint: {
+          type: 'Coincident',
+          segments: [10, 11],
+        },
+      },
+      label: '',
+      comments: '',
+      artifact_id: '0',
+      source: { type: 'Simple', range: [0, 0, 0] },
+    } as ApiObject
+    const coincidentConstraint2 = {
+      id: 21,
+      kind: {
+        type: 'Constraint',
+        constraint: {
+          type: 'Coincident',
+          segments: [11, 12],
+        },
+      },
+      label: '',
+      comments: '',
+      artifact_id: '0',
+      source: { type: 'Simple', range: [0, 0, 0] },
+    } as ApiObject
+    const sceneGraphDelta = createSceneGraphDelta([
+      line4Start,
+      line5End,
+      line7Start,
+      point1,
+      point2,
+      point3,
+      line4,
+      line5,
+      line7,
+      coincidentConstraint1,
+      coincidentConstraint2,
+    ])
+    const getContextData = vi.fn(() => ({
+      selectedIds: [30, 31, 32],
+      sketchId: 0,
+      sketchExecOutcome: { sceneGraphDelta },
+    }))
+    const editSegments = vi.fn(() =>
+      Promise.resolve({
+        kclSource: { text: '' },
+        sceneGraphDelta,
+      })
+    )
+    const onNewSketchOutcome = vi.fn()
+
+    const callback = createOnDragCallback({
+      getIsSolveInProgress,
+      setIsSolveInProgress,
+      getLastSuccessfulDragFromPoint,
+      setLastSuccessfulDragFromPoint,
+      getDraggedEntityId,
+      getContextData,
+      editSegments,
+      onNewSketchOutcome,
+      getDefaultLengthUnit: vi.fn((): UnitLength => 'mm'),
+      getJsAppSettings: vi.fn(() => Promise.resolve({})),
+      ...createDragSnappingDeps(),
+    })
+
+    await callback({
+      intersectionPoint: {
+        twoD: new Vector2(18, -4.5),
+        threeD: new Vector3(18, -4.5, 0),
+      },
+      selected: undefined,
+      mouseEvent: createTestMouseEvent(),
+      intersects: [],
+    })
+
+    expect(editSegments).toHaveBeenCalledTimes(1)
+    const editCall = editSegments.mock.calls[0] as unknown as
+      | [
+          number,
+          number,
+          { id: number; ctor: { type: string; position: unknown } }[],
+          unknown,
+        ]
+      | undefined
+    const segments = editCall?.[2] ?? []
+    const expectedPosition = {
+      x: { type: 'Var', value: 18, units: 'Mm' },
+      y: { type: 'Var', value: -4.5, units: 'Mm' },
+    }
+
+    expect(segments.map((segment) => segment.id)).toEqual([
+      30, 31, 32, 10, 11, 12,
+    ])
+    for (const id of [10, 11, 12]) {
+      expect(segments.find((segment) => segment.id === id)?.ctor).toEqual({
+        type: 'Point',
+        position: expectedPosition,
+      })
+    }
+    expect(segments.find((segment) => segment.id === 30)?.ctor).toMatchObject({
+      type: 'Line',
+      end: {
+        x: { type: 'Var', value: 17.64, units: 'Mm' },
+        y: { type: 'Var', value: -4.7, units: 'Mm' },
+      },
+    })
+  })
+
   it('should prevent race conditions and only update drag point after successful edit resolves', async () => {
     // Simulate state that persists across calls
     let isSolveInProgress = false

--- a/src/machines/sketchSolve/tools/moveTool/moveTool.ts
+++ b/src/machines/sketchSolve/tools/moveTool/moveTool.ts
@@ -194,13 +194,15 @@ function buildSegmentCtorWithDrag({
   currentCursorPosition,
   dragVec,
   units,
+  pointPositionOverride,
 }: {
   objUnderCursor: ApiObject
-  selectedObjects: Array<ApiObject>
+  selectedObjects: ApiObject[]
   isEntityUnderCursor: boolean
   currentCursorPosition: Vector2
   dragVec: Vector2
   units: NumericSuffix
+  pointPositionOverride?: Extract<SegmentCtor, { type: 'Point' }>['position']
 }): SegmentCtor | null {
   const baseCtor = buildSegmentCtorFromObject(obj, objects)
   if (!baseCtor) {
@@ -208,37 +210,35 @@ function buildSegmentCtorWithDrag({
   }
 
   if (baseCtor.type === 'Point') {
+    if (pointPositionOverride) {
+      return {
+        type: 'Point',
+        position: pointPositionOverride,
+      }
+    }
+
     if (isEntityUnderCursor) {
       // Use twoD directly for entity under cursor
       // Note: currentCursorPosition comes from intersectionPoint.twoD which is in world coordinates and scaled to match current units
       return {
         type: 'Point',
-        position: {
-          x: {
-            type: 'Var',
-            value: roundOff(currentCursorPosition.x),
-            units,
-          },
-          y: {
-            type: 'Var',
-            value: roundOff(currentCursorPosition.y),
-            units,
-          },
-        },
-      }
-    } else {
-      // Apply drag vector to current position
-      const currentPos = {
-        x: baseCtor.position.x,
-        y: baseCtor.position.y,
-      }
-      const newPos = applyVectorToPoint2D(currentPos, dragVec)
-      return {
-        type: 'Point',
-        position: newPos,
+        position: buildCursorPointPosition(currentCursorPosition, units),
       }
     }
-  } else if (baseCtor.type === 'Line') {
+
+    // Apply drag vector to current position
+    const currentPos = {
+      x: baseCtor.position.x,
+      y: baseCtor.position.y,
+    }
+    const newPos = applyVectorToPoint2D(currentPos, dragVec)
+    return {
+      type: 'Point',
+      position: newPos,
+    }
+  }
+
+  if (baseCtor.type === 'Line') {
     // For lines, always apply the drag vector to both endpoints (translate the line)
     // This applies whether it's the entity under cursor or another selected entity
     const newStart = applyVectorToPoint2D(baseCtor.start, dragVec)
@@ -248,7 +248,9 @@ function buildSegmentCtorWithDrag({
       start: newStart,
       end: newEnd,
     }
-  } else if (baseCtor.type === 'Arc') {
+  }
+
+  if (baseCtor.type === 'Arc') {
     // For arcs, always apply the drag vector to center, start, and end points (translate the arc)
     // This applies whether it's the entity under cursor or another selected entity
     const newCenter = applyVectorToPoint2D(baseCtor.center, dragVec)
@@ -264,7 +266,9 @@ function buildSegmentCtorWithDrag({
       start: newStart,
       end: newEnd,
     }
-  } else if (baseCtor.type === 'Circle') {
+  }
+
+  if (baseCtor.type === 'Circle') {
     const newCenter = applyVectorToPoint2D(baseCtor.center, dragVec)
     const newStart = applyVectorToPoint2D(baseCtor.start, dragVec)
 
@@ -277,6 +281,24 @@ function buildSegmentCtorWithDrag({
   }
 
   return baseCtor
+}
+
+function buildCursorPointPosition(
+  position: Vector2,
+  units: NumericSuffix
+): Extract<SegmentCtor, { type: 'Point' }>['position'] {
+  return {
+    x: {
+      type: 'Var',
+      value: roundOff(position.x),
+      units,
+    },
+    y: {
+      type: 'Var',
+      value: roundOff(position.y),
+      units,
+    },
+  }
 }
 
 function buildConstraintLabelPosition(
@@ -1305,18 +1327,29 @@ export function createOnDragCallback({
 
       const objects = editObjects
       const segmentsToEdit: ExistingSegmentCtor[] = []
-
-      // Collect all IDs to edit (entity under cursor + coincident points + selectedIds)
-      const idsToEdit = new Set<number>()
-      coincidentClusterPointIds.forEach((id) => {
-        idsToEdit.add(id)
-      })
-      selectedIds.forEach((id) => {
-        idsToEdit.add(id)
-      })
-
-      // Build ctors for each segment with drag applied
       const units = baseUnitToNumericSuffix(getDefaultLengthUnit())
+      const isDraggingPointCluster =
+        entityUnderCursorId !== null &&
+        coincidentClusterPointIds.length > 1 &&
+        isPointSegment(objects[entityUnderCursorId])
+      const coincidentClusterPointIdSet = new Set(
+        isDraggingPointCluster ? coincidentClusterPointIds : []
+      )
+      const coincidentClusterDragTarget = isDraggingPointCluster
+        ? buildCursorPointPosition(twoD, units)
+        : null
+
+      // Collect all IDs to edit. Coincident point edits are intentionally last:
+      // Rust flattens point edits into owner segment edits in order, and the
+      // point under the cursor should override broader selected-segment edits.
+      const idsToEdit = new Set<number>()
+      for (const id of selectedIds) {
+        idsToEdit.add(id)
+      }
+      for (const id of coincidentClusterPointIds) {
+        idsToEdit.delete(id)
+        idsToEdit.add(id)
+      }
 
       for (const id of idsToEdit) {
         const obj = objects[id]
@@ -1330,6 +1363,10 @@ export function createOnDragCallback({
         }
 
         const isEntityUnderCursor = id === entityUnderCursorId
+        const pointPositionOverride =
+          coincidentClusterDragTarget && coincidentClusterPointIdSet.has(id)
+            ? coincidentClusterDragTarget
+            : undefined
 
         const ctor = buildSegmentCtorWithDrag({
           objUnderCursor: obj,
@@ -1338,6 +1375,7 @@ export function createOnDragCallback({
           currentCursorPosition: twoD,
           dragVec: dragVec,
           units,
+          pointPositionOverride,
         })
 
         if (ctor) {


### PR DESCRIPTION
This fixes drag drift and resistance when moving partially constrained coincident endpoint clusters in sketch solve mode.

The move tool now gives every point in a dragged coincident cluster one shared cursor-pinned target, instead of mixing cursor-based and drag-vector-based targets. It also orders edit requests so broader selected segment edits are applied before coincident point edits, allowing the actual dragged point cluster to win when Rust flattens point edits into owner segment edits.

```zoo-kcl
@settings(kclVersion = 2.0)

sketch001 = sketch(on = XZ) {
  line1 = line(start = [var 0mm, var 0mm], end = [var 2.03mm, var -3.45mm])
  coincident([line1.start, ORIGIN])
  line2 = line(start = [var 2.03mm, var -3.45mm], end = [var 2.03mm, var -8.05mm])
  coincident([line1.end, line2.start])
  line3 = line(start = [var 2.03mm, var -8.05mm], end = [var 10.49mm, var -8.05mm])
  coincident([line2.end, line3.start])
  line4 = line(start = [var 10.49mm, var -8.05mm], end = [var 10.49mm, var -3.45mm])
  coincident([line3.end, line4.start])
  line5 = line(start = [var 10.49mm, var -3.45mm], end = [var 12.52mm, var 0mm])
  coincident([line4.end, line5.start])
  line6 = line(start = [var 12.52mm, var 0mm], end = [var 0mm, var 0mm])
  coincident([line5.end, line6.start])
  coincident([line6.end, line1.start])
  line7 = line(start = [var 2.03mm, var -3.45mm], end = [var 10.49mm, var -3.45mm])
  coincident([line7.start, line2.start])
  coincident([line7.end, line5.start])
  horizontal(line7)
  horizontal(line6)
  equalLength([line5, line1])
  vertical(line2)
  vertical(line4)
  horizontal(line3)
}
```

## Before

https://github.com/user-attachments/assets/79d57ed7-7fad-4b53-a4b8-ea9a59019ebc

## After

https://github.com/user-attachments/assets/f9086ea3-4652-4115-a0c6-2b1aefbf9189

