### PR TITLE
Use model bbox for default GDT font size

### DIFF
--- a/src/lib/gdtFramePosition.test.ts
+++ b/src/lib/gdtFramePosition.test.ts
@@ -215,7 +215,8 @@ describe('GD&T frame defaults', () => {
     ])
   })
 
-  it('fills omitted framePosition and fontSize from the selected bounding box', async () => {
+  it('fills omitted framePosition from the selected bounding box and fontSize from the model bounding box', async () => {
+    formatNumberLiteral.mockReturnValue('5.25cm')
     const sendSceneCommand = vi
       .fn()
       .mockResolvedValueOnce({
@@ -245,6 +246,21 @@ describe('GD&T frame defaults', () => {
           },
         },
       })
+      .mockResolvedValueOnce({
+        success: true,
+        resp: {
+          type: 'modeling',
+          data: {
+            modeling_response: {
+              type: 'bounding_box',
+              data: {
+                center: { x: 0, y: 0, z: 0 },
+                dimensions: { x: 100, y: 50, z: 0 },
+              },
+            },
+          },
+        },
+      })
 
     const data = {
       name: 'A',
@@ -268,7 +284,8 @@ describe('GD&T frame defaults', () => {
       wasmInstance,
     })
 
-    expect(sendSceneCommand).toHaveBeenCalledWith(
+    expect(sendSceneCommand).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         cmd: expect.objectContaining({
           type: 'bounding_box',
@@ -277,14 +294,79 @@ describe('GD&T frame defaults', () => {
         }),
       })
     )
+    expect(sendSceneCommand).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        cmd: expect.objectContaining({
+          type: 'bounding_box',
+          entity_ids: [],
+          output_unit: 'cm',
+        }),
+      })
+    )
     expect(result.framePosition?.valueText).toBe('[6, 6]')
-    expect(result.fontSize?.valueText).toBe('1.2cm')
+    expect(result.fontSize?.valueText).toBe('5.25cm')
     expect(result.fontSize?.valueAst).toMatchObject({
       type: 'Literal',
-      raw: '1.2cm',
+      raw: '5.25cm',
     })
-    expect(formatNumberLiteral).toHaveBeenCalledWith(1.2, '"Cm"', 4)
-    expect(GDT_FONT_SIZE_TO_BOUNDING_BOX_AVERAGE_RATIO).toBe(0.2)
+    expect(formatNumberLiteral).toHaveBeenCalledWith(5.25, '"Cm"', 4)
+    expect(GDT_FONT_SIZE_TO_BOUNDING_BOX_AVERAGE_RATIO).toBe(0.07)
+  })
+
+  it('uses only the model bounding box when only fontSize is omitted', async () => {
+    formatNumberLiteral.mockReturnValue('7mm')
+    const sendSceneCommand = vi.fn().mockResolvedValueOnce({
+      success: true,
+      resp: {
+        type: 'modeling',
+        data: {
+          modeling_response: {
+            type: 'bounding_box',
+            data: {
+              center: { x: 0, y: 0, z: 0 },
+              dimensions: { x: 80, y: 120, z: 100 },
+            },
+          },
+        },
+      },
+    })
+
+    const data = {
+      name: 'A',
+      framePosition: testFramePosition(),
+      framePlane: 'XZ',
+      faces: {
+        graphSelections: [
+          {
+            codeRef: { range: [0, 1, 0], pathToNode: [] },
+            artifact: testArtifact({ type: 'cap', id: 'cap-1' }),
+          },
+        ],
+        otherSelections: [],
+      },
+    } as ModelingCommandSchema['GDT Datum']
+
+    const result = await withDefaultGdtFrameDefaults({
+      data,
+      engineCommandManager: {
+        sendSceneCommand,
+      } as unknown as ConnectionManager,
+      wasmInstance,
+    })
+
+    expect(sendSceneCommand).toHaveBeenCalledOnce()
+    expect(sendSceneCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cmd: expect.objectContaining({
+          type: 'bounding_box',
+          entity_ids: [],
+          output_unit: 'mm',
+        }),
+      })
+    )
+    expect(result.fontSize?.valueText).toBe('7mm')
+    expect(formatNumberLiteral).toHaveBeenCalledWith(7, '"Mm"', 4)
   })
 
   it('signs omitted framePosition from the selected face normal', async () => {

--- a/src/lib/gdtFramePosition.ts
+++ b/src/lib/gdtFramePosition.ts
@@ -49,7 +49,7 @@ type GdtCommandData =
   | ModelingCommandSchema['GDT Parallelism']
   | ModelingCommandSchema['GDT Annotation']
 
-export const GDT_FONT_SIZE_TO_BOUNDING_BOX_AVERAGE_RATIO = 0.2
+export const GDT_FONT_SIZE_TO_BOUNDING_BOX_AVERAGE_RATIO = 0.07
 
 function getSelectionsFromGdtData(
   data: GdtCommandData
@@ -495,16 +495,18 @@ async function getDefaultGdtFrameDefaultsFromSelectionNormals({
   return undefined
 }
 
-async function getBoundingBoxForGdtSelections({
+async function getBoundingBoxForGdtEntities({
   engineCommandManager,
   entityIds,
   outputUnit,
+  includeEntireScene = false,
 }: {
   engineCommandManager: ConnectionManager
   entityIds: ArtifactId[]
   outputUnit: UnitLength
+  includeEntireScene?: boolean
 }): Promise<BoundingBox | undefined> {
-  if (entityIds.length === 0) {
+  if (entityIds.length === 0 && !includeEntireScene) {
     return undefined
   }
 
@@ -592,19 +594,19 @@ export async function withDefaultGdtFrameDefaults<T extends GdtCommandData>({
     return nextData
   }
 
-  const boundingBox = await getBoundingBoxForGdtSelections({
-    engineCommandManager,
-    entityIds,
-    outputUnit,
-  })
+  const needsSelectionBoundingBox =
+    !hasResolvedFramePlane || !nextData.framePosition
+  const selectionBoundingBox = needsSelectionBoundingBox
+    ? await getBoundingBoxForGdtEntities({
+        engineCommandManager,
+        entityIds,
+        outputUnit,
+      })
+    : undefined
 
-  if (!boundingBox) {
-    return nextData
-  }
-
-  if (!hasResolvedFramePlane) {
+  if (!hasResolvedFramePlane && selectionBoundingBox) {
     const framePlaneFromBoundingBox = getDefaultGdtFramePlaneFromBoundingBox(
-      boundingBox.dimensions
+      selectionBoundingBox.dimensions
     )
 
     if (framePlaneFromBoundingBox) {
@@ -619,14 +621,11 @@ export async function withDefaultGdtFrameDefaults<T extends GdtCommandData>({
   }
 
   const averageDimension =
-    !nextData.framePosition || !nextData.fontSize
-      ? getAverageBoundingBoxDimension(boundingBox.dimensions)
+    !nextData.framePosition && selectionBoundingBox
+      ? getAverageBoundingBoxDimension(selectionBoundingBox.dimensions)
       : undefined
 
-  if (!nextData.framePosition) {
-    if (averageDimension === undefined) {
-      return nextData
-    }
+  if (!nextData.framePosition && averageDimension !== undefined) {
     const [xSign, ySign] = framePositionSigns ?? [1, 1]
 
     nextData = {
@@ -640,14 +639,24 @@ export async function withDefaultGdtFrameDefaults<T extends GdtCommandData>({
   }
 
   if (!nextData.fontSize) {
-    if (averageDimension === undefined) {
+    const modelBoundingBox = await getBoundingBoxForGdtEntities({
+      engineCommandManager,
+      entityIds: [],
+      outputUnit,
+      includeEntireScene: true,
+    })
+    const modelAverageDimension = modelBoundingBox
+      ? getAverageBoundingBoxDimension(modelBoundingBox.dimensions)
+      : undefined
+
+    if (modelAverageDimension === undefined) {
       return nextData
     }
 
     nextData = {
       ...nextData,
       fontSize: createFontSizeCommandValue(
-        averageDimension,
+        modelAverageDimension,
         outputUnit,
         wasmInstance
       ),


### PR DESCRIPTION
ai assisted
## Problem
GD&T annotations derive the first automatic text size from whichever selection happens to be active, so measuring a tiny local feature or a large span can make all later annotations inherit an arbitrary default. Fixes #11677.

## Solution
Use the whole model bounding box for the first automatic GD&T font size, keep frame placement based on the selected entities, and tune the ratio to 0.07 so defaults are predictable without being oversized.



New default:
<img width="582" height="446" alt="Screenshot 2026-05-17 at 21 32 54" src="https://github.com/user-attachments/assets/a5f8cfc6-ea24-4a6d-a584-e9a5c259c6a7" />


Old default:
<img width="907" height="427" alt="Screenshot 2026-05-17 at 21 33 45" src="https://github.com/user-attachments/assets/46f40453-24c8-4c29-bae1-97786edf4632" />