### PR TITLE
Bring Zookeeper Provider down into the pane to eliminate race

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -5,39 +5,20 @@ import { OpenInDesktopAppHandler } from '@src/components/OpenInDesktopAppHandler
 import { SystemIOMachineLogicListener } from '@src/components/SystemIOMachineLogicListener'
 import { RouteProvider } from '@src/components/RouteProvider'
 import { Outlet } from 'react-router-dom'
-import { MlEphantManagerReactContext } from '@src/machines/mlEphantManagerMachine'
-import { useApp } from '@src/lib/boot'
 
 // Root component will live for the entire applications runtime
 // This is a great place to add polling code.
 function RootLayout() {
-  const { auth } = useApp()
-  // Many providers need at the very least a Zoo API token to work.
-  // We can provide that here.
-  const apiToken = auth.useToken()
-
   return (
     <OpenInDesktopAppHandler>
       <RouteProvider>
         <Auth>
-          {/* It's possible the ML agent will interact with the user
-        on the project view or anywhere else in the app in the future. It should
-        work regardless of the LSP or sketching being available, as users
-        may simply want to ask it questions. */}
-          <MlEphantManagerReactContext.Provider
-            options={{
-              input: {
-                apiToken,
-              },
-            }}
-          >
-            <LspProvider>
-              <AppStateProvider>
-                <SystemIOMachineLogicListener />
-                <Outlet />
-              </AppStateProvider>
-            </LspProvider>
-          </MlEphantManagerReactContext.Provider>
+          <LspProvider>
+            <AppStateProvider>
+              <SystemIOMachineLogicListener />
+              <Outlet />
+            </AppStateProvider>
+          </LspProvider>
         </Auth>
       </RouteProvider>
     </OpenInDesktopAppHandler>

--- a/src/components/OpenedProject.tsx
+++ b/src/components/OpenedProject.tsx
@@ -45,10 +45,7 @@ import { reportRejection } from '@src/lib/trap'
 import { withSiteBaseURL } from '@src/lib/withBaseURL'
 import { xStateValueToString } from '@src/lib/xStateValueToString'
 import { BillingTransition } from '@src/machines/billingMachine'
-import {
-  MlEphantManagerReactContext,
-  MlEphantManagerTransitions,
-} from '@src/machines/mlEphantManagerMachine'
+
 import { useFolders, useLastOperation } from '@src/machines/systemIO/hooks'
 import { SystemIOMachineStates } from '@src/machines/systemIO/utils'
 import {
@@ -86,8 +83,6 @@ export function OpenedProject() {
   const { state: modelingState, send: modelingSend } = useModelingContext()
   useQueryParamEffects(kclManager)
   const [nativeFileMenuCreated, setNativeFileMenuCreated] = useState(false)
-  const mlEphantManagerActor2 = MlEphantManagerReactContext.useActorRef()
-
   const location = useLocation()
   const navigate = useNavigate()
   const autoUpdateDownloadProgress = autoUpdateDownloadProgressSignal.value
@@ -168,14 +163,6 @@ export function OpenedProject() {
       project?.executingPath ? project.executingFileEntry.value : null
     )
   }, [onProjectOpen, projectName, projectPath, project])
-
-  useEffect(() => {
-    // Clear conversation
-    mlEphantManagerActor2.send({
-      type: MlEphantManagerTransitions.ConversationClose,
-    })
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-  }, [projectName, projectPath])
 
   useHotKeyListener(kclManager)
 

--- a/src/components/SystemIOMachineLogicListener.tsx
+++ b/src/components/SystemIOMachineLogicListener.tsx
@@ -33,7 +33,7 @@ import { useNavigate } from 'react-router-dom'
 import { useLocation } from 'react-router-dom'
 
 export function SystemIOMachineLogicListener() {
-  const { auth, settings, systemIOActor } = useApp()
+  const { settings, systemIOActor } = useApp()
   const { kclManager } = useSingletons()
   // We gotta stop with this pattern. It doesn't scale. "Eager hook creation"
   const requestedProjectName = useRequestedProjectName()

--- a/src/components/SystemIOMachineLogicListener.tsx
+++ b/src/components/SystemIOMachineLogicListener.tsx
@@ -16,28 +16,24 @@ import {
   webSafePathSplit,
 } from '@src/lib/paths'
 import { useApp, useSingletons } from '@src/lib/boot'
-import { MlEphantManagerReactContext } from '@src/machines/mlEphantManagerMachine'
 import {
   useHasListedProjects,
   useLastOperation,
   useProjectDirectoryPath,
-  useProjectIdToConversationId,
   useRequestedFileName,
   useRequestedProjectName,
-  useWatchForNewFileRequestsFromMlEphant,
 } from '@src/machines/systemIO/hooks'
 import {
   NO_PROJECT_DIRECTORY,
   SystemIOMachineEvents,
   SystemIOMachineStates,
-  prepareMlEphantNewFileRequest,
 } from '@src/machines/systemIO/utils'
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useLocation } from 'react-router-dom'
 
 export function SystemIOMachineLogicListener() {
-  const { auth, billing, settings, systemIOActor } = useApp()
+  const { auth, settings, systemIOActor } = useApp()
   const { kclManager } = useSingletons()
   // We gotta stop with this pattern. It doesn't scale. "Eager hook creation"
   const requestedProjectName = useRequestedProjectName()
@@ -48,7 +44,6 @@ export function SystemIOMachineLogicListener() {
 
   const navigate = useNavigate()
   const settingsValues = settings.useSettings()
-  const token = auth.useToken()
   const { onFileOpen, onFileClose } = useLspContext()
   const { pathname } = useLocation()
 
@@ -277,42 +272,6 @@ export function SystemIOMachineLogicListener() {
         : []
     )
   }
-
-  const mlEphantManagerActor = MlEphantManagerReactContext.useActorRef()
-
-  useWatchForNewFileRequestsFromMlEphant(
-    mlEphantManagerActor,
-    billing.actor,
-    token,
-    kclManager.engineCommandManager,
-    (props) => {
-      const payload = prepareMlEphantNewFileRequest(props)
-
-      if (payload) {
-        kclManager.mlEphantManagerMachineBulkManipulatingFileSystem = true
-        systemIOActor.send({
-          type: SystemIOMachineEvents.bulkCreateAndDeleteKCLFilesAndNavigateToFile,
-          data: {
-            files: payload.files,
-            filesToDelete: payload.filesToDelete,
-            override: true,
-            // Gotcha: Both are called "project name" and "file name", but one of them
-            // has to include the project-relative file path between the two.
-            requestedProjectName: payload.requestedProjectName,
-            requestedFileNameWithExtension:
-              payload.requestedFileNameWithExtension ?? '',
-          },
-        })
-      }
-    }
-  )
-
-  // Save the conversation id for the project id if necessary.
-  useProjectIdToConversationId(
-    mlEphantManagerActor,
-    systemIOActor,
-    settingsValues
-  )
 
   useGlobalProjectNavigation()
   useGlobalFileNavigation()

--- a/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
+++ b/src/components/layout/areas/MlEphantConversationPaneWrapper.tsx
@@ -14,11 +14,36 @@ import {
   MlEphantConversationToMarkdown,
   MlEphantManagerReactContext,
 } from '@src/machines/mlEphantManagerMachine'
+import {
+  useProjectIdToConversationId,
+  useWatchForNewFileRequestsFromMlEphant,
+} from '@src/machines/systemIO/hooks'
+import {
+  SystemIOMachineEvents,
+  prepareMlEphantNewFileRequest,
+} from '@src/machines/systemIO/utils'
 // Yea, feels bad, but literally every other pane is doing this.
 // TODO: Don't use CSS module for this? More generic module?
 import styles from './KclEditorMenu.module.css'
 
 export function MlEphantConversationPaneWrapper(props: AreaTypeComponentProps) {
+  const { auth } = useApp()
+  const token = auth.useToken()
+
+  return (
+    <MlEphantManagerReactContext.Provider
+      options={{
+        input: {
+          apiToken: token,
+        },
+      }}
+    >
+      <MlEphantConversationPaneInner {...props} />
+    </MlEphantManagerReactContext.Provider>
+  )
+}
+
+function MlEphantConversationPaneInner(props: AreaTypeComponentProps) {
   useSignals()
   const app = useApp()
   const { auth, billing, settings, project, systemIOActor } = app
@@ -46,6 +71,38 @@ export function MlEphantConversationPaneWrapper(props: AreaTypeComponentProps) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Only run on mount
   }, [])
+
+  useWatchForNewFileRequestsFromMlEphant(
+    mlEphantManagerActor,
+    billing.actor,
+    token,
+    kclManager.engineCommandManager,
+    (requestProps) => {
+      const payload = prepareMlEphantNewFileRequest(requestProps)
+
+      if (payload) {
+        kclManager.mlEphantManagerMachineBulkManipulatingFileSystem = true
+        systemIOActor.send({
+          type: SystemIOMachineEvents.bulkCreateAndDeleteKCLFilesAndNavigateToFile,
+          data: {
+            files: payload.files,
+            filesToDelete: payload.filesToDelete,
+            override: true,
+            requestedProjectName: payload.requestedProjectName,
+            requestedFileNameWithExtension:
+              payload.requestedFileNameWithExtension ?? '',
+          },
+        })
+      }
+    }
+  )
+
+  // Save the conversation id for the project id if necessary.
+  useProjectIdToConversationId(
+    mlEphantManagerActor,
+    systemIOActor,
+    settingsValues
+  )
 
   const sendBillingUpdate = () => {
     billing.send({


### PR DESCRIPTION
Before the provider would cause the MlEphant actor to live for the entire lifetime of the application ("God Actor"). This change brings it down into the pane so that opening and closing the pane starts its own actor instance, eliminating the chances of a race when closing, which was the original problem.