### PR TITLE
Fix external edits not reloading in app

### DIFF
--- a/src/lang/KclManager.spec.ts
+++ b/src/lang/KclManager.spec.ts
@@ -503,6 +503,34 @@ describe('KclManager diagnostics', () => {
     expect(kclManager.code).toBe('external edit')
   })
 
+  it('arms disk watcher when reusing the singleton editor for an opened file', async () => {
+    const { kclManager } = createKclManagerTestHarness('')
+    const path = '/tmp/kcl-manager-watch-open-test.kcl'
+    const readSpy = vi
+      .spyOn(File.ioImplementations, 'read')
+      .mockResolvedValue('opened code')
+    const watchSpy = vi
+      .spyOn(File.ioImplementations, 'watch')
+      .mockImplementation(() => {})
+
+    const opened = await KclManager.fromFile(
+      new File(path, 101),
+      (kclManager as any).systemDeps,
+      kclManager
+    )
+
+    expect(opened).toBe(kclManager)
+    expect(kclManager.watching).toBe(true)
+    expect(watchSpy).toHaveBeenCalledWith(
+      path,
+      expect.any(String),
+      expect.any(Function)
+    )
+
+    readSpy.mockRestore()
+    watchSpy.mockRestore()
+  })
+
   it('does not overwrite dirty editor state when an external reload resolves later', async () => {
     const { kclManager } = createKclManagerTestHarness('local base')
     const deferredRead = createDeferred<string>()

--- a/src/lang/KclManager.ts
+++ b/src/lang/KclManager.ts
@@ -434,7 +434,9 @@ export class ZDSProject {
       this.files = [...this.files, newEditor]
     }
 
-    newEditor.path = path
+    if (newEditor.path !== path) {
+      newEditor.path = path
+    }
 
     // Initialize the editor theme
     // Subsequent changes are listened for within app.onSettingsUpdate()
@@ -1723,6 +1725,7 @@ export class KclManager extends File {
       if (!isCodeTheSame(initialCode, diskCode)) {
         editor.markFileCodeAsSynced(diskCode)
       }
+      editor.watch()
       return editor
     }
 
@@ -1741,6 +1744,7 @@ export class KclManager extends File {
       shouldWriteToDisk: false,
     })
     providedEditor.markFileCodeAsSynced(diskCode)
+    providedEditor.watch()
     return providedEditor
   }
 


### PR DESCRIPTION
Fixes #11423

@franknoirot this is what Codex suggested when prompted with the issue. Testing with `make run-desktop`, if I try to edit the executing file on with a text editor it doesn't reload on main but it does on this branch.

By reload I mean seeing the new changes in codemirror as well as a reexecution.