### PR TITLE
Add 'S' shortcut support for Start sketch with existing selection

### DIFF
--- a/src/registry/extensions/commands/toolbarCommands.ts
+++ b/src/registry/extensions/commands/toolbarCommands.ts
@@ -1,7 +1,11 @@
 import type { KclManager } from '@src/lang/KclManager'
-import { isCursorInFunctionDefinition } from '@src/lang/queryAst'
+import {
+  getSelectedSketchTarget,
+  isCursorInFunctionDefinition,
+} from '@src/lang/queryAst'
 import { isCursorInSketchCommandRange } from '@src/lang/util'
 import type { Command } from '@src/lib/commandTypes'
+import { selectSketchPlane } from '@src/lib/selections'
 import { userHasFeature } from '@src/lib/settings/settingsUtils'
 import type { CommandBarContext } from '@src/machines/commandBarMachine'
 import type {
@@ -266,15 +270,40 @@ async function enterSketch(input: unknown) {
         state.context.selectionRanges
       )
   const isSketchBlock = isSketchBlockSelected(state.context.selectionRanges)
+  const selectedSketchTarget = getSelectedSketchTarget(
+    state.context.selectionRanges
+  )
 
   if ((kclManager.editorView.hasFocus && sketchPathId) || isSketchBlock) {
     return sendModelingEvent(input, { type: 'Enter sketch' })
   }
 
-  return sendModelingEvent(input, {
+  if (!selectedSketchTarget) {
+    return sendModelingEvent(input, {
+      type: 'Enter sketch',
+      data: { forceNewSketch: true },
+    })
+  }
+
+  const result = sendModelingEvent(input, {
     type: 'Enter sketch',
-    data: { forceNewSketch: true },
+    data: {
+      forceNewSketch: true,
+      keepDefaultPlaneVisibility: true,
+    },
   })
+
+  if (result instanceof Error) {
+    return result
+  }
+
+  void selectSketchPlane(
+    selectedSketchTarget,
+    state.context.store.useSketchSolveMode?.current,
+    kclManager
+  )
+
+  return result
 }
 
 function exitSketch(input: unknown) {


### PR DESCRIPTION
Now `S` shortcut works with a plane pre-selection.

I missed this from https://github.com/KittyCAD/modeling-app/pull/11596
