### PR TITLE
[codex] Reload settings through settings actor

### DIFF
--- a/src/components/RouteProvider.tsx
+++ b/src/components/RouteProvider.tsx
@@ -1,16 +1,15 @@
+import { useSignals } from '@preact/signals-react/runtime'
+import { useAuthNavigation } from '@src/hooks/useAuthNavigation'
+import { useFileSystemWatcher } from '@src/hooks/useFileSystemWatcher'
+import { useApp, useSingletons } from '@src/lib/boot'
+import { getAppSettingsFilePath } from '@src/lib/desktop'
 import fsZds from '@src/lib/fs-zds'
+import { PATHS, getStringAfterLastSeparator } from '@src/lib/paths'
+import { markOnce } from '@src/lib/performance'
+import { trap } from '@src/lib/trap'
 import type { ReactNode } from 'react'
 import { createContext, useEffect, useState } from 'react'
 import { useLocation, useNavigate, useNavigation } from 'react-router-dom'
-import { useAuthNavigation } from '@src/hooks/useAuthNavigation'
-import { useFileSystemWatcher } from '@src/hooks/useFileSystemWatcher'
-import { getAppSettingsFilePath } from '@src/lib/desktop'
-import { PATHS, getStringAfterLastSeparator } from '@src/lib/paths'
-import { markOnce } from '@src/lib/performance'
-import { loadAndValidateSettings } from '@src/lib/settings/settingsUtils'
-import { useApp, useSingletons } from '@src/lib/boot'
-import { trap } from '@src/lib/trap'
-import { useSignals } from '@preact/signals-react/runtime'
 
 export const RouteProviderContext = createContext({})
 
