### PR TITLE
Add deprecation warning when consumed solids are used with hide() and flatten()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29041,7 +29041,7 @@
         "typescript": "^6.0.2"
       },
       "engines": {
-        "vscode": "^1.110.0"
+        "vscode": "^1.120.0"
       }
     },
     "rust/kcl-language-server/node_modules/@esbuild/aix-ppc64": {

--- a/rust/kcl-lib/src/execution/fn_call.rs
+++ b/rust/kcl-lib/src/execution/fn_call.rs
@@ -31,7 +31,9 @@ use crate::execution::types::RuntimeType;
 use crate::parsing::ast::types::CallExpressionKw;
 use crate::parsing::ast::types::Node;
 use crate::parsing::ast::types::Type;
+use crate::std::ConsumedSolidArgCheck;
 use crate::std::solid_consumption::validate_value_not_consumed;
+use crate::std::solid_consumption::warn_if_value_consumed_for_deprecated_call;
 
 #[derive(Debug, Clone)]
 pub struct Args<Status: ArgsStatus = Desugared> {
@@ -961,17 +963,34 @@ fn type_check_params_kw(
         }
     }
 
-    let check_consumed_solid_args = fn_def
+    let consumed_solid_arg_check = fn_def
         .std_props
         .as_ref()
-        .is_none_or(|props| props.check_consumed_solid_args);
-    if check_consumed_solid_args {
-        result
-            .unlabeled
-            .iter()
-            .map(|(_, arg)| arg)
-            .chain(result.labeled.values())
-            .try_for_each(|arg| validate_value_not_consumed(&arg.value, exec_state, arg.source_range))?;
+        .map_or(ConsumedSolidArgCheck::Error, |props| props.consumed_solid_arg_check);
+    match consumed_solid_arg_check {
+        ConsumedSolidArgCheck::Error => {
+            result
+                .unlabeled
+                .iter()
+                .map(|(_, arg)| arg)
+                .chain(result.labeled.values())
+                .try_for_each(|arg| validate_value_not_consumed(&arg.value, exec_state, arg.source_range))?;
+        }
+        ConsumedSolidArgCheck::WarnDeprecated => {
+            let std_fn_name = fn_def
+                .std_props
+                .as_ref()
+                .map(|props| props.name.as_str())
+                .unwrap_or("function");
+            for arg in result
+                .unlabeled
+                .iter()
+                .map(|(_, arg)| arg)
+                .chain(result.labeled.values())
+            {
+                warn_if_value_consumed_for_deprecated_call(&arg.value, exec_state, arg.source_range, std_fn_name);
+            }
+        }
     }
 
     Ok(result)

--- a/rust/kcl-lib/src/std/array.rs
+++ b/rust/kcl-lib/src/std/array.rs
@@ -337,11 +337,13 @@ fn infer_flattened_type(original_ty: RuntimeType, values: &[KclValue]) -> Runtim
 
 #[cfg(test)]
 mod tests {
+    use crate::errors::Severity;
+    use crate::errors::Tag;
     use crate::execution::KclValue;
     use crate::execution::MockConfig;
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn flatten_consumed_solid_does_not_report_kcl_error() {
+    async fn flatten_consumed_solid_reports_deprecation_warning() {
         let code = r#"
 targetSketch = sketch(on = XY) {
   line1 = line(start = [var -10, var -10], end = [var 10, var -10])
@@ -387,6 +389,20 @@ flattened = flatten([[target]])
                     panic!("expected `flattened` to be an array, got: {flattened:?}");
                 };
                 assert_eq!(value.len(), 1);
+                assert!(
+                    outcome.issues.iter().any(|issue| {
+                        issue.severity == Severity::Warning
+                            && issue.tag == Tag::Deprecated
+                            && issue
+                                .message
+                                .contains("Calling `flatten` with a consumed solid is deprecated")
+                            && issue
+                                .message
+                                .contains("`target` was already consumed by a `subtract` operation")
+                    }),
+                    "expected flatten consumed-solid deprecation warning, got: {:#?}",
+                    outcome.issues
+                );
             }
             Err(err) => {
                 let message = err.error.message();
@@ -394,7 +410,7 @@ flattened = flatten([[target]])
                     message.contains("`target` was already consumed by a `subtract` operation"),
                     "{message}"
                 );
-                panic!("flatten should ignore consumed-solid validation, but failed with: {message}");
+                panic!("flatten should warn for consumed-solid validation, but failed with: {message}");
             }
         }
     }

--- a/rust/kcl-lib/src/std/csg.rs
+++ b/rust/kcl-lib/src/std/csg.rs
@@ -658,59 +658,6 @@ second = subtract(first, tools = [tool])
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn hide_consumed_solid_does_not_report_kcl_error() {
-        let code = r#"
-targetSketch = sketch(on = XY) {
-  line1 = line(start = [var -10, var -10], end = [var 10, var -10])
-  line2 = line(start = [var 10, var -10], end = [var 10, var 10])
-  line3 = line(start = [var 10, var 10], end = [var -10, var 10])
-  line4 = line(start = [var -10, var 10], end = [var -10, var -10])
-  coincident([line1.end, line2.start])
-  coincident([line2.end, line3.start])
-  coincident([line3.end, line4.start])
-  coincident([line4.end, line1.start])
-  equalLength([line1, line2, line3, line4])
-}
-
-target = extrude(region(point = [0, 0], sketch = targetSketch), length = 20)
-
-toolSketch = sketch(on = XY) {
-  line1 = line(start = [var -2, var -2], end = [var 2, var -2])
-  line2 = line(start = [var 2, var -2], end = [var 2, var 2])
-  line3 = line(start = [var 2, var 2], end = [var -2, var 2])
-  line4 = line(start = [var -2, var 2], end = [var -2, var -2])
-  coincident([line1.end, line2.start])
-  coincident([line2.end, line3.start])
-  coincident([line3.end, line4.start])
-  coincident([line4.end, line1.start])
-  equalLength([line1, line2, line3, line4])
-}
-
-tool = extrude(region(point = [0, 0], sketch = toolSketch), length = 4)
-
-result = subtract(target, tools = [tool])
-hidden = hide(target)
-"#;
-
-        let ctx = crate::ExecutorContext::new_mock(None).await;
-        let program = crate::Program::parse_no_errs(code).unwrap();
-        let result = ctx.run_mock(&program, &MockConfig::default()).await;
-        ctx.close().await;
-
-        match result {
-            Ok(outcome) => assert!(outcome.variables.contains_key("hidden")),
-            Err(err) => {
-                let message = err.error.message();
-                assert!(
-                    message.contains("`target` was already consumed by a `subtract` operation"),
-                    "{message}"
-                );
-                panic!("hide should ignore consumed-solid validation, but failed with: {message}");
-            }
-        }
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
     async fn union_reusing_consumed_solid_reports_kcl_error() {
         let code = r#"
 leftSketch = sketch(on = XY) {

--- a/rust/kcl-lib/src/std/mod.rs
+++ b/rust/kcl-lib/src/std/mod.rs
@@ -50,22 +50,29 @@ pub type StdFn =
         Args,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<KclValueControlFlow, KclError>> + Send + '_>>;
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum ConsumedSolidArgCheck {
+    #[default]
+    Error,
+    WarnDeprecated,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StdFnProps {
     pub name: String,
-    pub check_consumed_solid_args: bool,
+    pub(crate) consumed_solid_arg_check: ConsumedSolidArgCheck,
 }
 
 impl StdFnProps {
     pub(crate) fn default(name: &str) -> Self {
         Self {
             name: name.to_owned(),
-            check_consumed_solid_args: true,
+            consumed_solid_arg_check: Default::default(),
         }
     }
 
-    pub(crate) fn skip_consumed_solid_arg_check(mut self) -> Self {
-        self.check_consumed_solid_args = false;
+    pub(crate) fn warn_deprecated_on_consumed_solid_args(mut self) -> Self {
+        self.consumed_solid_arg_check = ConsumedSolidArgCheck::WarnDeprecated;
         self
     }
 }
@@ -231,7 +238,7 @@ pub(crate) fn std_fn(path: &str, fn_name: &str) -> (crate::std::StdFn, StdFnProp
         ),
         ("transform", "hide") => (
             |e, a| Box::pin(crate::std::transform::hide(e, a).map(|r| r.map(KclValue::continue_))),
-            StdFnProps::default("std::transform::hide").skip_consumed_solid_arg_check(),
+            StdFnProps::default("std::transform::hide").warn_deprecated_on_consumed_solid_args(),
         ),
         ("prelude", "offsetPlane") => (
             |e, a| Box::pin(crate::std::planes::offset_plane(e, a).map(|r| r.map(KclValue::continue_))),
@@ -327,7 +334,7 @@ pub(crate) fn std_fn(path: &str, fn_name: &str) -> (crate::std::StdFn, StdFnProp
         ),
         ("array", "flatten") => (
             |e, a| Box::pin(crate::std::array::flatten(e, a).map(|r| r.map(KclValue::continue_))),
-            StdFnProps::default("std::array::flatten").skip_consumed_solid_arg_check(),
+            StdFnProps::default("std::array::flatten").warn_deprecated_on_consumed_solid_args(),
         ),
         ("prelude", "clone") => (
             |e, a| Box::pin(crate::std::clone::clone(e, a).map(|r| r.map(KclValue::continue_))),

--- a/rust/kcl-lib/src/std/solid_consumption.rs
+++ b/rust/kcl-lib/src/std/solid_consumption.rs
@@ -1,27 +1,60 @@
+use crate::CompilationIssue;
 use crate::SourceRange;
 use crate::errors::KclError;
 use crate::errors::KclErrorDetails;
+use crate::errors::Tag;
 use crate::execution::ConsumedSolidInfo;
 use crate::execution::ConsumedSolidKey;
 use crate::execution::ConsumedSolidOperation;
 use crate::execution::ExecState;
 use crate::execution::KclValue;
 use crate::execution::Solid;
+use crate::execution::annotations;
 
 pub(crate) fn validate_value_not_consumed(
     value: &KclValue,
     exec_state: &ExecState,
     source_range: SourceRange,
 ) -> Result<(), KclError> {
+    if let Some(message) = consumed_value_error_message(value, exec_state) {
+        return Err(KclError::new_semantic(KclErrorDetails::new(
+            message,
+            vec![source_range],
+        )));
+    }
+
+    Ok(())
+}
+
+pub(crate) fn warn_if_value_consumed_for_deprecated_call(
+    value: &KclValue,
+    exec_state: &mut ExecState,
+    source_range: SourceRange,
+    std_fn_name: &str,
+) {
+    let Some(consumed_message) = consumed_value_error_message(value, exec_state) else {
+        return;
+    };
+
+    let function_name = std_fn_name.rsplit("::").next().unwrap_or(std_fn_name);
+    let mut issue = CompilationIssue::err(
+        source_range,
+        format!(
+            "Calling `{function_name}` with a consumed solid is deprecated and will become an error in the next KCL version. {consumed_message}"
+        ),
+    );
+    issue.tag = Tag::Deprecated;
+    exec_state.warn(issue, annotations::WARN_DEPRECATED);
+}
+
+fn consumed_value_error_message(value: &KclValue, exec_state: &ExecState) -> Option<String> {
     match value {
-        KclValue::Solid { value } => validate_solid_not_consumed(value, exec_state, source_range),
-        KclValue::HomArray { value, .. } | KclValue::Tuple { value, .. } => value
-            .iter()
-            .try_for_each(|v| validate_value_not_consumed(v, exec_state, source_range)),
-        KclValue::Object { value, .. } => value
-            .values()
-            .try_for_each(|v| validate_value_not_consumed(v, exec_state, source_range)),
-        _ => Ok(()),
+        KclValue::Solid { value } => consumed_solid_error_message(value, exec_state),
+        KclValue::HomArray { value, .. } | KclValue::Tuple { value, .. } => {
+            value.iter().find_map(|v| consumed_value_error_message(v, exec_state))
+        }
+        KclValue::Object { value, .. } => value.values().find_map(|v| consumed_value_error_message(v, exec_state)),
+        _ => None,
     }
 }
 
@@ -40,6 +73,17 @@ fn validate_solid_not_consumed(
     exec_state: &ExecState,
     source_range: SourceRange,
 ) -> Result<(), KclError> {
+    if let Some(message) = consumed_solid_error_message(solid, exec_state) {
+        return Err(KclError::new_semantic(KclErrorDetails::new(
+            message,
+            vec![source_range],
+        )));
+    }
+
+    Ok(())
+}
+
+fn consumed_solid_error_message(solid: &Solid, exec_state: &ExecState) -> Option<String> {
     let key = consumed_solid_key(solid);
     let Some(info) = exec_state.check_solid_consumed(&key) else {
         if let Some(info) = exec_state.check_solid_id_consumed(&solid.id)
@@ -52,13 +96,10 @@ fn validate_solid_not_consumed(
                 .and_then(|key| exec_state.find_var_name_for_solid_key(key));
             let message = build_stale_body_error_message(current_var.as_deref(), operation, output_var.as_deref());
 
-            return Err(KclError::new_semantic(KclErrorDetails::new(
-                message,
-                vec![source_range],
-            )));
+            return Some(message);
         }
 
-        return Ok(());
+        return None;
     };
     let operation = info.operation();
     let suggested_replacement_key = info.suggested_replacement_key();
@@ -68,10 +109,7 @@ fn validate_solid_not_consumed(
         .and_then(|key| exec_state.find_var_name_for_solid_key(key));
     let message = build_consumed_error_message(consumed_var.as_deref(), operation, output_var.as_deref());
 
-    Err(KclError::new_semantic(KclErrorDetails::new(
-        message,
-        vec![source_range],
-    )))
+    Some(message)
 }
 
 pub(super) fn record_consumed_solids(

--- a/rust/kcl-lib/src/std/transform.rs
+++ b/rust/kcl-lib/src/std/transform.rs
@@ -509,6 +509,9 @@ async fn hide_inner(
 mod tests {
     use pretty_assertions::assert_eq;
 
+    use crate::errors::Severity;
+    use crate::errors::Tag;
+    use crate::execution::MockConfig;
     use crate::execution::parse_execute;
 
     const PIPE: &str = r#"sweepPath = startSketchOn(XZ)
@@ -761,6 +764,63 @@ sweepSketch = startSketchOn(XY)
     |> hide()
 "#;
         parse_execute(&ast).await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn hide_consumed_solid_reports_deprecation_warning() {
+        let code = r#"
+targetSketch = sketch(on = XY) {
+  line1 = line(start = [var -10, var -10], end = [var 10, var -10])
+  line2 = line(start = [var 10, var -10], end = [var 10, var 10])
+  line3 = line(start = [var 10, var 10], end = [var -10, var 10])
+  line4 = line(start = [var -10, var 10], end = [var -10, var -10])
+  coincident([line1.end, line2.start])
+  coincident([line2.end, line3.start])
+  coincident([line3.end, line4.start])
+  coincident([line4.end, line1.start])
+  equalLength([line1, line2, line3, line4])
+}
+
+target = extrude(region(point = [0, 0], sketch = targetSketch), length = 20)
+
+toolSketch = sketch(on = XY) {
+  line1 = line(start = [var -2, var -2], end = [var 2, var -2])
+  line2 = line(start = [var 2, var -2], end = [var 2, var 2])
+  line3 = line(start = [var 2, var 2], end = [var -2, var 2])
+  line4 = line(start = [var -2, var 2], end = [var -2, var -2])
+  coincident([line1.end, line2.start])
+  coincident([line2.end, line3.start])
+  coincident([line3.end, line4.start])
+  coincident([line4.end, line1.start])
+  equalLength([line1, line2, line3, line4])
+}
+
+tool = extrude(region(point = [0, 0], sketch = toolSketch), length = 4)
+
+result = subtract(target, tools = [tool])
+hidden = hide(target)
+"#;
+
+        let program = crate::Program::parse_no_errs(code).unwrap();
+        let ctx = crate::ExecutorContext::new_mock(None).await;
+        let outcome = ctx.run_mock(&program, &MockConfig::default()).await;
+        ctx.close().await;
+        let outcome = outcome.unwrap();
+
+        assert!(
+            outcome.issues.iter().any(|issue| {
+                issue.severity == Severity::Warning
+                    && issue.tag == Tag::Deprecated
+                    && issue
+                        .message
+                        .contains("Calling `hide` with a consumed solid is deprecated")
+                    && issue
+                        .message
+                        .contains("`target` was already consumed by a `subtract` operation")
+            }),
+            "expected hide consumed-solid deprecation warning, got: {:#?}",
+            outcome.issues
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Resolves #11672

<img width="1529" height="909" alt="Screenshot 2026-05-22 at 3 42 00 PM" src="https://github.com/user-attachments/assets/13e83333-0595-41bb-a38f-1cc9fc5f2e31" />
