### PR TITLE
Fix GD&T flatness inch tolerance display

### DIFF
--- a/e2e/playwright/point-click-sketch-v1.spec.ts
+++ b/e2e/playwright/point-click-sketch-v1.spec.ts
@@ -3080,15 +3080,15 @@ extrude001 = extrude(sketch001, length = 30)
             stage: 'arguments',
             commandName: 'GDT Flatness',
             currentArgKey: 'tolerance',
-            currentArgValue: '0.1mm',
+            currentArgValue: '0.1in',
             headerArguments: {
               Faces: '1 face',
               Tolerance: '',
             },
             highlightedHeaderArg: 'tolerance',
           })
-          // Set tolerance to 0.1mm
-          await cmdBar.currentArgumentInput.locator('.cm-content').fill('0.1mm')
+          // Set tolerance to 0.1in
+          await cmdBar.currentArgumentInput.locator('.cm-content').fill('0.1in')
         })
 
         await test.step('Review basic parameters', async () => {
@@ -3098,7 +3098,7 @@ extrude001 = extrude(sketch001, length = 30)
             commandName: 'GDT Flatness',
             headerArguments: {
               Faces: '1 face',
-              Tolerance: '0.1mm',
+              Tolerance: '0.1in',
             },
           })
         })
@@ -3114,7 +3114,7 @@ extrude001 = extrude(sketch001, length = 30)
             currentArgValue: '3',
             headerArguments: {
               Faces: '1 face',
-              Tolerance: '0.1mm',
+              Tolerance: '0.1in',
               Precision: '',
             },
             highlightedHeaderArg: 'precision',
@@ -3128,7 +3128,7 @@ extrude001 = extrude(sketch001, length = 30)
             commandName: 'GDT Flatness',
             headerArguments: {
               Faces: '1 face',
-              Tolerance: '0.1mm',
+              Tolerance: '0.1in',
               Precision: '5',
             },
           })
@@ -3144,7 +3144,7 @@ extrude001 = extrude(sketch001, length = 30)
             currentArgValue: '[0, 0]',
             headerArguments: {
               Faces: '1 face',
-              Tolerance: '0.1mm',
+              Tolerance: '0.1in',
               Precision: '5',
               FramePosition: '',
             },
@@ -3160,7 +3160,7 @@ extrude001 = extrude(sketch001, length = 30)
             commandName: 'GDT Flatness',
             headerArguments: {
               Faces: '1 face',
-              Tolerance: '0.1mm',
+              Tolerance: '0.1in',
               Precision: '5',
               FramePosition: '[10, 10]',
             },
