### PR TITLE
Upgrade to rust toolchain 1.96.0

### DIFF
--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
https://blog.rust-lang.org/2026/05/28/Rust-1.96.0/