### PR TITLE
#11864 Delete loft of surfaces should work

### DIFF
--- a/src/lang/modifyAst.spec.ts
+++ b/src/lang/modifyAst.spec.ts
@@ -33,10 +33,14 @@ import {
 } from '@src/lang/queryAst'
 import { getNodePathFromSourceRange } from '@src/lang/queryAstNodePathUtils'
 import type { Artifact } from '@src/lang/std/artifactGraph'
-import { codeRefFromRange, getFaceCodeRef } from '@src/lang/std/artifactGraph'
+import {
+  codeRefFromRange,
+  getArtifactFromRange,
+  getFaceCodeRef,
+} from '@src/lang/std/artifactGraph'
 import { topLevelRange } from '@src/lang/util'
 import type { Identifier, Literal } from '@src/lang/wasm'
-import { assertParse, recast } from '@src/lang/wasm'
+import { assertParse, getAllOperations, recast } from '@src/lang/wasm'
 import type { Selections } from '@src/machines/modelingSharedTypes'
 import { enginelessExecutor } from '@src/lib/testHelpers'
 import { err } from '@src/lib/trap'
@@ -737,6 +741,48 @@ ${!replace1 ? `  |> ${line}\n` : ''}  |> angledLine(angle = -65deg, length = ${
 })
 
 describe('Testing deleteFromSelection', () => {
+  it('deletes a surface loft selected from the feature tree operation range', async () => {
+    const codeBefore = `@settings(kclVersion = 2.0)
+
+sketch001 = sketch(on = XZ) {
+  line1 = line(start = [var 0mm, var 0mm], end = [var 1mm, var 0mm])
+}
+sketch002 = sketch(on = YZ) {
+  line1 = line(start = [var 0mm, var 0mm], end = [var 1mm, var 0mm])
+}
+loft001 = loft([sketch001.line1, sketch002.line1], bodyType = SURFACE)`
+    const ast = assertParse(codeBefore, instanceInThisFile)
+    const execState = await enginelessExecutor(ast, rustContextInThisFile)
+    const loftOperation = getAllOperations(execState.operations).find(
+      (op) => op.type === 'StdLibCall' && op.name === 'loft'
+    )
+    if (!loftOperation || loftOperation.type !== 'StdLibCall') {
+      throw new Error('Could not find loft operation')
+    }
+    const artifact =
+      getArtifactFromRange(
+        loftOperation.sourceRange,
+        execState.artifactGraph
+      ) ?? undefined
+    expect(artifact?.type).toBe('path')
+    if (artifact?.type === 'path') {
+      expect(artifact.subType).toBe('sketch')
+    }
+    const result = await deleteFromSelection(
+      ast,
+      {
+        codeRef: codeRefFromRange(loftOperation.sourceRange, ast),
+        artifact,
+      },
+      execState.variables,
+      execState.artifactGraph,
+      instanceInThisFile
+    )
+    if (err(result)) throw result
+    const newCode = recast(result, instanceInThisFile)
+    expect(newCode).not.toContain('loft001 = loft')
+  })
+
   const cases = [
     [
       'basicCase',

--- a/src/lang/modifyAst.spec.ts
+++ b/src/lang/modifyAst.spec.ts
@@ -783,6 +783,45 @@ loft001 = loft([sketch001.line1, sketch002.line1], bodyType = SURFACE)`
     expect(newCode).not.toContain('loft001 = loft')
   })
 
+  it('deletes a surface extrude of a sketch segment selected from the feature tree operation range', async () => {
+    const codeBefore = `@settings(kclVersion = 2.0)
+
+sketch001 = sketch(on = XZ) {
+  line1 = line(start = [var 0mm, var 0mm], end = [var 1mm, var 0mm])
+}
+extrude001 = extrude(sketch001.line1, length = 5, bodyType = SURFACE)`
+    const ast = assertParse(codeBefore, instanceInThisFile)
+    const execState = await enginelessExecutor(ast, rustContextInThisFile)
+    const extrudeOperation = getAllOperations(execState.operations).find(
+      (op) => op.type === 'StdLibCall' && op.name === 'extrude'
+    )
+    if (!extrudeOperation || extrudeOperation.type !== 'StdLibCall') {
+      throw new Error('Could not find extrude operation')
+    }
+    const artifact =
+      getArtifactFromRange(
+        extrudeOperation.sourceRange,
+        execState.artifactGraph
+      ) ?? undefined
+    expect(artifact?.type).toBe('path')
+    if (artifact?.type === 'path') {
+      expect(artifact.subType).toBe('sketch')
+    }
+    const result = await deleteFromSelection(
+      ast,
+      {
+        codeRef: codeRefFromRange(extrudeOperation.sourceRange, ast),
+        artifact,
+      },
+      execState.variables,
+      execState.artifactGraph,
+      instanceInThisFile
+    )
+    if (err(result)) throw result
+    const newCode = recast(result, instanceInThisFile)
+    expect(newCode).not.toContain('extrude001 = extrude')
+  })
+
   const cases = [
     [
       'basicCase',

--- a/src/lang/modifyAst.spec.ts
+++ b/src/lang/modifyAst.spec.ts
@@ -822,6 +822,52 @@ extrude001 = extrude(sketch001.line1, length = 5, bodyType = SURFACE)`
     expect(newCode).not.toContain('extrude001 = extrude')
   })
 
+  it.each([
+    ['transform', `translate(bracket, x = 1, y = 2)`],
+    [
+      'fillet',
+      `fillet(extrude001, radius = 5, tags = [getOppositeEdge(seg02)])`,
+    ],
+    ['appearance', `appearance(extrude001, color = "#00ff00")`],
+    [
+      'gdt flatness',
+      `gdt::flatness(
+  faces = [capEnd001],
+  tolerance = 0.2in,
+  precision = 3,
+  framePlane = XZ,
+  framePosition = [20, 30],
+  fontSize = 24,
+)`,
+    ],
+    [
+      'gdt datum',
+      `gdt::datum(
+  face = capEnd001,
+  name = "B",
+  framePlane = YZ,
+  framePosition = [10, 5],
+  fontSize = 32,
+)`,
+    ],
+  ])(
+    'deletes an unassigned %s call expression selected from the feature tree operation range',
+    async (_name, codeBefore) => {
+      const ast = assertParse(codeBefore, instanceInThisFile)
+      const result = await deleteFromSelection(
+        ast,
+        {
+          codeRef: codeRefFromRange([0, codeBefore.length, 0], ast),
+        },
+        {},
+        new Map(),
+        instanceInThisFile
+      )
+      if (err(result)) throw result
+      expect(recast(result, instanceInThisFile)).toBe('')
+    }
+  )
+
   const cases = [
     [
       'basicCase',

--- a/src/lang/modifyAst/deleteFromSelection.ts
+++ b/src/lang/modifyAst/deleteFromSelection.ts
@@ -161,6 +161,14 @@ export async function deleteFromSelection(
     'VariableDeclarator'
   )
   if (err(varDec)) return varDec
+  const selectedCallName =
+    varDec.node.init.type === 'CallExpressionKw'
+      ? varDec.node.init.callee.name.name
+      : null
+  const isSweepLikePathSelection =
+    selection.artifact?.type === 'path' &&
+    selectedCallName !== null &&
+    ['extrude', 'revolve', 'sweep', 'loft', 'blend'].includes(selectedCallName)
 
   if (
     selection.artifact?.type === 'pattern' &&
@@ -192,7 +200,7 @@ export async function deleteFromSelection(
     selection.artifact?.type === 'sweep' ||
     selection.artifact?.type === 'plane' ||
     (selection.artifact?.type === 'path' &&
-      selection.artifact.subType === 'region') ||
+      (selection.artifact.subType === 'region' || isSweepLikePathSelection)) ||
     selection.artifact?.type === 'compositeSolid' ||
     selection.artifact?.type === 'pattern' ||
     selection.artifact?.type === 'helix' ||

--- a/src/lang/modifyAst/deleteFromSelection.ts
+++ b/src/lang/modifyAst/deleteFromSelection.ts
@@ -154,17 +154,23 @@ export async function deleteFromSelection(
   }
 
   // Below is all AST-based deletion logic
-  const varDec = getNodeFromPath<VariableDeclarator>(
+  const varDec = getNodeFromPath<VariableDeclarator | CallExpressionKw>(
     ast,
     selection?.codeRef?.pathToNode,
     wasmInstance,
     'VariableDeclarator'
   )
   if (err(varDec)) return varDec
-  const selectedCallName =
-    varDec.node.init.type === 'CallExpressionKw'
-      ? varDec.node.init.callee.name.name
-      : null
+  const varDecNode =
+    varDec.node.type === 'VariableDeclarator' ? varDec.node : null
+  const varDecNodeInit = varDecNode?.init ?? null
+  const selectedCallExpression =
+    varDecNodeInit?.type === 'CallExpressionKw'
+      ? varDecNodeInit
+      : varDec.node.type === 'CallExpressionKw'
+        ? varDec.node
+        : null
+  const selectedCallName = selectedCallExpression?.callee.name.name ?? null
   const isSweepLikePathSelection =
     selection.artifact?.type === 'path' &&
     selectedCallName !== null &&
@@ -172,13 +178,13 @@ export async function deleteFromSelection(
 
   if (
     selection.artifact?.type === 'pattern' &&
-    varDec.node.init.type === 'PipeExpression'
+    varDecNodeInit?.type === 'PipeExpression'
   ) {
     const pipeBodyIndex = selection.codeRef.pathToNode.findIndex(
       ([key, kind]) => key === 'body' && kind === 'PipeExpression'
     )
     const pipeItemIndex = selection.codeRef.pathToNode[pipeBodyIndex + 1]?.[0]
-    if (typeof pipeItemIndex === 'number' && varDec.node.init.body.length > 1) {
+    if (typeof pipeItemIndex === 'number' && varDecNodeInit.body.length > 1) {
       const varDecClone = getNodeFromPath<VariableDeclarator>(
         astClone,
         selection.codeRef.pathToNode,
@@ -196,7 +202,7 @@ export async function deleteFromSelection(
   if (
     ((selection?.artifact?.type === 'wall' ||
       selection?.artifact?.type === 'cap') &&
-      varDec.node.init.type === 'PipeExpression') ||
+      varDecNodeInit?.type === 'PipeExpression') ||
     selection.artifact?.type === 'sweep' ||
     selection.artifact?.type === 'plane' ||
     (selection.artifact?.type === 'path' &&
@@ -219,7 +225,8 @@ export async function deleteFromSelection(
       selection.artifact.type !== 'path' &&
       selection.artifact.type !== 'planeOfFace'
     ) {
-      const varDecName = varDec.node.id.name
+      if (!varDecNode) return new Error('Could not find sketch variable')
+      const varDecName = varDecNode.id.name
       traverse(astClone, {
         enter: (node, path) => {
           if (node.type === 'VariableDeclaration') {
@@ -252,8 +259,8 @@ export async function deleteFromSelection(
       if (!pathToNode) return new Error('Could not find extrude variable')
     } else {
       pathToNode = selection.codeRef.pathToNode
-      if (varDec.node.type === 'VariableDeclarator') {
-        extrudeNameToDelete = varDec.node.id.name
+      if (varDecNode) {
+        extrudeNameToDelete = varDecNode.id.name
       } else if (varDec.node.type === 'CallExpressionKw') {
         const callExp = getNodeFromPath<CallExpressionKw>(
           astClone,
@@ -453,8 +460,8 @@ export async function deleteFromSelection(
     return astClone
   } else if (selection.artifact?.type === 'edgeCut') {
     return deleteEdgeTreatment(astClone, selection, wasmInstance)
-  } else if (varDec.node.init.type === 'PipeExpression') {
-    const pipeBody = varDec.node.init.body
+  } else if (varDecNodeInit?.type === 'PipeExpression') {
+    const pipeBody = varDecNodeInit.body
     const doNotDeleteProfileIfItHasBeenExtruded = !(
       selection?.artifact?.type === 'segment' && selection?.artifact?.surfaceId
     )
@@ -471,10 +478,8 @@ export async function deleteFromSelection(
     }
   } else if (
     // single expression profiles or clone
-    varDec.node.init.type === 'CallExpressionKw' &&
-    ['circleThreePoint', 'circle', 'clone'].includes(
-      varDec.node.init.callee.name.name
-    )
+    varDecNodeInit?.type === 'CallExpressionKw' &&
+    ['circleThreePoint', 'circle', 'clone'].includes(selectedCallName ?? '')
   ) {
     const varDecIndex = varDec.shallowPath[1][0] as number
     astClone.body.splice(varDecIndex, 1)


### PR DESCRIPTION
Fixes #11864 

This entire `deleteFromSelection` is getting complex..

Deleting a surface `loft` or `extrude` from the feature tree could fail with “Selection not recognised”
These operations can create synthetic sketch path artifacts at the operation’s source range, so the selection arrived as artifact.type === 'path' and subType === 'sketch' instead of as a sweep. The old delete logic only allowed region paths through that branch.

The fix supports path selections when the selected top-level call is a sweep-like operation (extrude, revolve, sweep, loft, or blend).
Added regression coverage for surface loft and surface extrude from sketch segments.