@@ -130,14 +129,8 @@ export function RouteProvider({ children }: { children: ReactNode }) {
 
       // Note: currently settings are watched, reloaded even if it was initiated by us (e.g. by a user changing some settings),
       // writeCausedByAppCheckedInFileTreeFileSystemWatcher is not used here.
-      const data = await loadAndValidateSettings(
-        kclManager.wasmInstancePromise,
-        loadedProject?.path
-      )
       settingsActor.send({
-        type: 'Set all settings',
-        settings: data.settings,
-        doNotPersist: true,
+        type: 'reload.settings',
       })
     },
     [settingsPath, loadedProject?.path].filter(

--- a/src/lib/app.spec.ts
+++ b/src/lib/app.spec.ts
@@ -1,13 +1,13 @@
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { pluginsValueSpec } from '@kittycad/registry'
-import { App } from '@src/lib/app'
 import { File } from '@src/lang/KclManager'
+import { App } from '@src/lib/app'
+import { StorageName, moduleFsViaModuleImport } from '@src/lib/fs-zds'
 import type { Project } from '@src/lib/project'
 import { getChangedSettingsAtLevel } from '@src/lib/settings/settingsUtils'
 import { appHeaderItemsValueSpec } from '@src/registry/contracts/appHeader'
 import { executingEditorService } from '@src/registry/contracts/executingEditor'
 import { loadWasm } from '@src/unitTestUtils'
-import { moduleFsViaModuleImport, StorageName } from '@src/lib/fs-zds'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
 const mockProject: Project = {
   name: 'test',
@@ -160,6 +160,30 @@ describe('project system', () => {
       >
       expect(textEditorSettings.automaticallyRender.current).toBe(true)
       expect(textEditorSettings.automaticallyRender.hideOnLevel).toBe('project')
+    } finally {
+      disposeApp(app)
+    }
+  })
+
+  it('reloads settings without dropping extension-backed plugin settings', async () => {
+    const app = App.fromProvided({
+      wasmPromise: loadWasm(),
+    })
+
+    try {
+      await waitForSettingsIdle(app)
+
+      const telemetryPlugin = app.registry
+        .get(pluginsValueSpec)
+        .find((plugin) => plugin.id === 'telemetry')
+      expect(telemetryPlugin).toBeDefined()
+
+      app.settings.actor.send({ type: 'reload.settings' } as never)
+
+      await waitForSettingsIdle(app)
+
+      expect(app.settings.get().plugins.telemetry.current).toBe(true)
+      expect(app.registry.get(telemetryPlugin!.service).active.value).toBe(true)
     } finally {
       disposeApp(app)
     }

--- a/src/machines/settingsMachine.ts
+++ b/src/machines/settingsMachine.ts
@@ -18,9 +18,9 @@ import {
 } from '@src/lib/commandBarConfigs/settingsCommandConfig'
 import type { Command } from '@src/lib/commandTypes'
 import type { Project } from '@src/lib/project'
+import type { ResolvedExtensionSettings } from '@src/lib/settings/extensionSettings'
 import type { SettingsType } from '@src/lib/settings/initialSettings'
 import { createSettings } from '@src/lib/settings/initialSettings'
-import type { ResolvedExtensionSettings } from '@src/lib/settings/extensionSettings'
 import type {
   BaseUnit,
   SetEventTypes,
@@ -39,8 +39,8 @@ import {
   getSystemTheme,
   setThemeClass,
 } from '@src/lib/theme'
-import type { commandBarMachine } from '@src/machines/commandBarMachine'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
+import type { commandBarMachine } from '@src/machines/commandBarMachine'
 
 export type SettingsActorDepsType = {
   currentProject?: Project
@@ -80,6 +80,7 @@ export const settingsMachine = setup({
           }
         }
       | { type: 'load.project'; project: Project }
+      | { type: 'reload.settings' }
       | { type: 'clear.project' }
     ) & { doNotPersist?: boolean },
   },
@@ -144,6 +145,23 @@ export const settingsMachine = setup({
         {
           extensionSettings: input.extensionSettings,
           projectPath: input.project.path,
+        }
+      )
+      return settings
+    }),
+    reloadSettings: fromPromise<
+      SettingsType,
+      {
+        currentProject?: Project
+        extensionSettings: ResolvedExtensionSettings
+        wasmInstancePromise: Promise<ModuleType>
+      }
+    >(async ({ input }) => {
+      const { settings } = await loadAndValidateSettings(
+        input.wasmInstancePromise,
+        {
+          extensionSettings: input.extensionSettings,
+          projectPath: input.currentProject?.path,
         }
       )
       return settings
@@ -499,6 +517,10 @@ export const settingsMachine = setup({
           target: 'loadingProject',
         },
 
+        'reload.settings': {
+          target: 'reloadingSettings',
+        },
+
         'clear.project': {
           target: 'idle',
           reenter: true,
@@ -512,6 +534,34 @@ export const settingsMachine = setup({
             })),
           ],
         },
+      },
+    },
+    reloadingSettings: {
+      invoke: {
+        src: 'reloadSettings',
+        onDone: {
+          target: 'idle',
+          actions: [
+            'setAllSettings',
+            'sendThemeToWatcher',
+            sendTo('registerCommands', ({ context }) => ({
+              type: 'update',
+              settings: getOnlySettingsFromContext(context),
+              commandBarActor: context.commandBarActor,
+            })),
+          ],
+        },
+        onError: {
+          target: 'idle',
+          actions: ({ event }) => {
+            console.error('Error reloading settings', event)
+          },
+        },
+        input: ({ context }) => ({
+          currentProject: context.currentProject,
+          extensionSettings: context.extensionSettings,
+          wasmInstancePromise: context.wasmInstancePromise,
+        }),
       },
     },
 


### PR DESCRIPTION
## Summary

- Route desktop settings file watcher reloads through the settings actor with `reload.settings`.
- Reuse the actor's stored `extensionSettings` when reloading user/project settings.
- Add a regression test that reloads settings without dropping extension-backed plugin settings.

## Root Cause

The desktop settings watcher called `loadAndValidateSettings(...)` directly with only the project path. That bypassed the settings actor input and rebuilt settings without registry-provided `extensionSettings`, so extension-contributed settings such as plugin activation settings could disappear on desktop reload.

## Validation

- `NODE_OPTIONS=--localstorage-file=/private/tmp/zds-vitest-localstorage npx vitest run --mode=development --project=integration src/lib/app.spec.ts`
- `npx tsc --noEmit --pretty false`