### PR TITLE
Remove extraneous assertions, causing flakiness

### DIFF
--- a/e2e/playwright/testing-samples-loading.spec.ts
+++ b/e2e/playwright/testing-samples-loading.spec.ts
@@ -2,7 +2,6 @@ import { join } from 'node:path'
 import { bracket } from '@e2e/playwright/fixtures/bracket'
 import { FILE_EXT } from '@src/lib/constants'
 
-import type { CmdBarSerialised } from '@e2e/playwright/fixtures/cmdBarFixture'
 import { getUtils } from '@e2e/playwright/test-utils'
 import { expect, test } from '@e2e/playwright/zoo-test'
 import { DefaultLayoutPaneID } from '@src/lib/layout/configs/default'
@@ -91,8 +90,6 @@ test.describe('Testing loading external models', { tag: '@desktop' }, () => {
       )
     })
     const u = await getUtils(page)
-
-    // Locators and constants
     const sampleOne = {
       file: `ball-bearing${FILE_EXT}`,
       title: 'Ball Bearing',
@@ -101,51 +98,19 @@ test.describe('Testing loading external models', { tag: '@desktop' }, () => {
       folderName1: 'ball-bearing-1',
     }
     const projectCard = page.getByRole('link', { name: 'bracket' })
-    const overwriteWarning = page.getByText(
-      'Overwrite current file with sample?'
-    )
-    const newlyCreatedFile = (name: string) =>
-      page.getByRole('listitem').filter({
-        has: page.getByRole('button', { name }),
-      })
-    const defaultLoadCmdBarState: CmdBarSerialised = {
-      commandName: 'Add file to project',
-      currentArgKey: 'sample',
-      currentArgValue: '',
-      headerArguments: {
-        Method: 'Existing project',
-        Sample: '',
-        Source: 'kcl-samples',
-        ProjectName: 'bracket',
-      },
-      highlightedHeaderArg: 'sample',
-      stage: 'arguments',
-    }
 
-    await test.step('Test setup', async () => {
-      await page.setBodyDimensions({ width: 1200, height: 500 })
-      await projectCard.click()
-      await scene.settled()
-    })
-
-    await test.step('Precondition: check the initial code', async () => {
-      await u.openKclCodePanel()
-      await editor.scrollToText(bracket.split('\n')[0])
-      await editor.expectEditor.toContain(bracket.split('\n')[0])
-      await u.openFilePanel()
-      await expect(newlyCreatedFile(sampleOne.file)).not.toBeVisible()
-    })
+    await page.setBodyDimensions({ width: 1200, height: 500 })
+    await projectCard.click()
+    await scene.settled()
 
     await test.step('Load a KCL sample with the command palette', async () => {
       await toolbar.loadButton.click()
       await cmdBar.selectOption({ name: 'KCL Samples' }).click()
-      await cmdBar.expectState(defaultLoadCmdBarState)
       await cmdBar.selectOption({ name: sampleOne.title }).click()
-      await expect(overwriteWarning).not.toBeVisible()
     })
 
     await test.step('Ensure we made and opened a new file', async () => {
-      await editor.expectEditor.toContain(`// ${sampleOne.title}`)
+      await u.openFilePanel()
       await expect(
         page.getByTestId('file-tree-item').getByText(sampleOne.folderName)
       ).toBeVisible()
@@ -154,13 +119,11 @@ test.describe('Testing loading external models', { tag: '@desktop' }, () => {
     await test.step('Load a KCL sample with the command palette', async () => {
       await toolbar.loadButton.click()
       await cmdBar.selectOption({ name: 'KCL Samples' }).click()
-      await cmdBar.expectState(defaultLoadCmdBarState)
       await cmdBar.selectOption({ name: sampleOne.title }).click()
-      await expect(overwriteWarning).not.toBeVisible()
     })
 
     await test.step('Ensure we made and opened a new file with a unique name', async () => {
-      await editor.expectEditor.toContain(`// ${sampleOne.title}`)
+      await u.openFilePanel()
       await expect(
         page.getByTestId('file-tree-item').getByText(sampleOne.folderName1)
       ).toBeVisible()

--- a/e2e/playwright/testing-samples-loading.spec.ts
+++ b/e2e/playwright/testing-samples-loading.spec.ts
@@ -104,7 +104,6 @@ test.describe('Testing loading external models', { tag: '@desktop' }, () => {
     const overwriteWarning = page.getByText(
       'Overwrite current file with sample?'
     )
-    const headerFileName = page.getByTestId('app-header-file-name')
     const newlyCreatedFile = (name: string) =>
       page.getByRole('listitem').filter({
         has: page.getByRole('button', { name }),
@@ -134,8 +133,6 @@ test.describe('Testing loading external models', { tag: '@desktop' }, () => {
       await editor.scrollToText(bracket.split('\n')[0])
       await editor.expectEditor.toContain(bracket.split('\n')[0])
       await u.openFilePanel()
-
-      await expect(headerFileName).toContainText('main.kcl')
       await expect(newlyCreatedFile(sampleOne.file)).not.toBeVisible()
     })
 
@@ -145,7 +142,6 @@ test.describe('Testing loading external models', { tag: '@desktop' }, () => {
       await cmdBar.expectState(defaultLoadCmdBarState)
       await cmdBar.selectOption({ name: sampleOne.title }).click()
       await expect(overwriteWarning).not.toBeVisible()
-      await expect(headerFileName).toContainText('main.kcl')
     })
 
     await test.step('Ensure we made and opened a new file', async () => {
@@ -153,7 +149,6 @@ test.describe('Testing loading external models', { tag: '@desktop' }, () => {
       await expect(
         page.getByTestId('file-tree-item').getByText(sampleOne.folderName)
       ).toBeVisible()
-      await expect(headerFileName).toContainText('main.kcl')
     })
 
     await test.step('Load a KCL sample with the command palette', async () => {
@@ -162,9 +157,6 @@ test.describe('Testing loading external models', { tag: '@desktop' }, () => {
       await cmdBar.expectState(defaultLoadCmdBarState)
       await cmdBar.selectOption({ name: sampleOne.title }).click()
       await expect(overwriteWarning).not.toBeVisible()
-      await expect(headerFileName).toContainText('main.kcl', {
-        timeout: 30_000,
-      })
     })
 
     await test.step('Ensure we made and opened a new file with a unique name', async () => {
@@ -172,9 +164,6 @@ test.describe('Testing loading external models', { tag: '@desktop' }, () => {
       await expect(
         page.getByTestId('file-tree-item').getByText(sampleOne.folderName1)
       ).toBeVisible()
-      await expect(headerFileName).toContainText('main.kcl', {
-        timeout: 30_000,
-      })
     })
   })
 })


### PR DESCRIPTION
[This test](https://test-analysis-bot.corp.zoo.dev/projects/KittyCAD/modeling-app/tests/15048?branch=fix-samples-test) was doing way too much: checking KCL contents and header labels after every step. The goal of this test is to verify that a sample can be inserted twice and gets a unique name. The other checks are unnecessary and introduced flakiness so have been removed.
