### PR TITLE
KCL: Bump ezpz, gracefully handle solver DidNotConverge

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1116,7 +1116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1143,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "ezpz"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb90926f923c8bf9fb803d1b8023a3f288fa73540cdedb532dfeb054ad3f955"
+checksum = "0928f6a0ebd0cbc7ecb75d2457a84de6931cb20201e118cda73cfc16514ce283"
 dependencies = [
  "faer",
  "indexmap 2.14.0",
@@ -2272,7 +2272,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3155,7 +3155,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3803,7 +3803,7 @@ dependencies = [
  "bitflags 2.10.0",
  "num-traits 0.2.19",
  "rand 0.9.4",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.10",
  "rusty-fork",
@@ -4383,7 +4383,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5125,7 +5125,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5134,7 +5134,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6151,7 +6151,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -24,7 +24,7 @@ console_error_panic_hook = "0.1.7"
 dashmap = { version = "6.1.0" }
 http = "1"
 indexmap = "2.13.1"
-ezpz = "0.2.25"
+ezpz = "0.2.26"
 kittycad = { version = "0.4.13", default-features = false, features = [
   "js",
   "requests",

--- a/rust/kcl-lib/src/execution/exec_ast.rs
+++ b/rust/kcl-lib/src/execution/exec_ast.rs
@@ -1812,6 +1812,12 @@ impl Node<SketchBlock> {
         let (solve_outcome, solve_analysis) = match solve_result {
             Ok((solved, freedom)) => {
                 let outcome = Solved::from_ezpz_outcome(solved, &all_constraints, num_required_constraints);
+                if !outcome.converged {
+                    exec_state.warn(
+                        CompilationIssue::err(range, "Constraint solver failed to find a solution".to_owned()),
+                        annotations::WARN_SOLVER,
+                    );
+                }
                 (outcome, freedom)
             }
             Err(failure) => {
@@ -1819,12 +1825,11 @@ impl Node<SketchBlock> {
                     NonLinearSystemError::FaerMatrix { .. }
                     | NonLinearSystemError::Faer { .. }
                     | NonLinearSystemError::FaerSolve { .. }
-                    | NonLinearSystemError::FaerSvd(..)
-                    | NonLinearSystemError::DidNotConverge => {
+                    | NonLinearSystemError::FaerSvd(..) => {
                         // Constraint solver failed to find a solution. Build a
                         // solution that is the initial guesses.
                         exec_state.warn(
-                            CompilationIssue::err(range, "Constraint solver failed to find a solution".to_owned()),
+                            CompilationIssue::err(range, "Internal error in constraint solver".to_owned()),
                             annotations::WARN_SOLVER,
                         );
                         let final_values = initial_guesses.iter().map(|(_, v)| *v).collect::<Vec<_>>();
@@ -1835,6 +1840,7 @@ impl Node<SketchBlock> {
                                 warnings: failure.warnings,
                                 priority_solved: Default::default(),
                                 variables_in_conflicts: Default::default(),
+                                converged: false,
                             },
                             None,
                         )

--- a/rust/kcl-lib/src/execution/sketch_solve.rs
+++ b/rust/kcl-lib/src/execution/sketch_solve.rs
@@ -495,6 +495,8 @@ pub(crate) struct Solved {
     pub(crate) priority_solved: u32,
     /// Variables involved in unsatisfied constraints (for conflict detection)
     pub(crate) variables_in_conflicts: AHashSet<ezpz::Id>,
+    /// Did the solver converge on a solution?
+    pub(crate) converged: bool,
 }
 
 impl Solved {
@@ -524,6 +526,7 @@ impl Solved {
             warnings: value.warnings().to_owned(),
             priority_solved: value.priority_solved(),
             variables_in_conflicts,
+            converged: value.converged(),
         }
     }
 }
@@ -1099,6 +1102,7 @@ mod tests {
             warnings: vec![],
             priority_solved: 0,
             variables_in_conflicts: AHashSet::new(),
+            converged: true,
         };
 
         let substituted = substitute_sketch_vars(

--- a/rust/kcl-lib/tests/inconsistent_sketch/artifact_commands.snap
+++ b/rust/kcl-lib/tests/inconsistent_sketch/artifact_commands.snap
@@ -68,8 +68,8 @@ description: Artifact commands inconsistent_sketch.kcl
         "type": "move_path_pen",
         "path": "[uuid]",
         "to": {
-          "x": -3.83,
-          "y": 2.98,
+          "x": -2.6470452934402346,
+          "y": 2.7895987741173176,
           "z": 0.0
         }
       }
@@ -90,8 +90,8 @@ description: Artifact commands inconsistent_sketch.kcl
         "segment": {
           "type": "line",
           "end": {
-            "x": 2.88,
-            "y": 1.9,
+            "x": 1.6970452659913564,
+            "y": 2.0904012258826823,
             "z": 0.0
           },
           "relative": false

--- a/rust/kcl-lib/tests/inconsistent_sketch/program_memory.snap
+++ b/rust/kcl-lib/tests/inconsistent_sketch/program_memory.snap
@@ -59,7 +59,7 @@ description: Variables in memory after executing inconsistent_sketch.kcl
                   "line": {
                     "start": [
                       {
-                        "n": -3.83,
+                        "n": -2.6470452934402346,
                         "ty": {
                           "mm": null,
                           "type": "Known",
@@ -67,7 +67,7 @@ description: Variables in memory after executing inconsistent_sketch.kcl
                         }
                       },
                       {
-                        "n": 2.98,
+                        "n": 2.7895987741173176,
                         "ty": {
                           "mm": null,
                           "type": "Known",
@@ -77,7 +77,7 @@ description: Variables in memory after executing inconsistent_sketch.kcl
                     ],
                     "end": [
                       {
-                        "n": 2.88,
+                        "n": 1.6970452659913564,
                         "ty": {
                           "mm": null,
                           "type": "Known",
@@ -85,7 +85,7 @@ description: Variables in memory after executing inconsistent_sketch.kcl
                         }
                       },
                       {
-                        "n": 1.9,
+                        "n": 2.0904012258826823,
                         "ty": {
                           "mm": null,
                           "type": "Known",
@@ -121,6 +121,8 @@ description: Variables in memory after executing inconsistent_sketch.kcl
                     },
                     "start_object_id": 2,
                     "end_object_id": 3,
+                    "start_freedom": "Conflict",
+                    "end_freedom": "Conflict",
                     "construction": false
                   }
                 },
@@ -180,8 +182,8 @@ description: Variables in memory after executing inconsistent_sketch.kcl
                     "sourceRange": []
                   },
                   "from": [
-                    -3.83,
-                    2.98
+                    -2.6470452934402346,
+                    2.7895987741173176
                   ],
                   "tag": {
                     "commentStart": 61,
@@ -192,8 +194,8 @@ description: Variables in memory after executing inconsistent_sketch.kcl
                     "value": "line1"
                   },
                   "to": [
-                    2.88,
-                    1.9
+                    1.6970452659913564,
+                    2.0904012258826823
                   ],
                   "type": "ToPoint",
                   "units": "mm"
@@ -232,12 +234,12 @@ description: Variables in memory after executing inconsistent_sketch.kcl
               },
               "start": {
                 "from": [
-                  -3.83,
-                  2.98
+                  -2.6470452934402346,
+                  2.7895987741173176
                 ],
                 "to": [
-                  -3.83,
-                  2.98
+                  -2.6470452934402346,
+                  2.7895987741173176
                 ],
                 "units": "mm",
                 "tag": null,

--- a/rust/kcl-lib/tests/inconsistent_sketch_converge/artifact_commands.snap
+++ b/rust/kcl-lib/tests/inconsistent_sketch_converge/artifact_commands.snap
@@ -68,8 +68,8 @@ description: Artifact commands inconsistent_sketch_converge.kcl
         "type": "move_path_pen",
         "path": "[uuid]",
         "to": {
-          "x": -3.83,
-          "y": 2.98,
+          "x": -1.7913914572449539,
+          "y": 2.651878509047543,
           "z": 0.0
         }
       }
@@ -90,8 +90,8 @@ description: Artifact commands inconsistent_sketch_converge.kcl
         "segment": {
           "type": "line",
           "end": {
-            "x": 2.88,
-            "y": 1.9,
+            "x": 0.8413905505799008,
+            "y": 2.2281214909524567,
             "z": 0.0
           },
           "relative": false
@@ -105,8 +105,8 @@ description: Artifact commands inconsistent_sketch_converge.kcl
         "type": "move_path_pen",
         "path": "[uuid]",
         "to": {
-          "x": -2.64,
-          "y": -0.33,
+          "x": -2.1864998384498913,
+          "y": -0.3364174653417452,
           "z": 0.0
         }
       }
@@ -120,8 +120,8 @@ description: Artifact commands inconsistent_sketch_converge.kcl
         "segment": {
           "type": "line",
           "end": {
-            "x": 1.6,
-            "y": -0.39,
+            "x": 1.146499796615717,
+            "y": -0.3835825346582548,
             "z": 0.0
           },
           "relative": false

--- a/rust/kcl-lib/tests/inconsistent_sketch_converge/program_memory.snap
+++ b/rust/kcl-lib/tests/inconsistent_sketch_converge/program_memory.snap
@@ -59,7 +59,7 @@ description: Variables in memory after executing inconsistent_sketch_converge.kc
                   "line": {
                     "start": [
                       {
-                        "n": -3.83,
+                        "n": -1.7913914572449539,
                         "ty": {
                           "mm": null,
                           "type": "Known",
@@ -67,7 +67,7 @@ description: Variables in memory after executing inconsistent_sketch_converge.kc
                         }
                       },
                       {
-                        "n": 2.98,
+                        "n": 2.651878509047543,
                         "ty": {
                           "mm": null,
                           "type": "Known",
@@ -77,7 +77,7 @@ description: Variables in memory after executing inconsistent_sketch_converge.kc
                     ],
                     "end": [
                       {
-                        "n": 2.88,
+                        "n": 0.8413905505799008,
                         "ty": {
                           "mm": null,
                           "type": "Known",
@@ -85,7 +85,7 @@ description: Variables in memory after executing inconsistent_sketch_converge.kc
                         }
                       },
                       {
-                        "n": 1.9,
+                        "n": 2.2281214909524567,
                         "ty": {
                           "mm": null,
                           "type": "Known",
@@ -121,6 +121,8 @@ description: Variables in memory after executing inconsistent_sketch_converge.kc
                     },
                     "start_object_id": 2,
                     "end_object_id": 3,
+                    "start_freedom": "Conflict",
+                    "end_freedom": "Conflict",
                     "construction": false
                   }
                 },
@@ -177,7 +179,7 @@ description: Variables in memory after executing inconsistent_sketch_converge.kc
                   "line": {
                     "start": [
                       {
-                        "n": -2.64,
+                        "n": -2.1864998384498913,
                         "ty": {
                           "mm": null,
                           "type": "Known",
@@ -185,7 +187,7 @@ description: Variables in memory after executing inconsistent_sketch_converge.kc
                         }
                       },
                       {
-                        "n": -0.33,
+                        "n": -0.3364174653417452,
                         "ty": {
                           "mm": null,
                           "type": "Known",
@@ -195,7 +197,7 @@ description: Variables in memory after executing inconsistent_sketch_converge.kc
                     ],
                     "end": [
                       {
-                        "n": 1.6,
+                        "n": 1.146499796615717,
                         "ty": {
                           "mm": null,
                           "type": "Known",
@@ -203,7 +205,7 @@ description: Variables in memory after executing inconsistent_sketch_converge.kc
                         }
                       },
                       {
-                        "n": -0.39,
+                        "n": -0.3835825346582548,
                         "ty": {
                           "mm": null,
                           "type": "Known",
@@ -239,6 +241,8 @@ description: Variables in memory after executing inconsistent_sketch_converge.kc
                     },
                     "start_object_id": 6,
                     "end_object_id": 7,
+                    "start_freedom": "Conflict",
+                    "end_freedom": "Conflict",
                     "construction": false
                   }
                 },
@@ -298,8 +302,8 @@ description: Variables in memory after executing inconsistent_sketch_converge.kc
                     "sourceRange": []
                   },
                   "from": [
-                    -3.83,
-                    2.98
+                    -1.7913914572449539,
+                    2.651878509047543
                   ],
                   "tag": {
                     "commentStart": 61,
@@ -310,8 +314,8 @@ description: Variables in memory after executing inconsistent_sketch_converge.kc
                     "value": "line1"
                   },
                   "to": [
-                    2.88,
-                    1.9
+                    0.8413905505799008,
+                    2.2281214909524567
                   ],
                   "type": "ToPoint",
                   "units": "mm"
@@ -322,13 +326,13 @@ description: Variables in memory after executing inconsistent_sketch_converge.kc
                     "sourceRange": []
                   },
                   "from": [
-                    2.88,
-                    1.9
+                    0.8413905505799008,
+                    2.2281214909524567
                   ],
                   "tag": null,
                   "to": [
-                    -2.64,
-                    -0.33
+                    -2.1864998384498913,
+                    -0.3364174653417452
                   ],
                   "type": "ToPoint",
                   "units": "mm"
@@ -339,8 +343,8 @@ description: Variables in memory after executing inconsistent_sketch_converge.kc
                     "sourceRange": []
                   },
                   "from": [
-                    -2.64,
-                    -0.33
+                    -2.1864998384498913,
+                    -0.3364174653417452
                   ],
                   "tag": {
                     "commentStart": 184,
@@ -351,8 +355,8 @@ description: Variables in memory after executing inconsistent_sketch_converge.kc
                     "value": "line2"
                   },
                   "to": [
-                    1.6,
-                    -0.39
+                    1.146499796615717,
+                    -0.3835825346582548
                   ],
                   "type": "ToPoint",
                   "units": "mm"
@@ -391,12 +395,12 @@ description: Variables in memory after executing inconsistent_sketch_converge.kc
               },
               "start": {
                 "from": [
-                  -3.83,
-                  2.98
+                  -1.7913914572449539,
+                  2.651878509047543
                 ],
                 "to": [
-                  -3.83,
-                  2.98
+                  -1.7913914572449539,
+                  2.651878509047543
                 ],
                 "units": "mm",
                 "tag": null,


### PR DESCRIPTION
Biggest change is that when the constraint solver doesn't resolve, it'll still return a best-effort solution. This is a better UX than everything completely exploding and becoming garbage. See https://github.com/KittyCAD/ezpz/pull/266.