### PR TITLE
KCL Python: close ctx more often

### DIFF
--- a/rust/kcl-python-bindings/src/lib.rs
+++ b/rust/kcl-python-bindings/src/lib.rs
@@ -216,9 +216,10 @@ async fn run_kcl(input: KclInput, mock: bool) -> PyResult<ExecutedKcl> {
     } = load_and_parse(input).await?;
 
     let (ctx, mut state) = new_context_state(path, mock).await.map_err(to_py_exception)?;
-    ctx.run(&program, &mut state)
-        .await
-        .map_err(|err| into_miette(err, &code))?;
+    if let Err(err) = ctx.run(&program, &mut state).await {
+        ctx.close().await;
+        return Err(into_miette(err, &code));
+    }
 
     Ok(ExecutedKcl {
         ctx,
@@ -323,14 +324,17 @@ async fn execute_and_export_impl(input: KclInput, export_format: FileExportForma
         filename,
     } = run_kcl(input, false).await?;
 
-    let settings = program
-        .meta_settings()
-        .map_err(|err| into_miette_for_parse(&filename, &code, err))?
-        .unwrap_or_default();
+    let settings = match program.meta_settings() {
+        Ok(x) => x.unwrap_or_default(),
+        Err(err) => {
+            ctx.close().await;
+            return Err(into_miette_for_parse(&filename, &code, err));
+        }
+    };
     let units: UnitLength = settings.default_length_units.into();
 
     // This will not return until there are files.
-    let resp = ctx
+    let export_res = ctx
         .engine
         .send_modeling_cmd(
             &ctx.engine_batch,
@@ -346,7 +350,14 @@ async fn execute_and_export_impl(input: KclInput, export_format: FileExportForma
                     .build(),
             ),
         )
-        .await?;
+        .await;
+    let resp = match export_res {
+        Ok(x) => x,
+        Err(e) => {
+            ctx.close().await;
+            return Err(e.into());
+        }
+    };
 
     let result = match resp {
         kittycad_modeling_cmds::websocket::OkWebSocketResponseData::Export { files } => Ok(files),
@@ -496,7 +507,10 @@ async fn import_and_snapshot_views(
     let zoom = zoom.unwrap_or(true);
     spawn_py(async move {
         let (ctx, _state) = new_context_state(None, false).await.map_err(to_py_exception)?;
-        import(&ctx, filepaths, format).await?;
+        if let Err(e) = import(&ctx, filepaths, format).await {
+            ctx.close().await;
+            return Err(e);
+        }
         let result = take_snaps(&ctx, image_format, snapshot_options, zoom).await;
         ctx.close().await;
         result


### PR DESCRIPTION
There were some cases (early returns via `?`) where the `ctx` wasn't calling its `.close()` method. This isn't _terrible_ but it means there's idle engine connections lingering around that should be closed. So I went back and added explicit `.close()` calls for the early return paths.

It's really annoying that we need to do this, I wish this could just be a `Drop` impl. That's the whole point of Rust, doing these RAII things for you. But because `.close()` is async we can't use `Drop`.