### PR TITLE
Fix bumper to include kcl-syntax

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2530,7 +2530,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-syntax"
-version = "0.1.1"
+version = "0.2.159"
 dependencies = [
  "logos",
  "proptest",

--- a/rust/kcl-bumper/src/main.rs
+++ b/rust/kcl-bumper/src/main.rs
@@ -90,7 +90,7 @@ fn update_semver(bump: Option<SemverBump>, cargo_dot_toml: &mut DocumentMut) -> 
 fn update_kcl_lib_dependency_versions(cargo_dot_toml: &mut DocumentMut, next_version: &semver::Version) {
     // Make kcl-lib depend on the new versions so that crates that depend on
     // kcl-lib also update these.
-    for dependency in ["kcl-derive-docs", "kcl-error"] {
+    for dependency in ["kcl-derive-docs", "kcl-error", "kcl-syntax"] {
         if !update_dependency_version(cargo_dot_toml, dependency, next_version) {
             eprintln!("Warning: could not find dependency `{dependency}` in kcl-lib [dependencies]");
         }

--- a/rust/kcl-lib/Cargo.toml
+++ b/rust/kcl-lib/Cargo.toml
@@ -71,7 +71,7 @@ indexmap = { workspace = true, features = ["serde", "rayon"] }
 itertools = "0.14.0"
 kcl-derive-docs = { version = "0.2.159", path = "../kcl-derive-docs" }
 kcl-error = { version = "0.2.159", path = "../kcl-error" }
-kcl-syntax = { version = "0.1.1", path = "../kcl-syntax", optional = true }
+kcl-syntax = { version = "0.2.159", path = "../kcl-syntax", optional = true }
 ezpz = { workspace = true }
 kittycad = { workspace = true }
 kittycad-modeling-cmds = { workspace = true }

--- a/rust/kcl-syntax/Cargo.toml
+++ b/rust/kcl-syntax/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-syntax"
 description = "Lossless syntax trees for KCL"
-version = "0.1.1"
+version = "0.2.159"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/KittyCAD/modeling-app"


### PR DESCRIPTION
This also changes kcl-syntax version to match the other kcl crates.

When we bump crate versions before a release, kcl-lib deps need to be updated so that users who only update kcl-lib in their project automatically get the updated transitive deps. I.e. this prevents the problem we had recently with faer.