### PR TITLE
Use debug again for kcl

### DIFF
--- a/rust/kcl-python-bindings/pyproject.toml
+++ b/rust/kcl-python-bindings/pyproject.toml
@@ -17,7 +17,6 @@ test = ["pytest", "pytest-asyncio", "flaky"]
 
 [tool.maturin]
 features = ["pyo3/extension-module"]
-profile = "release"
 
 [tool.setuptools]
 include-package-data = false


### PR DESCRIPTION
I didn't meant to merge https://github.com/KittyCAD/modeling-app/pull/11523 yet as I'm hunting for weird crashes on text-to-cad right now.

using release likely hides those errors