### PR TITLE
Add annotated viewport screenshots for Zookeeper

### DIFF
--- a/src/components/MlEphantConversation.spec.tsx
+++ b/src/components/MlEphantConversation.spec.tsx
@@ -1,4 +1,11 @@
-import { act, fireEvent, render, screen, within } from '@testing-library/react'
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
 import { expect, vi, describe, test, beforeEach, afterEach } from 'vitest'
 
 // Mock modules that access localStorage at import time
@@ -23,6 +30,15 @@ vi.mock('@src/lib/boot', () => ({
   }),
 }))
 
+vi.mock('@src/lib/screenshot', async (importOriginal) => {
+  const original = await importOriginal<typeof ScreenshotModule>()
+
+  return {
+    ...original,
+    takeViewportScreenshot: vi.fn(),
+  }
+})
+
 import { MlEphantConversation } from '@src/components/MlEphantConversation'
 import type {
   Conversation,
@@ -31,6 +47,8 @@ import type {
 } from '@src/machines/mlEphantManagerMachine'
 import { withSiteBaseURL } from '@src/lib/withBaseURL'
 import { MAKEATHON_ANNOUNCEMENT_DISMISSED_STORAGE_KEY } from '@src/components/MakeathonAnnouncement'
+import { takeViewportScreenshot } from '@src/lib/screenshot'
+import type * as ScreenshotModule from '@src/lib/screenshot'
 
 const SERVER_MODE_OPTIONS: MlCopilotModeOption[] = [
   {
@@ -821,6 +839,9 @@ describe('MlEphantConversation', () => {
 
     beforeEach(() => {
       vi.clearAllMocks()
+      vi.mocked(takeViewportScreenshot).mockReturnValue(
+        'data:image/png;base64,aGVsbG8='
+      )
     })
 
     afterEach(() => {
@@ -832,6 +853,57 @@ describe('MlEphantConversation', () => {
       expect(
         screen.getByTestId('ml-ephant-attachments-button')
       ).toBeInTheDocument()
+    })
+
+    test('displays screenshot annotation button', () => {
+      renderConversation()
+      expect(
+        screen.getByTestId('ml-ephant-annotate-screenshot-button')
+      ).toBeInTheDocument()
+    })
+
+    test('adds annotated viewport screenshot as an attachment', async () => {
+      const OriginalImage = globalThis.Image
+      class MockImage {
+        onload: (() => void) | null = null
+        onerror: (() => void) | null = null
+        complete = true
+        naturalWidth = 16
+        naturalHeight = 16
+        width = 16
+        height = 16
+
+        set src(_value: string) {
+          queueMicrotask(() => this.onload?.())
+        }
+      }
+
+      const drawImageSpy = vi
+        .spyOn(CanvasRenderingContext2D.prototype, 'drawImage')
+        .mockImplementation(() => {})
+      globalThis.Image = MockImage as typeof Image
+      try {
+        renderConversation()
+
+        fireEvent.click(
+          screen.getByTestId('ml-ephant-annotate-screenshot-button')
+        )
+
+        expect(
+          screen.getByTestId('viewport-annotation-overlay')
+        ).toBeInTheDocument()
+
+        const sendButton = screen.getByTestId('viewport-annotation-send-button')
+        await waitFor(() => expect(sendButton).not.toBeDisabled())
+        fireEvent.click(sendButton)
+
+        expect(
+          await screen.findByText('annotated-viewport-screenshot.png')
+        ).toBeInTheDocument()
+      } finally {
+        drawImageSpy.mockRestore()
+        globalThis.Image = OriginalImage
+      }
     })
 
     test('shows attached files when files are added via drag and drop', async () => {

--- a/src/components/MlEphantConversation.tsx
+++ b/src/components/MlEphantConversation.tsx
@@ -13,9 +13,11 @@ import type { ChangeEvent, ReactNode } from 'react'
 import { useEffect, useRef, useState } from 'react'
 import Tooltip from '@src/components/Tooltip'
 import { isExternalFileDrag } from '@src/components/Explorer/utils'
-import { takeViewportScreenshot } from '@src/lib/screenshot'
+import { dataUrlToFile, takeViewportScreenshot } from '@src/lib/screenshot'
 import { isNonNullable } from '@src/lib/utils'
 import { MakeathonAnnouncement } from '@src/components/MakeathonAnnouncement'
+import { err } from '@src/lib/trap'
+import { ViewportAnnotationOverlay } from '@src/components/ViewportAnnotationOverlay'
 
 const noop = () => {}
 
@@ -126,6 +128,7 @@ export interface MlEphantExtraInputsProps {
   onSetMode: (mode: MlCopilotModeId) => void
   onAttachFiles: () => void
   onCaptureScreenshot: () => void
+  onAnnotateScreenshot: () => void
   attachmentsDisabled?: boolean
   modeOptions?: MlCopilotModeOption[]
 }
@@ -171,6 +174,19 @@ export const MlEphantExtraInputs = (props: MlEphantExtraInputsProps) => {
           <CustomIcon name="camera" className="w-5 h-5" />
           <Tooltip position="top" hoverOnly={true}>
             <span>Capture viewport screenshot</span>
+          </Tooltip>
+        </button>
+        <button
+          type="button"
+          data-testid="ml-ephant-annotate-screenshot-button"
+          onClick={props.onAnnotateScreenshot}
+          disabled={props.attachmentsDisabled}
+          className="h-7 w-7 bg-default flex items-center justify-center rounded-sm m-0 p-0 flex-none disabled:opacity-60"
+          aria-label="Annotate viewport screenshot"
+        >
+          <CustomIcon name="trimTool" className="w-5 h-5" />
+          <Tooltip position="top" hoverOnly={true}>
+            <span>Annotate viewport screenshot</span>
           </Tooltip>
         </button>
       </div>
@@ -225,6 +241,9 @@ export const MlEphantConversationInput = (
   const lastModeScopeKey = useRef(props.modeScopeKey)
   const [attachments, setAttachments] = useState<File[]>([])
   const [isDraggingOver, setIsDraggingOver] = useState(false)
+  const [annotationImageDataUrl, setAnnotationImageDataUrl] = useState<
+    string | null
+  >(null)
 
   // Without this the cursor ends up at the start of the text
   useEffect(() => setValue(props.defaultPrompt || ''), [props.defaultPrompt])
@@ -310,6 +329,14 @@ export const MlEphantConversationInput = (
     })
   }
 
+  const appendDataUrlAttachment = (dataUrl: string, fileName: string) => {
+    const file = dataUrlToFile(dataUrl, fileName)
+    if (err(file)) {
+      return
+    }
+    appendAttachments([file])
+  }
+
   const onAttachFiles = () => {
     if (props.disabled) return
     fileInputRef.current?.click()
@@ -320,19 +347,20 @@ export const MlEphantConversationInput = (
     try {
       const dataUrl = takeViewportScreenshot()
       if (!dataUrl) return
-      // Convert data URL to File without fetch (fetch of data: URLs is
-      // blocked by CSP in the browser).
-      const [header, base64] = dataUrl.split(',')
-      const mime = header.match(/:(.*?);/)?.[1] ?? 'image/png'
-      const bytes = atob(base64)
-      const buf = new Uint8Array(bytes.length)
-      for (let i = 0; i < bytes.length; i++) {
-        buf[i] = bytes.charCodeAt(i)
-      }
-      const file = new File([buf], 'viewport-screenshot.png', { type: mime })
-      appendAttachments([file])
+      appendDataUrlAttachment(dataUrl, 'viewport-screenshot.png')
     } catch (e) {
       console.error('Failed to capture viewport screenshot', e)
+    }
+  }
+
+  const onAnnotateScreenshot = () => {
+    if (props.disabled) return
+    try {
+      const dataUrl = takeViewportScreenshot()
+      if (!dataUrl) return
+      setAnnotationImageDataUrl(dataUrl)
+    } catch (e) {
+      console.error('Failed to capture viewport screenshot for annotation', e)
     }
   }
 
@@ -480,6 +508,7 @@ export const MlEphantConversationInput = (
             }}
             onAttachFiles={onAttachFiles}
             onCaptureScreenshot={onCaptureScreenshot}
+            onAnnotateScreenshot={onAnnotateScreenshot}
             attachmentsDisabled={props.disabled}
             modeOptions={props.modeOptions}
           />
@@ -523,6 +552,19 @@ export const MlEphantConversationInput = (
         Zookeeper can make mistakes. We send selection context to help. Always
         verify information.
       </div>
+      {annotationImageDataUrl && (
+        <ViewportAnnotationOverlay
+          imageDataUrl={annotationImageDataUrl}
+          onCancel={() => setAnnotationImageDataUrl(null)}
+          onSend={(annotatedDataUrl) => {
+            appendDataUrlAttachment(
+              annotatedDataUrl,
+              'annotated-viewport-screenshot.png'
+            )
+            setAnnotationImageDataUrl(null)
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/MlEphantConversation.tsx
+++ b/src/components/MlEphantConversation.tsx
@@ -184,7 +184,7 @@ export const MlEphantExtraInputs = (props: MlEphantExtraInputsProps) => {
           className="h-7 w-7 bg-default flex items-center justify-center rounded-sm m-0 p-0 flex-none disabled:opacity-60"
           aria-label="Annotate viewport screenshot"
         >
-          <CustomIcon name="trimTool" className="w-5 h-5" />
+          <CustomIcon name="sketch" className="w-5 h-5" />
           <Tooltip position="top" hoverOnly={true}>
             <span>Annotate viewport screenshot</span>
           </Tooltip>

--- a/src/components/ViewportAnnotationOverlay.tsx
+++ b/src/components/ViewportAnnotationOverlay.tsx
@@ -1,0 +1,294 @@
+import type { PointerEvent as ReactPointerEvent } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import {
+  getTrimPreviewLineWidth,
+  TRIM_PREVIEW_LINE_COLOR,
+} from '@src/lib/freehandLineDrawing'
+
+type ViewportAnnotationRect = {
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
+const getViewportAnnotationRect = (): ViewportAnnotationRect => {
+  const viewport = document.querySelector('[data-engine]')
+  if (viewport instanceof HTMLElement) {
+    const rect = viewport.getBoundingClientRect()
+    if (rect.width > 0 && rect.height > 0) {
+      return {
+        left: rect.left,
+        top: rect.top,
+        width: rect.width,
+        height: rect.height,
+      }
+    }
+  }
+
+  return {
+    left: 0,
+    top: 0,
+    width: window.innerWidth,
+    height: window.innerHeight,
+  }
+}
+
+const loadImage = (src: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const image = new Image()
+    let settled = false
+    const resolveOnce = () => {
+      if (settled) {
+        return
+      }
+      settled = true
+      resolve(image)
+    }
+    image.onload = resolveOnce
+    image.onerror = () => {
+      if (settled) {
+        return
+      }
+      settled = true
+      reject(new Error('Failed to load viewport screenshot annotation image'))
+    }
+    image.src = src
+    if (image.complete && (image.naturalWidth || image.width)) {
+      resolveOnce()
+    }
+  })
+
+const getCanvasPoint = (
+  canvas: HTMLCanvasElement,
+  event: ReactPointerEvent<HTMLCanvasElement>
+) => {
+  const rect = canvas.getBoundingClientRect()
+  const scaleX = rect.width > 0 ? canvas.width / rect.width : 1
+  const scaleY = rect.height > 0 ? canvas.height / rect.height : 1
+  return {
+    x: (event.clientX - rect.left) * scaleX,
+    y: (event.clientY - rect.top) * scaleY,
+  }
+}
+
+interface ViewportAnnotationOverlayProps {
+  imageDataUrl: string
+  onCancel: () => void
+  onSend: (annotatedDataUrl: string) => void
+}
+
+export const ViewportAnnotationOverlay = (
+  props: ViewportAnnotationOverlayProps
+) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const lastPoint = useRef<{ x: number; y: number } | null>(null)
+  const [viewportRect, setViewportRect] = useState(getViewportAnnotationRect)
+  const [imageSize, setImageSize] = useState<{
+    width: number
+    height: number
+  } | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    void loadImage(props.imageDataUrl)
+      .then((image) => {
+        if (cancelled) {
+          return
+        }
+
+        const width = image.naturalWidth || image.width
+        const height = image.naturalHeight || image.height
+        setImageSize({ width, height })
+
+        const canvas = canvasRef.current
+        if (!canvas) {
+          return
+        }
+        canvas.width = width
+        canvas.height = height
+        canvas.getContext('2d')?.clearRect(0, 0, width, height)
+      })
+      .catch((error) => {
+        console.error('Failed to prepare viewport annotation image', error)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [props.imageDataUrl])
+
+  useEffect(() => {
+    const updateViewportRect = () =>
+      setViewportRect(getViewportAnnotationRect())
+    const viewport = document.querySelector('[data-engine]')
+    const resizeObserver =
+      typeof ResizeObserver === 'undefined'
+        ? undefined
+        : new ResizeObserver(updateViewportRect)
+
+    if (viewport instanceof HTMLElement) {
+      resizeObserver?.observe(viewport)
+    }
+    window.addEventListener('resize', updateViewportRect)
+    window.addEventListener('scroll', updateViewportRect, true)
+
+    return () => {
+      resizeObserver?.disconnect()
+      window.removeEventListener('resize', updateViewportRect)
+      window.removeEventListener('scroll', updateViewportRect, true)
+    }
+  }, [])
+
+  const drawTo = (event: ReactPointerEvent<HTMLCanvasElement>) => {
+    const canvas = canvasRef.current
+    if (!canvas || !lastPoint.current) {
+      return
+    }
+
+    const ctx = canvas.getContext('2d')
+    if (!ctx) {
+      return
+    }
+
+    const nextPoint = getCanvasPoint(canvas, event)
+    const rect = canvas.getBoundingClientRect()
+    const pixelRatio = rect.width > 0 ? canvas.width / rect.width : 1
+    ctx.strokeStyle = TRIM_PREVIEW_LINE_COLOR
+    ctx.lineWidth = getTrimPreviewLineWidth(pixelRatio)
+    ctx.lineCap = 'round'
+    ctx.lineJoin = 'round'
+    ctx.beginPath()
+    ctx.moveTo(lastPoint.current.x, lastPoint.current.y)
+    ctx.lineTo(nextPoint.x, nextPoint.y)
+    ctx.stroke()
+    lastPoint.current = nextPoint
+  }
+
+  const onPointerDown = (event: ReactPointerEvent<HTMLCanvasElement>) => {
+    if (event.button !== 0) {
+      return
+    }
+
+    const canvas = canvasRef.current
+    if (!canvas || !imageSize) {
+      return
+    }
+
+    event.currentTarget.setPointerCapture(event.pointerId)
+    lastPoint.current = getCanvasPoint(canvas, event)
+  }
+
+  const onPointerMove = (event: ReactPointerEvent<HTMLCanvasElement>) => {
+    if (!lastPoint.current) {
+      return
+    }
+    drawTo(event)
+  }
+
+  const onPointerUp = (event: ReactPointerEvent<HTMLCanvasElement>) => {
+    if (!lastPoint.current) {
+      return
+    }
+    drawTo(event)
+    lastPoint.current = null
+    event.currentTarget.releasePointerCapture(event.pointerId)
+  }
+
+  const clearDrawing = () => {
+    const canvas = canvasRef.current
+    if (!canvas) {
+      return
+    }
+    canvas.getContext('2d')?.clearRect(0, 0, canvas.width, canvas.height)
+  }
+
+  const createAnnotatedImageDataUrl = async () => {
+    const drawingCanvas = canvasRef.current
+    if (!drawingCanvas) {
+      return props.imageDataUrl
+    }
+
+    const image = await loadImage(props.imageDataUrl)
+    const width = image.naturalWidth || drawingCanvas.width
+    const height = image.naturalHeight || drawingCanvas.height
+    const compositeCanvas = document.createElement('canvas')
+    compositeCanvas.width = width
+    compositeCanvas.height = height
+    const ctx = compositeCanvas.getContext('2d')
+    if (!ctx) {
+      return props.imageDataUrl
+    }
+
+    ctx.drawImage(image, 0, 0, width, height)
+    ctx.drawImage(drawingCanvas, 0, 0, width, height)
+    return compositeCanvas.toDataURL('image/png')
+  }
+
+  const onSend = () => {
+    void createAnnotatedImageDataUrl()
+      .then(props.onSend)
+      .catch((error) => {
+        console.error('Failed to create viewport annotation image', error)
+      })
+  }
+
+  return createPortal(
+    <div
+      data-testid="viewport-annotation-overlay"
+      className="fixed z-50 bg-chalkboard-100"
+      style={{
+        left: viewportRect.left,
+        top: viewportRect.top,
+        width: viewportRect.width,
+        height: viewportRect.height,
+      }}
+    >
+      <img
+        src={props.imageDataUrl}
+        alt=""
+        className="absolute inset-0 h-full w-full select-none"
+        draggable={false}
+      />
+      <canvas
+        ref={canvasRef}
+        data-testid="viewport-annotation-canvas"
+        className="absolute inset-0 h-full w-full cursor-crosshair touch-none"
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={() => {
+          lastPoint.current = null
+        }}
+      />
+      <div className="absolute top-2 left-2 flex items-center gap-1 rounded-sm border border-chalkboard-30 dark:border-chalkboard-70 bg-chalkboard-10/95 dark:bg-chalkboard-90/95 p-1 shadow-sm">
+        <button
+          type="button"
+          className="m-0 h-7 px-2 rounded-sm border-none bg-transparent hover:bg-chalkboard-20 dark:hover:bg-chalkboard-80 text-xs"
+          onClick={clearDrawing}
+        >
+          Clear
+        </button>
+        <button
+          type="button"
+          className="m-0 h-7 px-2 rounded-sm border-none bg-transparent hover:bg-chalkboard-20 dark:hover:bg-chalkboard-80 text-xs"
+          onClick={props.onCancel}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          data-testid="viewport-annotation-send-button"
+          disabled={!imageSize}
+          className="m-0 h-7 px-2 rounded-sm border-none bg-ml-green hover:bg-ml-green text-chalkboard-100 disabled:opacity-60 text-xs"
+          onClick={onSend}
+        >
+          Send
+        </button>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/src/lib/freehandLineDrawing.ts
+++ b/src/lib/freehandLineDrawing.ts
@@ -1,0 +1,6 @@
+export const TRIM_PREVIEW_LINE_COLOR = '#ff8800'
+export const TRIM_PREVIEW_LINE_COLOR_HEX = 0xff8800
+export const TRIM_PREVIEW_LINE_WIDTH_PX = 2
+
+export const getTrimPreviewLineWidth = (pixelRatio: number) =>
+  TRIM_PREVIEW_LINE_WIDTH_PX * pixelRatio

--- a/src/lib/screenshot.ts
+++ b/src/lib/screenshot.ts
@@ -69,6 +69,22 @@ export function takeViewportScreenshot(): string {
   return compositeCanvas.toDataURL('image/png')
 }
 
+export function dataUrlToFile(dataUrl: string, fileName: string): File | Error {
+  const [header, base64] = dataUrl.split(',')
+  if (!header || !base64) {
+    return new Error('Invalid data URL')
+  }
+
+  const mime = header.match(/:(.*?);/)?.[1] ?? 'application/octet-stream'
+  const bytes = atob(base64)
+  const buf = new Uint8Array(bytes.length)
+  for (let i = 0; i < bytes.length; i++) {
+    buf[i] = bytes.charCodeAt(i)
+  }
+
+  return new File([buf], fileName, { type: mime })
+}
+
 export function createThumbnailPNGOnDesktop({
   projectDirectoryWithoutEndingSlash,
 }: {

--- a/src/machines/sketchSolve/tools/trimToolDiagram.ts
+++ b/src/machines/sketchSolve/tools/trimToolDiagram.ts
@@ -15,6 +15,10 @@ import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js'
 import { createOnAreaSelectEndCallback } from '@src/machines/sketchSolve/tools/trimToolImpl'
 import { SKETCH_SOLVE_GROUP } from '@src/clientSideScene/sceneUtils'
 import type { SketchSolveMachineEvent } from '@src/machines/sketchSolve/sketchSolveImpl'
+import {
+  getTrimPreviewLineWidth,
+  TRIM_PREVIEW_LINE_COLOR_HEX,
+} from '@src/lib/freehandLineDrawing'
 
 // Trim tool draws an ephemeral polyline during an area-select drag.
 // At drag end the preview is removed – no sketch entities are created (yet).
@@ -168,8 +172,8 @@ export const machine = setup({
               const geom = new LineGeometry()
               geom.setPositions(positions)
               const mat = new LineMaterial({
-                color: 0xff8800,
-                linewidth: 2 * window.devicePixelRatio,
+                color: TRIM_PREVIEW_LINE_COLOR_HEX,
+                linewidth: getTrimPreviewLineWidth(window.devicePixelRatio),
               })
               const line = new Line2(geom, mat)
               line.name = 'trim-tool-preview'


### PR DESCRIPTION
ai assisted, proof of concept, review sceptically!

https://github.com/user-attachments/assets/6520af49-47ab-4df4-a0b3-ceaeadda3f01

## Problem
Zookeeper can already receive a raw viewport screenshot as context, but users cannot mark up the exact part of the 3D view they want the model to reason about. That makes visual edit requests harder to communicate when a prompt needs a specific face, edge, region, or relationship called out.

## Solution
Add an adjacent annotate screenshot action that captures the current viewport, opens it directly over the 3D view for freehand markup, and sends the resulting annotated image back through the same Zookeeper attachment flow as the existing capture action. The drawing stroke uses the same visual treatment as the trim tool so the interaction feels familiar and lightweight.