### PR TITLE
Rename viewport annotation to Zoodle

### DIFF
--- a/src/components/MlEphantConversation.spec.tsx
+++ b/src/components/MlEphantConversation.spec.tsx
@@ -893,9 +893,7 @@ describe('MlEphantConversation', () => {
         await waitFor(() => expect(sendButton).not.toBeDisabled())
         fireEvent.click(sendButton)
 
-        expect(
-          await screen.findByText('zoodle-viewport-screenshot.png')
-        ).toBeInTheDocument()
+        expect(await screen.findByText('zoodle')).toBeInTheDocument()
       } finally {
         drawImageSpy.mockRestore()
         globalThis.Image = OriginalImage

--- a/src/components/MlEphantConversation.spec.tsx
+++ b/src/components/MlEphantConversation.spec.tsx
@@ -855,14 +855,12 @@ describe('MlEphantConversation', () => {
       ).toBeInTheDocument()
     })
 
-    test('displays screenshot annotation button', () => {
+    test('displays Zoodle button', () => {
       renderConversation()
-      expect(
-        screen.getByTestId('ml-ephant-annotate-screenshot-button')
-      ).toBeInTheDocument()
+      expect(screen.getByTestId('ml-ephant-zoodle-button')).toBeInTheDocument()
     })
 
-    test('adds annotated viewport screenshot as an attachment', async () => {
+    test('adds Zoodle viewport screenshot as an attachment', async () => {
       const OriginalImage = globalThis.Image
       class MockImage {
         onload: (() => void) | null = null
@@ -885,9 +883,7 @@ describe('MlEphantConversation', () => {
       try {
         renderConversation()
 
-        fireEvent.click(
-          screen.getByTestId('ml-ephant-annotate-screenshot-button')
-        )
+        fireEvent.click(screen.getByTestId('ml-ephant-zoodle-button'))
 
         expect(
           screen.getByTestId('viewport-annotation-overlay')
@@ -898,7 +894,7 @@ describe('MlEphantConversation', () => {
         fireEvent.click(sendButton)
 
         expect(
-          await screen.findByText('annotated-viewport-screenshot.png')
+          await screen.findByText('zoodle-viewport-screenshot.png')
         ).toBeInTheDocument()
       } finally {
         drawImageSpy.mockRestore()

--- a/src/components/MlEphantConversation.spec.tsx
+++ b/src/components/MlEphantConversation.spec.tsx
@@ -860,7 +860,7 @@ describe('MlEphantConversation', () => {
       expect(screen.getByTestId('ml-ephant-zoodle-button')).toBeInTheDocument()
     })
 
-    test('adds Zoodle viewport screenshot as an attachment', async () => {
+    test('adds Zoodle as an attachment', async () => {
       const OriginalImage = globalThis.Image
       class MockImage {
         onload: (() => void) | null = null

--- a/src/components/MlEphantConversation.tsx
+++ b/src/components/MlEphantConversation.tsx
@@ -557,10 +557,7 @@ export const MlEphantConversationInput = (
           imageDataUrl={annotationImageDataUrl}
           onCancel={() => setAnnotationImageDataUrl(null)}
           onSend={(annotatedDataUrl) => {
-            appendDataUrlAttachment(
-              annotatedDataUrl,
-              'zoodle-viewport-screenshot.png'
-            )
+            appendDataUrlAttachment(annotatedDataUrl, 'zoodle')
             setAnnotationImageDataUrl(null)
           }}
         />

--- a/src/components/MlEphantConversation.tsx
+++ b/src/components/MlEphantConversation.tsx
@@ -178,15 +178,15 @@ export const MlEphantExtraInputs = (props: MlEphantExtraInputsProps) => {
         </button>
         <button
           type="button"
-          data-testid="ml-ephant-annotate-screenshot-button"
+          data-testid="ml-ephant-zoodle-button"
           onClick={props.onAnnotateScreenshot}
           disabled={props.attachmentsDisabled}
           className="h-7 w-7 bg-default flex items-center justify-center rounded-sm m-0 p-0 flex-none disabled:opacity-60"
-          aria-label="Annotate viewport screenshot"
+          aria-label="Zoodle viewport screenshot"
         >
           <CustomIcon name="sketch" className="w-5 h-5" />
           <Tooltip position="top" hoverOnly={true}>
-            <span>Annotate viewport screenshot</span>
+            <span>Zoodle</span>
           </Tooltip>
         </button>
       </div>
@@ -559,7 +559,7 @@ export const MlEphantConversationInput = (
           onSend={(annotatedDataUrl) => {
             appendDataUrlAttachment(
               annotatedDataUrl,
-              'annotated-viewport-screenshot.png'
+              'zoodle-viewport-screenshot.png'
             )
             setAnnotationImageDataUrl(null)
           }}

--- a/src/components/MlEphantConversation.tsx
+++ b/src/components/MlEphantConversation.tsx
@@ -182,7 +182,7 @@ export const MlEphantExtraInputs = (props: MlEphantExtraInputsProps) => {
           onClick={props.onAnnotateScreenshot}
           disabled={props.attachmentsDisabled}
           className="h-7 w-7 bg-default flex items-center justify-center rounded-sm m-0 p-0 flex-none disabled:opacity-60"
-          aria-label="Zoodle viewport screenshot"
+          aria-label="Zoodle"
         >
           <CustomIcon name="sketch" className="w-5 h-5" />
           <Tooltip position="top" hoverOnly={true}>


### PR DESCRIPTION
ai assisted

## Problem
People using Zookeeper need the viewport drawing workflow to have the product name they will see and talk about, instead of generic annotation language.
<img width="209" height="92" alt="Screenshot 2026-05-28 at 23 31 35" src="https://github.com/user-attachments/assets/eddf0e73-420a-42dc-9165-18603e235e19" />

## Solution
Rename the screenshot drawing affordance to Zoodle in the chat controls and make sent drawings attach with a Zoodle filename, while preserving the existing drawing and send behavior.
<img width="113" height="80" alt="Screenshot 2026-05-28 at 23 32 02" src="https://github.com/user-attachments/assets/a8e1dae0-8ed9-4639-8b32-991dae554dcd" />
