### PR TITLE
Fix kcl-lib crate publish since kcl-syntax was added

### DIFF
--- a/rust/justfile
+++ b/rust/justfile
@@ -94,6 +94,7 @@ publish-kcl version:
     cargo publish -p kcl-derive-docs
     cargo publish -p kcl-directory-test-macro
     cargo publish -p kcl-error
+    cargo publish -p kcl-syntax
     cargo publish -p kcl-lib
     cargo publish -p kcl-test-server
     # We push the tag at the end of publish since pushing the tag

--- a/rust/kcl-lib/Cargo.toml
+++ b/rust/kcl-lib/Cargo.toml
@@ -71,7 +71,7 @@ indexmap = { workspace = true, features = ["serde", "rayon"] }
 itertools = "0.14.0"
 kcl-derive-docs = { version = "0.2.159", path = "../kcl-derive-docs" }
 kcl-error = { version = "0.2.159", path = "../kcl-error" }
-kcl-syntax = { path = "../kcl-syntax", optional = true }
+kcl-syntax = { version = "0.1.1", path = "../kcl-syntax", optional = true }
 ezpz = { workspace = true }
 kittycad = { workspace = true }
 kittycad-modeling-cmds = { workspace = true }


### PR DESCRIPTION
It needs an explicit version for kcl-syntax. Also, kcl-syntax needs to be published before it.

TODO: The bumper needs to bump kcl-syntax version.