### PR TITLE
Set up client error reporting for Zookeeper in ZDS

### DIFF
--- a/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
+++ b/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
@@ -44,7 +44,8 @@ export function MlEphantConversationPaneWrapper(props: AreaTypeComponentProps) {
         delete app.debug.mlEphantManagerActor
       }
     }
-  }, [app, mlEphantManagerActor])
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Only run on mount
+  }, [])
 
   const sendBillingUpdate = () => {
     billing.send({

--- a/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
+++ b/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
@@ -1,5 +1,6 @@
 import { Menu } from '@headlessui/react'
 import { useSignals } from '@preact/signals-react/runtime'
+import { useEffect } from 'react'
 import { LayoutPanel, LayoutPanelHeader } from '@src/components/layout/Panel'
 import { HeaderMenu } from '@src/components/layout/Panel/HeaderMenu'
 import { MlEphantConversationPane } from '@src/components/layout/areas/MlEphantConversationPane'
@@ -7,6 +8,7 @@ import { useModelingContext } from '@src/hooks/useModelingContext'
 import { useApp, useSingletons } from '@src/lib/boot'
 import { browserSaveFile } from '@src/lib/browserSaveFile'
 import type { AreaTypeComponentProps } from '@src/lib/layout'
+import { IS_STAGING_OR_DEBUG } from '@src/routes/utils'
 import { BillingTransition } from '@src/machines/billingMachine'
 import {
   MlEphantConversationToMarkdown,
@@ -18,7 +20,8 @@ import styles from './KclEditorMenu.module.css'
 
 export function MlEphantConversationPaneWrapper(props: AreaTypeComponentProps) {
   useSignals()
-  const { auth, billing, settings, project, systemIOActor } = useApp()
+  const app = useApp()
+  const { auth, billing, settings, project, systemIOActor } = app
   const { kclManager } = useSingletons()
   const settingsValues = settings.useSettings()
   const user = auth.useUser()
@@ -30,6 +33,18 @@ export function MlEphantConversationPaneWrapper(props: AreaTypeComponentProps) {
   } = useModelingContext()
   const loaderFile = project?.executingFileEntry.value
   const mlEphantManagerActor = MlEphantManagerReactContext.useActorRef()
+
+  useEffect(() => {
+    if (!IS_STAGING_OR_DEBUG) return
+
+    app.debug.mlEphantManagerActor = mlEphantManagerActor
+
+    return () => {
+      if (app.debug.mlEphantManagerActor === mlEphantManagerActor) {
+        delete app.debug.mlEphantManagerActor
+      }
+    }
+  }, [app, mlEphantManagerActor])
 
   const sendBillingUpdate = () => {
     billing.send({

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -49,6 +49,7 @@ import {
   BILLING_CONTEXT_DEFAULTS,
   billingMachine,
 } from '@src/machines/billingMachine'
+import type { MlEphantManagerActor } from '@src/machines/mlEphantManagerMachine'
 import {
   type SettingsActorType,
   getOnlySettingsFromContext,
@@ -156,6 +157,10 @@ export type AppLayoutSystem = {
 
 export type AppRegistrySystem = Registry
 
+export type AppDebug = {
+  mlEphantManagerActor?: MlEphantManagerActor
+}
+
 /** All of the subsystems needed to run the ZDS app */
 export interface AppSubsystems {
   wasmPromise: Promise<ModuleType>
@@ -172,6 +177,7 @@ export interface AppSubsystems {
 
 export class App implements AppSubsystems {
   public projectSignal: Signal<ZDSProject | undefined> = signal(undefined)
+  public debug: AppDebug = {}
   get project() {
     return this.projectSignal.value
   }

--- a/src/lib/clientErrors.ts
+++ b/src/lib/clientErrors.ts
@@ -34,11 +34,24 @@ const getAuthToken = () => {
   }
 }
 
+export const errorToMessage = (
+  error: unknown,
+  fallback = 'Unknown client error'
+) => {
+  if (error instanceof Error) return error.message
+  if (typeof error === 'string') return error
+  if (error === undefined) return fallback
+
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return fallback
+  }
+}
+
 const getErrorMessage = (params: ReportClientErrorParams) => {
   if (params.message) return params.message
-  if (params.error instanceof Error) return params.error.message
-  if (typeof params.error === 'string') return params.error
-  return 'Unknown client error'
+  return errorToMessage(params.error)
 }
 
 const getErrorName = (params: ReportClientErrorParams) => {

--- a/src/machines/mlEphantManagerMachine.test.ts
+++ b/src/machines/mlEphantManagerMachine.test.ts
@@ -1,4 +1,19 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { FileMeta } from '@src/lib/types'
+
+const mockClientErrors = vi.hoisted(() => ({
+  reportClientError: vi.fn(async () => undefined),
+}))
+
+vi.mock('@src/lib/clientErrors', () => ({
+  errorToMessage: (error: unknown, fallback = 'Unknown client error') => {
+    if (error instanceof Error) return error.message
+    if (typeof error === 'string') return error
+    return fallback
+  },
+  reportClientError: mockClientErrors.reportClientError,
+}))
+
 import {
   type Conversation,
   type MlCopilotModeOption,
@@ -11,7 +26,6 @@ import {
   parseMlCopilotModesResult,
 } from '@src/machines/mlEphantManagerMachine'
 import { S } from '@src/machines/utils'
-import { describe, expect, it, vi } from 'vitest'
 import { createActor, fromPromise, waitFor } from 'xstate'
 
 class TestSocket extends EventTarget {
@@ -51,6 +65,10 @@ const completedConversation: Conversation = {
 }
 
 describe('mlEphantManagerMachine', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   describe('parseMlCopilotModesResult', () => {
     const modes = [
       {
@@ -348,6 +366,122 @@ describe('mlEphantManagerMachine', () => {
       )
       expect(actor.getSnapshot().context.conversationId).toBe('conversation-id')
       expect(actor.getSnapshot().context.abruptlyClosed).toBe(true)
+      expect(mockClientErrors.reportClientError).not.toHaveBeenCalled()
+
+      actor.stop()
+    })
+  })
+
+  describe('ResponseReceive', () => {
+    it('does not report server error responses as client errors', async () => {
+      const ws: TestWebSocket = new TestSocket() as TestWebSocket
+      const machine = mlEphantManagerMachine.provide({
+        actors: {
+          [MlEphantManagerStates.Setup]: fromPromise<
+            Partial<MlEphantManagerContext>,
+            SetupActorInput
+          >(async () => ({
+            ws,
+            conversation: { exchanges: [] },
+            conversationId: 'conversation-id',
+          })),
+        },
+      })
+      const actor = createActor(machine, {
+        input: {
+          apiToken: '',
+        },
+      }).start()
+
+      actor.send({
+        type: MlEphantManagerTransitions.CacheSetupAndConnect,
+        refParentSend: vi.fn(),
+      })
+
+      await waitFor(actor, (state) =>
+        state.matches(MlEphantManagerStates.WaitForContinueCheck)
+      )
+
+      actor.send({
+        type: MlEphantManagerStates.ContinueCheck,
+        projectName: 'zoo-project',
+        projectFiles: [],
+      })
+
+      await waitFor(actor, (state) =>
+        state.matches(MlEphantManagerStates.Ready)
+      )
+
+      actor.send({
+        type: MlEphantManagerTransitions.ResponseReceive,
+        response: {
+          error: {
+            detail: 'Zookeeper backend failed',
+          },
+        },
+      })
+
+      await waitFor(
+        actor,
+        (state) => state.context.conversation?.exchanges.length === 1
+      )
+
+      expect(mockClientErrors.reportClientError).not.toHaveBeenCalled()
+      expect(actor.getSnapshot().context.awaitingResponse).toBe(false)
+
+      actor.stop()
+    })
+  })
+
+  describe('client-side actor errors', () => {
+    it('reports local actor invocation failures', async () => {
+      const machine = mlEphantManagerMachine.provide({
+        actors: {
+          [MlEphantManagerStates.Setup]: fromPromise<
+            Partial<MlEphantManagerContext>,
+            SetupActorInput
+          >(async () => ({
+            conversation: { exchanges: [] },
+            conversationId: 'conversation-id',
+          })),
+        },
+      })
+      const actor = createActor(machine, {
+        input: {
+          apiToken: '',
+        },
+      }).start()
+
+      actor.send({
+        type: MlEphantManagerTransitions.CacheSetupAndConnect,
+        refParentSend: vi.fn(),
+      })
+
+      await waitFor(actor, (state) =>
+        state.matches(MlEphantManagerStates.WaitForContinueCheck)
+      )
+
+      actor.send({
+        type: MlEphantManagerStates.ContinueCheck,
+        projectName: 'zoo-project',
+        projectFiles: [],
+      })
+
+      await waitFor(actor, (state) => state.matches(S.Await))
+
+      expect(mockClientErrors.reportClientError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'zookeeper_actor_error',
+          message: 'WebSocket not present',
+          dedupeKey: expect.stringContaining(
+            'MlEphantManagerMachine:actor-error'
+          ),
+          extra: expect.objectContaining({
+            source: 'MlEphantManagerMachine',
+            conversationId: 'conversation-id',
+          }),
+        })
+      )
 
       actor.stop()
     })

--- a/src/machines/mlEphantManagerMachine.test.ts
+++ b/src/machines/mlEphantManagerMachine.test.ts
@@ -1,18 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ClientErrorReport } from '@kittycad/lib'
 import type { FileMeta } from '@src/lib/types'
-
-const mockClientErrors = vi.hoisted(() => ({
-  reportClientError: vi.fn(async () => undefined),
-}))
-
-vi.mock('@src/lib/clientErrors', () => ({
-  errorToMessage: (error: unknown, fallback = 'Unknown client error') => {
-    if (error instanceof Error) return error.message
-    if (typeof error === 'string') return error
-    return fallback
-  },
-  reportClientError: mockClientErrors.reportClientError,
-}))
+import { resetReportedClientErrorsForTests } from '@src/lib/clientErrors'
 
 import {
   type Conversation,
@@ -27,6 +16,25 @@ import {
 } from '@src/machines/mlEphantManagerMachine'
 import { S } from '@src/machines/utils'
 import { createActor, fromPromise, waitFor } from 'xstate'
+
+function stubClientErrorFetch() {
+  resetReportedClientErrorsForTests()
+  const reports: ClientErrorReport[] = []
+  const fetchMock = vi
+    .spyOn(globalThis, 'fetch')
+    .mockImplementation(async (_input, init) => {
+      if (typeof init?.body !== 'string') {
+        throw new Error('Expected a client error report request body')
+      }
+      reports.push(JSON.parse(init.body))
+
+      return new Response(JSON.stringify({ accepted: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+  return { fetchMock, reports }
+}
 
 class TestSocket extends EventTarget {
   sentPayloads: string[] = []
@@ -67,6 +75,10 @@ const completedConversation: Conversation = {
 describe('mlEphantManagerMachine', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   describe('parseMlCopilotModesResult', () => {
@@ -317,6 +329,7 @@ describe('mlEphantManagerMachine', () => {
     })
 
     it('keeps recoverable context after an abrupt close', async () => {
+      const { fetchMock } = stubClientErrorFetch()
       const ws: TestWebSocket = new TestSocket() as TestWebSocket
       const machine = mlEphantManagerMachine.provide({
         actors: {
@@ -366,68 +379,7 @@ describe('mlEphantManagerMachine', () => {
       )
       expect(actor.getSnapshot().context.conversationId).toBe('conversation-id')
       expect(actor.getSnapshot().context.abruptlyClosed).toBe(true)
-      expect(mockClientErrors.reportClientError).not.toHaveBeenCalled()
-
-      actor.stop()
-    })
-  })
-
-  describe('ResponseReceive', () => {
-    it('does not report server error responses as client errors', async () => {
-      const ws: TestWebSocket = new TestSocket() as TestWebSocket
-      const machine = mlEphantManagerMachine.provide({
-        actors: {
-          [MlEphantManagerStates.Setup]: fromPromise<
-            Partial<MlEphantManagerContext>,
-            SetupActorInput
-          >(async () => ({
-            ws,
-            conversation: { exchanges: [] },
-            conversationId: 'conversation-id',
-          })),
-        },
-      })
-      const actor = createActor(machine, {
-        input: {
-          apiToken: '',
-        },
-      }).start()
-
-      actor.send({
-        type: MlEphantManagerTransitions.CacheSetupAndConnect,
-        refParentSend: vi.fn(),
-      })
-
-      await waitFor(actor, (state) =>
-        state.matches(MlEphantManagerStates.WaitForContinueCheck)
-      )
-
-      actor.send({
-        type: MlEphantManagerStates.ContinueCheck,
-        projectName: 'zoo-project',
-        projectFiles: [],
-      })
-
-      await waitFor(actor, (state) =>
-        state.matches(MlEphantManagerStates.Ready)
-      )
-
-      actor.send({
-        type: MlEphantManagerTransitions.ResponseReceive,
-        response: {
-          error: {
-            detail: 'Zookeeper backend failed',
-          },
-        },
-      })
-
-      await waitFor(
-        actor,
-        (state) => state.context.conversation?.exchanges.length === 1
-      )
-
-      expect(mockClientErrors.reportClientError).not.toHaveBeenCalled()
-      expect(actor.getSnapshot().context.awaitingResponse).toBe(false)
+      expect(fetchMock).not.toHaveBeenCalled()
 
       actor.stop()
     })
@@ -435,6 +387,7 @@ describe('mlEphantManagerMachine', () => {
 
   describe('client-side actor errors', () => {
     it('reports local actor invocation failures', async () => {
+      const { fetchMock, reports } = stubClientErrorFetch()
       const machine = mlEphantManagerMachine.provide({
         actors: {
           [MlEphantManagerStates.Setup]: fromPromise<
@@ -469,19 +422,24 @@ describe('mlEphantManagerMachine', () => {
 
       await waitFor(actor, (state) => state.matches(S.Await))
 
-      expect(mockClientErrors.reportClientError).toHaveBeenCalledWith(
-        expect.objectContaining({
-          code: 'zookeeper_actor_error',
-          message: 'WebSocket not present',
-          dedupeKey: expect.stringContaining(
-            'MlEphantManagerMachine:actor-error'
-          ),
-          extra: expect.objectContaining({
-            source: 'MlEphantManagerMachine',
-            conversationId: 'conversation-id',
-          }),
-        })
-      )
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(reports).toHaveLength(1)
+      const report = reports[0]
+      if (!report) {
+        throw new Error('Expected a client error report')
+      }
+      expect(report).toMatchObject({
+        code: 'zookeeper_actor_error',
+        error_name: 'Error',
+        message: 'WebSocket not present',
+      })
+      if (typeof report.stack !== 'string') {
+        throw new Error('Expected client error report stack')
+      }
+      expect(JSON.parse(report.stack)).toMatchObject({
+        source: 'MlEphantManagerMachine',
+        conversationId: 'conversation-id',
+      })
 
       actor.stop()
     })

--- a/src/machines/mlEphantManagerMachine.ts
+++ b/src/machines/mlEphantManagerMachine.ts
@@ -330,9 +330,21 @@ function xstateEventError(event: unknown): unknown {
   return undefined
 }
 
+type ZookeeperErrorContext = Pick<
+  MlEphantManagerContext,
+  | 'conversationId'
+  | 'awaitingResponse'
+  | 'pendingBackendShutdown'
+  | 'lastMessageId'
+  | 'lastMessageType'
+> & {
+  exchangeCount: Conversation['exchanges']['length'] | undefined
+  readyState: ReturnType<typeof getWebSocketReadyStateLabel>
+}
+
 function zookeeperErrorContext(
   context: MlEphantManagerContext
-): Record<string, unknown> {
+): ZookeeperErrorContext {
   return {
     conversationId: context.conversationId,
     awaitingResponse: context.awaitingResponse,

--- a/src/machines/mlEphantManagerMachine.ts
+++ b/src/machines/mlEphantManagerMachine.ts
@@ -17,6 +17,8 @@ import {
 } from '@src/components/CustomIcon'
 
 import { isArray } from '@src/lib/utils'
+import { errorToMessage, reportClientError } from '@src/lib/clientErrors'
+import { isErr } from '@src/lib/trap'
 
 import { S, transitions } from '@src/machines/utils'
 import { getKclVersion } from '@src/lib/kclVersion'
@@ -318,6 +320,56 @@ function logZookeeperDisconnect(message: string, metadata?: unknown) {
   console.warn(ZOOKEEPER_DISCONNECT_LOG_PREFIX, message, metadata)
 }
 
+function xstateEventError(event: unknown): unknown {
+  if (typeof event !== 'object' || event === null) return undefined
+
+  if ('output' in event) return event.output
+  if ('data' in event) return event.data
+  if ('error' in event) return event.error
+
+  return undefined
+}
+
+function zookeeperErrorContext(
+  context: MlEphantManagerContext
+): Record<string, unknown> {
+  return {
+    conversationId: context.conversationId,
+    awaitingResponse: context.awaitingResponse,
+    pendingBackendShutdown: context.pendingBackendShutdown,
+    lastMessageId: context.lastMessageId,
+    lastMessageType: context.lastMessageType,
+    exchangeCount: context.conversation?.exchanges.length,
+    readyState: getWebSocketReadyStateLabel(context.ws?.readyState),
+  }
+}
+
+function reportZookeeperClientError(args: {
+  code: string
+  message: string
+  error?: unknown
+  errorName?: string
+  dedupeKey?: string
+  extra?: Record<string, unknown>
+}) {
+  // Keep this scoped to exceptions raised while the client handles the pane.
+  // Backend error responses and normal websocket lifecycle events are not
+  // client bugs, even when they produce user-visible Zookeeper errors.
+  void reportClientError({
+    code: args.code,
+    message: args.message,
+    error: args.error,
+    errorName:
+      args.errorName ??
+      (isErr(args.error) ? undefined : 'ZookeeperClientError'),
+    dedupeKey: args.dedupeKey,
+    extra: {
+      source: 'MlEphantManagerMachine',
+      ...args.extra,
+    },
+  })
+}
+
 function getWebSocketReadyStateLabel(
   readyState: number | undefined
 ): string | undefined {
@@ -523,20 +575,49 @@ export const mlEphantManagerMachine = setup({
     events: {} as MlEphantManagerEvents,
   },
   actions: {
-    toastError: ({ event }) => {
+    toastError: ({ event, context }) => {
       console.error(event)
-      if ('output' in event && event.output instanceof Error) {
+      const error = xstateEventError(event)
+      reportZookeeperClientError({
+        code: 'zookeeper_actor_error',
+        message: errorToMessage(error, 'Zookeeper actor failed'),
+        error,
+        errorName: isErr(error) ? undefined : 'ZookeeperActorError',
+        dedupeKey: `MlEphantManagerMachine:actor-error:${event.type}:${errorToMessage(error, 'unknown')}`,
+        extra: {
+          eventType: event.type,
+          ...zookeeperErrorContext(context),
+        },
+      })
+      if ('output' in event && isErr(event.output)) {
         toast.error(event.output.message)
-      } else if ('data' in event && event.data instanceof Error) {
+      } else if ('data' in event && isErr(event.data)) {
         toast.error(event.data.message)
-      } else if ('error' in event && event.error instanceof Error) {
+      } else if ('error' in event && isErr(event.error)) {
         toast.error(event.error.message)
       }
     },
-    handleAbruptClose: assign(({ event }) => {
+    reportSetupError: ({ event, context }) => {
+      if (!('error' in event)) return
+      if (event.error === MlEphantSetupErrors.ConversationNotFound) return
+
+      reportZookeeperClientError({
+        code: 'zookeeper_setup_error',
+        message: errorToMessage(event.error, 'Zookeeper setup failed'),
+        error: event.error,
+        errorName: isErr(event.error) ? undefined : 'ZookeeperSetupError',
+        dedupeKey: `MlEphantManagerMachine:setup-error:${errorToMessage(event.error, 'unknown')}`,
+        extra: {
+          eventType: event.type,
+          ...zookeeperErrorContext(context),
+        },
+      })
+    },
+    handleAbruptClose: assign(({ event, context }) => {
       assertEvent(event, MlEphantManagerTransitions.AbruptClose)
       logZookeeperDisconnect('machine handling abrupt websocket close', {
         closeReason: event.closeReason,
+        ...zookeeperErrorContext(context),
       })
       if (event.closeReason) {
         toast.error(event.closeReason)
@@ -645,6 +726,8 @@ export const mlEphantManagerMachine = setup({
         ? `?${queryParams.toString()}`
         : ''
       const url = withMlephantWebSocketURL(querystring)
+      const conversationIdForReport =
+        args.input.context.conversationId ?? args.input.event.conversationId
 
       // Defensive: if there's already an open connection, close it.
       closeMlEphantWebSocket(args.input.context.ws)
@@ -653,8 +736,7 @@ export const mlEphantManagerMachine = setup({
       ws.binaryType = 'arraybuffer'
 
       logZookeeperDisconnect('websocket opened and authenticated', {
-        conversationId:
-          args.input.context.conversationId ?? args.input.event.conversationId,
+        conversationId: conversationIdForReport,
         url,
         readyState: getWebSocketReadyStateLabel(ws.readyState),
       })
@@ -676,9 +758,7 @@ export const mlEphantManagerMachine = setup({
 
           ws.addEventListener('error', function (event: Event) {
             logZookeeperDisconnect('websocket error event received', {
-              conversationId:
-                args.input.context.conversationId ??
-                args.input.event.conversationId,
+              conversationId: conversationIdForReport,
               readyState: getWebSocketReadyStateLabel(ws.readyState),
               eventType: event.type,
             })
@@ -691,16 +771,56 @@ export const mlEphantManagerMachine = setup({
               try {
                 response = msgpackDecode(binaryData)
               } catch (msgpackError) {
-                return console.error(
+                console.error(
                   'failed to deserialize binary websocket message',
-                  { msgpackError }
+                  {
+                    msgpackError,
+                  }
                 )
+                reportZookeeperClientError({
+                  code: 'zookeeper_websocket_binary_decode_error',
+                  message: errorToMessage(
+                    msgpackError,
+                    'Failed to deserialize binary Zookeeper websocket message.'
+                  ),
+                  error: msgpackError,
+                  errorName: isErr(msgpackError)
+                    ? undefined
+                    : 'ZookeeperWebSocketDecodeError',
+                  dedupeKey: `MlEphantManagerMachine:binary-decode:${String(conversationIdForReport)}:${errorToMessage(msgpackError, 'unknown')}`,
+                  extra: {
+                    ...zookeeperErrorContext(args.input.context),
+                    conversationId: conversationIdForReport,
+                    byteLength: binaryData.byteLength,
+                    readyState: getWebSocketReadyStateLabel(ws.readyState),
+                  },
+                })
+                return
               }
             } else {
               try {
                 response = JSON.parse(event.data)
               } catch (e: unknown) {
-                return console.error(e)
+                console.error(e)
+                reportZookeeperClientError({
+                  code: 'zookeeper_websocket_json_parse_error',
+                  message: errorToMessage(
+                    e,
+                    'Failed to parse Zookeeper websocket JSON message.'
+                  ),
+                  error: e,
+                  errorName: isErr(e)
+                    ? undefined
+                    : 'ZookeeperWebSocketParseError',
+                  dedupeKey: `MlEphantManagerMachine:json-parse:${String(conversationIdForReport)}:${errorToMessage(e, 'unknown')}`,
+                  extra: {
+                    ...zookeeperErrorContext(args.input.context),
+                    conversationId: conversationIdForReport,
+                    dataLength: event.data.length,
+                    readyState: getWebSocketReadyStateLabel(ws.readyState),
+                  },
+                })
+                return
               }
             }
 
@@ -721,9 +841,7 @@ export const mlEphantManagerMachine = setup({
             if (isBackendShutdownMessage(response)) {
               logZookeeperDisconnect('server sent backend_shutdown', {
                 backendShutdownReason: response.backend_shutdown.reason,
-                conversationId:
-                  args.input.context.conversationId ??
-                  args.input.event.conversationId,
+                conversationId: conversationIdForReport,
                 lastMessageType: args.input.context.lastMessageType,
                 readyState: getWebSocketReadyStateLabel(ws.readyState),
               })
@@ -735,8 +853,7 @@ export const mlEphantManagerMachine = setup({
               return
             }
 
-            if (!isMlCopilotServerMessage(response))
-              return new Error('Not a MlCopilotServerMessage')
+            if (!isMlCopilotServerMessage(response)) return
 
             // Ignore the authorization bug
             if (
@@ -769,9 +886,7 @@ export const mlEphantManagerMachine = setup({
                 'closing websocket because conversation replay/setup is invalid',
                 {
                   errorDetail: response.error.detail,
-                  conversationId:
-                    args.input.context.conversationId ??
-                    args.input.event.conversationId,
+                  conversationId: conversationIdForReport,
                   readyState: getWebSocketReadyStateLabel(ws.readyState),
                 }
               )
@@ -882,9 +997,7 @@ export const mlEphantManagerMachine = setup({
               wasClean: event.wasClean,
               devCalledClose,
               intentionallyClosed,
-              conversationId:
-                args.input.context.conversationId ??
-                args.input.event.conversationId,
+              conversationId: conversationIdForReport,
               lastMessageType: args.input.context.lastMessageType,
               readyState: getWebSocketReadyStateLabel(ws.readyState),
             })
@@ -1144,6 +1257,7 @@ export const mlEphantManagerMachine = setup({
         onError: {
           target: MlEphantManagerStates.Setup,
           actions: [
+            'reportSetupError',
             assign(({ event, context }) => {
               if (event.error === MlEphantSetupErrors.ConversationNotFound) {
                 // set the conversation Id to undefined to have the reenter make a new conversation id

--- a/src/machines/mlEphantManagerMachine.ts
+++ b/src/machines/mlEphantManagerMachine.ts
@@ -342,6 +342,13 @@ type ZookeeperErrorContext = Pick<
   readyState: ReturnType<typeof getWebSocketReadyStateLabel>
 }
 
+enum ZookeeperClientErrorCode {
+  ActorError = 'zookeeper_actor_error',
+  SetupError = 'zookeeper_setup_error',
+  WebsocketBinaryDecodeError = 'zookeeper_websocket_binary_decode_error',
+  WebsocketJsonParseError = 'zookeeper_websocket_json_parse_error',
+}
+
 function zookeeperErrorContext(
   context: MlEphantManagerContext
 ): ZookeeperErrorContext {
@@ -357,7 +364,7 @@ function zookeeperErrorContext(
 }
 
 function reportZookeeperClientError(args: {
-  code: string
+  code: ZookeeperClientErrorCode
   error: Error
   dedupeKey?: string
   extra?: Record<string, unknown>
@@ -588,7 +595,7 @@ export const mlEphantManagerMachine = setup({
       if (!isErr(error)) return
 
       reportZookeeperClientError({
-        code: 'zookeeper_actor_error',
+        code: ZookeeperClientErrorCode.ActorError,
         error,
         dedupeKey: `MlEphantManagerMachine:actor-error:${event.type}:${error.message}`,
         extra: {
@@ -604,7 +611,7 @@ export const mlEphantManagerMachine = setup({
       if (!isErr(event.error)) return
 
       reportZookeeperClientError({
-        code: 'zookeeper_setup_error',
+        code: ZookeeperClientErrorCode.SetupError,
         error: event.error,
         dedupeKey: `MlEphantManagerMachine:setup-error:${event.error.message}`,
         extra: {
@@ -780,7 +787,7 @@ export const mlEphantManagerMachine = setup({
                 if (!isErr(msgpackError)) return
 
                 reportZookeeperClientError({
-                  code: 'zookeeper_websocket_binary_decode_error',
+                  code: ZookeeperClientErrorCode.WebsocketBinaryDecodeError,
                   error: msgpackError,
                   dedupeKey: `MlEphantManagerMachine:binary-decode:${String(conversationId)}:${msgpackError.message}`,
                   extra: {
@@ -800,7 +807,7 @@ export const mlEphantManagerMachine = setup({
                 if (!isErr(e)) return
 
                 reportZookeeperClientError({
-                  code: 'zookeeper_websocket_json_parse_error',
+                  code: ZookeeperClientErrorCode.WebsocketJsonParseError,
                   error: e,
                   dedupeKey: `MlEphantManagerMachine:json-parse:${String(conversationId)}:${e.message}`,
                   extra: {

--- a/src/machines/mlEphantManagerMachine.ts
+++ b/src/machines/mlEphantManagerMachine.ts
@@ -17,7 +17,7 @@ import {
 } from '@src/components/CustomIcon'
 
 import { isArray } from '@src/lib/utils'
-import { errorToMessage, reportClientError } from '@src/lib/clientErrors'
+import { reportClientError } from '@src/lib/clientErrors'
 import { isErr } from '@src/lib/trap'
 
 import { S, transitions } from '@src/machines/utils'
@@ -346,9 +346,7 @@ function zookeeperErrorContext(
 
 function reportZookeeperClientError(args: {
   code: string
-  message: string
-  error?: unknown
-  errorName?: string
+  error: Error
   dedupeKey?: string
   extra?: Record<string, unknown>
 }) {
@@ -357,11 +355,8 @@ function reportZookeeperClientError(args: {
   // client bugs, even when they produce user-visible Zookeeper errors.
   void reportClientError({
     code: args.code,
-    message: args.message,
+    message: args.error.message,
     error: args.error,
-    errorName:
-      args.errorName ??
-      (isErr(args.error) ? undefined : 'ZookeeperClientError'),
     dedupeKey: args.dedupeKey,
     extra: {
       source: 'MlEphantManagerMachine',
@@ -578,35 +573,28 @@ export const mlEphantManagerMachine = setup({
     toastError: ({ event, context }) => {
       console.error(event)
       const error = xstateEventError(event)
+      if (!isErr(error)) return
+
       reportZookeeperClientError({
         code: 'zookeeper_actor_error',
-        message: errorToMessage(error, 'Zookeeper actor failed'),
         error,
-        errorName: isErr(error) ? undefined : 'ZookeeperActorError',
-        dedupeKey: `MlEphantManagerMachine:actor-error:${event.type}:${errorToMessage(error, 'unknown')}`,
+        dedupeKey: `MlEphantManagerMachine:actor-error:${event.type}:${error.message}`,
         extra: {
           eventType: event.type,
           ...zookeeperErrorContext(context),
         },
       })
-      if ('output' in event && isErr(event.output)) {
-        toast.error(event.output.message)
-      } else if ('data' in event && isErr(event.data)) {
-        toast.error(event.data.message)
-      } else if ('error' in event && isErr(event.error)) {
-        toast.error(event.error.message)
-      }
+      toast.error(error.message)
     },
     reportSetupError: ({ event, context }) => {
       if (!('error' in event)) return
       if (event.error === MlEphantSetupErrors.ConversationNotFound) return
+      if (!isErr(event.error)) return
 
       reportZookeeperClientError({
         code: 'zookeeper_setup_error',
-        message: errorToMessage(event.error, 'Zookeeper setup failed'),
         error: event.error,
-        errorName: isErr(event.error) ? undefined : 'ZookeeperSetupError',
-        dedupeKey: `MlEphantManagerMachine:setup-error:${errorToMessage(event.error, 'unknown')}`,
+        dedupeKey: `MlEphantManagerMachine:setup-error:${event.error.message}`,
         extra: {
           eventType: event.type,
           ...zookeeperErrorContext(context),
@@ -726,7 +714,7 @@ export const mlEphantManagerMachine = setup({
         ? `?${queryParams.toString()}`
         : ''
       const url = withMlephantWebSocketURL(querystring)
-      const conversationIdForReport =
+      const conversationId =
         args.input.context.conversationId ?? args.input.event.conversationId
 
       // Defensive: if there's already an open connection, close it.
@@ -736,7 +724,7 @@ export const mlEphantManagerMachine = setup({
       ws.binaryType = 'arraybuffer'
 
       logZookeeperDisconnect('websocket opened and authenticated', {
-        conversationId: conversationIdForReport,
+        conversationId,
         url,
         readyState: getWebSocketReadyStateLabel(ws.readyState),
       })
@@ -758,7 +746,7 @@ export const mlEphantManagerMachine = setup({
 
           ws.addEventListener('error', function (event: Event) {
             logZookeeperDisconnect('websocket error event received', {
-              conversationId: conversationIdForReport,
+              conversationId,
               readyState: getWebSocketReadyStateLabel(ws.readyState),
               eventType: event.type,
             })
@@ -777,20 +765,15 @@ export const mlEphantManagerMachine = setup({
                     msgpackError,
                   }
                 )
+                if (!isErr(msgpackError)) return
+
                 reportZookeeperClientError({
                   code: 'zookeeper_websocket_binary_decode_error',
-                  message: errorToMessage(
-                    msgpackError,
-                    'Failed to deserialize binary Zookeeper websocket message.'
-                  ),
                   error: msgpackError,
-                  errorName: isErr(msgpackError)
-                    ? undefined
-                    : 'ZookeeperWebSocketDecodeError',
-                  dedupeKey: `MlEphantManagerMachine:binary-decode:${String(conversationIdForReport)}:${errorToMessage(msgpackError, 'unknown')}`,
+                  dedupeKey: `MlEphantManagerMachine:binary-decode:${String(conversationId)}:${msgpackError.message}`,
                   extra: {
                     ...zookeeperErrorContext(args.input.context),
-                    conversationId: conversationIdForReport,
+                    conversationId,
                     byteLength: binaryData.byteLength,
                     readyState: getWebSocketReadyStateLabel(ws.readyState),
                   },
@@ -802,20 +785,15 @@ export const mlEphantManagerMachine = setup({
                 response = JSON.parse(event.data)
               } catch (e: unknown) {
                 console.error(e)
+                if (!isErr(e)) return
+
                 reportZookeeperClientError({
                   code: 'zookeeper_websocket_json_parse_error',
-                  message: errorToMessage(
-                    e,
-                    'Failed to parse Zookeeper websocket JSON message.'
-                  ),
                   error: e,
-                  errorName: isErr(e)
-                    ? undefined
-                    : 'ZookeeperWebSocketParseError',
-                  dedupeKey: `MlEphantManagerMachine:json-parse:${String(conversationIdForReport)}:${errorToMessage(e, 'unknown')}`,
+                  dedupeKey: `MlEphantManagerMachine:json-parse:${String(conversationId)}:${e.message}`,
                   extra: {
                     ...zookeeperErrorContext(args.input.context),
-                    conversationId: conversationIdForReport,
+                    conversationId,
                     dataLength: event.data.length,
                     readyState: getWebSocketReadyStateLabel(ws.readyState),
                   },
@@ -841,7 +819,7 @@ export const mlEphantManagerMachine = setup({
             if (isBackendShutdownMessage(response)) {
               logZookeeperDisconnect('server sent backend_shutdown', {
                 backendShutdownReason: response.backend_shutdown.reason,
-                conversationId: conversationIdForReport,
+                conversationId,
                 lastMessageType: args.input.context.lastMessageType,
                 readyState: getWebSocketReadyStateLabel(ws.readyState),
               })
@@ -886,7 +864,7 @@ export const mlEphantManagerMachine = setup({
                 'closing websocket because conversation replay/setup is invalid',
                 {
                   errorDetail: response.error.detail,
-                  conversationId: conversationIdForReport,
+                  conversationId,
                   readyState: getWebSocketReadyStateLabel(ws.readyState),
                 }
               )
@@ -997,7 +975,7 @@ export const mlEphantManagerMachine = setup({
               wasClean: event.wasClean,
               devCalledClose,
               intentionallyClosed,
-              conversationId: conversationIdForReport,
+              conversationId,
               lastMessageType: args.input.context.lastMessageType,
               readyState: getWebSocketReadyStateLabel(ws.readyState),
             })


### PR DESCRIPTION
Fixes #11656

### How to test?

1. Open the Vercel preview
2. Open the Zookeeper pane
3. Paste the following in your web console
4. Check the [axiom logs](https://app.axiom.co/kittycad-xx0p/query?qid=55FjfBANDlI-tezh75&relative=1)

```
const actor = window.app.debug.mlEphantManagerActor
actor.getSnapshot().context.ws.send = () => {
  throw new Error('Manual Zookeeper client-side send failure')
}
actor.send({ type: 'cancel' })
```