### PR TITLE
Open imported Aquarium entry file

### DIFF
--- a/src/components/Explorer/ProjectExplorer.spec.tsx
+++ b/src/components/Explorer/ProjectExplorer.spec.tsx
@@ -5,7 +5,13 @@ import {
 } from '@src/components/Explorer/utils'
 import type { FileEntry, Project } from '@src/lib/project'
 import type { ModuleType } from '@src/lib/wasm_lib_wrapper'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
 import { beforeAll, expect, describe, it, beforeEach, afterEach } from 'vitest'
 import { moduleFsViaModuleImport, StorageName } from '@src/lib/fs-zds'
 
@@ -197,6 +203,60 @@ describe('ProjectExplorer', () => {
     expect(items.length).toBe(2)
     expect(items[0].innerText).toBe('parts')
     expect(items[1].innerText).toBe('main.kcl')
+    expect(items[1]).toHaveAttribute('aria-selected', 'true')
+  })
+  it('should select the current file when it changes after load', async () => {
+    const rootFile = createFile('main.kcl')
+    const importedMainFile = createFile('main.kcl', 'shared-project/')
+    project.children = [
+      rootFile,
+      createFolder('shared-project', [importedMainFile]),
+    ]
+    addPlaceHoldersForNewFileAndFolder(project.children, project.path)
+    const { rerender } = render(
+      <ProjectExplorer
+        wasmInstance={wasmInstance}
+        project={project}
+        file={rootFile}
+        createFilePressed={-1}
+        createFolderPressed={-1}
+        refreshExplorerPressed={-1}
+        collapsePressed={-1}
+        onRowClicked={(row: FileExplorerEntry, index: number) => {}}
+        onRowEnter={(row: FileExplorerEntry, index: number) => {}}
+        readOnly={false}
+        canNavigate={true}
+        overrideApplicationProjectDirectory="applicationDirectory/"
+      />
+    )
+
+    rerender(
+      <ProjectExplorer
+        wasmInstance={wasmInstance}
+        project={project}
+        file={importedMainFile}
+        createFilePressed={-1}
+        createFolderPressed={-1}
+        refreshExplorerPressed={-1}
+        collapsePressed={-1}
+        onRowClicked={(row: FileExplorerEntry, index: number) => {}}
+        onRowEnter={(row: FileExplorerEntry, index: number) => {}}
+        readOnly={false}
+        canNavigate={true}
+        overrideApplicationProjectDirectory="applicationDirectory/"
+      />
+    )
+
+    await waitFor(() => {
+      const items = screen.getAllByTestId('file-tree-item')
+      const selectedRows = items.filter(
+        (item) => item.getAttribute('aria-selected') === 'true'
+      )
+      expect(selectedRows).toHaveLength(1)
+      expect(selectedRows[0].innerText).toBe('main.kcl')
+      expect(items[0].innerText).toBe('shared-project')
+      expect(selectedRows[0]).toBe(items[1])
+    })
   })
   it('should render main.kcl on initialization within 3 nested folders', () => {
     const mainFile = createFile('main.kcl', 'parts/very/cool/')

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -71,6 +71,15 @@ const getDropTargetPath = (
   return getParentAbsolutePath(target.path)
 }
 
+const rowPathMatchesTreeParent = (
+  row: FileExplorerEntry,
+  project: Project
+): boolean => {
+  const [, ...relativeParentParts] = desktopSafePathSplit(row.parentPath)
+  const expectedParentPath = joinOSPaths(project.path, ...relativeParentParts)
+  return getParentAbsolutePath(row.path) === expectedParentPath
+}
+
 const readAllDirectoryEntriesRecursively = async (
   dirEntry: FileSystemDirectoryEntry
 ): Promise<FileSystemEntry[]> => {
@@ -448,7 +457,10 @@ export const ProjectExplorer = ({
 
     const openedRowsForRender = { ...openedRows }
     const currentFileRow = file?.path
-      ? flattenedData.find((child) => child.path === file.path)
+      ? flattenedData.find(
+          (child) =>
+            child.path === file.path && rowPathMatchesTreeParent(child, project)
+        )
       : undefined
     let openedRowsChanged = false
     if (currentFileRow) {

--- a/src/components/Explorer/ProjectExplorer.tsx
+++ b/src/components/Explorer/ProjectExplorer.tsx
@@ -446,6 +446,21 @@ export const ProjectExplorer = ({
       // insert fake row if one is present
     }
 
+    const openedRowsForRender = { ...openedRows }
+    const currentFileRow = file?.path
+      ? flattenedData.find((child) => child.path === file.path)
+      : undefined
+    let openedRowsChanged = false
+    if (currentFileRow) {
+      const pathIterator = desktopSafePathSplit(currentFileRow.parentPath)
+      while (pathIterator.length > 0) {
+        const key = desktopSafePathJoin(pathIterator)
+        openedRowsChanged = openedRowsChanged || !openedRowsForRender[key]
+        openedRowsForRender[key] = true
+        pathIterator.pop()
+      }
+    }
+
     const requestedRows: FileExplorerRow[] =
       flattenedData.map((child) => {
         const isFile = child.children === null
@@ -458,14 +473,15 @@ export const ProjectExplorer = ({
         const pathIterator = desktopSafePathSplit(child.parentPath)
         while (pathIterator.length > 0) {
           const key = desktopSafePathJoin(pathIterator)
-          const isOpened = openedRows[key] || project.name === key
+          const isOpened = openedRowsForRender[key] || project.name === key
           isAnyParentClosed = isAnyParentClosed || !isOpened
           pathIterator.pop()
         }
 
-        const isOpen = openedRows[child.key]
+        const isOpen = openedRowsForRender[child.key]
         const render =
-          (openedRows[child.parentPath] || project.name === child.parentPath) &&
+          (openedRowsForRender[child.parentPath] ||
+            project.name === child.parentPath) &&
           !isAnyParentClosed
 
         let icon: CustomIconName = 'file'
@@ -903,11 +919,22 @@ export const ProjectExplorer = ({
       return row.render && skipPlaceHolder
     })
 
+    const currentFileRowIndex = requestedRowsToRender.findIndex(
+      (row) => row.path === file?.path
+    )
+    if (currentFileRowIndex >= 0) {
+      setSelectedRowWrapper(requestedRowsToRender[currentFileRowIndex])
+      setActiveIndex(currentFileRowIndex)
+    }
+    if (openedRowsChanged) {
+      setOpenedRows(openedRowsForRender)
+      openedRowsRef.current = openedRowsForRender
+    }
     setRowsToRender(requestedRowsToRender)
     rowsToRenderRef.current = requestedRowsToRender
     previousProject.current = project
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO: blanket-ignored fix me!
-  }, [project, openedRows, fakeRow, activeIndex, errors])
+  }, [project, openedRows, fakeRow, activeIndex, errors, file?.path])
 
   // Handle clicks and keyboard presses within the global DOM level
   useEffect(() => {

--- a/src/hooks/useQueryParamEffects.ts
+++ b/src/hooks/useQueryParamEffects.ts
@@ -116,6 +116,9 @@ export function useQueryParamEffects(kclManager: KclManager) {
     }
 
     void (async () => {
+      // File navigation removes the project-id param while preserving the new
+      // file route. Calling setSearchParams here can re-navigate from the
+      // original query-param route and reopen the project default file.
       await waitForIdleState({ systemIOActor: app.systemIOActor })
       if (cancelled) {
         return
@@ -171,9 +174,6 @@ export function useQueryParamEffects(kclManager: KclManager) {
       })
 
       await waitForIdleState({ systemIOActor: app.systemIOActor })
-      if (!cancelled) {
-        clearProjectIdSearchParam()
-      }
     })().catch((error) => {
       if (cancelled) {
         return

--- a/src/machines/systemIO/systemIOMachine.spec.ts
+++ b/src/machines/systemIO/systemIOMachine.spec.ts
@@ -160,6 +160,13 @@ describe('systemIOMachine - XState', () => {
 
         try {
           actor.send({
+            type: SystemIOMachineEvents.navigateToProject,
+            data: {
+              requestedProjectName: 'demo-project',
+            },
+          })
+
+          actor.send({
             type: SystemIOMachineEvents.bulkImportProjectFilesAndNavigateToFile,
             data: {
               files: [],

--- a/src/machines/systemIO/systemIOMachine.spec.ts
+++ b/src/machines/systemIO/systemIOMachine.spec.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import { DEFAULT_PROJECT_NAME } from '@src/lib/constants'
+import type { Project } from '@src/lib/project'
 import { systemIOMachine } from '@src/machines/systemIO/systemIOMachine'
 import { systemIOMachineImpl } from '@src/machines/systemIO/systemIOMachineImpl'
 import {
@@ -130,6 +131,57 @@ describe('systemIOMachine - XState', () => {
               SystemIOMachineStates.bulkImportingProjectFilesAndNavigateToFile
             )
           )
+        } finally {
+          actor.stop()
+        }
+      })
+      it('should prefer opening the imported entry file over navigating to the project', async () => {
+        const actor = createActor(
+          systemIOMachine.provide({
+            actors: {
+              [SystemIOMachineActors.readFoldersFromProjectDirectory]:
+                fromPromise(async () => [] as Project[]),
+              [SystemIOMachineActors.bulkImportProjectFilesAndNavigateToFile]:
+                fromPromise(async () => ({
+                  message: 'Imported',
+                  projectName: 'demo-project',
+                  fileName: 'shared-project/main.kcl',
+                  subRoute: '',
+                })),
+            },
+          }),
+          {
+            input: {
+              wasmInstancePromise: Promise.resolve(instanceInThisFile),
+              app: appInstanceInThisFile,
+            },
+          }
+        ).start()
+
+        try {
+          actor.send({
+            type: SystemIOMachineEvents.bulkImportProjectFilesAndNavigateToFile,
+            data: {
+              files: [],
+              requestedProjectName: 'demo-project',
+              requestedFileNameWithExtension: 'shared-project/main.kcl',
+            },
+          })
+
+          await waitFor(actor, (state) =>
+            state.matches(SystemIOMachineStates.idle)
+          )
+
+          expect(actor.getSnapshot().context.requestedFileName).toStrictEqual({
+            project: 'demo-project',
+            file: 'shared-project/main.kcl',
+            subRoute: '',
+          })
+          expect(
+            actor.getSnapshot().context.requestedProjectName
+          ).toStrictEqual({
+            name: NO_PROJECT_DIRECTORY,
+          })
         } finally {
           actor.stop()
         }

--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -1377,7 +1377,7 @@ export const systemIOMachine = setup({
                   subRoute: output.subRoute,
                 }
               },
-              requestedProjectName: ({ context, event }) => {
+              requestedProjectName: ({ event }) => {
                 const output = (
                   event as {
                     output: {
@@ -1389,7 +1389,7 @@ export const systemIOMachine = setup({
                 ).output
 
                 if (output.fileName) {
-                  return context.requestedProjectName
+                  return { name: NO_PROJECT_DIRECTORY }
                 }
 
                 return {

--- a/src/machines/systemIO/systemIOMachine.ts
+++ b/src/machines/systemIO/systemIOMachine.ts
@@ -1377,18 +1377,24 @@ export const systemIOMachine = setup({
                   subRoute: output.subRoute,
                 }
               },
-              requestedProjectName: ({ event }) => {
+              requestedProjectName: ({ context, event }) => {
+                const output = (
+                  event as {
+                    output: {
+                      projectName: string
+                      fileName: string
+                      subRoute?: string
+                    }
+                  }
+                ).output
+
+                if (output.fileName) {
+                  return context.requestedProjectName
+                }
+
                 return {
-                  name: (
-                    event as {
-                      output: { projectName: string; subRoute?: string }
-                    }
-                  ).output.projectName,
-                  subRoute: (
-                    event as {
-                      output: { projectName: string; subRoute?: string }
-                    }
-                  ).output.subRoute,
+                  name: output.projectName,
+                  subRoute: output.subRoute,
                 }
               },
             }),


### PR DESCRIPTION
Currently when an Aquarium project is imported, it won't open by default on web. It's confusing to users. So with input from @persis-randolph , we now open the imported project's main.kcl by default.