### PR TITLE
Bump Python to 160

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2514,7 +2514,7 @@ dependencies = [
 
 [[package]]
 name = "kcl-python-bindings"
-version = "0.3.159"
+version = "0.3.160"
 dependencies = [
  "anyhow",
  "kcl-lib",

--- a/rust/kcl-python-bindings/Cargo.toml
+++ b/rust/kcl-python-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-python-bindings"
-version = "0.3.159"
+version = "0.3.160"
 edition = "2024"
 repository = "https://github.com/kittycad/modeling-app"
 exclude = ["tests/*", "files/*", "venv/*"]


### PR DESCRIPTION
Hotfix to the python bindings, so we can release https://github.com/KittyCAD/modeling-app/pull/11882