### PR TITLE
Run Vercel e2e even when the deployment fails

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -457,6 +457,7 @@ jobs:
         uses: patrickedqvist/wait-for-vercel-preview@v1.3.3
         id: wait-for-vercel-preview
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           max_timeout: 1200 # average build times are 17-18 minutes
@@ -467,6 +468,7 @@ jobs:
         uses: patrickedqvist/wait-for-vercel-preview@v1.3.3
         id: wait-for-vercel-staging
         if: github.event_name == 'push' && github.ref_name == 'main'
+        continue-on-error: true
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           environment: staging
@@ -476,6 +478,7 @@ jobs:
 
       - name: Check Vercel
         run: .github/ci-cd-scripts/check-vercel.sh
+        continue-on-error: true
         env:
           VERCEL_BASE_URL: ${{ steps.wait-for-vercel-preview.outputs.url || steps.wait-for-vercel-staging.outputs.url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}


### PR DESCRIPTION
This builds on https://github.com/KittyCAD/modeling-app/pull/11765 to let the Test Analysis Bot be the source of truth for blocking merges on the health of the Vercel deployment.