### PR TITLE
Double click to enter sketch fix

### DIFF
--- a/src/components/layout/areas/FeatureTreePane.tsx
+++ b/src/components/layout/areas/FeatureTreePane.tsx
@@ -701,6 +701,20 @@ const OperationItem = ({
           item.sourceRange,
           systemDeps.kclManager.artifactGraph
         ) ?? undefined
+      if (
+        item.type === 'GroupBegin' &&
+        item.group.type === 'SketchBlock' &&
+        artifact?.type === 'sketchBlock' &&
+        artifact.id &&
+        typeof artifact.sketchId === 'number'
+      ) {
+        // Allow double clicking on any sketch even with shift pressed
+        modelingActor.send({
+          type: 'Edit sketch solve',
+          data: { artifactId: artifact.id },
+        })
+        return
+      }
       prepareEditCommand({
         artifactGraph: systemDeps.kclManager.artifactGraph,
         code: systemDeps.kclManager.code,
@@ -712,6 +726,7 @@ const OperationItem = ({
     }
   }, [
     item,
+    modelingActor,
     commandBarActor,
     systemDeps.kclManager.artifactGraph,
     systemDeps.kclManager.code,

--- a/src/hooks/useHotKeyListener.ts
+++ b/src/hooks/useHotKeyListener.ts
@@ -15,11 +15,25 @@ export function useHotKeyListener(kclManager: KclManager) {
       event.key === keyName && kclManager.setIsShiftDown(true)
     const handleKeyUp = (event: KeyboardEvent) =>
       event.key === keyName && kclManager.setIsShiftDown(false)
+    const resetShiftKey = () => kclManager.setIsShiftDown(false)
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        resetShiftKey()
+      }
+    }
     window.addEventListener('keydown', handleKeyDown)
     window.addEventListener('keyup', handleKeyUp)
+    // If shift is released while window is out of focus, its state gets stuck in true
+    // and the app thinks shift is still pressed down while it's not anymore.
+    // -> better to reset on blur, it causes less problems and is more likely to be correct.
+    // Ideally we don't keep track of isShiftDown but that's an involved refactor.
+    window.addEventListener('blur', resetShiftKey)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
     return () => {
       window.removeEventListener('keydown', handleKeyDown)
       window.removeEventListener('keyup', handleKeyUp)
+      window.removeEventListener('blur', resetShiftKey)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
     }
-  })
+  }, [kclManager])
 }


### PR DESCRIPTION
Reported by @max-mrgrsk in uzin-products where double clicking a sketch sometimes didn't work.
"double-clicking the sketch in the feature tree triggers start sketch instead of edit sketch"

https://github.com/user-attachments/assets/ac25d65c-ba60-4dd3-bef3-4eff13b2029a


One possible scenario that can cause this is a stuck shift key:
- press shift down (keep it pressed)
- lose the focus of ZDS (eg. by clicking outside the app's window)
- release shift key (this release event is missed by ZDS)
- go back to ZDS and double click a sketch in the feature tree

Expected: the sketch is opened
What happens: we go into "sketch no face" state where the app is waiting for a sketch plane to be selected. This is because it thinks shift is still pressed down, so before the double click that sketch row was selected + unselected, resulting in nothing to be selected, then we go into Enter sketch without any selections.

Fixes in this PR:
- When leaving the ZDS app (blur event) we reset `kclManager.isShiftDown` to false. This means the shift key won't get stuck in `true` if it was released outside ZDS.
It also means if we shift is pressed during a ZDS focus loss + focus regain, it will be considered released even though it's still pressed down. I believe this is not a big issue because this will happen less frequently and it's less of a problem, the user can just press shift again if they realize shift is not registering.
This bug happens eventually with every application in my experience that stores the state of keys, unfortunately it's not possible to track that 100%. Ideally we only use `event.shiftKey` which is possible because typically you want to check shift state in response to a user action - here that would be a bigger refactor because modelingMachine calls into actions so this param would have to be carried over throughout those calls.

- Additionally double clicking on a sketch in the feature tree uses that sketch to enter sketch solve directly. This makes sure to avoid using the current selection when entering sketch mode from the feature tree and so makes it usable even if you have shift key pressed during a double click.


If the issue is not a stuck shift key then my next guess is that artifact lookup from the source fails.
