### PR TITLE
Stop sending Git-ignored files to Zookeeper

### DIFF
--- a/src/machines/systemIO/utils.spec.ts
+++ b/src/machines/systemIO/utils.spec.ts
@@ -143,11 +143,12 @@ describe('System IO Utils', () => {
     expect(preparedPayload?.filesToDelete).toEqual([])
   })
 
-  it('collects project files from disk instead of filtered explorer children', async () => {
+  it('collects project files from disk and excludes .gitignore patterns', async () => {
     const projectPath = `/tmp/opencode/zookeeper-project-${crypto.randomUUID()}`
     await fsZds.mkdir(fsZds.join(projectPath, '.hidden-dir'), {
       recursive: true,
     })
+    await fsZds.mkdir(fsZds.join(projectPath, 'dist'), { recursive: true })
     await fsZds.writeFile(
       fsZds.join(projectPath, 'main.kcl'),
       new TextEncoder().encode('cube()')
@@ -162,11 +163,15 @@ describe('System IO Utils', () => {
     )
     await fsZds.writeFile(
       fsZds.join(projectPath, '.gitignore'),
-      new TextEncoder().encode('dist')
+      new TextEncoder().encode('dist\nnotes.txt\n.hidden-dir/\n')
     )
     await fsZds.writeFile(
       fsZds.join(projectPath, '.hidden-dir', 'secret.txt'),
       new TextEncoder().encode('secret')
+    )
+    await fsZds.writeFile(
+      fsZds.join(projectPath, 'dist', 'ignored.kcl'),
+      new TextEncoder().encode('ignored = 1')
     )
 
     try {
@@ -199,9 +204,7 @@ describe('System IO Utils', () => {
 
       expect(projectFiles.map((file) => file.relPath).sort()).toEqual([
         '.gitignore',
-        '.hidden-dir/secret.txt',
         'main.kcl',
-        'notes.txt',
         'project.toml',
       ])
     } finally {

--- a/src/machines/systemIO/utils.ts
+++ b/src/machines/systemIO/utils.ts
@@ -3,6 +3,12 @@ import type { App } from '@src/lib/app'
 import { FILE_EXT, REGEXP_UUIDV4 } from '@src/lib/constants'
 import { fsZdsConstants } from '@src/lib/fs-zds/constants'
 import { getUniqueProjectName } from '@src/lib/desktopFS'
+import {
+  appendGitignoreForDirectory,
+  createInitialGitignoreStack,
+  isPathIgnoredByGitignore,
+  type GitignoreStackEntry,
+} from '@src/lib/gitignore'
 import { getFilePathRelativeToProject, joinOSPaths } from '@src/lib/paths'
 import type { Project } from '@src/lib/project'
 import type { FileMeta } from '@src/lib/types'
@@ -344,15 +350,34 @@ export const collectProjectFiles = async (args: {
       )
     }
 
-    const recursivelyPushFilePromisesFromPath = async (path: string) => {
+    const recursivelyPushFilePromisesFromPath = async (
+      path: string,
+      gitignoreStack: GitignoreStackEntry[]
+    ) => {
       const entries = await fsZds.readdir(path)
       for (const entry of entries) {
         const absolutePathToFileNameWithExtension = fsZds.join(path, entry)
+        const relativePath = (
+          fsZds.relative(basePath, absolutePathToFileNameWithExtension) ?? ''
+        ).replace(/\\/g, '/')
         const stat = await fsZds.stat(absolutePathToFileNameWithExtension)
+        const isDirectory = Boolean(stat.mode & fsZdsConstants.S_IFDIR)
 
-        if (Boolean(stat.mode & fsZdsConstants.S_IFDIR)) {
+        if (
+          isPathIgnoredByGitignore(gitignoreStack, relativePath, isDirectory)
+        ) {
+          continue
+        }
+
+        if (isDirectory) {
+          const childGitignoreStack = await appendGitignoreForDirectory(
+            gitignoreStack,
+            absolutePathToFileNameWithExtension,
+            basePath
+          )
           await recursivelyPushFilePromisesFromPath(
-            absolutePathToFileNameWithExtension
+            absolutePathToFileNameWithExtension,
+            childGitignoreStack
           )
           continue
         }
@@ -361,7 +386,8 @@ export const collectProjectFiles = async (args: {
       }
     }
 
-    await recursivelyPushFilePromisesFromPath(basePath)
+    const gitignoreStack = await createInitialGitignoreStack(basePath)
+    await recursivelyPushFilePromisesFromPath(basePath, gitignoreStack)
     projectFiles = (await Promise.all(filePromises)).filter(isNonNullable)
     const MB64 = 2 ** 20 * 64
     if (args.warnIfProjectExceeds64Mb !== false && uploadSize > MB64) {


### PR DESCRIPTION
This builds on https://github.com/KittyCAD/modeling-app/pull/11730 to stop sending files matching `.gitignore` to Zookeeper, which is wasteful and might create confusing results.

To test this:

1. Open the preview
2. Create a basic part (to generate a thumbnail)
3. Ask Zookeepers what files it can see

Before this would have included `thumbnail.png` and now it doesn't.