### PR TITLE
Fix: "start sketch" icon color in light mode

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -98,6 +98,9 @@ export const KCL_DEFAULT_COLOR = `#3c73ff`
 export const SKETCH_SELECTION_RGB = [255, 183, 39]
 /** The sketch mode revamp selection rgb values as a string */
 export const SKETCH_SELECTION_RGB_STR = SKETCH_SELECTION_RGB.join(', ')
+export const SKETCH_DEFAULT_PLANE_XY = '#ef4444'
+export const SKETCH_DEFAULT_PLANE_XZ = '#3b82f6'
+export const SKETCH_DEFAULT_PLANE_YZ = '#22c55e'
 
 /**
  * Converts an RGB array [r, g, b] to a single integer color value (0xRRGGBB format).

--- a/src/lib/toolbar.ts
+++ b/src/lib/toolbar.ts
@@ -4,6 +4,12 @@ import type { EventFrom, StateFrom } from 'xstate'
 import type { CustomIconName } from '@src/components/CustomIcon'
 import { createLiteral } from '@src/lang/create'
 import { useApp } from '@src/lib/boot'
+import {
+  SKETCH_DEFAULT_PLANE_XY,
+  SKETCH_DEFAULT_PLANE_XZ,
+  SKETCH_DEFAULT_PLANE_YZ,
+  SKETCH_SELECTION_RGB_STR,
+} from '@src/lib/constants'
 import type { HotkeySequence } from '@src/lib/hotkeys'
 import { isDesktop } from '@src/lib/isDesktop'
 import { userHasFeature } from '@src/lib/settings/settingsUtils'
@@ -2337,25 +2343,23 @@ function getSelectedSketchTargetPlane(selectionRanges: Selections) {
   })
 }
 
-const sketchIconColors = {
-  faceOrPlane: '#eab308',
-  xy: '#ef4444',
-  xz: '#3b82f6',
-  yz: '#22c55e',
-}
-
 function getSelectedSketchIconColor(
   selectionRanges: Selections
 ): string | undefined {
   const defaultPlane = getSelectedDefaultPlane(selectionRanges)
   if (defaultPlane) {
-    return sketchIconColors[
-      defaultPlane.name.toLowerCase() as keyof typeof sketchIconColors
-    ]
+    switch (defaultPlane.name.toLowerCase()) {
+      case 'xy':
+        return SKETCH_DEFAULT_PLANE_XY
+      case 'xz':
+        return SKETCH_DEFAULT_PLANE_XZ
+      case 'yz':
+        return SKETCH_DEFAULT_PLANE_YZ
+    }
   }
 
   return getSelectedSketchTargetPlane(selectionRanges)
-    ? sketchIconColors.faceOrPlane
+    ? `rgb(${SKETCH_SELECTION_RGB_STR})`
     : undefined
 }
 

--- a/src/lib/toolbar.ts
+++ b/src/lib/toolbar.ts
@@ -2338,26 +2338,25 @@ function getSelectedSketchTargetPlane(selectionRanges: Selections) {
 }
 
 const sketchIconColors = {
-  default: '#fff',
   faceOrPlane: '#eab308',
   xy: '#ef4444',
   xz: '#3b82f6',
   yz: '#22c55e',
 }
 
-function getSelectedSketchIconColor(selectionRanges: Selections): string {
+function getSelectedSketchIconColor(
+  selectionRanges: Selections
+): string | undefined {
   const defaultPlane = getSelectedDefaultPlane(selectionRanges)
   if (defaultPlane) {
-    return (
-      sketchIconColors[
-        defaultPlane.name.toLowerCase() as keyof typeof sketchIconColors
-      ] ?? sketchIconColors.default
-    )
+    return sketchIconColors[
+      defaultPlane.name.toLowerCase() as keyof typeof sketchIconColors
+    ]
   }
 
   return getSelectedSketchTargetPlane(selectionRanges)
     ? sketchIconColors.faceOrPlane
-    : sketchIconColors.default
+    : undefined
 }
 
 export const useToolbarConfig = () => {


### PR DESCRIPTION
https://github.com/KittyCAD/modeling-app/pull/11596/changes#diff-fb60b5fd05d445996d60b5c16813a421baa18c41014f87f43af3a40585f651c1R2351-R2356 broke this

It was a mistake to use a default #fff color, now we just fallback to inherit the normal toolbar text color, which is black/white based on the current theme.