@@ -3176,7 +3176,7 @@ extrude001 = extrude(sketch001, length = 30)
             currentArgValue: '',
             headerArguments: {
               Faces: '1 face',
-              Tolerance: '0.1mm',
+              Tolerance: '0.1in',
               Precision: '5',
               FramePosition: '[10, 10]',
               FramePlane: '',
@@ -3191,7 +3191,7 @@ extrude001 = extrude(sketch001, length = 30)
             commandName: 'GDT Flatness',
             headerArguments: {
               Faces: '1 face',
-              Tolerance: '0.1mm',
+              Tolerance: '0.1in',
               Precision: '5',
               FramePosition: '[10, 10]',
               FramePlane: 'XY',
@@ -3208,7 +3208,7 @@ extrude001 = extrude(sketch001, length = 30)
             currentArgValue: '10mm',
             headerArguments: {
               Faces: '1 face',
-              Tolerance: '0.1mm',
+              Tolerance: '0.1in',
               Precision: '5',
               FramePosition: '[10, 10]',
               FramePlane: 'XY',
@@ -3225,7 +3225,7 @@ extrude001 = extrude(sketch001, length = 30)
             commandName: 'GDT Flatness',
             headerArguments: {
               Faces: '1 face',
-              Tolerance: '0.1mm',
+              Tolerance: '0.1in',
               Precision: '5',
               FramePosition: '[10, 10]',
               FramePlane: 'XY',
@@ -3241,7 +3241,7 @@ extrude001 = extrude(sketch001, length = 30)
         await editor.expectEditor.not.toContain('experimentalFeatures = allow')
         await editor.expectEditor.toContain('gdt::flatness(')
         await editor.expectEditor.toContain('faces = [capEnd001]')
-        await editor.expectEditor.toContain('tolerance = 0.1mm')
+        await editor.expectEditor.toContain('tolerance = 0.1in')
         await editor.expectEditor.toContain('precision = 5')
         await editor.expectEditor.toContain('framePosition = [10, 10]')
         await editor.expectEditor.toContain('framePlane = XY')
@@ -3262,9 +3262,9 @@ extrude001 = extrude(sketch001, length = 30)
           stage: 'arguments',
           commandName: 'GDT Flatness',
           currentArgKey: 'tolerance',
-          currentArgValue: '0.1mm',
+          currentArgValue: '0.1in',
           headerArguments: {
-            Tolerance: '0.1mm',
+            Tolerance: '0.1in',
             Precision: '5',
             FramePosition: '[10, 10]',
             FramePlane: 'XY',
@@ -3280,9 +3280,9 @@ extrude001 = extrude(sketch001, length = 30)
             stage: 'arguments',
             commandName: 'GDT Flatness',
             currentArgKey: 'tolerance',
-            currentArgValue: '0.1mm',
+            currentArgValue: '0.1in',
             headerArguments: {
-              Tolerance: '0.1mm',
+              Tolerance: '0.1in',
               Precision: '5',
               FramePosition: '[10, 10]',
               FramePlane: 'XY',
@@ -3290,15 +3290,15 @@ extrude001 = extrude(sketch001, length = 30)
             },
             highlightedHeaderArg: 'tolerance',
           })
-          // Update tolerance from 0.1mm to 0.2mm
-          await cmdBar.currentArgumentInput.locator('.cm-content').fill('0.2mm')
+          // Update tolerance from 0.1in to 0.2in
+          await cmdBar.currentArgumentInput.locator('.cm-content').fill('0.2in')
           await cmdBar.progressCmdBar()
           // Review changes to tolerance
           await cmdBar.expectState({
             stage: 'review',
             commandName: 'GDT Flatness',
             headerArguments: {
-              Tolerance: '0.2mm',
+              Tolerance: '0.2in',
               Precision: '5',
               FramePosition: '[10, 10]',
               FramePlane: 'XY',
@@ -3315,7 +3315,7 @@ extrude001 = extrude(sketch001, length = 30)
             currentArgKey: 'precision',
             currentArgValue: '5',
             headerArguments: {
-              Tolerance: '0.2mm',
+              Tolerance: '0.2in',
               Precision: '5',
               FramePosition: '[10, 10]',
               FramePlane: 'XY',
@@ -3331,7 +3331,7 @@ extrude001 = extrude(sketch001, length = 30)
             stage: 'review',
             commandName: 'GDT Flatness',
             headerArguments: {
-              Tolerance: '0.2mm',
+              Tolerance: '0.2in',
               Precision: '3',
               FramePosition: '[10, 10]',
               FramePlane: 'XY',
@@ -3348,7 +3348,7 @@ extrude001 = extrude(sketch001, length = 30)
             currentArgKey: 'framePosition',
             currentArgValue: '[10, 10]',
             headerArguments: {
-              Tolerance: '0.2mm',
+              Tolerance: '0.2in',
               Precision: '3',
               FramePosition: '[10, 10]',
               FramePlane: 'XY',
@@ -3365,7 +3365,7 @@ extrude001 = extrude(sketch001, length = 30)
             stage: 'review',
             commandName: 'GDT Flatness',
             headerArguments: {
-              Tolerance: '0.2mm',
+              Tolerance: '0.2in',
               Precision: '3',
               FramePosition: '[20, 30]',
               FramePlane: 'XY',
@@ -3382,7 +3382,7 @@ extrude001 = extrude(sketch001, length = 30)
             currentArgKey: 'framePlane',
             currentArgValue: '',
             headerArguments: {
-              Tolerance: '0.2mm',
+              Tolerance: '0.2in',
               Precision: '3',
               FramePosition: '[20, 30]',
               FramePlane: 'XY',
@@ -3397,7 +3397,7 @@ extrude001 = extrude(sketch001, length = 30)
             stage: 'review',
             commandName: 'GDT Flatness',
             headerArguments: {
-              Tolerance: '0.2mm',
+              Tolerance: '0.2in',
               Precision: '3',
               FramePosition: '[20, 30]',
               FramePlane: 'XZ',
@@ -3414,7 +3414,7 @@ extrude001 = extrude(sketch001, length = 30)
             currentArgKey: 'fontSize',
             currentArgValue: '12mm',
             headerArguments: {
-              Tolerance: '0.2mm',
+              Tolerance: '0.2in',
               Precision: '3',
               FramePosition: '[20, 30]',
               FramePlane: 'XZ',
@@ -3430,7 +3430,7 @@ extrude001 = extrude(sketch001, length = 30)
             stage: 'review',
             commandName: 'GDT Flatness',
             headerArguments: {
-              Tolerance: '0.2mm',
+              Tolerance: '0.2in',
               Precision: '3',
               FramePosition: '[20, 30]',
               FramePlane: 'XZ',
@@ -3445,7 +3445,7 @@ extrude001 = extrude(sketch001, length = 30)
         await scene.settled()
         await editor.expectEditor.toContain('gdt::flatness(')
         await editor.expectEditor.toContain('faces = [capEnd001]')
-        await editor.expectEditor.toContain('tolerance = 0.2mm')
+        await editor.expectEditor.toContain('tolerance = 0.2in')
         await editor.expectEditor.toContain('precision = 3')
         await editor.expectEditor.toContain('framePosition = [20, 30]')
         await editor.expectEditor.toContain('framePlane = XZ')

--- a/e2e/playwright/point-click.spec.ts
+++ b/e2e/playwright/point-click.spec.ts
@@ -3724,15 +3724,15 @@ extrude001 = extrude(region001, length = 30)`
             stage: 'arguments',
             commandName: 'GDT Flatness',
             currentArgKey: 'tolerance',
-            currentArgValue: '0.1mm',
+            currentArgValue: '0.1in',
             headerArguments: {
               Faces: '1 face',
               Tolerance: '',
             },
             highlightedHeaderArg: 'tolerance',
           })
-          // Set tolerance to 0.1mm
-          await cmdBar.currentArgumentInput.locator('.cm-content').fill('0.1mm')
+          // Set tolerance to 0.1in
+          await cmdBar.currentArgumentInput.locator('.cm-content').fill('0.1in')
         })
 
         await test.step('Review basic parameters', async () => {
@@ -3742,7 +3742,7 @@ extrude001 = extrude(region001, length = 30)`
             commandName: 'GDT Flatness',
             headerArguments: {
               Faces: '1 face',
-              Tolerance: '0.1mm',
+              Tolerance: '0.1in',
             },
           })
         })
@@ -3758,7 +3758,7 @@ extrude001 = extrude(region001, length = 30)`
             currentArgValue: '3',
             headerArguments: {
               Faces: '1 face',
-              Tolerance: '0.1mm',
+              Tolerance: '0.1in',
               Precision: '',
             },
             highlightedHeaderArg: 'precision',
@@ -3772,7 +3772,7 @@ extrude001 = extrude(region001, length = 30)`
             commandName: 'GDT Flatness',
             headerArguments: {
               Faces: '1 face',
-              Tolerance: '0.1mm',
+              Tolerance: '0.1in',
               Precision: '5',
             },
           })
@@ -3788,7 +3788,7 @@ extrude001 = extrude(region001, length = 30)`
             currentArgValue: '[0, 0]',
             headerArguments: {
               Faces: '1 face',
-              Tolerance: '0.1mm',
+              Tolerance: '0.1in',
               Precision: '5',
               FramePosition: '',
             },
@@ -3804,7 +3804,7 @@ extrude001 = extrude(region001, length = 30)`
             commandName: 'GDT Flatness',
             headerArguments: {
               Faces: '1 face',
-              Tolerance: '0.1mm',
+              Tolerance: '0.1in',
               Precision: '5',
               FramePosition: '[10, 10]',
             },
@@ -3820,7 +3820,7 @@ extrude001 = extrude(region001, length = 30)`
             currentArgValue: '',
             headerArguments: {
               Faces: '1 face',
-              Tolerance: '0.1mm',
+              Tolerance: '0.1in',
               Precision: '5',
               FramePosition: '[10, 10]',
               FramePlane: '',
@@ -3835,7 +3835,7 @@ extrude001 = extrude(region001, length = 30)`
             commandName: 'GDT Flatness',
             headerArguments: {
               Faces: '1 face',
-              Tolerance: '0.1mm',
+              Tolerance: '0.1in',
               Precision: '5',
               FramePosition: '[10, 10]',
               FramePlane: 'XY',
@@ -3852,7 +3852,7 @@ extrude001 = extrude(region001, length = 30)`
             currentArgValue: '10mm',
             headerArguments: {
               Faces: '1 face',
-              Tolerance: '0.1mm',
+              Tolerance: '0.1in',
               Precision: '5',
               FramePosition: '[10, 10]',
               FramePlane: 'XY',
@@ -3869,7 +3869,7 @@ extrude001 = extrude(region001, length = 30)`
             commandName: 'GDT Flatness',
             headerArguments: {
               Faces: '1 face',
-              Tolerance: '0.1mm',
+              Tolerance: '0.1in',
               Precision: '5',
               FramePosition: '[10, 10]',
               FramePlane: 'XY',
@@ -3885,7 +3885,7 @@ extrude001 = extrude(region001, length = 30)`
         await editor.expectEditor.not.toContain('experimentalFeatures = allow')
         await editor.expectEditor.toContain('gdt::flatness(')
         await editor.expectEditor.toContain('faces = [capEnd001]')
-        await editor.expectEditor.toContain('tolerance = 0.1mm')
+        await editor.expectEditor.toContain('tolerance = 0.1in')
         await editor.expectEditor.toContain('precision = 5')
         await editor.expectEditor.toContain('framePosition = [10, 10]')
         await editor.expectEditor.toContain('framePlane = XY')
@@ -3906,9 +3906,9 @@ extrude001 = extrude(region001, length = 30)`
           stage: 'arguments',
           commandName: 'GDT Flatness',
           currentArgKey: 'tolerance',
-          currentArgValue: '0.1mm',
+          currentArgValue: '0.1in',
           headerArguments: {
-            Tolerance: '0.1mm',
+            Tolerance: '0.1in',
             Precision: '5',
             FramePosition: '[10, 10]',
             FramePlane: 'XY',
@@ -3924,9 +3924,9 @@ extrude001 = extrude(region001, length = 30)`
             stage: 'arguments',
             commandName: 'GDT Flatness',
             currentArgKey: 'tolerance',
-            currentArgValue: '0.1mm',
+            currentArgValue: '0.1in',
             headerArguments: {
-              Tolerance: '0.1mm',
+              Tolerance: '0.1in',
               Precision: '5',
               FramePosition: '[10, 10]',
               FramePlane: 'XY',
@@ -3934,15 +3934,15 @@ extrude001 = extrude(region001, length = 30)`
             },
             highlightedHeaderArg: 'tolerance',
           })
-          // Update tolerance from 0.1mm to 0.2mm
-          await cmdBar.currentArgumentInput.locator('.cm-content').fill('0.2mm')
+          // Update tolerance from 0.1in to 0.2in
+          await cmdBar.currentArgumentInput.locator('.cm-content').fill('0.2in')
           await cmdBar.progressCmdBar()
           // Review changes to tolerance
           await cmdBar.expectState({
             stage: 'review',
             commandName: 'GDT Flatness',
             headerArguments: {
-              Tolerance: '0.2mm',
+              Tolerance: '0.2in',
               Precision: '5',
               FramePosition: '[10, 10]',
               FramePlane: 'XY',
@@ -3959,7 +3959,7 @@ extrude001 = extrude(region001, length = 30)`
             currentArgKey: 'precision',
             currentArgValue: '5',
             headerArguments: {
-              Tolerance: '0.2mm',
+              Tolerance: '0.2in',
               Precision: '5',
               FramePosition: '[10, 10]',
               FramePlane: 'XY',
@@ -3975,7 +3975,7 @@ extrude001 = extrude(region001, length = 30)`
             stage: 'review',
             commandName: 'GDT Flatness',
             headerArguments: {
-              Tolerance: '0.2mm',
+              Tolerance: '0.2in',
               Precision: '3',
               FramePosition: '[10, 10]',
               FramePlane: 'XY',
@@ -3992,7 +3992,7 @@ extrude001 = extrude(region001, length = 30)`
             currentArgKey: 'framePosition',
             currentArgValue: '[10, 10]',
             headerArguments: {
-              Tolerance: '0.2mm',
+              Tolerance: '0.2in',
               Precision: '3',
               FramePosition: '[10, 10]',
               FramePlane: 'XY',
@@ -4009,7 +4009,7 @@ extrude001 = extrude(region001, length = 30)`
             stage: 'review',
             commandName: 'GDT Flatness',
             headerArguments: {
-              Tolerance: '0.2mm',
+              Tolerance: '0.2in',
               Precision: '3',
               FramePosition: '[20, 30]',
               FramePlane: 'XY',
@@ -4026,7 +4026,7 @@ extrude001 = extrude(region001, length = 30)`
             currentArgKey: 'framePlane',
             currentArgValue: '',
             headerArguments: {
-              Tolerance: '0.2mm',
+              Tolerance: '0.2in',
               Precision: '3',
               FramePosition: '[20, 30]',
               FramePlane: 'XY',
@@ -4041,7 +4041,7 @@ extrude001 = extrude(region001, length = 30)`
             stage: 'review',
             commandName: 'GDT Flatness',
             headerArguments: {
-              Tolerance: '0.2mm',
+              Tolerance: '0.2in',
               Precision: '3',
               FramePosition: '[20, 30]',
               FramePlane: 'XZ',
@@ -4058,7 +4058,7 @@ extrude001 = extrude(region001, length = 30)`
             currentArgKey: 'fontSize',
             currentArgValue: '12mm',
             headerArguments: {
-              Tolerance: '0.2mm',
+              Tolerance: '0.2in',
               Precision: '3',
               FramePosition: '[20, 30]',
               FramePlane: 'XZ',
@@ -4074,7 +4074,7 @@ extrude001 = extrude(region001, length = 30)`
             stage: 'review',
             commandName: 'GDT Flatness',
             headerArguments: {
-              Tolerance: '0.2mm',
+              Tolerance: '0.2in',
               Precision: '3',
               FramePosition: '[20, 30]',
               FramePlane: 'XZ',
@@ -4089,7 +4089,7 @@ extrude001 = extrude(region001, length = 30)`
         await scene.settled()
         await editor.expectEditor.toContain('gdt::flatness(')
         await editor.expectEditor.toContain('faces = [capEnd001]')
-        await editor.expectEditor.toContain('tolerance = 0.2mm')
+        await editor.expectEditor.toContain('tolerance = 0.2in')
         await editor.expectEditor.toContain('precision = 3')
         await editor.expectEditor.toContain('framePosition = [20, 30]')
         await editor.expectEditor.toContain('framePlane = XZ')

--- a/rust/kcl-lib/src/std/gdt.rs
+++ b/rust/kcl-lib/src/std/gdt.rs
@@ -973,6 +973,7 @@ async fn inner_flatness(
     )
     .await?;
     let mut annotations = Vec::with_capacity(faces.len());
+    let display_units = exec_state.length_unit();
     for face in &faces {
         let face_id = args.get_adjacent_face_to_tag(exec_state, face, false).await?;
         let meta = vec![Metadata::from(args.source_range)];
@@ -985,7 +986,7 @@ async fn inner_flatness(
             .control_frame(
                 AnnotationMbdControlFrame::builder()
                     .symbol(MbdSymbol::Flatness)
-                    .tolerance(tolerance.to_mm())
+                    .tolerance(tolerance.to_length_units(display_units))
                     .build(),
             )
             .plane_id(frame_plane.id)
@@ -1137,7 +1138,8 @@ async fn create_feature_control_annotation(
 ) -> Result<(), KclError> {
     let meta = vec![Metadata::from(args.source_range)];
     let annotation_id = exec_state.next_uuid();
-    let control_frame = gdt_control_frame(symbol, tolerance.to_mm(), datums);
+    let display_units = exec_state.length_unit();
+    let control_frame = gdt_control_frame(symbol, tolerance.to_length_units(display_units), datums);
     let feature_control = AnnotationFeatureControl::builder()
         .entity_id(entity_id)
         .entity_pos(KPoint2d { x: 0.5, y: 0.5 })
@@ -1385,6 +1387,35 @@ gdt::distance(
 )
 "#;
 
+    const GDT_FLATNESS_KCL_TEMPLATE: &str = r#"
+@settings(defaultLengthUnit = __UNIT__, kclVersion = 2)
+
+sketch001 = sketch(on = XY) {
+  line1 = line(start = [var 0mm, var 0mm], end = [var 10mm, var 0mm])
+  line2 = line(start = [var 10mm, var 0mm], end = [var 10mm, var 10mm])
+  line3 = line(start = [var 10mm, var 10mm], end = [var 0mm, var 10mm])
+  line4 = line(start = [var 0mm, var 10mm], end = [var 0mm, var 0mm])
+  coincident([line1.end, line2.start])
+  coincident([line2.end, line3.start])
+  coincident([line3.end, line4.start])
+  coincident([line4.end, line1.start])
+  parallel([line2, line4])
+  parallel([line3, line1])
+  perpendicular([line1, line2])
+  horizontal(line3)
+}
+
+region001 = region(point = [5mm, 5mm], sketch = sketch001)
+extrude001 = extrude(region001, length = 10mm, tagEnd = $capEnd001)
+gdt::flatness(
+  faces = [capEnd001],
+  tolerance = __TOLERANCE__,
+  framePosition = __FRAME_POSITION__,
+  framePlane = XZ,
+  fontSize = 2in,
+)
+"#;
+
     fn gdt_distance_kcl(unit: &str, tolerance: &str, frame_position: &str) -> String {
         GDT_DISTANCE_KCL_TEMPLATE
             .replace("__UNIT__", unit)
@@ -1392,7 +1423,14 @@ gdt::distance(
             .replace("__FRAME_POSITION__", frame_position)
     }
 
-    async fn gdt_distance_commands(code: &str) -> Vec<ModelingCmd> {
+    fn gdt_flatness_kcl(unit: &str, tolerance: &str, frame_position: &str) -> String {
+        GDT_FLATNESS_KCL_TEMPLATE
+            .replace("__UNIT__", unit)
+            .replace("__TOLERANCE__", tolerance)
+            .replace("__FRAME_POSITION__", frame_position)
+    }
+
+    async fn gdt_commands(code: &str) -> Vec<ModelingCmd> {
         let result = parse_execute(code).await.unwrap();
         result
             .root_module_artifact_commands()
@@ -1415,6 +1453,14 @@ gdt::distance(
             panic!("expected new_annotation command, got {command:?}");
         };
         new_annotation.options.dimension.as_ref().unwrap()
+    }
+
+    #[track_caller]
+    fn feature_control(command: &ModelingCmd) -> &AnnotationFeatureControl {
+        let ModelingCmd::NewAnnotation(new_annotation) = command else {
+            panic!("expected new_annotation command, got {command:?}");
+        };
+        new_annotation.options.feature_control.as_ref().unwrap()
     }
 
     #[track_caller]
@@ -1444,6 +1490,30 @@ gdt::distance(
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn gdt_flatness_uses_scene_units_for_control_frame_tolerance() {
+        let cases = [
+            ("in", "0.1in", "[10, -10]", 0.1, 254.0, -254.0),
+            ("cm", "10mm", "[1, -1]", 1.0, 10.0, -10.0),
+        ];
+
+        for (default_unit, tolerance, frame_position, expected_tolerance, expected_x, expected_y) in cases {
+            let code = gdt_flatness_kcl(default_unit, tolerance, frame_position);
+            let commands = gdt_commands(&code).await;
+            let annotation_index = new_annotation_command_index(&commands);
+            let feature_control = feature_control(&commands[annotation_index]);
+            let control_frame = feature_control.control_frame.as_ref().unwrap();
+
+            assert_close(control_frame.tolerance, expected_tolerance);
+            assert_close(feature_control.offset.x, expected_x);
+            assert_close(feature_control.offset.y, expected_y);
+            assert_close(
+                f64::from(feature_control.font_scale),
+                gdt_font_scale_for_height_mm(50.8).into(),
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn gdt_distance_sets_scene_units_around_non_mm_annotation() {
         let cases = [
             (
@@ -1468,7 +1538,7 @@ gdt::distance(
 
         for (default_unit, tolerance, frame_position, scene_unit, expected_tolerance, expected_x, expected_y) in cases {
             let code = gdt_distance_kcl(default_unit, tolerance, frame_position);
-            let commands = gdt_distance_commands(&code).await;
+            let commands = gdt_commands(&code).await;
             let annotation_index = new_annotation_command_index(&commands);
             let dimension = basic_dimension(&commands[annotation_index]);
 
@@ -1491,7 +1561,7 @@ gdt::distance(
     #[tokio::test(flavor = "multi_thread")]
     async fn gdt_distance_keeps_mm_annotation_in_current_scene_units() {
         let code = gdt_distance_kcl("mm", "2.54mm", "[10, -10]");
-        let commands = gdt_distance_commands(&code).await;
+        let commands = gdt_commands(&code).await;
         let annotation_index = new_annotation_command_index(&commands);
         let dimension = basic_dimension(&commands[annotation_index]);
 

--- a/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
@@ -1,5 +1,11 @@
 import { getNextAvailableDatumName } from '@src/lang/modifyAst/gdt'
 import { assertParse } from '@src/lang/wasm'
+import {
+  getDefaultGdtTolerance,
+  modelingMachineCommandConfig,
+} from '@src/lib/commandBarConfigs/modelingCommandConfig'
+import type { KclCommandValue } from '@src/lib/commandTypes'
+import type { ModelingMachineContext } from '@src/machines/modelingSharedTypes'
 import { buildTheWorldAndNoEngineConnection } from '@src/unitTestUtils'
 import { describe, expect, it } from 'vitest'
 
@@ -18,5 +24,46 @@ gdt::datum(face = capEnd001, name = "A")`
 
     // Should return 'B' since 'A' is already used
     expect(getNextAvailableDatumName(ast)).toBe('B')
+  })
+})
+
+describe('GDT tolerance defaults', () => {
+  it('uses the current file unit for the tolerance input default', () => {
+    const modelingContext = {
+      kclManager: {
+        fileSettings: {
+          defaultLengthUnit: 'in',
+        },
+      },
+    } as unknown as ModelingMachineContext
+
+    expect(getDefaultGdtTolerance({}, modelingContext)).toBe('0.1in')
+    expect(getDefaultGdtTolerance({})).toBe('0.1mm')
+  })
+
+  it('wires the unit-aware default into tolerance-bearing GD&T commands', () => {
+    const commandNames = [
+      'GDT Flatness',
+      'GDT Position',
+      'GDT Profile',
+      'GDT Distance',
+      'GDT Perpendicularity',
+      'GDT Parallelism',
+    ] as const
+
+    for (const commandName of commandNames) {
+      const commandConfig = modelingMachineCommandConfig[commandName]
+      expect(Array.isArray(commandConfig)).toBe(false)
+      expect(commandConfig?.args?.tolerance).toMatchObject({
+        inputType: 'kcl',
+        defaultValue: getDefaultGdtTolerance,
+      })
+      expect(
+        commandConfig?.args?.tolerance?.valueSummary?.({
+          valueCalculated: '2.54mm',
+          valueText: '0.1in',
+        } as KclCommandValue)
+      ).toBe('0.1in')
+    }
   })
 })

--- a/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.integration.spec.ts
@@ -5,6 +5,7 @@ import {
   modelingMachineCommandConfig,
 } from '@src/lib/commandBarConfigs/modelingCommandConfig'
 import type { KclCommandValue } from '@src/lib/commandTypes'
+import { isArray } from '@src/lib/utils'
 import type { ModelingMachineContext } from '@src/machines/modelingSharedTypes'
 import { buildTheWorldAndNoEngineConnection } from '@src/unitTestUtils'
 import { describe, expect, it } from 'vitest'
@@ -53,13 +54,16 @@ describe('GDT tolerance defaults', () => {
 
     for (const commandName of commandNames) {
       const commandConfig = modelingMachineCommandConfig[commandName]
-      expect(Array.isArray(commandConfig)).toBe(false)
-      expect(commandConfig?.args?.tolerance).toMatchObject({
+      if (!commandConfig || isArray(commandConfig)) {
+        throw new Error(`${commandName} should have a single command config`)
+      }
+
+      expect(commandConfig.args?.tolerance).toMatchObject({
         inputType: 'kcl',
         defaultValue: getDefaultGdtTolerance,
       })
       expect(
-        commandConfig?.args?.tolerance?.valueSummary?.({
+        commandConfig.args?.tolerance?.valueSummary?.({
           valueCalculated: '2.54mm',
           valueText: '0.1in',
         } as KclCommandValue)

--- a/src/lib/commandBarConfigs/modelingCommandConfig.ts
+++ b/src/lib/commandBarConfigs/modelingCommandConfig.ts
@@ -595,6 +595,26 @@ const summarizeDatumKclValue = (value?: KclCommandValue) =>
       )
     : ''
 
+export const getDefaultGdtTolerance = (
+  _commandBarContext: unknown,
+  modelingContext?: ModelingMachineContext
+) => {
+  const defaultLengthUnit =
+    modelingContext?.kclManager.fileSettings.defaultLengthUnit ||
+    DEFAULT_DEFAULT_LENGTH_UNIT
+  return `${KCL_DEFAULT_TOLERANCE}${defaultLengthUnit}`
+}
+
+const summarizeGdtToleranceKclValue = (value?: KclCommandValue) =>
+  value?.valueText ?? ''
+
+const gdtToleranceProps = {
+  inputType: 'kcl',
+  defaultValue: getDefaultGdtTolerance,
+  valueSummary: summarizeGdtToleranceKclValue,
+  required: true,
+} satisfies CommandArgumentConfig<KclCommandValue, ModelingMachineContext>
+
 const datumsProps = {
   inputType: 'kcl',
   defaultValue: KCL_DEFAULT_DATUM_REFS,
@@ -2716,9 +2736,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         hidden: (context) => Boolean(context.argumentsToSubmit.nodeToEdit),
       },
       tolerance: {
-        inputType: 'kcl',
-        defaultValue: KCL_DEFAULT_TOLERANCE,
-        required: true,
+        ...gdtToleranceProps,
       },
       precision: {
         inputType: 'kcl',
@@ -2869,9 +2887,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         ...datumsProps,
       },
       tolerance: {
-        inputType: 'kcl',
-        defaultValue: KCL_DEFAULT_TOLERANCE,
-        required: true,
+        ...gdtToleranceProps,
       },
       precision: {
         inputType: 'kcl',
@@ -2948,9 +2964,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         ...datumsProps,
       },
       tolerance: {
-        inputType: 'kcl',
-        defaultValue: KCL_DEFAULT_TOLERANCE,
-        required: true,
+        ...gdtToleranceProps,
       },
       precision: {
         inputType: 'kcl',
@@ -3028,9 +3042,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         hidden: (context) => Boolean(context.argumentsToSubmit.nodeToEdit),
       },
       tolerance: {
-        inputType: 'kcl',
-        defaultValue: KCL_DEFAULT_TOLERANCE,
-        required: true,
+        ...gdtToleranceProps,
       },
       precision: {
         inputType: 'kcl',
@@ -3107,9 +3119,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         ...datumsProps,
       },
       tolerance: {
-        inputType: 'kcl',
-        defaultValue: KCL_DEFAULT_TOLERANCE,
-        required: true,
+        ...gdtToleranceProps,
       },
       precision: {
         inputType: 'kcl',
@@ -3186,9 +3196,7 @@ export const modelingMachineCommandConfig: StateMachineCommandSetConfig<
         ...datumsProps,
       },
       tolerance: {
-        inputType: 'kcl',
-        defaultValue: KCL_DEFAULT_TOLERANCE,
-        required: true,
+        ...gdtToleranceProps,
       },
       precision: {
         inputType: 'kcl',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -64,8 +64,8 @@ export const KCL_DEFAULT_CONSTANT_PREFIXES = {
 /** The default KCL length expression */
 export const KCL_DEFAULT_LENGTH = `5`
 
-/** The default KCL tolerance expression */
-export const KCL_DEFAULT_TOLERANCE = `0.1mm`
+/** The default KCL tolerance magnitude. Command configs add the active file unit. */
+export const KCL_DEFAULT_TOLERANCE = '0.1'
 
 /** The default KCL datum reference expression */
 export const KCL_DEFAULT_DATUM_REFS = `["A"]`

--- a/src/lib/kclHelpers.spec.ts
+++ b/src/lib/kclHelpers.spec.ts
@@ -2,9 +2,10 @@ import type { ParseResult, SourceRange } from '@src/lang/wasm'
 import {
   getCalculatedKclExpressionValue,
   getStringValue,
+  stringToKclExpression,
 } from '@src/lib/kclHelpers'
 import { buildTheWorldAndNoEngineConnection } from '@src/unitTestUtils'
-import { expect, describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 describe('KCL expression calculations', () => {
   it('calculates a simple expression without units', async () => {
@@ -26,6 +27,19 @@ describe('KCL expression calculations', () => {
     expect(coercedActual.valueAsString).toEqual('31deg')
     expect(coercedActual?.astNode).toBeDefined()
   })
+
+  it('preserves source units on KCL command expressions', async () => {
+    const { rustContext } = await buildTheWorldAndNoEngineConnection()
+    const actual = await stringToKclExpression('0.1in', rustContext)
+    const coercedActual = actual as Exclude<typeof actual, Error | ParseResult>
+    expect(coercedActual).not.toHaveProperty('errors')
+    expect(coercedActual.valueText).toBe('0.1in')
+    expect(coercedActual.valueAst).toMatchObject({
+      raw: '0.1in',
+      type: 'Literal',
+    })
+  })
+
   it('returns NAN for an invalid expression', async () => {
     const { rustContext } = await buildTheWorldAndNoEngineConnection()
     const actual = await getCalculatedKclExpressionValue('1 + x', rustContext)
@@ -207,7 +221,7 @@ describe('getStringValue', () => {
   })
 
   it('an empty string on bad range', () => {
-    const code = `badboi`
+    const code = 'badboi'
     const range: SourceRange = [10, 12, 0]
     const result = getStringValue(code, range)
     expect(result).toBe('')


### PR DESCRIPTION
ai assisted

## Problem
GD&T first-run workflows in inch files displayed tolerance magnitudes as millimeters. A user entering 0.1in could see 2.54 in the annotation path, which made the inch scene look like it ignored the file unit. This fixes #11737 and is a follow-up for #11568.

## Solution
GD&T tolerance command defaults now use the active file unit and command summaries preserve the source KCL text. Feature-control annotations send tolerance values in the scene default length unit instead of pre-converting them to millimeters, while distance annotations keep their existing temporary scene-unit switch because the engine auto-measures those dimensions.